### PR TITLE
Provide drag origin for canvas and side panel

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -126,6 +126,7 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
       publish({
         type: "dragStart",
         payload: {
+          origin: "panel",
           type: "insert",
           dragComponent: componentName,
         },

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -67,7 +67,8 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
             // We need the node to be rendered but hidden
             // to keep receiving the drag events.
             visibility:
-              dragAndDropState.isDragging && dragAndDropState.origin === "panel"
+              dragAndDropState.isDragging &&
+              dragAndDropState.dragPayload?.origin === "panel"
                 ? "hidden"
                 : "visible",
           }}

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -48,7 +48,11 @@ export const NavigatorTree = () => {
       onDragItemChange={(dragInstanceSelector) => {
         setState({
           ...state,
-          dragPayload: { type: "reparent", dragInstanceSelector },
+          dragPayload: {
+            origin: "panel",
+            type: "reparent",
+            dragInstanceSelector,
+          },
         });
       }}
       onDropTargetChange={(dropTarget) => {

--- a/apps/builder/app/canvas/shared/use-drag-drop.ts
+++ b/apps/builder/app/canvas/shared/use-drag-drop.ts
@@ -41,9 +41,15 @@ declare module "~/shared/pubsub" {
   }
 }
 
+type Origin = "canvas" | "panel";
+
 export type DragStartPayload =
-  | { type: "insert"; dragComponent: Instance["component"] }
-  | { type: "reparent"; dragInstanceSelector: InstanceSelector };
+  | { origin: Origin; type: "insert"; dragComponent: Instance["component"] }
+  | {
+      origin: Origin;
+      type: "reparent";
+      dragInstanceSelector: InstanceSelector;
+    };
 
 export type DragEndPayload = {
   isCanceled: boolean;
@@ -221,6 +227,7 @@ export const useDragAndDrop = () => {
         type: "dragStart",
         payload: {
           type: "reparent",
+          origin: "canvas",
           dragInstanceSelector,
         },
       });

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -430,7 +430,6 @@ export const useTextEditingInstanceId = () =>
 
 export type DragAndDropState = {
   isDragging: boolean;
-  origin?: "canvas" | "panel";
   dropTarget?: ItemDropTarget;
   dragPayload?: DragStartPayload;
   placementIndicator?: Placement;


### PR DESCRIPTION
I broke in one of recent PRs drag origin. Here put it back to support hiding components panel to show preview.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
