### PR TITLE
Fix a bug when link to Home doesn't work on a published site

### DIFF
--- a/packages/react-sdk/src/app/custom-components/shared/remix-link.tsx
+++ b/packages/react-sdk/src/app/custom-components/shared/remix-link.tsx
@@ -12,7 +12,7 @@ export const wrapLinkComponent = (BaseLink: LinkComponent) => {
     const href = usePropUrl(getInstanceIdFromComponentProps(props), "href");
 
     if (href?.type === "page") {
-      let to = href.page.path;
+      let to = href.page.path === "" ? "/" : href.page.path;
       if (href.hash !== undefined) {
         to += `#${href.hash}`;
       }

--- a/packages/react-sdk/src/components/link.tsx
+++ b/packages/react-sdk/src/components/link.tsx
@@ -23,7 +23,7 @@ export const Link = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
 
   switch (href?.type) {
     case "page":
-      url = href.page.path;
+      url = href.page.path === "" ? "/" : href.page.path;
       if (href.hash !== undefined) {
         url += `#${href.hash}`;
       }


### PR DESCRIPTION
## Description

Context: https://discord.com/channels/955905230107738152/1098457250235957258

Fix of the bug: on a published site, when you point a link to Page=Home, the rendered `href` contains path of the current page.

This is most likely due to `homePage.path === ""` and when we pass `to=""` to RemixLink it behaves like this.

So I made sure we pass `to="/"` for the home page.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
