### PR TITLE
Add instruction to run "pnpm build" before running database migration

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,8 +29,9 @@ If you want to contribute and don't know where to start, here is a step-by-step 
 4. Clone the repository `git clone git@github.com:webstudio-is/webstudio-builder.git`
 5. Connect to the [database](https://www.prisma.io/docs/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-postgres): add a database URL to the env variables by creating an .env file in the `apps/builder` and adding there `DATABASE_URL=postgresql://user:pass@localhost/webstudio` or `DATABASE_URL=postgresql://user@localhost/webstudio` if using Postgres.app.
 6. Run `pnpm install` - install dependencies
-7. Run `pnpm migrations migrate` - apply database migrations
-8. Run `pnpm dev` - URL will be logged
+7. Run `pnpm build`
+8. Run `pnpm migrations migrate` - apply database migrations
+9. Run `pnpm dev` - URL will be logged
 
 ## Login locally
 


### PR DESCRIPTION
Hi team. When I was following the step by step guide to run the webstudio builder for the first time locally, I got stuck in the database migration step. I kept getting below error:

![Screen Shot 2023-05-03 at 20 17 12](https://user-images.githubusercontent.com/32300655/236213703-a7261f9e-56fe-44b7-9779-c1ad9f1162b2.png)

It says I am missing the `__generated__` folder in the prisma-client package. So I tried to run the `pnpm build` and it generated the `__generated__` folders. That is pure luck on my side. I didn't know the build command will generate the `__generated__` folder.

Anyway, I just think that we need to add the instruction to run `pnpm build` before running the database migration so other people won't get into the same situation as me. What do you all think? 
