### PR TITLE
Drop cjs support

### DIFF
--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -39,8 +39,7 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./index.server": {
       "source": "./src/index.server.ts",

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -26,8 +26,7 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./index.server": {
       "source": "./src/index.server.ts",

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -35,8 +35,7 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -20,8 +20,7 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -27,8 +27,7 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./index.server": {
       "source": "./src/index.server.ts",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -28,7 +28,6 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js",
       "types": "./lib/types/index.d.ts"
     },
     "./index.server": {

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -34,8 +34,7 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./index.server": {
       "source": "./src/index.server.ts",

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -23,8 +23,7 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -38,14 +38,12 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./svg": {
       "source": "./src/__generated__/svg/index.ts",
       "types": "./lib/types/__generated__/svg/index.d.ts",
-      "import": "./lib/__generated__/svg/index.js",
-      "require": "./lib/cjs/__generated__/svg/index.js"
+      "import": "./lib/__generated__/svg/index.js"
     }
   },
   "files": [

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -39,8 +39,7 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -29,8 +29,7 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "license": "MIT",
   "private": false,

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -10,8 +10,7 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./index.server": {
       "source": "./src/index.server.ts",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -33,8 +33,7 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./index.server": {
       "source": "./src/index.server.ts",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -55,14 +55,12 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./css-normalize": {
       "source": "./src/css/normalize.ts",
       "types": "./lib/types/css/normalize.d.ts",
-      "import": "./lib/css/normalize.js",
-      "require": "./lib/cjs/css/normalize.js"
+      "import": "./lib/css/normalize.js"
     }
   },
   "files": [

--- a/packages/scripts/build-package.ts
+++ b/packages/scripts/build-package.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 
-import { rm, cp, access, writeFile, mkdir } from "node:fs/promises";
+import { rm, cp, access, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { totalist } from "totalist";
 import { build, context, type BuildOptions } from "esbuild";
@@ -32,7 +32,6 @@ await rm("lib", { recursive: true, force: true });
 // regenerate them so we can safely write files into those directories without relying on esbuild creating them
 // in the watch mode esbuild might not create them soon enough for them to be available for other parts of the script
 await mkdir("lib");
-await mkdir("lib/cjs");
 
 const esmConfig: BuildOptions = {
   entryPoints,
@@ -40,42 +39,21 @@ const esmConfig: BuildOptions = {
   format: "esm",
 };
 
-const cjsConfig: BuildOptions = {
-  entryPoints,
-  outdir: "lib/cjs",
-  format: "cjs",
-};
-
 if (watch) {
   const esmContext = await context(esmConfig);
   await esmContext.watch();
-  const cjsContext = await context(cjsConfig);
-  await cjsContext.watch();
 } else {
   await build(esmConfig);
-  await build(cjsConfig);
 }
-
-await writeFile(
-  "lib/cjs/package.json",
-  JSON.stringify({ type: "commonjs" }) + "\n",
-  "utf8"
-);
 
 for (const rel of assets) {
   await cp(join("src", rel), join("lib", rel));
-  await cp(join("src", rel), join("lib/cjs", rel));
 }
 
 if (noGeneratedAsEntries) {
   try {
     await access("./src/__generated__");
-    await Promise.all([
-      cp("./src/__generated__", "./lib/__generated__", { recursive: true }),
-      cp("./src/__generated__", "./lib/cjs/__generated__", {
-        recursive: true,
-      }),
-    ]);
+    await cp("./src/__generated__", "./lib/__generated__", { recursive: true });
   } catch {
     // noop
   }

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -16,20 +16,17 @@
     ".": {
       "source": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
-      "import": "./lib/components.js",
-      "require": "./lib/cjs/components.js"
+      "import": "./lib/components.js"
     },
     "./metas": {
       "source": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js",
-      "require": "./lib/cjs/metas.js"
+      "import": "./lib/metas.js"
     },
     "./props": {
       "source": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js",
-      "require": "./lib/cjs/props.js"
+      "import": "./lib/props.js"
     }
   },
   "scripts": {

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -16,20 +16,17 @@
     ".": {
       "source": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
-      "import": "./lib/components.js",
-      "require": "./lib/cjs/components.js"
+      "import": "./lib/components.js"
     },
     "./metas": {
       "source": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js",
-      "require": "./lib/cjs/metas.js"
+      "import": "./lib/metas.js"
     },
     "./props": {
       "source": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js",
-      "require": "./lib/cjs/props.js"
+      "import": "./lib/props.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Commonjs was used only for tests. Now tests consume sources so we can drop commonjs.

This will run twice less watchers and simplify package setup.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @Andarist, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
