### PR TITLE
Show current states in style panel

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
@@ -36,7 +36,10 @@ describe("setLayerProperty", () => {
             ([property]) => property === propertyName
           );
 
-          styleInfo[propertyName] = { value: newValue, local: newValue };
+          styleInfo[propertyName] = {
+            value: newValue,
+            local: { state: undefined, active: true, value: newValue },
+          };
 
           if (index !== -1) {
             changedProps[index] = [propertyName, newValue];
@@ -45,10 +48,10 @@ describe("setLayerProperty", () => {
 
           changedProps.push([propertyName, newValue]);
         },
-      deleteProperty: (propertyName: string) => {
+      deleteProperty: (_propertyName: string) => {
         // not used
       },
-      publish: (options?: unknown) => {
+      publish: (_options?: unknown) => {
         published = true;
       },
     });
@@ -81,7 +84,11 @@ describe("setLayerProperty", () => {
     // Set non array value, should be restored to array
     styleInfo.backgroundClip = {
       value: { type: "keyword", value: "repeat" },
-      local: { type: "keyword", value: "repeat" },
+      local: {
+        state: undefined,
+        active: true,
+        value: { type: "keyword", value: "repeat" },
+      },
     };
     setProperty("backgroundRepeat")({ type: "keyword", value: "no-repeat" });
 
@@ -101,8 +108,12 @@ describe("setLayerProperty", () => {
         value: [],
       },
       local: {
-        type: "layers",
-        value: [],
+        state: undefined,
+        active: false,
+        value: {
+          type: "layers",
+          value: [],
+        },
       },
     };
 
@@ -159,7 +170,10 @@ describe("setLayerProperty", () => {
             ([property]) => property === propertyName
           );
 
-          styleInfo[propertyName] = { value: newValue, local: newValue };
+          styleInfo[propertyName] = {
+            value: newValue,
+            local: { state: undefined, active: true, value: newValue },
+          };
 
           if (index !== -1) {
             changedProps[index] = [propertyName, newValue];
@@ -168,10 +182,10 @@ describe("setLayerProperty", () => {
 
           changedProps.push([propertyName, newValue]);
         },
-      deleteProperty: (propertyName: string) => {
+      deleteProperty: (_propertyName: string) => {
         // not used
       },
-      publish: (options?: unknown) => {
+      publish: (_options?: unknown) => {
         published = true;
       },
     });
@@ -269,12 +283,15 @@ describe("setLayerProperty", () => {
             throw new Error("newValue.type !== layers");
           }
 
-          styleInfo[propertyName] = { value: newValue, local: newValue };
+          styleInfo[propertyName] = {
+            value: newValue,
+            local: { state: undefined, active: true, value: newValue },
+          };
         },
-      deleteProperty: (propertyName: string) => {
+      deleteProperty: (_propertyName: string) => {
         // not used
       },
-      publish: (options?: unknown) => {
+      publish: (_options?: unknown) => {
         published = true;
       },
     });
@@ -426,13 +443,16 @@ describe("deleteLayer", () => {
           throw new Error("newValue.type !== layers");
         }
 
-        styleInfo[propertyName] = { value: newValue, local: newValue };
+        styleInfo[propertyName] = {
+          value: newValue,
+          local: { state: undefined, active: true, value: newValue },
+        };
       },
     deleteProperty: (propertyName: string) => {
       // not used
       deletedProperties.add(propertyName);
     },
-    publish: (options?: unknown) => {
+    publish: (_options?: unknown) => {
       published = true;
     },
   });
@@ -491,12 +511,15 @@ describe("swapLayers", () => {
             throw new Error("newValue.type !== layers");
           }
 
-          styleInfo[propertyName] = { value: newValue, local: newValue };
+          styleInfo[propertyName] = {
+            value: newValue,
+            local: { state: undefined, active: true, value: newValue },
+          };
         },
-      deleteProperty: (propertyName: string) => {
+      deleteProperty: (_propertyName: string) => {
         // not used
       },
-      publish: (options?: unknown) => {
+      publish: (_options?: unknown) => {
         published = true;
       },
     });
@@ -514,7 +537,7 @@ describe("swapLayers", () => {
     });
 
     expect(styleInfo.backgroundImage?.value).toEqual(
-      styleInfo.backgroundImage?.local
+      styleInfo.backgroundImage?.local?.value
     );
 
     swapLayers(0, 1, styleInfo, createBatchUpdate);

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
@@ -109,9 +109,13 @@ export const getLayerBackgroundStyleInfo = (
       resultProperty["value"] = styleValue;
     }
 
-    if (localStyle?.type === "layers") {
-      const styleValue = localStyle.value[layerNum];
-      resultProperty["local"] = styleValue;
+    if (localStyle?.value?.type === "layers") {
+      const styleValue = localStyle?.value.value[layerNum];
+      resultProperty["local"] = {
+        state: localStyle.state,
+        active: localStyle.active,
+        value: styleValue,
+      };
     }
 
     if (previousSourceStyle?.value?.type === "layers") {
@@ -167,8 +171,8 @@ export type SetBackgroundProperty = ReturnType<typeof setLayerProperty>;
 const getLayersValue = (styleValue?: StyleValueInfo) => {
   const clonedStyleValue: StyleValueInfo | undefined =
     structuredClone(styleValue);
-  if (clonedStyleValue?.local?.type === "layers") {
-    return clonedStyleValue.local;
+  if (clonedStyleValue?.local?.value.type === "layers") {
+    return clonedStyleValue.local.value;
   }
 
   if (clonedStyleValue?.nextSource?.value?.type === "layers") {
@@ -231,7 +235,7 @@ const normalizeLayers = (
       );
     }
 
-    let isStyleChanged = styleValue?.local?.type !== "layers";
+    let isStyleChanged = styleValue?.local?.value.type !== "layers";
 
     if (newPropertyStyle.value.length !== layerCount) {
       // All background properties must have the same number of layers

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
@@ -123,7 +123,7 @@ export const Backgrounds = () => {
     useStyleInfo({
       backgroundImage: {
         value: backgroundImageStyle,
-        local: backgroundImageStyle,
+        local: { state: undefined, active: true, value: backgroundImageStyle },
       },
     });
 

--- a/apps/builder/app/builder/features/style-panel/sections/borders/borders.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/borders.stories.tsx
@@ -12,7 +12,11 @@ setEnv("*");
 
 const styleInfoInitial: StyleInfo = {
   borderTopColor: {
-    local: { type: "rgb", r: 0, g: 0, b: 0, alpha: 1 },
+    local: {
+      state: undefined,
+      active: true,
+      value: { type: "rgb", r: 0, g: 0, b: 0, alpha: 1 },
+    },
     value: { type: "rgb", r: 0, g: 0, b: 0, alpha: 1 },
   },
 };

--- a/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadow-utils.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadow-utils.test.ts
@@ -27,12 +27,15 @@ afterEach(() => {
 
 const createBatchUpdate: CreateBatchUpdate = () => ({
   setProperty: (propertyName: StyleProperty) => (newValue: StyleValue) => {
-    styleInfo[propertyName] = { value: newValue, local: newValue };
+    styleInfo[propertyName] = {
+      value: newValue,
+      local: { state: undefined, active: true, value: newValue },
+    };
   },
   deleteProperty: (propertyName: string) => {
     deletedProperties.add(propertyName);
   },
-  publish: (options?: unknown) => {
+  publish: (_options?: unknown) => {
     published = true;
   },
 });

--- a/apps/builder/app/builder/features/style-panel/sections/position/position-control.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/position/position-control.stories.tsx
@@ -87,14 +87,18 @@ const bigValue = {
   },
 
   local: {
-    type: "unit",
-    value: 123.27,
-    unit: "rem",
+    state: undefined,
+    active: true,
+    value: {
+      type: "unit",
+      value: 123.27,
+      unit: "rem",
+    },
   },
 } as const;
 
 export const PositionControlComponent = (
-  args: Omit<React.ComponentProps<typeof PositionControl>, "renderCell">
+  _args: Omit<React.ComponentProps<typeof PositionControl>, "renderCell">
 ) => {
   const { styleInfo, setProperty, deleteProperty, createBatchUpdate } =
     useStyleInfo({

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -56,9 +56,11 @@ const getSourceName = (
   }
 
   if (styleValueInfo.local) {
+    const state = styleValueInfo.local.state;
+    const suffix = state === undefined ? "" : `:${state}`;
     return selectedStyleSource?.type === "token"
-      ? selectedStyleSource.name
-      : "Local";
+      ? `${selectedStyleSource.name}${suffix}`
+      : `Local${suffix}`;
   }
 
   if (styleValueInfo.previousSource) {

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -13,6 +13,9 @@ import {
   dataSourceValuesStore,
   selectedInstanceSelectorStore,
   dataSourceVariablesStore,
+  $selectedInstanceStates,
+  selectedStyleSourceStore,
+  stylesStore,
 } from "~/shared/nano-states";
 import htmlTags, { type htmlTags as HtmlTags } from "html-tags";
 import {
@@ -137,7 +140,7 @@ const subscribeSelectedInstance = (
       return;
     }
 
-    const element = elements[0];
+    const [element] = elements;
     // trigger style recomputing every time instance styles are changed
     selectedInstanceBrowserStyleStore.set(getBrowserStyle(element));
 
@@ -160,6 +163,27 @@ const subscribeSelectedInstance = (
 
     const unitSizes = calculateUnitSizes(element);
     selectedInstanceUnitSizesStore.set(unitSizes);
+
+    const states = new Set<string>();
+    const selectedStyleSourceId = selectedStyleSourceStore.get()?.id;
+    if (selectedStyleSourceId) {
+      const styles = stylesStore.get();
+      for (const styleDecl of styles.values()) {
+        if (
+          styleDecl.styleSourceId === selectedStyleSourceId &&
+          styleDecl.state
+        ) {
+          states.add(styleDecl.state);
+        }
+      }
+    }
+    const activeStates = new Set<string>();
+    for (const state of states) {
+      if (element.matches(state)) {
+        activeStates.add(state);
+      }
+    }
+    $selectedInstanceStates.set(activeStates);
   };
 
   let updateStoreTimeouHandle: undefined | ReturnType<typeof setTimeout>;

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -279,6 +279,8 @@ export const selectedInstanceIntanceToTagStore = atom<
   undefined | Map<Instance["id"], HtmlTags>
 >();
 
+export const $selectedInstanceStates = atom(new Set<string>());
+
 /**
  * pending means: previous selected instance unmounted,
  * and we don't know yet whether a new one will mount

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -29,6 +29,7 @@ import {
   selectedStyleSourceSelectorStore,
   synchronizedComponentsMetaStores,
   dataSourceVariablesStore,
+  $selectedInstanceStates,
 } from "~/shared/nano-states";
 
 enableMapSet();
@@ -99,6 +100,8 @@ export const registerContainers = () => {
     "selectedStyleSourceSelector",
     selectedStyleSourceSelectorStore
   );
+  clientStores.set("selectedInstanceStates", $selectedInstanceStates);
+
   for (const [name, store] of synchronizedBreakpointsStores) {
     clientStores.set(name, store);
   }


### PR DESCRIPTION
Here fixed the bug when matching states with props set are not shown in style panel. Now they are shown as remote.

1. add radix button
2. choose destructive variant in settings
3. see background color as remote
4. switch to destructive state
5. see flex section is remote

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
- [ ] hi @taylornowotny, I need you to do
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
