### PR TITLE
feat: Use pgbouncer for prisma client

### DIFF
--- a/packages/prisma-client/src/prisma.ts
+++ b/packages/prisma-client/src/prisma.ts
@@ -22,21 +22,20 @@ const logPrisma = process.env.NODE_ENV === "production";
  * getPgBouncerUrl() can be moved as a default fallback for db url at apps/builder/app/env/env.server.ts
  **/
 const getPgBouncerUrl = () => {
-  // The URL constructor does not support the "postgresql" protocol, so we replace it with "https"
-  // to ensure that the connection is made over HTTPS instead of plain text.
-  const databaseUrl = new URL(
-    process.env.DATABASE_URL!.replace("postgresql://", "https://")
-  );
-
-  if (databaseUrl.hostname.endsWith("supabase.co")) {
-    // https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler
-    databaseUrl.port = "6543";
-    // https://www.prisma.io/docs/guides/performance-and-optimization/connection-management/configure-pg-bouncer
-    databaseUrl.searchParams.set("pgbouncer", "true");
+  if (process.env.PGBOUNCER !== "true") {
+    return process.env.DATABASE_URL;
   }
 
-  // Convert protocol back to "postgresql"
-  return databaseUrl.href.replace("https://", "postgresql://");
+  const databaseUrl = new URL(
+    process.env.DATABASE_URL ?? "postgresql://localhost:5432/postgres"
+  );
+
+  // https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler
+  databaseUrl.port = "6543";
+  // https://www.prisma.io/docs/guides/performance-and-optimization/connection-management/configure-pg-bouncer
+  databaseUrl.searchParams.set("pgbouncer", "true");
+
+  return databaseUrl.href;
 };
 
 // this fixes the issue with `warn(prisma-client) There are already 10 instances of Prisma Client actively running.`

--- a/packages/prisma-client/src/prisma.ts
+++ b/packages/prisma-client/src/prisma.ts
@@ -16,13 +16,42 @@ declare global {
 
 const logPrisma = process.env.NODE_ENV === "production";
 
+/**
+ * All the code below like initialize prisma should be moved into the builder and apps if used.
+ * The issue that this project depends on env variables not available in some frameworks
+ * getPgBouncerUrl() can be moved as a default fallback for db url at apps/builder/app/env/env.server.ts
+ **/
+const getPgBouncerUrl = () => {
+  // The URL constructor does not support the "postgresql" protocol, so we replace it with "https"
+  // to ensure that the connection is made over HTTPS instead of plain text.
+  const databaseUrl = new URL(
+    process.env.DATABASE_URL!.replace("postgresql://", "https://")
+  );
+
+  if (databaseUrl.hostname.endsWith("supabase.co")) {
+    // https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler
+    databaseUrl.port = "6543";
+    // https://www.prisma.io/docs/guides/performance-and-optimization/connection-management/configure-pg-bouncer
+    databaseUrl.searchParams.set("pgbouncer", "true");
+  }
+
+  // Convert protocol back to "postgresql"
+  return databaseUrl.href.replace("https://", "postgresql://");
+};
+
 // this fixes the issue with `warn(prisma-client) There are already 10 instances of Prisma Client actively running.`
 // explanation here
 // https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices
 export const prisma =
   global.prisma ||
-  new PrismaClient(
-    logPrisma
+  new PrismaClient({
+    datasources: {
+      db: {
+        url: getPgBouncerUrl(),
+      },
+    },
+
+    ...(logPrisma
       ? {
           log: [
             { emit: "event", level: "query" },
@@ -41,8 +70,8 @@ export const prisma =
             },
           ],
         }
-      : {}
-  );
+      : {}),
+  });
 
 prisma.$on("query", (e) => {
   // Try to minify the query as vercel/new relic log size is limited


### PR DESCRIPTION
## Description

Add pgbouncer
- [x] - Checked that on supabase connections goes through pgbouncer

closes https://github.com/webstudio-is/webstudio-builder/issues/1878

Tested using following k6
```js
import encoding from 'k6/encoding'
import http from 'k6/http'
import { check } from 'k6'

export const options = {
  vus: 100,
  duration: '20s',
}

export default function () {
  const res = http.get("https://webstudio-builder-git-bgbouncer-webstudio-is.vercel.app/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview", {
  "headers": {
    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
    "accept-language": "en-US,en;q=0.9",
    "cache-control": "max-age=0",
    "sec-ch-prefers-color-scheme": "dark",
    "sec-ch-ua": "\"Chromium\";v=\"116\", \"Not)A;Brand\";v=\"24\", \"Google Chrome\";v=\"116\"",
    "sec-ch-ua-mobile": "?0",
    "sec-ch-ua-platform": "\"macOS\"",
    "sec-fetch-dest": "document",
    "sec-fetch-mode": "navigate",
    "sec-fetch-site": "same-origin",
    "sec-fetch-user": "?1",
    "upgrade-insecure-requests": "1"
  },
});

  // Verify response (checking the echoed data from the httpbin.org basic auth test API endpoint)
  check(res, {
    'status is 200': (r) => r.status === 200,
    'has data': (r) => r.body.includes("rootInstanceId"),    
  })
}
```

Increased pg_bouncer max_client_conn from 100 to 400 based on results


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
