### PR TITLE
Use PlusIcon for new page

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -17,8 +17,8 @@ import {
 import {
   ChevronRightIcon,
   MenuIcon,
-  NewPageIcon,
   PageIcon,
+  PlusIcon,
 } from "@webstudio-is/icons";
 import type { Page, Pages } from "@webstudio-is/project-build";
 import type { Publish } from "~/shared/pubsub";
@@ -197,7 +197,7 @@ const PagesPanel = ({
                 <Button
                   onClick={() => onCreateNewPage()}
                   aria-label="New page"
-                  prefix={<NewPageIcon />}
+                  prefix={<PlusIcon />}
                   color="ghost"
                 />
               </Tooltip>


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/1991
## Description

Updated new page icon to using Plus icon

## Steps for reproduction

1. open pages panel
2. see new icon

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
