### PR TITLE
Hide additional states, they should go into a submenu

### DIFF
--- a/packages/sdk-components-react/src/input.ws.tsx
+++ b/packages/sdk-components-react/src/input.ws.tsx
@@ -36,10 +36,11 @@ export const meta: WsComponentMeta = {
     { selector: ":invalid", label: "Invalid" },
     { selector: ":required", label: "Required" },
     { selector: ":optional", label: "Optional" },
-    { selector: ":disabled", label: "Disabled" },
-    { selector: ":enabled", label: "Enabled" },
-    { selector: ":read-only", label: "Read Only" },
-    { selector: ":read-write", label: "Read Write" },
+    // Additional states will go into submenu
+    //{ selector: ":disabled", label: "Disabled" },
+    //{ selector: ":enabled", label: "Enabled" },
+    //{ selector: ":read-only", label: "Read Only" },
+    //{ selector: ":read-write", label: "Read Write" },
   ],
 };
 

--- a/packages/sdk-components-react/src/radio-button.ws.tsx
+++ b/packages/sdk-components-react/src/radio-button.ws.tsx
@@ -34,10 +34,11 @@ export const meta: WsComponentMeta = {
     { selector: ":checked", label: "Checked" },
     { selector: ":required", label: "Required" },
     { selector: ":optional", label: "Optional" },
-    { selector: ":disabled", label: "Disabled" },
-    { selector: ":enabled", label: "Enabled" },
-    { selector: ":read-only", label: "Read Only" },
-    { selector: ":read-write", label: "Read Write" },
+    // Additional states will go into submenu
+    //{ selector: ":disabled", label: "Disabled" },
+    //{ selector: ":enabled", label: "Enabled" },
+    //{ selector: ":read-only", label: "Read Only" },
+    //{ selector: ":read-write", label: "Read Write" },
   ],
   template: [
     {

--- a/packages/sdk-components-react/src/textarea.ws.tsx
+++ b/packages/sdk-components-react/src/textarea.ws.tsx
@@ -37,10 +37,11 @@ export const meta: WsComponentMeta = {
     { selector: ":invalid", label: "Invalid" },
     { selector: ":required", label: "Required" },
     { selector: ":optional", label: "Optional" },
-    { selector: ":disabled", label: "Disabled" },
-    { selector: ":enabled", label: "Enabled" },
-    { selector: ":read-only", label: "Read Only" },
-    { selector: ":read-write", label: "Read Write" },
+    // Additional states will go into submenu
+    //{ selector: ":disabled", label: "Disabled" },
+    //{ selector: ":enabled", label: "Enabled" },
+    //{ selector: ":read-only", label: "Read Only" },
+    //{ selector: ":read-write", label: "Read Write" },
   ],
 };
 


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/2029

## Description

Once we add a submenu, all advanced states will go there

## Steps for reproduction

1.  see that button, input, textarea no longer have these states on style source

disabled", 
enabled", 
read-only",
read-write"



## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
