### PR TITLE
Remove assets stubbing

### DIFF
--- a/apps/builder/app/builder/shared/assets/types.ts
+++ b/apps/builder/app/builder/shared/assets/types.ts
@@ -1,6 +1,6 @@
 import type { Asset } from "@webstudio-is/asset-uploader";
 
-export type PreviewAsset = Pick<
+type PreviewAsset = Pick<
   Asset,
   "name" | "id" | "format" | "description" | "type"
 >;
@@ -13,7 +13,7 @@ export type UploadedAssetContainer = {
 export type UploadingAssetContainer = {
   status: "uploading";
   objectURL: string;
-  asset: Asset | PreviewAsset;
+  asset: PreviewAsset;
 };
 
 /**

--- a/packages/asset-uploader/src/patch.ts
+++ b/packages/asset-uploader/src/patch.ts
@@ -46,10 +46,6 @@ export const patchAssets = async (
   // add new assets found in patched version
   const addedAssets: Asset[] = [];
   for (const [assetId, asset] of patchedAssets) {
-    // skip stubbed assets
-    if (asset === undefined) {
-      continue;
-    }
     if (assets.has(assetId) === false) {
       addedAssets.push(asset);
     }

--- a/packages/asset-uploader/src/schema.ts
+++ b/packages/asset-uploader/src/schema.ts
@@ -45,7 +45,5 @@ export type ImageAsset = z.infer<typeof ImageAsset>;
 export const Asset = z.union([FontAsset, ImageAsset]);
 export type Asset = z.infer<typeof Asset>;
 
-// undefined is necessary to represent uploading state
-// to be able to upload data while preserving order
-export const Assets = z.map(AssetId, z.union([z.undefined(), Asset]));
+export const Assets = z.map(AssetId, Asset);
 export type Assets = z.infer<typeof Assets>;

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -43,9 +43,7 @@ export const createImageValueTransformer =
   };
 
 export const generateCssText = (data: Data, options: CssOptions) => {
-  const assets = new Map<Asset["id"], Asset>(
-    data.assets.map((asset) => [asset.id, asset])
-  );
+  const assets: Assets = new Map(data.assets.map((asset) => [asset.id, asset]));
   const breakpoints = new Map(data.breakpoints);
   const styles = new Map(data.styles);
   const styleSourceSelections = new Map(data.styleSourceSelections);

--- a/packages/react-sdk/src/css/global-rules.ts
+++ b/packages/react-sdk/src/css/global-rules.ts
@@ -14,7 +14,7 @@ export const addGlobalRules = (
 
   const fontAssets: FontAsset[] = [];
   for (const asset of assets.values()) {
-    if (asset?.type === "font") {
+    if (asset.type === "font") {
       fontAssets.push(asset);
     }
   }


### PR DESCRIPTION
We used to set undefined in assets map value to preserve the order between uploading and uploaded states. Now we started sorting uploaded assets by create time and stubbing no longer do anything useful.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
