### PR TITLE
Add admin (publish) permissions to tokens

### DIFF
--- a/apps/builder/app/builder/features/footer/breadcrumbs.tsx
+++ b/apps/builder/app/builder/features/footer/breadcrumbs.tsx
@@ -15,6 +15,7 @@ import {
 import { getAncestorInstanceSelector } from "~/shared/tree-utils";
 import { textEditingInstanceSelectorStore } from "~/shared/nano-states";
 import { getInstanceLabel } from "~/shared/instance-utils";
+import { Fragment } from "react";
 
 export const Breadcrumbs = () => {
   const instances = useStore(instancesStore);
@@ -47,7 +48,7 @@ export const Breadcrumbs = () => {
               return;
             }
             return (
-              <>
+              <Fragment key={index}>
                 <DeprecatedButton
                   ghost
                   css={{
@@ -72,7 +73,7 @@ export const Breadcrumbs = () => {
                 {index < selectedInstanceSelector.length - 1 ? (
                   <ChevronRightIcon />
                 ) : null}
-              </>
+              </Fragment>
             );
           })
       )}

--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -101,14 +101,15 @@ export const Menu = ({ publish }: MenuProps) => {
   const [isPreviewMode, setIsPreviewMode] = useIsPreviewMode();
   const [authPermit] = useAuthPermit();
 
-  const isPublishDisabled = authPermit !== "own";
+  const isPublishEnabled = authPermit === "own" || authPermit === "admin";
+
   const isShareDisabled = authPermit !== "own";
 
-  const disabledPublishTooltipContent = isPublishDisabled
-    ? "Only owner can publish projects"
-    : undefined;
+  const disabledPublishTooltipContent = isPublishEnabled
+    ? undefined
+    : "Only owner or admin can publish projects";
 
-  const disabledShareTooltipContent = isPublishDisabled
+  const disabledShareTooltipContent = isShareDisabled
     ? "Only owner can share projects"
     : undefined;
 
@@ -210,7 +211,7 @@ export const Menu = ({ publish }: MenuProps) => {
               onSelect={() => {
                 setIsPublishOpen(true);
               }}
-              disabled={isPublishDisabled}
+              disabled={isPublishEnabled === false}
             >
               Publish
             </DropdownMenuItem>

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -472,17 +472,18 @@ export const PublishButton = ({ projectId }: PublishProps) => {
   const [isOpen, setIsOpen] = useIsPublishDialogOpen();
   const [authPermit] = useAuthPermit();
 
-  const isPublishDisabled = authPermit !== "own";
-  const tooltipContent = isPublishDisabled
-    ? "Only owner can publish projects"
-    : undefined;
+  const isPublishEnabled = authPermit === "own" || authPermit === "admin";
+
+  const tooltipContent = isPublishEnabled
+    ? undefined
+    : "Only owner can publish projects";
 
   return (
     <FloatingPanelPopover modal open={isOpen} onOpenChange={setIsOpen}>
       <FloatingPanelAnchor>
         <Tooltip side="bottom" content={tooltipContent}>
           <FloatingPanelPopoverTrigger asChild>
-            <Button disabled={isPublishDisabled} color="positive">
+            <Button disabled={isPublishEnabled === false} color="positive">
               Publish
             </Button>
           </FloatingPanelPopoverTrigger>

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -476,7 +476,7 @@ export const PublishButton = ({ projectId }: PublishProps) => {
 
   const tooltipContent = isPublishEnabled
     ? undefined
-    : "Only owner can publish projects";
+    : "Only owner or admin can publish projects";
 
   return (
     <FloatingPanelPopover modal open={isOpen} onOpenChange={setIsOpen}>

--- a/apps/builder/app/routes/builder.$projectId.tsx
+++ b/apps/builder/app/routes/builder.$projectId.tsx
@@ -42,7 +42,7 @@ export const loader = async ({
           projectId: project.id,
           // At this point we already knew that if project loaded we have at least "view" permit
           // having that getProjectPermit is heavy operation we can skip check "view" permit
-          permits: ["own", "build"] as const,
+          permits: ["own", "admin", "build"] as const,
         },
         context
       )) ?? "view";

--- a/apps/builder/app/routes/builder.domains.$method.ts
+++ b/apps/builder/app/routes/builder.domains.$method.ts
@@ -1,16 +1,9 @@
 import type { ActionArgs } from "@remix-run/node";
 import { domainRouter } from "@webstudio-is/domain/index.server";
-import { findAuthenticatedUser } from "~/services/auth.server";
 import { createContext } from "~/shared/context.server";
 import { handleTrpcRemixAction } from "~/shared/remix/trpc-remix-request.server";
 
 export const action = async ({ request, params }: ActionArgs) => {
-  const authenticatedUser = await findAuthenticatedUser(request);
-
-  if (authenticatedUser === null) {
-    throw new Error("Not authenticated");
-  }
-
   const context = await createContext(request);
 
   return await handleTrpcRemixAction({

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -2,6 +2,7 @@ import type { AUTH_PROVIDERS } from "~/shared/session";
 import type { Project } from "@webstudio-is/project";
 import type { ThemeSetting } from "~/shared/theme";
 import env from "~/shared/env";
+import { authTokenStore } from "../nano-states";
 
 const searchParams = (params: Record<string, string | undefined | null>) => {
   const searchParams = new URLSearchParams();
@@ -59,8 +60,18 @@ export const dashboardPath = () => {
   return "/dashboard";
 };
 
-export const builderDomainsPath = (method: string) =>
-  `/builder/domains/${method}`;
+export const builderDomainsPath = (method: string) => {
+  const authToken = authTokenStore.get();
+  const urlSearchParams = new URLSearchParams();
+  if (authToken !== undefined) {
+    urlSearchParams.set("authToken", authToken);
+  }
+  const urlSearchParamsString = urlSearchParams.toString();
+
+  return `/builder/domains/${method}${
+    urlSearchParamsString ? `?${urlSearchParamsString}` : ""
+  }`;
+};
 
 export const dashboardProjectPath = (method: string) =>
   `/dashboard/projects/${method}`;

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -125,7 +125,7 @@ const Menu = ({
             onCheckedChange={handleCheckedChange("builders")}
             checked={relation === "builders"}
             title="Build"
-            info="Recipients can view the site and edit content like text and images and change the styles or structure of your site."
+            info="Recipients can make any changes but can not publish the site."
           />
 
           {isFeatureEnabled("adminRole") && (
@@ -133,7 +133,7 @@ const Menu = ({
               onCheckedChange={handleCheckedChange("administrators")}
               checked={relation === "administrators"}
               title="Admin"
-              info="Recipients can view the site and edit content like text and images and change the styles or structure of your site. Can publish."
+              info="Recipients can make any changes and can also publish the site."
             />
           )}
         </Item>

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -126,6 +126,13 @@ const Menu = ({
             title="Build"
             info="Recipients can view the site and edit content like text and images and change the styles or structure of your site."
           />
+
+          <Permission
+            onCheckedChange={handleCheckedChange("administrators")}
+            checked={relation === "administrators"}
+            title="Admin"
+            info="Recipients can view the site and edit content like text and images and change the styles or structure of your site. Can publish."
+          />
         </Item>
         <Separator />
         <Item>
@@ -153,7 +160,7 @@ const itemStyle = css({
   backgroundColor: theme.colors.backgroundPanel,
 });
 
-type Relation = "viewers" | "editors" | "builders";
+type Relation = "viewers" | "editors" | "builders" | "administrators";
 
 export type LinkOptions = {
   token: string;

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -19,6 +19,7 @@ import {
 } from "@webstudio-is/design-system";
 import { CopyIcon, InfoIcon, MenuIcon, PlusIcon } from "@webstudio-is/icons";
 import { Fragment, useState, type ComponentProps } from "react";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 const Item = (props: ComponentProps<typeof Flex>) => (
   <Flex
@@ -127,12 +128,14 @@ const Menu = ({
             info="Recipients can view the site and edit content like text and images and change the styles or structure of your site."
           />
 
-          <Permission
-            onCheckedChange={handleCheckedChange("administrators")}
-            checked={relation === "administrators"}
-            title="Admin"
-            info="Recipients can view the site and edit content like text and images and change the styles or structure of your site. Can publish."
-          />
+          {isFeatureEnabled("adminRole") && (
+            <Permission
+              onCheckedChange={handleCheckedChange("administrators")}
+              checked={relation === "administrators"}
+              title="Admin"
+              info="Recipients can view the site and edit content like text and images and change the styles or structure of your site. Can publish."
+            />
+          )}
         </Item>
         <Separator />
         <Item>

--- a/packages/authorization-token/src/trpc/authorization-tokens-router.ts
+++ b/packages/authorization-token/src/trpc/authorization-tokens-router.ts
@@ -5,7 +5,12 @@ import { db } from "../db";
 
 const { router, procedure } = initTRPC.context<AppContext>().create();
 
-const TokenProjectRelation = z.enum(["viewers", "editors", "builders"]);
+const TokenProjectRelation = z.enum([
+  "viewers",
+  "editors",
+  "builders",
+  "administrators",
+]);
 
 export const authorizationTokenRouter = router({
   findMany: procedure

--- a/packages/domain/src/db/domain.ts
+++ b/packages/domain/src/db/domain.ts
@@ -93,7 +93,7 @@ export const create = async (
   const { userId: ownerId } = project;
 
   if (ownerId === null) {
-    throw new AuthorizationError("Project must have userid defined");
+    throw new AuthorizationError("Project must have project userId defined");
   }
 
   // Query amount of domains

--- a/packages/domain/src/db/domain.ts
+++ b/packages/domain/src/db/domain.ts
@@ -11,6 +11,7 @@ import {
   type AppContext,
   AuthorizationError,
 } from "@webstudio-is/trpc-interface/index.server";
+import { db as projectDb } from "@webstudio-is/project/index.server";
 import { validateDomain } from "./validate";
 import { cnameFromUserId } from "./cname-from-user-id";
 
@@ -75,9 +76,9 @@ export const create = async (
   },
   context: AppContext
 ): Promise<Result> => {
-  // Only owner of the project can create domains
+  // Only owner or admin of the project can create domains
   const canCreateDomain = await authorizeProject.hasProjectPermit(
-    { projectId: props.projectId, permit: "own" },
+    { projectId: props.projectId, permit: "admin" },
     context
   );
 
@@ -87,16 +88,18 @@ export const create = async (
     );
   }
 
-  const { userId } = context.authorization;
+  const project = await projectDb.project.loadById(props.projectId, context);
 
-  if (userId === undefined) {
-    throw new AuthorizationError("User must be logged in to create domain");
+  const { userId: ownerId } = project;
+
+  if (ownerId === null) {
+    throw new AuthorizationError("Project must have userid defined");
   }
 
   // Query amount of domains
   const projectDomainsCount = await prisma.projectWithDomain.count({
     where: {
-      userId: context.authorization.userId,
+      userId: ownerId,
     },
   });
 
@@ -137,7 +140,7 @@ export const create = async (
       domainId: dbDomain.id,
       projectId: props.projectId,
       txtRecord,
-      cname: await cnameFromUserId(userId),
+      cname: await cnameFromUserId(ownerId),
     },
   });
 
@@ -154,9 +157,9 @@ export const verify = async (
   },
   context: AppContext
 ): Promise<Result> => {
-  // Only owner of the project can register domains
+  // Only owner or admin of the project can register domains
   const canRegisterDomain = await authorizeProject.hasProjectPermit(
-    { projectId: props.projectId, permit: "own" },
+    { projectId: props.projectId, permit: "admin" },
     context
   );
 
@@ -217,9 +220,9 @@ export const remove = async (
   },
   context: AppContext
 ): Promise<Result> => {
-  // Only owner of the project can register domains
+  // Only owner or admin of the project can register domains
   const canDeleteDomain = await authorizeProject.hasProjectPermit(
-    { projectId: props.projectId, permit: "own" },
+    { projectId: props.projectId, permit: "admin" },
     context
   );
 
@@ -270,9 +273,9 @@ export const updateStatus = async (
   },
   context: AppContext
 ): Promise<RefreshResult> => {
-  // Only owner of the project can register domains
+  // Only owner or admin of the project can register domains
   const canRefreshDomain = await authorizeProject.hasProjectPermit(
-    { projectId: props.projectId, permit: "own" },
+    { projectId: props.projectId, permit: "admin" },
     context
   );
 

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -3,3 +3,5 @@ export const dark = false;
 export const unsupportedBrowsers = false;
 export const displayContents = false;
 export const radix = false;
+// @todo this should be pro users check
+export const adminRole = false;

--- a/packages/prisma-client/prisma/migrations/20230831150459_add-administrators/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230831150459_add-administrators/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "AuthorizationRelation" ADD VALUE 'administrators';

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -113,6 +113,7 @@ enum AuthorizationRelation {
   viewers
   editors
   builders
+  administrators
 }
 
 model AuthorizationToken {

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -31,7 +31,8 @@
   "exports": {
     "./index.server": {
       "source": "./src/index.server.ts",
-      "import": "./lib/index.server.js"
+      "import": "./lib/index.server.js",
+      "types": "./lib/types/index.server.d.ts"
     }
   },
   "files": [

--- a/packages/trpc-interface/src/authorize/authorization-token.server.ts
+++ b/packages/trpc-interface/src/authorize/authorization-token.server.ts
@@ -10,7 +10,7 @@ export const registerToken = async (
   props: {
     projectId: string;
     tokenId: string;
-    relation: "viewers" | "editors" | "builders";
+    relation: "viewers" | "editors" | "builders" | "administrators";
   },
   context: AppContext
 ) => {
@@ -36,9 +36,9 @@ export const registerToken = async (
 export const patchToken = async (
   props: { projectId: string; tokenId: string },
 
-  prevRelation: "viewers" | "editors" | "builders",
+  prevRelation: "viewers" | "editors" | "builders" | "administrators",
 
-  nextRelation: "viewers" | "editors" | "builders",
+  nextRelation: "viewers" | "editors" | "builders" | "administrators",
 
   context: AppContext
 ) => {

--- a/packages/trpc-interface/src/shared/authorization-router.ts
+++ b/packages/trpc-interface/src/shared/authorization-router.ts
@@ -3,8 +3,14 @@ import { router, procedure } from "./trpc";
 
 import { prisma } from "@webstudio-is/prisma-client";
 
-const Relation = z.enum(["viewers", "editors", "builders", "owners"]);
-const AuthPermit = z.enum(["view", "edit", "build", "own"]);
+const Relation = z.enum([
+  "viewers",
+  "editors",
+  "builders",
+  "administrators",
+  "owners",
+]);
+const AuthPermit = z.enum(["view", "edit", "build", "admin", "own"]);
 export type AuthPermit = z.infer<typeof AuthPermit>;
 
 const DeleteCreateInput = z.discriminatedUnion("namespace", [
@@ -152,9 +158,10 @@ export const authorizationRouter = router({
       }
 
       const permitToRelationRewrite = {
-        view: ["viewers", "editors", "builders"],
-        edit: ["editors", "builders"],
-        build: ["builders"],
+        view: ["viewers", "editors", "builders", "administrators"],
+        edit: ["editors", "builders", "administrators"],
+        build: ["builders", "administrators"],
+        admin: ["administrators"],
       } as const;
 
       if (subjectSet.namespace === "Token" && input.permit !== "own") {

--- a/packages/trpc-interface/src/shared/trpc.ts
+++ b/packages/trpc-interface/src/shared/trpc.ts
@@ -1,7 +1,9 @@
 import { initTRPC, type inferAsyncReturnType } from "@trpc/server";
 
 export const createContext = async () => {
-  return {};
+  // Use any for typecheck at saas to not use ctx router types in satisfies constraints
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return {} as any;
 };
 
 export type Context = inferAsyncReturnType<typeof createContext>;


### PR DESCRIPTION
## Description

Add admin permissions to shared links

<img width="328" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/972a46b9-154b-4426-9d8c-ab62ebf9a9e3">

<img width="283" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/d187da84-4d49-4308-b6ea-f09cb7a09e8c">


Share links for now disabled for admin role. Will do in the next iteration after releasing above.


## Steps for reproduction

Create admin token link.
Open in incognito, see Publish is working.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
