### PR TITLE
Enforce local style source at the end

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
@@ -114,38 +114,25 @@ test("add style source to instance", () => {
   selectedStyleSourceSelectorStore.set(undefined);
 
   addStyleSourceToInstance("token1");
-  expect(styleSourceSelectionsStore.get()).toEqual(
-    new Map([["root", { instanceId: "root", values: ["token1"] }]])
-  );
+  expect(styleSourceSelectionsStore.get().get("root")).toEqual({
+    instanceId: "root",
+    values: ["token1"],
+  });
   expect(selectedStyleSourceSelectorStore.get()).toEqual({
     styleSourceId: "token1",
   });
 
   // put new style source last
   addStyleSourceToInstance("local1");
-  expect(styleSourceSelectionsStore.get()).toEqual(
-    new Map([
-      [
-        "root",
-        {
-          instanceId: "root",
-          values: ["token1", "local1"],
-        },
-      ],
-    ])
-  );
+  expect(styleSourceSelectionsStore.get().get("root")).toEqual({
+    instanceId: "root",
+    values: ["token1", "local1"],
+  });
 
   // put new token before local
   addStyleSourceToInstance("token2");
-  expect(styleSourceSelectionsStore.get()).toEqual(
-    new Map([
-      [
-        "root",
-        {
-          instanceId: "root",
-          values: ["token1", "token2", "local1"],
-        },
-      ],
-    ])
-  );
+  expect(styleSourceSelectionsStore.get().get("root")).toEqual({
+    instanceId: "root",
+    values: ["token1", "token2", "local1"],
+  });
 });

--- a/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
@@ -1,11 +1,23 @@
+import { enableMapSet } from "immer";
 import { expect, test } from "@jest/globals";
 import type { Breakpoint } from "@webstudio-is/sdk";
 import type { WsComponentMeta } from "@webstudio-is/react-sdk";
+import { registerContainers } from "~/shared/sync";
 import {
   breakpointsStore,
   registeredComponentMetasStore,
+  selectedInstanceSelectorStore,
+  selectedStyleSourceSelectorStore,
+  styleSourceSelectionsStore,
+  styleSourcesStore,
 } from "~/shared/nano-states";
-import { $presetTokens } from "./style-source-section";
+import {
+  $presetTokens,
+  addStyleSourceToInstance,
+} from "./style-source-section";
+
+enableMapSet();
+registerContainers();
 
 test("generate Styles from preset tokens", () => {
   breakpointsStore.set(
@@ -89,6 +101,49 @@ test("generate Styles from preset tokens", () => {
               value: { type: "keyword", value: "black" },
             },
           ],
+        },
+      ],
+    ])
+  );
+});
+
+test("add style source to instance", () => {
+  selectedInstanceSelectorStore.set(["root"]);
+  styleSourcesStore.set(new Map([["local1", { id: "local1", type: "local" }]]));
+  styleSourceSelectionsStore.set(new Map());
+  selectedStyleSourceSelectorStore.set(undefined);
+
+  addStyleSourceToInstance("token1");
+  expect(styleSourceSelectionsStore.get()).toEqual(
+    new Map([["root", { instanceId: "root", values: ["token1"] }]])
+  );
+  expect(selectedStyleSourceSelectorStore.get()).toEqual({
+    styleSourceId: "token1",
+  });
+
+  // put new style source last
+  addStyleSourceToInstance("local1");
+  expect(styleSourceSelectionsStore.get()).toEqual(
+    new Map([
+      [
+        "root",
+        {
+          instanceId: "root",
+          values: ["token1", "local1"],
+        },
+      ],
+    ])
+  );
+
+  // put new token before local
+  addStyleSourceToInstance("token2");
+  expect(styleSourceSelectionsStore.get()).toEqual(
+    new Map([
+      [
+        "root",
+        {
+          instanceId: "root",
+          values: ["token1", "token2", "local1"],
         },
       ],
     ])

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -429,20 +429,7 @@ export const StyleSourceInput = (
     },
   });
 
-  const inputProps = getInputProps({
-    onKeyDown(event) {
-      if (
-        event.key === "Backspace" &&
-        label === "" &&
-        props.editingItemId === undefined
-      ) {
-        const item = value[value.length - 1];
-        if (item.source !== "local") {
-          props.onRemoveItem?.(item.id);
-        }
-      }
-    },
-  });
+  const inputProps = getInputProps();
 
   let hasNewTokenItem = false;
   let hasGlobalTokenItem = false;

--- a/apps/builder/app/builder/features/style-panel/style-source/use-sortable.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/use-sortable.tsx
@@ -104,7 +104,7 @@ export const useSortable = <Item extends { id: string; source: ItemSource }>({
     onStart({ data: itemId }) {
       const item = items.find((item) => item.id === itemId);
       if (items.at(-1) === item && item?.source === "local") {
-        toast.error("Local token is always last and can not be moved");
+        toast.error("Local style source is always last and can not be moved");
         useDragHandlers.cancelCurrentDrag();
         return;
       }

--- a/apps/builder/app/builder/features/style-panel/style-source/use-sortable.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/use-sortable.tsx
@@ -8,7 +8,9 @@ import {
   useDrop,
   type DropTarget,
   computeIndicatorPlacement,
+  toast,
 } from "@webstudio-is/design-system";
+import type { ItemSource } from "./style-source";
 
 type UseSortable<Item> = {
   items: Array<Item>;
@@ -27,7 +29,7 @@ const sharedDropOptions = {
   childrenOrientation: { type: "horizontal", reverse: false },
 } as const;
 
-export const useSortable = <Item extends { id: string }>({
+export const useSortable = <Item extends { id: string; source: ItemSource }>({
   items,
   onSort,
 }: UseSortable<Item>) => {
@@ -58,6 +60,17 @@ export const useSortable = <Item extends { id: string }>({
       if (dropTarget === undefined) {
         setPlacementIndicator(undefined);
       } else {
+        // when local style source is last always drop before it
+        if (items.at(-1)?.source === "local") {
+          const lastIndex = items.length - 1;
+          const { placement } = dropTarget;
+          const { indexAdjustment, closestChildIndex } = placement;
+          placement.indexAdjustment = Math.min(indexAdjustment, lastIndex - 1);
+          placement.closestChildIndex = Math.min(
+            closestChildIndex,
+            lastIndex - 1
+          );
+        }
         setPlacementIndicator(
           computeIndicatorPlacement({
             ...sharedDropOptions,
@@ -81,10 +94,24 @@ export const useSortable = <Item extends { id: string }>({
         return false;
       }
 
-      return getItemId(closest) || false;
+      const itemId = getItemId(closest);
+      if (itemId === undefined) {
+        return false;
+      }
+
+      return itemId;
     },
-    onStart({ data }) {
-      setDragItemId(data);
+    onStart({ data: itemId }) {
+      const item = items.find((item) => item.id === itemId);
+      if (items.at(-1) === item && item?.source === "local") {
+        toast.error(
+          "Local style source should be last and cannot be reordered"
+        );
+        useDragHandlers.cancelCurrentDrag();
+        return;
+      }
+
+      setDragItemId(itemId);
       useDropHandlers.handleStart();
     },
     onMove: (point) => {
@@ -108,6 +135,11 @@ export const useSortable = <Item extends { id: string }>({
         // we need to do this to account for it.
         if (oldIndex < newIndex) {
           newIndex = Math.max(0, newIndex - 1);
+        }
+        // when local style source is last always drop before it
+        if (items.at(-1)?.source === "local") {
+          const lastIndex = items.length - 1;
+          newIndex = Math.min(newIndex, lastIndex - 1);
         }
 
         if (oldIndex !== newIndex) {

--- a/apps/builder/app/builder/features/style-panel/style-source/use-sortable.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/use-sortable.tsx
@@ -104,9 +104,7 @@ export const useSortable = <Item extends { id: string; source: ItemSource }>({
     onStart({ data: itemId }) {
       const item = items.find((item) => item.id === itemId);
       if (items.at(-1) === item && item?.source === "local") {
-        toast.error(
-          "Local style source should be last and cannot be reordered"
-        );
+        toast.error("Local token is always last and can not be moved");
         useDragHandlers.cancelCurrentDrag();
         return;
       }

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -328,7 +328,8 @@ export const selectedInstanceStyleSourcesStore = computed(
     // generate style source when selection has not local style sources
     // it is synchronized whenever styles are updated
     if (hasLocal === false) {
-      selectedInstanceStyleSources.unshift({
+      // always put local style source last
+      selectedInstanceStyleSources.push({
         type: "local",
         id: nanoid(),
       });

--- a/packages/design-system/src/components/primitives/dnd/use-drag.ts
+++ b/packages/design-system/src/components/primitives/dnd/use-drag.ts
@@ -131,7 +131,10 @@ export const useDrag = <DragItemData>(
         state.current.dragItemData !== undefined
       ) {
         onStart({ data: state.current.dragItemData });
-        state.current.status = "dragging";
+        // onStart may call cancel and reset state
+        if (state.current.status === "pending") {
+          state.current.status = "dragging";
+        }
       }
 
       if (state.current.status === "dragging") {

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -284,6 +284,7 @@ const createInstancesFromTemplate = (
           type: "local",
           id: styleSourceId,
         });
+        // always put local style source last
         styleSourceIds.push(styleSourceId);
         for (const styleDecl of item.styles) {
           styles.push({


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1965

Tweaked logic and dnd to always put local style source in the end and tokens before it.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
- [ ] hi @taylornowotny, I need you to do
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
