### PR TITLE
Ensure no conflicts on undo and redo hotkeys

### DIFF
--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -31,7 +31,11 @@ export const useSharedShortcuts = ({
     // safari use cmd+z to reopen closed tabs so fallback to ctrl
     "meta+z, ctrl+z",
     () => store.undo(),
-    { enableOnFormTags: source === "canvas", enableOnContentEditable: false },
+    {
+      // prevents undoing when user is editing text in a control on style panel etc.
+      enableOnFormTags: source === "canvas",
+      enableOnContentEditable: false,
+    },
     []
   );
 
@@ -39,7 +43,11 @@ export const useSharedShortcuts = ({
     // safari use cmd+shift+z to close reopened tabs so fallback to ctrl
     "meta+shift+z, ctrl+shift+z",
     () => store.redo(),
-    { enableOnFormTags: source === "canvas", enableOnContentEditable: false },
+    {
+      // prevents undoing when user is editing text in a control on style panel etc.
+      enableOnFormTags: source === "canvas",
+      enableOnContentEditable: false,
+    },
     []
   );
 

--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -31,7 +31,7 @@ export const useSharedShortcuts = ({
     // safari use cmd+z to reopen closed tabs so fallback to ctrl
     "meta+z, ctrl+z",
     () => store.undo(),
-    { enableOnFormTags: true, enableOnContentEditable: false },
+    { enableOnFormTags: source === "canvas", enableOnContentEditable: false },
     []
   );
 
@@ -39,7 +39,7 @@ export const useSharedShortcuts = ({
     // safari use cmd+shift+z to close reopened tabs so fallback to ctrl
     "meta+shift+z, ctrl+shift+z",
     () => store.redo(),
-    { enableOnFormTags: true, enableOnContentEditable: false },
+    { enableOnFormTags: source === "canvas", enableOnContentEditable: false },
     []
   );
 


### PR DESCRIPTION
## Description

Ref: https://github.com/webstudio-is/webstudio/issues/2028

Changed `useHotkeys.enableOnFormTags` to be enabled just when in canvas for undo/redo.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview
  
- [ ] hi @taylornowotny, I need you to do
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [x] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
