### PR TITLE
Drop unused db validation

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -7,7 +7,6 @@ import {
   type Instance,
   type Instances,
   type StyleDecl,
-  type StylesList,
 } from "@webstudio-is/project-build";
 import {
   breakpointsStore,
@@ -250,7 +249,7 @@ test("compute styles from previous sources", () => {
   const selectedStyleSourceSelector = {
     styleSourceId: "3",
   };
-  const stylesByInstanceId = new Map<Instance["id"], StylesList>([
+  const stylesByInstanceId = new Map<Instance["id"], StyleDecl[]>([
     [
       "3",
       [
@@ -317,7 +316,7 @@ test("compute styles from next sources", () => {
   const selectedStyleSourceSelector = {
     styleSourceId: "3",
   };
-  const stylesByInstanceId = new Map<Instance["id"], StylesList>([
+  const stylesByInstanceId = new Map<Instance["id"], StyleDecl[]>([
     [
       "3",
       [

--- a/apps/builder/app/canvas/features/text-editor/interop.ts
+++ b/apps/builder/app/canvas/features/text-editor/interop.ts
@@ -11,11 +11,7 @@ import {
   $isLineBreakNode,
 } from "lexical";
 import { $createLinkNode, $isLinkNode } from "@lexical/link";
-import type {
-  Instance,
-  Instances,
-  InstancesList,
-} from "@webstudio-is/project-build";
+import type { Instance, Instances } from "@webstudio-is/project-build";
 import { nanoid } from "nanoid";
 import { $isSpanNode, $setNodeSpan } from "./toolbar-connector";
 
@@ -32,7 +28,7 @@ const lexicalFormats = [
 const $writeUpdates = (
   node: ElementNode,
   instanceChildren: Instance["children"],
-  instancesList: InstancesList,
+  instancesList: Instance[],
   refs: Refs
 ) => {
   const children = node.getChildren();
@@ -105,7 +101,7 @@ const $writeUpdates = (
 
 export const $convertToUpdates = (treeRootInstance: Instance, refs: Refs) => {
   const treeRootInstanceChildren: Instance["children"] = [];
-  const instancesList: InstancesList = [
+  const instancesList: Instance[] = [
     {
       ...treeRootInstance,
       children: treeRootInstanceChildren,

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -19,11 +19,7 @@ import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { nanoid } from "nanoid";
 import { createCssEngine } from "@webstudio-is/css-engine";
-import type {
-  Instance,
-  Instances,
-  InstancesList,
-} from "@webstudio-is/project-build";
+import type { Instance, Instances } from "@webstudio-is/project-build";
 import { idAttribute } from "@webstudio-is/react-sdk";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { ToolbarConnectorPlugin } from "./toolbar-connector";
@@ -179,7 +175,7 @@ type TextEditorProps = {
   rootInstanceSelector: InstanceSelector;
   instances: Instances;
   contentEditable: JSX.Element;
-  onChange: (instancesList: InstancesList) => void;
+  onChange: (instancesList: Instance[]) => void;
   onSelectInstance: (instanceId: Instance["id"]) => void;
 };
 

--- a/apps/builder/app/routes/rest.patch.ts
+++ b/apps/builder/app/routes/rest.patch.ts
@@ -9,8 +9,6 @@ import {
   Pages,
   Props,
   DataSources,
-  parseDataSources,
-  serializeDataSources,
   StyleSourceSelections,
   StyleSources,
   Styles,
@@ -23,6 +21,7 @@ import {
   parseStyles,
   parseProps,
   parseBreakpoints,
+  parseDataSources,
   serializePages,
   serializeBreakpoints,
   serializeInstances,
@@ -30,6 +29,7 @@ import {
   serializeStyleSources,
   serializeStyleSourceSelections,
   serializeStyles,
+  serializeDataSources,
 } from "@webstudio-is/project-build/index.server";
 import { patchAssets } from "@webstudio-is/asset-uploader/index.server";
 import type { Project } from "@webstudio-is/project";
@@ -94,8 +94,6 @@ export const action = async ({ request }: ActionArgs) => {
       styles?: Styles;
     } = {};
 
-    const skipValidation = true;
-
     // Used to optimize by validating only changed styles, as they accounted for 99% of validation time
     const patchedStyleDeclKeysSet = new Set<string>();
 
@@ -108,16 +106,14 @@ export const action = async ({ request }: ActionArgs) => {
 
         if (namespace === "pages") {
           // lazily parse build data before patching
-          const pages =
-            buildData.pages ?? parsePages(build.pages, skipValidation);
+          const pages = buildData.pages ?? parsePages(build.pages);
           buildData.pages = applyPatches(pages, patches);
           continue;
         }
 
         if (namespace === "instances") {
           const instances =
-            buildData.instances ??
-            parseInstances(build.instances, skipValidation);
+            buildData.instances ?? parseInstances(build.instances);
           buildData.instances = applyPatches(instances, patches);
           continue;
         }
@@ -125,10 +121,7 @@ export const action = async ({ request }: ActionArgs) => {
         if (namespace === "styleSourceSelections") {
           const styleSourceSelections =
             buildData.styleSourceSelections ??
-            parseStyleSourceSelections(
-              build.styleSourceSelections,
-              skipValidation
-            );
+            parseStyleSourceSelections(build.styleSourceSelections);
           buildData.styleSourceSelections = applyPatches(
             styleSourceSelections,
             patches
@@ -138,8 +131,7 @@ export const action = async ({ request }: ActionArgs) => {
 
         if (namespace === "styleSources") {
           const styleSources =
-            buildData.styleSources ??
-            parseStyleSources(build.styleSources, skipValidation);
+            buildData.styleSources ?? parseStyleSources(build.styleSources);
           buildData.styleSources = applyPatches(styleSources, patches);
           continue;
         }
@@ -150,15 +142,13 @@ export const action = async ({ request }: ActionArgs) => {
             patchedStyleDeclKeysSet.add(`${patch.path[0]}`);
           }
 
-          const styles =
-            buildData.styles ?? parseStyles(build.styles, skipValidation);
+          const styles = buildData.styles ?? parseStyles(build.styles);
           buildData.styles = applyPatches(styles, patches);
           continue;
         }
 
         if (namespace === "props") {
-          const props =
-            buildData.props ?? parseProps(build.props, skipValidation);
+          const props = buildData.props ?? parseProps(build.props);
           buildData.props = applyPatches(props, patches);
           continue;
         }
@@ -172,8 +162,7 @@ export const action = async ({ request }: ActionArgs) => {
 
         if (namespace === "breakpoints") {
           const breakpoints =
-            buildData.breakpoints ??
-            parseBreakpoints(build.breakpoints, skipValidation);
+            buildData.breakpoints ?? parseBreakpoints(build.breakpoints);
           buildData.breakpoints = applyPatches(breakpoints, patches);
           continue;
         }

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -16,8 +16,6 @@ import {
   StyleSources,
   StyleSourceSelection,
   StyleSourceSelections,
-  StyleSourceSelectionsList,
-  StyleSourcesList,
 } from "@webstudio-is/project-build";
 import { equalMedia } from "@webstudio-is/css-engine";
 import type { WsComponentMeta } from "@webstudio-is/react-sdk";
@@ -306,10 +304,10 @@ export const cloneStyles = (
 };
 
 export const findLocalStyleSourcesWithinInstances = (
-  styleSources: IterableIterator<StyleSource> | StyleSourcesList,
+  styleSources: IterableIterator<StyleSource> | StyleSource[],
   styleSourceSelections:
     | IterableIterator<StyleSourceSelection>
-    | StyleSourceSelectionsList,
+    | StyleSourceSelection[],
   instanceIds: Set<Instance["id"]>
 ) => {
   const localStyleSourceIds = new Set<StyleSource["id"]>();

--- a/packages/project-build/src/db/breakpoints.ts
+++ b/packages/project-build/src/db/breakpoints.ts
@@ -1,25 +1,17 @@
 import { nanoid } from "nanoid";
 import {
   type Breakpoint,
-  Breakpoints,
-  BreakpointsList,
+  type Breakpoints,
   initialBreakpoints,
 } from "../schema/breakpoints";
 
-export const parseBreakpoints = (
-  breakpointsString: string,
-  skipValidation = false
-): Breakpoints => {
-  const breakpointssList = skipValidation
-    ? (JSON.parse(breakpointsString) as BreakpointsList)
-    : BreakpointsList.parse(JSON.parse(breakpointsString));
+export const parseBreakpoints = (breakpointsString: string): Breakpoints => {
+  const breakpointssList = JSON.parse(breakpointsString) as Breakpoint[];
   return new Map(breakpointssList.map((item) => [item.id, item]));
 };
 
 export const serializeBreakpoints = (breakpointssMap: Breakpoints) => {
-  const breakpointssList: BreakpointsList = Array.from(
-    breakpointssMap.values()
-  );
+  const breakpointssList: Breakpoint[] = Array.from(breakpointssMap.values());
   return JSON.stringify(breakpointssList);
 };
 

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -22,38 +22,27 @@ import { parseStyles } from "./styles";
 import { parseStyleSources } from "./style-sources";
 import { parseStyleSourceSelections } from "./style-source-selections";
 import { parseProps } from "./props";
-import { parseDataSources } from "../schema/data-sources";
+import { parseDataSources } from "./data-sources";
 import { parseInstances, serializeInstances } from "./instances";
 import { parseDeployment, serializeDeployment } from "./deployment";
 import type { Deployment } from "../schema/deployment";
 
 const parseBuild = async (build: DbBuild): Promise<Build> => {
-  // Hardcode skipValidation to true for now
-  const skipValidation = true;
   // eslint-disable-next-line no-console
   console.time("parseBuild");
   try {
-    const pages = skipValidation
-      ? (JSON.parse(build.pages) as Pages)
-      : Pages.parse(JSON.parse(build.pages));
-
-    const breakpoints = Array.from(
-      parseBreakpoints(build.breakpoints, skipValidation)
-    );
-    const styles = Array.from(parseStyles(build.styles, skipValidation));
-    const styleSources = Array.from(
-      parseStyleSources(build.styleSources, skipValidation)
-    );
+    const pages = JSON.parse(build.pages) as Pages;
+    const breakpoints = Array.from(parseBreakpoints(build.breakpoints));
+    const styles = Array.from(parseStyles(build.styles));
+    const styleSources = Array.from(parseStyleSources(build.styleSources));
     const styleSourceSelections = Array.from(
-      parseStyleSourceSelections(build.styleSourceSelections, skipValidation)
+      parseStyleSourceSelections(build.styleSourceSelections)
     );
-    const props = Array.from(parseProps(build.props, skipValidation));
+    const props = Array.from(parseProps(build.props));
     const dataSources = Array.from(parseDataSources(build.dataSources));
-    const instances = Array.from(
-      parseInstances(build.instances, skipValidation)
-    );
+    const instances = Array.from(parseInstances(build.instances));
 
-    const deployment = parseDeployment(build.deployment, skipValidation);
+    const deployment = parseDeployment(build.deployment);
 
     return {
       id: build.id,

--- a/packages/project-build/src/db/data-sources.ts
+++ b/packages/project-build/src/db/data-sources.ts
@@ -1,0 +1,13 @@
+import type { DataSource, DataSources } from "../schema/data-sources";
+
+export const parseDataSources = (dataSourcesString: string): DataSources => {
+  const dataSourcesList = JSON.parse(dataSourcesString) as DataSource[];
+  return new Map(
+    dataSourcesList.map((dataSource) => [dataSource.id, dataSource])
+  );
+};
+
+export const serializeDataSources = (dataSources: DataSources) => {
+  const dataSourcesList: DataSource[] = Array.from(dataSources.values());
+  return JSON.stringify(dataSourcesList);
+};

--- a/packages/project-build/src/db/deployment.ts
+++ b/packages/project-build/src/db/deployment.ts
@@ -1,16 +1,11 @@
-import { Deployment } from "../schema/deployment";
+import type { Deployment } from "../schema/deployment";
 
-export const parseDeployment = (
-  deployment: string | null,
-  skipValidation = false
-) => {
+export const parseDeployment = (deployment: string | null) => {
   if (deployment === null) {
     return;
   }
 
-  return skipValidation
-    ? (JSON.parse(deployment) as Deployment)
-    : Deployment.parse(JSON.parse(deployment));
+  return JSON.parse(deployment) as Deployment;
 };
 
 export const serializeDeployment = (deployment: Deployment) => {

--- a/packages/project-build/src/db/instances.ts
+++ b/packages/project-build/src/db/instances.ts
@@ -1,16 +1,11 @@
-import { Instances, InstancesList } from "../schema/instances";
+import { Instances, Instance } from "../schema/instances";
 
-export const parseInstances = (
-  instancesString: string,
-  skipValidation = false
-): Instances => {
-  const instancesList = skipValidation
-    ? (JSON.parse(instancesString) as InstancesList)
-    : InstancesList.parse(JSON.parse(instancesString));
+export const parseInstances = (instancesString: string): Instances => {
+  const instancesList = JSON.parse(instancesString) as Instance[];
   return new Map(instancesList.map((prop) => [prop.id, prop]));
 };
 
 export const serializeInstances = (instances: Instances) => {
-  const instancesList: InstancesList = Array.from(instances.values());
+  const instancesList: Instance[] = Array.from(instances.values());
   return JSON.stringify(instancesList);
 };

--- a/packages/project-build/src/db/pages.ts
+++ b/packages/project-build/src/db/pages.ts
@@ -1,12 +1,7 @@
-import { Pages } from "../schema/pages";
+import type { Pages } from "../schema/pages";
 
-export const parsePages = (
-  pagesString: string,
-  skipValidation = false
-): Pages => {
-  return skipValidation
-    ? (JSON.parse(pagesString) as Pages)
-    : Pages.parse(JSON.parse(pagesString));
+export const parsePages = (pagesString: string): Pages => {
+  return JSON.parse(pagesString) as Pages;
 };
 
 export const serializePages = (pages: Pages) => {

--- a/packages/project-build/src/db/props.ts
+++ b/packages/project-build/src/db/props.ts
@@ -1,16 +1,11 @@
-import { Props, PropsList } from "../schema/props";
+import { Props, Prop } from "../schema/props";
 
-export const parseProps = (
-  propsString: string,
-  skipValidation = false
-): Props => {
-  const propsList = skipValidation
-    ? (JSON.parse(propsString) as PropsList)
-    : PropsList.parse(JSON.parse(propsString));
+export const parseProps = (propsString: string): Props => {
+  const propsList = JSON.parse(propsString) as Prop[];
   return new Map(propsList.map((prop) => [prop.id, prop]));
 };
 
 export const serializeProps = (props: Props) => {
-  const propsList: PropsList = Array.from(props.values());
+  const propsList: Prop[] = Array.from(props.values());
   return JSON.stringify(propsList);
 };

--- a/packages/project-build/src/db/style-source-selections.ts
+++ b/packages/project-build/src/db/style-source-selections.ts
@@ -1,15 +1,14 @@
-import {
-  StyleSourceSelectionsList,
+import type {
   StyleSourceSelections,
+  StyleSourceSelection,
 } from "../schema/style-source-selections";
 
 export const parseStyleSourceSelections = (
-  styleSourceSelectionsString: string,
-  skipValidation = false
+  styleSourceSelectionsString: string
 ): StyleSourceSelections => {
-  const styleSourceSelectionsList = skipValidation
-    ? (JSON.parse(styleSourceSelectionsString) as StyleSourceSelectionsList)
-    : StyleSourceSelectionsList.parse(JSON.parse(styleSourceSelectionsString));
+  const styleSourceSelectionsList = JSON.parse(
+    styleSourceSelectionsString
+  ) as StyleSourceSelection[];
 
   return new Map(
     styleSourceSelectionsList.map((item) => [item.instanceId, item])
@@ -19,7 +18,7 @@ export const parseStyleSourceSelections = (
 export const serializeStyleSourceSelections = (
   styleSourceSelectionsMap: StyleSourceSelections
 ) => {
-  const styleSourceSelectionsList: StyleSourceSelectionsList = Array.from(
+  const styleSourceSelectionsList: StyleSourceSelection[] = Array.from(
     styleSourceSelectionsMap.values()
   );
   return JSON.stringify(styleSourceSelectionsList);

--- a/packages/project-build/src/db/style-sources.ts
+++ b/packages/project-build/src/db/style-sources.ts
@@ -1,18 +1,11 @@
-import { StyleSourcesList, StyleSources } from "../schema/style-sources";
+import type { StyleSource, StyleSources } from "../schema/style-sources";
 
-export const parseStyleSources = (
-  styleSourceString: string,
-  skipValidation = false
-): StyleSources => {
-  const styleSourcesList = skipValidation
-    ? (JSON.parse(styleSourceString) as StyleSourcesList)
-    : StyleSourcesList.parse(JSON.parse(styleSourceString));
+export const parseStyleSources = (styleSourceString: string): StyleSources => {
+  const styleSourcesList = JSON.parse(styleSourceString) as StyleSource[];
   return new Map(styleSourcesList.map((item) => [item.id, item]));
 };
 
 export const serializeStyleSources = (styleSourcesMap: StyleSources) => {
-  const styleSourcesList: StyleSourcesList = Array.from(
-    styleSourcesMap.values()
-  );
+  const styleSourcesList: StyleSource[] = Array.from(styleSourcesMap.values());
   return JSON.stringify(styleSourcesList);
 };

--- a/packages/project-build/src/db/styles.ts
+++ b/packages/project-build/src/db/styles.ts
@@ -1,17 +1,11 @@
-import { Styles, StylesList, getStyleDeclKey } from "../schema/styles";
+import { type Styles, type StyleDecl, getStyleDeclKey } from "../schema/styles";
 
-export const parseStyles = (
-  stylesString: string,
-  skipValidation = false
-): Styles => {
-  const stylesList = skipValidation
-    ? (JSON.parse(stylesString) as StylesList)
-    : StylesList.parse(JSON.parse(stylesString));
-
+export const parseStyles = (stylesString: string): Styles => {
+  const stylesList = JSON.parse(stylesString) as StyleDecl[];
   return new Map(stylesList.map((item) => [getStyleDeclKey(item), item]));
 };
 
 export const serializeStyles = (stylesMap: Styles) => {
-  const stylesList: StylesList = Array.from(stylesMap.values());
+  const stylesList: StyleDecl[] = Array.from(stylesMap.values());
   return JSON.stringify(stylesList);
 };

--- a/packages/project-build/src/index.server.ts
+++ b/packages/project-build/src/index.server.ts
@@ -6,3 +6,4 @@ export * from "./db/style-sources";
 export * from "./db/instances";
 export * from "./db/props";
 export * from "./db/style-source-selections";
+export * from "./db/data-sources";

--- a/packages/project-build/src/schema/breakpoints.ts
+++ b/packages/project-build/src/schema/breakpoints.ts
@@ -21,10 +21,6 @@ export const Breakpoint = z
 
 export type Breakpoint = z.infer<typeof Breakpoint>;
 
-export const BreakpointsList = z.array(Breakpoint);
-
-export type BreakpointsList = z.infer<typeof BreakpointsList>;
-
 export const Breakpoints = z.map(BreakpointId, Breakpoint);
 
 export type Breakpoints = z.infer<typeof Breakpoints>;

--- a/packages/project-build/src/schema/data-sources.ts
+++ b/packages/project-build/src/schema/data-sources.ts
@@ -41,22 +41,6 @@ export const DataSource = z.union([
 
 export type DataSource = z.infer<typeof DataSource>;
 
-export const DataSourcesList = z.array(DataSource);
-
-export type DataSourcesList = z.infer<typeof DataSourcesList>;
-
 export const DataSources = z.map(DataSourceId, DataSource);
 
 export type DataSources = z.infer<typeof DataSources>;
-
-export const parseDataSources = (dataSourcesString: string): DataSources => {
-  const dataSourcesList = JSON.parse(dataSourcesString) as DataSourcesList;
-  return new Map(
-    dataSourcesList.map((dataSource) => [dataSource.id, dataSource])
-  );
-};
-
-export const serializeDataSources = (dataSources: DataSources) => {
-  const dataSourcesList: DataSourcesList = Array.from(dataSources.values());
-  return JSON.stringify(dataSourcesList);
-};

--- a/packages/project-build/src/schema/instances.ts
+++ b/packages/project-build/src/schema/instances.ts
@@ -25,10 +25,6 @@ export const Instance = z.object({
 
 export type Instance = z.infer<typeof Instance>;
 
-export const InstancesList = z.array(Instance);
-
-export type InstancesList = z.infer<typeof InstancesList>;
-
 export const Instances = z.map(InstanceId, Instance);
 
 export type Instances = z.infer<typeof Instances>;

--- a/packages/project-build/src/schema/props.ts
+++ b/packages/project-build/src/schema/props.ts
@@ -67,10 +67,6 @@ export const Prop = z.union([
 
 export type Prop = z.infer<typeof Prop>;
 
-export const PropsList = z.array(Prop);
-
-export type PropsList = z.infer<typeof PropsList>;
-
 export const Props = z.map(PropId, Prop);
 
 export type Props = z.infer<typeof Props>;

--- a/packages/project-build/src/schema/style-source-selections.ts
+++ b/packages/project-build/src/schema/style-source-selections.ts
@@ -11,12 +11,6 @@ export const StyleSourceSelection = z.object({
 
 export type StyleSourceSelection = z.infer<typeof StyleSourceSelection>;
 
-export const StyleSourceSelectionsList = z.array(StyleSourceSelection);
-
-export type StyleSourceSelectionsList = z.infer<
-  typeof StyleSourceSelectionsList
->;
-
 export const StyleSourceSelections = z.map(InstanceId, StyleSourceSelection);
 
 export type StyleSourceSelections = z.infer<typeof StyleSourceSelections>;

--- a/packages/project-build/src/schema/style-sources.ts
+++ b/packages/project-build/src/schema/style-sources.ts
@@ -19,10 +19,6 @@ export const StyleSource = z.union([StyleSourceToken, StyleSourceLocal]);
 
 export type StyleSource = z.infer<typeof StyleSource>;
 
-export const StyleSourcesList = z.array(StyleSource);
-
-export type StyleSourcesList = z.infer<typeof StyleSourcesList>;
-
 export const StyleSources = z.map(StyleSourceId, StyleSource);
 
 export type StyleSources = z.infer<typeof StyleSources>;

--- a/packages/project-build/src/schema/styles.ts
+++ b/packages/project-build/src/schema/styles.ts
@@ -28,10 +28,6 @@ export const getStyleDeclKey = (
   }:${styleDecl.state ?? ""}`;
 };
 
-export const StylesList = z.array(StyleDecl);
-
-export type StylesList = z.infer<typeof StylesList>;
-
 export const Styles = z.map(z.string(), StyleDecl);
 
 export type Styles = Map<string, StyleDecl>;

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -2,13 +2,12 @@ import { z } from "zod";
 import { nanoid } from "nanoid";
 import { titleCase } from "title-case";
 import { noCase } from "no-case";
-import {
+import type {
   Instance,
-  type InstancesList,
-  PropsList,
-  StyleSourceSelectionsList,
-  StyleSourcesList,
-  StylesList,
+  Prop,
+  StyleSourceSelection,
+  StyleSource,
+  StyleDecl,
   Breakpoint,
   DataSource,
 } from "@webstudio-is/project-build";
@@ -151,12 +150,12 @@ const getDataSourceValue = (
 
 const createInstancesFromTemplate = (
   treeTemplate: WsEmbedTemplate,
-  instances: InstancesList,
-  props: PropsList,
+  instances: Instance[],
+  props: Prop[],
   dataSourceByRef: Map<string, DataSource>,
-  styleSourceSelections: StyleSourceSelectionsList,
-  styleSources: StyleSourcesList,
-  styles: StylesList,
+  styleSourceSelections: StyleSourceSelection[],
+  styleSources: StyleSource[],
+  styles: StyleDecl[],
   metas: Map<Instance["component"], WsComponentMeta>,
   defaultBreakpointId: Breakpoint["id"]
 ) => {
@@ -346,12 +345,12 @@ export const generateDataFromEmbedTemplate = (
   metas: Map<Instance["component"], WsComponentMeta>,
   defaultBreakpointId: Breakpoint["id"]
 ) => {
-  const instances: InstancesList = [];
-  const props: PropsList = [];
+  const instances: Instance[] = [];
+  const props: Prop[] = [];
   const dataSourceByRef = new Map<string, DataSource>();
-  const styleSourceSelections: StyleSourceSelectionsList = [];
-  const styleSources: StyleSourcesList = [];
-  const styles: StylesList = [];
+  const styleSourceSelections: StyleSourceSelection[] = [];
+  const styleSources: StyleSource[] = [];
+  const styles: StyleDecl[] = [];
 
   const children = createInstancesFromTemplate(
     treeTemplate,


### PR DESCRIPTION
We had db data validation enabled before but it made api requests very slow. We disabled this validation and seems like there is no need to enable again.

Also dropped all zod list types of our data because validation was the only use case.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @JayaKrishnaNamburu, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
