### PR TITLE
Add missing build files for `npm` publish for cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,17 @@
     "p-limit": "^4.0.0",
     "strip-indent": "^4.0.0"
   },
+  "exports": {
+    "source": "./src/cli.ts",
+    "link": "./lib/commands/link.js",
+    "build": "./lib/commands/build.js",
+    "sync": "./lib/commands/sync.js"
+  },
+  "files": [
+    "lib/*",
+    "src/*",
+    "!*.test.*"
+  ],
   "devDependencies": {
     "@types/node": "^18.13.0",
     "@webstudio-is/scripts": "workspace:^",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,11 @@
   "bin": {
     "webstudio": "./bin.js"
   },
+  "files": [
+    "lib/*",
+    "src/*",
+    "!*.test.*"
+  ],
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
@@ -29,17 +34,6 @@
     "p-limit": "^4.0.0",
     "strip-indent": "^4.0.0"
   },
-  "exports": {
-    "source": "./src/cli.ts",
-    "link": "./lib/commands/link.js",
-    "build": "./lib/commands/build.js",
-    "sync": "./lib/commands/sync.js"
-  },
-  "files": [
-    "lib/*",
-    "src/*",
-    "!*.test.*"
-  ],
   "devDependencies": {
     "@types/node": "^18.13.0",
     "@webstudio-is/scripts": "workspace:^",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "webstudio",
+  "name": "@webstudio/cli",
   "version": "0.91.0",
   "description": "Webstudio CLI",
   "author": "Webstudio <github@webstudio.is>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,8 @@
   "files": [
     "lib/*",
     "src/*",
+    "templates/*",
+    "bin.js",
     "!*.test.*"
   ],
   "scripts": {


### PR DESCRIPTION
This PR will revert the name of the package back to `@webstudio/cli`. And adds the `files` field in package.json. This will fix the publish of files to npm


## Code Review

- [ ] hi @TrySound , I need you to do
  - detailed review (read every line)
  
## Before requesting a review
- [x] made a self-review with `pnpm pack` and `npm pack` it is bundling `lib` folder too now.