### PR TITLE
Prevent submit inside dialog in builder

### DIFF
--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -60,11 +60,17 @@ export const subscribeInterceptedEvents = () => {
     }
   };
   document.documentElement.addEventListener("click", handleClick);
-  document.documentElement.addEventListener("submit", handleSubmit);
+  // preventDefault in form submit event does not work inside dialog
+  // in bubble mode, capture solves the issue
+  document.documentElement.addEventListener("submit", handleSubmit, {
+    capture: true,
+  });
   document.documentElement.addEventListener("keydown", handleKeydown);
   return () => {
     document.documentElement.removeEventListener("click", handleClick);
-    document.documentElement.removeEventListener("submit", handleSubmit);
+    document.documentElement.removeEventListener("submit", handleSubmit, {
+      capture: true,
+    });
     document.documentElement.removeEventListener("keydown", handleKeydown);
   };
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2233

Capture mode fixes unexpected submit of form when placed inside radix dialog. Though didn't find a trace why this happen. There is `form.method = 'dialog'` which has special behavior inside `<dialog>` but it is not our case.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
