### PR TITLE
Drop commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@storybook/react-vite": "^7.4.0",
     "@types/css-tree": "^2.3.1",
     "@webstudio-is/eslint-config-custom": "workspace:^",
+    "esbuild": "^0.19.2",
     "nano-staged": "^0.8.0",
     "prettier": "3.0.3",
     "simple-git-hooks": "^2.9.0",

--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -9,8 +9,8 @@
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck && pnpm test",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {
@@ -32,7 +32,6 @@
     "@types/node": "^18.11.18",
     "@types/sharp": "^0.30.4",
     "@webstudio-is/jest-config": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.4",
     "typescript": "5.2.2",
@@ -42,8 +41,7 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./index.server": {
       "source": "./src/index.server.ts",

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {
@@ -18,7 +18,6 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "typescript": "5.2.2"
   },
@@ -26,8 +25,7 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./index.server": {
       "source": "./src/index.server.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,9 +42,7 @@
     "@types/node": "^18.13.0",
     "@types/prompts": "^2.4.4",
     "@webstudio-is/form-handlers": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
-    "esbuild": "^0.19.2",
     "tsx": "^3.12.8",
     "typescript": "5.2.2"
   }

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "build:mdn-data": "tsx ./bin/mdn-data.ts ./src/__generated__ &&  prettier --write \"./src/__generated__/\" \"../css-engine/src/__generated__/\"",
     "build:descriptions": "tsx ./bin/property-value-descriptions.ts",
     "dts": "tsc --project tsconfig.dts.json",
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@types/css-tree": "^2.3.1",
     "@webstudio-is/jest-config": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "camelcase": "^7.0.1",
     "html-tags": "^3.3.1",
@@ -35,8 +34,7 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck && pnpm test",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "storybook:dev": "storybook dev -p 6006",
@@ -26,7 +26,6 @@
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@webstudio-is/jest-config": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/storybook-config": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.4",

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -8,20 +8,17 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "devDependencies": {
-    "@webstudio-is/scripts": "workspace:^",
-    "@webstudio-is/tsconfig": "workspace:^",
-    "typescript": "5.2.2"
+    "@webstudio-is/tsconfig": "workspace:^"
   },
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {
@@ -19,7 +19,6 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "typescript": "5.2.2"
   },
@@ -27,8 +26,7 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./index.server": {
       "source": "./src/index.server.ts",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -6,8 +6,8 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "build-figma-tokens": "tsx ./bin/transform-figma-tokens.ts",
     "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc",
@@ -23,7 +23,6 @@
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@webstudio-is/jest-config": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/storybook-config": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.4",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {
@@ -20,7 +20,6 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "typescript": "5.2.2"
   },
@@ -28,7 +27,6 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js",
       "types": "./lib/types/index.d.ts"
     },
     "./index.server": {

--- a/packages/error-utils/package.json
+++ b/packages/error-utils/package.json
@@ -8,20 +8,17 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "devDependencies": {
-    "@webstudio-is/scripts": "workspace:^",
-    "@webstudio-is/tsconfig": "workspace:^",
-    "typescript": "5.2.2"
+    "@webstudio-is/tsconfig": "workspace:^"
   },
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -8,13 +8,12 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {},
   "devDependencies": {
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^"
   },
   "exports": {

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -9,14 +9,13 @@
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck && pnpm test",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "devDependencies": {
     "@jest/globals": "^29.6.4",
     "@webstudio-is/jest-config": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.4",
     "typescript": "5.2.2",
@@ -28,8 +27,7 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -8,23 +8,20 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {
     "@webstudio-is/sdk": "workspace:^"
   },
   "devDependencies": {
-    "@webstudio-is/scripts": "workspace:^",
-    "@webstudio-is/tsconfig": "workspace:^",
-    "typescript": "5.2.2"
+    "@webstudio-is/tsconfig": "workspace:^"
   },
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/generate-arg-types/package.json
+++ b/packages/generate-arg-types/package.json
@@ -6,8 +6,6 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "dev": "build-package --watch",
-    "build": "build-package",
     "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc",
     "checks": "pnpm typecheck"
@@ -20,7 +18,6 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "tsx": "^3.12.8",
     "typescript": "5.2.2"

--- a/packages/html-data/package.json
+++ b/packages/html-data/package.json
@@ -8,21 +8,19 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "devDependencies": {
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^"
   },
   "peerDependencies": {},
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -6,8 +6,8 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "typecheck": "tsc",
@@ -19,8 +19,6 @@
   "devDependencies": {
     "@jest/globals": "^29.6.4",
     "@webstudio-is/jest-config": "workspace:^",
-    "@webstudio-is/prisma-client": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.4",
     "typescript": "5.2.2"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -6,8 +6,8 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --declarationDir lib/types",
     "generate": "rm -fr src/__generated__ && NODE_OPTIONS='--loader=tsx' svgo-jsx svgo-jsx.config.ts && tsx svg-string.ts && prettier --write src/__generated__",
     "typecheck": "tsc",
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@svgo/jsx": "^0.4.2",
     "@types/react": "^18.2.21",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/storybook-config": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "react": "^18.2.0",
@@ -38,14 +37,12 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./svg": {
       "source": "./src/__generated__/svg/index.ts",
       "types": "./lib/types/__generated__/svg/index.d.ts",
-      "import": "./lib/__generated__/svg/index.js",
-      "require": "./lib/cjs/__generated__/svg/index.js"
+      "import": "./lib/__generated__/svg/index.js"
     }
   },
   "files": [

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -9,8 +9,8 @@
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck && pnpm test",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json",
     "storybook:dev": "storybook dev -p 6006",
     "storybook:build": "storybook build"
@@ -24,7 +24,6 @@
     "@storybook/react": "^7.4.0",
     "@types/react": "^18.2.21",
     "@webstudio-is/jest-config": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/storybook-config": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.4",
@@ -39,8 +38,7 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -10,8 +10,7 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./index.server": {
       "source": "./src/index.server.ts",
@@ -29,8 +28,8 @@
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck && pnpm test",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {
@@ -43,7 +42,6 @@
   "devDependencies": {
     "@jest/globals": "^29.6.4",
     "@webstudio-is/jest-config": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.4",
     "type-fest": "^4.3.1",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@types/uuid": "^8.3.4",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "typescript": "5.2.2"
   },
@@ -33,8 +32,7 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./index.server": {
       "source": "./src/index.server.ts",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -6,8 +6,8 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
@@ -19,7 +19,6 @@
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@webstudio-is/jest-config": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.4",
     "react": "^18.2.0",
@@ -52,14 +51,12 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "import": "./lib/index.js"
     },
     "./css-normalize": {
       "source": "./src/css/normalize.ts",
       "types": "./lib/types/css/normalize.d.ts",
-      "import": "./lib/css/normalize.js",
-      "require": "./lib/cjs/css/normalize.js"
+      "import": "./lib/css/normalize.js"
     }
   },
   "files": [

--- a/packages/sdk-components-react-radix/package.json
+++ b/packages/sdk-components-react-radix/package.json
@@ -16,31 +16,27 @@
     ".": {
       "source": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
-      "import": "./lib/components.js",
-      "require": "./lib/cjs/components.js"
+      "import": "./lib/components.js"
     },
     "./metas": {
       "source": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js",
-      "require": "./lib/cjs/metas.js"
+      "import": "./lib/metas.js"
     },
     "./props": {
       "source": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js",
-      "require": "./lib/cjs/props.js"
+      "import": "./lib/props.js"
     },
     "./hooks": {
       "source": "./src/hooks.ts",
       "types": "./lib/types/hooks.d.ts",
-      "import": "./lib/hooks.js",
-      "require": "./lib/cjs/hooks.js"
+      "import": "./lib/hooks.js"
     }
   },
   "scripts": {
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "build:args": "NODE_OPTIONS=--conditions=source generate-arg-types './src/*.tsx !./src/*.stories.tsx !./src/*.ws.tsx' -e asChild -e modal -e defaultValue -e defaultOpen -e defaultChecked && prettier --write \"**/*.props.ts\"",
     "build:tailwind": "tsx scripts/generate-tailwind-theme.ts && prettier --write src/theme/__generated__",
     "dts": "tsc --project tsconfig.dts.json",
@@ -76,7 +72,6 @@
     "@types/react-dom": "^18.2.7",
     "@webstudio-is/css-data": "workspace:^",
     "@webstudio-is/generate-arg-types": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/sdk-components-react": "workspace:^",
     "@webstudio-is/storybook-config": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -16,25 +16,22 @@
     ".": {
       "source": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
-      "import": "./lib/components.js",
-      "require": "./lib/cjs/components.js"
+      "import": "./lib/components.js"
     },
     "./metas": {
       "source": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js",
-      "require": "./lib/cjs/metas.js"
+      "import": "./lib/metas.js"
     },
     "./props": {
       "source": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js",
-      "require": "./lib/cjs/props.js"
+      "import": "./lib/props.js"
     }
   },
   "scripts": {
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "build:args": "NODE_OPTIONS=--conditions=source generate-arg-types './src/*.tsx !./src/**/*.stories.tsx !./src/**/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
     "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc",
@@ -56,7 +53,6 @@
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@webstudio-is/generate-arg-types": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -16,25 +16,22 @@
     ".": {
       "source": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
-      "import": "./lib/components.js",
-      "require": "./lib/cjs/components.js"
+      "import": "./lib/components.js"
     },
     "./metas": {
       "source": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js",
-      "require": "./lib/cjs/metas.js"
+      "import": "./lib/metas.js"
     },
     "./props": {
       "source": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js",
-      "require": "./lib/cjs/props.js"
+      "import": "./lib/props.js"
     }
   },
   "scripts": {
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "build:args": "NODE_OPTIONS=--conditions=source generate-arg-types './src/*.tsx !./src/*.stories.tsx !./src/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
     "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc",
@@ -60,7 +57,6 @@
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@webstudio-is/generate-arg-types": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/storybook-config": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "react": "^18.2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -9,8 +9,7 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",
@@ -22,8 +21,8 @@
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck && pnpm test",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {
@@ -34,7 +33,6 @@
   "devDependencies": {
     "@jest/globals": "^29.6.4",
     "@webstudio-is/jest-config": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.4"
   }

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -9,8 +9,8 @@
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck",
-    "dev": "build-package --watch",
-    "build": "build-package",
+    "dev": "pnpm build --watch",
+    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {
@@ -24,7 +24,6 @@
   "devDependencies": {
     "@types/node": "^18.11.18",
     "@webstudio-is/jest-config": "workspace:^",
-    "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "typescript": "5.2.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@webstudio-is/eslint-config-custom':
         specifier: workspace:^
         version: link:packages/eslint-config-custom
+      esbuild:
+        specifier: ^0.19.2
+        version: 0.19.2
       nano-staged:
         specifier: ^0.8.0
         version: 0.8.0
@@ -410,9 +413,6 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -438,9 +438,6 @@ importers:
         specifier: ^3.21.4
         version: 3.21.4
     devDependencies:
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -499,15 +496,9 @@ importers:
       '@webstudio-is/form-handlers':
         specifier: workspace:^
         version: link:../form-handlers
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
-      esbuild:
-        specifier: ^0.19.2
-        version: 0.19.2
       tsx:
         specifier: ^3.12.8
         version: 3.12.8
@@ -542,9 +533,6 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -600,9 +588,6 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/storybook-config':
         specifier: workspace:^
         version: link:../storybook-config
@@ -624,15 +609,9 @@ importers:
 
   packages/css-vars:
     devDependencies:
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
-      typescript:
-        specifier: 5.2.2
-        version: 5.2.2
 
   packages/dashboard:
     dependencies:
@@ -649,9 +628,6 @@ importers:
         specifier: ^3.21.4
         version: 3.21.4
     devDependencies:
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -797,9 +773,6 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/storybook-config':
         specifier: workspace:^
         version: link:../storybook-config
@@ -840,9 +813,6 @@ importers:
         specifier: ^3.21.4
         version: 3.21.4
     devDependencies:
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -852,15 +822,9 @@ importers:
 
   packages/error-utils:
     devDependencies:
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
-      typescript:
-        specifier: 5.2.2
-        version: 5.2.2
 
   packages/eslint-config-custom:
     dependencies:
@@ -891,9 +855,6 @@ importers:
 
   packages/feature-flags:
     devDependencies:
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -906,9 +867,6 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -928,15 +886,9 @@ importers:
         specifier: workspace:^
         version: link:../sdk
     devDependencies:
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
-      typescript:
-        specifier: 5.2.2
-        version: 5.2.2
 
   packages/form-handlers-mailchannels-test:
     dependencies:
@@ -975,9 +927,6 @@ importers:
         specifier: ^3.21.4
         version: 3.21.4
     devDependencies:
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -990,9 +939,6 @@ importers:
 
   packages/html-data:
     devDependencies:
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -1009,12 +955,6 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config
-      '@webstudio-is/prisma-client':
-        specifier: workspace:^
-        version: link:../prisma-client
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -1037,9 +977,6 @@ importers:
       '@types/react':
         specifier: ^18.2.21
         version: 18.2.21
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/storybook-config':
         specifier: workspace:^
         version: link:../storybook-config
@@ -1083,9 +1020,6 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/storybook-config':
         specifier: workspace:^
         version: link:../storybook-config
@@ -1190,9 +1124,6 @@ importers:
       '@types/uuid':
         specifier: ^8.3.4
         version: 8.3.4
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -1224,9 +1155,6 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -1294,9 +1222,6 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -1359,9 +1284,6 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -1405,9 +1327,6 @@ importers:
       '@webstudio-is/generate-arg-types':
         specifier: workspace:^
         version: link:../generate-arg-types
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/storybook-config':
         specifier: workspace:^
         version: link:../storybook-config
@@ -1487,9 +1406,6 @@ importers:
       '@webstudio-is/generate-arg-types':
         specifier: workspace:^
         version: link:../generate-arg-types
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/sdk-components-react':
         specifier: workspace:^
         version: link:../sdk-components-react
@@ -1539,9 +1455,6 @@ importers:
       '@webstudio-is/generate-arg-types':
         specifier: workspace:^
         version: link:../generate-arg-types
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -1667,9 +1580,6 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config
-      '@webstudio-is/scripts':
-        specifier: workspace:^
-        version: link:../scripts
       '@webstudio-is/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig


### PR DESCRIPTION
Seems like we no longer need commonjs in most packages. Only prisma cannot be bundled on server because has binary.

Now new package setup is easier and require only esbuild instead of custom solution.

Cli install size

```diff
du -ck node_modules
- 35516
+ 33192
```

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
