### PR TITLE
Mark unused packages as private

### DIFF
--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -55,6 +55,6 @@
     "!*.test.*"
   ],
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "sideEffects": false
 }

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -39,6 +39,6 @@
     "!*.test.*"
   ],
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "sideEffects": false
 }

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -42,7 +42,7 @@
     "!*.test.*"
   ],
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "sideEffects": false,
   "dependencies": {
     "@webstudio-is/css-engine": "workspace:^",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -40,6 +40,6 @@
     "!*.test.*"
   ],
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "sideEffects": false
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -87,6 +87,6 @@
     "!*.test.*"
   ],
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "sideEffects": false
 }

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -41,6 +41,6 @@
     "!*.test.*"
   ],
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "sideEffects": false
 }

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -27,6 +27,6 @@
     "!*.test.*"
   ],
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "sideEffects": false
 }

--- a/packages/generate-arg-types/package.json
+++ b/packages/generate-arg-types/package.json
@@ -32,6 +32,6 @@
     "generate-arg-types": "./src/cli.ts"
   },
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "sideEffects": false
 }

--- a/packages/html-data/package.json
+++ b/packages/html-data/package.json
@@ -28,7 +28,7 @@
     "!*.test.*"
   ],
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "sideEffects": false,
   "dependencies": {}
 }

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -33,7 +33,7 @@
     "require": "./lib/cjs/index.js"
   },
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "dependencies": {
     "@inquirer/confirm": "^0.0.25-alpha.0",
     "dotenv": "^16.3.1",

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -5,6 +5,7 @@
   "author": "Webstudio <github@webstudio.is>",
   "homepage": "https://webstudio.is",
   "license": "AGPL-3.0-or-later",
+  "private": true,
   "type": "module",
   "exports": {
     ".": {

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -45,6 +45,6 @@
     "src/*"
   ],
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "sideEffects": false
 }

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -40,6 +40,6 @@
     "!*.test.*"
   ],
   "license": "AGPL-3.0-or-later",
-  "private": false,
+  "private": true,
   "sideEffects": false
 }


### PR DESCRIPTION
We need to stop publishig all packages. Many of them not used and maybe never be used in public. Though they bloat packages search, makes publish step longer. Prisma client publishes 700MB package every time.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
