### PR TITLE
Stop publishing sources and stories

### DIFF
--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -51,8 +51,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -35,8 +35,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,10 +10,9 @@
   },
   "files": [
     "lib/*",
-    "src/*",
     "templates/*",
     "bin.js",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "scripts": {
     "typecheck": "tsc",

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -38,8 +38,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -40,8 +40,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -22,8 +22,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -36,8 +36,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -83,8 +83,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -37,8 +37,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/error-utils/package.json
+++ b/packages/error-utils/package.json
@@ -22,8 +22,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -23,8 +23,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -31,8 +31,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -25,8 +25,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/generate-arg-types/package.json
+++ b/packages/generate-arg-types/package.json
@@ -24,9 +24,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "README.md",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "bin": {
     "generate-arg-types": "./src/cli.ts"

--- a/packages/html-data/package.json
+++ b/packages/html-data/package.json
@@ -24,8 +24,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -30,8 +30,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -47,8 +47,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -42,8 +42,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -20,8 +20,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "sideEffects": false,
   "scripts": {

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -42,7 +42,7 @@
   },
   "files": [
     "lib/*",
-    "src/*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -61,8 +61,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/sdk-components-react-radix/package.json
+++ b/packages/sdk-components-react-radix/package.json
@@ -10,7 +10,7 @@
   "sideEffects": false,
   "files": [
     "lib/*",
-    "src/*"
+    "!*.{test,stories}.*"
   ],
   "exports": {
     ".": {

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "files": [
     "lib/*",
-    "src/*"
+    "!*.{test,stories}.*"
   ],
   "sideEffects": false,
   "exports": {

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -10,7 +10,7 @@
   "sideEffects": false,
   "files": [
     "lib/*",
-    "src/*"
+    "!*.{test,stories}.*"
   ],
   "exports": {
     ".": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -13,8 +13,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "sideEffects": false,
   "scripts": {

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -36,8 +36,7 @@
   },
   "files": [
     "lib/*",
-    "src/*",
-    "!*.test.*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,


### PR DESCRIPTION
Here removed sources and stories from published packages. Sources were used in the past instead off .d.ts. But since we generate them we can reduce packages size significantly.

Cli install size

```diff
du -ck node_modules
- 33192
+ 29176
```

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
