### PR TITLE
Generate jsx component with CLI

### DIFF
--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
+import { type ReactNode, useContext } from "react";
+import { useStore } from "@nanostores/react";
 import * as sdk from "@webstudio-is/react-sdk";
 import type { PageData } from "~/routes/_index";
-import type { Components } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import type { Asset } from "@webstudio-is/sdk";
 import {
   Body as Body,
@@ -14,16 +16,6 @@ import {
 } from "@webstudio-is/sdk-components-react";
 import { Link as Link } from "@webstudio-is/sdk-components-react-remix";
 
-export const components = new Map(
-  Object.entries({
-    Body: Body,
-    Heading: Heading,
-    Box: Box,
-    Paragraph: Paragraph,
-    Image: Image,
-    Link: Link,
-  })
-) as Components;
 export const fontAssets: Asset[] = [];
 export const pageData: PageData = {
   build: {
@@ -247,3 +239,48 @@ export const utils = {
 };
 
 /* eslint-enable */
+
+export const Page = (props: { scripts: ReactNode }) => {
+  const {
+    dataSourceValuesStore,
+    setDataSourceValues,
+    executeEffectfulExpression,
+  } = useContext(ReactSdkContext);
+  const dataSourceValues = useStore(dataSourceValuesStore);
+  return (
+    <Body data-ws-id="On9cvWCxr5rdZtY9O1Bv0" data-ws-component="Body">
+      <Heading data-ws-id="nVMWvMsaLCcb0o1wuNQgg" data-ws-component="Heading">
+        {"DO NOT TOUCH THIS PROJECT, IT'S USED FOR FIXTURES"}
+      </Heading>
+      <Box data-ws-id="f0kF-WmL7DQg7MSyRvqY1" data-ws-component="Box">
+        <Box data-ws-id="5XDbqPrZDeCwq4YJ3CHsc" data-ws-component="Box">
+          <Heading
+            data-ws-id="oLXYe1UQiVMhVnZGvJSMr"
+            data-ws-component="Heading"
+          >
+            {"Heading"}
+          </Heading>
+          <Paragraph
+            data-ws-id="p34JHWcU6UNrd9FVnY80Q"
+            data-ws-component="Paragraph"
+          >
+            {
+              "a little kitten painted in black and white gouache with a thick brush"
+            }
+          </Paragraph>
+          <Link
+            data-ws-id="l9AI_pShC-BH4ibxK6kNT"
+            data-ws-component="Link"
+            href={"https://github.com/"}
+          >
+            {"Click here to adore more kittens"}
+          </Link>
+        </Box>
+        <Box data-ws-id="qPnkiFGDj8dITWb1kmpGl" data-ws-component="Box">
+          <Image data-ws-id="pX1ovPI7NdC0HRjkw6Kpw" data-ws-component="Image" />
+        </Box>
+      </Box>
+      {props.scripts}
+    </Body>
+  );
+};

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -23,6 +23,7 @@
     "jest": "^29.6.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "strip-indent": "^4.0.0",
     "type-fest": "^4.3.1",
     "typescript": "5.2.2",
     "zod": "^3.21.4"

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@jest/globals";
 import stripIndent from "strip-indent";
-import type { Instance, Prop } from "@webstudio-is/sdk";
+import { createScope, type Instance, type Prop } from "@webstudio-is/sdk";
 import { showAttribute } from "./tree/webstudio-component";
 import {
   generateJsxChildren,
@@ -34,6 +34,7 @@ const createPropPair = (prop: Prop): [Prop["id"], Prop] => {
 test("generate jsx element with children and without them", () => {
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("body", "Body", [
         { type: "id", value: "childId" },
       ]),
@@ -43,15 +44,16 @@ test("generate jsx element with children and without them", () => {
     })
   ).toEqual(
     clear(`
-      <__Body
+      <Body
       data-ws-id="body"
       data-ws-component="Body">
       Children
-      </__Body>
+      </Body>
     `)
   );
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("image", "Image", []),
       props: new Map(),
       indexesWithinAncestors: new Map(),
@@ -59,7 +61,7 @@ test("generate jsx element with children and without them", () => {
     })
   ).toEqual(
     clear(`
-      <__Image
+      <Image
       data-ws-id="image"
       data-ws-component="Image" />
     `)
@@ -69,6 +71,7 @@ test("generate jsx element with children and without them", () => {
 test("generate jsx element with namespaces components", () => {
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("body", "@webstudio-is/library:Body", [
         { type: "id", value: "childId" },
       ]),
@@ -78,15 +81,16 @@ test("generate jsx element with namespaces components", () => {
     })
   ).toEqual(
     clear(`
-      <__webstudio__is__library__Body
+      <Body
       data-ws-id="body"
       data-ws-component="@webstudio-is/library:Body">
       Children
-      </__webstudio__is__library__Body>
+      </Body>
     `)
   );
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("image", "@webstudio-is/library:Image", []),
       props: new Map(),
       indexesWithinAncestors: new Map(),
@@ -94,7 +98,7 @@ test("generate jsx element with namespaces components", () => {
     })
   ).toEqual(
     clear(`
-      <__webstudio__is__library__Image
+      <Image
       data-ws-id="image"
       data-ws-component="@webstudio-is/library:Image" />
     `)
@@ -134,6 +138,7 @@ test("generate jsx element with literal props", () => {
   ]);
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("body", "Body", [
         { type: "id", value: "image" },
       ]),
@@ -143,17 +148,18 @@ test("generate jsx element with literal props", () => {
     })
   ).toEqual(
     clear(`
-      <__Body
+      <Body
       data-ws-id="body"
       data-ws-component="Body"
       string={"string"}
       number={0}>
       Children
-      </__Body>
+      </Body>
     `)
   );
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("image", "Image", []),
       props,
       indexesWithinAncestors: new Map(),
@@ -161,7 +167,7 @@ test("generate jsx element with literal props", () => {
     })
   ).toEqual(
     clear(`
-      <__Image
+      <Image
       data-ws-id="image"
       data-ws-component="Image"
       boolean={true}
@@ -173,6 +179,7 @@ test("generate jsx element with literal props", () => {
 test("ignore asset and page props", () => {
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("box", "Box", []),
       props: new Map([
         createPropPair({
@@ -195,7 +202,7 @@ test("ignore asset and page props", () => {
     })
   ).toEqual(
     clear(`
-      <__Box
+      <Box
       data-ws-id="box"
       data-ws-component="Box" />
     `)
@@ -205,6 +212,7 @@ test("ignore asset and page props", () => {
 test("generate jsx element with data sources and action", () => {
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("box", "Box", []),
       props: new Map([
         createPropPair({
@@ -244,7 +252,7 @@ test("generate jsx element with data sources and action", () => {
     })
   ).toEqual(
     clear(`
-      <__Box
+      <Box
       data-ws-id="box"
       data-ws-component="Box"
       variable={$ws$dataSource$variableId}
@@ -258,6 +266,7 @@ test("generate jsx element with data sources and action", () => {
 test("generate jsx element with condition based on show prop", () => {
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("box", "Box", []),
       props: new Map([
         createPropPair({
@@ -273,13 +282,14 @@ test("generate jsx element with condition based on show prop", () => {
     })
   ).toEqual(
     clear(`
-      <__Box
+      <Box
       data-ws-id="box"
       data-ws-component="Box" />
     `)
   );
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("box", "Box", []),
       props: new Map([
         createPropPair({
@@ -296,6 +306,7 @@ test("generate jsx element with condition based on show prop", () => {
   ).toEqual("");
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("box", "Box", []),
       props: new Map([
         createPropPair({
@@ -312,7 +323,7 @@ test("generate jsx element with condition based on show prop", () => {
   ).toEqual(
     clear(`
       {$ws$dataSource$condition &&
-      <__Box
+      <Box
       data-ws-id="box"
       data-ws-component="Box" />
       }
@@ -323,6 +334,7 @@ test("generate jsx element with condition based on show prop", () => {
 test("generate jsx element with index prop", () => {
   expect(
     generateJsxElement({
+      scope: createScope(),
       instance: createInstance("box", "Box", []),
       props: new Map(),
       indexesWithinAncestors: new Map([["box", 5]]),
@@ -330,7 +342,7 @@ test("generate jsx element with index prop", () => {
     })
   ).toEqual(
     clear(`
-      <__Box
+      <Box
       data-ws-id="box"
       data-ws-component="Box"
       data-ws-index="5" />
@@ -341,6 +353,7 @@ test("generate jsx element with index prop", () => {
 test("generate jsx children with text", () => {
   expect(
     generateJsxChildren({
+      scope: createScope(),
       children: [
         { type: "text", value: "Some\ntext" },
         { type: "text", value: 'Escaped "text"' },
@@ -362,6 +375,7 @@ test("generate jsx children with text", () => {
 test("generate jsx children with nested instances", () => {
   expect(
     generateJsxChildren({
+      scope: createScope(),
       children: [{ type: "id", value: "form" }],
       instances: new Map([
         createInstancePair("form", "Form", [
@@ -384,17 +398,48 @@ test("generate jsx children with nested instances", () => {
     })
   ).toEqual(
     clear(`
-    <__Form
+    <Form
     data-ws-id="form"
     data-ws-component="Form"
     prop={"value"}>
-    <__Input
+    <Input
     data-ws-id="input"
     data-ws-component="Input" />
-    <__Button
+    <Button
     data-ws-id="button"
     data-ws-component="Button" />
-    </__Form>
+    </Form>
+    `)
+  );
+});
+
+test("deduplicate base and namespaced components with same short name", () => {
+  expect(
+    generateJsxChildren({
+      scope: createScope(),
+      children: [
+        { type: "id", value: "button1" },
+        { type: "id", value: "button2" },
+      ],
+      instances: new Map([
+        createInstancePair("button1", "Button", []),
+        createInstancePair(
+          "button2",
+          "@webstudio-is/sdk-component-react-radix:Button",
+          []
+        ),
+      ]),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+    })
+  ).toEqual(
+    clear(`
+    <Button
+    data-ws-id="button1"
+    data-ws-component="Button" />
+    <Button_1
+    data-ws-id="button2"
+    data-ws-component="@webstudio-is/sdk-component-react-radix:Button" />
     `)
   );
 });
@@ -402,6 +447,7 @@ test("generate jsx children with nested instances", () => {
 test("generate page component", () => {
   expect(
     generatePageComponent({
+      scope: createScope(),
       rootInstanceId: "body",
       instances: new Map([
         createInstancePair("body", "Body", [{ type: "id", value: "input" }]),
@@ -445,17 +491,17 @@ test("generate page component", () => {
       );
       setDataSourceValues(newValues);
       };
-      return <__Body
+      return <Body
       data-ws-id="body"
       data-ws-component="Body">
-      <__Input
+      <Input
       data-ws-id="input"
       data-ws-component="Input"
       data-ws-index="0"
       value={$ws$dataSource$variable}
       onChange={$ws$prop$2} />
       {props.scripts}
-      </__Body>
+      </Body>
       };
     `)
   );

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -257,8 +257,8 @@ test("generate jsx element with data sources and action", () => {
       data-ws-component="Box"
       variable={$ws$dataSource$variableId}
       expression={$ws$dataSource$expressionId}
-      onClick={$ws$prop$3}
-      onChange={$ws$prop$4} />
+      onClick={onClick}
+      onChange={onChange} />
     `)
   );
 });
@@ -483,7 +483,7 @@ test("generate page component", () => {
       const { dataSourceValuesStore, setDataSourceValues, executeEffectfulExpression } = useContext(ReactSdkContext);
       const dataSourceValues = useStore(dataSourceValuesStore);
       const $ws$dataSource$variable = dataSourceValues.get("variable");
-      const $ws$prop$2 = (value: unknown) => {
+      const onChange = (value: unknown) => {
       const newValues = executeEffectfulExpression(
       value.code,
       new Map([["value", value]]),
@@ -499,7 +499,77 @@ test("generate page component", () => {
       data-ws-component="Input"
       data-ws-index="0"
       value={$ws$dataSource$variable}
-      onChange={$ws$prop$2} />
+      onChange={onChange} />
+      {props.scripts}
+      </Body>
+      };
+    `)
+  );
+});
+
+test("deduplicate action names", () => {
+  expect(
+    generatePageComponent({
+      scope: createScope(),
+      rootInstanceId: "body",
+      instances: new Map([
+        createInstancePair("body", "Body", [
+          { type: "id", value: "button1" },
+          { type: "id", value: "button2" },
+        ]),
+        createInstancePair("button1", "Button", []),
+        createInstancePair("button2", "Button", []),
+      ]),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "button1",
+          name: "onChange",
+          type: "action",
+          value: [{ type: "execute", args: [], code: "" }],
+        }),
+        createPropPair({
+          id: "2",
+          instanceId: "button2",
+          name: "onChange",
+          type: "action",
+          value: [{ type: "execute", args: [], code: "" }],
+        }),
+      ]),
+      indexesWithinAncestors: new Map([["input", 0]]),
+    })
+  ).toEqual(
+    clear(`
+      export const Page = (props: { scripts: ReactNode }) => {
+      const { dataSourceValuesStore, setDataSourceValues, executeEffectfulExpression } = useContext(ReactSdkContext);
+      const dataSourceValues = useStore(dataSourceValuesStore);
+      const onChange = () => {
+      const newValues = executeEffectfulExpression(
+      value.code,
+      new Map([]),
+      dataSourceValues
+      );
+      setDataSourceValues(newValues);
+      };
+      const onChange_1 = () => {
+      const newValues = executeEffectfulExpression(
+      value.code,
+      new Map([]),
+      dataSourceValues
+      );
+      setDataSourceValues(newValues);
+      };
+      return <Body
+      data-ws-id="body"
+      data-ws-component="Body">
+      <Button
+      data-ws-id="button1"
+      data-ws-component="Button"
+      onChange={onChange} />
+      <Button
+      data-ws-id="button2"
+      data-ws-component="Button"
+      onChange={onChange_1} />
       {props.scripts}
       </Body>
       };

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -1,0 +1,462 @@
+import { expect, test } from "@jest/globals";
+import stripIndent from "strip-indent";
+import type { Instance, Prop } from "@webstudio-is/sdk";
+import { showAttribute } from "./tree/webstudio-component";
+import {
+  generateJsxChildren,
+  generateJsxElement,
+  generatePageComponent,
+} from "./component-generator";
+
+const clear = (input: string) =>
+  stripIndent(input).trimStart().replace(/ +$/, "");
+
+const createInstance = (
+  id: Instance["id"],
+  component: string,
+  children: Instance["children"]
+): Instance => {
+  return { type: "instance", id, component, children };
+};
+
+const createInstancePair = (
+  id: Instance["id"],
+  component: string,
+  children: Instance["children"]
+): [Instance["id"], Instance] => {
+  return [id, createInstance(id, component, children)];
+};
+
+const createPropPair = (prop: Prop): [Prop["id"], Prop] => {
+  return [prop.id, prop];
+};
+
+test("generate jsx element with children and without them", () => {
+  expect(
+    generateJsxElement({
+      instance: createInstance("body", "Body", [
+        { type: "id", value: "childId" },
+      ]),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+      children: "Children\n",
+    })
+  ).toEqual(
+    clear(`
+      <__Body
+      data-ws-id="body"
+      data-ws-component="Body">
+      Children
+      </__Body>
+    `)
+  );
+  expect(
+    generateJsxElement({
+      instance: createInstance("image", "Image", []),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+      children: "Children\n",
+    })
+  ).toEqual(
+    clear(`
+      <__Image
+      data-ws-id="image"
+      data-ws-component="Image" />
+    `)
+  );
+});
+
+test("generate jsx element with namespaces components", () => {
+  expect(
+    generateJsxElement({
+      instance: createInstance("body", "@webstudio-is/library:Body", [
+        { type: "id", value: "childId" },
+      ]),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+      children: "Children\n",
+    })
+  ).toEqual(
+    clear(`
+      <__webstudio__is__library__Body
+      data-ws-id="body"
+      data-ws-component="@webstudio-is/library:Body">
+      Children
+      </__webstudio__is__library__Body>
+    `)
+  );
+  expect(
+    generateJsxElement({
+      instance: createInstance("image", "@webstudio-is/library:Image", []),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+      children: "Children\n",
+    })
+  ).toEqual(
+    clear(`
+      <__webstudio__is__library__Image
+      data-ws-id="image"
+      data-ws-component="@webstudio-is/library:Image" />
+    `)
+  );
+});
+
+test("generate jsx element with literal props", () => {
+  const props = new Map([
+    createPropPair({
+      id: "1",
+      instanceId: "body",
+      type: "string",
+      name: "string",
+      value: "string",
+    }),
+    createPropPair({
+      id: "2",
+      instanceId: "body",
+      type: "number",
+      name: "number",
+      value: 0,
+    }),
+    createPropPair({
+      id: "3",
+      instanceId: "image",
+      type: "boolean",
+      name: "boolean",
+      value: true,
+    }),
+    createPropPair({
+      id: "4",
+      instanceId: "image",
+      type: "string[]",
+      name: "stringArray",
+      value: ["value1", "value2"],
+    }),
+  ]);
+  expect(
+    generateJsxElement({
+      instance: createInstance("body", "Body", [
+        { type: "id", value: "image" },
+      ]),
+      props,
+      indexesWithinAncestors: new Map(),
+      children: "Children\n",
+    })
+  ).toEqual(
+    clear(`
+      <__Body
+      data-ws-id="body"
+      data-ws-component="Body"
+      string={"string"}
+      number={0}>
+      Children
+      </__Body>
+    `)
+  );
+  expect(
+    generateJsxElement({
+      instance: createInstance("image", "Image", []),
+      props,
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      <__Image
+      data-ws-id="image"
+      data-ws-component="Image"
+      boolean={true}
+      stringArray={["value1","value2"]} />
+    `)
+  );
+});
+
+test("ignore asset and page props", () => {
+  expect(
+    generateJsxElement({
+      instance: createInstance("box", "Box", []),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "box",
+          type: "page",
+          name: "page",
+          value: "pageId",
+        }),
+        createPropPair({
+          id: "2",
+          instanceId: "box",
+          type: "asset",
+          name: "asset",
+          value: "assetId",
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      <__Box
+      data-ws-id="box"
+      data-ws-component="Box" />
+    `)
+  );
+});
+
+test("generate jsx element with data sources and action", () => {
+  expect(
+    generateJsxElement({
+      instance: createInstance("box", "Box", []),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "box",
+          type: "dataSource",
+          name: "variable",
+          value: "variableId",
+        }),
+        createPropPair({
+          id: "2",
+          instanceId: "box",
+          type: "dataSource",
+          name: "expression",
+          value: "expressionId",
+        }),
+        createPropPair({
+          id: "3",
+          instanceId: "box",
+          type: "action",
+          name: "onClick",
+          value: [{ type: "execute", args: [], code: `variableName = 1` }],
+        }),
+        createPropPair({
+          id: "4",
+          instanceId: "box",
+          type: "action",
+          name: "onChange",
+          value: [
+            { type: "execute", args: ["value"], code: `variableName = value` },
+            { type: "execute", args: ["value"], code: `variableName = value` },
+          ],
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      <__Box
+      data-ws-id="box"
+      data-ws-component="Box"
+      variable={$ws$dataSource$variableId}
+      expression={$ws$dataSource$expressionId}
+      onClick={$ws$prop$3}
+      onChange={$ws$prop$4} />
+    `)
+  );
+});
+
+test("generate jsx element with condition based on show prop", () => {
+  expect(
+    generateJsxElement({
+      instance: createInstance("box", "Box", []),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "box",
+          type: "boolean",
+          name: showAttribute,
+          value: true,
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      <__Box
+      data-ws-id="box"
+      data-ws-component="Box" />
+    `)
+  );
+  expect(
+    generateJsxElement({
+      instance: createInstance("box", "Box", []),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "box",
+          type: "boolean",
+          name: showAttribute,
+          value: false,
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual("");
+  expect(
+    generateJsxElement({
+      instance: createInstance("box", "Box", []),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "box",
+          type: "dataSource",
+          name: showAttribute,
+          value: "condition",
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      {$ws$dataSource$condition &&
+      <__Box
+      data-ws-id="box"
+      data-ws-component="Box" />
+      }
+    `)
+  );
+});
+
+test("generate jsx element with index prop", () => {
+  expect(
+    generateJsxElement({
+      instance: createInstance("box", "Box", []),
+      props: new Map(),
+      indexesWithinAncestors: new Map([["box", 5]]),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      <__Box
+      data-ws-id="box"
+      data-ws-component="Box"
+      data-ws-index="5" />
+    `)
+  );
+});
+
+test("generate jsx children with text", () => {
+  expect(
+    generateJsxChildren({
+      children: [
+        { type: "text", value: "Some\ntext" },
+        { type: "text", value: 'Escaped "text"' },
+      ],
+      instances: new Map(),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+    })
+  ).toEqual(
+    clear(`
+      {"Some"}
+      <br />
+      {"text"}
+      {"Escaped \\"text\\""}
+    `)
+  );
+});
+
+test("generate jsx children with nested instances", () => {
+  expect(
+    generateJsxChildren({
+      children: [{ type: "id", value: "form" }],
+      instances: new Map([
+        createInstancePair("form", "Form", [
+          { type: "id", value: "input" },
+          { type: "id", value: "button" },
+        ]),
+        createInstancePair("input", "Input", []),
+        createInstancePair("button", "Button", []),
+      ]),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "form",
+          name: "prop",
+          type: "string",
+          value: "value",
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+    })
+  ).toEqual(
+    clear(`
+    <__Form
+    data-ws-id="form"
+    data-ws-component="Form"
+    prop={"value"}>
+    <__Input
+    data-ws-id="input"
+    data-ws-component="Input" />
+    <__Button
+    data-ws-id="button"
+    data-ws-component="Button" />
+    </__Form>
+    `)
+  );
+});
+
+test("generate page component", () => {
+  expect(
+    generatePageComponent({
+      rootInstanceId: "body",
+      instances: new Map([
+        createInstancePair("body", "Body", [{ type: "id", value: "input" }]),
+        createInstancePair("input", "Input", []),
+      ]),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "input",
+          name: "value",
+          type: "dataSource",
+          value: "variable",
+        }),
+        createPropPair({
+          id: "2",
+          instanceId: "input",
+          name: "onChange",
+          type: "action",
+          value: [
+            {
+              type: "execute",
+              args: ["value"],
+              code: `$ws$dataSource$variable = value`,
+            },
+          ],
+        }),
+      ]),
+      indexesWithinAncestors: new Map([["input", 0]]),
+    })
+  ).toEqual(
+    clear(`
+      export const Page = (props: { scripts: ReactNode }) => {
+      const { dataSourceValuesStore, setDataSourceValues, executeEffectfulExpression } = useContext(ReactSdkContext);
+      const dataSourceValues = useStore(dataSourceValuesStore);
+      const $ws$dataSource$variable = dataSourceValues.get("variable");
+      const $ws$prop$2 = (value: unknown) => {
+      const newValues = executeEffectfulExpression(
+      value.code,
+      new Map([["value", value]]),
+      dataSourceValues
+      );
+      setDataSourceValues(newValues);
+      };
+      return <__Body
+      data-ws-id="body"
+      data-ws-component="Body">
+      <__Input
+      data-ws-id="input"
+      data-ws-component="Input"
+      data-ws-index="0"
+      value={$ws$dataSource$variable}
+      onChange={$ws$prop$2} />
+      {props.scripts}
+      </__Body>
+      };
+    `)
+  );
+});

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -9,11 +9,6 @@ import {
 import { encodeDataSourceVariable } from "./expression";
 import type { IndexesWithinAncestors } from "./instance-utils";
 
-const encodePropVariable = (id: string) => {
-  const encoded = id.replaceAll("-", "__DASH__");
-  return `$ws$prop$${encoded}`;
-};
-
 export const generateJsxElement = ({
   scope,
   instance,
@@ -78,7 +73,7 @@ export const generateJsxElement = ({
       continue;
     }
     if (prop.type === "action") {
-      const propVariable = encodePropVariable(prop.id);
+      const propVariable = scope.getName(prop.id, prop.name);
       generatedProps += `\n${prop.name}={${propVariable}}`;
       continue;
     }
@@ -164,10 +159,12 @@ export const generateJsxChildren = ({
 };
 
 const generateDataSources = ({
+  scope,
   rootInstanceId,
   instances,
   props,
 }: {
+  scope: Scope;
   rootInstanceId: Instance["id"];
   instances: Instances;
   props: Props;
@@ -185,7 +182,7 @@ const generateDataSources = ({
       generatedDataSources += `const ${variableName} = dataSourceValues.get(${key});\n`;
     }
     if (prop.type === "action") {
-      const propVariable = encodePropVariable(prop.id);
+      const propVariable = scope.getName(prop.id, prop.name);
       let args = "";
       for (const value of prop.value) {
         const newArgs = value.args.map((arg) => `${arg}: unknown`).join(", ");
@@ -237,6 +234,7 @@ export const generatePageComponent = ({
     return "";
   }
   const generatedDataSources = generateDataSources({
+    scope,
     rootInstanceId,
     instances,
     props,

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -1,0 +1,268 @@
+import type { Instances, Instance, Props } from "@webstudio-is/sdk";
+import { findTreeInstanceIds } from "@webstudio-is/sdk";
+import {
+  componentAttribute,
+  idAttribute,
+  indexAttribute,
+  showAttribute,
+} from "./tree/webstudio-component";
+import { encodeDataSourceVariable } from "./expression";
+import type { IndexesWithinAncestors } from "./instance-utils";
+
+/**
+ * Namespaced components contain a lot of invalid characters for
+ * js identifier
+ * here normalized something like @webstudio-is/library:Box
+ * to __webstudio__is__library__Box
+ */
+export const createComponentVariableName = (componentName: string) => {
+  let normalized = componentName.replaceAll(/[^a-zA-Z0-9]/g, "__");
+  if (normalized.startsWith("__") === false) {
+    normalized = `__${normalized}`;
+  }
+  return normalized;
+};
+
+const encodePropVariable = (id: string) => {
+  const encoded = id.replaceAll("-", "__DASH__");
+  return `$ws$prop$${encoded}`;
+};
+
+export const generateJsxElement = ({
+  instance,
+  props,
+  indexesWithinAncestors,
+  children,
+}: {
+  instance: Instance;
+  props: Props;
+  indexesWithinAncestors: IndexesWithinAncestors;
+  children: string;
+}) => {
+  let conditionVariableName: undefined | string;
+
+  let generatedProps = "";
+
+  // id and component props are always defined for styles
+  generatedProps += `\n${idAttribute}=${JSON.stringify(instance.id)}`;
+  generatedProps += `\n${componentAttribute}=${JSON.stringify(
+    instance.component
+  )}`;
+  const index = indexesWithinAncestors.get(instance.id);
+  if (index !== undefined) {
+    generatedProps += `\n${indexAttribute}="${index}"`;
+  }
+
+  for (const prop of props.values()) {
+    if (prop.instanceId !== instance.id) {
+      continue;
+    }
+    // show prop controls conditional rendering and need to be handled separately
+    if (prop.name === showAttribute) {
+      // prevent instance rendering when hidden
+      if (prop.type === "boolean" && prop.value === false) {
+        return "";
+      }
+      if (prop.type === "dataSource") {
+        const dataSourceId = prop.value;
+        conditionVariableName = encodeDataSourceVariable(dataSourceId);
+      }
+      // ignore any other values
+      continue;
+    }
+    if (
+      prop.type === "string" ||
+      prop.type === "number" ||
+      prop.type === "boolean" ||
+      prop.type === "string[]"
+    ) {
+      generatedProps += `\n${prop.name}={${JSON.stringify(prop.value)}}`;
+      continue;
+    }
+    // ignore asset and page props which are handled by components internally
+    if (prop.type === "asset" || prop.type === "page") {
+      continue;
+    }
+    if (prop.type === "dataSource") {
+      const dataSourceId = prop.value;
+      const dataSourceVariable = encodeDataSourceVariable(dataSourceId);
+      generatedProps += `\n${prop.name}={${dataSourceVariable}}`;
+      continue;
+    }
+    if (prop.type === "action") {
+      const propVariable = encodePropVariable(prop.id);
+      generatedProps += `\n${prop.name}={${propVariable}}`;
+      continue;
+    }
+    prop satisfies never;
+  }
+
+  let generatedElement = "";
+  // coditionally render instance when show prop is data source
+  // {dataSourceVariable && <Instance>}
+  if (conditionVariableName) {
+    generatedElement += `{${conditionVariableName} &&\n`;
+  }
+
+  const componentVariable = createComponentVariableName(instance.component);
+  if (instance.children.length === 0) {
+    generatedElement += `<${componentVariable}${generatedProps} />\n`;
+  } else {
+    generatedElement += `<${componentVariable}${generatedProps}>\n`;
+    generatedElement += children;
+    generatedElement += `</${componentVariable}>\n`;
+  }
+
+  if (conditionVariableName) {
+    generatedElement += `}\n`;
+  }
+
+  return generatedElement;
+};
+
+/**
+ * Jsx element and children are generated separately to be able
+ * to inject some scripts into Body if necessary
+ */
+export const generateJsxChildren = ({
+  children,
+  instances,
+  props,
+  indexesWithinAncestors,
+}: {
+  children: Instance["children"];
+  instances: Instances;
+  props: Props;
+  indexesWithinAncestors: IndexesWithinAncestors;
+}) => {
+  let generatedChildren = "";
+  for (const child of children) {
+    if (child.type === "text") {
+      // instance text can contain newlines
+      // convert them too <br> tag
+      generatedChildren += child.value
+        .split("\n")
+        .map((line) => `{${JSON.stringify(line)}}\n`)
+        .join(`<br />\n`);
+      continue;
+    }
+    if (child.type === "id") {
+      const instanceId = child.value;
+      const instance = instances.get(instanceId);
+      if (instance === undefined) {
+        continue;
+      }
+      generatedChildren += generateJsxElement({
+        instance,
+        props,
+        indexesWithinAncestors,
+        children: generateJsxChildren({
+          children: instance.children,
+          instances,
+          props,
+          indexesWithinAncestors,
+        }),
+      });
+      continue;
+    }
+    child satisfies never;
+  }
+  return generatedChildren;
+};
+
+const generateDataSources = ({
+  rootInstanceId,
+  instances,
+  props,
+}: {
+  rootInstanceId: Instance["id"];
+  instances: Instances;
+  props: Props;
+}) => {
+  let generatedDataSources = "";
+  generatedDataSources += `const { dataSourceValuesStore, setDataSourceValues, executeEffectfulExpression } = useContext(ReactSdkContext);\n`;
+  generatedDataSources +=
+    "const dataSourceValues = useStore(dataSourceValuesStore);\n";
+  const usedInstanceIds = findTreeInstanceIds(instances, rootInstanceId);
+  for (const prop of props.values()) {
+    if (prop.type === "dataSource" && usedInstanceIds.has(prop.instanceId)) {
+      const dataSourceId = prop.value;
+      const variableName = encodeDataSourceVariable(dataSourceId);
+      const key = JSON.stringify(dataSourceId);
+      generatedDataSources += `const ${variableName} = dataSourceValues.get(${key});\n`;
+    }
+    if (prop.type === "action") {
+      const propVariable = encodePropVariable(prop.id);
+      let args = "";
+      for (const value of prop.value) {
+        const newArgs = value.args.map((arg) => `${arg}: unknown`).join(", ");
+        // skip execution when arguments do not match
+        if (args !== "" && newArgs !== args) {
+          console.error(
+            `Action prop arguments do not match: "${args}" and "${newArgs}"`
+          );
+          continue;
+        }
+        args = newArgs;
+      }
+      generatedDataSources += `const ${propVariable} = (${args}) => {\n`;
+      for (const value of prop.value) {
+        if (value.type === "execute") {
+          generatedDataSources += `const newValues = executeEffectfulExpression(\n`;
+          generatedDataSources += `value.code,\n`;
+          generatedDataSources += `new Map([`;
+          generatedDataSources += value.args
+            .map((arg) => `[${JSON.stringify(arg)}, ${arg}]`)
+            .join(", ");
+          generatedDataSources += `]),\n`;
+          generatedDataSources += `dataSourceValues\n`;
+          generatedDataSources += `);\n`;
+          generatedDataSources += `setDataSourceValues(newValues);\n`;
+        }
+      }
+      generatedDataSources += `};\n`;
+    }
+  }
+  return generatedDataSources;
+};
+
+export const generatePageComponent = ({
+  rootInstanceId,
+  instances,
+  props,
+  indexesWithinAncestors,
+}: {
+  rootInstanceId: Instance["id"];
+  instances: Instances;
+  props: Props;
+  indexesWithinAncestors: IndexesWithinAncestors;
+}) => {
+  const instance = instances.get(rootInstanceId);
+  if (instance === undefined) {
+    return "";
+  }
+  const generatedDataSources = generateDataSources({
+    rootInstanceId,
+    instances,
+    props,
+  });
+  const generatedJsx = generateJsxElement({
+    instance,
+    props,
+    indexesWithinAncestors,
+    children:
+      generateJsxChildren({
+        children: instance.children,
+        instances,
+        props,
+        indexesWithinAncestors,
+      }) + "{props.scripts}\n",
+  });
+
+  let generatedComponent = "";
+  generatedComponent += `export const Page = (props: { scripts: ReactNode }) => {\n`;
+  generatedComponent += `${generatedDataSources}`;
+  generatedComponent += `return ${generatedJsx}`;
+  generatedComponent += `};\n`;
+  return generatedComponent;
+};

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -38,7 +38,4 @@ export { renderComponentTemplate } from "./component-renderer";
 export { getIndexesWithinAncestors } from "./instance-utils";
 export * from "./hook";
 export { generateUtilsExport } from "./generator";
-export {
-  createComponentVariableName,
-  generatePageComponent,
-} from "./component-generator";
+export { generatePageComponent } from "./component-generator";

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -38,3 +38,7 @@ export { renderComponentTemplate } from "./component-renderer";
 export { getIndexesWithinAncestors } from "./instance-utils";
 export * from "./hook";
 export { generateUtilsExport } from "./generator";
+export {
+  createComponentVariableName,
+  generatePageComponent,
+} from "./component-generator";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1304,6 +1304,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      strip-indent:
+        specifier: ^4.0.0
+        version: 4.0.0
       type-fest:
         specifier: ^4.3.1
         version: 4.3.1
@@ -15470,7 +15473,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       min-indent: 1.0.1
-    dev: false
 
   /strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}


### PR DESCRIPTION
Here added jsx component generator. It allows us to have less tree traversing and more clear output for debugging.

For now data sources are managed the old way with stores. In the future we can switch to react `useState`.

See `fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx` for example