### PR TITLE
Show spinners after the prompts are responded and close the prompts on `ctrl + c` in the cli

### DIFF
--- a/packages/cli/src/commands/init-flow.ts
+++ b/packages/cli/src/commands/init-flow.ts
@@ -1,4 +1,3 @@
-import prompts from "prompts";
 import { ensureFolderExists, isFileExists } from "../fs-utils";
 import { chdir, cwd, stdout as shellOutput } from "node:process";
 import { spawn } from "node:child_process";
@@ -7,6 +6,7 @@ import ora from "ora";
 import { link } from "./link";
 import { sync } from "./sync";
 import { build, buildOptions } from "./build";
+import { prompt } from "../prompts";
 import type { StrictYargsOptionsToInterface } from "./yargs-types";
 
 export const initFlow = async (
@@ -16,37 +16,19 @@ export const initFlow = async (
   let shouldInstallDeps = false;
 
   if (isProjectConfigured === false) {
-    const { createFolder } = await prompts([
-      {
-        type: "confirm",
-        name: "createFolder",
-        message: "Do you want to create a folder",
-        initial: true,
-        onState: (state) => {
-          if (state.aborted) {
-            process.nextTick(() => {
-              process.exit(0);
-            });
-          }
-        },
-      },
-    ]);
+    const { shouldCreateFolder } = await prompt({
+      type: "confirm",
+      name: "shouldCreateFolder",
+      message: "Do you want to create a folder",
+      initial: true,
+    });
 
-    if (createFolder === true) {
-      const { folderName } = await prompts([
-        {
-          type: "text",
-          name: "folderName",
-          message: "Enter a project name",
-          onState: (state) => {
-            if (state.aborted) {
-              process.nextTick(() => {
-                process.exit(0);
-              });
-            }
-          },
-        },
-      ]);
+    if (shouldCreateFolder === true) {
+      const { folderName } = await prompt({
+        type: "text",
+        name: "folderName",
+        message: "Enter a project name",
+      });
 
       if (folderName === undefined) {
         throw new Error("Folder name is required");
@@ -55,34 +37,23 @@ export const initFlow = async (
       chdir(join(cwd(), folderName));
     }
 
-    const { projectLink } = await prompts([
-      {
-        type: "text",
-        name: "projectLink",
-        message: "Enter a project link",
-        onState: (state) => {
-          if (state.aborted) {
-            process.nextTick(() => {
-              process.exit(0);
-            });
-          }
-        },
-      },
-    ]);
+    const { projectLink } = await prompt({
+      type: "text",
+      name: "projectLink",
+      message: "Enter a project link",
+    });
 
     if (projectLink === undefined) {
       throw new Error(`Project Link is required`);
     }
     await link({ link: projectLink });
 
-    const { installDeps } = await prompts([
-      {
-        type: "confirm",
-        name: "installDeps",
-        message: "Do you want to install dependencies",
-        initial: true,
-      },
-    ]);
+    const { installDeps } = await prompt({
+      type: "confirm",
+      name: "installDeps",
+      message: "Do you want to install dependencies",
+      initial: true,
+    });
     shouldInstallDeps = installDeps;
   }
 

--- a/packages/cli/src/commands/init-flow.ts
+++ b/packages/cli/src/commands/init-flow.ts
@@ -22,34 +22,47 @@ export const initFlow = async (
         name: "folder",
         message: "Do you want to create a folder",
         initial: true,
+        onState: (state) => {
+          if (state.aborted) {
+            process.nextTick(() => {
+              process.exit(0);
+            });
+          }
+        },
       },
       {
         type: (prev) => (prev === true ? "text" : null),
         name: "folderName",
         message: "Enter a project name",
+        onState: (state) => {
+          if (state.aborted) {
+            process.nextTick(() => {
+              process.exit(0);
+            });
+          }
+        },
       },
       {
         type: (prev) => (prev === undefined ? null : "text"),
         name: "projectLink",
         message: "Enter a project link",
+        onState: (state) => {
+          if (state.aborted) {
+            process.nextTick(() => {
+              process.exit(0);
+            });
+          }
+        },
       }
     );
-  }
-
-  const response = await prompts(prompsList);
-
-  /*
-    If users wanted to create a folder, we need to create it and link the project.
-  */
-  if (response.folderName) {
-    await ensureFolderExists(join(cwd(), response.folderName));
-    chdir(join(cwd(), response.folderName));
+    const response = await prompts(prompsList);
+    if (response.folderName) {
+      await ensureFolderExists(join(cwd(), response.folderName));
+      chdir(join(cwd(), response.folderName));
+    }
     await link({ link: response.projectLink });
   }
 
-  /*
-    If the project is already set up, we can sync and build it.
-  */
   await sync();
   await build(options);
   const spinner = ora().start();

--- a/packages/cli/src/commands/init-flow.ts
+++ b/packages/cli/src/commands/init-flow.ts
@@ -14,7 +14,6 @@ export const initFlow = async (
 ) => {
   const isProjectConfigured = await isFileExists(".webstudio/config.json");
   const prompsList: PromptObject[] = [];
-  const spinner = ora().start();
 
   if (isProjectConfigured === false) {
     prompsList.push(
@@ -53,6 +52,7 @@ export const initFlow = async (
   */
   await sync();
   await build(options);
+  const spinner = ora().start();
 
   spinner.text = "Installing dependencies";
   const { stderr } = await exec("npm", ["install"]);

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -1,0 +1,16 @@
+import prompts, { type PromptObject } from "prompts";
+
+export const prompt = (prompt: PromptObject) => {
+  return prompts([
+    {
+      ...prompt,
+      onState: (state) => {
+        if (state.aborted) {
+          process.nextTick(() => {
+            process.exit(0);
+          });
+        }
+      },
+    },
+  ]);
+};


### PR DESCRIPTION
## Description

This PR
- Allows the prompts to be cancelable at any time.
- Prompts the user if the dependencies can be installed, when the project is being connected for the first time.
- Shows the spinner once all the prompts are responded. Which was previously clearing the prompts to be displayed.

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review
- [x] made a self-review