### PR TITLE
Drop instances checks from form server logic

### DIFF
--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -77,11 +77,7 @@ const getMethod = (value: string | undefined) => {
 export const action = async ({ request, context }: ActionArgs) => {
   const formData = await request.formData();
 
-  const formProperties = getFormProperties(
-    formData,
-    pageData.build.instances,
-    pageData.build.props
-  );
+  const formProperties = getFormProperties(formData, pageData.build.props);
 
   if (formProperties === undefined) {
     // We're throwing rather than returning { success: false }

--- a/packages/cli/src/__generated__/router.ts
+++ b/packages/cli/src/__generated__/router.ts
@@ -87,11 +87,7 @@ const getMethod = (value: string | undefined) => {
 export const action = async ({ request, context }: ActionArgs) => {
   const formData = await request.formData();
 
-  const formProperties = getFormProperties(
-    formData,
-    pageData.build.instances,
-    pageData.build.props
-  );
+  const formProperties = getFormProperties(formData, pageData.build.props);
 
   if (formProperties === undefined) {
     // We're throwing rather than returning { success: false }

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -77,11 +77,7 @@ const getMethod = (value: string | undefined) => {
 export const action = async ({ request, context }: ActionArgs) => {
   const formData = await request.formData();
 
-  const formProperties = getFormProperties(
-    formData,
-    pageData.build.instances,
-    pageData.build.props
-  );
+  const formProperties = getFormProperties(formData, pageData.build.props);
 
   if (formProperties === undefined) {
     // We're throwing rather than returning { success: false }

--- a/packages/form-handlers/src/index.ts
+++ b/packages/form-handlers/src/index.ts
@@ -3,7 +3,6 @@ export {
   formIdFieldName,
   formHiddenFieldPrefix,
   getFormId,
-  hasMatchingForm,
   getFormProperties,
   type EmailInfo,
   type FormInfo,

--- a/packages/form-handlers/src/shared.ts
+++ b/packages/form-handlers/src/shared.ts
@@ -1,4 +1,4 @@
-import type { Instance, Prop } from "@webstudio-is/sdk";
+import type { Prop } from "@webstudio-is/sdk";
 
 export const formHiddenFieldPrefix = "ws--form";
 export const formIdFieldName = `${formHiddenFieldPrefix}-id`;
@@ -111,42 +111,13 @@ export const getErrors = (
   }
 };
 
-/** Checks that `formData` corresponds to a form in the `instances` tree */
-export const hasMatchingForm = (
-  formData: FormData,
-  instances: [Instance["id"], Instance][]
-) => {
-  const formId = getFormId(formData);
-
-  if (formId === undefined) {
-    return false;
-  }
-
-  return instances.some(
-    ([, instance]) => instance.id === formId && instance.component === "Form"
-  );
-
-  // @todo:
-  // We could also check that each entry in formData has a corresponding input control in the tree,
-  // but that seem like an overkill for now.
-};
-
 export const getFormProperties = (
   formData: FormData,
-  instances: [Instance["id"], Instance][],
   props: [Prop["id"], Prop][]
 ) => {
   const formId = getFormId(formData);
 
   if (formId === undefined) {
-    return undefined;
-  }
-
-  const hasForm = instances.some(
-    ([, instance]) => instance.id === formId && instance.component === "Form"
-  );
-
-  if (hasForm === false) {
     return undefined;
   }
 


### PR DESCRIPTION
Instances checks are excessive and requires instances data to be present in runtime. We can remove it.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
