### PR TITLE
Add scope utility for code generation

### DIFF
--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -5,24 +5,24 @@ import * as sdk from "@webstudio-is/react-sdk";
 import type { PageData } from "~/routes/_index";
 import type { Components } from "@webstudio-is/react-sdk";
 import type { Asset } from "@webstudio-is/sdk";
-
 import {
-  Body as Body_0,
-  Heading as Heading_0,
-  Box as Box_0,
-  Paragraph as Paragraph_0,
-  Image as Image_0,
+  Body as Body,
+  Heading as Heading,
+  Box as Box,
+  Paragraph as Paragraph,
+  Image as Image,
 } from "@webstudio-is/sdk-components-react";
+
 import * as remixComponents from "@webstudio-is/sdk-components-react-remix";
 export const components = new Map(
   Object.entries(
     Object.assign(
       {
-        Body: Body_0,
-        Heading: Heading_0,
-        Box: Box_0,
-        Paragraph: Paragraph_0,
-        Image: Image_0,
+        Body: Body,
+        Heading: Heading,
+        Box: Box,
+        Paragraph: Paragraph,
+        Image: Image,
       },
       remixComponents
     )

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -10,3 +10,4 @@ export * from "./schema/styles";
 export * from "./schema/deployment";
 
 export * from "./instances-utils";
+export * from "./scope";

--- a/packages/sdk/src/scope.test.ts
+++ b/packages/sdk/src/scope.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@jest/globals";
+import { createScope } from "./scope";
+
+test("use variable name for specific id and suffix on collision", () => {
+  const scope = createScope();
+  expect(scope.getName("1", "myName")).toEqual("myName");
+  expect(scope.getName("2", "myName")).toEqual("myName_1");
+  // reuse already cached one
+  expect(scope.getName("1", "myName")).toEqual("myName");
+});
+
+test("allow to predefine already occupied identifiers", () => {
+  const scope = createScope(["myName", "anotherName"]);
+  expect(scope.getName("1", "myName")).toEqual("myName_1");
+  expect(scope.getName("2", "anotherName")).toEqual("anotherName_1");
+  expect(scope.getName("3", "newName")).toEqual("newName");
+});

--- a/packages/sdk/src/scope.ts
+++ b/packages/sdk/src/scope.ts
@@ -1,0 +1,42 @@
+export type Scope = {
+  /**
+   * Accepts unique id to identify specific variable
+   * and preferred name to use it as variable name
+   * or suffix if already used.
+   */
+  getName(id: string, preferredName: string): string;
+};
+
+/**
+ * Utility to maintain unique variable when generate code.
+ * Single scope is shared for generated module for simplicity.
+ *
+ * occupiedIdentifiers parameter prevents collision with hardcoded
+ * identifiers.
+ */
+export const createScope = (occupiedIdentifiers: string[] = []): Scope => {
+  const freeIndexByPreferredName = new Map<string, number>();
+  const scopedNameByIdMap = new Map<string, string>();
+  for (const identifier of occupiedIdentifiers) {
+    freeIndexByPreferredName.set(identifier, 1);
+  }
+
+  const getName = (id: string, preferredName: string) => {
+    const cachedName = scopedNameByIdMap.get(id);
+    if (cachedName !== undefined) {
+      return cachedName;
+    }
+    const index = freeIndexByPreferredName.get(preferredName);
+    freeIndexByPreferredName.set(preferredName, (index ?? 0) + 1);
+    let scopedName = preferredName;
+    if (index !== undefined) {
+      scopedName = `${preferredName}_${index}`;
+    }
+    scopedNameByIdMap.set(id, scopedName);
+    return scopedName;
+  };
+
+  return {
+    getName,
+  };
+};


### PR DESCRIPTION
Here added `createScope()` utility to maintain collision free and readable identifiers. Integrated it for component imports.

In the future will be used for jsx and data sources generation.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
