### PR TITLE
Improve help and run dev-server after init of a project while using cli

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,7 +31,6 @@ export const main = async () => {
       .wrap(null)
       .option("v", {
         describe: "Show version number",
-        alias: "version",
         type: "boolean",
       })
       .option("h", {
@@ -39,19 +38,17 @@ export const main = async () => {
         alias: "help",
         type: "boolean",
       })
-      .scriptName("webstudio");
+      .scriptName("webstudio")
+      .usage(
+        `Webstudio CLI (${packageJson.version}) allows you to setup, sync, build and preview your project.`
+      );
 
     cmd.version(packageJson.version).alias("v", "version");
 
-    cmd.command(["build"], "build the project", buildOptions, build);
-    cmd.command(
-      ["link"],
-      "link the project from your workspace",
-      linkOptions,
-      link
-    );
-    cmd.command(["sync"], "sync your project", {}, sync);
-    cmd.command("$0", "setup the project", buildOptions, initFlow);
+    cmd.command(["build"], "Build the project", buildOptions, build);
+    cmd.command(["link"], "Link the project with the cloud", linkOptions, link);
+    cmd.command(["sync"], "Sync your project", {}, sync);
+    cmd.command(["$0", "init"], "Setup the project", buildOptions, initFlow);
 
     await cmd.parse();
   } catch (error) {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -11,12 +11,12 @@ export const buildOptions = (yargs: CommonYargsArgv) =>
     .option("assets", {
       type: "boolean",
       default: true,
-      describe: "Download assets",
+      describe: "[Experimental] Download assets",
     })
     .option("preview", {
       type: "boolean",
       default: false,
-      describe: "use preview (opensource) version of the project",
+      describe: "[Experimental] Use preview version of the project",
     });
 
 // @todo: use options.assets to define if we need to download assets

--- a/packages/cli/src/commands/init-flow.ts
+++ b/packages/cli/src/commands/init-flow.ts
@@ -67,7 +67,12 @@ export const initFlow = async (
     if (stderr) {
       throw stderr;
     }
-    spinner.succeed("Installed dependencies");
+    spinner.succeed("Installed dependencies, starting dev server");
+
+    const { stderr: devServerError } = await exec("npm", ["run", "dev"]);
+    if (devServerError) {
+      throw devServerError;
+    }
   }
 };
 


### PR DESCRIPTION
## Description

- Improves the help message that is displayed for `webstudio --help`
- Runs the dev server if the user opts in for the dependencies installation.

## Code Review
- [ ] hi @kof , I need you to do
  - detailed review (read every line)
  
## Before requesting a review
- [x] made a self-review