### PR TITLE
Remove dev server from cli, add info about how to execute it

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
     "env-paths": "^3.0.0",
     "ora": "^7.0.1",
     "p-limit": "^4.0.0",
+    "picocolors": "^1.0.0",
     "prompts": "^2.4.2",
     "strip-indent": "^4.0.0",
     "yargs": "^17.7.2"

--- a/packages/cli/src/commands/init-flow.ts
+++ b/packages/cli/src/commands/init-flow.ts
@@ -71,8 +71,8 @@ export const initFlow = async (
     spinner.succeed("Installed dependencies");
   }
 
-  console.log(pc.bold(pc.green(`\nYour project was successfully synced 🎉`)));
-  console.log(`Now you can:
+  console.info(pc.bold(pc.green(`\nYour project was successfully synced 🎉`)));
+  console.info(`Now you can:
 Run ${pc.dim("npm dev")} to preview your site on a local server.
 Run ${pc.dim("npx vercel")} to publish on Vercel.`);
 };

--- a/packages/cli/src/commands/init-flow.ts
+++ b/packages/cli/src/commands/init-flow.ts
@@ -8,6 +8,7 @@ import { sync } from "./sync";
 import { build, buildOptions } from "./build";
 import { prompt } from "../prompts";
 import type { StrictYargsOptionsToInterface } from "./yargs-types";
+import pc from "picocolors";
 
 export const initFlow = async (
   options: StrictYargsOptionsToInterface<typeof buildOptions>
@@ -67,13 +68,13 @@ export const initFlow = async (
     if (stderr) {
       throw stderr;
     }
-    spinner.succeed("Installed dependencies, starting dev server");
-
-    const { stderr: devServerError } = await exec("npm", ["run", "dev"]);
-    if (devServerError) {
-      throw devServerError;
-    }
+    spinner.succeed("Installed dependencies");
   }
+
+  console.log(pc.bold(pc.green(`\nYour project was successfully synced 🎉`)));
+  console.log(`Now you can:
+Run ${pc.dim("npm dev")} to preview your site on a local server.
+Run ${pc.dim("npx vercel")} to publish on Vercel.`);
 };
 
 const exec = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,6 +541,9 @@ importers:
       p-limit:
         specifier: ^4.0.0
         version: 4.0.0
+      picocolors:
+        specifier: ^1.0.0
+        version: 1.0.0
       prompts:
         specifier: ^2.4.2
         version: 2.4.2


### PR DESCRIPTION
## Description

Dev server no longer executed in cli

<img width="467" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/8054656a-8c73-4ed2-a9ce-20fabb1f525c">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
