### PR TITLE
Fix shared link name is not editable

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "patchedDependencies": {
       "@stitches/react@1.3.1-1": "patches/@stitches__react@1.3.1-1.patch",
       "css-tree@2.3.1": "patches/css-tree@2.3.1.patch",
-      "@types/css-tree@2.3.1": "patches/@types__css-tree@2.3.1.patch"
+      "@types/css-tree@2.3.1": "patches/@types__css-tree@2.3.1.patch",
+      "@radix-ui/react-focus-scope@1.0.3": "patches/@radix-ui__react-focus-scope@1.0.3.patch"
     }
   }
 }

--- a/patches/@radix-ui__react-focus-scope@1.0.3.patch
+++ b/patches/@radix-ui__react-focus-scope@1.0.3.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/index.js b/dist/index.js
+index 0a98b8ec8f2a6d1160d035174c8979a4d0445863..6793b5290ece1c13cfb2af565899d9da810f9ede 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -76,6 +76,7 @@ const $2bc01e66e04aa9ed$export$20e40289641fbbb6 = /*#__PURE__*/ $buum9$react.for
+             // to keep focus trapped correctly.
+             function handleMutations(mutations) {
+                 const focusedElement = document.activeElement;
++                if (focusedElement !== document.body) return;
+                 for (const mutation of mutations){
+                     if (mutation.removedNodes.length > 0) {
+                         if (!(container1 !== null && container1 !== void 0 && container1.contains(focusedElement))) $2bc01e66e04aa9ed$var$focus(container1);
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 4a8b11cc2eb38b397590f20f819b6599e4d78e7d..f30c37a232e93be17e4247ada404d5160a916cc3 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -67,6 +67,7 @@ const $d3863c46a17e8a28$export$20e40289641fbbb6 = /*#__PURE__*/ $45QHv$forwardRe
+             // to keep focus trapped correctly.
+             function handleMutations(mutations) {
+                 const focusedElement = document.activeElement;
++                if (focusedElement !== document.body) return;
+                 for (const mutation of mutations){
+                     if (mutation.removedNodes.length > 0) {
+                         if (!(container1 !== null && container1 !== void 0 && container1.contains(focusedElement))) $d3863c46a17e8a28$var$focus(container1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,9 @@
 lockfileVersion: '6.0'
 
 patchedDependencies:
+  '@radix-ui/react-focus-scope@1.0.3':
+    hash: vwkv6fgcyenwdrasskh5q6guyu
+    path: patches/@radix-ui__react-focus-scope@1.0.3.patch
   '@stitches/react@1.3.1-1':
     hash: knml42mpr6mlzseo3d6gjljiq4
     path: patches/@stitches__react@1.3.1-1.patch
@@ -4958,7 +4961,7 @@ packages:
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.21)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.3(patch_hash=vwkv6fgcyenwdrasskh5q6guyu)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-id': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
@@ -5053,7 +5056,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-focus-scope@1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-focus-scope@1.0.3(patch_hash=vwkv6fgcyenwdrasskh5q6guyu)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-upXdPfqI4islj2CslyfUBNlaJCPybbqRHAi1KER7Isel9Q2AtSJ0zRBZv8mWQiFXD2nyAJ4BhC3yXgZ6kMBSrQ==}
     peerDependencies:
       '@types/react': '*'
@@ -5075,6 +5078,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
+    patched: true
 
   /@radix-ui/react-id@1.0.1(@types/react@18.2.21)(react@18.2.0):
     resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
@@ -5133,7 +5137,7 @@ packages:
       '@radix-ui/react-direction': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.21)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.3(patch_hash=vwkv6fgcyenwdrasskh5q6guyu)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-id': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-popper': 1.1.2(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
@@ -5203,7 +5207,7 @@ packages:
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.21)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.3(patch_hash=vwkv6fgcyenwdrasskh5q6guyu)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-id': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-popper': 1.1.2(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
@@ -5445,7 +5449,7 @@ packages:
       '@radix-ui/react-direction': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.21)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.3(patch_hash=vwkv6fgcyenwdrasskh5q6guyu)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-id': 1.0.1(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-popper': 1.1.2(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
## Description

Shared link name is not editable because every input change closes popover with the input.

Here is the fix and the explanation.

This is already fixed in rc radix versions and will be in the next stable release
https://github.com/radix-ui/primitives/blob/28bebf2c6992d056244845c898abeff45dec2871/packages/react/focus-scope/src/FocusScope.tsx#L115

Without this PR the issue looks:

Editing input 
<img width="353" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/b6ba547c-4286-45f2-b351-9122780cb482">
cause this button 
<img width="216" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/4d6a26c3-3336-4995-b0b4-c38200e34e07">
to switch onto `pending` state
<img width="211" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/f214d9a9-3454-4b1b-8603-48224fa370d1">
what cause handleMutations to move focus onto parent popover 
Child popover lost focus and closes.


## Steps for reproduction

Click Share, Edit link name, see it works

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
