### PR TITLE
Trick remix checks and avoid useless warnings

### DIFF
--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -36,7 +36,8 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "require": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -18,7 +18,8 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "require": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/error-utils/package.json
+++ b/packages/error-utils/package.json
@@ -18,7 +18,8 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "require": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -27,7 +27,8 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "require": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -21,7 +21,8 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "require": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -26,7 +26,8 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "require": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -37,12 +37,14 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.js"
     },
     "./svg": {
       "source": "./src/__generated__/svg/index.ts",
       "types": "./lib/types/__generated__/svg/index.d.ts",
-      "import": "./lib/__generated__/svg/index.js"
+      "import": "./lib/__generated__/svg/index.js",
+      "require": "./lib/__generated__/svg/index.js"
     }
   },
   "files": [

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -38,7 +38,8 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "require": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -51,12 +51,14 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.js"
     },
     "./css-normalize": {
       "source": "./src/css/normalize.ts",
       "types": "./lib/types/css/normalize.d.ts",
-      "import": "./lib/css/normalize.js"
+      "import": "./lib/css/normalize.js",
+      "require": "./lib/css/normalize.js"
     }
   },
   "files": [

--- a/packages/sdk-components-react-radix/package.json
+++ b/packages/sdk-components-react-radix/package.json
@@ -16,22 +16,26 @@
     ".": {
       "source": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
-      "import": "./lib/components.js"
+      "import": "./lib/components.js",
+      "require": "./lib/components.js"
     },
     "./metas": {
       "source": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js"
+      "import": "./lib/metas.js",
+      "require": "./lib/metas.js"
     },
     "./props": {
       "source": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js"
+      "import": "./lib/props.js",
+      "require": "./lib/props.js"
     },
     "./hooks": {
       "source": "./src/hooks.ts",
       "types": "./lib/types/hooks.d.ts",
-      "import": "./lib/hooks.js"
+      "import": "./lib/hooks.js",
+      "require": "./lib/hooks.js"
     }
   },
   "scripts": {

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -16,17 +16,20 @@
     ".": {
       "source": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
-      "import": "./lib/components.js"
+      "import": "./lib/components.js",
+      "require": "./lib/components.js"
     },
     "./metas": {
       "source": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js"
+      "import": "./lib/metas.js",
+      "require": "./lib/metas.js"
     },
     "./props": {
       "source": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js"
+      "import": "./lib/props.js",
+      "require": "./lib/props.js"
     }
   },
   "scripts": {

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -16,17 +16,20 @@
     ".": {
       "source": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
-      "import": "./lib/components.js"
+      "import": "./lib/components.js",
+      "require": "./lib/components.js"
     },
     "./metas": {
       "source": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js"
+      "import": "./lib/metas.js",
+      "require": "./lib/metas.js"
     },
     "./props": {
       "source": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js"
+      "import": "./lib/props.js",
+      "require": "./lib/props.js"
     }
   },
   "scripts": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -9,7 +9,8 @@
   "exports": {
     "source": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "require": "./lib/index.js"
   },
   "files": [
     "lib/*",


### PR DESCRIPTION
Remix do a few things wrong. Here it checks for dependencies to be present using commonjs only utility which fails to resolve. esm only packages.

Here I tricked it to resolve "require" export condition. Though it is dangerous as may give impression our packages has commonjs support.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
