### PR TITLE
Rename CLI to webstudio-cli

### DIFF
--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -484,7 +484,7 @@ const StyledLink = styled("a", {
 });
 
 const ExportContent = () => {
-  const npxCommand = "npx @webstudio-is/cli";
+  const npxCommand = "npx webstudio-cli";
   const npxVercelCommand = "npx vercel";
   return (
     <Grid

--- a/fixtures/webstudio-remix-vercel/README.md
+++ b/fixtures/webstudio-remix-vercel/README.md
@@ -1,4 +1,4 @@
-# Fixture to test/play with @webstudio/cli
+# Fixture to test/play with webstudio-cli
 
 ## How to develop
 

--- a/fixtures/webstudio-remix-vercel/package.json
+++ b/fixtures/webstudio-remix-vercel/package.json
@@ -29,7 +29,7 @@
     "@webstudio-is/http-client": "workspace:^",
     "eslint": "^8.48.0",
     "typescript": "5.2.2",
-    "@webstudio-is/cli": "workspace:^"
+    "webstudio-cli": "workspace:^"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@webstudio-is/cli",
+  "name": "webstudio-cli",
   "version": "0.94.0",
   "description": "Webstudio CLI",
   "author": "Webstudio <github@webstudio.is>",
   "homepage": "https://webstudio.is",
   "type": "module",
   "bin": {
-    "webstudio": "./lib/bin.js"
+    "webstudio-cli": "./lib/bin.js"
   },
   "files": [
     "lib/*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,9 +413,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.7
         version: 18.2.7
-      '@webstudio-is/cli':
-        specifier: workspace:^
-        version: link:../../packages/cli
       '@webstudio-is/http-client':
         specifier: workspace:^
         version: link:../../packages/http-client
@@ -425,6 +422,9 @@ importers:
       typescript:
         specifier: 5.2.2
         version: 5.2.2
+      webstudio-cli:
+        specifier: workspace:^
+        version: link:../../packages/cli
 
   packages/asset-uploader:
     dependencies:


### PR DESCRIPTION
As per discussion renaming it to be usable consistently with less typing using npx webstudio-cli as well as pnpm webstudio-cli