### PR TITLE
Simplify generated remix overrides

### DIFF
--- a/fixtures/webstudio-remix-vercel/.webstudio/data.json
+++ b/fixtures/webstudio-remix-vercel/.webstudio/data.json
@@ -1,9 +1,9 @@
 {
   "build": {
-    "id": "d8e941cb-835b-4f1f-bf8b-4d546a2a67d8",
+    "id": "c067c0f9-d5f2-47a4-9fac-fa4755e0175a",
     "projectId": "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    "version": 41,
-    "createdAt": "2023-09-06T11:37:11.556Z",
+    "version": 58,
+    "createdAt": "2023-09-08T10:02:53.659Z",
     "pages": {
       "homePage": {
         "id": "7Db64ZXgYiRqKSQNR-qTQ",
@@ -366,6 +366,16 @@
           "type": "asset",
           "value": "cd939c56-bcdd-4e64-bd9c-567a9bccd3da"
         }
+      ],
+      [
+        "SYK4hpLQ9tHnESKDtPvI9",
+        {
+          "id": "SYK4hpLQ9tHnESKDtPvI9",
+          "instanceId": "l9AI_pShC-BH4ibxK6kNT",
+          "name": "href",
+          "type": "string",
+          "value": "https://github.com/"
+        }
       ]
     ],
     "dataSources": [],
@@ -434,6 +444,10 @@
             {
               "type": "id",
               "value": "p34JHWcU6UNrd9FVnY80Q"
+            },
+            {
+              "type": "id",
+              "value": "l9AI_pShC-BH4ibxK6kNT"
             }
           ]
         }
@@ -487,6 +501,20 @@
           "id": "pX1ovPI7NdC0HRjkw6Kpw",
           "component": "Image",
           "children": []
+        }
+      ],
+      [
+        "l9AI_pShC-BH4ibxK6kNT",
+        {
+          "type": "instance",
+          "id": "l9AI_pShC-BH4ibxK6kNT",
+          "component": "Link",
+          "children": [
+            {
+              "type": "text",
+              "value": "Click here to adore more kittens"
+            }
+          ]
         }
       ]
     ],

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -12,21 +12,17 @@ import {
   Paragraph as Paragraph,
   Image as Image,
 } from "@webstudio-is/sdk-components-react";
+import { Link as Link } from "@webstudio-is/sdk-components-react-remix";
 
-import * as remixComponents from "@webstudio-is/sdk-components-react-remix";
 export const components = new Map(
-  Object.entries(
-    Object.assign(
-      {
-        Body: Body,
-        Heading: Heading,
-        Box: Box,
-        Paragraph: Paragraph,
-        Image: Image,
-      },
-      remixComponents
-    )
-  )
+  Object.entries({
+    Body: Body,
+    Heading: Heading,
+    Box: Box,
+    Paragraph: Paragraph,
+    Image: Image,
+    Link: Link,
+  })
 ) as Components;
 export const fontAssets: Asset[] = [];
 export const pageData: PageData = {
@@ -40,6 +36,16 @@ export const pageData: PageData = {
           name: "src",
           type: "asset",
           value: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+        },
+      ],
+      [
+        "SYK4hpLQ9tHnESKDtPvI9",
+        {
+          id: "SYK4hpLQ9tHnESKDtPvI9",
+          instanceId: "l9AI_pShC-BH4ibxK6kNT",
+          name: "href",
+          type: "string",
+          value: "https://github.com/",
         },
       ],
     ],
@@ -91,6 +97,7 @@ export const pageData: PageData = {
           children: [
             { type: "id", value: "oLXYe1UQiVMhVnZGvJSMr" },
             { type: "id", value: "p34JHWcU6UNrd9FVnY80Q" },
+            { type: "id", value: "l9AI_pShC-BH4ibxK6kNT" },
           ],
         },
       ],
@@ -134,6 +141,17 @@ export const pageData: PageData = {
           id: "pX1ovPI7NdC0HRjkw6Kpw",
           component: "Image",
           children: [],
+        },
+      ],
+      [
+        "l9AI_pShC-BH4ibxK6kNT",
+        {
+          type: "instance",
+          id: "l9AI_pShC-BH4ibxK6kNT",
+          component: "Link",
+          children: [
+            { type: "text", value: "Click here to adore more kittens" },
+          ],
         },
       ],
     ],

--- a/packages/sdk-components-react-remix/src/metas.ts
+++ b/packages/sdk-components-react-remix/src/metas.ts
@@ -1,1 +1,3 @@
+export { meta as Link } from "./link.ws";
+export { meta as RichTextLink } from "./rich-text-link.ws";
 export { meta as Form } from "./form.ws";

--- a/packages/sdk-components-react-remix/src/props.ts
+++ b/packages/sdk-components-react-remix/src/props.ts
@@ -1,3 +1,3 @@
-export { propsMeta as Form } from "./form.ws";
 export { propsMeta as Link } from "./link.ws";
 export { propsMeta as RichTextLink } from "./rich-text-link.ws";
+export { propsMeta as Form } from "./form.ws";

--- a/packages/sdk/src/instances-utils.test.ts
+++ b/packages/sdk/src/instances-utils.test.ts
@@ -3,6 +3,7 @@ import type { Instance, Instances } from "./schema/instances";
 import {
   findTreeInstanceIds,
   findTreeInstanceIdsExcludingSlotDescendants,
+  parseComponentName,
 } from "./instances-utils";
 
 const createInstance = (
@@ -67,4 +68,9 @@ test("find all tree instances excluding slot descendants", () => {
   expect(
     findTreeInstanceIdsExcludingSlotDescendants(instances, "box1")
   ).toEqual(new Set(["box1", "box12", "slot11"]));
+});
+
+test("extract short name and namespace from component name", () => {
+  expect(parseComponentName("Box")).toEqual([undefined, "Box"]);
+  expect(parseComponentName("radix:Box")).toEqual(["radix", "Box"]);
 });

--- a/packages/sdk/src/instances-utils.ts
+++ b/packages/sdk/src/instances-utils.ts
@@ -44,3 +44,15 @@ export const findTreeInstanceIdsExcludingSlotDescendants = (
   });
   return ids;
 };
+
+export const parseComponentName = (componentName: string) => {
+  const parts = componentName.split(":");
+  let namespace: undefined | string;
+  let name: string;
+  if (parts.length === 1) {
+    [name] = parts;
+  } else {
+    [namespace, name] = parts;
+  }
+  return [namespace, name] as const;
+};


### PR DESCRIPTION
Here replaced Object.assign logic with overriding components at build time. This will simplify migration to jsx generator and let bundler load less components.

Changed fixture to include link from remix overrides.

<img width="487" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5635476/8ba87f70-9edd-4b92-bf28-8457eea3b5c9">

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
