### PR TITLE
Fix local install of cli binaries

### DIFF
--- a/fixtures/webstudio-remix-vercel/README.md
+++ b/fixtures/webstudio-remix-vercel/README.md
@@ -10,12 +10,12 @@ pnpm dev
 
 ```bash
 # Terminal 2
-pnpm webstudio link
+pnpm webstudio-cli link
 # add following link https://webstudio-builder-git-main-webstudio-is.vercel.app/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview
 
-pnpm webstudio sync
+pnpm webstudio-cli sync
 # data.json generated
 
-pnpm webstudio build --preview && pnpm prettier --write ./app/
+pnpm webstudio-cli build --preview && pnpm prettier --write ./app/
 # exec `pnpm run dev` to see result
 ```

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -1,4 +1,3 @@
 #!/usr/bin/env node --experimental-specifier-resolution=node --no-warnings
-"use strict";
 // eslint-disable-next-line import/no-internal-modules
 import "./lib/bin";

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node --experimental-specifier-resolution=node --no-warnings
+"use strict";
+// eslint-disable-next-line import/no-internal-modules
+import "./lib/bin";

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node --experimental-specifier-resolution=node --no-warnings
 // eslint-disable-next-line import/no-internal-modules
-import "./lib/bin";
+import "./lib/bin.js";

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "bin": {
-    "webstudio-cli": "./lib/bin.js"
+    "webstudio-cli": "./bin.js"
   },
   "files": [
     "lib/*",


### PR DESCRIPTION
## Description

Fixes local installation of cli 
The issue was that at `pnpm install` 
`./lib/bin.js` wasn't exists.

Solution is to create it and forward all calls to `./lib/bin`


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
