### PR TITLE
Throw error message if the project config is missing in the users env when using cli

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -38,7 +38,7 @@ export const main = async () => {
         alias: "help",
         type: "boolean",
       })
-      .scriptName("webstudio")
+      .scriptName("webstudio-cli")
       .usage(
         `Webstudio CLI (${packageJson.version}) allows you to setup, sync, build and preview your project.`
       );

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -3,6 +3,7 @@ import { cwd } from "node:process";
 import { join } from "node:path";
 import ora from "ora";
 import { loadProjectDataById } from "@webstudio-is/http-client";
+import pc from "picocolors";
 
 import { ensureFileInPath, loadJSONFile } from "../fs-utils";
 import {
@@ -40,7 +41,7 @@ export const sync = async () => {
 
   if (projectConfig === undefined) {
     spinner.fail(
-      `Project config is not found. Please make sure the project is linked. \n Use webstudio link command to link your project`
+      `Project config is not found, please run ${pc.dim("webstudio-cli link")}`
     );
     return;
   }

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -36,7 +36,16 @@ export const sync = async () => {
     return;
   }
 
-  const { host, token } = globalConfig[localConfig.projectId];
+  const projectConfig = globalConfig[localConfig.projectId];
+
+  if (projectConfig === undefined) {
+    spinner.fail(
+      `Project config is not found. Please make sure the project is linked. \n Use webstudio link command to link your project`
+    );
+    return;
+  }
+
+  const { host, token } = projectConfig;
 
   spinner.text = "Loading project data from webstudio\n";
   const project = await loadProjectDataById({


### PR DESCRIPTION
…when using cli

## Description

Adds a error message when the project config like, `host` and `token` are missing from the root.

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)