### PR TITLE
Add jsx component generator

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -23,6 +23,7 @@
     "jest": "^29.6.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "strip-indent": "^4.0.0",
     "type-fest": "^4.3.1",
     "typescript": "5.2.2",
     "zod": "^3.21.4"

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -1,0 +1,578 @@
+import { expect, test } from "@jest/globals";
+import stripIndent from "strip-indent";
+import { createScope, type Instance, type Prop } from "@webstudio-is/sdk";
+import { showAttribute } from "./tree/webstudio-component";
+import {
+  generateJsxChildren,
+  generateJsxElement,
+  generatePageComponent,
+} from "./component-generator";
+
+const clear = (input: string) =>
+  stripIndent(input).trimStart().replace(/ +$/, "");
+
+const createInstance = (
+  id: Instance["id"],
+  component: string,
+  children: Instance["children"]
+): Instance => {
+  return { type: "instance", id, component, children };
+};
+
+const createInstancePair = (
+  id: Instance["id"],
+  component: string,
+  children: Instance["children"]
+): [Instance["id"], Instance] => {
+  return [id, createInstance(id, component, children)];
+};
+
+const createPropPair = (prop: Prop): [Prop["id"], Prop] => {
+  return [prop.id, prop];
+};
+
+test("generate jsx element with children and without them", () => {
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("body", "Body", [
+        { type: "id", value: "childId" },
+      ]),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+      children: "Children\n",
+    })
+  ).toEqual(
+    clear(`
+      <Body
+      data-ws-id="body"
+      data-ws-component="Body">
+      Children
+      </Body>
+    `)
+  );
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("image", "Image", []),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+      children: "Children\n",
+    })
+  ).toEqual(
+    clear(`
+      <Image
+      data-ws-id="image"
+      data-ws-component="Image" />
+    `)
+  );
+});
+
+test("generate jsx element with namespaces components", () => {
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("body", "@webstudio-is/library:Body", [
+        { type: "id", value: "childId" },
+      ]),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+      children: "Children\n",
+    })
+  ).toEqual(
+    clear(`
+      <Body
+      data-ws-id="body"
+      data-ws-component="@webstudio-is/library:Body">
+      Children
+      </Body>
+    `)
+  );
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("image", "@webstudio-is/library:Image", []),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+      children: "Children\n",
+    })
+  ).toEqual(
+    clear(`
+      <Image
+      data-ws-id="image"
+      data-ws-component="@webstudio-is/library:Image" />
+    `)
+  );
+});
+
+test("generate jsx element with literal props", () => {
+  const props = new Map([
+    createPropPair({
+      id: "1",
+      instanceId: "body",
+      type: "string",
+      name: "string",
+      value: "string",
+    }),
+    createPropPair({
+      id: "2",
+      instanceId: "body",
+      type: "number",
+      name: "number",
+      value: 0,
+    }),
+    createPropPair({
+      id: "3",
+      instanceId: "image",
+      type: "boolean",
+      name: "boolean",
+      value: true,
+    }),
+    createPropPair({
+      id: "4",
+      instanceId: "image",
+      type: "string[]",
+      name: "stringArray",
+      value: ["value1", "value2"],
+    }),
+  ]);
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("body", "Body", [
+        { type: "id", value: "image" },
+      ]),
+      props,
+      indexesWithinAncestors: new Map(),
+      children: "Children\n",
+    })
+  ).toEqual(
+    clear(`
+      <Body
+      data-ws-id="body"
+      data-ws-component="Body"
+      string={"string"}
+      number={0}>
+      Children
+      </Body>
+    `)
+  );
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("image", "Image", []),
+      props,
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      <Image
+      data-ws-id="image"
+      data-ws-component="Image"
+      boolean={true}
+      stringArray={["value1","value2"]} />
+    `)
+  );
+});
+
+test("ignore asset and page props", () => {
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("box", "Box", []),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "box",
+          type: "page",
+          name: "page",
+          value: "pageId",
+        }),
+        createPropPair({
+          id: "2",
+          instanceId: "box",
+          type: "asset",
+          name: "asset",
+          value: "assetId",
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      <Box
+      data-ws-id="box"
+      data-ws-component="Box" />
+    `)
+  );
+});
+
+test("generate jsx element with data sources and action", () => {
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("box", "Box", []),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "box",
+          type: "dataSource",
+          name: "variable",
+          value: "variableId",
+        }),
+        createPropPair({
+          id: "2",
+          instanceId: "box",
+          type: "dataSource",
+          name: "expression",
+          value: "expressionId",
+        }),
+        createPropPair({
+          id: "3",
+          instanceId: "box",
+          type: "action",
+          name: "onClick",
+          value: [{ type: "execute", args: [], code: `variableName = 1` }],
+        }),
+        createPropPair({
+          id: "4",
+          instanceId: "box",
+          type: "action",
+          name: "onChange",
+          value: [
+            { type: "execute", args: ["value"], code: `variableName = value` },
+            { type: "execute", args: ["value"], code: `variableName = value` },
+          ],
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      <Box
+      data-ws-id="box"
+      data-ws-component="Box"
+      variable={$ws$dataSource$variableId}
+      expression={$ws$dataSource$expressionId}
+      onClick={onClick}
+      onChange={onChange} />
+    `)
+  );
+});
+
+test("generate jsx element with condition based on show prop", () => {
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("box", "Box", []),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "box",
+          type: "boolean",
+          name: showAttribute,
+          value: true,
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      <Box
+      data-ws-id="box"
+      data-ws-component="Box" />
+    `)
+  );
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("box", "Box", []),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "box",
+          type: "boolean",
+          name: showAttribute,
+          value: false,
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual("");
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("box", "Box", []),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "box",
+          type: "dataSource",
+          name: showAttribute,
+          value: "condition",
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      {$ws$dataSource$condition &&
+      <Box
+      data-ws-id="box"
+      data-ws-component="Box" />
+      }
+    `)
+  );
+});
+
+test("generate jsx element with index prop", () => {
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("box", "Box", []),
+      props: new Map(),
+      indexesWithinAncestors: new Map([["box", 5]]),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      <Box
+      data-ws-id="box"
+      data-ws-component="Box"
+      data-ws-index="5" />
+    `)
+  );
+});
+
+test("generate jsx children with text", () => {
+  expect(
+    generateJsxChildren({
+      scope: createScope(),
+      children: [
+        { type: "text", value: "Some\ntext" },
+        { type: "text", value: 'Escaped "text"' },
+      ],
+      instances: new Map(),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+    })
+  ).toEqual(
+    clear(`
+      {"Some"}
+      <br />
+      {"text"}
+      {"Escaped \\"text\\""}
+    `)
+  );
+});
+
+test("generate jsx children with nested instances", () => {
+  expect(
+    generateJsxChildren({
+      scope: createScope(),
+      children: [{ type: "id", value: "form" }],
+      instances: new Map([
+        createInstancePair("form", "Form", [
+          { type: "id", value: "input" },
+          { type: "id", value: "button" },
+        ]),
+        createInstancePair("input", "Input", []),
+        createInstancePair("button", "Button", []),
+      ]),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "form",
+          name: "prop",
+          type: "string",
+          value: "value",
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+    })
+  ).toEqual(
+    clear(`
+    <Form
+    data-ws-id="form"
+    data-ws-component="Form"
+    prop={"value"}>
+    <Input
+    data-ws-id="input"
+    data-ws-component="Input" />
+    <Button
+    data-ws-id="button"
+    data-ws-component="Button" />
+    </Form>
+    `)
+  );
+});
+
+test("deduplicate base and namespaced components with same short name", () => {
+  expect(
+    generateJsxChildren({
+      scope: createScope(),
+      children: [
+        { type: "id", value: "button1" },
+        { type: "id", value: "button2" },
+      ],
+      instances: new Map([
+        createInstancePair("button1", "Button", []),
+        createInstancePair(
+          "button2",
+          "@webstudio-is/sdk-component-react-radix:Button",
+          []
+        ),
+      ]),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+    })
+  ).toEqual(
+    clear(`
+    <Button
+    data-ws-id="button1"
+    data-ws-component="Button" />
+    <Button_1
+    data-ws-id="button2"
+    data-ws-component="@webstudio-is/sdk-component-react-radix:Button" />
+    `)
+  );
+});
+
+test("generate page component", () => {
+  expect(
+    generatePageComponent({
+      scope: createScope(),
+      rootInstanceId: "body",
+      instances: new Map([
+        createInstancePair("body", "Body", [{ type: "id", value: "input" }]),
+        createInstancePair("input", "Input", []),
+      ]),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "input",
+          name: "value",
+          type: "dataSource",
+          value: "variable",
+        }),
+        createPropPair({
+          id: "2",
+          instanceId: "input",
+          name: "onChange",
+          type: "action",
+          value: [
+            {
+              type: "execute",
+              args: ["value"],
+              code: `$ws$dataSource$variable = value`,
+            },
+          ],
+        }),
+      ]),
+      indexesWithinAncestors: new Map([["input", 0]]),
+    })
+  ).toEqual(
+    clear(`
+      export const Page = (props: { scripts: ReactNode }) => {
+      const { dataSourceValuesStore, setDataSourceValues, executeEffectfulExpression } = useContext(ReactSdkContext);
+      const dataSourceValues = useStore(dataSourceValuesStore);
+      const $ws$dataSource$variable = dataSourceValues.get("variable");
+      const onChange = (value: unknown) => {
+      const newValues = executeEffectfulExpression(
+      value.code,
+      new Map([["value", value]]),
+      dataSourceValues
+      );
+      setDataSourceValues(newValues);
+      };
+      return <Body
+      data-ws-id="body"
+      data-ws-component="Body">
+      <Input
+      data-ws-id="input"
+      data-ws-component="Input"
+      data-ws-index="0"
+      value={$ws$dataSource$variable}
+      onChange={onChange} />
+      {props.scripts}
+      </Body>
+      };
+    `)
+  );
+});
+
+test("deduplicate action names", () => {
+  expect(
+    generatePageComponent({
+      scope: createScope(),
+      rootInstanceId: "body",
+      instances: new Map([
+        createInstancePair("body", "Body", [
+          { type: "id", value: "button1" },
+          { type: "id", value: "button2" },
+        ]),
+        createInstancePair("button1", "Button", []),
+        createInstancePair("button2", "Button", []),
+      ]),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "button1",
+          name: "onChange",
+          type: "action",
+          value: [{ type: "execute", args: [], code: "" }],
+        }),
+        createPropPair({
+          id: "2",
+          instanceId: "button2",
+          name: "onChange",
+          type: "action",
+          value: [{ type: "execute", args: [], code: "" }],
+        }),
+      ]),
+      indexesWithinAncestors: new Map([["input", 0]]),
+    })
+  ).toEqual(
+    clear(`
+      export const Page = (props: { scripts: ReactNode }) => {
+      const { dataSourceValuesStore, setDataSourceValues, executeEffectfulExpression } = useContext(ReactSdkContext);
+      const dataSourceValues = useStore(dataSourceValuesStore);
+      const onChange = () => {
+      const newValues = executeEffectfulExpression(
+      value.code,
+      new Map([]),
+      dataSourceValues
+      );
+      setDataSourceValues(newValues);
+      };
+      const onChange_1 = () => {
+      const newValues = executeEffectfulExpression(
+      value.code,
+      new Map([]),
+      dataSourceValues
+      );
+      setDataSourceValues(newValues);
+      };
+      return <Body
+      data-ws-id="body"
+      data-ws-component="Body">
+      <Button
+      data-ws-id="button1"
+      data-ws-component="Button"
+      onChange={onChange} />
+      <Button
+      data-ws-id="button2"
+      data-ws-component="Button"
+      onChange={onChange_1} />
+      {props.scripts}
+      </Body>
+      };
+    `)
+  );
+});

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -1,0 +1,260 @@
+import type { Instances, Instance, Props, Scope } from "@webstudio-is/sdk";
+import { findTreeInstanceIds, parseComponentName } from "@webstudio-is/sdk";
+import {
+  componentAttribute,
+  idAttribute,
+  indexAttribute,
+  showAttribute,
+} from "./tree/webstudio-component";
+import { encodeDataSourceVariable } from "./expression";
+import type { IndexesWithinAncestors } from "./instance-utils";
+
+export const generateJsxElement = ({
+  scope,
+  instance,
+  props,
+  indexesWithinAncestors,
+  children,
+}: {
+  scope: Scope;
+  instance: Instance;
+  props: Props;
+  indexesWithinAncestors: IndexesWithinAncestors;
+  children: string;
+}) => {
+  let conditionVariableName: undefined | string;
+
+  let generatedProps = "";
+
+  // id and component props are always defined for styles
+  generatedProps += `\n${idAttribute}=${JSON.stringify(instance.id)}`;
+  generatedProps += `\n${componentAttribute}=${JSON.stringify(
+    instance.component
+  )}`;
+  const index = indexesWithinAncestors.get(instance.id);
+  if (index !== undefined) {
+    generatedProps += `\n${indexAttribute}="${index}"`;
+  }
+
+  for (const prop of props.values()) {
+    if (prop.instanceId !== instance.id) {
+      continue;
+    }
+    // show prop controls conditional rendering and need to be handled separately
+    if (prop.name === showAttribute) {
+      // prevent instance rendering when hidden
+      if (prop.type === "boolean" && prop.value === false) {
+        return "";
+      }
+      if (prop.type === "dataSource") {
+        const dataSourceId = prop.value;
+        conditionVariableName = encodeDataSourceVariable(dataSourceId);
+      }
+      // ignore any other values
+      continue;
+    }
+    if (
+      prop.type === "string" ||
+      prop.type === "number" ||
+      prop.type === "boolean" ||
+      prop.type === "string[]"
+    ) {
+      generatedProps += `\n${prop.name}={${JSON.stringify(prop.value)}}`;
+      continue;
+    }
+    // ignore asset and page props which are handled by components internally
+    if (prop.type === "asset" || prop.type === "page") {
+      continue;
+    }
+    if (prop.type === "dataSource") {
+      const dataSourceId = prop.value;
+      const dataSourceVariable = encodeDataSourceVariable(dataSourceId);
+      generatedProps += `\n${prop.name}={${dataSourceVariable}}`;
+      continue;
+    }
+    if (prop.type === "action") {
+      const propVariable = scope.getName(prop.id, prop.name);
+      generatedProps += `\n${prop.name}={${propVariable}}`;
+      continue;
+    }
+    prop satisfies never;
+  }
+
+  let generatedElement = "";
+  // coditionally render instance when show prop is data source
+  // {dataSourceVariable && <Instance>}
+  if (conditionVariableName) {
+    generatedElement += `{${conditionVariableName} &&\n`;
+  }
+
+  const [_namespace, shortName] = parseComponentName(instance.component);
+  const componentVariable = scope.getName(instance.component, shortName);
+  if (instance.children.length === 0) {
+    generatedElement += `<${componentVariable}${generatedProps} />\n`;
+  } else {
+    generatedElement += `<${componentVariable}${generatedProps}>\n`;
+    generatedElement += children;
+    generatedElement += `</${componentVariable}>\n`;
+  }
+
+  if (conditionVariableName) {
+    generatedElement += `}\n`;
+  }
+
+  return generatedElement;
+};
+
+/**
+ * Jsx element and children are generated separately to be able
+ * to inject some scripts into Body if necessary
+ */
+export const generateJsxChildren = ({
+  scope,
+  children,
+  instances,
+  props,
+  indexesWithinAncestors,
+}: {
+  scope: Scope;
+  children: Instance["children"];
+  instances: Instances;
+  props: Props;
+  indexesWithinAncestors: IndexesWithinAncestors;
+}) => {
+  let generatedChildren = "";
+  for (const child of children) {
+    if (child.type === "text") {
+      // instance text can contain newlines
+      // convert them too <br> tag
+      generatedChildren += child.value
+        .split("\n")
+        .map((line) => `{${JSON.stringify(line)}}\n`)
+        .join(`<br />\n`);
+      continue;
+    }
+    if (child.type === "id") {
+      const instanceId = child.value;
+      const instance = instances.get(instanceId);
+      if (instance === undefined) {
+        continue;
+      }
+      generatedChildren += generateJsxElement({
+        scope,
+        instance,
+        props,
+        indexesWithinAncestors,
+        children: generateJsxChildren({
+          scope,
+          children: instance.children,
+          instances,
+          props,
+          indexesWithinAncestors,
+        }),
+      });
+      continue;
+    }
+    child satisfies never;
+  }
+  return generatedChildren;
+};
+
+const generateDataSources = ({
+  scope,
+  rootInstanceId,
+  instances,
+  props,
+}: {
+  scope: Scope;
+  rootInstanceId: Instance["id"];
+  instances: Instances;
+  props: Props;
+}) => {
+  let generatedDataSources = "";
+  generatedDataSources += `const { dataSourceValuesStore, setDataSourceValues, executeEffectfulExpression } = useContext(ReactSdkContext);\n`;
+  generatedDataSources +=
+    "const dataSourceValues = useStore(dataSourceValuesStore);\n";
+  const usedInstanceIds = findTreeInstanceIds(instances, rootInstanceId);
+  for (const prop of props.values()) {
+    if (prop.type === "dataSource" && usedInstanceIds.has(prop.instanceId)) {
+      const dataSourceId = prop.value;
+      const variableName = encodeDataSourceVariable(dataSourceId);
+      const key = JSON.stringify(dataSourceId);
+      generatedDataSources += `const ${variableName} = dataSourceValues.get(${key});\n`;
+    }
+    if (prop.type === "action") {
+      const propVariable = scope.getName(prop.id, prop.name);
+      let args = "";
+      for (const value of prop.value) {
+        const newArgs = value.args.map((arg) => `${arg}: unknown`).join(", ");
+        // skip execution when arguments do not match
+        if (args !== "" && newArgs !== args) {
+          continue;
+        }
+        args = newArgs;
+      }
+      generatedDataSources += `const ${propVariable} = (${args}) => {\n`;
+      for (const value of prop.value) {
+        if (value.type === "execute") {
+          generatedDataSources += `const newValues = executeEffectfulExpression(\n`;
+          generatedDataSources += `value.code,\n`;
+          generatedDataSources += `new Map([`;
+          generatedDataSources += value.args
+            .map((arg) => `[${JSON.stringify(arg)}, ${arg}]`)
+            .join(", ");
+          generatedDataSources += `]),\n`;
+          generatedDataSources += `dataSourceValues\n`;
+          generatedDataSources += `);\n`;
+          generatedDataSources += `setDataSourceValues(newValues);\n`;
+        }
+      }
+      generatedDataSources += `};\n`;
+    }
+  }
+  return generatedDataSources;
+};
+
+export const generatePageComponent = ({
+  scope,
+  rootInstanceId,
+  instances,
+  props,
+  indexesWithinAncestors,
+}: {
+  scope: Scope;
+  rootInstanceId: Instance["id"];
+  instances: Instances;
+  props: Props;
+  indexesWithinAncestors: IndexesWithinAncestors;
+}) => {
+  const instance = instances.get(rootInstanceId);
+  if (instance === undefined) {
+    return "";
+  }
+  const generatedDataSources = generateDataSources({
+    scope,
+    rootInstanceId,
+    instances,
+    props,
+  });
+  const generatedJsx = generateJsxElement({
+    scope,
+    instance,
+    props,
+    indexesWithinAncestors,
+    children:
+      generateJsxChildren({
+        scope,
+        children: instance.children,
+        instances,
+        props,
+        indexesWithinAncestors,
+      }) + "{props.scripts}\n",
+  });
+
+  let generatedComponent = "";
+  generatedComponent += `export const Page = (props: { scripts: ReactNode }) => {\n`;
+  generatedComponent += `${generatedDataSources}`;
+  generatedComponent += `return ${generatedJsx}`;
+  generatedComponent += `};\n`;
+  return generatedComponent;
+};

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -38,3 +38,4 @@ export { renderComponentTemplate } from "./component-renderer";
 export { getIndexesWithinAncestors } from "./instance-utils";
 export * from "./hook";
 export { generateUtilsExport } from "./generator";
+export { generatePageComponent } from "./component-generator";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1304,6 +1304,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      strip-indent:
+        specifier: ^4.0.0
+        version: 4.0.0
       type-fest:
         specifier: ^4.3.1
         version: 4.3.1
@@ -15470,7 +15473,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       min-indent: 1.0.1
-    dev: false
 
   /strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}


### PR DESCRIPTION
Here added jsx component generator. It allows us to have less tree traversing and more clear output for debugging.

For now data sources are managed the old way with stores. In the future we can switch to react `useState`.

In the future will be integrated into stories generator and cli

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
