### PR TITLE
Make route-templates typeable

### DIFF
--- a/fixtures/webstudio-remix-vercel/app/constants.ts
+++ b/fixtures/webstudio-remix-vercel/app/constants.ts
@@ -1,0 +1,2 @@
+export const assetBaseUrl = "/assets/";
+export const imageBaseUrl = "/assets/";

--- a/fixtures/webstudio-remix-vercel/app/routes/[blog].[page].[deep-nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[blog].[page].[deep-nested-page]._index.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
 import {
-  V2_MetaFunction,
-  LinksFunction,
-  LinkDescriptor,
-  ActionArgs,
+  type V2_MetaFunction,
+  type LinksFunction,
+  type LinkDescriptor,
+  type ActionArgs,
   json,
 } from "@remix-run/node";
 
@@ -24,6 +24,7 @@ import {
 } from "../__generated__/[blog].[page].[deep-nested-page]._index.tsx";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
+import { assetBaseUrl, imageBaseUrl } from "~/constants.ts";
 
 export type PageData = Omit<Data, "build"> & {
   build: Pick<Data["build"], "props" | "instances" | "dataSources">;
@@ -46,7 +47,7 @@ export const links: LinksFunction = () => {
     if (asset.type === "font") {
       result.push({
         rel: "preload",
-        href: "/assets/" + asset.name,
+        href: assetBaseUrl + asset.name,
         as: "font",
         crossOrigin: "anonymous",
         // @todo add mimeType
@@ -146,9 +147,6 @@ const Outlet = () => {
       status: 404,
     });
   }
-
-  const assetBaseUrl = "/assets/";
-  const imageBaseUrl = "/assets/";
 
   const params: Params = {
     assetBaseUrl,

--- a/fixtures/webstudio-remix-vercel/app/routes/[blog].[page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[blog].[page]._index.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
 import {
-  V2_MetaFunction,
-  LinksFunction,
-  LinkDescriptor,
-  ActionArgs,
+  type V2_MetaFunction,
+  type LinksFunction,
+  type LinkDescriptor,
+  type ActionArgs,
   json,
 } from "@remix-run/node";
 
@@ -24,6 +24,7 @@ import {
 } from "../__generated__/[blog].[page]._index.tsx";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
+import { assetBaseUrl, imageBaseUrl } from "~/constants.ts";
 
 export type PageData = Omit<Data, "build"> & {
   build: Pick<Data["build"], "props" | "instances" | "dataSources">;
@@ -46,7 +47,7 @@ export const links: LinksFunction = () => {
     if (asset.type === "font") {
       result.push({
         rel: "preload",
-        href: "/assets/" + asset.name,
+        href: assetBaseUrl + asset.name,
         as: "font",
         crossOrigin: "anonymous",
         // @todo add mimeType
@@ -146,9 +147,6 @@ const Outlet = () => {
       status: 404,
     });
   }
-
-  const assetBaseUrl = "/assets/";
-  const imageBaseUrl = "/assets/";
 
   const params: Params = {
     assetBaseUrl,

--- a/fixtures/webstudio-remix-vercel/app/routes/[blog]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[blog]._index.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
 import {
-  V2_MetaFunction,
-  LinksFunction,
-  LinkDescriptor,
-  ActionArgs,
+  type V2_MetaFunction,
+  type LinksFunction,
+  type LinkDescriptor,
+  type ActionArgs,
   json,
 } from "@remix-run/node";
 
@@ -24,6 +24,7 @@ import {
 } from "../__generated__/[blog]._index.tsx";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
+import { assetBaseUrl, imageBaseUrl } from "~/constants.ts";
 
 export type PageData = Omit<Data, "build"> & {
   build: Pick<Data["build"], "props" | "instances" | "dataSources">;
@@ -46,7 +47,7 @@ export const links: LinksFunction = () => {
     if (asset.type === "font") {
       result.push({
         rel: "preload",
-        href: "/assets/" + asset.name,
+        href: assetBaseUrl + asset.name,
         as: "font",
         crossOrigin: "anonymous",
         // @todo add mimeType
@@ -146,9 +147,6 @@ const Outlet = () => {
       status: 404,
     });
   }
-
-  const assetBaseUrl = "/assets/";
-  const imageBaseUrl = "/assets/";
 
   const params: Params = {
     assetBaseUrl,

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
 import {
-  V2_MetaFunction,
-  LinksFunction,
-  LinkDescriptor,
-  ActionArgs,
+  type V2_MetaFunction,
+  type LinksFunction,
+  type LinkDescriptor,
+  type ActionArgs,
   json,
 } from "@remix-run/node";
 
@@ -24,6 +24,7 @@ import {
 } from "../__generated__/[radix]._index.tsx";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
+import { assetBaseUrl, imageBaseUrl } from "~/constants.ts";
 
 export type PageData = Omit<Data, "build"> & {
   build: Pick<Data["build"], "props" | "instances" | "dataSources">;
@@ -46,7 +47,7 @@ export const links: LinksFunction = () => {
     if (asset.type === "font") {
       result.push({
         rel: "preload",
-        href: "/assets/" + asset.name,
+        href: assetBaseUrl + asset.name,
         as: "font",
         crossOrigin: "anonymous",
         // @todo add mimeType
@@ -146,9 +147,6 @@ const Outlet = () => {
       status: 404,
     });
   }
-
-  const assetBaseUrl = "/assets/";
-  const imageBaseUrl = "/assets/";
 
   const params: Params = {
     assetBaseUrl,

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
 import {
-  V2_MetaFunction,
-  LinksFunction,
-  LinkDescriptor,
-  ActionArgs,
+  type V2_MetaFunction,
+  type LinksFunction,
+  type LinkDescriptor,
+  type ActionArgs,
   json,
 } from "@remix-run/node";
 
@@ -24,6 +24,7 @@ import {
 } from "../__generated__/_index.tsx";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
+import { assetBaseUrl, imageBaseUrl } from "~/constants.ts";
 
 export type PageData = Omit<Data, "build"> & {
   build: Pick<Data["build"], "props" | "instances" | "dataSources">;
@@ -46,7 +47,7 @@ export const links: LinksFunction = () => {
     if (asset.type === "font") {
       result.push({
         rel: "preload",
-        href: "/assets/" + asset.name,
+        href: assetBaseUrl + asset.name,
         as: "font",
         crossOrigin: "anonymous",
         // @todo add mimeType
@@ -146,9 +147,6 @@ const Outlet = () => {
       status: 404,
     });
   }
-
-  const assetBaseUrl = "/assets/";
-  const imageBaseUrl = "/assets/";
 
   const params: Params = {
     assetBaseUrl,

--- a/packages/cli/__generated__/index.ts
+++ b/packages/cli/__generated__/index.ts
@@ -1,0 +1,56 @@
+/**
+ * The only intent of this file is to support typings inside ../templates/route-template for easier development.
+ **/
+import type { PageData } from "../templates/route-template";
+import type { Components } from "@webstudio-is/react-sdk";
+import type { Asset } from "@webstudio-is/sdk";
+
+export const components = new Map() as Components;
+
+export const fontAssets: Asset[] = [];
+
+export const pageData: PageData = {
+  build: {
+    props: [],
+    instances: [],
+    dataSources: [],
+  },
+  pages: [],
+
+  page: {
+    id: "",
+    name: "",
+    title: "",
+    meta: {},
+    rootInstanceId: "",
+    path: "",
+  },
+  assets: [],
+};
+
+export const user: { email: string | null } | undefined = {
+  email: "email@domain",
+};
+export const projectId = "project-id";
+
+const indexesWithinAncestors = new Map<string, number>([]);
+
+const executeComputingExpressions = (
+  variables: Map<string, unknown>
+): Map<string, unknown> => {
+  return new Map();
+};
+
+const executeEffectfulExpression = (
+  code: string,
+  args: Map<string, unknown>,
+  variables: Map<string, unknown>
+): Map<string, unknown> => {
+  return new Map();
+};
+
+export const utils = {
+  indexesWithinAncestors,
+  executeComputingExpressions,
+  executeEffectfulExpression,
+};

--- a/packages/cli/src/__generated__/router.ts
+++ b/packages/cli/src/__generated__/router.ts
@@ -5,15 +5,13 @@ If needed to make any changes. Add them to ./templates folder and run pnpm run b
 
 */
 
-import { ASSETS_BASE } from "../config";
-
 export const getRouteTemplate = () => {
   return `/* eslint-disable camelcase */
 import {
-  V2_MetaFunction,
-  LinksFunction,
-  LinkDescriptor,
-  ActionArgs,
+  type V2_MetaFunction,
+  type LinksFunction,
+  type LinkDescriptor,
+  type ActionArgs,
   json,
 } from "@remix-run/node";
 
@@ -34,6 +32,7 @@ import {
 } from "../__generated__/index";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
+import { assetBaseUrl, imageBaseUrl } from "~/constants.ts";
 
 export type PageData = Omit<Data, "build"> & {
   build: Pick<Data["build"], "props" | "instances" | "dataSources">;
@@ -56,7 +55,7 @@ export const links: LinksFunction = () => {
     if (asset.type === "font") {
       result.push({
         rel: "preload",
-        href: "${ASSETS_BASE}" + asset.name,
+        href: assetBaseUrl + asset.name,
         as: "font",
         crossOrigin: "anonymous",
         // @todo add mimeType
@@ -156,9 +155,6 @@ const Outlet = () => {
       status: 404,
     });
   }
-
-  const assetBaseUrl = "${ASSETS_BASE}";
-  const imageBaseUrl = "${ASSETS_BASE}";
 
   const params: Params = {
     assetBaseUrl,

--- a/packages/cli/src/__generated__/templates.ts
+++ b/packages/cli/src/__generated__/templates.ts
@@ -45,6 +45,13 @@ export const templates: Record<ProjectTarget, Folder> = {
         name: "app",
         files: [
           {
+            name: "constants.ts",
+            content:
+              'export const assetBaseUrl = "/assets/";\nexport const imageBaseUrl = "/assets/";\n',
+            encoding: "utf-8",
+            merge: false,
+          },
+          {
             name: "root.tsx",
             content:
               'export { Root as default } from "@webstudio-is/react-sdk";\n',

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -11,6 +11,7 @@ export const GLOBAL_CONFIG_FILE = join(
 export const LOCAL_CONFIG_FILE = ".webstudio/config.json";
 export const LOCAL_DATA_FILE = ".webstudio/data.json";
 
+// @todo remove
 export const ASSETS_BASE = "/assets/";
 
 export type LocalConfig = {

--- a/packages/cli/templates/build.ts
+++ b/packages/cli/templates/build.ts
@@ -117,10 +117,10 @@ If needed to make any changes. Add them to ./templates folder and run pnpm run b
 
 */
 
-import { ASSETS_BASE } from "../config";
+
 
 export const getRouteTemplate = () => {
-  return \`${routeTemplateFile.replace(/ASSETS_BASE/g, '"${ASSETS_BASE}"')}\`
+  return \`${routeTemplateFile}\`
   }`;
 
 await ensureFileInPath(ROUTER_TEMPLATE_PATH, routeTemplateContent);

--- a/packages/cli/templates/defaults/app/constants.ts
+++ b/packages/cli/templates/defaults/app/constants.ts
@@ -1,0 +1,2 @@
+export const assetBaseUrl = "/assets/";
+export const imageBaseUrl = "/assets/";

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
 import {
-  V2_MetaFunction,
-  LinksFunction,
-  LinkDescriptor,
-  ActionArgs,
+  type V2_MetaFunction,
+  type LinksFunction,
+  type LinkDescriptor,
+  type ActionArgs,
   json,
 } from "@remix-run/node";
 
@@ -24,6 +24,7 @@ import {
 } from "../__generated__/index";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
+import { assetBaseUrl, imageBaseUrl } from "~/constants.ts";
 
 export type PageData = Omit<Data, "build"> & {
   build: Pick<Data["build"], "props" | "instances" | "dataSources">;
@@ -46,7 +47,7 @@ export const links: LinksFunction = () => {
     if (asset.type === "font") {
       result.push({
         rel: "preload",
-        href: ASSETS_BASE + asset.name,
+        href: assetBaseUrl + asset.name,
         as: "font",
         crossOrigin: "anonymous",
         // @todo add mimeType
@@ -146,9 +147,6 @@ const Outlet = () => {
       status: 404,
     });
   }
-
-  const assetBaseUrl = ASSETS_BASE;
-  const imageBaseUrl = ASSETS_BASE;
 
   const params: Params = {
     assetBaseUrl,

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "@webstudio-is/tsconfig/base.json",
-  "exclude": ["./templates/*"],
   "compilerOptions": {
-    "module": "esnext"
+    "module": "esnext",
+    "paths": {
+      "~/constants.ts": ["./templates/defaults/app/constants.ts"]
+    }
   }
 }


### PR DESCRIPTION
## Description

Now route-templates is normal ts file. And can be typechecked

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
