### PR TITLE
Add vercelignore to templates

### DIFF
--- a/fixtures/webstudio-remix-vercel/.vercelignore
+++ b/fixtures/webstudio-remix-vercel/.vercelignore
@@ -1,0 +1,8 @@
+node_modules
+
+.cache
+.env
+.vercel
+.webstudio
+build
+public/build

--- a/packages/cli/src/__generated__/templates.ts
+++ b/packages/cli/src/__generated__/templates.ts
@@ -12,6 +12,13 @@ export const templates: Record<ProjectTarget, Folder> = {
     name: "defaults",
     files: [
       {
+        name: ".vercelignore",
+        content:
+          "node_modules\n\n.cache\n.env\n.vercel\n.webstudio\nbuild\npublic/build\n",
+        encoding: "utf-8",
+        merge: false,
+      },
+      {
         name: "package.json",
         content:
           '{\n  "private": true,\n  "sideEffects": false,\n  "scripts": {\n    "build": "remix build",\n    "dev": "remix dev",\n    "start": "remix-serve build",\n    "typecheck": "tsc"\n  },\n  "dependencies": {\n    "@remix-run/node": "^1.19.2",\n    "@remix-run/react": "^1.19.2",\n    "@webstudio-is/react-sdk": "^0.97.0",\n    "@webstudio-is/sdk-components-react-radix": "^0.97.0",\n    "@webstudio-is/sdk-components-react-remix": "^0.97.0",\n    "@webstudio-is/sdk-components-react": "^0.97.0",\n    "@webstudio-is/form-handlers": "^0.97.0",\n    "@webstudio-is/image": "^0.97.0",\n    "@webstudio-is/sdk": "^0.97.0",\n    "isbot": "^3.6.8",\n    "react": "^18.2.0",\n    "react-dom": "^18.2.0"\n  },\n  "devDependencies": {\n    "@remix-run/serve": "^1.19.2",\n    "@remix-run/dev": "^1.19.2",\n    "@types/react": "^18.2.20",\n    "@types/react-dom": "^18.2.7",\n    "@webstudio-is/http-client": "^0.97.0",\n    "eslint": "^8.48.0",\n    "typescript": "5.2.2"\n  },\n  "engines": {\n    "node": ">=18.0.0"\n  }\n}\n',

--- a/packages/cli/src/commands/init-flow.ts
+++ b/packages/cli/src/commands/init-flow.ts
@@ -13,6 +13,12 @@ import pc from "picocolors";
 export const initFlow = async (
   options: StrictYargsOptionsToInterface<typeof buildOptions>
 ) => {
+  await prompt({
+    type: "text",
+    name: "folderName",
+    message: "Please enter a project name",
+  });
+
   const isProjectConfigured = await isFileExists(".webstudio/config.json");
   let shouldInstallDeps = false;
   let folderName;

--- a/packages/cli/templates/defaults/.vercelignore
+++ b/packages/cli/templates/defaults/.vercelignore
@@ -1,0 +1,8 @@
+node_modules
+
+.cache
+.env
+.vercel
+.webstudio
+build
+public/build


### PR DESCRIPTION
## Description

This avoid uploading builds/caches etc onto vercel

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
