### PR TITLE
Limit images formats to upload

### DIFF
--- a/apps/builder/app/builder/shared/assets/asset-upload.tsx
+++ b/apps/builder/app/builder/shared/assets/asset-upload.tsx
@@ -44,8 +44,17 @@ const useUpload = (type: AssetType) => {
   return { inputRef, onChange };
 };
 
+// https://developers.cloudflare.com/images/image-resizing/format-limitations/
+const imageMimeTypes = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/svg+xml",
+];
+
 const acceptMap = {
-  image: "image/*",
+  image: imageMimeTypes.join(", "),
   font: FONT_MIME_TYPES,
 };
 


### PR DESCRIPTION
Cloudflare supports only jpeg, png, gif, webp and svg as input. We should forbid any other format.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
