### PR TITLE
Fix folder name prompt in the cli init flow

### DIFF
--- a/packages/cli/src/commands/init-flow.ts
+++ b/packages/cli/src/commands/init-flow.ts
@@ -13,12 +13,6 @@ import pc from "picocolors";
 export const initFlow = async (
   options: StrictYargsOptionsToInterface<typeof buildOptions>
 ) => {
-  await prompt({
-    type: "text",
-    name: "folderName",
-    message: "Please enter a project name",
-  });
-
   const isProjectConfigured = await isFileExists(".webstudio/config.json");
   let shouldInstallDeps = false;
   let folderName;


### PR DESCRIPTION
## Description

Removed a default `folderName` prompt that is not needed. We need to check for folder name only when the config is missing.

## Code Review

- [ ] hi @kof, I need you to do
 - detailed review (read every line)

- [ ] hi @istarkov , I need you to do
 - detailed review (read every line)