### PR TITLE
Fix image loader warning in cli

### DIFF
--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -251,7 +251,7 @@ export const prebuild = async (options: {
   for (const asset of siteData.assets) {
     if (asset.type === "image") {
       const imageSrc = imageLoader({
-        width: 1,
+        width: 16,
         quality: 100,
         src: asset.name,
         format: "raw",


### PR DESCRIPTION
## Description

Remove warning

![image](https://github.com/webstudio-is/webstudio/assets/5077042/f0994436-c2a3-4dc7-8e96-600d1aa74928)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
