### PR TITLE
Add beta publish

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -45,4 +45,4 @@ jobs:
         run: pnpm -r exec pnpm version prepatch --preid ${{ steps.short_sha.outputs.value }}
 
       - name: Publishing ${{ steps.tag.outputs.value }} tag with sha ${{ steps.short_sha.outputs.value }}
-        run: pnpm -r publish --dry-run --tag "${{ steps.tag.outputs.value }}" --no-git-checks --access public
+        run: pnpm -r publish --tag "${{ steps.tag.outputs.value }}" --no-git-checks --access public

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/ci-setup
 
-      - run: pnpm turbo run build dts
-
       - name: Creating .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
@@ -43,6 +41,8 @@ jobs:
 
       - name: Creating version using ${{ steps.short_sha.outputs.value }} sha
         run: pnpm -r exec pnpm version prepatch --preid ${{ steps.short_sha.outputs.value }}
+
+      - run: pnpm turbo run build dts
 
       - name: Publishing ${{ steps.tag.outputs.value }} tag with sha ${{ steps.short_sha.outputs.value }}
         run: pnpm -r publish --tag "${{ steps.tag.outputs.value }}" --no-git-checks --access public

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Creating beta version
         run: pnpm -r exec pnpm version prepatch --preid ${{ steps.short_sha.outputs.value }}
 
-      - run: pnpm -r publish --tag beta --no-git-checks --dry-run --access public
+      - run: pnpm -r publish --tag beta --no-git-checks --access public

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -22,6 +22,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
+
       - uses: ./.github/actions/ci-setup
 
       - name: Creating .npmrc
@@ -34,7 +37,7 @@ jobs:
 
       # compute short sha
       - id: short_sha
-        run: echo "value=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+        run: echo "value=$(echo ${{ github.event.pull_request.head.sha || github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - id: tag
         run: echo "value=$(echo ${{ github.event.label.name }} | cut -d ':' -f2)" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   publish:
-    if: github.event.label.name == 'publish:beta'
+    # prevents this action from running on forks
+    if: |
+      github.repository_owner == 'webstudio-is' &&
+      github.event.label.name == 'publish:beta'
 
     timeout-minutes: 20
 

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -13,6 +13,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      DATABASE_URL: postgres://
+      AUTH_SECRET: test
+
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/ci-setup

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -10,7 +10,7 @@ jobs:
     # prevents this action from running on forks
     if: |
       github.repository_owner == 'webstudio-is' &&
-      github.event.label.name == 'publish:beta'
+      startsWith(github.event.label.name, 'publish:')
 
     timeout-minutes: 20
 
@@ -37,9 +37,12 @@ jobs:
       # compute short sha
       - id: short_sha
         run: echo "value=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-      - run: echo short_sha=${{ steps.short_sha.outputs.value }}
 
-      - name: Creating beta version
+      - id: tag
+        run: echo "value=$(echo ${{ github.event.label.name }} | cut -d ':' -f2)" >> $GITHUB_OUTPUT
+
+      - name: Creating version using ${{ steps.short_sha.outputs.value }} sha
         run: pnpm -r exec pnpm version prepatch --preid ${{ steps.short_sha.outputs.value }}
 
-      - run: pnpm -r publish --tag beta --no-git-checks --access public
+      - name: Publishing ${{ steps.tag.outputs.value }} tag with sha ${{ steps.short_sha.outputs.value }}
+        run: pnpm -r publish --dry-run --tag "${{ steps.tag.outputs.value }}" --no-git-checks --access public

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -1,0 +1,38 @@
+name: Publish beta packages on NPM 📦
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  publish:
+    if: github.event.label.name == 'publish:beta'
+
+    timeout-minutes: 20
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/ci-setup
+
+      - run: pnpm turbo run build dts
+
+      - name: Creating .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # compute short sha
+      - id: short_sha
+        run: echo "value=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+      - run: echo short_sha=${{ steps.short_sha.outputs.value }}
+
+      - name: Creating beta version
+        run: pnpm -r exec pnpm version prepatch --preid ${{ steps.short_sha.outputs.value }}
+
+      - run: pnpm -r publish --tag beta --no-git-checks --dry-run --access public


### PR DESCRIPTION
## Description

Publish npm to `xxx` tag every time you add Label `publish:xxx` to your PR
To republish remove label and add again.


<img width="387" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/45defb60-b710-4966-a171-7f5389cdea50">

If we would need to republish on every commit since published we would need to use `contains(github.event.pull_request.labels.*.name, 'publish:')` check


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
