### PR TITLE
Use eval to parse shared consts during prebuild, add windows support

### DIFF
--- a/fixtures/webstudio-remix-vercel/app/constants.mjs
+++ b/fixtures/webstudio-remix-vercel/app/constants.mjs
@@ -1,9 +1,10 @@
-import type { ImageLoader } from "@webstudio-is/image";
-
 export const assetBaseUrl = "/assets/";
 export const imageBaseUrl = "/assets/";
 
-export const imageLoader: ImageLoader = ({ quality, src, width }) => {
+/**
+ * @type {import("@webstudio-is/image").ImageLoader}
+ */
+export const imageLoader = ({ quality, src, width }) => {
   if (process.env.NODE_ENV !== "production") {
     return imageBaseUrl + src;
   }

--- a/fixtures/webstudio-remix-vercel/app/constants.mjs
+++ b/fixtures/webstudio-remix-vercel/app/constants.mjs
@@ -1,3 +1,7 @@
+/**
+ * We use mjs extension as constants in this file is shared with the build script
+ * and we use `node --eval` to extract the constants.
+ */
 export const assetBaseUrl = "/assets/";
 export const imageBaseUrl = "/assets/";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -24,7 +24,7 @@ import {
 } from "../__generated__/[_route_with_symbols_]._index.tsx";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.ts";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = Omit<Data, "build"> & {
   build: Pick<Data["build"], "props" | "instances" | "dataSources">;

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -24,7 +24,7 @@ import {
 } from "../__generated__/[radix]._index.tsx";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.ts";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = Omit<Data, "build"> & {
   build: Pick<Data["build"], "props" | "instances" | "dataSources">;

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -24,7 +24,7 @@ import {
 } from "../__generated__/_index.tsx";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.ts";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = Omit<Data, "build"> & {
   build: Pick<Data["build"], "props" | "instances" | "dataSources">;

--- a/fixtures/webstudio-remix-vercel/tsconfig.json
+++ b/fixtures/webstudio-remix-vercel/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "isolatedModules": true,
@@ -10,6 +10,7 @@
     "target": "ES2022",
     "strict": true,
     "allowJs": true,
+    "checkJs": true,
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "baseUrl": ".",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
     "@webstudio-is/sdk-components-react-remix": "workspace:^",
     "deepmerge": "^4.3.1",
     "env-paths": "^3.0.0",
+    "execa": "^7.2.0",
     "ora": "^7.0.1",
     "p-limit": "^4.0.0",
     "picocolors": "^1.0.0",

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -11,9 +11,6 @@ export const GLOBAL_CONFIG_FILE = join(
 export const LOCAL_CONFIG_FILE = ".webstudio/config.json";
 export const LOCAL_DATA_FILE = ".webstudio/data.json";
 
-// @todo remove
-export const ASSETS_BASE = "/assets/";
-
 export type LocalConfig = {
   projectId: string;
 };

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -43,6 +43,7 @@ import { ensureFileInPath, ensureFolderExists, loadJSONFile } from "./fs-utils";
 import merge from "deepmerge";
 import { createImageLoader } from "@webstudio-is/image";
 import { $ } from "execa";
+import { fileURLToPath } from "node:url";
 
 const limit = pLimit(10);
 
@@ -134,18 +135,11 @@ const mergeJsonFiles = async (sourcePath: string, destinationPath: string) => {
 };
 
 const copyTemplates = async () => {
-  const templatesPath = normalize(
-    join(
-      dirname(new URL(import.meta.url).pathname),
-      "..",
-      "templates",
-      "defaults"
-    )
-  );
+  const currentPath = fileURLToPath(new URL(import.meta.url));
 
-  console.log("\n0", import.meta.url);
-  console.log("\n1: ", dirname(new URL(import.meta.url).pathname));
-  console.log("\n2: ", templatesPath);
+  const templatesPath = normalize(
+    join(dirname(currentPath), "..", "templates", "defaults")
+  );
 
   await cp(templatesPath, cwd(), {
     recursive: true,
@@ -345,7 +339,7 @@ export const prebuild = async (options: {
   const routeFileTemplate = await readFile(
     normalize(
       join(
-        dirname(new URL(import.meta.url).pathname),
+        dirname(fileURLToPath(new URL(import.meta.url))),
         "..",
         "templates",
         "route-template.tsx"

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -465,7 +465,7 @@ ${utilsExport}
 
     const routeFileContent = routeFileTemplate.replace(
       "../__generated__/index",
-      join("../__generated__", fileName)
+      `../__generated__/${fileName}`
     );
 
     await ensureFileInPath(join(routesDir, fileName), routeFileContent);

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -143,18 +143,9 @@ const copyTemplates = async () => {
     )
   );
 
+  console.log("\n0", import.meta.url);
   console.log("\n1: ", dirname(new URL(import.meta.url).pathname));
-  console.log(
-    "\n2: ",
-    normalize(
-      join(
-        dirname(new URL(import.meta.url).pathname),
-        "..",
-        "templates",
-        "defaults"
-      )
-    )
-  );
+  console.log("\n2: ", templatesPath);
 
   await cp(templatesPath, cwd(), {
     recursive: true,

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -172,10 +172,7 @@ export const prebuild = async (options: {
   await copyTemplates();
 
   const constantsJson =
-    await $`node --input-type=module --eval ${`import * as consts from '${join(
-      cwd(),
-      "app/constants.mjs"
-    )}'; console.log(JSON.stringify(consts))`}`;
+    await $`node --input-type=module --eval ${`import * as consts from './app/constants.mjs'; console.log(JSON.stringify(consts))`}`;
 
   const constants = JSON.parse(constantsJson.stdout);
   const assetBaseUrl =

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -174,7 +174,7 @@ export const prebuild = async (options: {
   await copyTemplates();
 
   const constantsJson =
-    await $`node --experimental-specifier-resolution=node --input-type=module --eval ${`import * as consts from '${join(
+    await $`node --input-type=module --eval ${`import * as consts from '${join(
       cwd(),
       "app/constants.mjs"
     )}'; console.log(JSON.stringify(consts))`}`;

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -143,6 +143,19 @@ const copyTemplates = async () => {
     )
   );
 
+  console.log("\n1: ", dirname(new URL(import.meta.url).pathname));
+  console.log(
+    "\n2: ",
+    normalize(
+      join(
+        dirname(new URL(import.meta.url).pathname),
+        "..",
+        "templates",
+        "defaults"
+      )
+    )
+  );
+
   await cp(templatesPath, cwd(), {
     recursive: true,
     filter: (source) => {

--- a/packages/cli/templates/defaults/app/constants.mjs
+++ b/packages/cli/templates/defaults/app/constants.mjs
@@ -1,9 +1,14 @@
-import type { ImageLoader } from "@webstudio-is/image";
-
+/**
+ * We use mjs extension as constants in this file is shared with the build script
+ * and we use `node --eval` to extract the constants.
+ */
 export const assetBaseUrl = "/assets/";
 export const imageBaseUrl = "/assets/";
 
-export const imageLoader: ImageLoader = ({ quality, src, width }) => {
+/**
+ * @type {import("@webstudio-is/image").ImageLoader}
+ */
+export const imageLoader = ({ quality, src, width }) => {
   if (process.env.NODE_ENV !== "production") {
     return imageBaseUrl + src;
   }

--- a/packages/cli/templates/defaults/tsconfig.json
+++ b/packages/cli/templates/defaults/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "isolatedModules": true,
@@ -10,6 +10,7 @@
     "target": "ES2022",
     "strict": true,
     "allowJs": true,
+    "checkJs": true,
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "baseUrl": ".",

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -24,7 +24,7 @@ import {
 } from "../__generated__/index";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.ts";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = Omit<Data, "build"> & {
   build: Pick<Data["build"], "props" | "instances" | "dataSources">;

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@webstudio-is/tsconfig/base.json",
-
+  "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
     "module": "esnext",
     "allowJs": true,

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "@webstudio-is/tsconfig/base.json",
+
   "compilerOptions": {
     "module": "esnext",
+    "allowJs": true,
+    "checkJs": true,
     "paths": {
-      "~/constants.ts": ["./templates/defaults/app/constants.ts"]
+      "~/constants.mjs": ["./templates/defaults/app/constants.mjs"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,6 +538,9 @@ importers:
       env-paths:
         specifier: ^3.0.0
         version: 3.0.0
+      execa:
+        specifier: ^7.2.0
+        version: 7.2.0
       ora:
         specifier: ^7.0.1
         version: 7.0.1


### PR DESCRIPTION
## Description

Read constants.mjs during prebuild step and use that constants. (need for saas and other templates)

Fixes windows version of cli. Now everything works on windows platform too.
Changes:
using `execa` instead of `exec`
using `import { fileURLToPath } from "node:url";` instead of url.pathname
do not using `join` for import generation


<img width="975" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/761cd741-d609-48ef-a54a-027fe3f0d49f">
<img width="975" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/52c9f2d7-4389-4bb6-8fa7-5329a4b6d9c8">
<img width="972" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/cb5d2c1d-34d9-412d-942e-c78276c9dd6c">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
