### PR TITLE
Drop legacy data sources from builder

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -9,7 +9,7 @@ import {
 import type { PropValue } from "../shared";
 import { useStore } from "@nanostores/react";
 import {
-  dataSourceValuesStore,
+  dataSourcesLogicStore,
   dataSourcesStore,
   registeredComponentPropsMetasStore,
 } from "~/shared/nano-states";
@@ -173,7 +173,7 @@ export const usePropsLogic = ({
     instance.component
   );
   const dataSources = useStore(dataSourcesStore);
-  const dataSourceValues = useStore(dataSourceValuesStore);
+  const dataSourcesLogic = useStore(dataSourcesLogicStore);
 
   if (meta === undefined) {
     throw new Error(`Could not get meta for component "${instance.component}"`);
@@ -186,7 +186,7 @@ export const usePropsLogic = ({
     // convert data source prop to typed prop
     const dataSourceId = prop.value;
     const dataSource = dataSources.get(dataSourceId);
-    const dataSourceValue = dataSourceValues.get(dataSourceId);
+    const dataSourceValue = dataSourcesLogic.get(dataSourceId);
     if (dataSource === undefined) {
       return [];
     }

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -10,7 +10,7 @@ import {
   stylesIndexStore,
   instancesStore,
   propsStore,
-  dataSourceValuesStore,
+  dataSourcesLogicStore,
   selectedInstanceSelectorStore,
   dataSourceVariablesStore,
 } from "~/shared/nano-states";
@@ -228,8 +228,8 @@ const subscribeSelectedInstance = (
   const unsubscribeStylesIndexStore = stylesIndexStore.subscribe(update);
   const unsubscribeInstancesStore = instancesStore.subscribe(update);
   const unsubscribePropsStore = propsStore.subscribe(update);
-  const unsubscribeDataSourceValuesStore =
-    dataSourceValuesStore.subscribe(update);
+  const unsubscribeDataSourcesLogicStore =
+    dataSourcesLogicStore.subscribe(update);
 
   const unsubscribeDataSourceVariablesStore =
     dataSourceVariablesStore.subscribe(update);
@@ -276,7 +276,7 @@ const subscribeSelectedInstance = (
     unsubscribeStylesIndexStore();
     unsubscribeInstancesStore();
     unsubscribePropsStore();
-    unsubscribeDataSourceValuesStore();
+    unsubscribeDataSourcesLogicStore();
     unsubscribeDataSourceVariablesStore();
   };
 };

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -33,8 +33,8 @@ import {
   assetsStore,
   projectStore,
   registeredComponentMetasStore,
-  dataSourceValuesStore,
   dataSourcesStore,
+  dataSourcesLogicStore,
 } from "../nano-states";
 import {
   type InstanceSelector,
@@ -246,7 +246,7 @@ const getTreeData = (targetInstanceSelector: InstanceSelector) => {
     treeDataSources.map((dataSource) => dataSource.id)
   );
 
-  const dataSourceValues = dataSourceValuesStore.get();
+  const dataSourcesLogic = dataSourcesLogicStore.get();
   const treeProps = getMapValuesBy(propsStore.get(), (prop) =>
     treeInstanceIds.has(prop.instanceId)
   ).map((prop) => {
@@ -258,7 +258,7 @@ const getTreeData = (targetInstanceSelector: InstanceSelector) => {
       }
       // convert data source prop to typed prop
       // when data source is not scoped to one of copied instances
-      const value = dataSourceValues.get(dataSourceId);
+      const value = dataSourcesLogic.get(dataSourceId);
       return {
         id: prop.id,
         instanceId: prop.instanceId,

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -22,12 +22,7 @@ import {
   type StyleSourceSelection,
   type StyleSourceSelections,
 } from "@webstudio-is/sdk";
-import {
-  executeComputingExpressions,
-  encodeDataSourceVariable,
-  decodeDataSourceVariable,
-  generateDataSources,
-} from "@webstudio-is/react-sdk";
+import { generateDataSources } from "@webstudio-is/react-sdk";
 import type { Style } from "@webstudio-is/css-engine";
 import type { DragStartPayload } from "~/canvas/shared/use-drag-drop";
 import { useMount } from "~/shared/hook-utils/use-mount";
@@ -80,42 +75,6 @@ export const useSetDataSources = (
     dataSourcesStore.set(new Map(dataSources));
   });
 };
-export const dataSourceValuesStore = computed(
-  [dataSourcesStore, dataSourceVariablesStore],
-  (dataSources, dataSourceVariables) => {
-    const outputValues = new Map<DataSource["id"], unknown>();
-    const variables = new Map<string, unknown>();
-    const expressions = new Map<string, string>();
-    for (const [dataSourceId, dataSource] of dataSources) {
-      const name = encodeDataSourceVariable(dataSourceId);
-      if (dataSource.type === "variable") {
-        const value =
-          dataSourceVariables.get(dataSourceId) ?? dataSource.value.value;
-        variables.set(name, value);
-        outputValues.set(dataSourceId, value);
-      }
-      if (dataSource.type === "expression") {
-        expressions.set(name, dataSource.code);
-      }
-    }
-    try {
-      const outputVariables = executeComputingExpressions(
-        expressions,
-        variables
-      );
-      for (const [name, value] of outputVariables) {
-        const id = decodeDataSourceVariable(name);
-        if (id !== undefined) {
-          outputValues.set(id, value);
-        }
-      }
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(error);
-    }
-    return outputValues;
-  }
-);
 
 export const propsStore = atom<Props>(new Map());
 export const propsIndexStore = computed(propsStore, (props) => {

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -357,11 +357,7 @@ export const prebuild = async (options: {
       "user",
       "projectId",
       "indexesWithinAncestors",
-      "rawExecuteComputingExpressions",
-      "executeComputingExpressions",
-      "generatedEffectfulExpressions",
-      "rawExecuteEffectfulExpression",
-      "executeEffectfulExpression",
+      "getDataSourcesLogic",
       "utils",
     ]);
     const namespaces = new Map<

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -2,11 +2,7 @@ import { expect, test } from "@jest/globals";
 import {
   decodeDataSourceVariable,
   encodeDataSourceVariable,
-  executeComputingExpressions,
-  executeEffectfulExpression,
   computeExpressionsDependencies,
-  generateComputingExpressions,
-  generateEffectfulExpression,
   validateExpression,
   generateDataSources,
 } from "./expression";
@@ -91,92 +87,6 @@ test("transform identifiers", () => {
   ).toEqual(`$ws$a + $ws$b`);
 });
 
-test("generate computing expressions", () => {
-  const variables = new Set(["var0"]);
-  const expressions = new Map([
-    ["exp3", "exp2 + exp1"],
-    ["exp1", "var0"],
-    ["exp2", "exp1"],
-    ["exp4", "exp2"],
-  ]);
-  expect(generateComputingExpressions(expressions, variables))
-    .toMatchInlineSnapshot(`
-    "const var0 = _variables.get('var0');
-    const exp1 = (var0);
-    const exp2 = (exp1);
-    const exp3 = (exp2 + exp1);
-    const exp4 = (exp2);
-    return new Map([
-      ['exp1', exp1],
-      ['exp2', exp2],
-      ['exp3', exp3],
-      ['exp4', exp4],
-    ]);"
-  `);
-});
-
-test("add only used variables in computing expression", () => {
-  const expressions = new Map([["exp1", "var0"]]);
-  expect(generateComputingExpressions(expressions, new Set(["var0", "var1"])))
-    .toMatchInlineSnapshot(`
-    "const var0 = _variables.get('var0');
-    const exp1 = (var0);
-    return new Map([
-      ['exp1', exp1],
-    ]);"
-  `);
-});
-
-test("execute expression", () => {
-  const variables = new Map();
-  const expressions = new Map([["exp1", "1 + 1"]]);
-  expect(executeComputingExpressions(expressions, variables)).toEqual(
-    new Map([["exp1", 2]])
-  );
-});
-
-test("execute expression dependent on variables", () => {
-  const variables = new Map([["var1", 5]]);
-  const expressions = new Map([["exp1", "var1 + 1"]]);
-  expect(executeComputingExpressions(expressions, variables)).toEqual(
-    new Map([["exp1", 6]])
-  );
-});
-
-test("execute expression dependent on another expressions", () => {
-  const variables = new Map([["var1", 3]]);
-  const expressions = new Map([
-    ["exp1", "exp0 + 1"],
-    ["exp0", "var1 + 2"],
-  ]);
-  expect(executeComputingExpressions(expressions, variables)).toEqual(
-    new Map([
-      ["exp1", 6],
-      ["exp0", 5],
-    ])
-  );
-});
-
-test("forbid circular expressions", () => {
-  const variables = new Map([["var1", 3]]);
-  const expressions = new Map([
-    ["exp0", "exp2 + 1"],
-    ["exp1", "exp0 + 2"],
-    ["exp2", "exp1 + 3"],
-  ]);
-  expect(() => {
-    executeComputingExpressions(expressions, variables);
-  }).toThrowError(/Cannot access 'exp0' before initialization/);
-});
-
-test("make sure dependency exists", () => {
-  const variables = new Map();
-  const expressions = new Map([["exp1", "var1 + 1"]]);
-  expect(() => {
-    executeComputingExpressions(expressions, variables);
-  }).toThrowError(/Unknown dependency "var1"/);
-});
-
 test("encode/decode variable names", () => {
   expect(encodeDataSourceVariable("my--id")).toEqual(
     "$ws$dataSource$my__DASH____DASH__id"
@@ -185,99 +95,6 @@ test("encode/decode variable names", () => {
     "my--id"
   );
   expect(decodeDataSourceVariable("myVarName")).toEqual(undefined);
-});
-
-test("generate effectful expression", () => {
-  expect(
-    generateEffectfulExpression(
-      `var0 = var0 + var1`,
-      new Set(),
-      new Set(["var0", "var1"])
-    )
-  ).toMatchInlineSnapshot(`
-    "let var0 = _variables.get('var0');
-    let var1 = _variables.get('var1');
-    var0 = var0 + var1;
-    return new Map([
-      ['var0', var0],
-    ]);"
-  `);
-
-  expect(
-    generateEffectfulExpression(
-      `var0 = var1 + 1`,
-      new Set(),
-      new Set(["var0", "var1"])
-    )
-  ).toMatchInlineSnapshot(`
-    "let var1 = _variables.get('var1');
-    let var0;
-    var0 = var1 + 1;
-    return new Map([
-      ['var0', var0],
-    ]);"
-  `);
-});
-
-test("add only used variables in effectful expression", () => {
-  expect(
-    generateEffectfulExpression(
-      `var0 = var1 + 1`,
-      new Set(),
-      new Set(["var0", "var1", "var2"])
-    )
-  ).toMatchInlineSnapshot(`
-    "let var1 = _variables.get('var1');
-    let var0;
-    var0 = var1 + 1;
-    return new Map([
-      ['var0', var0],
-    ]);"
-  `);
-});
-
-test("support effectful expression arguments", () => {
-  expect(
-    generateEffectfulExpression(
-      `var0 = arg0 + 1`,
-      new Set(["arg0"]),
-      new Set(["var0"])
-    )
-  ).toMatchInlineSnapshot(`
-    "let arg0 = _args.get('arg0');
-    let var0;
-    var0 = arg0 + 1;
-    return new Map([
-      ['var0', var0],
-    ]);"
-  `);
-});
-
-test("forbid not allowed variables or arguments in effectful expression", () => {
-  expect(() => {
-    generateEffectfulExpression(
-      `var0 = var0 + var1`,
-      new Set(),
-      new Set(["var0"])
-    );
-  }).toThrowError(/Unknown dependency "var1"/);
-  expect(() => {
-    generateEffectfulExpression(`var0 = arg0`, new Set(), new Set(["var0"]));
-  }).toThrowError(/Unknown dependency "arg0"/);
-});
-
-test("execute effectful expression", () => {
-  const variables = new Map([
-    ["var0", 2],
-    ["var1", 3],
-  ]);
-  expect(
-    executeEffectfulExpression(`var0 = var0 + var1`, new Map(), variables)
-  ).toEqual(new Map([["var0", 5]]));
-
-  expect(
-    executeEffectfulExpression(`arg0 = 5`, new Map([["arg0", 0]]), new Map())
-  ).toEqual(new Map());
 });
 
 test("compute expressions dependencies", () => {

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -23,15 +23,9 @@ export {
 export { type Params, ReactSdkContext } from "./context";
 export {
   validateExpression,
-  generateComputingExpressions,
-  executeComputingExpressions,
-  generateEffectfulExpression,
-  executeEffectfulExpression,
   computeExpressionsDependencies,
   encodeDataSourceVariable,
-  encodeVariablesMap,
   decodeDataSourceVariable,
-  decodeVariablesMap,
   generateDataSources,
 } from "./expression";
 export { renderComponentTemplate } from "./component-renderer";


### PR DESCRIPTION
Here removed all left usages of previous data sources implementation and removed no longer used expression utilities.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
