### PR TITLE
Pregenerate forms properties

### DIFF
--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -126,6 +126,11 @@ const getDataSourcesLogic = (
   return _output;
 };
 
+export const formsProperties = new Map<
+  string,
+  { method?: string; action?: string }
+>([]);
+
 export const utils = {
   indexesWithinAncestors,
   getDataSourcesLogic,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -469,6 +469,11 @@ const getDataSourcesLogic = (
   return _output;
 };
 
+export const formsProperties = new Map<
+  string,
+  { method?: string; action?: string }
+>([]);
+
 export const utils = {
   indexesWithinAncestors,
   getDataSourcesLogic,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -262,6 +262,11 @@ const getDataSourcesLogic = (
   return _output;
 };
 
+export const formsProperties = new Map<
+  string,
+  { method?: string; action?: string }
+>([]);
+
 export const utils = {
   indexesWithinAncestors,
   getDataSourcesLogic,

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -12,7 +12,7 @@ import {
   type RootPropsData,
   type Params,
 } from "@webstudio-is/react-sdk";
-import { n8nHandler, getFormProperties } from "@webstudio-is/form-handlers";
+import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import { Scripts, ScrollRestoration } from "@remix-run/react";
 import {
   fontAssets,
@@ -21,6 +21,7 @@ import {
   user,
   projectId,
   utils,
+  formsProperties,
 } from "../__generated__/[_route_with_symbols_]._index.tsx";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
@@ -78,7 +79,9 @@ const getMethod = (value: string | undefined) => {
 export const action = async ({ request, context }: ActionArgs) => {
   const formData = await request.formData();
 
-  const formProperties = getFormProperties(formData, pageData.build.props);
+  const formId = getFormId(formData);
+  const formProperties =
+    formId === undefined ? undefined : formsProperties.get(formId);
 
   if (formProperties === undefined) {
     // We're throwing rather than returning { success: false }

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -12,7 +12,7 @@ import {
   type RootPropsData,
   type Params,
 } from "@webstudio-is/react-sdk";
-import { n8nHandler, getFormProperties } from "@webstudio-is/form-handlers";
+import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import { Scripts, ScrollRestoration } from "@remix-run/react";
 import {
   fontAssets,
@@ -21,6 +21,7 @@ import {
   user,
   projectId,
   utils,
+  formsProperties,
 } from "../__generated__/[radix]._index.tsx";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
@@ -78,7 +79,9 @@ const getMethod = (value: string | undefined) => {
 export const action = async ({ request, context }: ActionArgs) => {
   const formData = await request.formData();
 
-  const formProperties = getFormProperties(formData, pageData.build.props);
+  const formId = getFormId(formData);
+  const formProperties =
+    formId === undefined ? undefined : formsProperties.get(formId);
 
   if (formProperties === undefined) {
     // We're throwing rather than returning { success: false }

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -12,7 +12,7 @@ import {
   type RootPropsData,
   type Params,
 } from "@webstudio-is/react-sdk";
-import { n8nHandler, getFormProperties } from "@webstudio-is/form-handlers";
+import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import { Scripts, ScrollRestoration } from "@remix-run/react";
 import {
   fontAssets,
@@ -21,6 +21,7 @@ import {
   user,
   projectId,
   utils,
+  formsProperties,
 } from "../__generated__/_index.tsx";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
@@ -78,7 +79,9 @@ const getMethod = (value: string | undefined) => {
 export const action = async ({ request, context }: ActionArgs) => {
   const formData = await request.formData();
 
-  const formProperties = getFormProperties(formData, pageData.build.props);
+  const formId = getFormId(formData);
+  const formProperties =
+    formId === undefined ? undefined : formsProperties.get(formId);
 
   if (formProperties === undefined) {
     // We're throwing rather than returning { success: false }

--- a/packages/cli/__generated__/index.ts
+++ b/packages/cli/__generated__/index.ts
@@ -39,6 +39,11 @@ const getDataSourcesLogic = () => {
   return new Map();
 };
 
+export const formsProperties = new Map<
+  string,
+  { method?: string; action?: string }
+>([]);
+
 export const utils = {
   indexesWithinAncestors,
   getDataSourcesLogic,

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -356,6 +356,7 @@ export const prebuild = async (options: {
       "pageData",
       "user",
       "projectId",
+      "formsProperties",
       "indexesWithinAncestors",
       "getDataSourcesLogic",
       "utils",

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -12,7 +12,7 @@ import {
   type RootPropsData,
   type Params,
 } from "@webstudio-is/react-sdk";
-import { n8nHandler, getFormProperties } from "@webstudio-is/form-handlers";
+import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import { Scripts, ScrollRestoration } from "@remix-run/react";
 import {
   fontAssets,
@@ -21,6 +21,7 @@ import {
   user,
   projectId,
   utils,
+  formsProperties,
 } from "../__generated__/index";
 import css from "../__generated__/index.css";
 import type { Data } from "@webstudio-is/http-client";
@@ -78,7 +79,9 @@ const getMethod = (value: string | undefined) => {
 export const action = async ({ request, context }: ActionArgs) => {
   const formData = await request.formData();
 
-  const formProperties = getFormProperties(formData, pageData.build.props);
+  const formId = getFormId(formData);
+  const formProperties =
+    formId === undefined ? undefined : formsProperties.get(formId);
 
   if (formProperties === undefined) {
     // We're throwing rather than returning { success: false }

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -12,9 +12,6 @@
     "build": "rm -rf lib && esbuild src/index.ts --outdir=lib --bundle --format=esm --packages=external",
     "dts": "tsc --project tsconfig.dts.json"
   },
-  "dependencies": {
-    "@webstudio-is/sdk": "workspace:^"
-  },
   "devDependencies": {
     "@webstudio-is/tsconfig": "workspace:^"
   },

--- a/packages/form-handlers/src/index.ts
+++ b/packages/form-handlers/src/index.ts
@@ -3,7 +3,6 @@ export {
   formIdFieldName,
   formHiddenFieldPrefix,
   getFormId,
-  getFormProperties,
   type EmailInfo,
   type FormInfo,
 } from "./shared";

--- a/packages/form-handlers/src/shared.ts
+++ b/packages/form-handlers/src/shared.ts
@@ -1,5 +1,3 @@
-import type { Prop } from "@webstudio-is/sdk";
-
 export const formHiddenFieldPrefix = "ws--form";
 export const formIdFieldName = `${formHiddenFieldPrefix}-id`;
 
@@ -109,33 +107,4 @@ export const getErrors = (
   ) {
     return json.errors;
   }
-};
-
-export const getFormProperties = (
-  formData: FormData,
-  props: [Prop["id"], Prop][]
-) => {
-  const formId = getFormId(formData);
-
-  if (formId === undefined) {
-    return undefined;
-  }
-
-  const objectProps = Object.fromEntries(
-    props
-      .filter(([_, value]) => value.instanceId === formId)
-      .map(([_, value]) => [value.name, value])
-  );
-
-  const action =
-    objectProps.action?.type === "string"
-      ? objectProps.action.value
-      : undefined;
-
-  const method =
-    objectProps.method?.type === "string"
-      ? objectProps.method.value
-      : undefined;
-
-  return { action, method };
 };

--- a/packages/react-sdk/src/generator.test.ts
+++ b/packages/react-sdk/src/generator.test.ts
@@ -86,6 +86,39 @@ test("generates utils", () => {
             ],
           },
         ],
+
+        [
+          "method1Id",
+          {
+            id: "method1Id",
+            instanceId: "1",
+            name: "method",
+            type: "string",
+            value: "post",
+          },
+        ],
+
+        [
+          "method2Id",
+          {
+            id: "method2Id",
+            instanceId: "2",
+            name: "method",
+            type: "string",
+            value: "get",
+          },
+        ],
+
+        [
+          "action1Id",
+          {
+            id: "action1Id",
+            instanceId: "2",
+            name: "action",
+            type: "string",
+            value: "/index.php",
+          },
+        ],
       ]),
       dataSources: new Map([
         [
@@ -126,6 +159,8 @@ test("generates utils", () => {
   return _output
   }
 
+
+    export const formsProperties = new Map<string, { method?: string, action?: string }>([["1",{"method":"post"}],["2",{"method":"get","action":"/index.php"}]])
 
     export const utils = {
       indexesWithinAncestors,

--- a/packages/react-sdk/src/generator.ts
+++ b/packages/react-sdk/src/generator.ts
@@ -77,12 +77,34 @@ export const generateUtilsExport = (siteData: PageData) => {
   generatedDataSources += `return _output\n`;
   generatedDataSources += `}\n`;
 
+  const formsProperties = new Map<
+    string,
+    { method?: string; action?: string }
+  >();
+  for (const prop of siteData.props.values()) {
+    if (prop.type === "string") {
+      if (prop.name === "action" || prop.name === "method") {
+        let properties = formsProperties.get(prop.instanceId);
+        if (properties === undefined) {
+          properties = {};
+        }
+        properties[prop.name] = prop.value;
+        formsProperties.set(prop.instanceId, properties);
+      }
+    }
+  }
+  const generatedFormsProperties = `export const formsProperties = new Map<string, { method?: string, action?: string }>(${JSON.stringify(
+    Array.from(formsProperties.entries())
+  )})`;
+
   return `
   /* eslint-disable */
 
   ${generatedIndexesWithinAncestors.trim()}
 
   ${generatedDataSources}
+
+  ${generatedFormsProperties}
 
   export const utils = {
     indexesWithinAncestors,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -954,10 +954,6 @@ importers:
         version: 3.21.4
 
   packages/form-handlers:
-    dependencies:
-      '@webstudio-is/sdk':
-        specifier: workspace:^
-        version: link:../sdk
     devDependencies:
       '@webstudio-is/tsconfig':
         specifier: workspace:^


### PR DESCRIPTION
Here decoupled actions from props data in runtime by generating prepared forms data. It will let us get rid of props after migrating to jsx generator.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
