### PR TITLE
Fix font item cursor

### DIFF
--- a/packages/design-system/src/components/__DEPRECATED__/list.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/list.tsx
@@ -73,7 +73,7 @@ export const DeprecatedListItem = forwardRef<
       {...props}
     >
       {prefix}
-      <Flex css={{ gridColumn: 2 }} align="center">
+      <Flex css={{ gridColumn: 2, cursor: "default" }} align="center">
         <DeprecatedText2
           variant="label"
           truncate


### PR DESCRIPTION
## Description

Currently it was showing text cursor in font manager font item

## Steps for reproduction

1. open font manager
2. hover font item
3. cursor should be default, not text

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
