### PR TITLE
Fix remix watcher

### DIFF
--- a/apps/builder/remix.config.js
+++ b/apps/builder/remix.config.js
@@ -39,7 +39,7 @@ module.exports = {
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   watchPaths: () => {
-    return ["../../packages/*/lib/**.js"];
+    return ["../../packages/*/lib/**/*.js"];
   },
   // remix will disable all polyfills by default
   serverNodeBuiltinsPolyfill: { modules: {} },


### PR DESCRIPTION
Need to use slightly different glob for watching packages. `**` means anything between slashes and `**.js` in the end looks like `**/.js`

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
