### PR TITLE
[Refactor] Replace Node eval Hack with Dynamic Import

### DIFF
--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -43,8 +43,8 @@ import { LOCAL_DATA_FILE } from "./config";
 import { ensureFileInPath, ensureFolderExists, loadJSONFile } from "./fs-utils";
 import merge from "deepmerge";
 import { createImageLoader } from "@webstudio-is/image";
-import { $ } from "execa";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type * as sharedConstants from "~/constants.mjs";
 
 const limit = pLimit(10);
 
@@ -197,17 +197,11 @@ export const prebuild = async (options: {
     await copyTemplates(options.template);
   }
 
-  const constantsJson =
-    await $`node --input-type=module --eval ${`import * as consts from './app/constants.mjs'; console.log(JSON.stringify(consts))`}`;
+  const constants: typeof sharedConstants = await import(
+    pathToFileURL(join(cwd(), "/app/constants.mjs")).href
+  );
 
-  const constants = JSON.parse(constantsJson.stdout);
-
-  console.log(await import(join(cwd(), "/app/constants.mjs")));
-
-  const assetBaseUrl =
-    "assetBaseUrl" in constants
-      ? (constants.assetBaseUrl as string)
-      : "/assets";
+  const { assetBaseUrl } = constants;
 
   const siteData = await loadJSONFile<
     Data & { user?: { email: string | null } }

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -198,7 +198,7 @@ export const prebuild = async (options: {
   }
 
   const constants: typeof sharedConstants = await import(
-    pathToFileURL(join(cwd(), "/app/constants.mjs")).href
+    pathToFileURL(join(cwd(), "app/constants.mjs")).href
   );
 
   const { assetBaseUrl } = constants;

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -201,6 +201,9 @@ export const prebuild = async (options: {
     await $`node --input-type=module --eval ${`import * as consts from './app/constants.mjs'; console.log(JSON.stringify(consts))`}`;
 
   const constants = JSON.parse(constantsJson.stdout);
+
+  console.log(await import(join(cwd(), "/app/constants.mjs")));
+
   const assetBaseUrl =
     "assetBaseUrl" in constants
       ? (constants.assetBaseUrl as string)


### PR DESCRIPTION
## Description

Use dynamic import instead of `node --eval`
`pathToFileURL` is used in import to support windows

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
