### PR TITLE
fix: prevent error when insert components

### DIFF
--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -290,16 +290,18 @@ export const insertTemplateData = (
   store.createTransaction(
     [
       instancesStore,
-      propsStore,
+      // insert data sources before props to avoid error
+      // about missing data source when compute data source logic
       dataSourcesStore,
+      propsStore,
       styleSourceSelectionsStore,
       styleSourcesStore,
       stylesStore,
     ],
     (
       instances,
-      props,
       dataSources,
+      props,
       styleSourceSelections,
       styleSources,
       styles


### PR DESCRIPTION
This fixes the issue with computing data sources logic. insertTemplateData first calls propsStore.set and then dataSourceStore.set which triggers computing 2 times and first time prop refers to not existing data source.

Here fixed by setting data sources first and then props.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
