### PR TITLE
build: use webstudio export condition for tools

### DIFF
--- a/apps/builder/.storybook/main.ts
+++ b/apps/builder/.storybook/main.ts
@@ -16,7 +16,7 @@ export default {
       },
       resolve: {
         ...config.resolve,
-        conditions: ["source", "import", "module", "browser", "default"],
+        conditions: ["webstudio", "import", "module", "browser", "default"],
         alias: [
           {
             find: "~",

--- a/fixtures/webstudio-custom-template/tsconfig.json
+++ b/fixtures/webstudio-custom-template/tsconfig.json
@@ -17,7 +17,7 @@
     "paths": {
       "~/*": ["./app/*"]
     },
-    "customConditions": ["source"],
+    "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.
     "noEmit": true,

--- a/fixtures/webstudio-custom-template/tsconfig.json
+++ b/fixtures/webstudio-custom-template/tsconfig.json
@@ -17,6 +17,7 @@
     "paths": {
       "~/*": ["./app/*"]
     },
+    "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.
     "noEmit": true,

--- a/fixtures/webstudio-custom-template/tsconfig.json
+++ b/fixtures/webstudio-custom-template/tsconfig.json
@@ -17,7 +17,6 @@
     "paths": {
       "~/*": ["./app/*"]
     },
-    "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.
     "noEmit": true,

--- a/fixtures/webstudio-remix-vercel/tsconfig.json
+++ b/fixtures/webstudio-remix-vercel/tsconfig.json
@@ -17,7 +17,7 @@
     "paths": {
       "~/*": ["./app/*"]
     },
-    "customConditions": ["source"],
+    "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.
     "noEmit": true,

--- a/fixtures/webstudio-remix-vercel/tsconfig.json
+++ b/fixtures/webstudio-remix-vercel/tsconfig.json
@@ -17,6 +17,7 @@
     "paths": {
       "~/*": ["./app/*"]
     },
+    "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.
     "noEmit": true,

--- a/fixtures/webstudio-remix-vercel/tsconfig.json
+++ b/fixtures/webstudio-remix-vercel/tsconfig.json
@@ -17,7 +17,6 @@
     "paths": {
       "~/*": ["./app/*"]
     },
-    "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.
     "noEmit": true,

--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -38,12 +38,12 @@
   },
   "exports": {
     ".": {
-      "source": "./src/index.ts",
+      "webstudio": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/index.js"
     },
     "./index.server": {
-      "source": "./src/index.server.ts",
+      "webstudio": "./src/index.server.ts",
       "types": "./lib/types/index.server.d.ts",
       "import": "./lib/index.server.js"
     }

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -23,12 +23,12 @@
   },
   "exports": {
     ".": {
-      "source": "./src/index.ts",
+      "webstudio": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/index.js"
     },
     "./index.server": {
-      "source": "./src/index.server.ts",
+      "webstudio": "./src/index.server.ts",
       "types": "./lib/types/index.server.d.ts",
       "import": "./lib/index.server.js"
     }

--- a/packages/cli/templates/defaults/tsconfig.json
+++ b/packages/cli/templates/defaults/tsconfig.json
@@ -17,7 +17,6 @@
     "paths": {
       "~/*": ["./app/*"]
     },
-    "customConditions": ["source"],
 
     // Remix takes care of building everything in `remix build`.
     "noEmit": true,

--- a/packages/cli/templates/defaults/tsconfig.json
+++ b/packages/cli/templates/defaults/tsconfig.json
@@ -17,6 +17,7 @@
     "paths": {
       "~/*": ["./app/*"]
     },
+    "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.
     "noEmit": true,

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -32,7 +32,7 @@
     "zod": "^3.19.1"
   },
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
     "import": "./lib/index.js"
   },

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -34,7 +34,7 @@
     "typescript": "5.2.2"
   },
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
     "import": "./lib/index.js",
     "require": "./lib/index.js"

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -16,7 +16,7 @@
     "@webstudio-is/tsconfig": "workspace:*"
   },
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
     "import": "./lib/index.js",
     "require": "./lib/index.js"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -24,12 +24,12 @@
   },
   "exports": {
     ".": {
-      "source": "./src/index.ts",
+      "webstudio": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/index.js"
     },
     "./index.server": {
-      "source": "./src/index.server.ts",
+      "webstudio": "./src/index.server.ts",
       "types": "./lib/types/index.server.d.ts",
       "import": "./lib/index.server.js"
     }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -77,7 +77,7 @@
     "warn-once": "^0.1.1"
   },
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "import": "./lib/index.js",
     "types": "./lib/types/index.d.ts"
   },

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -25,12 +25,12 @@
   },
   "exports": {
     ".": {
-      "source": "./src/index.ts",
+      "webstudio": "./src/index.ts",
       "import": "./lib/index.js",
       "types": "./lib/types/index.d.ts"
     },
     "./index.server": {
-      "source": "./src/index.server.ts",
+      "webstudio": "./src/index.server.ts",
       "import": "./lib/index.server.js",
       "types": "./lib/types/index.server.d.ts"
     }

--- a/packages/error-utils/package.json
+++ b/packages/error-utils/package.json
@@ -16,7 +16,7 @@
     "@webstudio-is/tsconfig": "workspace:*"
   },
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
     "import": "./lib/index.js",
     "require": "./lib/index.js"

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -17,7 +17,7 @@
     "@webstudio-is/tsconfig": "workspace:*"
   },
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
     "import": "./lib/index.js"
   },

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -25,7 +25,7 @@
     "zod": "^3.19.1"
   },
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
     "import": "./lib/index.js",
     "require": "./lib/index.js"

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -16,7 +16,7 @@
     "@webstudio-is/tsconfig": "workspace:*"
   },
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
     "import": "./lib/index.js",
     "require": "./lib/index.js"

--- a/packages/html-data/jest.config.js
+++ b/packages/html-data/jest.config.js
@@ -1,1 +1,0 @@
-export { default } from "@webstudio-is/jest-config";

--- a/packages/html-data/package.json
+++ b/packages/html-data/package.json
@@ -10,15 +10,14 @@
     "checks": "pnpm typecheck",
     "dev": "pnpm build --watch",
     "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
-    "dts": "tsc --project tsconfig.dts.json",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
+    "dts": "tsc --project tsconfig.dts.json"
   },
   "devDependencies": {
     "@webstudio-is/tsconfig": "workspace:*"
   },
   "peerDependencies": {},
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
     "import": "./lib/index.js"
   },

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -24,7 +24,7 @@
     "typescript": "5.2.2"
   },
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
     "import": "./lib/index.js",
     "require": "./lib/index.js"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -35,13 +35,13 @@
   },
   "exports": {
     ".": {
-      "source": "./src/index.ts",
+      "webstudio": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/index.js",
       "require": "./lib/index.js"
     },
     "./svg": {
-      "source": "./src/__generated__/svg/index.ts",
+      "webstudio": "./src/__generated__/svg/index.ts",
       "types": "./lib/types/__generated__/svg/index.d.ts",
       "import": "./lib/__generated__/svg/index.js",
       "require": "./lib/__generated__/svg/index.js"

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -36,7 +36,7 @@
     "react-dom": "^18.2.0"
   },
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
     "import": "./lib/index.js",
     "require": "./lib/index.js"

--- a/packages/jest-config/index.js
+++ b/packages/jest-config/index.js
@@ -4,7 +4,7 @@
 module.exports = {
   testEnvironment: "node",
   testEnvironmentOptions: {
-    customExportConditions: ["source"],
+    customExportConditions: ["webstudio"],
   },
   testMatch: ["<rootDir>/src/**/*.test.ts"],
   transform: {

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -27,7 +27,7 @@
     "zod": "^3.21.4"
   },
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/index.d.ts",
     "import": "./lib/index.js",
     "require": "./lib/cjs/index.js"

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -9,12 +9,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "source": "./src/index.ts",
+      "webstudio": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/index.js"
     },
     "./index.server": {
-      "source": "./src/index.server.ts",
+      "webstudio": "./src/index.server.ts",
       "types": "./lib/types/index.server.d.ts",
       "import": "./lib/index.server.js"
     }

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -30,12 +30,12 @@
   },
   "exports": {
     ".": {
-      "source": "./src/index.ts",
+      "webstudio": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/index.js"
     },
     "./index.server": {
-      "source": "./src/index.server.ts",
+      "webstudio": "./src/index.server.ts",
       "types": "./lib/types/index.server.d.ts",
       "import": "./lib/index.server.js"
     }

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -50,13 +50,13 @@
   },
   "exports": {
     ".": {
-      "source": "./src/index.ts",
+      "webstudio": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/index.js",
       "require": "./lib/index.js"
     },
     "./css-normalize": {
-      "source": "./src/css/normalize.ts",
+      "webstudio": "./src/css/normalize.ts",
       "types": "./lib/types/css/normalize.d.ts",
       "import": "./lib/css/normalize.js",
       "require": "./lib/css/normalize.js"

--- a/packages/sdk-cli/src/bin.ts
+++ b/packages/sdk-cli/src/bin.ts
@@ -1,2 +1,2 @@
-#!/usr/bin/env tsx --conditions=source --experimental-specifier-resolution=node --no-warnings
+#!/usr/bin/env tsx --conditions=webstudio --experimental-specifier-resolution=node --no-warnings
 import "./cli";

--- a/packages/sdk-components-react-radix/package.json
+++ b/packages/sdk-components-react-radix/package.json
@@ -14,25 +14,25 @@
   ],
   "exports": {
     ".": {
-      "source": "./src/components.ts",
+      "webstudio": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
       "import": "./lib/components.js",
       "require": "./lib/components.js"
     },
     "./metas": {
-      "source": "./src/metas.ts",
+      "webstudio": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
       "import": "./lib/metas.js",
       "require": "./lib/metas.js"
     },
     "./props": {
-      "source": "./src/props.ts",
+      "webstudio": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
       "import": "./lib/props.js",
       "require": "./lib/props.js"
     },
     "./hooks": {
-      "source": "./src/hooks.ts",
+      "webstudio": "./src/hooks.ts",
       "types": "./lib/types/hooks.d.ts",
       "import": "./lib/hooks.js",
       "require": "./lib/hooks.js"
@@ -41,7 +41,7 @@
   "scripts": {
     "dev": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib --watch",
     "build": "rm -rf lib && esbuild src/components.ts src/metas.ts src/props.ts src/hooks.ts --outdir=lib --bundle --format=esm --packages=external",
-    "build:args": "NODE_OPTIONS=--conditions=source generate-arg-types './src/accordion.tsx !./src/*.stories.tsx !./src/*.ws.tsx' -e asChild -e modal -e defaultValue -e defaultOpen -e defaultChecked && prettier --write \"**/*.props.ts\"",
+    "build:args": "NODE_OPTIONS=--conditions=webstudio generate-arg-types './src/accordion.tsx !./src/*.stories.tsx !./src/*.ws.tsx' -e asChild -e modal -e defaultValue -e defaultOpen -e defaultChecked && prettier --write \"**/*.props.ts\"",
     "build:tailwind": "tsx scripts/generate-tailwind-theme.ts && prettier --write src/theme/__generated__",
     "build:stories": "webstudio-sdk generate-stories && prettier --write \"src/__generated__/*.stories.tsx\"",
     "dts": "tsc --project tsconfig.dts.json",

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -14,19 +14,19 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "source": "./src/components.ts",
+      "webstudio": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
       "import": "./lib/components.js",
       "require": "./lib/components.js"
     },
     "./metas": {
-      "source": "./src/metas.ts",
+      "webstudio": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
       "import": "./lib/metas.js",
       "require": "./lib/metas.js"
     },
     "./props": {
-      "source": "./src/props.ts",
+      "webstudio": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
       "import": "./lib/props.js",
       "require": "./lib/props.js"
@@ -35,7 +35,7 @@
   "scripts": {
     "dev": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib --watch",
     "build": "rm -rf lib && esbuild src/components.ts src/metas.ts src/props.ts --outdir=lib --bundle --format=esm --packages=external",
-    "build:args": "NODE_OPTIONS=--conditions=source generate-arg-types './src/*.tsx !./src/**/*.stories.tsx !./src/**/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
+    "build:args": "NODE_OPTIONS=--conditions=webstudio generate-arg-types './src/*.tsx !./src/**/*.stories.tsx !./src/**/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
     "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc",
     "checks": "pnpm typecheck"

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -14,19 +14,19 @@
   ],
   "exports": {
     ".": {
-      "source": "./src/components.ts",
+      "webstudio": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
       "import": "./lib/components.js",
       "require": "./lib/components.js"
     },
     "./metas": {
-      "source": "./src/metas.ts",
+      "webstudio": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
       "import": "./lib/metas.js",
       "require": "./lib/metas.js"
     },
     "./props": {
-      "source": "./src/props.ts",
+      "webstudio": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
       "import": "./lib/props.js",
       "require": "./lib/props.js"
@@ -35,7 +35,7 @@
   "scripts": {
     "dev": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib --watch",
     "build": "rm -rf lib && esbuild src/components.ts src/metas.ts src/props.ts --outdir=lib --bundle --format=esm --packages=external",
-    "build:args": "NODE_OPTIONS=--conditions=source generate-arg-types './src/*.tsx !./src/*.stories.tsx !./src/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
+    "build:args": "NODE_OPTIONS=--conditions=webstudio generate-arg-types './src/*.tsx !./src/*.stories.tsx !./src/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
     "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc",
     "checks": "pnpm typecheck",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -7,7 +7,7 @@
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "exports": {
-    "source": "./src/index.ts",
+    "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
     "import": "./lib/index.js",
     "require": "./lib/index.js"

--- a/packages/storybook-config/index.ts
+++ b/packages/storybook-config/index.ts
@@ -18,7 +18,7 @@ export default {
       },
       resolve: {
         ...config.resolve,
-        conditions: ["source", "import", "module", "browser", "default"],
+        conditions: ["webstudio", "import", "module", "browser", "default"],
       },
     };
   },

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -29,7 +29,7 @@
   },
   "exports": {
     "./index.server": {
-      "source": "./src/index.server.ts",
+      "webstudio": "./src/index.server.ts",
       "import": "./lib/index.server.js",
       "types": "./lib/types/index.server.d.ts"
     }

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -9,7 +9,7 @@
     "inlineSources": false,
     "isolatedModules": true,
     "moduleResolution": "bundler",
-    "customConditions": ["source"],
+    "customConditions": ["webstudio"],
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "preserveWatchOutput": true,


### PR DESCRIPTION
This fixes the issue with eventsource-parser package having source export condition with different setup.

Now everywhere "webstudio" is used to reference our sources.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @gsppe, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
