### PR TITLE
fix: Allow client-only embeds to avoid hydration errors

### DIFF
--- a/packages/sdk-components-react/src/__generated__/html-embed.props.ts
+++ b/packages/sdk-components-react/src/__generated__/html-embed.props.ts
@@ -1,6 +1,7 @@
 import type { PropMeta } from "@webstudio-is/react-sdk";
 
 export const props: Record<string, PropMeta> = {
+  clientOnly: { required: false, control: "boolean", type: "boolean" },
   code: { required: true, control: "text", type: "string" },
   executeScriptOnCanvas: {
     required: false,

--- a/packages/sdk-components-react/src/html-embed.tsx
+++ b/packages/sdk-components-react/src/html-embed.tsx
@@ -11,6 +11,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 type Props = {
   code: string;
   executeScriptOnCanvas?: boolean;
+  clientOnly?: boolean;
 };
 
 type ChildProps = {
@@ -79,7 +80,7 @@ const Placeholder = (props: ChildProps) => {
 
 export const HtmlEmbed = forwardRef<HTMLDivElement, Props>((props, ref) => {
   const { renderer } = useContext(ReactSdkContext);
-  const { code, executeScriptOnCanvas, ...rest } = props;
+  const { code, executeScriptOnCanvas, clientOnly, ...rest } = props;
 
   // code can be actually undefined when prop is not provided
   if (code === undefined || code.trim().length === 0) {
@@ -88,7 +89,8 @@ export const HtmlEmbed = forwardRef<HTMLDivElement, Props>((props, ref) => {
 
   if (
     (renderer === "canvas" && executeScriptOnCanvas === true) ||
-    renderer === "preview"
+    renderer === "preview" ||
+    clientOnly
   ) {
     return <ExecutableHtml innerRef={ref} code={code} {...rest} />;
   }

--- a/packages/sdk-components-react/src/html-embed.ws.ts
+++ b/packages/sdk-components-react/src/html-embed.ws.ts
@@ -30,5 +30,5 @@ export const propsMeta: WsComponentPropsMeta = {
       rows: 10,
     },
   },
-  initialProps: ["executeScriptOnCanvas"],
+  initialProps: ["clientOnly", "executeScriptOnCanvas"],
 };


### PR DESCRIPTION
## Description

Some scripts cause hydration errors on execution and must be executed only after hydration
https://discord.com/channels/955905230107738152/1136275535572516986

After release this https://apps.webstudio.is/builder/12c30bde-73af-40f0-8fcf-bc3581f06fac?authToken=6c442116-66ce-4a45-8471-db1e9a667069&mode=preview should work well after publish


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
