### PR TITLE
fix: Prevent crash on clicking links within sheet component

### DIFF
--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -59,15 +59,23 @@ export const subscribeInterceptedEvents = () => {
       event.preventDefault();
     }
   };
-  document.documentElement.addEventListener("click", handleClick);
-  // preventDefault in form submit event does not work inside dialog
-  // in bubble mode, capture solves the issue
+
+  // Note: Event handlers behave unexpectedly when used inside a dialog component.
+  // In Dialogs, React intercepts and processes events before they reach our handlers.
+  // To ensure consistent behavior across all components, we're using event capturing.
+  // This allows us to intercept events before React gets a chance to handle them.
+  document.documentElement.addEventListener("click", handleClick, {
+    capture: true,
+  });
   document.documentElement.addEventListener("submit", handleSubmit, {
     capture: true,
   });
+
   document.documentElement.addEventListener("keydown", handleKeydown);
   return () => {
-    document.documentElement.removeEventListener("click", handleClick);
+    document.documentElement.removeEventListener("click", handleClick, {
+      capture: true,
+    });
     document.documentElement.removeEventListener("submit", handleSubmit, {
       capture: true,
     });


### PR DESCRIPTION
## Description

Usually React handlers are processed bedore any document event listeners. In out case for a reason I don't know we had that our handlers were executed before React but not inside Dialog.

capture flag solves the issue.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
