### PR TITLE
perf: generate page prop for links

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -8,6 +8,8 @@ import {
   type Components,
   createElementsTree,
   getIndexesWithinAncestors,
+  normalizeProps,
+  getPropsByInstanceId,
 } from "@webstudio-is/react-sdk";
 import * as baseComponents from "@webstudio-is/sdk-components-react";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
@@ -33,7 +35,6 @@ import {
   WebstudioComponentPreview,
 } from "./features/webstudio-component";
 import {
-  propsIndexStore,
   assetsStore,
   pagesStore,
   instancesStore,
@@ -44,6 +45,7 @@ import {
   registeredComponentMetasStore,
   subscribeComponentHooks,
   dataSourcesLogicStore,
+  propsStore,
 } from "~/shared/nano-states";
 import { useDragAndDrop } from "./shared/use-drag-drop";
 import { useCopyPaste } from "~/shared/copy-paste";
@@ -58,11 +60,6 @@ import { subscribeInterceptedEvents } from "./interceptor";
 import type { ImageLoader } from "@webstudio-is/image";
 
 registerContainers();
-
-const propsByInstanceIdStore = computed(
-  propsIndexStore,
-  (propsIndex) => propsIndex.propsByInstanceId
-);
 
 const useElementsTree = (
   components: Components,
@@ -105,6 +102,28 @@ const useElementsTree = (
       page ? [page.rootInstanceId] : []
     );
   }, [metas, instances, page]);
+
+  const propsByInstanceIdStore = useMemo(() => {
+    return computed(
+      [propsStore, assetsStore, pagesStore],
+      (props, assets, pages) => {
+        if (pages === undefined) {
+          return new Map();
+        }
+        const normalizedProps = normalizeProps({
+          props: Array.from(props.values()),
+          assetBaseUrl: params.assetBaseUrl,
+          assets,
+          pages: new Map(
+            [pages.homePage, ...pages.pages].map((page) => [page.id, page])
+          ),
+        });
+        return getPropsByInstanceId(
+          new Map(normalizedProps.map((prop) => [prop.id, prop]))
+        );
+      }
+    );
+  }, [params.assetBaseUrl]);
 
   return useMemo(() => {
     return createElementsTree({

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -105,7 +105,7 @@ const useElementsTree = (
 
   const propsByInstanceIdStore = useMemo(() => {
     return computed(
-      [propsStore, assetsStore, pagesStore],
+      [propsStore, assetsStore, pagesMapStore],
       (props, assets, pages) => {
         if (pages === undefined) {
           return new Map();
@@ -114,16 +114,14 @@ const useElementsTree = (
           props: Array.from(props.values()),
           assetBaseUrl: params.assetBaseUrl,
           assets,
-          pages: new Map(
-            [pages.homePage, ...pages.pages].map((page) => [page.id, page])
-          ),
+          pages: pages,
         });
         return getPropsByInstanceId(
           new Map(normalizedProps.map((prop) => [prop.id, prop]))
         );
       }
     );
-  }, [params.assetBaseUrl]);
+  }, [params.assetBaseUrl, pagesMapStore]);
 
   return useMemo(() => {
     return createElementsTree({
@@ -155,6 +153,7 @@ const useElementsTree = (
     rootInstanceId,
     components,
     pagesMapStore,
+    propsByInstanceIdStore,
     isPreviewMode,
     indexesWithinAncestors,
     imageLoader,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -43,10 +43,10 @@ export const pageData: PageData = {
         "tUn-hTQ0dKjsaRZ4q3m21",
         {
           id: "tUn-hTQ0dKjsaRZ4q3m21",
-          instanceId: "9I4GRU1sev48hREkQcKQ-",
           name: "href",
-          type: "page",
-          value: "szYLvBduHPmbtqQKCDY0b",
+          instanceId: "9I4GRU1sev48hREkQcKQ-",
+          type: "string",
+          value: "/_route_with_symbols_",
         },
       ],
       [
@@ -73,6 +73,7 @@ export const pageData: PageData = {
         "z8GMy7HFi_j_felIKxGP5",
         {
           id: "z8GMy7HFi_j_felIKxGP5",
+<<<<<<< HEAD
           instanceId: "81ejLVXyFEV1SxiJrWhyw",
           name: "href",
           type: "page",
@@ -80,6 +81,12 @@ export const pageData: PageData = {
             pageId: "-J9I4Oo6mONfQlf_3-OqG",
             instanceId: "qmxnOlSxUGpuhuonVArWJ",
           },
+=======
+          name: "href",
+          instanceId: "81ejLVXyFEV1SxiJrWhyw",
+          type: "string",
+          value: "/heading-with-id#my-heading",
+>>>>>>> cc73fb384 (perf: generate page prop for links)
         },
       ],
     ],
@@ -208,10 +215,22 @@ const Page = (props: { scripts?: ReactNode }) => {
             {"go download this little kitten"}
           </Link>
           <Box data-ws-id="82HYqzxZeahPxSDFNWem5" data-ws-component="Box" />
-          <Link data-ws-id="9I4GRU1sev48hREkQcKQ-" data-ws-component="Link">
+          <Link
+            data-ws-id="9I4GRU1sev48hREkQcKQ-"
+            data-ws-component="Link"
+            href={"/_route_with_symbols_"}
+          >
             {"Symbols in path"}
           </Link>
+<<<<<<< HEAD
           <Link data-ws-id="81ejLVXyFEV1SxiJrWhyw" data-ws-component="Link">
+=======
+          <Link
+            data-ws-id="81ejLVXyFEV1SxiJrWhyw"
+            data-ws-component="Link"
+            href={"/heading-with-id#my-heading"}
+          >
+>>>>>>> cc73fb384 (perf: generate page prop for links)
             {"Link to instance"}
           </Link>
         </Box>

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -73,20 +73,10 @@ export const pageData: PageData = {
         "z8GMy7HFi_j_felIKxGP5",
         {
           id: "z8GMy7HFi_j_felIKxGP5",
-<<<<<<< HEAD
-          instanceId: "81ejLVXyFEV1SxiJrWhyw",
-          name: "href",
-          type: "page",
-          value: {
-            pageId: "-J9I4Oo6mONfQlf_3-OqG",
-            instanceId: "qmxnOlSxUGpuhuonVArWJ",
-          },
-=======
           name: "href",
           instanceId: "81ejLVXyFEV1SxiJrWhyw",
           type: "string",
           value: "/heading-with-id#my-heading",
->>>>>>> cc73fb384 (perf: generate page prop for links)
         },
       ],
     ],
@@ -222,15 +212,11 @@ const Page = (props: { scripts?: ReactNode }) => {
           >
             {"Symbols in path"}
           </Link>
-<<<<<<< HEAD
-          <Link data-ws-id="81ejLVXyFEV1SxiJrWhyw" data-ws-component="Link">
-=======
           <Link
             data-ws-id="81ejLVXyFEV1SxiJrWhyw"
             data-ws-component="Link"
             href={"/heading-with-id#my-heading"}
           >
->>>>>>> cc73fb384 (perf: generate page prop for links)
             {"Link to instance"}
           </Link>
         </Box>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "turbo run build",
+    "build": "turbo run build --filter='!./fixtures/*'",
     "build-packages": "turbo run build --filter=\"!@webstudio-is/builder\"",
     "dts": "turbo run dts",
     "size-test": "turbo run size-test",

--- a/packages/react-sdk/src/hook.test.ts
+++ b/packages/react-sdk/src/hook.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@jest/globals";
-import { getClosestInstance, type InstancePath } from ".";
+import { getClosestInstance, type InstancePath } from "./hook";
 
 test("get closest instance", () => {
   const instancePath: InstancePath = [

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -17,9 +17,9 @@ export {
   normalizeProps,
   useInstanceProps,
   getPropsByInstanceId,
-  usePropUrl,
   getInstanceIdFromComponentProps,
   getIndexWithinAncestorFromComponentProps,
+  usePages,
 } from "./props";
 export { type Params, ReactSdkContext } from "./context";
 export {

--- a/packages/react-sdk/src/props.test.ts
+++ b/packages/react-sdk/src/props.test.ts
@@ -1,13 +1,6 @@
-import { describe, test, expect } from "@jest/globals";
-import type { Page, Prop, Asset, Assets } from "@webstudio-is/sdk";
-import {
-  resolveUrlProp,
-  type Pages,
-  type PropsByInstanceId,
-  normalizeProps,
-} from "./props";
-
-const unique = () => Math.random().toString();
+import { test, expect } from "@jest/globals";
+import type { Prop } from "@webstudio-is/sdk";
+import { normalizeProps } from "./props";
 
 test("normalize asset prop into string", () => {
   expect(
@@ -38,6 +31,7 @@ test("normalize asset prop into string", () => {
           },
         ],
       ]),
+      pages: new Map(),
     })
   ).toEqual([
     {
@@ -50,189 +44,92 @@ test("normalize asset prop into string", () => {
   ]);
 });
 
-describe("resolveUrlProp", () => {
-  const instanceId = unique();
-  const projectId = unique();
-
-  const page1: Page = {
-    id: unique(),
-    path: `/${unique()}`,
-    name: "",
-    title: "",
-    meta: {},
-    rootInstanceId: "0",
-  };
-
-  const page2: Page = {
-    id: unique(),
-    path: `/${unique()}`,
-    name: "",
-    title: "",
-    meta: {},
-    rootInstanceId: "0",
-  };
-
-  const asset1: Asset = {
-    id: unique(),
-    name: unique(),
-    type: "image",
-    projectId,
-    format: "png",
-    size: 100000,
-    createdAt: new Date().toISOString(),
-    description: null,
-    meta: { width: 128, height: 180 },
-  };
-
-  const assetProp: Prop = {
-    type: "asset",
-    id: unique(),
-    instanceId,
-    name: unique(),
-    value: asset1.id,
-  };
-
-  const pageByIdProp: Prop = {
-    type: "page",
-    id: unique(),
-    instanceId,
-    name: unique(),
-    value: page1.id,
-  };
-
-  const instnaceIdProp: Prop = {
-    type: "string",
-    id: unique(),
-    instanceId: unique(),
-    name: "id",
-    value: unique(),
-  };
-
-  const pageSectionProp: Prop = {
-    type: "page",
-    id: unique(),
-    instanceId,
-    name: unique(),
-    value: { pageId: page1.id, instanceId: instnaceIdProp.instanceId },
-  };
-
-  const pageByPathProp: Prop = {
-    type: "string",
-    id: unique(),
-    instanceId,
-    name: unique(),
-    value: page2.path,
-  };
-
-  const arbitraryUrlProp: Prop = {
-    type: "string",
-    id: unique(),
-    instanceId,
-    name: unique(),
-    value: unique(),
-  };
-
-  const duplicatePropName = unique();
-
-  const duplicateUrlPropFirst: Prop = {
-    type: "string",
-    id: unique(),
-    instanceId,
-    name: duplicatePropName,
-    value: unique(),
-  };
-
-  const duplicateUrlPropSecond: Prop = {
-    type: "string",
-    id: unique(),
-    instanceId,
-    name: duplicatePropName,
-    value: unique(),
-  };
-
-  const props: PropsByInstanceId = new Map([
-    [
-      instanceId,
-      [
-        pageByIdProp,
-        pageByPathProp,
-        arbitraryUrlProp,
-        assetProp,
-        pageSectionProp,
-        duplicateUrlPropFirst,
-        duplicateUrlPropSecond,
+test("normalize page prop with path into string", () => {
+  expect(
+    normalizeProps({
+      props: [
+        {
+          id: "prop1",
+          instanceId: "instance1",
+          name: "href",
+          type: "page",
+          value: "page1Id",
+        },
       ],
-    ],
-    [instnaceIdProp.instanceId, [instnaceIdProp]],
+      assetBaseUrl: "",
+      assets: new Map(),
+      pages: new Map([
+        [
+          "page1Id",
+          {
+            id: "page1Id",
+            path: "page1",
+            rootInstanceId: "",
+            name: "",
+            title: "",
+            meta: {},
+          },
+        ],
+      ]),
+    })
+  ).toEqual([
+    {
+      id: "prop1",
+      instanceId: "instance1",
+      name: "href",
+      type: "string",
+      value: "/page1",
+    },
   ]);
+});
 
-  const pages: Pages = new Map([
-    [page1.id, page1],
-    [page2.id, page2],
-  ]);
-
-  const assets: Assets = new Map([[asset1.id, asset1]]);
-
-  const stores = {
-    assetBaseUrl: "/assets/",
-    props,
-    pages,
-    assets,
+test("normalize page prop with path and hash into string", () => {
+  const idProp: Prop = {
+    id: "prop1",
+    instanceId: "instance1",
+    name: "id",
+    type: "string",
+    value: "my anchor",
   };
-
-  test("if instanceId is unknown returns undefined", () => {
-    expect(
-      resolveUrlProp("unknown", pageByIdProp.name, stores)
-    ).toBeUndefined();
-  });
-
-  test("if prop name is unknown returns undefined", () => {
-    expect(resolveUrlProp(instanceId, "unknown", stores)).toBeUndefined();
-  });
-
-  test("asset by id", () => {
-    expect(resolveUrlProp(instanceId, assetProp.name, stores)).toEqual({
+  expect(
+    normalizeProps({
+      props: [
+        {
+          id: "prop1",
+          instanceId: "instance1",
+          name: "href",
+          type: "page",
+          value: {
+            pageId: "page1Id",
+            instanceId: "instance1",
+          },
+        },
+        idProp,
+      ],
+      assetBaseUrl: "",
+      assets: new Map(),
+      pages: new Map([
+        [
+          "page1Id",
+          {
+            id: "page1Id",
+            path: "page1",
+            rootInstanceId: "",
+            name: "",
+            title: "",
+            meta: {},
+          },
+        ],
+      ]),
+    })
+  ).toEqual([
+    {
+      id: "prop1",
+      instanceId: "instance1",
+      name: "href",
       type: "string",
-      url: `/assets/${asset1.name}`,
-    });
-  });
-
-  test("page by id", () => {
-    expect(resolveUrlProp(instanceId, pageByIdProp.name, stores)).toEqual({
-      type: "page",
-      page: page1,
-    });
-  });
-
-  test("page by path", () => {
-    expect(resolveUrlProp(instanceId, pageByPathProp.name, stores)).toEqual({
-      type: "page",
-      page: page2,
-    });
-  });
-
-  test("section on a page", () => {
-    expect(resolveUrlProp(instanceId, pageSectionProp.name, stores)).toEqual({
-      type: "page",
-      page: page1,
-      instanceId: instnaceIdProp.instanceId,
-      hash: instnaceIdProp.value,
-    });
-  });
-
-  test("arbitrary url", () => {
-    expect(resolveUrlProp(instanceId, arbitraryUrlProp.name, stores)).toEqual({
-      type: "string",
-      url: arbitraryUrlProp.value,
-    });
-  });
-
-  // We had a bug that some props were duplicated https://github.com/webstudio-is/webstudio/pull/2170
-  // Use the latest prop to ensure consistency with the builder settings panel.
-  test("duplicate prop name", () => {
-    expect(resolveUrlProp(instanceId, duplicatePropName, stores)).toEqual({
-      type: "string",
-      url: duplicateUrlPropSecond.value,
-    });
-  });
+      value: "/page1#my%20anchor",
+    },
+    idProp,
+  ]);
 });

--- a/packages/sdk-components-react/src/link.tsx
+++ b/packages/sdk-components-react/src/link.tsx
@@ -1,8 +1,4 @@
 import { forwardRef, type ComponentProps } from "react";
-import {
-  usePropUrl,
-  getInstanceIdFromComponentProps,
-} from "@webstudio-is/react-sdk";
 
 export const defaultTag = "a";
 
@@ -12,27 +8,7 @@ type Props = Omit<ComponentProps<"a">, "target"> & {
 };
 
 export const Link = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
-  const href = usePropUrl(getInstanceIdFromComponentProps(props), "href");
-
-  let url = "#";
-
-  switch (href?.type) {
-    case "page": {
-      url = href.page.path === "" ? "/" : href.page.path;
-      const urlTo = new URL(url, "https://any-valid.url");
-      url = urlTo.pathname;
-
-      if (href.hash !== undefined) {
-        urlTo.hash = encodeURIComponent(href.hash);
-        url = `${urlTo.pathname}${urlTo.hash}`;
-      }
-      break;
-    }
-    case "string":
-      url = href.url;
-  }
-
-  return <a {...props} href={url} ref={ref} />;
+  return <a {...props} href={props.href ?? "#"} ref={ref} />;
 });
 
 Link.displayName = "Link";


### PR DESCRIPTION
Moved links resolve into props normalizing which is called for whole project before rendering converting page prop into string.

Remix links now check only if provided path matches any page. Ideally it should be handled with navigation api to remove all complexity from links components.

This will let us stop rendering props and assets data in generated pages.

Also fixed links with hashes.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
