### PR TITLE
perf: generate pages paths

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -114,7 +114,7 @@ const useElementsTree = (
           props: Array.from(props.values()),
           assetBaseUrl: params.assetBaseUrl,
           assets,
-          pages: pages,
+          pages,
         });
         return getPropsByInstanceId(
           new Map(normalizedProps.map((prop) => [prop.id, prop]))
@@ -134,7 +134,6 @@ const useElementsTree = (
       indexesWithinAncestors,
       propsByInstanceIdStore,
       assetsStore,
-      pagesStore: pagesMapStore,
       dataSourcesLogicStore,
       Component: isPreviewMode
         ? WebstudioComponentPreview
@@ -152,7 +151,6 @@ const useElementsTree = (
     instances,
     rootInstanceId,
     components,
-    pagesMapStore,
     propsByInstanceIdStore,
     isPreviewMode,
     indexesWithinAncestors,

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -54,6 +54,8 @@ const Page = (props: { scripts?: ReactNode }) => {
 
 export { Page };
 
+export const pagesPaths = new Set([""]);
+
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import {
   pageData,
   user,
   projectId,
+  pagesPaths,
   formsProperties,
   Page,
 } from "../__generated__/_index.tsx";
@@ -171,13 +172,11 @@ const Outlet = () => {
         assetsStore: atom(
           new Map(pageData.assets.map((asset) => [asset.id, asset]))
         ),
-        pagesStore: atom(
-          new Map(pageData.pages.map((page) => [page.id, page]))
-        ),
         dataSourcesLogicStore: atom(new Map()),
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
+        pagesPaths,
         indexesWithinAncestors: new Map(),
       }}
     >

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -54,6 +54,8 @@ const Page = (props: { scripts?: ReactNode }) => {
 
 export { Page };
 
+export const pagesPaths = new Set([""]);
+
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import {
   pageData,
   user,
   projectId,
+  pagesPaths,
   formsProperties,
   Page,
 } from "../__generated__/_index.tsx";
@@ -171,13 +172,11 @@ const Outlet = () => {
         assetsStore: atom(
           new Map(pageData.assets.map((asset) => [asset.id, asset]))
         ),
-        pagesStore: atom(
-          new Map(pageData.pages.map((page) => [page.id, page]))
-        ),
         dataSourcesLogicStore: atom(new Map()),
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
+        pagesPaths,
         indexesWithinAncestors: new Map(),
       }}
     >

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -54,6 +54,8 @@ const Page = (props: { scripts?: ReactNode }) => {
 
 export { Page };
 
+export const pagesPaths = new Set([""]);
+
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import {
   pageData,
   user,
   projectId,
+  pagesPaths,
   formsProperties,
   Page,
 } from "../__generated__/_index.tsx";
@@ -171,13 +172,11 @@ const Outlet = () => {
         assetsStore: atom(
           new Map(pageData.assets.map((asset) => [asset.id, asset]))
         ),
-        pagesStore: atom(
-          new Map(pageData.pages.map((page) => [page.id, page]))
-        ),
         dataSourcesLogicStore: atom(new Map()),
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
+        pagesPaths,
         indexesWithinAncestors: new Map(),
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -120,6 +120,14 @@ const Page = (props: { scripts?: ReactNode }) => {
 
 export { Page };
 
+export const pagesPaths = new Set([
+  "",
+  "/radix",
+  "/_route_with_symbols_",
+  "/form",
+  "/heading-with-id",
+]);
+
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -420,6 +420,14 @@ const Page = (props: { scripts?: ReactNode }) => {
 
 export { Page };
 
+export const pagesPaths = new Set([
+  "",
+  "/radix",
+  "/_route_with_symbols_",
+  "/form",
+  "/heading-with-id",
+]);
+
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -122,6 +122,14 @@ const Page = (props: { scripts?: ReactNode }) => {
 
 export { Page };
 
+export const pagesPaths = new Set([
+  "",
+  "/radix",
+  "/_route_with_symbols_",
+  "/form",
+  "/heading-with-id",
+]);
+
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -302,6 +302,14 @@ const Page = (props: { scripts?: ReactNode }) => {
 
 export { Page };
 
+export const pagesPaths = new Set([
+  "",
+  "/radix",
+  "/_route_with_symbols_",
+  "/form",
+  "/heading-with-id",
+]);
+
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -237,6 +237,14 @@ const Page = (props: { scripts?: ReactNode }) => {
 
 export { Page };
 
+export const pagesPaths = new Set([
+  "",
+  "/radix",
+  "/_route_with_symbols_",
+  "/form",
+  "/heading-with-id",
+]);
+
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -15,6 +15,7 @@ import {
   pageData,
   user,
   projectId,
+  pagesPaths,
   formsProperties,
   Page,
 } from "../__generated__/[_route_with_symbols_]._index.tsx";
@@ -171,13 +172,11 @@ const Outlet = () => {
         assetsStore: atom(
           new Map(pageData.assets.map((asset) => [asset.id, asset]))
         ),
-        pagesStore: atom(
-          new Map(pageData.pages.map((page) => [page.id, page]))
-        ),
         dataSourcesLogicStore: atom(new Map()),
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
+        pagesPaths,
         indexesWithinAncestors: new Map(),
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -15,6 +15,7 @@ import {
   pageData,
   user,
   projectId,
+  pagesPaths,
   formsProperties,
   Page,
 } from "../__generated__/[form]._index.tsx";
@@ -171,13 +172,11 @@ const Outlet = () => {
         assetsStore: atom(
           new Map(pageData.assets.map((asset) => [asset.id, asset]))
         ),
-        pagesStore: atom(
-          new Map(pageData.pages.map((page) => [page.id, page]))
-        ),
         dataSourcesLogicStore: atom(new Map()),
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
+        pagesPaths,
         indexesWithinAncestors: new Map(),
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -15,6 +15,7 @@ import {
   pageData,
   user,
   projectId,
+  pagesPaths,
   formsProperties,
   Page,
 } from "../__generated__/[heading-with-id]._index.tsx";
@@ -171,13 +172,11 @@ const Outlet = () => {
         assetsStore: atom(
           new Map(pageData.assets.map((asset) => [asset.id, asset]))
         ),
-        pagesStore: atom(
-          new Map(pageData.pages.map((page) => [page.id, page]))
-        ),
         dataSourcesLogicStore: atom(new Map()),
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
+        pagesPaths,
         indexesWithinAncestors: new Map(),
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -15,6 +15,7 @@ import {
   pageData,
   user,
   projectId,
+  pagesPaths,
   formsProperties,
   Page,
 } from "../__generated__/[radix]._index.tsx";
@@ -171,13 +172,11 @@ const Outlet = () => {
         assetsStore: atom(
           new Map(pageData.assets.map((asset) => [asset.id, asset]))
         ),
-        pagesStore: atom(
-          new Map(pageData.pages.map((page) => [page.id, page]))
-        ),
         dataSourcesLogicStore: atom(new Map()),
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
+        pagesPaths,
         indexesWithinAncestors: new Map(),
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import {
   pageData,
   user,
   projectId,
+  pagesPaths,
   formsProperties,
   Page,
 } from "../__generated__/_index.tsx";
@@ -171,13 +172,11 @@ const Outlet = () => {
         assetsStore: atom(
           new Map(pageData.assets.map((asset) => [asset.id, asset]))
         ),
-        pagesStore: atom(
-          new Map(pageData.pages.map((page) => [page.id, page]))
-        ),
         dataSourcesLogicStore: atom(new Map()),
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
+        pagesPaths,
         indexesWithinAncestors: new Map(),
       }}
     >

--- a/packages/cli/__generated__/index.tsx
+++ b/packages/cli/__generated__/index.tsx
@@ -35,6 +35,8 @@ const Page = (_props: { scripts: ReactNode }) => {
 
 export { Page };
 
+export const pagesPaths = new Set<string>();
+
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -466,6 +466,7 @@ export const prebuild = async (options: {
     const props = new Map(pageData.build.props);
     const dataSources = new Map(pageData.build.dataSources);
     const utilsExport = generateUtilsExport({
+      pages: siteData.build.pages,
       props,
     });
     const pageComponent = generatePageComponent({

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -15,6 +15,7 @@ import {
   pageData,
   user,
   projectId,
+  pagesPaths,
   formsProperties,
   Page,
 } from "../__generated__/index";
@@ -171,13 +172,11 @@ const Outlet = () => {
         assetsStore: atom(
           new Map(pageData.assets.map((asset) => [asset.id, asset]))
         ),
-        pagesStore: atom(
-          new Map(pageData.pages.map((page) => [page.id, page]))
-        ),
         dataSourcesLogicStore: atom(new Map()),
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
+        pagesPaths,
         indexesWithinAncestors: new Map(),
       }}
     >

--- a/packages/react-sdk/src/context.tsx
+++ b/packages/react-sdk/src/context.tsx
@@ -1,7 +1,7 @@
 import { type ReadableAtom, atom } from "nanostores";
 import { createContext } from "react";
-import type { Assets } from "@webstudio-is/sdk";
-import type { Pages, PropsByInstanceId } from "./props";
+import type { Assets, Page } from "@webstudio-is/sdk";
+import type { PropsByInstanceId } from "./props";
 import type { IndexesWithinAncestors } from "./instance-utils";
 import type { ImageLoader } from "@webstudio-is/image";
 
@@ -35,9 +35,14 @@ export type Params = {
 export const ReactSdkContext = createContext<
   Params & {
     imageLoader: ImageLoader;
+    /**
+     * List of pages paths for link component
+     * to navigate without reloading on published sites
+     * always empty for builder which handle anchor clicks globally
+     */
+    pagesPaths: Set<Page["path"]>;
     propsByInstanceIdStore: ReadableAtom<PropsByInstanceId>;
     assetsStore: ReadableAtom<Assets>;
-    pagesStore: ReadableAtom<Pages>;
     dataSourcesLogicStore: ReadableAtom<Map<string, unknown>>;
     indexesWithinAncestors: IndexesWithinAncestors;
   }
@@ -45,9 +50,9 @@ export const ReactSdkContext = createContext<
   assetBaseUrl: "/",
   imageBaseUrl: "/",
   imageLoader: ({ src }) => src,
+  pagesPaths: new Set(),
   propsByInstanceIdStore: atom(new Map()),
   assetsStore: atom(new Map()),
-  pagesStore: atom(new Map()),
   dataSourcesLogicStore: atom(new Map()),
   indexesWithinAncestors: new Map(),
 });

--- a/packages/react-sdk/src/generator.test.ts
+++ b/packages/react-sdk/src/generator.test.ts
@@ -1,9 +1,22 @@
 import { expect, test } from "@jest/globals";
 import { generateUtilsExport } from "./generator";
 
-test("generates utils", () => {
+const createPage = (path: string) => ({
+  id: "",
+  path,
+  name: "",
+  title: "",
+  rootInstanceId: "",
+  meta: {},
+});
+
+test("generates forms properties", () => {
   expect(
     generateUtilsExport({
+      pages: {
+        homePage: createPage("1"),
+        pages: [],
+      },
       props: new Map([
         [
           "method1Id",
@@ -41,7 +54,27 @@ test("generates utils", () => {
     })
   ).toMatchInlineSnapshot(`
   "
+    export const pagesPaths = new Set(["1"])
+
     export const formsProperties = new Map<string, { method?: string, action?: string }>([["1",{"method":"post"}],["2",{"method":"get","action":"/index.php"}]])
+    "
+  `);
+});
+
+test("generates list of pages paths", () => {
+  expect(
+    generateUtilsExport({
+      pages: {
+        homePage: createPage("/path1"),
+        pages: [createPage("/path2"), createPage("/path3")],
+      },
+      props: new Map(),
+    })
+  ).toMatchInlineSnapshot(`
+  "
+    export const pagesPaths = new Set(["/path1","/path2","/path3"])
+
+    export const formsProperties = new Map<string, { method?: string, action?: string }>([])
     "
   `);
 });

--- a/packages/react-sdk/src/generator.ts
+++ b/packages/react-sdk/src/generator.ts
@@ -1,6 +1,7 @@
-import type { Props } from "@webstudio-is/sdk";
+import type { Pages, Props } from "@webstudio-is/sdk";
 
 type PageData = {
+  pages: Pages;
   props: Props;
 };
 
@@ -8,6 +9,17 @@ type PageData = {
  * Generates data based utilities at build time
  */
 export const generateUtilsExport = (siteData: PageData) => {
+  // list of paths from pages to use framework link component
+  // for ui routes
+  const pagesPaths: string[] = [siteData.pages.homePage.path];
+  for (const page of siteData.pages.pages) {
+    pagesPaths.push(page.path);
+  }
+  const generatedPagesPaths = `export const pagesPaths = new Set(${JSON.stringify(
+    pagesPaths
+  )})`;
+
+  // method and action per instance extracted from props
   const formsProperties = new Map<
     string,
     { method?: string; action?: string }
@@ -29,6 +41,8 @@ export const generateUtilsExport = (siteData: PageData) => {
   )})`;
 
   return `
+  ${generatedPagesPaths}
+
   ${generatedFormsProperties}
   `;
 };

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -19,7 +19,6 @@ export {
   getPropsByInstanceId,
   getInstanceIdFromComponentProps,
   getIndexWithinAncestorFromComponentProps,
-  usePages,
 } from "./props";
 export { type Params, ReactSdkContext } from "./context";
 export {

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -9,12 +9,6 @@ export type PropsByInstanceId = Map<Instance["id"], Prop[]>;
 
 export type Pages = Map<Page["id"], Page>;
 
-export const usePages = (): Pages => {
-  const { pagesStore } = useContext(ReactSdkContext);
-  const pages = useStore(pagesStore);
-  return pages;
-};
-
 export const normalizeProps = ({
   props,
   assetBaseUrl,

--- a/packages/react-sdk/src/tree/create-elements-tree.tsx
+++ b/packages/react-sdk/src/tree/create-elements-tree.tsx
@@ -8,7 +8,7 @@ import type { ReadableAtom } from "nanostores";
 import type { Instance, Instances, Assets } from "@webstudio-is/sdk";
 import type { Components } from "../components/components-utils";
 import { type Params, ReactSdkContext } from "../context";
-import type { Pages, PropsByInstanceId } from "../props";
+import type { PropsByInstanceId } from "../props";
 import type { WebstudioComponentProps } from "./webstudio-component";
 import type { IndexesWithinAncestors } from "../instance-utils";
 import type { ImageLoader } from "@webstudio-is/image";
@@ -24,7 +24,6 @@ export const createElementsTree = ({
   rootInstanceId,
   propsByInstanceIdStore,
   assetsStore,
-  pagesStore,
   dataSourcesLogicStore,
   indexesWithinAncestors,
   Component,
@@ -36,7 +35,6 @@ export const createElementsTree = ({
   rootInstanceId: Instance["id"];
   propsByInstanceIdStore: ReadableAtom<PropsByInstanceId>;
   assetsStore: ReadableAtom<Assets>;
-  pagesStore: ReadableAtom<Pages>;
   dataSourcesLogicStore: ReadableAtom<Map<string, unknown>>;
   indexesWithinAncestors: IndexesWithinAncestors;
 
@@ -76,10 +74,10 @@ export const createElementsTree = ({
       value={{
         propsByInstanceIdStore,
         assetsStore,
-        pagesStore,
         dataSourcesLogicStore,
         renderer,
         imageLoader,
+        pagesPaths: new Set(),
         assetBaseUrl,
         imageBaseUrl,
         indexesWithinAncestors,

--- a/packages/sdk-components-react-remix/src/shared/remix-link.tsx
+++ b/packages/sdk-components-react-remix/src/shared/remix-link.tsx
@@ -1,6 +1,6 @@
-import { forwardRef, type ComponentPropsWithoutRef } from "react";
+import { forwardRef, type ComponentPropsWithoutRef, useContext } from "react";
 import { NavLink as RemixLink } from "@remix-run/react";
-import { usePages } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import type { Link } from "@webstudio-is/sdk-components-react";
 
 type Props = Omit<ComponentPropsWithoutRef<typeof Link>, "target"> & {
@@ -16,16 +16,14 @@ type Props = Omit<ComponentPropsWithoutRef<typeof Link>, "target"> & {
 
 export const wrapLinkComponent = (BaseLink: typeof Link) => {
   const Component = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
-    const pages = usePages();
+    const { pagesPaths } = useContext(ReactSdkContext);
     const href = props.href;
 
     // use remix link when url references webstudio page
     if (href !== undefined) {
       const url = new URL(href, "https://any-valid.url");
-      for (const page of pages.values()) {
-        if (page.path === url.pathname) {
-          return <RemixLink {...props} to={href} ref={ref} />;
-        }
+      if (pagesPaths.has(url.pathname)) {
+        return <RemixLink {...props} to={href} ref={ref} />;
       }
     }
 

--- a/packages/sdk-components-react-remix/src/shared/remix-link.tsx
+++ b/packages/sdk-components-react-remix/src/shared/remix-link.tsx
@@ -22,7 +22,7 @@ export const wrapLinkComponent = (BaseLink: typeof Link) => {
     // use remix link when url references webstudio page
     if (href !== undefined) {
       const url = new URL(href, "https://any-valid.url");
-      if (pagesPaths.has(url.pathname)) {
+      if (pagesPaths.has(url.pathname === "/" ? "" : url.pathname)) {
         return <RemixLink {...props} to={href} ref={ref} />;
       }
     }


### PR DESCRIPTION
Here generated a list of pages paths. It is used in link component to switch to remix link internally when the link is app route.

Providing whole pages list can bloat runtime when there are many pages or when there are many seo data so having single page per route should be enough.

The list is always empty in builder because links are managed with global interceptor. Ideally frameworks should uses navigation api and distinct routes from other paths so we would not need to generate anything.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
