### PR TITLE
refactor: move props logic to canvas

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -32,6 +32,7 @@ import { useCanvasShortcuts } from "./canvas-shortcuts";
 import { useManageDesignModeStyles, GlobalStyles } from "./shared/styles";
 import {
   WebstudioComponentCanvas,
+  WebstudioComponentContext,
   WebstudioComponentPreview,
 } from "./features/webstudio-component";
 import {
@@ -124,28 +125,32 @@ const useElementsTree = (
   }, [params.assetBaseUrl, pagesMapStore]);
 
   return useMemo(() => {
-    return createElementsTree({
-      renderer: isPreviewMode ? "preview" : "canvas",
-      imageBaseUrl: params.imageBaseUrl,
-      assetBaseUrl: params.assetBaseUrl,
-      imageLoader,
-      instances,
-      rootInstanceId,
-      indexesWithinAncestors,
-      propsByInstanceIdStore,
-      assetsStore,
-      dataSourcesLogicStore,
-      Component: isPreviewMode
-        ? WebstudioComponentPreview
-        : WebstudioComponentCanvas,
-      components,
-      scripts: (
-        <>
-          <ScrollRestoration />
-          <Scripts />
-        </>
-      ),
-    });
+    return (
+      <WebstudioComponentContext.Provider value={{ propsByInstanceIdStore }}>
+        {createElementsTree({
+          renderer: isPreviewMode ? "preview" : "canvas",
+          imageBaseUrl: params.imageBaseUrl,
+          assetBaseUrl: params.assetBaseUrl,
+          imageLoader,
+          instances,
+          rootInstanceId,
+          indexesWithinAncestors,
+          propsByInstanceIdStore,
+          assetsStore,
+          dataSourcesLogicStore,
+          Component: isPreviewMode
+            ? WebstudioComponentPreview
+            : WebstudioComponentCanvas,
+          components,
+          scripts: (
+            <>
+              <ScrollRestoration />
+              <Scripts />
+            </>
+          ),
+        })}
+      </WebstudioComponentContext.Provider>
+    );
   }, [
     params,
     instances,

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -15,7 +15,6 @@ export {
 export * from "./embed-template";
 export {
   normalizeProps,
-  useInstanceProps,
   getPropsByInstanceId,
   getInstanceIdFromComponentProps,
   getIndexWithinAncestorFromComponentProps,

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -1,8 +1,4 @@
-import { useContext, useMemo } from "react";
-import { computed } from "nanostores";
-import { useStore } from "@nanostores/react";
 import type { Instance, Page, Prop, Props, Assets } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "./context";
 import { idAttribute, indexAttribute } from "./tree/webstudio-component";
 
 export type PropsByInstanceId = Map<Instance["id"], Prop[]>;
@@ -93,55 +89,6 @@ export const getPropsByInstanceId = (props: Props) => {
 
 // this utility is be used only for preview with static props
 // so there is no need to use computed to optimize rerenders
-export const useInstanceProps = (instanceId: Instance["id"]) => {
-  const {
-    propsByInstanceIdStore,
-    dataSourcesLogicStore,
-    indexesWithinAncestors,
-  } = useContext(ReactSdkContext);
-  const index = indexesWithinAncestors.get(instanceId);
-  const instancePropsObjectStore = useMemo(() => {
-    return computed(
-      [propsByInstanceIdStore, dataSourcesLogicStore],
-      (propsByInstanceId, dataSourcesLogic) => {
-        const instancePropsObject: Record<Prop["name"], unknown> = {};
-        if (index !== undefined) {
-          instancePropsObject[indexAttribute] = index.toString();
-        }
-        const instanceProps = propsByInstanceId.get(instanceId);
-        if (instanceProps === undefined) {
-          return instancePropsObject;
-        }
-        for (const prop of instanceProps) {
-          // asset and page are normalized to string
-          if (prop.type === "asset" || prop.type === "page") {
-            continue;
-          }
-          if (prop.type === "dataSource") {
-            const dataSourceId = prop.value;
-            const value = dataSourcesLogic.get(dataSourceId);
-            if (value !== undefined) {
-              instancePropsObject[prop.name] = value;
-            }
-            continue;
-          }
-          if (prop.type === "action") {
-            const action = dataSourcesLogic.get(prop.id);
-            if (typeof action === "function") {
-              instancePropsObject[prop.name] = action;
-            }
-            continue;
-          }
-          instancePropsObject[prop.name] = prop.value;
-        }
-        return instancePropsObject;
-      }
-    );
-  }, [propsByInstanceIdStore, dataSourcesLogicStore, instanceId, index]);
-  const instancePropsObject = useStore(instancePropsObjectStore);
-  return instancePropsObject;
-};
-
 export const getInstanceIdFromComponentProps = (
   props: Record<string, unknown>
 ) => {

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -87,8 +87,6 @@ export const getPropsByInstanceId = (props: Props) => {
   return propsByInstanceId;
 };
 
-// this utility is be used only for preview with static props
-// so there is no need to use computed to optimize rerenders
 export const getInstanceIdFromComponentProps = (
   props: Record<string, unknown>
 ) => {


### PR DESCRIPTION
Moved canvas props logic from react-sdk to builder. Added new context to pass props store, not global because depends on params.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
