### PR TITLE
refactor: drop store initial value setters

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -24,20 +24,19 @@ import {
 } from "./features/workspace";
 import { usePublishShortcuts } from "./shared/shortcuts";
 import {
+  assetsStore,
+  authPermitStore,
+  authTokenStore,
+  breakpointsStore,
+  dataSourcesStore,
+  instancesStore,
   pagesStore,
   projectStore,
+  propsStore,
+  styleSourceSelectionsStore,
+  styleSourcesStore,
+  stylesStore,
   useIsPreviewMode,
-  useSetAssets,
-  useSetAuthPermit,
-  useSetAuthToken,
-  useSetBreakpoints,
-  useSetDataSources,
-  useSetInstances,
-  useSetPages,
-  useSetProps,
-  useSetStyles,
-  useSetStyleSources,
-  useSetStyleSourceSelections,
 } from "~/shared/nano-states";
 import { type Settings, useClientSettings } from "./shared/client-settings";
 import { getBuildUrl } from "~/shared/router-utils";
@@ -45,6 +44,7 @@ import { useCopyPaste } from "~/shared/copy-paste";
 import { BlockingAlerts } from "./features/blocking-alerts";
 import { useStore } from "@nanostores/react";
 import { useSyncPageUrl } from "~/shared/pages";
+import { useMount } from "~/shared/hook-utils/use-mount";
 
 registerContainers();
 
@@ -54,12 +54,6 @@ export const links = () => {
     { rel: "stylesheet", href: builderStyles },
     { rel: "stylesheet", href: prismStyles },
   ];
-};
-
-const useSetProject = (project: Project) => {
-  useEffect(() => {
-    projectStore.set(project);
-  }, [project]);
 };
 
 const useNavigatorLayout = () => {
@@ -240,25 +234,30 @@ export const Builder = ({
   authToken,
   authPermit,
 }: BuilderProps) => {
-  useSetProject(project);
-  useSetPages(build.pages);
-  useSetBreakpoints(build.breakpoints);
-  useSetProps(build.props);
-  useSetDataSources(build.dataSources);
-  useSetStyles(build.styles);
-  useSetStyleSources(build.styleSources);
-  useSetStyleSourceSelections(build.styleSourceSelections);
-  useSetInstances(build.instances);
+  useMount(() => {
+    // additional data stores
+    projectStore.set(project);
+    authPermitStore.set(authPermit);
+    authTokenStore.set(authToken);
+
+    // set initial containers value
+    assetsStore.set(new Map(assets));
+    instancesStore.set(new Map(build.instances));
+    dataSourcesStore.set(new Map(build.dataSources));
+    // props should be after data sources to compute logic
+    propsStore.set(new Map(build.props));
+    pagesStore.set(build.pages);
+    styleSourcesStore.set(new Map(build.styleSources));
+    styleSourceSelectionsStore.set(new Map(build.styleSourceSelections));
+    breakpointsStore.set(new Map(build.breakpoints));
+    stylesStore.set(new Map(build.styles));
+  });
 
   useUnmount(() => {
     pagesStore.set(undefined);
   });
 
   useSyncPageUrl();
-
-  useSetAssets(assets);
-  useSetAuthToken(authToken);
-  useSetAuthPermit(authPermit);
 
   const [publish, publishRef] = usePublish();
   useBuilderStore(publish);

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -1,8 +1,6 @@
 import { atom, computed } from "nanostores";
-import type { Instance, Instances } from "@webstudio-is/sdk";
+import type { Instances } from "@webstudio-is/sdk";
 import type { InstanceSelector } from "../tree-utils";
-import type { ItemId } from "node_modules/@webstudio-is/design-system/src/components/tree/item-utils";
-import { useMount } from "~/shared/hook-utils/use-mount";
 
 export const isResizingCanvasStore = atom(false);
 
@@ -10,18 +8,13 @@ export const selectedInstanceSelectorStore = atom<undefined | InstanceSelector>(
   undefined
 );
 
-export const editingItemIdStore = atom<undefined | ItemId>(undefined);
+export const editingItemIdStore = atom<undefined | string>(undefined);
 
 export const textEditingInstanceSelectorStore = atom<
   undefined | InstanceSelector
 >();
 
 export const instancesStore = atom<Instances>(new Map());
-export const useSetInstances = (instances: [Instance["id"], Instance][]) => {
-  useMount(() => {
-    instancesStore.set(new Map(instances));
-  });
-};
 
 export const selectedInstanceStore = computed(
   [instancesStore, selectedInstanceSelectorStore],

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -6,30 +6,24 @@ import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
 import type { ItemDropTarget, Placement } from "@webstudio-is/design-system";
 import {
   createScope,
-  type Asset,
   type Assets,
-  type Breakpoint,
   type DataSource,
   type DataSources,
   type Instance,
   type Prop,
   type Props,
   type StyleDecl,
-  type StyleDeclKey,
   type Styles,
   type StyleSource,
   type StyleSources,
-  type StyleSourceSelection,
   type StyleSourceSelections,
 } from "@webstudio-is/sdk";
 import { generateDataSources } from "@webstudio-is/react-sdk";
 import type { Style } from "@webstudio-is/css-engine";
 import type { DragStartPayload } from "~/canvas/shared/use-drag-drop";
-import { useMount } from "~/shared/hook-utils/use-mount";
 import { shallowComputed } from "../store-utils";
 import { type InstanceSelector } from "../tree-utils";
 import type { htmlTags as HtmlTags } from "html-tags";
-import { breakpointsStore } from "./breakpoints";
 import { instancesStore, selectedInstanceSelectorStore } from "./instances";
 import { selectedPageStore } from "./pages";
 import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
@@ -68,13 +62,6 @@ export const dataSourcesStore = atom<DataSources>(new Map());
 export const dataSourceVariablesStore = atom<Map<DataSource["id"], unknown>>(
   new Map()
 );
-export const useSetDataSources = (
-  dataSources: [DataSource["id"], DataSource][]
-) => {
-  useMount(() => {
-    dataSourcesStore.set(new Map(dataSources));
-  });
-};
 
 export const propsStore = atom<Props>(new Map());
 export const propsIndexStore = computed(propsStore, (props) => {
@@ -92,11 +79,6 @@ export const propsIndexStore = computed(propsStore, (props) => {
     propsByInstanceId,
   };
 });
-export const useSetProps = (props: [Prop["id"], Prop][]) => {
-  useMount(() => {
-    propsStore.set(new Map(props));
-  });
-};
 
 // result of executing generated code
 // includes variables, computed expressions and action callbacks
@@ -147,11 +129,6 @@ export const dataSourcesLogicStore = computed(
 
 export const stylesStore = atom<Styles>(new Map());
 
-export const useSetStyles = (styles: [StyleDeclKey, StyleDecl][]) => {
-  useMount(() => {
-    stylesStore.set(new Map(styles));
-  });
-};
 export const useInstanceStyles = (instanceId: undefined | Instance["id"]) => {
   const instanceStylesStore = useMemo(() => {
     return shallowComputed([stylesIndexStore], (stylesIndex) => {
@@ -167,24 +144,9 @@ export const useInstanceStyles = (instanceId: undefined | Instance["id"]) => {
 
 export const styleSourcesStore = atom<StyleSources>(new Map());
 
-export const useSetStyleSources = (
-  styleSources: [StyleSource["id"], StyleSource][]
-) => {
-  useMount(() => {
-    styleSourcesStore.set(new Map(styleSources));
-  });
-};
-
 export const styleSourceSelectionsStore = atom<StyleSourceSelections>(
   new Map()
 );
-export const useSetStyleSourceSelections = (
-  styleSourceSelections: [Instance["id"], StyleSourceSelection][]
-) => {
-  useMount(() => {
-    styleSourceSelectionsStore.set(new Map(styleSourceSelections));
-  });
-};
 
 export type StyleSourceSelector = {
   styleSourceId: StyleSource["id"];
@@ -237,20 +199,7 @@ export const stylesIndexStore = computed(
   }
 );
 
-export const useSetBreakpoints = (
-  breakpoints: [Breakpoint["id"], Breakpoint][]
-) => {
-  useMount(() => {
-    breakpointsStore.set(new Map(breakpoints));
-  });
-};
-
 export const assetsStore = atom<Assets>(new Map());
-export const useSetAssets = (assets: [Asset["id"], Asset][]) => {
-  useMount(() => {
-    assetsStore.set(new Map(assets));
-  });
-};
 
 export const selectedInstanceBrowserStyleStore = atom<undefined | Style>();
 
@@ -382,21 +331,11 @@ export const hoveredInstanceSelectorStore = atom<undefined | InstanceSelector>(
 export const isPreviewModeStore = atom<boolean>(false);
 export const useIsPreviewMode = () => useValue(isPreviewModeStore);
 
-const authPermitStore = atom<AuthPermit>("view");
+export const authPermitStore = atom<AuthPermit>("view");
 export const useAuthPermit = () => useValue(authPermitStore);
-export const useSetAuthPermit = (authPermit: AuthPermit) => {
-  useMount(() => {
-    authPermitStore.set(authPermit);
-  });
-};
 
 export const authTokenStore = atom<string | undefined>(undefined);
 export const useAuthToken = () => useValue(authTokenStore);
-export const useSetAuthToken = (authToken: string | undefined) => {
-  useMount(() => {
-    authTokenStore.set(authToken);
-  });
-};
 
 export type DragAndDropState = {
   isDragging: boolean;

--- a/apps/builder/app/shared/nano-states/pages.ts
+++ b/apps/builder/app/shared/nano-states/pages.ts
@@ -1,13 +1,7 @@
 import { atom, computed } from "nanostores";
 import type { Page, Pages } from "@webstudio-is/sdk";
-import { useMount } from "~/shared/hook-utils/use-mount";
 
 export const pagesStore = atom<undefined | Pages>(undefined);
-export const useSetPages = (pages: Pages) => {
-  useMount(() => {
-    pagesStore.set(pages);
-  });
-};
 
 export const selectedPageIdStore = atom<undefined | Page["id"]>(undefined);
 export const selectedPageHashStore = atom<string>("");


### PR DESCRIPTION
These functions are unnecessary boilerplate. Having single useMount in builder root give us better understanding of set logic and allow to easily find other store references.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
