### PR TITLE
refactor: drop react wrapper from preview mode store

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from "react";
+import { useStore } from "@nanostores/react";
 import { useUnmount } from "react-use";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { type Publish, usePublish } from "~/shared/pubsub";
@@ -30,19 +31,18 @@ import {
   breakpointsStore,
   dataSourcesStore,
   instancesStore,
+  $isPreviewMode,
   pagesStore,
   projectStore,
   propsStore,
   styleSourceSelectionsStore,
   styleSourcesStore,
   stylesStore,
-  useIsPreviewMode,
 } from "~/shared/nano-states";
 import { type Settings, useClientSettings } from "./shared/client-settings";
 import { getBuildUrl } from "~/shared/router-utils";
 import { useCopyPaste } from "~/shared/copy-paste";
 import { BlockingAlerts } from "./features/blocking-alerts";
-import { useStore } from "@nanostores/react";
 import { useSyncPageUrl } from "~/shared/pages";
 import { useMount } from "~/shared/hook-utils/use-mount";
 
@@ -270,7 +270,7 @@ export const Builder = ({
   });
   useSharedShortcuts({ source: "builder" });
 
-  const [isPreviewMode] = useIsPreviewMode();
+  const isPreviewMode = useStore($isPreviewMode);
   usePublishShortcuts(publish);
   const { onRef: onRefReadCanvas, onTransitionEnd } = useReadCanvasRect();
   // We need to initialize this in both canvas and builder,

--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -28,10 +28,11 @@ import {
 } from "~/shared/theme";
 import { useClientSettings } from "~/builder/shared/client-settings";
 import { dashboardPath } from "~/shared/router-utils";
-import { useIsPreviewMode } from "~/shared/nano-states";
+import { $isPreviewMode } from "~/shared/nano-states";
 import { deleteSelectedInstance } from "~/shared/instance-utils";
 import { MenuButton } from "./menu-button";
 import { useAuthPermit } from "~/shared/nano-states";
+import { useStore } from "@nanostores/react";
 
 const ThemeMenuItem = () => {
   if (isFeatureEnabled("dark") === false) {
@@ -98,7 +99,7 @@ export const Menu = ({ publish }: MenuProps) => {
   const navigate = useNavigate();
   const [, setIsShareOpen] = useIsShareDialogOpen();
   const [, setIsPublishOpen] = useIsPublishDialogOpen();
-  const [isPreviewMode, setIsPreviewMode] = useIsPreviewMode();
+  const isPreviewMode = useStore($isPreviewMode);
   const [authPermit] = useAuthPermit();
 
   const isPublishEnabled = authPermit === "own" || authPermit === "admin";
@@ -186,7 +187,7 @@ export const Menu = ({ publish }: MenuProps) => {
           <ViewMenuItem />
           <DropdownMenuItem
             onSelect={() => {
-              setIsPreviewMode(!isPreviewMode);
+              $isPreviewMode.set(isPreviewMode === false);
             }}
           >
             Preview

--- a/apps/builder/app/builder/features/topbar/preview.tsx
+++ b/apps/builder/app/builder/features/topbar/preview.tsx
@@ -1,15 +1,10 @@
+import { useStore } from "@nanostores/react";
 import { PlayIcon } from "@webstudio-is/icons";
 import { ToolbarToggleItem } from "@webstudio-is/design-system";
-import { useIsPreviewMode } from "~/shared/nano-states";
-
-declare module "~/shared/pubsub" {
-  export interface PubsubMap {
-    previewMode: boolean;
-  }
-}
+import { $isPreviewMode } from "~/shared/nano-states";
 
 export const PreviewButton = () => {
-  const [isPreviewMode, setIsPreviewMode] = useIsPreviewMode();
+  const isPreviewMode = useStore($isPreviewMode);
 
   return (
     <ToolbarToggleItem
@@ -17,7 +12,7 @@ export const PreviewButton = () => {
       aria-label="Toggle Preview"
       variant="preview"
       data-state={isPreviewMode ? "on" : "off"}
-      onClick={() => setIsPreviewMode(isPreviewMode === false)}
+      onClick={() => $isPreviewMode.set(isPreviewMode === false)}
       tabIndex={0}
     >
       <PlayIcon />

--- a/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
@@ -3,9 +3,9 @@ import type { Publish } from "~/shared/pubsub";
 import { css } from "@webstudio-is/design-system";
 import { PlacementIndicator } from "@webstudio-is/design-system";
 import {
-  useIsPreviewMode,
   useDragAndDropState,
   instancesStore,
+  $isPreviewMode,
 } from "~/shared/nano-states";
 import { HoveredInstanceOutline, SelectedInstanceOutline } from "./outline";
 import { TextToolbar } from "./text-toolbar";
@@ -38,7 +38,7 @@ export const CanvasTools = ({ publish }: CanvasToolsProps) => {
   // @todo try to setup cross-frame atoms to avoid this
   useSubscribeDragAndDropState();
 
-  const [isPreviewMode] = useIsPreviewMode();
+  const isPreviewMode = useStore($isPreviewMode);
   const [dragAndDropState] = useDragAndDropState();
   const instances = useStore(instancesStore);
   const scale = useStore(scaleStore);

--- a/apps/builder/app/canvas/canvas-shortcuts.ts
+++ b/apps/builder/app/canvas/canvas-shortcuts.ts
@@ -1,7 +1,7 @@
 import { useHotkeys } from "react-hotkeys-hook";
 import { shortcuts, instanceTreeShortcuts, options } from "~/shared/shortcuts";
 import { publish, useSubscribe } from "~/shared/pubsub";
-import { isPreviewModeStore } from "~/shared/nano-states";
+import { $isPreviewMode } from "~/shared/nano-states";
 import { enterEditingMode, escapeSelection } from "~/shared/instance-utils";
 
 declare module "~/shared/pubsub" {
@@ -12,7 +12,7 @@ declare module "~/shared/pubsub" {
 }
 
 const togglePreviewMode = () => {
-  isPreviewModeStore.set(!isPreviewModeStore.get());
+  $isPreviewMode.set(!$isPreviewMode.get());
 };
 
 const publishOpenBreakpointsMenu = () => {

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -39,7 +39,6 @@ import {
   assetsStore,
   pagesStore,
   instancesStore,
-  useIsPreviewMode,
   selectedPageStore,
   registerComponentLibrary,
   registeredComponentsStore,
@@ -47,6 +46,7 @@ import {
   subscribeComponentHooks,
   dataSourcesLogicStore,
   propsStore,
+  $isPreviewMode,
 } from "~/shared/nano-states";
 import { useDragAndDrop } from "./shared/use-drag-drop";
 import { useCopyPaste } from "~/shared/copy-paste";
@@ -70,7 +70,7 @@ const useElementsTree = (
 ) => {
   const metas = useStore(registeredComponentMetasStore);
   const page = useStore(selectedPageStore);
-  const [isPreviewMode] = useIsPreviewMode();
+  const isPreviewMode = useStore($isPreviewMode);
   const rootInstanceId = page?.rootInstanceId ?? "";
 
   if (typeof window === "undefined") {
@@ -190,7 +190,7 @@ export const Canvas = ({
 }: CanvasProps): JSX.Element | null => {
   const handshaken = useStore(handshakenStore);
   useCanvasStore(publish);
-  const [isPreviewMode] = useIsPreviewMode();
+  const isPreviewMode = useStore($isPreviewMode);
 
   useMount(() => {
     registerComponentLibrary({

--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -1,5 +1,5 @@
 import { findPageByIdOrPath } from "@webstudio-is/project-build";
-import { isPreviewModeStore, pagesStore } from "~/shared/nano-states";
+import { $isPreviewMode, pagesStore } from "~/shared/nano-states";
 import { switchPage } from "~/shared/pages";
 
 const isAbsoluteUrl = (href: string) => {
@@ -37,7 +37,7 @@ export const subscribeInterceptedEvents = () => {
       const a = event.target.closest("a");
       if (a) {
         event.preventDefault();
-        if (isPreviewModeStore.get()) {
+        if ($isPreviewMode.get()) {
           handleLinkClick(a);
         }
       }
@@ -48,7 +48,7 @@ export const subscribeInterceptedEvents = () => {
     event.preventDefault();
   };
   const handleKeydown = (event: KeyboardEvent) => {
-    if (isPreviewModeStore.get()) {
+    if ($isPreviewMode.get()) {
       return;
     }
     // prevent typing in inputs only in canvas mode

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -20,7 +20,7 @@ import {
 import {
   assetsStore,
   breakpointsStore,
-  isPreviewModeStore,
+  $isPreviewMode,
   registeredComponentMetasStore,
   selectedInstanceSelectorStore,
   selectedStyleSourceSelectorStore,
@@ -94,7 +94,7 @@ const helperStyles = [
 const subscribePreviewMode = () => {
   let isRendered = false;
 
-  const unsubscribe = isPreviewModeStore.subscribe((isPreviewMode) => {
+  const unsubscribe = $isPreviewMode.subscribe((isPreviewMode) => {
     helpersCssEngine.setAttribute("media", isPreviewMode ? "not all" : "all");
     if (isRendered === false) {
       for (const style of helperStyles) {

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -328,8 +328,7 @@ export const hoveredInstanceSelectorStore = atom<undefined | InstanceSelector>(
   undefined
 );
 
-export const isPreviewModeStore = atom<boolean>(false);
-export const useIsPreviewMode = () => useValue(isPreviewModeStore);
+export const $isPreviewMode = atom<boolean>(false);
 
 export const authPermitStore = atom<AuthPermit>("view");
 export const useAuthPermit = () => useValue(authPermitStore);

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -12,7 +12,7 @@ import {
   selectedPageIdStore,
   selectedPageHashStore,
   selectedInstanceSelectorStore,
-  isPreviewModeStore,
+  $isPreviewMode,
 } from "~/shared/nano-states";
 import { builderPath } from "~/shared/router-utils";
 
@@ -39,7 +39,7 @@ const setPageStateFromUrl = () => {
   const pageId = searchParams.get("pageId") ?? pages?.homePage.id;
   const pageHash = searchParams.get("pageHash") ?? "";
 
-  isPreviewModeStore.set(searchParams.get("mode") === "preview");
+  $isPreviewMode.set(searchParams.get("mode") === "preview");
 
   switchPage(pageId, pageHash);
 };
@@ -57,7 +57,7 @@ export const useSyncPageUrl = () => {
   const navigate = useNavigate();
   const page = useStore(selectedPageStore);
   const pageHash = useStore(selectedPageHashStore);
-  const isPreviewMode = useStore(isPreviewModeStore);
+  const isPreviewMode = useStore($isPreviewMode);
 
   // Get pageId and pageHash from URL
   useMount(() => {

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -22,7 +22,7 @@ import {
   selectedInstanceIntanceToTagStore,
   selectedInstanceRenderStateStore,
   hoveredInstanceSelectorStore,
-  isPreviewModeStore,
+  $isPreviewMode,
   synchronizedCanvasStores,
   synchronizedInstancesStores,
   synchronizedBreakpointsStores,
@@ -94,7 +94,7 @@ export const registerContainers = () => {
     selectedInstanceRenderStateStore
   );
   clientStores.set("hoveredInstanceSelector", hoveredInstanceSelectorStore);
-  clientStores.set("isPreviewMode", isPreviewModeStore);
+  clientStores.set("isPreviewMode", $isPreviewMode);
   clientStores.set(
     "selectedStyleSourceSelector",
     selectedStyleSourceSelectorStore


### PR DESCRIPTION
Nanostore react wrappers in many cases introduce additional renders because of subscription even when only store.set is used. Searching for references become complicated because we have both direct store access and react wrapper.

Here migrated to use direct store access for preview mode store and renamed it to $previewMode according to new convention.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
