### PR TITLE
refactor: drop react wrappers from auth stores

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -26,8 +26,8 @@ import {
 import { usePublishShortcuts } from "./shared/shortcuts";
 import {
   assetsStore,
-  authPermitStore,
-  authTokenStore,
+  $authPermit,
+  $authToken,
   breakpointsStore,
   dataSourcesStore,
   instancesStore,
@@ -237,8 +237,8 @@ export const Builder = ({
   useMount(() => {
     // additional data stores
     projectStore.set(project);
-    authPermitStore.set(authPermit);
-    authTokenStore.set(authToken);
+    $authPermit.set(authPermit);
+    $authToken.set(authToken);
 
     // set initial containers value
     assetsStore.set(new Map(assets));

--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "@remix-run/react";
+import { useStore } from "@nanostores/react";
 import store from "immerhin";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import {
@@ -28,11 +29,9 @@ import {
 } from "~/shared/theme";
 import { useClientSettings } from "~/builder/shared/client-settings";
 import { dashboardPath } from "~/shared/router-utils";
-import { $isPreviewMode } from "~/shared/nano-states";
+import { $isPreviewMode, $authPermit } from "~/shared/nano-states";
 import { deleteSelectedInstance } from "~/shared/instance-utils";
 import { MenuButton } from "./menu-button";
-import { useAuthPermit } from "~/shared/nano-states";
-import { useStore } from "@nanostores/react";
 
 const ThemeMenuItem = () => {
   if (isFeatureEnabled("dark") === false) {
@@ -100,7 +99,7 @@ export const Menu = ({ publish }: MenuProps) => {
   const [, setIsShareOpen] = useIsShareDialogOpen();
   const [, setIsPublishOpen] = useIsPublishDialogOpen();
   const isPreviewMode = useStore($isPreviewMode);
-  const [authPermit] = useAuthPermit();
+  const authPermit = useStore($authPermit);
 
   const isPublishEnabled = authPermit === "own" || authPermit === "admin";
 

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useStore } from "@nanostores/react";
 import {
   Button,
   useId,
@@ -24,7 +25,7 @@ import { useIsPublishDialogOpen } from "../../shared/nano-states";
 import { validateProjectDomain, type Project } from "@webstudio-is/project";
 import { getPublishedUrl } from "~/shared/router-utils";
 import { theme } from "@webstudio-is/design-system";
-import { useAuthPermit } from "~/shared/nano-states";
+import { $authPermit } from "~/shared/nano-states";
 import {
   Domains,
   getPublishStatusAndText,
@@ -601,7 +602,7 @@ type PublishProps = {
 
 export const PublishButton = ({ projectId }: PublishProps) => {
   const [isOpen, setIsOpen] = useIsPublishDialogOpen();
-  const [authPermit] = useAuthPermit();
+  const authPermit = useStore($authPermit);
   const [dialogContentType, setDialogContentType] = useState<
     "publish" | "export"
   >("publish");

--- a/apps/builder/app/builder/features/topbar/share.tsx
+++ b/apps/builder/app/builder/features/topbar/share.tsx
@@ -1,3 +1,4 @@
+import { useStore } from "@nanostores/react";
 import {
   Button,
   FloatingPanelPopover,
@@ -11,12 +12,12 @@ import {
 } from "@webstudio-is/design-system";
 import type { Project } from "@webstudio-is/prisma-client";
 import { ShareProjectContainer } from "~/shared/share-project";
-import { useAuthPermit } from "~/shared/nano-states";
+import { $authPermit } from "~/shared/nano-states";
 import { useIsShareDialogOpen } from "~/builder/shared/nano-states";
 
 export const ShareButton = ({ projectId }: { projectId: Project["id"] }) => {
   const [isShareOpen, setIsShareOpen] = useIsShareDialogOpen();
-  const [authPermit] = useAuthPermit();
+  const authPermit = useStore($authPermit);
 
   const isShareDisabled = authPermit !== "own";
   const tooltipContent = isShareDisabled

--- a/apps/builder/app/builder/features/topbar/view-mode.tsx
+++ b/apps/builder/app/builder/features/topbar/view-mode.tsx
@@ -1,3 +1,4 @@
+import { useStore } from "@nanostores/react";
 import {
   Flex,
   AccessibleIcon,
@@ -5,10 +6,10 @@ import {
   Tooltip,
 } from "@webstudio-is/design-system";
 import { CloudIcon } from "@webstudio-is/icons";
-import { useAuthPermit } from "~/shared/nano-states";
+import { $authPermit } from "~/shared/nano-states";
 
 export const ViewMode = () => {
-  const [authPermit] = useAuthPermit();
+  const authPermit = useStore($authPermit);
 
   if (authPermit !== "view") {
     return null;

--- a/apps/builder/app/builder/shared/assets/asset-upload.tsx
+++ b/apps/builder/app/builder/shared/assets/asset-upload.tsx
@@ -1,4 +1,5 @@
 import { type ChangeEvent, useRef } from "react";
+import { useStore } from "@nanostores/react";
 import { Button, Flex, Tooltip, toast } from "@webstudio-is/design-system";
 import { UploadIcon } from "@webstudio-is/icons";
 import {
@@ -8,7 +9,7 @@ import {
 } from "@webstudio-is/asset-uploader";
 import { FONT_MIME_TYPES } from "@webstudio-is/fonts";
 import { useUploadAsset } from "./use-assets";
-import { useAuthPermit } from "~/shared/nano-states";
+import { $authPermit } from "~/shared/nano-states";
 
 const maxSize = toBytes(MAX_UPLOAD_SIZE);
 
@@ -91,7 +92,7 @@ const EnabledAssetUpload = ({ accept, type }: AssetUploadProps) => {
 };
 
 export const AssetUpload = ({ type }: AssetUploadProps) => {
-  const [authPermit] = useAuthPermit();
+  const authPermit = useStore($authPermit);
 
   if (authPermit !== "view") {
     // Split into a separate component to avoid using `useUpload` hook unnecessarily

--- a/apps/builder/app/builder/shared/assets/use-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/use-assets.tsx
@@ -13,11 +13,7 @@ import type {
   UploadingAssetContainer,
 } from "./types";
 import type { ActionData } from "~/builder/shared/assets";
-import {
-  assetsStore,
-  authTokenStore,
-  projectStore,
-} from "~/shared/nano-states";
+import { assetsStore, $authToken, projectStore } from "~/shared/nano-states";
 import { atom, computed } from "nanostores";
 
 export const deleteAssets = (assetIds: Asset["id"][]) => {
@@ -174,7 +170,7 @@ export const useUploadAsset = () => {
 
   const uploadAssets = (type: AssetType, files: File[]) => {
     const projectId = projectStore.get()?.id;
-    const authToken = authTokenStore.get();
+    const authToken = $authToken.get();
     if (projectId === undefined) {
       return;
     }

--- a/apps/builder/app/builder/shared/fonts-manager/item-menu.tsx
+++ b/apps/builder/app/builder/shared/fonts-manager/item-menu.tsx
@@ -1,3 +1,4 @@
+import { useStore } from "@nanostores/react";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -12,7 +13,7 @@ import {
 import { MenuIcon } from "@webstudio-is/icons";
 import { type FocusEventHandler, useState, useRef, useEffect } from "react";
 import { theme } from "@webstudio-is/design-system";
-import { useAuthPermit } from "~/shared/nano-states";
+import { $authPermit } from "~/shared/nano-states";
 
 const MenuButton = styled(DeprecatedIconButton, {
   color: theme.colors.hint,
@@ -44,7 +45,7 @@ const ItemMenu = ({
     };
   }, []);
 
-  const [authPermit] = useAuthPermit();
+  const authPermit = useStore($authPermit);
 
   const isDeleteDisabled = authPermit === "view";
   const tooltipContent = isDeleteDisabled

--- a/apps/builder/app/builder/shared/image-manager/image-info.tsx
+++ b/apps/builder/app/builder/shared/image-manager/image-info.tsx
@@ -1,3 +1,4 @@
+import { useStore } from "@nanostores/react";
 import prettyBytes from "pretty-bytes";
 import {
   theme,
@@ -17,7 +18,7 @@ import {
 import type { Asset } from "@webstudio-is/sdk";
 import { Filename } from "./filename";
 import { getFormattedAspectRatio } from "./utils";
-import { useAuthPermit } from "~/shared/nano-states";
+import { $authPermit } from "~/shared/nano-states";
 
 type ImageInfoProps = {
   asset: Asset;
@@ -26,7 +27,7 @@ type ImageInfoProps = {
 
 export const ImageInfo = ({ asset, onDelete }: ImageInfoProps) => {
   const { size, meta, id, name } = asset;
-  const [authPermit] = useAuthPermit();
+  const authPermit = useStore($authPermit);
 
   const isDeleteDisabled = authPermit === "view";
   const tooltipContent = isDeleteDisabled

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -330,11 +330,9 @@ export const hoveredInstanceSelectorStore = atom<undefined | InstanceSelector>(
 
 export const $isPreviewMode = atom<boolean>(false);
 
-export const authPermitStore = atom<AuthPermit>("view");
-export const useAuthPermit = () => useValue(authPermitStore);
+export const $authPermit = atom<AuthPermit>("view");
 
-export const authTokenStore = atom<string | undefined>(undefined);
-export const useAuthToken = () => useValue(authTokenStore);
+export const $authToken = atom<string | undefined>(undefined);
 
 export type DragAndDropState = {
   isDragging: boolean;

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -5,7 +5,7 @@ import type { Page } from "@webstudio-is/sdk";
 import { findPageByIdOrPath } from "@webstudio-is/project-build";
 import { useMount } from "~/shared/hook-utils/use-mount";
 import {
-  authTokenStore,
+  $authToken,
   pagesStore,
   projectStore,
   selectedPageStore,
@@ -98,7 +98,7 @@ export const useSyncPageUrl = () => {
       builderPath({
         projectId: project.id,
         pageId: page.id === pages.homePage.id ? undefined : page.id,
-        authToken: authTokenStore.get(),
+        authToken: $authToken.get(),
         pageHash: pageHash === "" ? undefined : pageHash,
         mode: isPreviewMode ? "preview" : undefined,
       })

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -2,7 +2,7 @@ import type { AUTH_PROVIDERS } from "~/shared/session";
 import type { Project } from "@webstudio-is/project";
 import type { ThemeSetting } from "~/shared/theme";
 import env from "~/shared/env";
-import { authTokenStore } from "../nano-states";
+import { $authToken } from "../nano-states";
 
 const searchParams = (params: Record<string, string | undefined | null>) => {
   const searchParams = new URLSearchParams();
@@ -61,7 +61,7 @@ export const dashboardPath = () => {
 };
 
 export const builderDomainsPath = (method: string) => {
-  const authToken = authTokenStore.get();
+  const authToken = $authToken.get();
   const urlSearchParams = new URLSearchParams();
   if (authToken !== undefined) {
     urlSearchParams.set("authToken", authToken);


### PR DESCRIPTION
Similar to https://github.com/webstudio-is/webstudio/pull/2365

Here migrated auth permit and auth token to direct access and renamed them according to new convention.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
