### PR TITLE
refactor: drop react wrappers from dnd store

### DIFF
--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { computed } from "nanostores";
 import { useStore } from "@nanostores/react";
 import type { Instance } from "@webstudio-is/sdk";
 import {
@@ -20,8 +21,8 @@ import { SettingsPanelContainer } from "~/builder/features/settings-panel";
 import { FloatingPanelProvider } from "~/builder/shared/floating-panel";
 import {
   selectedInstanceStore,
-  isDraggingStore,
   registeredComponentMetasStore,
+  $dragAndDropState,
 } from "~/shared/nano-states";
 import { NavigatorTree } from "~/builder/shared/navigator-tree";
 import type { Settings } from "~/builder/shared/client-settings";
@@ -65,11 +66,13 @@ const contentStyle = {
   overflow: "auto",
 };
 
+const $isDragging = computed([$dragAndDropState], (state) => state.isDragging);
+
 export const Inspector = ({ publish, navigatorLayout }: InspectorProps) => {
   const selectedInstance = useStore(selectedInstanceStore);
   const tabsRef = useRef<HTMLDivElement>(null);
   const [tab, setTab] = useState("style");
-  const isDragging = useStore(isDraggingStore);
+  const isDragging = useStore($isDragging);
   const metas = useStore(registeredComponentMetasStore);
 
   if (navigatorLayout === "docked" && isDragging) {

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -8,7 +8,7 @@ import {
   Tooltip,
 } from "@webstudio-is/design-system";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
-import { useDragAndDropState } from "~/shared/nano-states";
+import { $dragAndDropState } from "~/shared/nano-states";
 import { panels } from "./panels";
 import type { TabName } from "./types";
 import { useClientSettings } from "~/builder/shared/client-settings";
@@ -16,6 +16,7 @@ import { Flex } from "@webstudio-is/design-system";
 import { theme } from "@webstudio-is/design-system";
 import { BugIcon, HelpIcon } from "@webstudio-is/icons";
 import { HelpPopover } from "./help-popover";
+import { useStore } from "@nanostores/react";
 
 const none = { TabContent: () => null };
 
@@ -24,7 +25,7 @@ type SidebarLeftProps = {
 };
 
 export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
-  const [dragAndDropState] = useDragAndDropState();
+  const dragAndDropState = useStore($dragAndDropState);
   const [activeTab, setActiveTab] = useState<TabName>("none");
   const { TabContent } = activeTab === "none" ? none : panels[activeTab];
   const [clientSettings] = useClientSettings();

--- a/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
@@ -3,9 +3,9 @@ import type { Publish } from "~/shared/pubsub";
 import { css } from "@webstudio-is/design-system";
 import { PlacementIndicator } from "@webstudio-is/design-system";
 import {
-  useDragAndDropState,
   instancesStore,
   $isPreviewMode,
+  $dragAndDropState,
 } from "~/shared/nano-states";
 import { HoveredInstanceOutline, SelectedInstanceOutline } from "./outline";
 import { TextToolbar } from "./text-toolbar";
@@ -39,7 +39,7 @@ export const CanvasTools = ({ publish }: CanvasToolsProps) => {
   useSubscribeDragAndDropState();
 
   const isPreviewMode = useStore($isPreviewMode);
-  const [dragAndDropState] = useDragAndDropState();
+  const dragAndDropState = useStore($dragAndDropState);
   const instances = useStore(instancesStore);
   const scale = useStore(scaleStore);
   if (

--- a/apps/builder/app/builder/features/workspace/canvas-tools/use-subscribe-drag-drop-state.ts
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/use-subscribe-drag-drop-state.ts
@@ -1,24 +1,22 @@
 import { useSubscribe } from "~/shared/pubsub";
-import { useDragAndDropState } from "~/shared/nano-states";
+import { $dragAndDropState } from "~/shared/nano-states";
 
 export const useSubscribeDragAndDropState = () => {
-  const [, setState] = useDragAndDropState();
-
   useSubscribe("dragStart", (dragPayload) => {
     // It's possible that dropTargetChange comes before dragStart.
     // So it's important to spread the current ...state here.
-    setState((state) => ({ ...state, isDragging: true, dragPayload }));
+    $dragAndDropState.set({
+      ...$dragAndDropState.get(),
+      isDragging: true,
+      dragPayload,
+    });
   });
 
   useSubscribe("dropTargetChange", (dropTarget) => {
-    setState((state) => ({ ...state, dropTarget }));
-  });
-
-  useSubscribe("placementIndicatorChange", (placementIndicator) => {
-    setState((state) => ({ ...state, placementIndicator }));
+    $dragAndDropState.set({ ...$dragAndDropState.get(), dropTarget });
   });
 
   useSubscribe("dragEnd", () => {
-    setState({ isDragging: false });
+    $dragAndDropState.set({ isDragging: false });
   });
 };

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -8,10 +8,10 @@ import {
   instancesStore,
   rootInstanceStore,
   selectedInstanceSelectorStore,
-  useDragAndDropState,
   textEditingInstanceSelectorStore,
   selectedStyleSourceSelectorStore,
   registeredComponentMetasStore,
+  $dragAndDropState,
 } from "~/shared/nano-states";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import {
@@ -29,7 +29,7 @@ export const NavigatorTree = () => {
   const rootInstance = useStore(rootInstanceStore);
   const instances = useStore(instancesStore);
   const metas = useStore(registeredComponentMetasStore);
-  const [state, setState] = useDragAndDropState();
+  const state = useStore($dragAndDropState);
 
   const dragPayload = state.dragPayload;
 
@@ -102,9 +102,9 @@ export const NavigatorTree = () => {
         parentSelector: payload.dropTarget.itemSelector,
         position: payload.dropTarget.position,
       });
-      setState({ isDragging: false });
+      $dragAndDropState.set({ isDragging: false });
     },
-    [setState]
+    []
   );
 
   const handleSelect = useCallback((instanceSelector: InstanceSelector) => {
@@ -140,21 +140,21 @@ export const NavigatorTree = () => {
           );
           return;
         }
-        setState((state) => ({
-          ...state,
+        $dragAndDropState.set({
+          ...$dragAndDropState.get(),
           dragPayload: {
             origin: "panel",
             type: "reparent",
             dragInstanceSelector,
           },
-        }));
+        });
       }}
       onDropTargetChange={(dropTarget) => {
-        setState((state) => ({ ...state, dropTarget }));
+        $dragAndDropState.set({ ...$dragAndDropState.get(), dropTarget });
       }}
       onDragEnd={handleDragEnd}
       onCancel={() => {
-        setState({ isDragging: false });
+        $dragAndDropState.set({ isDragging: false });
       }}
     />
   );

--- a/apps/builder/app/canvas/shared/use-drag-drop.ts
+++ b/apps/builder/app/canvas/shared/use-drag-drop.ts
@@ -2,7 +2,6 @@ import { useLayoutEffect, useRef } from "react";
 import type { Instance } from "@webstudio-is/sdk";
 import {
   type Point,
-  type Placement,
   type ItemDropTarget,
   useAutoScroll,
   useDrag,
@@ -10,6 +9,7 @@ import {
   computeIndicatorPlacement,
 } from "@webstudio-is/design-system";
 import {
+  $dragAndDropState,
   instancesStore,
   registeredComponentMetasStore,
 } from "~/shared/nano-states";
@@ -39,7 +39,6 @@ declare module "~/shared/pubsub" {
     dragMove: DragMovePayload;
     dragStart: DragStartPayload;
     dropTargetChange: undefined | ItemDropTarget;
-    placementIndicatorChange: undefined | Placement;
   }
 }
 
@@ -296,9 +295,9 @@ export const useDragAndDrop = () => {
   useSubscribe("dropTargetChange", (dropTarget) => {
     state.current.dropTarget = dropTarget;
     if (dropTarget === undefined) {
-      publish({
-        type: "placementIndicatorChange",
-        payload: undefined,
+      $dragAndDropState.set({
+        ...$dragAndDropState.get(),
+        placementIndicator: undefined,
       });
       return;
     }
@@ -306,9 +305,9 @@ export const useDragAndDrop = () => {
     if (element === undefined) {
       return;
     }
-    publish({
-      type: "placementIndicatorChange",
-      payload: computeIndicatorPlacement({
+    $dragAndDropState.set({
+      ...$dragAndDropState.get(),
+      placementIndicator: computeIndicatorPlacement({
         ...sharedDropOptions,
         element,
         placement: dropTarget.placement,

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -1,5 +1,5 @@
-import { useCallback, useMemo } from "react";
-import { atom, computed, type WritableAtom } from "nanostores";
+import { useMemo } from "react";
+import { atom, computed } from "nanostores";
 import { useStore } from "@nanostores/react";
 import { nanoid } from "nanoid";
 import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
@@ -28,23 +28,6 @@ import { instancesStore, selectedInstanceSelectorStore } from "./instances";
 import { selectedPageStore } from "./pages";
 import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
 import type { Project } from "@webstudio-is/project";
-
-const useValue = <T>(atom: WritableAtom<T>) => {
-  const value = useStore(atom);
-
-  const set = useCallback(
-    (value: T | ((current: T) => T)) => {
-      if (typeof value === "function") {
-        atom.set((value as (current: T) => T)(atom.get()));
-      } else {
-        atom.set(value);
-      }
-    },
-    [atom]
-  );
-
-  return [value, set] as const;
-};
 
 export const projectStore = atom<Project | undefined>();
 
@@ -341,12 +324,6 @@ export type DragAndDropState = {
   placementIndicator?: Placement;
 };
 
-const dragAndDropStateContainer = atom<DragAndDropState>({
+export const $dragAndDropState = atom<DragAndDropState>({
   isDragging: false,
 });
-export const useDragAndDropState = () => useValue(dragAndDropStateContainer);
-
-export const isDraggingStore = computed(
-  [dragAndDropStateContainer],
-  (state) => state.isDragging
-);


### PR DESCRIPTION
Similar to https://github.com/webstudio-is/webstudio/pull/2365

Here migrated drag and drop store away from react wrapper.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
