### PR TITLE
feat: Parse tailwind to ordinary css compatible with webstudio

### DIFF
--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -44,6 +44,8 @@
   "private": true,
   "sideEffects": false,
   "dependencies": {
+    "@unocss/core": "^0.56.4",
+    "@unocss/preset-uno": "^0.56.4",
     "@webstudio-is/css-engine": "workspace:*",
     "colord": "^2.9.3",
     "css-tree": "^2.3.1",

--- a/packages/css-data/src/tailwind-parser/parse.test.ts
+++ b/packages/css-data/src/tailwind-parser/parse.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it as test, jest } from "@jest/globals";
+
+import { parseTailwindToCss } from "./parse";
+
+describe("parseTailwindToCss", () => {
+  test("expand margins", async () => {
+    const tailwindClasses = `m-4`;
+
+    expect(await parseTailwindToCss(tailwindClasses)).toMatchInlineSnapshot(
+      `".mb-4{margin-bottom:1rem}.ml-4{margin-left:1rem}.mr-4{margin-right:1rem}.mt-4{margin-top:1rem}"`
+    );
+  });
+
+  test("substitute variables - gradient", async () => {
+    const tailwindClasses = `bg-gradient-to-r from-indigo-500`;
+
+    expect(await parseTailwindToCss(tailwindClasses)).toMatchInlineSnapshot(
+      `".bg-gradient-to-r{background-image:linear-gradient(to right,rgba(99,102,241,1) 0%,rgba(99,102,241,0) 100%)}"`
+    );
+  });
+
+  test("substitute variables - transform", async () => {
+    const tailwindClasses = `translate-x-0 rotate-3`;
+
+    expect(await parseTailwindToCss(tailwindClasses)).toMatchInlineSnapshot(
+      `".translate-x-0{transform:translateX(0) translateY(0) translateZ(0) rotate(3deg) rotateX(0) rotateY(0) rotateZ(0) skewX(0) skewY(0) scaleX(1) scaleY(1) scaleZ(1)}.rotate-3{transform:translateX(0) translateY(0) translateZ(0) rotate(3deg) rotateX(0) rotateY(0) rotateZ(0) skewX(0) skewY(0) scaleX(1) scaleY(1) scaleZ(1)}"`
+    );
+  });
+
+  test("substitute variables - shadows", async () => {
+    const tailwindClasses = `shadow`;
+
+    expect(await parseTailwindToCss(tailwindClasses)).toMatchInlineSnapshot(
+      `".shadow{box-shadow:0 0 rgba(0,0,0,0),0 0 rgba(0,0,0,0),0 1px 3px 0 rgba(0,0,0,0.1),0 1px 2px -1px rgba(0,0,0,0.1)}"`
+    );
+  });
+
+  test("substitute variables skipping pseudo and media selectors", async () => {
+    const tailwindClasses = `shadow`;
+    const tailwindClassesWithPseudoAndMedia = `shadow hover:shadow-md md:shadow-lg`;
+
+    expect(await parseTailwindToCss(tailwindClasses)).toBe(
+      await parseTailwindToCss(tailwindClassesWithPseudoAndMedia)
+    );
+  });
+
+  test("warn if variable is not defined and omits property and empty selectors", async () => {
+    const tailwindClasses = `bg-gradient-to-r`;
+    const warn = jest.fn();
+
+    expect(
+      await parseTailwindToCss(tailwindClasses, warn)
+    ).toMatchInlineSnapshot(`""`);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      true,
+      'Variable var(--un-gradient-stops) cannot be resolved for property "background-image:linear-gradient(to right,var(--un-gradient-stops))" in selector ".bg-gradient-to-r"'
+    );
+  });
+});

--- a/packages/css-data/src/tailwind-parser/parse.ts
+++ b/packages/css-data/src/tailwind-parser/parse.ts
@@ -1,0 +1,25 @@
+import { UnoGenerator, createGenerator } from "@unocss/core";
+import presetMini, { type Theme } from "@unocss/preset-uno";
+import { expandTailwindShorthand } from "./shorthand";
+import { substituteVariables } from "./substitute";
+import warnOnce from "warn-once";
+
+let unoLazy: UnoGenerator<Theme> | undefined = undefined;
+
+const uno = () => {
+  unoLazy = createGenerator({
+    presets: [presetMini()],
+  });
+  return unoLazy;
+};
+
+/**
+ * Parses Tailwind classes to CSS by expanding shorthands and substituting variables.
+ */
+export const parseTailwindToCss = async (classes: string, warn = warnOnce) => {
+  const expandedClasses = expandTailwindShorthand(classes);
+  const generated = await uno().generate(expandedClasses, { preflights: true });
+
+  const cssWithClasses = substituteVariables(generated.css, warn);
+  return cssWithClasses;
+};

--- a/packages/css-data/src/tailwind-parser/substitute.test.ts
+++ b/packages/css-data/src/tailwind-parser/substitute.test.ts
@@ -97,7 +97,8 @@ describe("expandTailwindShorthand", () => {
     );
   });
 
-  test("work with media queries", () => {
+  // @todo add support
+  test("remove media queries", () => {
     const css = `
     ${cssPreflight}
     @media (min-width: 640px) {
@@ -106,9 +107,24 @@ describe("expandTailwindShorthand", () => {
       background: linear-gradient(var(--var-c));
     }
     `;
-    expect(substituteVariables(css)).toMatchInlineSnapshot(
-      `"@media (min-width:640px){.sm\\:shadow-md{background:linear-gradient(rgba(111,111,111,0.5),rgba(222,222,222,0.5))}}"`
-    );
+    expect(substituteVariables(css)).toMatchInlineSnapshot(`""`);
+  });
+
+  // @todo add support
+  test("remove pseudo selectors", () => {
+    const css = `
+    ${cssPreflight}
+    .test {
+      margin: 0;
+    }
+    .test:hover {
+      margin: 0;
+    }
+    .test:focus {
+      margin: 0;
+    }
+    `;
+    expect(substituteVariables(css)).toMatchInlineSnapshot(`".test{margin:0}"`);
   });
 
   test("don't respect non * and class selectors i.e. ::backdrop", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -849,6 +849,12 @@ importers:
 
   packages/css-data:
     dependencies:
+      '@unocss/core':
+        specifier: ^0.56.4
+        version: 0.56.4
+      '@unocss/preset-uno':
+        specifier: ^0.56.4
+        version: 0.56.4
       '@webstudio-is/css-engine':
         specifier: workspace:*
         version: link:../css-engine
@@ -8020,6 +8026,48 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.5.0
       eslint-visitor-keys: 3.4.3
+    dev: false
+
+  /@unocss/core@0.56.4:
+    resolution: {integrity: sha512-9DL+2adfjWWnFWp2QOJTq2OcfKKo++agaXnCX7CzeD8KgfWCBqxs2RDoxP3HrDbTflhDHdbjz23B+vJoVykhZw==}
+    dev: false
+
+  /@unocss/extractor-arbitrary-variants@0.56.4:
+    resolution: {integrity: sha512-Q93Bu3wZld+Vj5dqfJYH6phcmjm7fy6mEul64RexLWF00As9WrRzWEXbLVYmmVwUm9e5xcxZO6s98gKq1nTH6Q==}
+    dependencies:
+      '@unocss/core': 0.56.4
+    dev: false
+
+  /@unocss/preset-mini@0.56.4:
+    resolution: {integrity: sha512-FCKs3sUUiHLXQ/ON/ZCQc2JZQox4tv0W8Du+8Y1mRZ6w1yazqqBhR2yDPaEZ51yKcHmDf6ndiTvcJ2tPIz/o8g==}
+    dependencies:
+      '@unocss/core': 0.56.4
+      '@unocss/extractor-arbitrary-variants': 0.56.4
+      '@unocss/rule-utils': 0.56.4
+    dev: false
+
+  /@unocss/preset-uno@0.56.4:
+    resolution: {integrity: sha512-E4VbUe1nIeJ7D1en84osGzwP79IBJ1P9v37Pcx2PvaRAQTKf6WRF7EXzmzEm6HPF+skyGOX9RWuXs9QFODsW8A==}
+    dependencies:
+      '@unocss/core': 0.56.4
+      '@unocss/preset-mini': 0.56.4
+      '@unocss/preset-wind': 0.56.4
+      '@unocss/rule-utils': 0.56.4
+    dev: false
+
+  /@unocss/preset-wind@0.56.4:
+    resolution: {integrity: sha512-llQYQxrA531kl1juYMyaDEEl/IVdHoIPXaaJTdNHbGkSbMqrpZSRzLPsGE+CpaOBKTNqa93UyU1qlUGSr9ZB+A==}
+    dependencies:
+      '@unocss/core': 0.56.4
+      '@unocss/preset-mini': 0.56.4
+      '@unocss/rule-utils': 0.56.4
+    dev: false
+
+  /@unocss/rule-utils@0.56.4:
+    resolution: {integrity: sha512-pZmTPqi/Tb+vbwjNXu9+PwxEh7PVe+FwP+pzUbfNSUpE5Hg9CCbl8hpsXRE/r8kdaoKhmw2ryxvjocOgKXG/ag==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@unocss/core': 0.56.4
     dev: false
 
   /@vanilla-extract/babel-plugin-debug-ids@1.0.2:


### PR DESCRIPTION
## Description

- apply tailwind transform, expand and substitute to get compatible css with webstudio
- media and pseudo classes temporarily removed from variable substitution (need specificity calculations for both, we don't support media in templates)

## Steps for reproduction

see tests

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
