### PR TITLE
feat: transform tailwind classes to webstudio format

### DIFF
--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -19,6 +19,7 @@
     "@types/css-tree": "^2.3.1",
     "@webstudio-is/jest-config": "workspace:*",
     "@webstudio-is/tsconfig": "workspace:*",
+    "@webstudio-is/react-sdk": "workspace:*",
     "camelcase": "^7.0.1",
     "html-tags": "^3.3.1",
     "jest": "^29.6.4",

--- a/packages/css-data/src/tailwind-parser/parse.test.ts
+++ b/packages/css-data/src/tailwind-parser/parse.test.ts
@@ -17,7 +17,7 @@ Quick Validation of Generated CSS in WebStudio:
       ],
       "styles": [
         {
-          "property": "background-image",
+          "property": "backgroundImage",
           "value": {
             "type": "unparsed",
             "value": "linear-gradient(to right,rgba(99,102,241,1) 0%,rgba(99,102,241,0) 100%)"
@@ -39,7 +39,7 @@ describe("parseTailwindToWebstudio", () => {
       .toMatchInlineSnapshot(`
 [
   {
-    "property": "margin-bottom",
+    "property": "marginBottom",
     "value": {
       "type": "unit",
       "unit": "rem",
@@ -47,7 +47,7 @@ describe("parseTailwindToWebstudio", () => {
     },
   },
   {
-    "property": "margin-left",
+    "property": "marginLeft",
     "value": {
       "type": "unit",
       "unit": "rem",
@@ -55,7 +55,7 @@ describe("parseTailwindToWebstudio", () => {
     },
   },
   {
-    "property": "margin-right",
+    "property": "marginRight",
     "value": {
       "type": "unit",
       "unit": "rem",
@@ -63,7 +63,7 @@ describe("parseTailwindToWebstudio", () => {
     },
   },
   {
-    "property": "margin-top",
+    "property": "marginTop",
     "value": {
       "type": "unit",
       "unit": "rem",
@@ -81,7 +81,7 @@ describe("parseTailwindToWebstudio", () => {
       .toMatchInlineSnapshot(`
 [
   {
-    "property": "background-image",
+    "property": "backgroundImage",
     "value": {
       "type": "unparsed",
       "value": "linear-gradient(to right,rgba(99,102,241,1) 0%,rgba(99,102,241,0) 100%)",

--- a/packages/css-data/src/tailwind-parser/parse.test.ts
+++ b/packages/css-data/src/tailwind-parser/parse.test.ts
@@ -1,6 +1,96 @@
 import { describe, expect, it as test, jest } from "@jest/globals";
 
-import { parseTailwindToCss } from "./parse";
+import { parseTailwindToCss, parseTailwindToWebstudio } from "./parse";
+
+/*
+Quick Validation of Generated CSS in WebStudio:
+1. Customize the example JSON below with your desired styles (from snapshots).
+2. Copy and paste it into your project at https://apps.webstudio.is/
+
+```json
+{
+  "@webstudio/template": [
+    {
+      "type": "instance",
+      "component": "Box",
+      "props": [
+      ],
+      "styles": [
+        {
+          "property": "background-image",
+          "value": {
+            "type": "unparsed",
+            "value": "linear-gradient(to right,rgba(99,102,241,1) 0%,rgba(99,102,241,0) 100%)"
+          }
+        }
+      ],
+      "children": [{ "type": "text", "value": "-" }]
+    }
+  ]
+}
+```
+*/
+
+describe("parseTailwindToWebstudio", () => {
+  test("expand margins", async () => {
+    const tailwindClasses = `m-4`;
+
+    expect(await parseTailwindToWebstudio(tailwindClasses))
+      .toMatchInlineSnapshot(`
+[
+  {
+    "property": "margin-bottom",
+    "value": {
+      "type": "unit",
+      "unit": "rem",
+      "value": 1,
+    },
+  },
+  {
+    "property": "margin-left",
+    "value": {
+      "type": "unit",
+      "unit": "rem",
+      "value": 1,
+    },
+  },
+  {
+    "property": "margin-right",
+    "value": {
+      "type": "unit",
+      "unit": "rem",
+      "value": 1,
+    },
+  },
+  {
+    "property": "margin-top",
+    "value": {
+      "type": "unit",
+      "unit": "rem",
+      "value": 1,
+    },
+  },
+]
+`);
+  });
+
+  test("substitute variables - gradient", async () => {
+    const tailwindClasses = `bg-gradient-to-r from-indigo-500`;
+
+    expect(await parseTailwindToWebstudio(tailwindClasses))
+      .toMatchInlineSnapshot(`
+[
+  {
+    "property": "background-image",
+    "value": {
+      "type": "unparsed",
+      "value": "linear-gradient(to right,rgba(99,102,241,1) 0%,rgba(99,102,241,0) 100%)",
+    },
+  },
+]
+`);
+  });
+});
 
 describe("parseTailwindToCss", () => {
   test("expand margins", async () => {

--- a/packages/css-data/src/tailwind-parser/parse.ts
+++ b/packages/css-data/src/tailwind-parser/parse.ts
@@ -1,14 +1,18 @@
+import * as csstree from "css-tree";
 import { UnoGenerator, createGenerator } from "@unocss/core";
-import presetMini, { type Theme } from "@unocss/preset-uno";
+import { type Theme, presetUno } from "@unocss/preset-uno";
+import type { EmbedTemplateStyleDecl } from "@webstudio-is/react-sdk";
 import { expandTailwindShorthand } from "./shorthand";
 import { substituteVariables } from "./substitute";
 import warnOnce from "warn-once";
+import { parseCssValue } from "../parse-css-value";
+import { type StyleProperty } from "@webstudio-is/css-engine";
 
 let unoLazy: UnoGenerator<Theme> | undefined = undefined;
 
 const uno = () => {
   unoLazy = createGenerator({
-    presets: [presetMini()],
+    presets: [presetUno()],
   });
   return unoLazy;
 };
@@ -22,4 +26,42 @@ export const parseTailwindToCss = async (classes: string, warn = warnOnce) => {
 
   const cssWithClasses = substituteVariables(generated.css, warn);
   return cssWithClasses;
+};
+
+/**
+ * Convert CSS prepared by parseTailwindToCss to Webstudio format.
+ */
+const parseCssToWebstudio = (css: string) => {
+  const ast = csstree.parse(css);
+  const styles: EmbedTemplateStyleDecl[] = [];
+
+  csstree.walk(ast, {
+    enter: (node, item, list) => {
+      if (node.type === "Declaration") {
+        const property = node.property.trim();
+        const cssValue = csstree.generate(node.value);
+
+        const style: EmbedTemplateStyleDecl = {
+          property: property as StyleProperty,
+          value: parseCssValue(property as StyleProperty, cssValue),
+        };
+
+        styles.push(style);
+      }
+    },
+  });
+
+  return styles;
+};
+
+/**
+ * Parses Tailwind classes to webstudio template format.
+ */
+export const parseTailwindToWebstudio = async (
+  classes: string,
+  warn = warnOnce
+) => {
+  const css = await parseTailwindToCss(classes, warn);
+  const styles = parseCssToWebstudio(css);
+  return styles;
 };

--- a/packages/css-data/src/tailwind-parser/parse.ts
+++ b/packages/css-data/src/tailwind-parser/parse.ts
@@ -1,4 +1,5 @@
 import * as csstree from "css-tree";
+import camelCase from "camelcase";
 import { UnoGenerator, createGenerator } from "@unocss/core";
 import { type Theme, presetUno } from "@unocss/preset-uno";
 import type { EmbedTemplateStyleDecl } from "@webstudio-is/react-sdk";
@@ -38,7 +39,7 @@ const parseCssToWebstudio = (css: string) => {
   csstree.walk(ast, {
     enter: (node, item, list) => {
       if (node.type === "Declaration") {
-        const property = node.property.trim();
+        const property = camelCase(node.property.trim());
         const cssValue = csstree.generate(node.value);
 
         const style: EmbedTemplateStyleDecl = {

--- a/packages/css-data/tsconfig.json
+++ b/packages/css-data/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "compilerOptions": {
-    "noUncheckedIndexedAccess": true
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,6 +880,9 @@ importers:
       '@webstudio-is/jest-config':
         specifier: workspace:*
         version: link:../jest-config
+      '@webstudio-is/react-sdk':
+        specifier: workspace:*
+        version: link:../react-sdk
       '@webstudio-is/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig


### PR DESCRIPTION
## Description

transform tailwind classes to webstudio format

Next PRs.
Postprocessing backgrounds and shadows support. As of now backgrounds will be drawn but will not be visible at style panel


## Steps for reproduction

see tests

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
