### PR TITLE
feat: Add Webstudio borders and shadows support to Tailwind conversion

### DIFF
--- a/packages/css-data/src/tailwind-parser/parse.test.ts
+++ b/packages/css-data/src/tailwind-parser/parse.test.ts
@@ -119,6 +119,116 @@ describe("parseTailwindToWebstudio", () => {
 ]
 `);
   });
+
+  test("border", async () => {
+    const tailwindClasses = `border border-sky-500`;
+
+    expect(await parseTailwindToWebstudio(tailwindClasses))
+      .toMatchInlineSnapshot(`
+[
+  {
+    "property": "borderBottomWidth",
+    "value": {
+      "type": "unit",
+      "unit": "px",
+      "value": 1,
+    },
+  },
+  {
+    "property": "borderLeftWidth",
+    "value": {
+      "type": "unit",
+      "unit": "px",
+      "value": 1,
+    },
+  },
+  {
+    "property": "borderRightWidth",
+    "value": {
+      "type": "unit",
+      "unit": "px",
+      "value": 1,
+    },
+  },
+  {
+    "property": "borderTopWidth",
+    "value": {
+      "type": "unit",
+      "unit": "px",
+      "value": 1,
+    },
+  },
+  {
+    "property": "borderBottomColor",
+    "value": {
+      "alpha": 1,
+      "b": 233,
+      "g": 165,
+      "r": 14,
+      "type": "rgb",
+    },
+  },
+  {
+    "property": "borderLeftColor",
+    "value": {
+      "alpha": 1,
+      "b": 233,
+      "g": 165,
+      "r": 14,
+      "type": "rgb",
+    },
+  },
+  {
+    "property": "borderRightColor",
+    "value": {
+      "alpha": 1,
+      "b": 233,
+      "g": 165,
+      "r": 14,
+      "type": "rgb",
+    },
+  },
+  {
+    "property": "borderTopColor",
+    "value": {
+      "alpha": 1,
+      "b": 233,
+      "g": 165,
+      "r": 14,
+      "type": "rgb",
+    },
+  },
+  {
+    "property": "borderTopStyle",
+    "value": {
+      "type": "keyword",
+      "value": "solid",
+    },
+  },
+  {
+    "property": "borderRightStyle",
+    "value": {
+      "type": "keyword",
+      "value": "solid",
+    },
+  },
+  {
+    "property": "borderBottomStyle",
+    "value": {
+      "type": "keyword",
+      "value": "solid",
+    },
+  },
+  {
+    "property": "borderLeftStyle",
+    "value": {
+      "type": "keyword",
+      "value": "solid",
+    },
+  },
+]
+`);
+  });
 });
 
 describe("parseTailwindToCss", () => {

--- a/packages/css-data/src/tailwind-parser/parse.test.ts
+++ b/packages/css-data/src/tailwind-parser/parse.test.ts
@@ -121,6 +121,132 @@ describe("parseTailwindToWebstudio", () => {
   });
 
   test("border", async () => {
+    const tailwindClasses = `shadow-md`;
+
+    expect(await parseTailwindToWebstudio(tailwindClasses))
+      .toMatchInlineSnapshot(`
+[
+  {
+    "property": "boxShadow",
+    "value": {
+      "type": "layers",
+      "value": [
+        {
+          "type": "tuple",
+          "value": [
+            {
+              "type": "unit",
+              "unit": "number",
+              "value": 0,
+            },
+            {
+              "type": "unit",
+              "unit": "number",
+              "value": 0,
+            },
+            {
+              "alpha": 0,
+              "b": 0,
+              "g": 0,
+              "r": 0,
+              "type": "rgb",
+            },
+          ],
+        },
+        {
+          "type": "tuple",
+          "value": [
+            {
+              "type": "unit",
+              "unit": "number",
+              "value": 0,
+            },
+            {
+              "type": "unit",
+              "unit": "number",
+              "value": 0,
+            },
+            {
+              "alpha": 0,
+              "b": 0,
+              "g": 0,
+              "r": 0,
+              "type": "rgb",
+            },
+          ],
+        },
+        {
+          "type": "tuple",
+          "value": [
+            {
+              "type": "unit",
+              "unit": "number",
+              "value": 0,
+            },
+            {
+              "type": "unit",
+              "unit": "px",
+              "value": 4,
+            },
+            {
+              "type": "unit",
+              "unit": "px",
+              "value": 6,
+            },
+            {
+              "type": "unit",
+              "unit": "px",
+              "value": -1,
+            },
+            {
+              "alpha": 0.1,
+              "b": 0,
+              "g": 0,
+              "r": 0,
+              "type": "rgb",
+            },
+          ],
+        },
+        {
+          "type": "tuple",
+          "value": [
+            {
+              "type": "unit",
+              "unit": "number",
+              "value": 0,
+            },
+            {
+              "type": "unit",
+              "unit": "px",
+              "value": 2,
+            },
+            {
+              "type": "unit",
+              "unit": "px",
+              "value": 4,
+            },
+            {
+              "type": "unit",
+              "unit": "px",
+              "value": -2,
+            },
+            {
+              "alpha": 0.1,
+              "b": 0,
+              "g": 0,
+              "r": 0,
+              "type": "rgb",
+            },
+          ],
+        },
+      ],
+    },
+  },
+]
+`);
+  });
+
+  test("border", async () => {
     const tailwindClasses = `border border-sky-500`;
 
     expect(await parseTailwindToWebstudio(tailwindClasses))

--- a/packages/css-data/src/tailwind-parser/parse.test.ts
+++ b/packages/css-data/src/tailwind-parser/parse.test.ts
@@ -120,7 +120,7 @@ describe("parseTailwindToWebstudio", () => {
 `);
   });
 
-  test("border", async () => {
+  test("shadow", async () => {
     const tailwindClasses = `shadow-md`;
 
     expect(await parseTailwindToWebstudio(tailwindClasses))

--- a/packages/css-data/src/tailwind-parser/parse.ts
+++ b/packages/css-data/src/tailwind-parser/parse.ts
@@ -98,6 +98,40 @@ const postprocessBackgrounds = (
 };
 
 /**
+ * Tailwind by default has border-style: solid, but WebStudio doesn't.
+ * Provide boder-style: solid if border-width is provided.
+ **/
+const postprocessBorder = (styles: EmbedTemplateStyleDecl[]) => {
+  const borderPairs = [
+    ["borderTopWidth", "borderTopStyle"],
+    ["borderRightWidth", "borderRightStyle"],
+    ["borderBottomWidth", "borderBottomStyle"],
+    ["borderLeftWidth", "borderLeftStyle"],
+  ] as const;
+
+  const resultStyles = [...styles];
+
+  for (const [borderWidthProperty, borderStyleProperty] of borderPairs) {
+    const hasWidth = styles.some(
+      (style) => style.property === borderWidthProperty
+    );
+    const hasStyle = styles.some(
+      (style) => style.property === borderStyleProperty
+    );
+    if (hasWidth && hasStyle === false) {
+      resultStyles.push({
+        property: borderStyleProperty,
+        value: {
+          type: "keyword",
+          value: "solid",
+        },
+      });
+    }
+  }
+  return resultStyles;
+};
+
+/**
  * Parses Tailwind classes to webstudio template format.
  */
 export const parseTailwindToWebstudio = async (
@@ -108,6 +142,7 @@ export const parseTailwindToWebstudio = async (
   let styles = parseCssToWebstudio(css);
   // postprocessing
   styles = postprocessBackgrounds(styles, warn);
+  styles = postprocessBorder(styles);
 
   return styles;
 };

--- a/packages/css-data/src/tailwind-parser/parse.ts
+++ b/packages/css-data/src/tailwind-parser/parse.ts
@@ -132,6 +132,9 @@ const postprocessBorder = (styles: EmbedTemplateStyleDecl[]) => {
   return resultStyles;
 };
 
+/**
+ * In WebStudio, box-shadow property is managed using a specialized "layer" type.
+ **/
 const postprocessBoxShadows = (styles: EmbedTemplateStyleDecl[]) => {
   return styles.map((style) => {
     if (style.property === "boxShadow" && style.value.type === "unparsed") {

--- a/packages/css-data/src/tailwind-parser/parse.ts
+++ b/packages/css-data/src/tailwind-parser/parse.ts
@@ -8,6 +8,7 @@ import { substituteVariables } from "./substitute";
 import warnOnce from "warn-once";
 import { parseCssValue } from "../parse-css-value";
 import { LayersValue, type StyleProperty } from "@webstudio-is/css-engine";
+import { parseBoxShadow } from "../property-parsers/box-shadow";
 
 let unoLazy: UnoGenerator<Theme> | undefined = undefined;
 
@@ -131,6 +132,19 @@ const postprocessBorder = (styles: EmbedTemplateStyleDecl[]) => {
   return resultStyles;
 };
 
+const postprocessBoxShadows = (styles: EmbedTemplateStyleDecl[]) => {
+  return styles.map((style) => {
+    if (style.property === "boxShadow" && style.value.type === "unparsed") {
+      const shadowStyle = parseBoxShadow(style.value.value);
+      return {
+        property: style.property,
+        value: shadowStyle,
+      };
+    }
+    return style;
+  });
+};
+
 /**
  * Parses Tailwind classes to webstudio template format.
  */
@@ -143,6 +157,7 @@ export const parseTailwindToWebstudio = async (
   // postprocessing
   styles = postprocessBackgrounds(styles, warn);
   styles = postprocessBorder(styles);
+  styles = postprocessBoxShadows(styles);
 
   return styles;
 };

--- a/packages/css-data/src/tailwind-parser/shorthand.test.ts
+++ b/packages/css-data/src/tailwind-parser/shorthand.test.ts
@@ -17,7 +17,9 @@ describe("expandTailwindShorthand", () => {
   });
 
   test("handle classes without a modifier", () => {
-    expect(expandTailwindShorthand("none")).toBe("grow-0 shrink-0 basis-auto");
+    expect(expandTailwindShorthand("flex-none")).toBe(
+      "grow-0 shrink-0 basis-auto"
+    );
   });
 
   test("handle dynamic values", () => {
@@ -26,5 +28,17 @@ describe("expandTailwindShorthand", () => {
 
   test("expand inset-x-4 to right-4 left-4", () => {
     expect(expandTailwindShorthand("inset-x-4")).toBe("right-4 left-4");
+  });
+
+  test("do not expand border color", () => {
+    expect(expandTailwindShorthand("border-sky-500")).toBe(
+      "border-t-sky-500 border-r-sky-500 border-b-sky-500 border-l-sky-500"
+    );
+  });
+
+  test("expand border width", () => {
+    expect(expandTailwindShorthand("border border-sky-500")).toBe(
+      "border-t border-r border-b border-l border-t-sky-500 border-r-sky-500 border-b-sky-500 border-l-sky-500"
+    );
   });
 });

--- a/packages/css-data/src/tailwind-parser/shorthand.ts
+++ b/packages/css-data/src/tailwind-parser/shorthand.ts
@@ -4,24 +4,35 @@ export const expandShorthand = (property: string) => {};
  * Expands shorthand CSS properties into their long-form equivalents.
  * For example, 'mx' is expanded to 'mr' (margin-right) and 'ml' (margin-left).
  **/
-export const expandTailwindShorthand = (classname: string) => {
-  let expanded = conflictingClassGroups[classname];
+export const expandTailwindShorthand = (classnames: string) => {
+  return classnames
+    .split(/\s+/g)
+    .map((classname) => {
+      const groupKey = Object.keys(conflictingClassGroups).find((key) =>
+        classname.startsWith(key)
+      );
+      if (groupKey === undefined) {
+        return classname;
+      }
 
-  if (expanded) {
-    return expanded.join(" ");
-  }
+      const group = conflictingClassGroups[groupKey];
+      const modifier = classname.substring(groupKey.length);
+      const expanded = group.map((cls) => `${cls}${modifier}`);
 
-  const parts = classname.split("-");
-  const modifier = parts.pop();
-  const base = parts.join("-");
+      return expanded.join(" ");
+    })
+    .join(" ");
+};
 
-  expanded = conflictingClassGroups[base];
-
-  if (expanded) {
-    return expanded.map((cls) => `${cls}-${modifier}`).join(" ");
-  }
-
-  return classname;
+const orderByKeysDesc = (obj: Record<string, string[]>) => {
+  const ordered: Record<string, string[]> = {};
+  Object.keys(obj)
+    .sort()
+    .reverse()
+    .forEach((key) => {
+      ordered[key] = obj[key];
+    });
+  return ordered;
 };
 
 /**
@@ -32,7 +43,7 @@ export const expandTailwindShorthand = (classname: string) => {
  * MIT License
  * Copyright (c) 2021 Dany Castillo
  **/
-const conflictingClassGroups: Record<string, string[]> = {
+const conflictingClassGroups: Record<string, string[]> = orderByKeysDesc({
   overflow: ["overflow-x", "overflow-y"],
   overscroll: ["overscroll-x", "overscroll-y"],
   inset: ["top", "right", "bottom", "left"],
@@ -41,7 +52,7 @@ const conflictingClassGroups: Record<string, string[]> = {
 
   "flex-initial": ["grow-0", "shrink", "basis-auto"], // 0 1 auto
   "flex-auto": ["grow", "shrink", "basis-auto"], // 1 1 auto
-  none: ["grow-0", "shrink-0", "basis-auto"], // 0 0 auto,
+  "flex-none": ["grow-0", "shrink-0", "basis-auto"], // 0 0 auto,
   "flex-1": ["grow", "shrink", "basis-[0%]"], // 1 1 0%,
 
   gap: ["gap-x", "gap-y"],
@@ -61,18 +72,8 @@ const conflictingClassGroups: Record<string, string[]> = {
 
   "border-spacing": ["border-spacing-x", "border-spacing-y"],
 
-  "border-w": ["border-w-t", "border-w-r", "border-w-b", "border-w-l"],
-  "border-w-x": ["border-w-r", "border-w-l"],
-  "border-w-y": ["border-w-t", "border-w-b"],
-  /*
-  We are supporting shorthand for border-color
-  "border-color": [
-    "border-color-t",
-    "border-color-r",
-    "border-color-b",
-    "border-color-l",
-  ],
-  "border-color-x": ["border-color-r", "border-color-l"],
-  "border-color-y": ["border-color-t", "border-color-b"],
-  */
-};
+  "border-x": ["border-r", "border-l"],
+  "border-y": ["border-t", "border-b"],
+
+  border: ["border-t", "border-r", "border-b", "border-l"],
+});

--- a/packages/css-data/src/tailwind-parser/shorthand.ts
+++ b/packages/css-data/src/tailwind-parser/shorthand.ts
@@ -6,7 +6,8 @@ export const expandShorthand = (property: string) => {};
  **/
 export const expandTailwindShorthand = (classnames: string) => {
   return classnames
-    .split(/\s+/g)
+    .trim()
+    .split(/\s+/)
     .map((classname) => {
       const groupKey = Object.keys(conflictingClassGroups).find((key) =>
         classname.startsWith(key)


### PR DESCRIPTION
## Description

1. I was wrong about borders conversion when wrote shorthand, fixed.
2. Add border-style: solid whenever needed if borderWidth is defined (tailwind has border-style: solid predefined)
3. Add box-shadows transform

## Steps for reproduction

tests

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
