### PR TITLE
refactor: move text editing into commands

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect } from "react";
 import { useStore } from "@nanostores/react";
 import { useUnmount } from "react-use";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
-import { type Publish, usePublish, $publisher } from "~/shared/pubsub";
+import { usePublish, $publisher } from "~/shared/pubsub";
 import type { Asset } from "@webstudio-is/sdk";
 import type { Build } from "@webstudio-is/project-build";
 import type { Project } from "@webstudio-is/project";
@@ -191,13 +191,11 @@ const ChromeWrapper = ({ children, isPreviewMode }: ChromeWrapperProps) => {
 type NavigatorPanelProps = {
   isPreviewMode: boolean;
   navigatorLayout: "docked" | "undocked";
-  publish: Publish;
 };
 
 const NavigatorPanel = ({
   isPreviewMode,
   navigatorLayout,
-  publish,
 }: NavigatorPanelProps) => {
   if (navigatorLayout === "docked") {
     return null;
@@ -212,7 +210,7 @@ const NavigatorPanel = ({
           height: "100%",
         }}
       >
-        <Navigator isClosable={false} publish={publish} />
+        <Navigator isClosable={false} />
       </Box>
     </SidePanel>
   );
@@ -323,7 +321,6 @@ export const Builder = ({
         <NavigatorPanel
           isPreviewMode={isPreviewMode}
           navigatorLayout={navigatorLayout}
-          publish={publish}
         />
         <SidePanel
           gridArea="inspector"

--- a/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
@@ -1,18 +1,21 @@
 import { Flex, Separator } from "@webstudio-is/design-system";
 import { NavigatorTree } from "~/builder/shared/navigator-tree";
 import { Header, CloseButton } from "../header";
-import type { Publish } from "~/shared/pubsub";
-import { usePublishInstanceTreeShortcuts } from "~/builder/shared/shortcuts";
 import { CssPreview } from "./css-preview";
+import { useHotkeys } from "react-hotkeys-hook";
+import { emitCommand } from "~/builder/shared/commands";
 
 type NavigatorProps = {
   isClosable?: boolean;
   onClose?: () => void;
-  publish: Publish;
 };
 
-export const Navigator = ({ isClosable, onClose, publish }: NavigatorProps) => {
-  const shortcutRef = usePublishInstanceTreeShortcuts<HTMLDivElement>(publish);
+export const Navigator = ({ isClosable, onClose }: NavigatorProps) => {
+  const shortcutRef = useHotkeys<HTMLDivElement>(
+    "enter",
+    () => emitCommand("editInstanceText"),
+    []
+  );
 
   return (
     <Flex ref={shortcutRef} css={{ height: "100%", flexDirection: "column" }}>

--- a/apps/builder/app/builder/features/sidebar-left/panels/navigator/navigator.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/navigator/navigator.tsx
@@ -1,17 +1,14 @@
 import { ListNestedIcon } from "@webstudio-is/icons";
 import { Navigator } from "../../navigator";
 import type { TabName } from "../../types";
-import type { Publish } from "~/shared/pubsub";
 
 type TabContentProps = {
   onSetActiveTab: (tabName: TabName) => void;
-  publish: Publish;
 };
 
-export const TabContent = ({ onSetActiveTab, publish }: TabContentProps) => {
+export const TabContent = ({ onSetActiveTab }: TabContentProps) => {
   return (
     <Navigator
-      publish={publish}
       onClose={() => {
         onSetActiveTab("none");
       }}

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -3,6 +3,7 @@ import { $isPreviewMode } from "~/shared/nano-states";
 
 export const { emitCommand, subscribeCommands } = createCommandsEmitter({
   source: "builder",
+  externalCommands: ["editInstanceText"],
   commands: [
     {
       name: "togglePreview",

--- a/apps/builder/app/builder/shared/shortcuts/use-publish-shortcuts.ts
+++ b/apps/builder/app/builder/shared/shortcuts/use-publish-shortcuts.ts
@@ -1,14 +1,10 @@
 import { useHotkeys } from "react-hotkeys-hook";
-import { shortcuts, options, instanceTreeShortcuts } from "~/shared/shortcuts";
+import { shortcuts, options } from "~/shared/shortcuts";
 import type { Publish } from "~/shared/pubsub";
-import { mergeRefs } from "@react-aria/utils";
-import type { Ref } from "react";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
-    shortcut:
-      | { name: keyof typeof shortcuts }
-      | { name: keyof typeof instanceTreeShortcuts };
+    shortcut: { name: keyof typeof shortcuts };
   }
 }
 
@@ -23,7 +19,7 @@ export const usePublishShortcuts = (publish: Publish) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useHotkeys(
       shortcuts[name],
-      (event) => {
+      (_event) => {
         publish({
           type: "shortcut",
           payload: { name },
@@ -33,33 +29,4 @@ export const usePublishShortcuts = (publish: Publish) => {
       []
     );
   });
-};
-
-/**
- * Forwarding shortcuts to the canvas.
- */
-export const usePublishInstanceTreeShortcuts = <T extends HTMLElement>(
-  publish: Publish
-) => {
-  const refs: Ref<T>[] = [];
-  for (const [name, instaceTreeShortcut] of Object.entries(
-    instanceTreeShortcuts
-  )) {
-    // as long as the array is static, it's ok
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const ref = useHotkeys(
-      instaceTreeShortcut,
-      (event) => {
-        publish({
-          type: "shortcut",
-          payload: { name: name as keyof typeof instanceTreeShortcuts },
-        });
-      },
-      options,
-      []
-    );
-    refs.push(ref as Ref<T>);
-  }
-
-  return mergeRefs<T>(...refs);
 };

--- a/apps/builder/app/canvas/canvas-shortcuts.ts
+++ b/apps/builder/app/canvas/canvas-shortcuts.ts
@@ -1,7 +1,6 @@
 import { useHotkeys } from "react-hotkeys-hook";
-import { shortcuts, instanceTreeShortcuts, options } from "~/shared/shortcuts";
+import { shortcuts, options } from "~/shared/shortcuts";
 import { publish, useSubscribe } from "~/shared/pubsub";
-import { enterEditingMode, escapeSelection } from "~/shared/instance-utils";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -22,11 +21,7 @@ export const useCanvasShortcuts = () => {
   const shortcutHandlerMap = {
     breakpointsMenu: publishOpenBreakpointsMenu,
     esc: publishCancelCurrentDrag,
-    enter: enterEditingMode,
-  } as const satisfies Record<
-    keyof typeof shortcuts | keyof typeof instanceTreeShortcuts,
-    unknown
-  >;
+  } as const satisfies Record<keyof typeof shortcuts, unknown>;
 
   useHotkeys(
     shortcuts.breakpointsMenu,
@@ -39,14 +34,10 @@ export const useCanvasShortcuts = () => {
     shortcuts.esc,
     () => {
       shortcutHandlerMap.esc();
-      // Reset selection for local canvas escape, but not for the Builder escape via useSubscribe
-      escapeSelection();
     },
     options,
     []
   );
-
-  useHotkeys(instanceTreeShortcuts.enter, shortcutHandlerMap.enter, {}, []);
 
   // Shortcuts from the parent window
   useSubscribe("shortcut", ({ name }) => {

--- a/apps/builder/app/canvas/shared/commands.ts
+++ b/apps/builder/app/canvas/shared/commands.ts
@@ -1,6 +1,68 @@
 import { createCommandsEmitter } from "~/shared/commands-emitter";
+import { getElementByInstanceSelector } from "~/shared/dom-utils";
+import { findClosestEditableInstanceSelector } from "~/shared/instance-utils";
+import {
+  instancesStore,
+  registeredComponentMetasStore,
+  selectedInstanceSelectorStore,
+  selectedStyleSourceSelectorStore,
+  textEditingInstanceSelectorStore,
+} from "~/shared/nano-states";
 
 export const { emitCommand, subscribeCommands } = createCommandsEmitter({
   source: "canvas",
-  commands: [],
+  commands: [
+    {
+      name: "editInstanceText",
+      defaultHotkeys: ["enter"],
+      // builder invokes command with custom hotkey setup
+      disableHotkeyOutsideApp: true,
+      handler: () => {
+        const selectedInstanceSelector = selectedInstanceSelectorStore.get();
+        if (selectedInstanceSelector === undefined) {
+          return;
+        }
+        const editableInstanceSelector = findClosestEditableInstanceSelector(
+          selectedInstanceSelector,
+          instancesStore.get(),
+          registeredComponentMetasStore.get()
+        );
+        if (editableInstanceSelector === undefined) {
+          return;
+        }
+        const element = getElementByInstanceSelector(editableInstanceSelector);
+        if (element === undefined) {
+          return;
+        }
+        // When an event is triggered from the Builder,
+        // the canvas element may be unfocused, so it's important to focus the element on the canvas.
+        element.focus();
+        selectedInstanceSelectorStore.set(editableInstanceSelector);
+        textEditingInstanceSelectorStore.set(editableInstanceSelector);
+      },
+    },
+
+    {
+      name: "escapeSelection",
+      defaultHotkeys: ["escape"],
+      // reset selection for canvas, but not for the builder
+      disableHotkeyOutsideApp: true,
+      handler: () => {
+        const selectedInstanceSelector = selectedInstanceSelectorStore.get();
+        const textEditingInstanceSelector =
+          textEditingInstanceSelectorStore.get();
+        if (selectedInstanceSelector === undefined) {
+          return;
+        }
+        // exit text editing mode first without unselecting instance
+        if (textEditingInstanceSelector) {
+          textEditingInstanceSelectorStore.set(undefined);
+          return;
+        }
+        // unselect both instance and style source
+        selectedInstanceSelectorStore.set(undefined);
+        selectedStyleSourceSelectorStore.set(undefined);
+      },
+    },
+  ],
 });

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -36,7 +36,6 @@ import {
 } from "./tree-utils";
 import { removeByMutable } from "./array-utils";
 import { isBaseBreakpoint } from "./breakpoints";
-import { getElementByInstanceSelector } from "./dom-utils";
 import { humanizeString } from "./string-utils";
 
 const getLabelFromComponentName = (component: Instance["component"]) => {
@@ -504,45 +503,4 @@ export const deleteSelectedInstance = () => {
     return;
   }
   deleteInstance(selectedInstanceSelector);
-};
-
-export const enterEditingMode = (event?: KeyboardEvent) => {
-  const selectedInstanceSelector = selectedInstanceSelectorStore.get();
-  if (selectedInstanceSelector === undefined) {
-    return;
-  }
-  const editableInstanceSelector = findClosestEditableInstanceSelector(
-    selectedInstanceSelector,
-    instancesStore.get(),
-    registeredComponentMetasStore.get()
-  );
-  if (editableInstanceSelector === undefined) {
-    return;
-  }
-  const element = getElementByInstanceSelector(editableInstanceSelector);
-  if (element === undefined) {
-    return;
-  }
-  // When an event is triggered from the Builder,
-  // the canvas element may be unfocused, so it's important to focus the element on the canvas.
-  element.focus();
-  // Prevents inserting a newline when entering text-editing mode
-  event?.preventDefault();
-  selectedInstanceSelectorStore.set(editableInstanceSelector);
-  textEditingInstanceSelectorStore.set(editableInstanceSelector);
-};
-
-export const escapeSelection = () => {
-  const selectedInstanceSelector = selectedInstanceSelectorStore.get();
-  const textEditingInstanceSelector = textEditingInstanceSelectorStore.get();
-  if (selectedInstanceSelector === undefined) {
-    return;
-  }
-  // exit text editing mode first without unselecting instance
-  if (textEditingInstanceSelector) {
-    textEditingInstanceSelectorStore.set(undefined);
-    return;
-  }
-  selectedInstanceSelectorStore.set(undefined);
-  selectedStyleSourceSelectorStore.set(undefined);
 };

--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -13,10 +13,6 @@ export const shortcuts = {
   breakpointsMenu: "meta+b, ctrl+b",
 } as const;
 
-export const instanceTreeShortcuts = {
-  enter: "enter",
-} as const;
-
 export const options: Options = {
   enableOnFormTags: true,
 };

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -72,8 +72,8 @@ export const registerContainers = () => {
   store.register("props", propsStore);
   store.register("dataSources", dataSourcesStore);
   store.register("assets", assetsStore);
+  store.register("commandMetas", $commandMetas);
   // synchronize whole states
-  clientStores.set("commandMetas", $commandMetas);
   clientStores.set("project", projectStore);
   clientStores.set("dataSourceVariables", dataSourceVariablesStore);
   clientStores.set("selectedPageId", selectedPageIdStore);


### PR DESCRIPTION
Here fixed two-way synchronization of commands between builder and canvas. Added flag to not share hotkey with other apps.

Added first two commands specific to canvas: editInstanceText and escapeSelection. Builder is able to reuse commands by specifying inn "externalCommands" which basically extends the union of commands.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
