### PR TITLE
refactor: migrate breakpoints to commands

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -300,7 +300,7 @@ export const Builder = ({
   return (
     <TooltipProvider>
       <ChromeWrapper isPreviewMode={isPreviewMode}>
-        <Topbar gridArea="header" project={project} publish={publish} />
+        <Topbar gridArea="header" project={project} />
         <Main>
           <Workspace onTransitionEnd={onTransitionEnd} publish={publish}>
             <CanvasIframe

--- a/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
@@ -34,6 +34,7 @@ import {
   selectedBreakpointStore,
 } from "~/shared/nano-states";
 import {
+  $breakpointsMenuView,
   groupBreakpoints,
   isBaseBreakpoint,
   minCanvasWidth,
@@ -42,9 +43,7 @@ import { scaleStore } from "~/builder/shared/nano-states";
 import { useSetInitialCanvasWidth } from "./use-set-initial-canvas-width";
 
 export const BreakpointsPopover = () => {
-  const [view, setView] = useState<
-    "initial" | "editor" | "confirmation" | undefined
-  >();
+  const view = useStore($breakpointsMenuView);
   const [breakpointToDelete, setBreakpointToDelete] = useState<
     Breakpoint | undefined
   >();
@@ -53,12 +52,8 @@ export const BreakpointsPopover = () => {
   const scale = useStore(scaleStore);
   const setInitialCanvasWidth = useSetInitialCanvasWidth();
 
-  useSubscribe("openBreakpointsMenu", () => {
-    setView("initial");
-  });
-
   useSubscribe("clickCanvas", () => {
-    setView(undefined);
+    $breakpointsMenuView.set(undefined);
   });
 
   if (selectedBreakpoint === undefined) {
@@ -90,14 +85,14 @@ export const BreakpointsPopover = () => {
       setInitialCanvasWidth(base.id);
     }
     setBreakpointToDelete(undefined);
-    setView("editor");
+    $breakpointsMenuView.set("editor");
   };
 
   return (
     <Popover
       open={view !== undefined}
       onOpenChange={(isOpen) => {
-        setView(isOpen ? "initial" : undefined);
+        $breakpointsMenuView.set(isOpen ? "initial" : undefined);
       }}
     >
       <PopoverTrigger aria-label="Show breakpoints" asChild>
@@ -119,7 +114,7 @@ export const BreakpointsPopover = () => {
               breakpoint={breakpointToDelete}
               onAbort={() => {
                 setBreakpointToDelete(undefined);
-                setView("editor");
+                $breakpointsMenuView.set("editor");
               }}
               onConfirm={handleDelete}
             />
@@ -128,7 +123,7 @@ export const BreakpointsPopover = () => {
             <BreakpointsEditor
               onDelete={(breakpoint) => {
                 setBreakpointToDelete(breakpoint);
-                setView("confirmation");
+                $breakpointsMenuView.set("confirmation");
               }}
             />
           )}
@@ -210,7 +205,9 @@ export const BreakpointsPopover = () => {
                   css={{ flexGrow: 1 }}
                   onClick={(event) => {
                     event.preventDefault();
-                    setView(view === "initial" ? "editor" : "initial");
+                    $breakpointsMenuView.set(
+                      view === "initial" ? "editor" : "initial"
+                    );
                   }}
                 >
                   {view === "editor" ? "Done" : "Edit breakpoints"}

--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -16,7 +16,6 @@ import {
   DropdownMenuPortal,
   Tooltip,
 } from "@webstudio-is/design-system";
-import type { Publish } from "~/shared/pubsub";
 import { ShortcutHint } from "./shortcut-hint";
 import {
   useIsShareDialogOpen,
@@ -91,11 +90,7 @@ const ViewMenuItem = () => {
   );
 };
 
-type MenuProps = {
-  publish: Publish;
-};
-
-export const Menu = ({ publish }: MenuProps) => {
+export const Menu = () => {
   const navigate = useNavigate();
   const [, setIsShareOpen] = useIsShareDialogOpen();
   const [, setIsPublishOpen] = useIsPublishDialogOpen();
@@ -171,11 +166,7 @@ export const Menu = ({ publish }: MenuProps) => {
             </DropdownMenuItemRightSlot>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onSelect={() => {
-              publish({ type: "openBreakpointsMenu" });
-            }}
-          >
+          <DropdownMenuItem onSelect={() => emitCommand("openBreakpointsMenu")}>
             Breakpoints
             <DropdownMenuItemRightSlot>
               <ShortcutHint value={["cmd", "b"]} />

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -8,7 +8,6 @@ import {
   ToolbarToggleGroup,
 } from "@webstudio-is/design-system";
 import type { Project } from "@webstudio-is/project";
-import type { Publish } from "~/shared/pubsub";
 import { selectedPageStore } from "~/shared/nano-states";
 import { PreviewButton } from "./preview";
 import { ShareButton } from "./share";
@@ -33,16 +32,15 @@ const topbarContainerStyle = css({
 type TopbarProps = {
   gridArea: string;
   project: Project;
-  publish: Publish;
 };
 
-export const Topbar = ({ gridArea, project, publish }: TopbarProps) => {
+export const Topbar = ({ gridArea, project }: TopbarProps) => {
   const page = useStore(selectedPageStore);
 
   return (
     <nav className={topbarContainerStyle({ css: { gridArea } })}>
       <Flex grow={false} shrink={false}>
-        <Menu publish={publish} />
+        <Menu />
       </Flex>
       <Flex
         css={{ px: theme.spacing[9], maxWidth: theme.spacing[24] }}

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -1,5 +1,20 @@
-import { createCommandsEmitter } from "~/shared/commands-emitter";
+import { createCommandsEmitter, type Command } from "~/shared/commands-emitter";
 import { $isPreviewMode } from "~/shared/nano-states";
+import {
+  $breakpointsMenuView,
+  selectBreakpointByOrder,
+} from "~/shared/breakpoints";
+
+const makeBreakpointCommand = <CommandName extends string>(
+  name: CommandName,
+  number: number
+): Command<CommandName> => ({
+  name,
+  defaultHotkeys: [`meta+${number}`, `ctrl+${number}`],
+  handler: () => {
+    selectBreakpointByOrder(number);
+  },
+});
 
 export const { emitCommand, subscribeCommands } = createCommandsEmitter({
   source: "builder",
@@ -12,5 +27,21 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
         $isPreviewMode.set($isPreviewMode.get() === false);
       },
     },
+    {
+      name: "openBreakpointsMenu",
+      defaultHotkeys: ["meta+b", "ctrl+b"],
+      handler: () => {
+        $breakpointsMenuView.set("initial");
+      },
+    },
+    makeBreakpointCommand("selectBreakpoint1", 1),
+    makeBreakpointCommand("selectBreakpoint2", 2),
+    makeBreakpointCommand("selectBreakpoint3", 3),
+    makeBreakpointCommand("selectBreakpoint4", 4),
+    makeBreakpointCommand("selectBreakpoint5", 5),
+    makeBreakpointCommand("selectBreakpoint6", 6),
+    makeBreakpointCommand("selectBreakpoint7", 7),
+    makeBreakpointCommand("selectBreakpoint8", 8),
+    makeBreakpointCommand("selectBreakpoint9", 9),
   ],
 });

--- a/apps/builder/app/canvas/canvas-shortcuts.ts
+++ b/apps/builder/app/canvas/canvas-shortcuts.ts
@@ -5,13 +5,8 @@ import { publish, useSubscribe } from "~/shared/pubsub";
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
     cancelCurrentDrag: undefined;
-    openBreakpointsMenu: undefined;
   }
 }
-
-const publishOpenBreakpointsMenu = () => {
-  publish({ type: "openBreakpointsMenu" });
-};
 
 const publishCancelCurrentDrag = () => {
   publish({ type: "cancelCurrentDrag" });
@@ -19,16 +14,8 @@ const publishCancelCurrentDrag = () => {
 
 export const useCanvasShortcuts = () => {
   const shortcutHandlerMap = {
-    breakpointsMenu: publishOpenBreakpointsMenu,
     esc: publishCancelCurrentDrag,
   } as const satisfies Record<keyof typeof shortcuts, unknown>;
-
-  useHotkeys(
-    shortcuts.breakpointsMenu,
-    shortcutHandlerMap.breakpointsMenu,
-    options,
-    []
-  );
 
   useHotkeys(
     shortcuts.esc,

--- a/apps/builder/app/shared/breakpoints/index.ts
+++ b/apps/builder/app/shared/breakpoints/index.ts
@@ -2,3 +2,4 @@ export * from "./is-base-breakpoint";
 export * from "./select-breakpoint-by-order";
 export * from "./group-breakpoints";
 export * from "./constants";
+export * from "./stores";

--- a/apps/builder/app/shared/breakpoints/select-breakpoint-by-order.ts
+++ b/apps/builder/app/shared/breakpoints/select-breakpoint-by-order.ts
@@ -1,4 +1,4 @@
-import { groupBreakpoints } from ".";
+import { groupBreakpoints } from "./group-breakpoints";
 import { selectedBreakpointIdStore, breakpointsStore } from "../nano-states";
 
 /**

--- a/apps/builder/app/shared/breakpoints/stores.ts
+++ b/apps/builder/app/shared/breakpoints/stores.ts
@@ -1,0 +1,5 @@
+import { atom } from "nanostores";
+
+export const $breakpointsMenuView = atom<
+  "initial" | "editor" | "confirmation" | undefined
+>();

--- a/apps/builder/app/shared/commands-emitter.ts
+++ b/apps/builder/app/shared/commands-emitter.ts
@@ -17,7 +17,7 @@ type CommandHandler = () => void;
 /**
  * Command can be registered by builder, canvas or plugin
  */
-type Command<CommandName extends string> = CommandMeta<CommandName> & {
+export type Command<CommandName extends string> = CommandMeta<CommandName> & {
   /**
    * Command handler accepting source where was triggered
    * which is builder, canvas or plugin name

--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -1,7 +1,6 @@
 import { type Options, useHotkeys } from "react-hotkeys-hook";
 import store from "immerhin";
 import { deleteSelectedInstance } from "../instance-utils";
-import { selectBreakpointByOrder } from "../breakpoints";
 import {
   editingItemIdStore,
   selectedInstanceSelectorStore,
@@ -10,7 +9,6 @@ import { onCopy, onPaste } from "../copy-paste/plugin-instance";
 
 export const shortcuts = {
   esc: "esc",
-  breakpointsMenu: "meta+b, ctrl+b",
 } as const;
 
 export const options: Options = {
@@ -80,18 +78,6 @@ export const useSharedShortcuts = ({
       editingItemIdStore.set(targetInstanceId);
     },
     {},
-    []
-  );
-
-  const breakpointShortcuts = Array.from(new Array(9))
-    .map((_, index) => `meta+${index + 1}, ctrl+${index + 1}`)
-    .join(", ");
-  useHotkeys(
-    breakpointShortcuts,
-    (event) => {
-      selectBreakpointByOrder(Number.parseInt(event.key, 10));
-    },
-    { enableOnFormTags: true, enableOnContentEditable: true },
     []
   );
 };


### PR DESCRIPTION
Moved breakpoints menu view state into nanostore.
Added open breakpoints menu and select breakpoint commands.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
