### PR TITLE
refactor: migrate instances to commands

### DIFF
--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -29,7 +29,6 @@ import {
 import { useClientSettings } from "~/builder/shared/client-settings";
 import { dashboardPath } from "~/shared/router-utils";
 import { $authPermit } from "~/shared/nano-states";
-import { deleteSelectedInstance } from "~/shared/instance-utils";
 import { emitCommand } from "~/builder/shared/commands";
 import { MenuButton } from "./menu-button";
 
@@ -159,7 +158,7 @@ export const Menu = () => {
           </DropdownMenuItem>
 
           */}
-          <DropdownMenuItem onSelect={deleteSelectedInstance}>
+          <DropdownMenuItem onSelect={() => emitCommand("deleteInstance")}>
             Delete
             <DropdownMenuItemRightSlot>
               <ShortcutHint value={["backspace"]} />

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -1,9 +1,15 @@
 import { createCommandsEmitter, type Command } from "~/shared/commands-emitter";
-import { $isPreviewMode } from "~/shared/nano-states";
+import {
+  $isPreviewMode,
+  editingItemIdStore,
+  selectedInstanceSelectorStore,
+} from "~/shared/nano-states";
 import {
   $breakpointsMenuView,
   selectBreakpointByOrder,
 } from "~/shared/breakpoints";
+import { onCopy, onPaste } from "~/shared/copy-paste/plugin-instance";
+import { deleteSelectedInstance } from "~/shared/instance-utils";
 
 const makeBreakpointCommand = <CommandName extends string>(
   name: CommandName,
@@ -20,6 +26,8 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
   source: "builder",
   externalCommands: ["editInstanceText"],
   commands: [
+    // ui
+
     {
       name: "togglePreview",
       defaultHotkeys: ["meta+shift+p", "ctrl+shift+p"],
@@ -43,5 +51,38 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
     makeBreakpointCommand("selectBreakpoint7", 7),
     makeBreakpointCommand("selectBreakpoint8", 8),
     makeBreakpointCommand("selectBreakpoint9", 9),
+
+    // instances
+
+    {
+      name: "deleteInstance",
+      defaultHotkeys: ["backspace", "delete"],
+      disableHotkeyOnContentEditable: true,
+      // this disables hotkey for inputs on style panel
+      // but still work for input on canvas which call event.preventDefault() in keydown handler
+      disableHotkeyOnFormTags: true,
+      handler: () => {
+        deleteSelectedInstance();
+      },
+    },
+    {
+      name: "duplicateInstance",
+      defaultHotkeys: ["meta+d", "ctrl+d"],
+      handler: () => {
+        onPaste(onCopy() ?? "");
+      },
+    },
+    {
+      name: "editInstanceLabel",
+      defaultHotkeys: ["meta+e", "ctrl+e"],
+      handler: () => {
+        const selectedInstanceSelector = selectedInstanceSelectorStore.get();
+        if (selectedInstanceSelector === undefined) {
+          return;
+        }
+        const [targetInstanceId] = selectedInstanceSelector;
+        editingItemIdStore.set(targetInstanceId);
+      },
+    },
   ],
 });

--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -1,11 +1,5 @@
 import { type Options, useHotkeys } from "react-hotkeys-hook";
 import store from "immerhin";
-import { deleteSelectedInstance } from "../instance-utils";
-import {
-  editingItemIdStore,
-  selectedInstanceSelectorStore,
-} from "../nano-states";
-import { onCopy, onPaste } from "../copy-paste/plugin-instance";
 
 export const shortcuts = {
   esc: "esc",
@@ -41,43 +35,6 @@ export const useSharedShortcuts = ({
       enableOnFormTags: source === "canvas",
       enableOnContentEditable: false,
     },
-    []
-  );
-
-  useHotkeys(
-    "backspace, delete",
-    deleteSelectedInstance,
-    {
-      // When in builder, we don't want to delete instances,
-      // when user edits text in a control on style panel etc.
-      // But when a form control on canvas has focus, we want the shortcut to work.
-      enableOnFormTags: source === "canvas",
-      enableOnContentEditable: false,
-    },
-    []
-  );
-
-  useHotkeys(
-    "meta+d, ctrl+d",
-    (event) => {
-      event.preventDefault();
-      onPaste(onCopy() ?? "");
-    },
-    {},
-    []
-  );
-
-  useHotkeys(
-    "meta+e, 'ctrl+e",
-    () => {
-      const selectedInstanceSelector = selectedInstanceSelectorStore.get();
-      if (selectedInstanceSelector === undefined) {
-        return;
-      }
-      const targetInstanceId = selectedInstanceSelector[0];
-      editingItemIdStore.set(targetInstanceId);
-    },
-    {},
     []
   );
 };


### PR DESCRIPTION
Here migrated instances shortcuts like delete, duplicate and edit label to commands.

Added two more options disableHotkeyOnContentEditable and disableHotkeyOnFormTags to not break builtin shortcuts.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
