### PR TITLE
fix: remove placeholders from data

### DIFF
--- a/packages/sdk-components-react/src/blockquote.tsx
+++ b/packages/sdk-components-react/src/blockquote.tsx
@@ -1,17 +1,16 @@
-import {
-  forwardRef,
-  createElement,
-  type ElementRef,
-  type ComponentProps,
-} from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 export const defaultTag = "blockquote";
 
 type Props = ComponentProps<typeof defaultTag>;
 
 export const Blockquote = forwardRef<ElementRef<typeof defaultTag>, Props>(
-  (props, ref) => {
-    return createElement(defaultTag, { ...props, ref });
+  ({ children, ...props }, ref) => {
+    return (
+      <blockquote {...props} ref={ref}>
+        {children ?? "Blockquote you can edit"}
+      </blockquote>
+    );
   }
 );
 

--- a/packages/sdk-components-react/src/blockquote.ws.tsx
+++ b/packages/sdk-components-react/src/blockquote.ws.tsx
@@ -68,13 +68,6 @@ export const meta: WsComponentMeta = {
   icon: BlockquoteIcon,
   states: defaultStates,
   presetStyle,
-  template: [
-    {
-      type: "instance",
-      component: "Blockquote",
-      children: [{ type: "text", value: "Blockquote you can edit" }],
-    },
-  ],
   order: 3,
 };
 

--- a/packages/sdk-components-react/src/button.tsx
+++ b/packages/sdk-components-react/src/button.tsx
@@ -7,7 +7,7 @@ type ButtonProps = ComponentProps<typeof defaultTag>;
 export const Button = forwardRef<ElementRef<typeof defaultTag>, ButtonProps>(
   ({ type = "submit", children, ...props }, ref) => (
     <button type={type} {...props} ref={ref}>
-      {children}
+      {children ?? "Button you can edit"}
     </button>
   )
 );

--- a/packages/sdk-components-react/src/button.ws.tsx
+++ b/packages/sdk-components-react/src/button.ws.tsx
@@ -28,13 +28,6 @@ export const meta: WsComponentMeta = {
     { selector: ":enabled", label: "Enabled" },
   ],
   order: 1,
-  template: [
-    {
-      type: "instance",
-      component: "Button",
-      children: [{ type: "text", value: "Button you can edit" }],
-    },
-  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/code-text.tsx
+++ b/packages/sdk-components-react/src/code-text.tsx
@@ -1,17 +1,16 @@
-import {
-  type ElementRef,
-  type ComponentProps,
-  forwardRef,
-  createElement,
-} from "react";
+import { type ElementRef, type ComponentProps, forwardRef } from "react";
 
 export const defaultTag = "code";
 
 export const CodeText = forwardRef<
   ElementRef<typeof defaultTag>,
   ComponentProps<typeof defaultTag>
->((props, ref) => {
-  return createElement(defaultTag, { ...props, ref });
+>(({ children, ...props }, ref) => {
+  return (
+    <code {...props} ref={ref}>
+      {children ?? "Code you can edit"}
+    </code>
+  );
 });
 
 CodeText.displayName = "CodeText";

--- a/packages/sdk-components-react/src/code-text.ws.tsx
+++ b/packages/sdk-components-react/src/code-text.ws.tsx
@@ -45,13 +45,6 @@ export const meta: WsComponentMeta = {
   invalidAncestors: ["CodeText"],
   states: defaultStates,
   presetStyle,
-  template: [
-    {
-      type: "instance",
-      component: "CodeText",
-      children: [{ type: "text", value: "Code you can edit" }],
-    },
-  ],
   order: 8,
 };
 

--- a/packages/sdk-components-react/src/heading.tsx
+++ b/packages/sdk-components-react/src/heading.tsx
@@ -1,9 +1,4 @@
-import {
-  forwardRef,
-  createElement,
-  type ElementRef,
-  type ComponentProps,
-} from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 const defaultTag = "h1";
 
@@ -13,8 +8,12 @@ type Props = ComponentProps<typeof defaultTag> & {
 };
 
 export const Heading = forwardRef<ElementRef<typeof defaultTag>, Props>(
-  ({ tag = defaultTag, ...props }, ref) => {
-    return createElement(tag, { ...props, ref });
+  ({ tag: Tag = defaultTag, children, ...props }, ref) => {
+    return (
+      <Tag {...props} ref={ref}>
+        {children ?? "Heading you can edit"}
+      </Tag>
+    );
   }
 );
 

--- a/packages/sdk-components-react/src/heading.ws.tsx
+++ b/packages/sdk-components-react/src/heading.ws.tsx
@@ -31,13 +31,6 @@ export const meta: WsComponentMeta = {
   invalidAncestors: ["Heading"],
   states: defaultStates,
   presetStyle,
-  template: [
-    {
-      type: "instance",
-      component: "Heading",
-      children: [{ type: "text", value: "Heading you can edit" }],
-    },
-  ],
   order: 1,
 };
 

--- a/packages/sdk-components-react/src/link.tsx
+++ b/packages/sdk-components-react/src/link.tsx
@@ -7,8 +7,14 @@ type Props = Omit<ComponentProps<"a">, "target"> & {
   target?: "_self" | "_blank" | "_parent" | "_top";
 };
 
-export const Link = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
-  return <a {...props} href={props.href ?? "#"} ref={ref} />;
-});
+export const Link = forwardRef<HTMLAnchorElement, Props>(
+  ({ children, ...props }, ref) => {
+    return (
+      <a {...props} href={props.href ?? "#"} ref={ref}>
+        {children ?? "Link text you can edit"}
+      </a>
+    );
+  }
+);
 
 Link.displayName = "Link";

--- a/packages/sdk-components-react/src/link.ws.tsx
+++ b/packages/sdk-components-react/src/link.ws.tsx
@@ -45,13 +45,6 @@ export const meta: WsComponentMeta = {
       label: "Current page",
     },
   ],
-  template: [
-    {
-      type: "instance",
-      component: "Link",
-      children: [{ type: "text", value: "Link text you can edit" }],
-    },
-  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/list-item.tsx
+++ b/packages/sdk-components-react/src/list-item.tsx
@@ -1,17 +1,16 @@
-import {
-  forwardRef,
-  createElement,
-  type ElementRef,
-  type ComponentProps,
-} from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 export const defaultTag = "li";
 
 type Props = ComponentProps<typeof defaultTag>;
 
 export const ListItem = forwardRef<ElementRef<typeof defaultTag>, Props>(
-  (props, ref) => {
-    return createElement(defaultTag, { ...props, ref });
+  ({ children, ...props }, ref) => {
+    return (
+      <li {...props} ref={ref}>
+        {children ?? "List Item you can edit"}
+      </li>
+    );
   }
 );
 

--- a/packages/sdk-components-react/src/list-item.ws.tsx
+++ b/packages/sdk-components-react/src/list-item.ws.tsx
@@ -22,13 +22,6 @@ export const meta: WsComponentMeta = {
   icon: ListItemIcon,
   states: defaultStates,
   presetStyle,
-  template: [
-    {
-      type: "instance",
-      component: "ListItem",
-      children: [{ type: "text", value: "List Item you can edit" }],
-    },
-  ],
   order: 4,
 };
 

--- a/packages/sdk-components-react/src/paragraph.tsx
+++ b/packages/sdk-components-react/src/paragraph.tsx
@@ -5,6 +5,10 @@ export const defaultTag = "p";
 export const Paragraph = forwardRef<
   ElementRef<typeof defaultTag>,
   ComponentProps<typeof defaultTag>
->((props, ref) => <p {...props} ref={ref} />);
+>(({ children, ...props }, ref) => (
+  <p {...props} ref={ref}>
+    {children ?? "Paragraph you can edit"}
+  </p>
+));
 
 Paragraph.displayName = "Paragraph";

--- a/packages/sdk-components-react/src/paragraph.ws.tsx
+++ b/packages/sdk-components-react/src/paragraph.ws.tsx
@@ -22,13 +22,6 @@ export const meta: WsComponentMeta = {
   invalidAncestors: ["Paragraph"],
   states: defaultStates,
   presetStyle,
-  template: [
-    {
-      type: "instance",
-      component: "Paragraph",
-      children: [{ type: "text", value: "Paragraph you can edit" }],
-    },
-  ],
   order: 2,
 };
 

--- a/packages/sdk-components-react/src/text.tsx
+++ b/packages/sdk-components-react/src/text.tsx
@@ -1,9 +1,4 @@
-import {
-  createElement,
-  forwardRef,
-  type ElementRef,
-  type ComponentProps,
-} from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 export const defaultTag = "div";
 
@@ -14,8 +9,12 @@ type Props = ComponentProps<typeof defaultTag> & {
 };
 
 export const Text = forwardRef<ElementRef<typeof defaultTag>, Props>(
-  ({ tag = defaultTag, ...props }, ref) => {
-    return createElement(tag, { ...props, ref });
+  ({ tag: Tag = defaultTag, children, ...props }, ref) => {
+    return (
+      <Tag {...props} ref={ref}>
+        {children}
+      </Tag>
+    );
   }
 );
 

--- a/packages/sdk-components-react/src/text.ws.tsx
+++ b/packages/sdk-components-react/src/text.ws.tsx
@@ -28,13 +28,6 @@ export const meta: WsComponentMeta = {
   icon: TextIcon,
   states: defaultStates,
   presetStyle,
-  template: [
-    {
-      type: "instance",
-      component: "Text",
-      children: [{ type: "text", value: "The text you can edit" }],
-    },
-  ],
   order: 0,
 };
 


### PR DESCRIPTION
When we put placeholders into data ai may confuse them with actual content. So here put placeholders into component and render when no content present.

Though this bring one side effect in UX. When user start to edit text it gets empty content without cursor. This will be fixed later.

For now just unblock ai changes.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
