### PR TITLE
fix: use proper heading props for dialog and sheet components

### DIFF
--- a/packages/sdk-components-react-radix/package.json
+++ b/packages/sdk-components-react-radix/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "dev": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib --watch",
     "build": "rm -rf lib && esbuild src/components.ts src/metas.ts src/props.ts src/hooks.ts --outdir=lib --bundle --format=esm --packages=external",
-    "build:args": "NODE_OPTIONS=--conditions=webstudio generate-arg-types './src/accordion.tsx !./src/*.stories.tsx !./src/*.ws.tsx' -e asChild -e modal -e defaultValue -e defaultOpen -e defaultChecked && prettier --write \"**/*.props.ts\"",
+    "build:args": "NODE_OPTIONS=--conditions=webstudio generate-arg-types './src/(accordion|sheet|dialog).tsx !./src/*.stories.tsx !./src/*.ws.tsx' -e asChild -e modal -e defaultValue -e defaultOpen -e defaultChecked && prettier --write \"**/*.props.ts\"",
     "build:tailwind": "tsx scripts/generate-tailwind-theme.ts && prettier --write src/theme/__generated__",
     "build:stories": "webstudio-sdk generate-stories && prettier --write \"src/__generated__/*.stories.tsx\"",
     "dts": "tsc --project tsconfig.dts.json",

--- a/packages/sdk-components-react-radix/package.json
+++ b/packages/sdk-components-react-radix/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "dev": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib --watch",
     "build": "rm -rf lib && esbuild src/components.ts src/metas.ts src/props.ts src/hooks.ts --outdir=lib --bundle --format=esm --packages=external",
-    "build:args": "NODE_OPTIONS=--conditions=webstudio generate-arg-types './src/(accordion|sheet|dialog).tsx !./src/*.stories.tsx !./src/*.ws.tsx' -e asChild -e modal -e defaultValue -e defaultOpen -e defaultChecked && prettier --write \"**/*.props.ts\"",
+    "build:args": "NODE_OPTIONS=--conditions=webstudio generate-arg-types './src/*.tsx !./src/*.stories.tsx !./src/*.ws.tsx' -e asChild -e modal -e defaultValue -e defaultOpen -e defaultChecked && prettier --write \"**/*.props.ts\"",
     "build:tailwind": "tsx scripts/generate-tailwind-theme.ts && prettier --write src/theme/__generated__",
     "build:stories": "webstudio-sdk generate-stories && prettier --write \"src/__generated__/*.stories.tsx\"",
     "dts": "tsc --project tsconfig.dts.json",

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.props.ts
@@ -2327,6 +2327,13 @@ export const propsDialogTitle: Record<string, PropMeta> = {
     description:
       "Overrides the browser's default tab order and follows the one specified instead.",
   },
+  tag: {
+    required: false,
+    control: "select",
+    type: "string",
+    defaultValue: "h1",
+    options: ["h2", "h3", "h1", "h4", "h5", "h6"],
+  },
   title: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.props.ts
@@ -1760,6 +1760,13 @@ export const propsSheetTitle: Record<string, PropMeta> = {
     description:
       "Overrides the browser's default tab order and follows the one specified instead.",
   },
+  tag: {
+    required: false,
+    control: "select",
+    type: "string",
+    defaultValue: "nav",
+    options: ["h2", "h3", "h1", "h4", "h5", "h6"],
+  },
   title: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -8,6 +8,7 @@ import {
   Children,
 } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Heading } from "@webstudio-is/sdk-components-react";
 import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk";
 
 // wrap in forwardRef because Root is functional component without ref
@@ -50,7 +51,15 @@ export const DialogOverlay = forwardRef<
 
 export const DialogContent = DialogPrimitive.Content;
 export const DialogClose = DialogPrimitive.Close;
-export const DialogTitle = DialogPrimitive.Title;
+export const DialogTitle = forwardRef<
+  HTMLHeadingElement,
+  React.ComponentProps<typeof DialogPrimitive.DialogTitle> &
+    React.ComponentProps<typeof Heading>
+>((props, ref) => (
+  <DialogPrimitive.DialogTitle asChild>
+    <Heading {...props} ref={ref} />
+  </DialogPrimitive.DialogTitle>
+));
 export const DialogDescription = DialogPrimitive.Description;
 
 /* BUILDER HOOKS */

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -7,6 +7,7 @@ import {
   forwardRef,
   Children,
   createElement,
+  type ComponentProps,
 } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk";
@@ -56,10 +57,12 @@ type Tag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 const defaultTag = "h1";
 export const DialogTitle = forwardRef<
   HTMLHeadingElement,
-  React.ComponentProps<typeof DialogPrimitive.DialogTitle> & { tag?: Tag }
->(({ tag = defaultTag, ...props }, ref) => (
+  ComponentProps<typeof DialogPrimitive.DialogTitle> & { tag?: Tag }
+>(({ tag: Tag = defaultTag, children, ...props }, ref) => (
   <DialogPrimitive.DialogTitle asChild>
-    {createElement(tag, { ...props, ref })}
+    <Tag ref={ref} {...props}>
+      {children ?? "Heading title you can edit"}
+    </Tag>
   </DialogPrimitive.DialogTitle>
 ));
 

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -6,9 +6,9 @@ import {
   type ReactNode,
   forwardRef,
   Children,
+  createElement,
 } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { Heading } from "@webstudio-is/sdk-components-react";
 import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk";
 
 // wrap in forwardRef because Root is functional component without ref
@@ -51,14 +51,17 @@ export const DialogOverlay = forwardRef<
 
 export const DialogContent = DialogPrimitive.Content;
 export const DialogClose = DialogPrimitive.Close;
+
+type Tag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 export const DialogTitle = forwardRef<
   HTMLHeadingElement,
-  React.ComponentProps<typeof DialogPrimitive.DialogTitle & typeof Heading>
+  React.ComponentProps<typeof DialogPrimitive.DialogTitle> & { tag?: Tag }
 >((props, ref) => (
   <DialogPrimitive.DialogTitle asChild>
-    <Heading {...props} ref={ref} />
+    {createElement(props.tag ?? "h1", { ...props, ref })}
   </DialogPrimitive.DialogTitle>
 ));
+
 export const DialogDescription = DialogPrimitive.Description;
 
 /* BUILDER HOOKS */

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -53,12 +53,13 @@ export const DialogContent = DialogPrimitive.Content;
 export const DialogClose = DialogPrimitive.Close;
 
 type Tag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+const defaultTag = "h1";
 export const DialogTitle = forwardRef<
   HTMLHeadingElement,
   React.ComponentProps<typeof DialogPrimitive.DialogTitle> & { tag?: Tag }
->((props, ref) => (
+>(({ tag = defaultTag, ...props }, ref) => (
   <DialogPrimitive.DialogTitle asChild>
-    {createElement(props.tag ?? "h1", { ...props, ref })}
+    {createElement(tag, { ...props, ref })}
   </DialogPrimitive.DialogTitle>
 ));
 

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -6,7 +6,6 @@ import {
   type ReactNode,
   forwardRef,
   Children,
-  createElement,
   type ComponentProps,
 } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -53,8 +53,7 @@ export const DialogContent = DialogPrimitive.Content;
 export const DialogClose = DialogPrimitive.Close;
 export const DialogTitle = forwardRef<
   HTMLHeadingElement,
-  React.ComponentProps<typeof DialogPrimitive.DialogTitle> &
-    React.ComponentProps<typeof Heading>
+  React.ComponentProps<typeof DialogPrimitive.DialogTitle & typeof Heading>
 >((props, ref) => (
   <DialogPrimitive.DialogTitle asChild>
     <Heading {...props} ref={ref} />

--- a/packages/sdk-components-react-radix/src/sheet.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.tsx
@@ -4,22 +4,13 @@ import {
   type ComponentPropsWithoutRef,
 } from "react";
 import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk";
-import { Heading } from "@webstudio-is/sdk-components-react";
 import * as Dialog from "./dialog";
 
 export const Sheet = Dialog.Dialog;
 export const SheetTrigger = Dialog.DialogTrigger;
 export const SheetOverlay = Dialog.DialogOverlay;
 export const SheetClose = Dialog.DialogClose;
-export const SheetTitle = forwardRef<
-  HTMLHeadingElement,
-  React.ComponentProps<typeof Dialog.DialogTitle & typeof Heading>
->((props, ref) => (
-  <Dialog.DialogTitle asChild>
-    <Heading {...props} ref={ref} />
-  </Dialog.DialogTitle>
-));
-SheetTitle.displayName = "SheetTitle";
+export const SheetTitle = Dialog.DialogTitle;
 export const SheetDescription = Dialog.DialogDescription;
 
 // eslint-disable-next-line react/display-name

--- a/packages/sdk-components-react-radix/src/sheet.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.tsx
@@ -13,8 +13,7 @@ export const SheetOverlay = Dialog.DialogOverlay;
 export const SheetClose = Dialog.DialogClose;
 export const SheetTitle = forwardRef<
   HTMLHeadingElement,
-  React.ComponentProps<typeof Dialog.DialogTitle> &
-    React.ComponentProps<typeof Heading>
+  React.ComponentProps<typeof Dialog.DialogTitle & typeof Heading>
 >((props, ref) => (
   <Dialog.DialogTitle asChild>
     <Heading {...props} ref={ref} />

--- a/packages/sdk-components-react-radix/src/sheet.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.tsx
@@ -4,13 +4,23 @@ import {
   type ComponentPropsWithoutRef,
 } from "react";
 import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk";
+import { Heading } from "@webstudio-is/sdk-components-react";
 import * as Dialog from "./dialog";
 
 export const Sheet = Dialog.Dialog;
 export const SheetTrigger = Dialog.DialogTrigger;
 export const SheetOverlay = Dialog.DialogOverlay;
 export const SheetClose = Dialog.DialogClose;
-export const SheetTitle = Dialog.DialogTitle;
+export const SheetTitle = forwardRef<
+  HTMLHeadingElement,
+  React.ComponentProps<typeof Dialog.DialogTitle> &
+    React.ComponentProps<typeof Heading>
+>((props, ref) => (
+  <Dialog.DialogTitle asChild>
+    <Heading {...props} ref={ref} />
+  </Dialog.DialogTitle>
+));
+SheetTitle.displayName = "SheetTitle";
 export const SheetDescription = Dialog.DialogDescription;
 
 // eslint-disable-next-line react/display-name


### PR DESCRIPTION
## Description

Fixes #2206 
Copies what the `sdk-components-react` package does for the Headings so users can control whats being rendered


## Steps for reproduction

1. Click the + button
2. Add a Radix Sheet or Radix Dialog component
3. Select the root on the layers
4. On the right side panel Toggle the `Open` to true
5. Select the Sheet/Dialog Title
6. On the right side panel go to `Settings`
7. Should be able to see a Tag input with a predefined value of `h1`

## Code Review

- [ ] @kof @TrySound Need you guys to check that this is how you imagined it working and that the current implementation follows the expected codebase pattern

## Before requesting a review
- [x] made a self-review

## Before merging
- [x] tested locally
- [ ] tested on preview environment (preview dev login: 5de6) -- First needs access to be able to deploy on vercel my preview env cc @kof 
