### PR TITLE
fix: Canvas width jump on initial load

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -302,7 +302,11 @@ export const Builder = ({
       <ChromeWrapper isPreviewMode={isPreviewMode}>
         <Topbar gridArea="header" project={project} />
         <Main>
-          <Workspace onTransitionEnd={onTransitionEnd} publish={publish}>
+          <Workspace
+            onTransitionEnd={onTransitionEnd}
+            publish={publish}
+            initialBreakpoints={build.breakpoints}
+          >
             <CanvasIframe
               ref={iframeRefCallback}
               src={canvasUrl}

--- a/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
@@ -12,7 +12,8 @@ import {
 } from "~/shared/nano-states";
 import { findInitialWidth } from "./find-initial-width";
 
-// Set canvas width based on workspace width, breakpoints and passed breakpoint id.
+// Fixes initial canvas width jump on wide screens.
+// Calculate canvas width during SSR based on known initial width for wide screens.
 export const useSetInitialCanvasWidth = () => {
   const [, setCanvasWidth] = useCanvasWidth();
   const workspaceRect = useStore(workspaceRectStore);

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -61,7 +61,7 @@ const getCanvasStyle = (
   }
 
   return {
-    width: canvasWidth,
+    width: canvasWidth ?? "100%",
     height: canvasHeight ?? "100%",
     left: "50%",
     // Chrome on Windows has a bug and makes everything slightly blurry if scale(1) is used together with translateX.
@@ -90,10 +90,12 @@ const useOutlineStyle = () => {
   const workspaceRect = useStore(workspaceRectStore);
   const [canvasWidth] = useCanvasWidth();
   const style = getCanvasStyle(100, workspaceRect, canvasWidth);
+
   return {
     ...style,
     pointerEvents: "none",
-    width: (canvasWidth ?? 0) * (scale / 100),
+    width:
+      canvasWidth === undefined ? "100%" : (canvasWidth ?? 0) * (scale / 100),
   } as const;
 };
 

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -14,6 +14,9 @@ import { textEditingInstanceSelectorStore } from "~/shared/nano-states";
 import { CanvasTools } from "./canvas-tools";
 import { useEffect, useRef } from "react";
 import { useSetCanvasWidth } from "../breakpoints";
+import type { Breakpoint } from "@webstudio-is/sdk";
+import { findInitialWidth } from "../breakpoints/find-initial-width";
+import { isBaseBreakpoint } from "~/shared/breakpoints";
 
 const workspaceStyle = css({
   flexGrow: 1,
@@ -49,7 +52,28 @@ const useMeasureWorkspace = () => {
   return ref;
 };
 
+/**
+ * Used to prevent initial canvas width jump on wide screens.
+ */
+const getCanvasInitialMaxWidth = (
+  initialBreakpoints: [Breakpoint["id"], Breakpoint][]
+) => {
+  const breakpointsArray = [...new Map(initialBreakpoints).values()];
+  const initialSelectedBreakpoint =
+    breakpointsArray.find(isBaseBreakpoint) ?? initialBreakpoints[0]?.[1];
+
+  if (initialSelectedBreakpoint) {
+    const initialWidth = findInitialWidth(
+      [...new Map(initialBreakpoints).values()],
+      initialSelectedBreakpoint,
+      Number.POSITIVE_INFINITY
+    );
+    return initialWidth;
+  }
+};
+
 const getCanvasStyle = (
+  initialBreakpoints: [Breakpoint["id"], Breakpoint][],
   scale: number,
   workspaceRect?: DOMRect,
   canvasWidth?: number
@@ -60,9 +84,15 @@ const getCanvasStyle = (
     canvasHeight = workspaceRect.height / (scale / 100);
   }
 
+  const maxWidth =
+    canvasWidth === undefined
+      ? getCanvasInitialMaxWidth(initialBreakpoints)
+      : undefined;
+
   return {
     width: canvasWidth ?? "100%",
     height: canvasHeight ?? "100%",
+    maxWidth,
     left: "50%",
     // Chrome on Windows has a bug and makes everything slightly blurry if scale(1) is used together with translateX.
     // We have done a lot of comparisons between various fixes and they were producing slightly different sharpness,
@@ -78,18 +108,28 @@ const getCanvasStyle = (
   };
 };
 
-const useCanvasStyle = () => {
+const useCanvasStyle = (
+  initialBreakpoints: [Breakpoint["id"], Breakpoint][]
+) => {
   const scale = useStore(scaleStore);
   const workspaceRect = useStore(workspaceRectStore);
   const [canvasWidth] = useCanvasWidth();
-  return getCanvasStyle(scale, workspaceRect, canvasWidth);
+
+  return getCanvasStyle(initialBreakpoints, scale, workspaceRect, canvasWidth);
 };
 
-const useOutlineStyle = () => {
+const useOutlineStyle = (
+  initialBreakpoints: [Breakpoint["id"], Breakpoint][]
+) => {
   const scale = useStore(scaleStore);
   const workspaceRect = useStore(workspaceRectStore);
   const [canvasWidth] = useCanvasWidth();
-  const style = getCanvasStyle(100, workspaceRect, canvasWidth);
+  const style = getCanvasStyle(
+    initialBreakpoints,
+    100,
+    workspaceRect,
+    canvasWidth
+  );
 
   return {
     ...style,
@@ -103,15 +143,17 @@ type WorkspaceProps = {
   children: JSX.Element;
   onTransitionEnd: () => void;
   publish: Publish;
+  initialBreakpoints: [Breakpoint["id"], Breakpoint][];
 };
 
 export const Workspace = ({
   children,
   onTransitionEnd,
   publish,
+  initialBreakpoints,
 }: WorkspaceProps) => {
-  const canvasStyle = useCanvasStyle();
-  const outlineStyle = useOutlineStyle();
+  const canvasStyle = useCanvasStyle(initialBreakpoints);
+  const outlineStyle = useOutlineStyle(initialBreakpoints);
   const workspaceRef = useMeasureWorkspace();
   useSetCanvasWidth();
   const handleWorkspaceClick = () => {


### PR DESCRIPTION
## Description

Fixes this.

![QuickTime movie](https://github.com/webstudio-is/webstudio/assets/5077042/255a7c67-c417-4d73-841b-456b2bdf6ffd)

Now on all screens initially rendered canvas width is same.


## Steps for reproduction

Reload project, see canvas not jumping.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
