### PR TITLE
feat: Optimize image loading to prevent layout shifts

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -33,6 +33,7 @@ import {
 } from "./use-props-logic";
 import { Row, getLabel } from "../shared";
 import { serverSyncStore } from "~/shared/sync";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 const itemToString = (item: NameAndLabel | null) =>
   item ? getLabel(item, item.name) : "";
@@ -119,6 +120,24 @@ const renderProperty = (
         "width" in asset.meta &&
         "height" in asset.meta
       ) {
+        if (isFeatureEnabled("image")) {
+          logic.handleChangeByPropName("width", {
+            value: asset.meta.width,
+            type: "number",
+          });
+          logic.handleChangeByPropName("height", {
+            value: asset.meta.height,
+            type: "number",
+          });
+
+          setCssProperty("height")({
+            type: "keyword",
+            value: "fit-content",
+          });
+
+          return;
+        }
+
         setCssProperty("aspectRatio")({
           type: "unit",
           unit: "number",

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -1,11 +1,7 @@
 import { useState } from "react";
 import { nanoid } from "nanoid";
 import type { Instance, Prop } from "@webstudio-is/sdk";
-import {
-  type PropMeta,
-  type WsComponentPropsMeta,
-  showAttribute,
-} from "@webstudio-is/react-sdk";
+import { type PropMeta, showAttribute } from "@webstudio-is/react-sdk";
 import type { PropValue } from "../shared";
 import { useStore } from "@nanostores/react";
 import {
@@ -109,24 +105,6 @@ type UsePropsLogicInput = {
   deleteProp: (id: Prop["id"]) => void;
 };
 
-type UsePropsLogicOutput = {
-  meta: WsComponentPropsMeta;
-  /** Similar to Initial, but displayed as a separate group in UI etc.
-   * Currentrly used only for the ID prop. */
-  systemProps: PropAndMeta[];
-  /** Initial (not deletable) props */
-  initialProps: PropAndMeta[];
-  /** Optional props that were added by user */
-  addedProps: PropAndMeta[];
-  /** List of remaining props still available to add */
-  availableProps: NameAndLabel[];
-  handleAdd: (propName: string) => void;
-  handleChange: (prop: PropOrName, value: PropValue) => void;
-  handleDelete: (prop: PropOrName) => void;
-  /** Delete the prop, but keep it in the list of added props */
-  handleSoftDelete: (prop: Prop) => void;
-};
-
 const getAndDelete = <Value>(map: Map<string, Value>, key: string) => {
   const value = map.get(key);
   map.delete(key);
@@ -168,7 +146,7 @@ export const usePropsLogic = ({
   props,
   updateProp,
   deleteProp,
-}: UsePropsLogicInput): UsePropsLogicOutput => {
+}: UsePropsLogicInput) => {
   const meta = useStore(registeredComponentPropsMetasStore).get(
     instance.component
   );
@@ -298,6 +276,16 @@ export const usePropsLogic = ({
     );
   };
 
+  const handleChangeByPropName = (propName: string, value: PropValue) => {
+    const prop = props.find((prop) => prop.name === propName);
+
+    updateProp(
+      prop === undefined
+        ? { id: nanoid(), instanceId: instance.id, name: propName, ...value }
+        : { ...prop, ...value }
+    );
+  };
+
   const handleDelete = ({ prop, propName }: PropOrName) => {
     if (prop) {
       deleteProp(prop.id);
@@ -310,17 +298,24 @@ export const usePropsLogic = ({
   };
 
   return {
+    handleAdd,
+    handleChange,
+    handleDelete,
+    /** Delete the prop, but keep it in the list of added props */
+    handleSoftDelete,
+    handleChangeByPropName,
     meta,
+    /** Similar to Initial, but displayed as a separate group in UI etc.
+     * Currentrly used only for the ID prop. */
     systemProps,
+    /** Initial (not deletable) props */
     initialProps,
+    /** Optional props that were added by user */
     addedProps,
+    /** List of remaining props still available to add */
     availableProps: Array.from(
       unprocessedKnown.entries(),
       ([name, { label }]) => ({ name, label })
     ),
-    handleAdd,
-    handleChange,
-    handleDelete,
-    handleSoftDelete,
   };
 };

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -119,6 +119,7 @@ export const useLocalValue = <Type,>(
   savedValue: Type,
   onSave: (value: Type) => void
 ) => {
+  const isEditingRef = useRef(false);
   const localValueRef = useRef(savedValue);
 
   const [_, setRefresh] = useState(0);
@@ -127,6 +128,7 @@ export const useLocalValue = <Type,>(
   onSaveRef.current = onSave;
 
   const save = () => {
+    isEditingRef.current = false;
     if (equal(localValueRef.current, savedValue) === false) {
       // To synchronize with setState immediately followed by save
       onSaveRef.current(localValueRef.current);
@@ -134,6 +136,7 @@ export const useLocalValue = <Type,>(
   };
 
   const setLocalValue = (value: Type) => {
+    isEditingRef.current = true;
     localValueRef.current = value;
     setRefresh((refresh) => refresh + 1);
   };
@@ -142,6 +145,17 @@ export const useLocalValue = <Type,>(
   // So we're saving at the unmount
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => save, []);
+
+  useEffect(() => {
+    // Update local value if saved value changes and control is not in edit mode.
+    if (
+      isEditingRef.current === false &&
+      localValueRef.current !== savedValue
+    ) {
+      localValueRef.current = savedValue;
+      setRefresh((refresh) => refresh + 1);
+    }
+  }, [savedValue]);
 
   return {
     /**

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -7,3 +7,5 @@ export const adminRole = false;
 // A general flag to enable/disable all the AI features.
 export const ai = process.env.NODE_ENV !== "production";
 export const aiCopy = ai && process.env.NODE_ENV !== "production";
+// New image optimisations
+export const image = false;


### PR DESCRIPTION
## Description

Instead of `aspect-ratio`  css property set `width` and `heigh` html attributes for the image and set css property `height` to `fit-content` to preserve ratio.

This removes all known issues we had with images. 
- No layout shift on published site load
- No layout shift on  published site  and 404
- No small image size jumps during canvas resize

Next PR.

Apply full image optimisation even if width property is set (with some adjustments).

## Steps for reproduction

Add image, see `width`, `height` html attributes has changed.
See css property `height` has changed to `fit-content`

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
