### PR TITLE
feat: Switch on viewport-based srcSets for width-defined Images

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -33,7 +33,6 @@ import {
 } from "./use-props-logic";
 import { Row, getLabel } from "../shared";
 import { serverSyncStore } from "~/shared/sync";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 const itemToString = (item: NameAndLabel | null) =>
   item ? getLabel(item, item.name) : "";
@@ -120,28 +119,18 @@ const renderProperty = (
         "width" in asset.meta &&
         "height" in asset.meta
       ) {
-        if (isFeatureEnabled("image")) {
-          logic.handleChangeByPropName("width", {
-            value: asset.meta.width,
-            type: "number",
-          });
-          logic.handleChangeByPropName("height", {
-            value: asset.meta.height,
-            type: "number",
-          });
+        logic.handleChangeByPropName("width", {
+          value: asset.meta.width,
+          type: "number",
+        });
+        logic.handleChangeByPropName("height", {
+          value: asset.meta.height,
+          type: "number",
+        });
 
-          setCssProperty("height")({
-            type: "keyword",
-            value: "fit-content",
-          });
-
-          return;
-        }
-
-        setCssProperty("aspectRatio")({
-          type: "unit",
-          unit: "number",
-          value: asset.meta.width / asset.meta.height,
+        setCssProperty("height")({
+          type: "keyword",
+          value: "fit-content",
         });
       }
     },

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -7,5 +7,3 @@ export const adminRole = false;
 // A general flag to enable/disable all the AI features.
 export const ai = process.env.NODE_ENV !== "production";
 export const aiCopy = ai && process.env.NODE_ENV !== "production";
-// New image optimisations
-export const image = false;

--- a/packages/image/src/image-optimize.test.ts
+++ b/packages/image/src/image-optimize.test.ts
@@ -16,9 +16,9 @@ describe("Image optimizations applied", () => {
 
     expect(imgAttr).toMatchInlineSnapshot(`
       {
-        "sizes": undefined,
+        "sizes": "100vw",
         "src": "/asset/image/logo.webp?width=256&quality=100&format=auto",
-        "srcSet": "/asset/image/logo.webp?width=128&quality=100&format=auto 1x, /asset/image/logo.webp?width=256&quality=100&format=auto 2x",
+        "srcSet": "/asset/image/logo.webp?width=16&quality=100&format=auto 16w, /asset/image/logo.webp?width=32&quality=100&format=auto 32w, /asset/image/logo.webp?width=48&quality=100&format=auto 48w, /asset/image/logo.webp?width=64&quality=100&format=auto 64w, /asset/image/logo.webp?width=96&quality=100&format=auto 96w, /asset/image/logo.webp?width=128&quality=100&format=auto 128w, /asset/image/logo.webp?width=256&quality=100&format=auto 256w",
       }
     `);
   });

--- a/packages/image/src/image-optimize.ts
+++ b/packages/image/src/image-optimize.ts
@@ -21,7 +21,7 @@
  *   source size value is 70vw  equal to 800px * 0,7 = 560px
  *
  *   browser internal srcset will be (we divide `w` descriptor by source size value):
- *   photo-small.jpg 320/560x, photo-medium.jpg 640/560x, photo-huge.jpg 1280/560x =>
+ *   photo-small.jpg 320w/560px, photo-medium.jpg 640w/560px, photo-huge.jpg 1280w/560px =>
  *   photo-small.jpg 0.57x, photo-medium.jpg 1.14x, photo-huge.jpg 2.28x
  *
  *   Finally same rules as for pixel density descriptor 'x' are applied.
@@ -36,8 +36,7 @@
  * > if allSizes.length is too big, you will have many caches misses.
  *
  * If img has a defined width property.
- *   1. find the first value from allSizes which is greater or equal to the width property
- *   2. use found value to generate srcset with pixel density descriptor 'x'
+ *   1. filter allSizes to exclude loading images higher that maxDevicePixelRatio * img.width
  *
  *
  * If img has no defined width property.
@@ -131,6 +130,19 @@ const getWidths = (
     return { widths: deviceSizes, kind: "w" };
   }
 
+  const MAX_DEVICE_PIXEL_RATIO = 2;
+
+  let index = allSizes.findIndex((p) => p >= MAX_DEVICE_PIXEL_RATIO * width);
+  index = index < 0 ? allSizes.length : index;
+
+  return {
+    widths: allSizes.slice(0, index + 1),
+    kind: "w",
+  };
+
+  /*
+  // Leave it here for future optimisations - icon like images
+
   const widths = [
     ...new Set(
       [width, width * 2].map(
@@ -139,6 +151,7 @@ const getWidths = (
     ),
   ];
   return { widths, kind: "x" };
+  */
 };
 
 const generateImgAttrs = ({

--- a/packages/image/src/image-optimize.ts
+++ b/packages/image/src/image-optimize.ts
@@ -119,7 +119,9 @@ const getWidths = (
       // we can exclude from srcSets all images which are smaller than the smallestRatio * smallesDeviceSize
       const smallestRatio = Math.min(...percentSizes) * 0.01;
       return {
-        widths: allSizes.filter((s) => s >= deviceSizes[0] * smallestRatio),
+        widths: allSizes.filter(
+          (size) => size >= deviceSizes[0] * smallestRatio
+        ),
         kind: "w",
       };
     }
@@ -132,7 +134,9 @@ const getWidths = (
 
   const MAX_DEVICE_PIXEL_RATIO = 2;
 
-  let index = allSizes.findIndex((p) => p >= MAX_DEVICE_PIXEL_RATIO * width);
+  let index = allSizes.findIndex(
+    (size) => size >= MAX_DEVICE_PIXEL_RATIO * width
+  );
   index = index < 0 ? allSizes.length : index;
 
   return {

--- a/packages/image/src/image-optimize.ts
+++ b/packages/image/src/image-optimize.ts
@@ -132,7 +132,8 @@ const getWidths = (
     return { widths: deviceSizes, kind: "w" };
   }
 
-  // There is no need to support ratios more than 2 https://blog.twitter.com/engineering/en_us/topics/infrastructure/2019/capping-image-fidelity-on-ultra-high-resolution-devices.html
+  // Max device pixel ratio capped at 2; higher ratios offer negligible benefits
+  // See Twitter Engineering's article on capping image fidelity: https://blog.twitter.com/engineering/en_us/topics/infrastructure/2019/capping-image-fidelity-on-ultra-high-resolution-devices.html
   const MAX_DEVICE_PIXEL_RATIO = 2;
 
   let index = allSizes.findIndex(

--- a/packages/image/src/image-optimize.ts
+++ b/packages/image/src/image-optimize.ts
@@ -132,6 +132,7 @@ const getWidths = (
     return { widths: deviceSizes, kind: "w" };
   }
 
+  // There is no need to support ratios more than 2 https://blog.twitter.com/engineering/en_us/topics/infrastructure/2019/capping-image-fidelity-on-ultra-high-resolution-devices.html
   const MAX_DEVICE_PIXEL_RATIO = 2;
 
   let index = allSizes.findIndex(


### PR DESCRIPTION
## Description

Previous PR: #2414

Now, by default, we set the width attribute when adding an image. This change could cause mobile screens to load oversized images—specifically, width * 2. To mitigate this, we're adopting the viewport width descriptor for srcSets. This approach ensures optimized image loading on smaller screens and maintains previous behavior on screens wider than the image's actual size.

## Steps for reproduction

Add images of various sizes, see srcSet

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
