### PR TITLE
feat: Collaborative instance outline

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/collaborative-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/collaborative-instance-outline.tsx
@@ -1,18 +1,14 @@
 import { useStore } from "@nanostores/react";
-import {
-  $collaborativeInstanceOutlineAndInstance,
-  $collaborativeInstanceSelector,
-} from "~/shared/nano-states";
+import { $collaborativeInstanceOutlineAndInstance } from "~/shared/nano-states";
 import { Outline } from "./outline";
 import { applyScale } from "./apply-scale";
 import { scaleStore } from "~/builder/shared/nano-states";
 
 // Outline of an instance that is being edited by AI or a human collaborator.
 export const CollaborativeInstanceOutline = () => {
-  const selectedInstanceSelector = useStore($collaborativeInstanceSelector);
   const outline = useStore($collaborativeInstanceOutlineAndInstance);
   const scale = useStore(scaleStore);
-  if (outline === undefined || selectedInstanceSelector === undefined) {
+  if (outline === undefined) {
     return null;
   }
   const rect = applyScale(outline.rect, scale);

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/collaborative-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/collaborative-instance-outline.tsx
@@ -1,0 +1,20 @@
+import { useStore } from "@nanostores/react";
+import {
+  $collaborativeInstanceOutlineAndInstance,
+  $collaborativeInstanceSelector,
+} from "~/shared/nano-states";
+import { Outline } from "./outline";
+import { applyScale } from "./apply-scale";
+import { scaleStore } from "~/builder/shared/nano-states";
+
+// Outline of an instance that is being edited by AI or a human collaborator.
+export const CollaborativeInstanceOutline = () => {
+  const selectedInstanceSelector = useStore($collaborativeInstanceSelector);
+  const outline = useStore($collaborativeInstanceOutlineAndInstance);
+  const scale = useStore(scaleStore);
+  if (outline === undefined || selectedInstanceSelector === undefined) {
+    return null;
+  }
+  const rect = applyScale(outline.rect, scale);
+  return <Outline rect={rect}></Outline>;
+};

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/index.ts
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/index.ts
@@ -1,3 +1,4 @@
 export { SelectedInstanceOutline } from "./selected-instance-outline";
 export { HoveredInstanceOutline } from "./hovered-instance-outline";
+export { CollaborativeInstanceOutline } from "./collaborative-instance-outline";
 export { applyScale } from "./apply-scale";

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
@@ -34,6 +34,7 @@ const baseStyle = css({
         outline: "none",
         [angleVar]: `0deg`,
         border: `1px solid`,
+        // @todo check with design on specific colors
         borderImage: `conic-gradient(from ${cssVars.use(
           angleVar
         )}, #FFAE3C 0%, #39FBBB 25%, #4A4EFA 50%, #E63CFE 100%) 1`,

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
@@ -1,17 +1,49 @@
 import { useMemo } from "react";
-import { styled, type Rect } from "@webstudio-is/design-system";
+import { css, keyframes, type Rect } from "@webstudio-is/design-system";
 import { theme } from "@webstudio-is/design-system";
+import { cssVars } from "@webstudio-is/css-vars";
 
-const OutlineContainer = styled("div", {
+const angleVar = cssVars.define("angle");
+
+const propertyStyle = (
+  <style>{`
+    @property ${angleVar} {
+      syntax: '<angle>';
+      initial-value: 0deg;
+      inherits: false;
+    }
+  `}</style>
+);
+
+const angleKeyframes = keyframes({
+  to: {
+    [angleVar]: "360deg",
+  },
+});
+
+const baseStyle = css({
   position: "absolute",
   pointerEvents: "none",
   outline: `1px solid ${theme.colors.blue9}`,
   outlineOffset: -1,
   top: 0,
   left: 0,
+  variants: {
+    variant: {
+      collaboration: {
+        outline: "none",
+        [angleVar]: `0deg`,
+        border: `1px solid`,
+        borderImage: `conic-gradient(from ${cssVars.use(
+          angleVar
+        )}, #FFAE3C 0%, #39FBBB 25%, #4A4EFA 50%, #E63CFE 100%) 1`,
+        animation: `2s ${angleKeyframes} linear infinite`,
+      },
+    },
+  },
 });
 
-const useStyle = (rect?: Rect) => {
+const useDynamicStyle = (rect?: Rect) => {
   return useMemo(() => {
     if (rect === undefined) {
       return;
@@ -25,11 +57,19 @@ const useStyle = (rect?: Rect) => {
 };
 
 type OutlineProps = {
-  children: JSX.Element;
+  children?: JSX.Element;
   rect?: Rect;
+  variant?: "collaboration";
 };
 
-export const Outline = ({ children, rect }: OutlineProps) => {
-  const style = useStyle(rect);
-  return <OutlineContainer style={style}>{children}</OutlineContainer>;
+export const Outline = ({ children, rect, variant }: OutlineProps) => {
+  const dynamicStyle = useDynamicStyle(rect);
+  return (
+    <>
+      {propertyStyle}
+      <div className={baseStyle({ variant })} style={dynamicStyle}>
+        {children}
+      </div>
+    </>
+  );
 };

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
@@ -5,6 +5,7 @@ import { cssVars } from "@webstudio-is/css-vars";
 
 const angleVar = cssVars.define("angle");
 
+// Won't work in current FF/Safari, but outline will still work, just no animation.
 const propertyStyle = (
   <style>{`
     @property ${angleVar} {

--- a/apps/builder/app/shared/nano-states/canvas.ts
+++ b/apps/builder/app/shared/nano-states/canvas.ts
@@ -55,6 +55,11 @@ export const hoveredInstanceOutlineAndInstanceStore = computed(
   getInstanceOutlineAndInstance
 );
 
+// @todo implement like above
+export const $collaborativeInstanceOutlineAndInstance = atom<
+  undefined | { instance: Instance; rect: DOMRect }
+>(undefined);
+
 export const synchronizedCanvasStores = [
   ["textToolbar", textToolbarStore],
   ["selectedInstanceOutline", selectedInstanceOutlineStore],

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -8,6 +8,10 @@ export const selectedInstanceSelectorStore = atom<undefined | InstanceSelector>(
   undefined
 );
 
+export const $collaborativeInstanceSelector = atom<
+  undefined | InstanceSelector
+>(undefined);
+
 export const editingItemIdStore = atom<undefined | string>(undefined);
 
 export const textEditingInstanceSelectorStore = atom<

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -8,10 +8,6 @@ export const selectedInstanceSelectorStore = atom<undefined | InstanceSelector>(
   undefined
 );
 
-export const $collaborativeInstanceSelector = atom<
-  undefined | InstanceSelector
->(undefined);
-
 export const editingItemIdStore = atom<undefined | string>(undefined);
 
 export const textEditingInstanceSelectorStore = atom<


### PR DESCRIPTION


https://github.com/webstudio-is/webstudio/assets/52824/06094b9e-ffd1-4888-ae92-c0c8306d7c47



## Description

This is the visual part of the collaborative instance outline we will use for AI and when other user is editing an instance

Not implemented in this PR:

CollaborativeInstanceOutline needs  $collaborativeInstanceSelector and $collaborativeInstanceOutlineAndInstance to have been set when AI is applying styles to an instance.

## Steps for reproduction

1. To test it right now just add  on <SelectedInstanceOutline  variant="collaboration" />


## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
