### PR TITLE
fix: JSX attributes parsing

### DIFF
--- a/apps/builder/app/routes/rest.ai.ts
+++ b/apps/builder/app/routes/rest.ai.ts
@@ -122,10 +122,10 @@ export const action = async ({ request }: ActionArgs) => {
         // so that the LLM won't miscategorize the task and for example handle an "edit-style" request as a "write-copy" one.
         // During testing the LLM misdetected a stylistic request like "make it bold" as a request to rewrite the text to sound more "bold".
         "write-copy",
-        "generate-images",
+        "generate-user-interface",
         "edit-styles",
-        "generate-ui",
         "delete-elements",
+        "generate-images-only",
       ],
     },
   });

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -48,7 +48,9 @@
     "@webstudio-is/sdk": "workspace:*",
     "ai": "^2.2.12",
     "escape-string-regexp": "^5.0.0",
+    "mdast-util-from-markdown": "^2.0.0",
     "openai": "^4.8.0",
+    "unist-util-visit-parents": "^6.0.1",
     "web-streams-polyfill": "^3.2.1",
     "zod": "^3.21.4",
     "zod-to-json-schema": "^3.21.4"

--- a/packages/ai/src/chains/template-generator/chain.ts
+++ b/packages/ai/src/chains/template-generator/chain.ts
@@ -9,6 +9,7 @@ import {
   postProcessTemplate,
 } from "../../utils/jsx-to-template.server";
 import { createErrorResponse } from "../../utils/create-error-response";
+import { getCode } from "../../utils/get-code";
 
 /**
  * Template Generator Chain.
@@ -69,7 +70,7 @@ export const createChain = <ModelMessageFormat>(): Chain<
     let template: WsEmbedTemplate;
 
     try {
-      template = await jsxToTemplate(completionText);
+      template = await jsxToTemplate(getCode(completionText, "jsx"));
     } catch (error) {
       return {
         id,

--- a/packages/ai/src/utils/get-code.ts
+++ b/packages/ai/src/utils/get-code.ts
@@ -1,0 +1,22 @@
+import { fromMarkdown as parseMarkdown } from "mdast-util-from-markdown";
+import { visitParents } from "unist-util-visit-parents";
+
+export const getCode = function getCode(text: string, lang: string) {
+  const tree = parseMarkdown(text);
+  let code = text;
+  const codeBlocks: string[] = [];
+
+  visitParents(tree, "code", (node) => {
+    if (node.lang === lang) {
+      codeBlocks.unshift(node.value.trim());
+    } else if (!node.lang) {
+      codeBlocks.push(node.value.trim());
+    }
+  });
+
+  if (codeBlocks.length > 0) {
+    code = codeBlocks[0];
+  }
+
+  return code;
+};

--- a/packages/jsx-utils/src/jsx.test.ts
+++ b/packages/jsx-utils/src/jsx.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "@jest/globals";
-import { WsEmbedTemplate } from "@webstudio-is/react-sdk";
+import { EmbedTemplateProp, WsEmbedTemplate } from "@webstudio-is/react-sdk";
 import { jsxToWSEmbedTemplate } from "./jsx";
+import { traverseTemplate } from ".";
 
 describe("jsx", () => {
   test("valid template", async () => {
@@ -64,28 +65,60 @@ describe("jsx", () => {
 `);
   });
 
-  test.only("parses props values correctly", async () => {
+  test("parses props values correctly", async () => {
     const parsed = await jsxToWSEmbedTemplate(`
-      <Image src alt="welcome to webstudio" width={1000} height={200} />`);
-    expect(() => WsEmbedTemplate.parse(parsed)).not.toThrow();
 
-    expect(parsed[0].props).toMatchInlineSnapshot(`
+
+    <Box className="flex flex-col items-center justify-center bg-white text-black p-10">
+  <Image src="" alt="Aromatic coffee in a cup" width="600" height="400" className="rounded-lg shadow-lg mb-6"/>
+</Box>
+
+`);
+    expect(() => WsEmbedTemplate.parse(parsed)).not.toThrow();
+    const props: EmbedTemplateProp[][] = [];
+
+    traverseTemplate(parsed, (node) => {
+      if (node.type === "instance" && node.props) {
+        props.push(node.props);
+      }
+    });
+
+    expect(props).toMatchInlineSnapshot(`
 [
-  {
-    "name": "alt",
-    "type": "string",
-    "value": "welcome to webstudio",
-  },
-  {
-    "name": "width",
-    "type": "number",
-    "value": 1000,
-  },
-  {
-    "name": "height",
-    "type": "number",
-    "value": 200,
-  },
+  [
+    {
+      "name": "className",
+      "type": "string",
+      "value": "flex flex-col items-center justify-center bg-white text-black p-10",
+    },
+  ],
+  [
+    {
+      "name": "src",
+      "type": "string",
+      "value": "",
+    },
+    {
+      "name": "alt",
+      "type": "string",
+      "value": "Aromatic coffee in a cup",
+    },
+    {
+      "name": "width",
+      "type": "number",
+      "value": 600,
+    },
+    {
+      "name": "height",
+      "type": "number",
+      "value": 400,
+    },
+    {
+      "name": "className",
+      "type": "string",
+      "value": "rounded-lg shadow-lg mb-6",
+    },
+  ],
 ]
 `);
   });

--- a/packages/jsx-utils/src/jsx.ts
+++ b/packages/jsx-utils/src/jsx.ts
@@ -14,12 +14,11 @@ import type { JsonObject } from "type-fest";
 export const jsxToWSEmbedTemplate = async (
   code: string
 ): Promise<WsEmbedTemplate> => {
-  const ast = parser.parseExpression(
-    code.replace(/^```(jsx)?/, "").replace(/```$/, ""),
-    {
-      plugins: ["jsx"],
-    }
-  );
+  code = code.trim();
+
+  const ast = parser.parseExpression(code, {
+    plugins: ["jsx"],
+  });
 
   if (ast.type === "JSXElement") {
     const template = await transform(ast, code);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,9 +687,15 @@ importers:
       escape-string-regexp:
         specifier: ^5.0.0
         version: 5.0.0
+      mdast-util-from-markdown:
+        specifier: ^2.0.0
+        version: 2.0.0
       openai:
         specifier: ^4.8.0
         version: 4.8.0
+      unist-util-visit-parents:
+        specifier: ^6.0.1
+        version: 6.0.1
       web-streams-polyfill:
         specifier: ^3.2.1
         version: 3.2.1


### PR DESCRIPTION
Removes markdown code block delimiters from JSX the parser utility and adds a new utility to extract code blocks from LLM responses.

The bug was that we were parsing the JSX stripped out of code blocks delimiters but when extracting the props from the source string we were slicing the original string with delimiters.