### PR TITLE
fix: Add right placeholders on audio transcribing, and shift-enter for new line in AI Command Bar

### DIFF
--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -226,7 +226,7 @@ const CommandBarContent = () => {
 
       <CommandBarContentSection>
         <Text variant={"labelsSentenceCase"} align={"center"}>
-          Previous propmts
+          Previous prompts
         </Text>
         <div />
         <CommandBarContentPrompt>

--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -73,7 +73,7 @@ export const AiCommandBar = () => {
       if (uploadId !== uploadIdRef.current) {
         return;
       }
-      setValue(text);
+      setValue((previousText) => `${previousText} ${text}`);
       setIsAudioTranscribing(false);
     },
     onReportSoundAmplitude: (amplitude) => {
@@ -86,7 +86,6 @@ export const AiCommandBar = () => {
 
   const longPressToggleProps = useLongPressToggle({
     onStart: () => {
-      setValue("");
       start();
       disableCanvasPointerEvents();
     },
@@ -108,8 +107,16 @@ export const AiCommandBar = () => {
     mediaRecorderState === "recording" || isAudioTranscribing;
 
   const recordButtonDisabled = isAudioTranscribing;
+
   const aiButtonDisabled =
     mediaRecorderState === "recording" || isAudioTranscribing;
+
+  const actionPlaceholder =
+    mediaRecorderState === "recording"
+      ? "Recording voice..."
+      : isAudioTranscribing
+      ? "Transcribing voice..."
+      : undefined;
 
   return (
     <Box
@@ -147,14 +154,8 @@ export const AiCommandBar = () => {
             <AutogrowTextArea
               autoFocus
               disabled={textAreaDisabled}
-              placeholder={
-                mediaRecorderState === "recording"
-                  ? "Recording voice..."
-                  : isAudioTranscribing
-                  ? "Transcribing voice..."
-                  : "Enter value..."
-              }
-              value={value}
+              placeholder={actionPlaceholder ?? "Enter value..."}
+              value={actionPlaceholder !== undefined ? "" : value}
               onChange={setValue}
               onKeyDown={(event) => {
                 if (event.key === "Enter" && event.shiftKey === false) {

--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -157,7 +157,7 @@ export const AiCommandBar = () => {
               value={value}
               onChange={setValue}
               onKeyDown={(event) => {
-                if (event.key === "Enter" && !event.shiftKey) {
+                if (event.key === "Enter" && event.shiftKey === false) {
                   event.preventDefault();
                   // @todo add text submit here
                 }

--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -14,6 +14,7 @@ import {
   ScrollArea,
   Text,
   theme,
+  useDisableCanvasPointerEvents,
 } from "@webstudio-is/design-system";
 import {
   AiIcon,
@@ -55,6 +56,8 @@ export const AiCommandBar = () => {
   const isAiCommandBarVisible = useStore($isAiCommandBarVisible);
   const recordButtonRef = useRef<HTMLButtonElement>(null);
   const uploadIdRef = useRef(0);
+  const { enableCanvasPointerEvents, disableCanvasPointerEvents } =
+    useDisableCanvasPointerEvents();
 
   const {
     start,
@@ -85,9 +88,16 @@ export const AiCommandBar = () => {
     onStart: () => {
       setValue("");
       start();
+      disableCanvasPointerEvents();
     },
-    onEnd: stop,
-    onCancel: cancel,
+    onEnd: () => {
+      stop();
+      enableCanvasPointerEvents();
+    },
+    onCancel: () => {
+      cancel();
+      enableCanvasPointerEvents();
+    },
   });
 
   if (isAiCommandBarVisible === false) {
@@ -139,9 +149,9 @@ export const AiCommandBar = () => {
               disabled={textAreaDisabled}
               placeholder={
                 mediaRecorderState === "recording"
-                  ? "Recording voice ..."
+                  ? "Recording voice..."
                   : isAudioTranscribing
-                  ? "Transcribing voice.."
+                  ? "Transcribing voice..."
                   : "Enter value..."
               }
               value={value}

--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -137,9 +137,21 @@ export const AiCommandBar = () => {
             <AutogrowTextArea
               autoFocus
               disabled={textAreaDisabled}
-              placeholder="Enter value..."
+              placeholder={
+                mediaRecorderState === "recording"
+                  ? "Recording voice ..."
+                  : isAudioTranscribing
+                  ? "Transcribing voice.."
+                  : "Enter value..."
+              }
               value={value}
               onChange={setValue}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  // @todo add text submit here
+                }
+              }}
             />
           </ScrollArea>
         </Grid>

--- a/apps/builder/app/builder/features/ai/hooks/media-recorder.ts
+++ b/apps/builder/app/builder/features/ai/hooks/media-recorder.ts
@@ -126,6 +126,7 @@ export const useMediaRecorder = (
 
       // Cancelled, do cleanup and return
       if (cancelRef.current) {
+        setState("inactive");
         chunks.length = 0;
         return;
       }
@@ -143,6 +144,7 @@ export const useMediaRecorder = (
           onReportSoundAmplitude?.(0);
         }
         chunks.length = 0;
+        setState("inactive");
       }
     };
 
@@ -153,7 +155,6 @@ export const useMediaRecorder = (
     isActiveRef.current = false;
     disposeRef.current?.();
     disposeRef.current = undefined;
-    setState("inactive");
   });
 
   const cancel = useEffectEvent(() => {

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -72,7 +72,9 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
           {isFeatureEnabled("ai") && (
             <SidebarTabsTrigger
               aria-label="ai"
-              value={isAiCommandBarVisible ? activeTab : "ai"}
+              value={
+                "anyValueNotInTabName" /* !!! This button does not have active state, use impossible tab value  !!! */
+              }
               onClick={() => {
                 $isAiCommandBarVisible.set(!isAiCommandBarVisible);
               }}

--- a/packages/design-system/src/components/button.tsx
+++ b/packages/design-system/src/components/button.tsx
@@ -65,7 +65,7 @@ const perColorStyle = (variant: ButtonColor) => ({
       : backgrounds[variant],
   color:
     variant === "dark-ghost"
-      ? theme.colors.foregroundMoreSubtle
+      ? theme.colors.foregroundSubtle
       : foregrounds[variant],
 
   "&[data-state=auto]:hover, &[data-state=hover]": {


### PR DESCRIPTION
## Description

Placeholder during audio:
1. On Recording start  - "Recording voice..."
2. On stop - "Transcribing voice..."

Shift-Enter now used to add newline inside AI Input

Cancel voice recording is now working well even on canvas (pointer up during long press out of recording button)

Additionally fixes from
https://github.com/webstudio-is/webstudio/issues/2418#issuecomment-1754059088

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
