### PR TITLE
fix: Trim the text we get from transcriptions

### DIFF
--- a/apps/builder/app/routes/rest.ai.audio.transcriptions.ts
+++ b/apps/builder/app/routes/rest.ai.audio.transcriptions.ts
@@ -18,24 +18,25 @@ export const action = async ({ request }: ActionArgs) => {
   );
 
   if (response.ok === false) {
-    const txt = await response.text();
+    const message = await response.text();
 
     // eslint-disable-next-line no-console
-    console.error("ERROR", response.status, txt);
+    console.error("ERROR", response.status, message);
 
     return {
       success: false,
       error: {
         status: response.status,
-        message: txt,
+        message,
       },
     };
   }
 
+  // @todo untyped
   const data = await response.json();
 
   return {
     success: true,
-    text: data.text,
+    text: data.text.trim(),
   };
 };


### PR DESCRIPTION
## Description

Whisper often returns lots of spaces before or after text, now we are trimming them


## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
