### PR TITLE
fix: Suggest to generate custom styles when requested

### DIFF
--- a/packages/ai/src/chains/operations/edit-styles.ts
+++ b/packages/ai/src/chains/operations/edit-styles.ts
@@ -14,7 +14,7 @@ export const aiOperation = z.object({
   className: z
     .string()
     .describe(
-      "A list of Tailwind CSS classes to add or override existing styles. When the user requests exact values you must use Tailwind's square bracket notation to generate a custom Tailwind class for the value eg. top-[10px]"
+      "A list of Tailwind CSS classes to add or override existing styles. Always use the square brackets notation eg. mb-[10px] instead of mb-10"
     ),
 });
 export type aiOperation = z.infer<typeof aiOperation>;

--- a/packages/ai/src/chains/template-generator/__generated__/template-generator.system.prompt.ts
+++ b/packages/ai/src/chains/template-generator/__generated__/template-generator.system.prompt.ts
@@ -18,8 +18,7 @@ Follow the rules below:
 - Don't use JSX Fragments
 - Don't use JSX comments
 - Don't use CSS grid for layout, use flexbox instead
-- Only use valid Tailwind CSS classes
-- When the user requests exact CSS values you must use Tailwind's square bracket notation to generate a custom Tailwind class for the value eg. top-[10px]
+- Only use valid Tailwind CSS classes. Always use the square brackets notation eg. mb-[10px] instead of mb-10
 - Don't add round corners and shadow to top-level containers
 - Don't add any props to components
 - For images leave the \`src\` prop empty and add a good on-topic description as \`alt\` attribute for screen readers. Additionally set a \`width\` and \`height\` props for the image size

--- a/packages/ai/src/chains/template-generator/template-generator.system.prompt.md
+++ b/packages/ai/src/chains/template-generator/template-generator.system.prompt.md
@@ -18,8 +18,7 @@ Follow the rules below:
 - Don't use JSX Fragments
 - Don't use JSX comments
 - Don't use CSS grid for layout, use flexbox instead
-- Only use valid Tailwind CSS classes
-- When the user requests exact CSS values you must use Tailwind's square bracket notation to generate a custom Tailwind class for the value eg. top-[10px]
+- Only use valid Tailwind CSS classes. Always use the square brackets notation eg. mb-[10px] instead of mb-10
 - Don't add round corners and shadow to top-level containers
 - Don't add any props to components
 - For images leave the `src` prop empty and add a good on-topic description as `alt` attribute for screen readers. Additionally set a `width` and `height` props for the image size


### PR DESCRIPTION
When asking specific values that don't have a Tailwind class, the AI should generate custom classes using Tailwind's square brackets notation.

Tweaking the prompts to ask for this. Test the preview a bit.