### PR TITLE
fix: Add prompt click to AI Command Bar

### DIFF
--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -78,7 +78,8 @@ export const AiCommandBar = () => {
       }
 
       const currentValue = getValue();
-      const newValue = `${currentValue} ${text}`;
+      const newValue = [currentValue, text].filter(Boolean).join(" ");
+
       setValue(newValue);
       setIsAudioTranscribing(false);
 
@@ -143,6 +144,10 @@ export const AiCommandBar = () => {
 
   const handleAiButtonClick = () => {
     handleAiRequest(value);
+  };
+
+  const handlePropmptClick = (prompt: string) => {
+    setValue(prompt);
   };
 
   if (isAiCommandBarVisible === false) {
@@ -229,7 +234,12 @@ export const AiCommandBar = () => {
       <CommandBar
         open={open}
         onOpenChange={setOpen}
-        content={<CommandBarContent prompts={prompts} />}
+        content={
+          <CommandBarContent
+            prompts={prompts}
+            onPromptClick={handlePropmptClick}
+          />
+        }
       >
         <CommandBarTrigger>
           <CommandBarButton color="dark-ghost">
@@ -303,7 +313,10 @@ export const AiCommandBar = () => {
   );
 };
 
-const CommandBarContent = (props: { prompts: string[] }) => {
+const CommandBarContent = (props: {
+  prompts: string[];
+  onPromptClick: (value: string) => void;
+}) => {
   const shortcutText = "⌘⇧Q";
   return (
     <>
@@ -354,7 +367,10 @@ const CommandBarContent = (props: { prompts: string[] }) => {
             <ScrollArea css={{ maxHeight: theme.spacing[29], margin: -4 }}>
               <Grid gap={2} css={{ margin: 4 }}>
                 {props.prompts.map((prompt, index) => (
-                  <CommandBarContentPrompt key={index}>
+                  <CommandBarContentPrompt
+                    key={index}
+                    onClick={() => props.onPromptClick(prompt)}
+                  >
                     {prompt}
                   </CommandBarContentPrompt>
                 ))}

--- a/packages/design-system/src/components/ai-command-bar/command-bar.tsx
+++ b/packages/design-system/src/components/ai-command-bar/command-bar.tsx
@@ -100,9 +100,12 @@ const CommandBarContentPromptText = styled("span", {
   whiteSpace: "break-spaces",
 });
 
-export const CommandBarContentPrompt = (props: { children: ReactNode }) => {
+export const CommandBarContentPrompt = (props: {
+  children: ReactNode;
+  onClick?: () => void;
+}) => {
   return (
-    <CommandBarContentPromptStyled color="dark">
+    <CommandBarContentPromptStyled color="dark" onClick={props.onClick}>
       <CommandBarContentPromptText>
         {props.children}
       </CommandBarContentPromptText>


### PR DESCRIPTION
## Description

Prompt click on AI Command Bar adds text to the input
Also fixed space on audio transcribing



## Steps for reproduction

Click on any prompt in prompts history, see it's text in input field


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
