### PR TITLE
feat: select sibling after delete instance

### DIFF
--- a/apps/builder/app/builder/shared/commands.test.ts
+++ b/apps/builder/app/builder/shared/commands.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "@jest/globals";
+import type { Instance } from "@webstudio-is/sdk";
+import * as baseMetas from "@webstudio-is/sdk-components-react/metas";
+import {
+  instancesStore,
+  registeredComponentMetasStore,
+  selectedInstanceSelectorStore,
+} from "~/shared/nano-states";
+import { registerContainers } from "~/shared/sync";
+import { emitCommand } from "./commands";
+
+registerContainers();
+
+const createInstancePair = (
+  id: Instance["id"],
+  component: string,
+  children: Instance["children"]
+): [Instance["id"], Instance] => {
+  return [id, { type: "instance", id, component, children }];
+};
+
+const metas = new Map(Object.entries(baseMetas));
+
+describe("deleteInstance", () => {
+  // body
+  //   parent
+  //     child1
+  //     child2
+  //     child3
+  const threeChildInstances = new Map([
+    createInstancePair("body", "Body", [{ type: "id", value: "parent" }]),
+    createInstancePair("parent", "Box", [
+      { type: "id", value: "child1" },
+      { type: "id", value: "child2" },
+      { type: "id", value: "child3" },
+    ]),
+    createInstancePair("child1", "Box", []),
+    createInstancePair("child2", "Box", []),
+    createInstancePair("child3", "Box", []),
+  ]);
+
+  test("delete selected instance and select next one", () => {
+    registeredComponentMetasStore.set(metas);
+    selectedInstanceSelectorStore.set(["child2", "parent", "body"]);
+    instancesStore.set(threeChildInstances);
+    emitCommand("deleteInstance");
+    expect(selectedInstanceSelectorStore.get()).toEqual([
+      "child3",
+      "parent",
+      "body",
+    ]);
+  });
+
+  test("delete selected instance and select previous one", () => {
+    registeredComponentMetasStore.set(metas);
+    selectedInstanceSelectorStore.set(["child3", "parent", "body"]);
+    instancesStore.set(threeChildInstances);
+    emitCommand("deleteInstance");
+    expect(selectedInstanceSelectorStore.get()).toEqual([
+      "child2",
+      "parent",
+      "body",
+    ]);
+  });
+
+  test("delete selected instance and select parent one", () => {
+    selectedInstanceSelectorStore.set(["child1", "parent", "body"]);
+    registeredComponentMetasStore.set(metas);
+    // body
+    //   parent
+    //     child1
+    instancesStore.set(
+      new Map([
+        createInstancePair("body", "Body", [{ type: "id", value: "parent" }]),
+        createInstancePair("parent", "Box", [{ type: "id", value: "child1" }]),
+        createInstancePair("child1", "Box", []),
+      ])
+    );
+    emitCommand("deleteInstance");
+    expect(selectedInstanceSelectorStore.get()).toEqual(["parent", "body"]);
+  });
+});

--- a/apps/builder/app/shared/commands-emitter.ts
+++ b/apps/builder/app/shared/commands-emitter.ts
@@ -66,13 +66,19 @@ export const createCommandsEmitter = <CommandName extends string>({
 
   const emitCommand = (name: CommandName) => {
     const { publish } = $publisher.get();
-    publish({
-      type: "command",
-      payload: {
-        source,
-        name,
-      },
-    });
+    // continue to work without emitter
+    // for example in tests
+    if (publish) {
+      publish({
+        type: "command",
+        payload: {
+          source,
+          name,
+        },
+      });
+    } else {
+      commandHandlers.get(name)?.();
+    }
   };
 
   /**

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -19,7 +19,6 @@ import {
   styleSourcesStore,
   instancesStore,
   selectedStyleSourceSelectorStore,
-  textEditingInstanceSelectorStore,
   breakpointsStore,
   registeredComponentMetasStore,
   dataSourcesStore,
@@ -393,13 +392,13 @@ export const reparentInstance = (
 export const deleteInstance = (instanceSelector: InstanceSelector) => {
   // @todo tell user they can't delete root
   if (instanceSelector.length === 1) {
-    return;
+    return false;
   }
   if (isInstanceDetachable(instanceSelector) === false) {
     toast.error(
       "This instance can not be moved outside of its parent component."
     );
-    return;
+    return false;
   }
   serverSyncStore.createTransaction(
     [
@@ -484,26 +483,7 @@ export const deleteInstance = (instanceSelector: InstanceSelector) => {
           styles.delete(styleDeclKey);
         }
       }
-
-      if (parentInstance) {
-        selectedInstanceSelectorStore.set(
-          getAncestorInstanceSelector(instanceSelector, parentInstance.id)
-        );
-        selectedStyleSourceSelectorStore.set(undefined);
-      }
     }
   );
-};
-
-export const deleteSelectedInstance = () => {
-  const textEditingInstanceSelector = textEditingInstanceSelectorStore.get();
-  const selectedInstanceSelector = selectedInstanceSelectorStore.get();
-  // cannot delete instance while editing
-  if (textEditingInstanceSelector) {
-    return;
-  }
-  if (selectedInstanceSelector === undefined) {
-    return;
-  }
-  deleteInstance(selectedInstanceSelector);
+  return true;
 };

--- a/apps/builder/app/shared/pubsub/index.ts
+++ b/apps/builder/app/shared/pubsub/index.ts
@@ -13,8 +13,4 @@ export const { publish, usePublish, useSubscribe, subscribe } =
 export type Publish = typeof publish;
 export type UsePublish = typeof usePublish;
 
-export const $publisher = atom<{
-  publish: Publish;
-}>({
-  publish: () => {},
-});
+export const $publisher = atom<{ publish?: Publish }>({});


### PR DESCRIPTION
Quite requested improvement. Instead of selecting parent on delete select next or previous sibling to be able to clean items within collections with minimal amount of actions.

For testing
- delete first item in a list
- delete last item in a list
- delete the only item in a list

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
