### PR TITLE
feat: add attribution to images generated by ai

### DIFF
--- a/packages/ai/src/image.ts
+++ b/packages/ai/src/image.ts
@@ -109,6 +109,17 @@ const queryImageAndMutateInstance = async (
   } else {
     instance.props[srcIndex] = newSrc;
   }
+  const title: EmbedTemplateProp = {
+    name: "title",
+    type: "string",
+    value: `Credit: ${result.photographer}`,
+  };
+  const titleIndex = instance.props.findIndex((prop) => prop.name === "title");
+  if (titleIndex === -1) {
+    instance.props.push(title);
+  } else {
+    instance.props[titleIndex] = title;
+  }
   // prevent image deformation when ai specifies image size
   const hasObjectFit = instance.styles?.some(
     (styleDecl) => styleDecl.property === "objectFit"


### PR DESCRIPTION
Added title prop with `Credit: author` for attribution.

<img width="978" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5635476/1e984fe1-f57d-4441-ae72-8fa3314133b1">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
