### PR TITLE
refactor: move undo/redo into commands

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -10,7 +10,6 @@ import { theme, Box, type CSS, Flex, Grid } from "@webstudio-is/design-system";
 import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
 import { registerContainers, useBuilderStore } from "~/shared/sync";
 import { useSyncServer } from "./shared/sync/sync-server";
-import { useSharedShortcuts } from "~/shared/shortcuts";
 import { SidebarLeft, Navigator } from "./features/sidebar-left";
 import { Inspector } from "./features/inspector";
 import { Topbar } from "./features/topbar";
@@ -276,7 +275,6 @@ export const Builder = ({
     authPermit,
     version: build.version,
   });
-  useSharedShortcuts({ source: "builder" });
 
   const isPreviewMode = useStore($isPreviewMode);
   usePublishShortcuts(publish);

--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -30,7 +30,6 @@ import { dashboardPath } from "~/shared/router-utils";
 import { $authPermit } from "~/shared/nano-states";
 import { emitCommand } from "~/builder/shared/commands";
 import { MenuButton } from "./menu-button";
-import { serverSyncStore } from "~/shared/sync";
 
 const ThemeMenuItem = () => {
   if (isFeatureEnabled("dark") === false) {
@@ -125,13 +124,13 @@ export const Menu = () => {
             Dashboard
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => serverSyncStore.undo()}>
+          <DropdownMenuItem onSelect={() => emitCommand("undo")}>
             Undo
             <DropdownMenuItemRightSlot>
               <ShortcutHint value={["cmd", "z"]} />
             </DropdownMenuItemRightSlot>
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => serverSyncStore.redo()}>
+          <DropdownMenuItem onSelect={() => emitCommand("redo")}>
             Redo
             <DropdownMenuItemRightSlot>
               <ShortcutHint value={["shift", "cmd", "z"]} />

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -14,6 +14,7 @@ import {
 import { onCopy, onPaste } from "~/shared/copy-paste/plugin-instance";
 import { deleteInstance } from "~/shared/instance-utils";
 import type { InstanceSelector } from "~/shared/tree-utils";
+import { serverSyncStore } from "~/shared/sync";
 
 const makeBreakpointCommand = <CommandName extends string>(
   name: CommandName,
@@ -95,6 +96,20 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
     makeBreakpointCommand("selectBreakpoint7", 7),
     makeBreakpointCommand("selectBreakpoint8", 8),
     makeBreakpointCommand("selectBreakpoint9", 9),
+    /*
+    // @todo: decide about keyboard shortcut, uncomment when ready
+    {
+      name: "toggleAiCommandBar",
+      defaultHotkeys: ["space"],
+      disableHotkeyOnContentEditable: true,
+      // this disables hotkey for inputs on style panel
+      // but still work for input on canvas which call event.preventDefault() in keydown handler
+      disableHotkeyOnFormTags: true,
+      handler: () => {
+        $isAiCommandBarVisible.set($isAiCommandBarVisible.get() === false);
+      },
+    },
+    */
 
     // instances
 
@@ -127,19 +142,27 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       },
     },
 
-    /*
-    // @todo: decide about keyboard shortcut, uncomment when ready
+    // history
+
     {
-      name: "toggleAiCommandBar",
-      defaultHotkeys: ["space"],
+      name: "undo",
+      // safari use cmd+z to reopen closed tabs, here added ctrl as alternative
+      defaultHotkeys: ["meta+z", "ctrl+z"],
       disableHotkeyOnContentEditable: true,
-      // this disables hotkey for inputs on style panel
-      // but still work for input on canvas which call event.preventDefault() in keydown handler
       disableHotkeyOnFormTags: true,
       handler: () => {
-        $isAiCommandBarVisible.set($isAiCommandBarVisible.get() === false);
+        serverSyncStore.undo();
       },
     },
-    */
+    {
+      name: "redo",
+      // safari use cmd+z to reopen closed tabs, here added ctrl as alternative
+      defaultHotkeys: ["meta+shift+z", "ctrl+shift+z"],
+      disableHotkeyOnContentEditable: true,
+      disableHotkeyOnFormTags: true,
+      handler: () => {
+        serverSyncStore.redo();
+      },
+    },
   ],
 });

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -22,7 +22,6 @@ import * as radixComponentPropsMetas from "@webstudio-is/sdk-components-react-ra
 import { hooks as radixComponentHooks } from "@webstudio-is/sdk-components-react-radix/hooks";
 import { $publisher, publish } from "~/shared/pubsub";
 import { registerContainers, useCanvasStore } from "~/shared/sync";
-import { useSharedShortcuts } from "~/shared/shortcuts";
 import { useCanvasShortcuts } from "./canvas-shortcuts";
 import { useManageDesignModeStyles, GlobalStyles } from "./shared/styles";
 import {
@@ -201,7 +200,6 @@ export const Canvas = ({
 
   // e.g. toggling preview is still needed in both modes
   useCanvasShortcuts();
-  useSharedShortcuts({ source: "canvas" });
   const selectedPage = useStore(selectedPageStore);
 
   useEffect(() => {

--- a/apps/builder/app/shared/commands-emitter.ts
+++ b/apps/builder/app/shared/commands-emitter.ts
@@ -42,6 +42,40 @@ export type Command<CommandName extends string> = CommandMeta<CommandName> & {
 export const $commandMetas = atom(new Map<string, CommandMeta<string>>());
 clientSyncStore.register("commandMetas", $commandMetas);
 
+// this is a hack to workaround react-hotkeys-hook implementation
+// of isHotkeyPressed which matches every specified keys
+// even when more keys pressed. This resulted in cmd+z and cmd+shift+z
+// both match when only cmd+z is pressed
+//
+// here find hotkeys which have more keys pressed at a time
+const findCommandsMatchingHeaviestHotkeys = () => {
+  const commandMetas = $commandMetas.get();
+  let maxHotkeySize = 0;
+  let matchingCommands = new Set<CommandMeta<string>>();
+  for (const commandMeta of commandMetas.values()) {
+    if (commandMeta.defaultHotkeys === undefined) {
+      continue;
+    }
+    for (const hotkey of commandMeta.defaultHotkeys) {
+      const keys = hotkey.split("+");
+      const hotkeySize = keys.length;
+      if (isHotkeyPressed(keys) === false) {
+        continue;
+      }
+      // reset commands list when found more heavy hotkey
+      if (maxHotkeySize < hotkeySize) {
+        maxHotkeySize = hotkeySize;
+        matchingCommands = new Set();
+      }
+      // hotkey matches haviest one
+      if (maxHotkeySize === hotkeySize) {
+        matchingCommands.add(commandMeta);
+      }
+    }
+  }
+  return matchingCommands;
+};
+
 export const createCommandsEmitter = <CommandName extends string>({
   source,
   commands,
@@ -90,19 +124,8 @@ export const createCommandsEmitter = <CommandName extends string>({
       commandHandlers.get(name)?.();
     });
     const handleKeyDown = (event: KeyboardEvent) => {
-      const commandMetas = $commandMetas.get();
       let emitted = false;
-      for (const commandMeta of commandMetas.values()) {
-        if (commandMeta.defaultHotkeys === undefined) {
-          continue;
-        }
-        if (
-          commandMeta.defaultHotkeys.some((hotkey) =>
-            isHotkeyPressed(hotkey.split("+"))
-          ) === false
-        ) {
-          continue;
-        }
+      for (const commandMeta of findCommandsMatchingHeaviestHotkeys()) {
         if (
           commandMeta.disableHotkeyOutsideApp &&
           commandHandlers.has(commandMeta.name) === false
@@ -128,8 +151,9 @@ export const createCommandsEmitter = <CommandName extends string>({
         }
         if (
           isOnContentEditable &&
-          disableHotkeyOnContentEditable &&
-          event.defaultPrevented === false
+          disableHotkeyOnContentEditable
+          // editors usually manage history in controlled way
+          // so do not check if event is prevented
         ) {
           continue;
         }

--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -1,5 +1,4 @@
-import { type Options, useHotkeys } from "react-hotkeys-hook";
-import { serverSyncStore } from "../sync";
+import type { Options } from "react-hotkeys-hook";
 
 export const shortcuts = {
   esc: "esc",
@@ -7,34 +6,4 @@ export const shortcuts = {
 
 export const options: Options = {
   enableOnFormTags: true,
-};
-
-export const useSharedShortcuts = ({
-  source,
-}: {
-  source: "canvas" | "builder";
-}) => {
-  useHotkeys(
-    // safari use cmd+z to reopen closed tabs so fallback to ctrl
-    "meta+z, ctrl+z",
-    () => serverSyncStore.undo(),
-    {
-      // prevents undoing when user is editing text in a control on style panel etc.
-      enableOnFormTags: source === "canvas",
-      enableOnContentEditable: false,
-    },
-    []
-  );
-
-  useHotkeys(
-    // safari use cmd+shift+z to close reopened tabs so fallback to ctrl
-    "meta+shift+z, ctrl+shift+z",
-    () => serverSyncStore.redo(),
-    {
-      // prevents undoing when user is editing text in a control on style panel etc.
-      enableOnFormTags: source === "canvas",
-      enableOnContentEditable: false,
-    },
-    []
-  );
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2354

Here moved last pieces of shared shortcuts into commands. Fixed distinction of cmd+z and cmd+shift+z to workaround react-hotkeys-hook implementation.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
