### PR TITLE
fix: prevent image delete when close image dialog

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/file.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/file.tsx
@@ -13,15 +13,12 @@ type FileControlProps = ControlProps<"file", "asset" | "string">;
 
 const UrlInput = ({
   id,
-  disabled,
   localValue,
 }: {
   id: string;
-  disabled: boolean;
   localValue: ReturnType<typeof useLocalValue<string>>;
 }) => (
   <InputField
-    disabled={disabled}
     id={id}
     value={localValue.value}
     placeholder="http://www.url.com"
@@ -73,11 +70,7 @@ export const FileControl = ({
       onDelete={onDelete}
     >
       <Row>
-        <UrlInput
-          id={id}
-          disabled={prop?.type === "asset"}
-          localValue={localStringValue}
-        />
+        <UrlInput id={id} localValue={localStringValue} />
       </Row>
       <Row>
         <SelectAsset
@@ -85,7 +78,6 @@ export const FileControl = ({
           accept={meta.accept}
           onChange={onChange}
           onSoftDelete={onSoftDelete}
-          disabled={localStringValue.value !== ""}
         />
       </Row>
     </VerticalLayout>

--- a/apps/builder/app/builder/features/settings-panel/controls/file.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/file.tsx
@@ -16,11 +16,11 @@ const UrlInput = ({
   localValue,
 }: {
   id: string;
-  localValue: ReturnType<typeof useLocalValue<string>>;
+  localValue: ReturnType<typeof useLocalValue<undefined | string>>;
 }) => (
   <InputField
     id={id}
-    value={localValue.value}
+    value={localValue.value ?? ""}
     placeholder="http://www.url.com"
     onChange={(event) => localValue.set(event.target.value)}
     onBlur={localValue.save}
@@ -50,9 +50,13 @@ export const FileControl = ({
   const id = useId();
 
   const localStringValue = useLocalValue(
-    prop?.type === "string" ? prop.value : "",
+    // use undefined for asset type to not delete
+    // when url is reset by asset selector
+    prop?.type === "string" ? prop.value : undefined,
     (value) => {
-      if (value === "") {
+      if (value === undefined) {
+        return;
+      } else if (value === "") {
         onSoftDelete();
       } else {
         onChange({ type: "string", value });

--- a/apps/builder/app/builder/features/settings-panel/controls/select-asset.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/select-asset.tsx
@@ -27,7 +27,6 @@ type AssetControlProps = ControlProps<unknown, "asset">;
 
 type Props = {
   accept?: string;
-  disabled?: boolean;
   prop: AssetControlProps["prop"];
   onChange: AssetControlProps["onChange"];
   onSoftDelete: AssetControlProps["onSoftDelete"];
@@ -38,7 +37,6 @@ export const SelectAsset = ({
   onChange,
   onSoftDelete,
   accept,
-  disabled = false,
 }: Props) => {
   const assetStore = useMemo(
     () =>
@@ -67,11 +65,11 @@ export const SelectAsset = ({
           />
         }
       >
-        <Button color="neutral" css={{ flex: 1 }} disabled={disabled}>
+        <Button color="neutral" css={{ flex: 1 }}>
           {asset?.name ?? "Choose source"}
         </Button>
       </FloatingPanel>
-      {prop && disabled === false ? (
+      {prop ? (
         <SmallIconButton
           icon={<TrashIcon />}
           onClick={onSoftDelete}


### PR DESCRIPTION
Looks like "disabled" state triggered "delete" button near "Choose source".

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
