### PR TITLE
fix: AI, Enable adding text to empty container nodes

### DIFF
--- a/apps/builder/app/builder/features/ai/ai-fetch-result.ts
+++ b/apps/builder/app/builder/features/ai/ai-fetch-result.ts
@@ -163,9 +163,9 @@ export const fetchResult = async (
                   patchTextInstance(operation);
                   appliedOperations.add(JSON.stringify(operation));
                 }
-              } catch {
+              } catch (error) {
                 // eslint-disable-next-line no-console
-                console.error("completion failed to parse", completion);
+                console.error(error);
               }
             }
           },

--- a/apps/builder/app/builder/features/ai/apply-operations.ts
+++ b/apps/builder/app/builder/features/ai/apply-operations.ts
@@ -206,6 +206,7 @@ export const patchTextInstance = (textInstance: copywriter.TextInstance) => {
 
     if (currentInstance.children.length === 0) {
       currentInstance.children = [{ type: "text", value: textInstance.text }];
+      return;
     }
 
     // Instances can have a number of text child nodes without interleaving components.

--- a/apps/builder/app/builder/features/ai/apply-operations.ts
+++ b/apps/builder/app/builder/features/ai/apply-operations.ts
@@ -191,11 +191,21 @@ export const patchTextInstance = (textInstance: copywriter.TextInstance) => {
   serverSyncStore.createTransaction([instancesStore], (instances) => {
     const currentInstance = instances.get(textInstance.instanceId);
 
-    if (
-      currentInstance === undefined ||
-      currentInstance.children.length === 0
-    ) {
+    if (currentInstance === undefined) {
       return;
+    }
+
+    const meta = registeredComponentMetasStore
+      .get()
+      .get(currentInstance.component);
+
+    // Only container components are allowed to have child elements.
+    if (meta?.type !== "container") {
+      return;
+    }
+
+    if (currentInstance.children.length === 0) {
+      currentInstance.children = [{ type: "text", value: textInstance.text }];
     }
 
     // Instances can have a number of text child nodes without interleaving components.


### PR DESCRIPTION
## Description

Check `currentInstance.children.length===0` was used as check does element can have children.

Fixed using meta.


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
