### PR TITLE
fix: Outline variants sizing

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.stories.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.stories.tsx
@@ -47,8 +47,8 @@ export const Basic = () => (
       <Box css={{ width: "min-content", textAlign: "center" }}>
         Selected outline over Collaboration
       </Box>
-      <Outline rect={new DOMRect(0, 0, 150, 150)} />
       <Outline rect={new DOMRect(0, 0, 150, 150)} variant="collaboration" />
+      <Outline rect={new DOMRect(0, 0, 150, 150)} />
     </Flex>
   </Grid>
 );

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.stories.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.stories.tsx
@@ -1,0 +1,54 @@
+import { Box, Flex, Grid } from "@webstudio-is/design-system";
+import { Outline } from "./outline";
+
+export default { component: Outline };
+
+export const Basic = () => (
+  <Grid gap={3} columns={2} css={{ margin: 16 }}>
+    <Grid
+      align="center"
+      justify="center"
+      css={{ position: "relative", height: 150, width: 150 }}
+    >
+      <Box css={{ width: "min-content", textAlign: "center" }}>
+        Selected outline
+      </Box>
+      <Outline rect={new DOMRect(0, 0, 150, 150)} />
+    </Grid>
+
+    <Flex
+      align="center"
+      justify="center"
+      css={{ position: "relative", height: 150, width: 150 }}
+    >
+      <Box css={{ width: "min-content", textAlign: "center" }}>
+        Collaboration outline
+      </Box>
+      <Outline rect={new DOMRect(0, 0, 150, 150)} variant="collaboration" />
+    </Flex>
+
+    <Flex
+      align="center"
+      justify="center"
+      css={{ position: "relative", height: 150, width: 150 }}
+    >
+      <Box css={{ width: "min-content", textAlign: "center" }}>
+        Collaboration outline over Selected
+      </Box>
+      <Outline rect={new DOMRect(0, 0, 150, 150)} />
+      <Outline rect={new DOMRect(0, 0, 150, 150)} variant="collaboration" />
+    </Flex>
+
+    <Flex
+      align="center"
+      justify="center"
+      css={{ position: "relative", height: 150, width: 150 }}
+    >
+      <Box css={{ width: "min-content", textAlign: "center" }}>
+        Selected outline over Collaboration
+      </Box>
+      <Outline rect={new DOMRect(0, 0, 150, 150)} />
+      <Outline rect={new DOMRect(0, 0, 150, 150)} variant="collaboration" />
+    </Flex>
+  </Grid>
+);

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
@@ -22,6 +22,7 @@ const angleKeyframes = keyframes({
 });
 
 const baseStyle = css({
+  boxSizing: "border-box",
   position: "absolute",
   pointerEvents: "none",
   outline: `1px solid ${theme.colors.blue9}`,


### PR DESCRIPTION
## Description

Issue: outline sizes do not match
<img width="552" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/6b9b2a01-f14d-4d04-9eda-1d26af857a47">

Fixed:
<img width="548" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/98040e1c-dc96-4755-9872-965f5b17bae6">

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
