### PR TITLE
feat: Add some default list items when creating a List instance

### DIFF
--- a/packages/sdk-components-react/src/list.ws.tsx
+++ b/packages/sdk-components-react/src/list.ws.tsx
@@ -51,6 +51,29 @@ export const meta: WsComponentMeta = {
   states: defaultStates,
   presetStyle,
   order: 3,
+  template: [
+    {
+      type: "instance",
+      component: "List",
+      children: [
+        {
+          type: "instance",
+          component: "ListItem",
+          children: [],
+        },
+        {
+          type: "instance",
+          component: "ListItem",
+          children: [],
+        },
+        {
+          type: "instance",
+          component: "ListItem",
+          children: [],
+        },
+      ],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {


### PR DESCRIPTION
## Description

When adding List component to canvas - its currently empty, but we should have some items inside by default

## Steps for reproduction

1. Drop List component on canvas
2. See some default items

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
