### PR TITLE
fix: Allow inserting templates only inside container components

### DIFF
--- a/apps/builder/app/builder/features/ai/apply-operations.ts
+++ b/apps/builder/app/builder/features/ai/apply-operations.ts
@@ -77,6 +77,15 @@ const insertTemplateByOp = (
 
   const instanceSelector = computeSelectorForInstanceId(operation.addTo);
   if (instanceSelector) {
+    const currentInstance = instancesStore.get().get(instanceSelector[0]);
+    // Only container components are allowed to have child elements.
+    if (
+      currentInstance &&
+      metas.get(currentInstance.component)?.type !== "container"
+    ) {
+      return;
+    }
+
     const dropTarget: DroppableTarget = {
       parentSelector: instanceSelector,
       position: operation.addAtIndex + 1,


### PR DESCRIPTION
Like with text insertions, when inserting a generated template we need to check whether the host element is a container.