### PR TITLE
feat: When user selects a page - close the pages tab

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -226,7 +226,7 @@ const PagesPanel = ({
   );
 };
 
-export const TabContent = (props: TabContentProps) => {
+export const TabContent = ({ onSetActiveTab }: TabContentProps) => {
   const currentPageId = useStore(selectedPageIdStore);
   const newPageId = "new-page";
   const [editingPageId, setEditingPageId] = useState<string>();
@@ -238,13 +238,16 @@ export const TabContent = (props: TabContentProps) => {
   return (
     <>
       <PagesPanel
-        onClose={() => props.onSetActiveTab("none")}
+        onClose={() => onSetActiveTab("none")}
         onCreateNewPage={() =>
           setEditingPageId((current) =>
             current === newPageId ? undefined : newPageId
           )
         }
-        onSelect={switchPage}
+        onSelect={(pageId) => {
+          switchPage(pageId);
+          onSetActiveTab("none");
+        }}
         selectedPageId={currentPageId}
         onEdit={setEditingPageId}
         editingPageId={editingPageId}


### PR DESCRIPTION
## Description

User pointed out that keeping pages tab open after selecting a page is confusing

## Steps for reproduction

1. open pages panel
2. click on any other page than current
3. see page is switched and pages tab is closed

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
