### PR TITLE
feat: Preverve AI menu state, make it initially open

### DIFF
--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -48,6 +48,7 @@ import { fetchTranscription } from "./ai-fetch-transcription";
 import { fetchResult } from "./ai-fetch-result";
 import { useEffectEvent } from "./hooks/effect-event";
 import { AiApiException, RateLimitException } from "./api-exceptions";
+import { useClientSettings } from "~/builder/shared/client-settings";
 
 type PartialButtonProps<T = ComponentPropsWithoutRef<typeof Button>> = {
   [key in keyof T]?: T[key];
@@ -56,7 +57,13 @@ type PartialButtonProps<T = ComponentPropsWithoutRef<typeof Button>> = {
 export const AiCommandBar = ({ isPreviewMode }: { isPreviewMode: boolean }) => {
   const [value, setValue] = useState("");
   const [prompts, setPrompts] = useState<string[]>([]);
-  const [open, setOpen] = useState(false);
+  const [clientSettings, setClientSetting, isClientSettingsLoaded] =
+    useClientSettings();
+  const open = isClientSettingsLoaded && clientSettings.isAiMenuOpen;
+  const setOpen = useEffectEvent((value: boolean) =>
+    setClientSetting("isAiMenuOpen", value)
+  );
+
   const [isAudioTranscribing, setIsAudioTranscribing] = useState(false);
   const [isAiRequesting, setIsAiRequesting] = useState(false);
   const abortController = useRef<AbortController>();

--- a/apps/builder/app/builder/shared/client-settings/config.ts
+++ b/apps/builder/app/builder/shared/client-settings/config.ts
@@ -1,4 +1,0 @@
-export const navigatorLayout = {
-  defaultValue: "undocked",
-  values: ["docked", "undocked"],
-} as const;

--- a/apps/builder/app/builder/shared/client-settings/index.ts
+++ b/apps/builder/app/builder/shared/client-settings/index.ts
@@ -1,2 +1,1 @@
 export * from "./settings";
-export * as config from "./config";


### PR DESCRIPTION
## Description

State of the AI menu now in local storage. Opened by default

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
