### PR TITLE
feat: Ai placeholder + select prompt text after inserting prompt from history

### DIFF
--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -280,6 +280,9 @@ export const AiCommandBar = ({ isPreviewMode }: { isPreviewMode: boolean }) => {
   };
 
   const handlePropmptClick = (prompt: string) => {
+    if (textAreaRef.current?.disabled) {
+      return;
+    }
     setValue(prompt);
     selectPrompt();
   };

--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -49,21 +49,17 @@ import { fetchResult } from "./ai-fetch-result";
 import { useEffectEvent } from "./hooks/effect-event";
 import { AiApiException, RateLimitException } from "./api-exceptions";
 import { useClientSettings } from "~/builder/shared/client-settings";
-import { useEffectQueue } from "~/shared/hook-utils/use-effect-queue";
+import { flushSync } from "react-dom";
 
 type PartialButtonProps<T = ComponentPropsWithoutRef<typeof Button>> = {
   [key in keyof T]?: T[key];
 };
 
 const useSelectText = () => {
-  // We can't select text right away because value will be set using setState.
-  const scheduleEffect = useEffectQueue();
   const ref = useRef<HTMLTextAreaElement>(null);
   const selectText = () => {
-    scheduleEffect(() => {
-      ref.current?.focus();
-      ref.current?.select();
-    });
+    ref.current?.focus();
+    ref.current?.select();
   };
   return [ref, selectText] as const;
 };
@@ -283,7 +279,10 @@ export const AiCommandBar = ({ isPreviewMode }: { isPreviewMode: boolean }) => {
     if (textAreaRef.current?.disabled) {
       return;
     }
-    setValue(prompt);
+    // We can't select text right away because value will be set using setState.
+    flushSync(() => {
+      setValue(prompt);
+    });
     selectPrompt();
   };
 

--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -272,7 +272,7 @@ export const AiCommandBar = ({ isPreviewMode }: { isPreviewMode: boolean }) => {
     return;
   }
 
-  let textAreaPlaceholder = "Enter value...";
+  let textAreaPlaceholder = "Welcome to Webstudio AI alpha!";
   let textAreaValue = value;
   let textAreaDisabled = false;
 

--- a/apps/builder/app/canvas/instance-selected-react.ts
+++ b/apps/builder/app/canvas/instance-selected-react.ts
@@ -1,27 +1,9 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect } from "react";
 import { subscribeSelected } from "./instance-selected";
-
-/**
- * Debounce task execution until useEffect
- */
-const useDebounceEffect = () => {
-  const [updateCallback, setUpdateCallback] = useState(() => () => {
-    /* empty */
-  });
-
-  useEffect(() => {
-    // Because of how our styles works we need to update after React render to be sure that
-    // all styles are applied
-    updateCallback();
-  }, [updateCallback]);
-
-  return useCallback((task: () => void) => {
-    setUpdateCallback(() => task);
-  }, []);
-};
+import { useEffectQueue } from "~/shared/hook-utils/use-effect-queue";
 
 export const useSelectedInstance = () => {
-  const execTaskInEffect = useDebounceEffect();
+  const execTaskInEffect = useEffectQueue();
 
   useEffect(() => {
     return subscribeSelected(execTaskInEffect);

--- a/apps/builder/app/shared/hook-utils/use-effect-queue.ts
+++ b/apps/builder/app/shared/hook-utils/use-effect-queue.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Debounce task execution until useEffect
+ * Example:
+ *   const scheduleEffect = useEffectQueue();
+ *   scheduleEffect(() => { ... })
+ */
+export const useEffectQueue = () => {
+  const [updateCallback, setUpdateCallback] = useState(() => () => {
+    /* empty */
+  });
+
+  useEffect(() => {
+    // Because of how our styles works we need to update after React render to be sure that
+    // all styles are applied
+    updateCallback();
+  }, [updateCallback]);
+
+  return useCallback((task: () => void) => {
+    setUpdateCallback(() => task);
+  }, []);
+};


### PR DESCRIPTION
## Description

- When inserting prompt from history, now I can hit enter right away or delete or copy.
- Update placeholder text
- Prevent inserting prompts when textarea disabled

## Steps for reproduction

1. click history item
2. see inserted text being selected

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
