### PR TITLE
feat: Remember the AI bar open state

### DIFF
--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -75,8 +75,8 @@ export const AiCommandBar = ({ isPreviewMode }: { isPreviewMode: boolean }) => {
   const [prompts, setPrompts] = useState<string[]>(initialPrompts);
   const [clientSettings, setClientSetting, isClientSettingsLoaded] =
     useClientSettings();
-  const open = isClientSettingsLoaded && clientSettings.isAiMenuOpen;
-  const setOpen = useEffectEvent((value: boolean) =>
+  const isMenuOpen = isClientSettingsLoaded && clientSettings.isAiMenuOpen;
+  const setIsMenuOpen = useEffectEvent((value: boolean) =>
     setClientSetting("isAiMenuOpen", value)
   );
 
@@ -364,8 +364,8 @@ export const AiCommandBar = ({ isPreviewMode }: { isPreviewMode: boolean }) => {
       }}
     >
       <CommandBar
-        open={open}
-        onOpenChange={setOpen}
+        open={isMenuOpen}
+        onOpenChange={setIsMenuOpen}
         content={
           <CommandBarContent
             prompts={prompts}

--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-internal-modules */
 import formatDistance from "date-fns/formatDistance";
-import { useStore } from "@nanostores/react";
 import {
   AutogrowTextArea,
   Box,

--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -37,7 +37,6 @@ import {
 } from "react";
 import {
   $collaborativeInstanceSelector,
-  $isAiCommandBarVisible,
   selectedInstanceSelectorStore,
   selectedPageStore,
 } from "~/shared/nano-states";
@@ -83,7 +82,6 @@ export const AiCommandBar = ({ isPreviewMode }: { isPreviewMode: boolean }) => {
   const [isAudioTranscribing, setIsAudioTranscribing] = useState(false);
   const [isAiRequesting, setIsAiRequesting] = useState(false);
   const abortController = useRef<AbortController>();
-  const isAiCommandBarVisible = useStore($isAiCommandBarVisible);
   const recordButtonRef = useRef<HTMLButtonElement>(null);
   const guardIdRef = useRef(0);
   const { enableCanvasPointerEvents, disableCanvasPointerEvents } =
@@ -286,7 +284,10 @@ export const AiCommandBar = ({ isPreviewMode }: { isPreviewMode: boolean }) => {
     selectPrompt();
   };
 
-  if (isAiCommandBarVisible === false) {
+  if (
+    isClientSettingsLoaded === false ||
+    clientSettings.isAiCommandBarVisible === false
+  ) {
     return;
   }
 

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Box,
   SidebarTabs,

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Box,
   SidebarTabs,
@@ -32,9 +32,9 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
   const dragAndDropState = useStore($dragAndDropState);
   const [activeTab, setActiveTab] = useState<TabName>("none");
   const { TabContent } = activeTab === "none" ? none : panels[activeTab];
-  const [clientSettings] = useClientSettings();
   const [helpIsOpen, setHelpIsOpen] = useState(false);
-  const isAiCommandBarVisible = useStore($isAiCommandBarVisible);
+  const [clientSettings, setClientSetting, isClientSettingsLoaded] =
+    useClientSettings();
 
   useSubscribe("clickCanvas", () => {
     setActiveTab("none");
@@ -42,6 +42,12 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
   useSubscribe("dragEnd", () => {
     setActiveTab("none");
   });
+
+  useEffect(() => {
+    if (isClientSettingsLoaded) {
+      $isAiCommandBarVisible.set(clientSettings.isAiCommandBarVisible);
+    }
+  }, [isClientSettingsLoaded, clientSettings.isAiCommandBarVisible]);
 
   const enabledPanels = (Object.keys(panels) as Array<TabName>).filter(
     (panel) => {
@@ -76,7 +82,12 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
                 "anyValueNotInTabName" /* !!! This button does not have active state, use impossible tab value  !!! */
               }
               onClick={() => {
-                $isAiCommandBarVisible.set(!isAiCommandBarVisible);
+                const isAiCommandBarVisible = !$isAiCommandBarVisible.get();
+                $isAiCommandBarVisible.set(isAiCommandBarVisible);
+                setClientSetting(
+                  "isAiCommandBarVisible",
+                  isAiCommandBarVisible
+                );
               }}
             >
               <AiIcon />

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -74,7 +74,7 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
               onClick={() => {
                 setClientSetting(
                   "isAiCommandBarVisible",
-                  !clientSettings.isAiCommandBarVisible
+                  clientSettings.isAiCommandBarVisible === true ? false : true
                 );
               }}
             >

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -8,10 +8,7 @@ import {
   Tooltip,
 } from "@webstudio-is/design-system";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
-import {
-  $dragAndDropState,
-  $isAiCommandBarVisible,
-} from "~/shared/nano-states";
+import { $dragAndDropState } from "~/shared/nano-states";
 import { panels } from "./panels";
 import type { TabName } from "./types";
 import { useClientSettings } from "~/builder/shared/client-settings";
@@ -33,8 +30,7 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
   const [activeTab, setActiveTab] = useState<TabName>("none");
   const { TabContent } = activeTab === "none" ? none : panels[activeTab];
   const [helpIsOpen, setHelpIsOpen] = useState(false);
-  const [clientSettings, setClientSetting, isClientSettingsLoaded] =
-    useClientSettings();
+  const [clientSettings, setClientSetting] = useClientSettings();
 
   useSubscribe("clickCanvas", () => {
     setActiveTab("none");
@@ -42,12 +38,6 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
   useSubscribe("dragEnd", () => {
     setActiveTab("none");
   });
-
-  useEffect(() => {
-    if (isClientSettingsLoaded) {
-      $isAiCommandBarVisible.set(clientSettings.isAiCommandBarVisible);
-    }
-  }, [isClientSettingsLoaded, clientSettings.isAiCommandBarVisible]);
 
   const enabledPanels = (Object.keys(panels) as Array<TabName>).filter(
     (panel) => {
@@ -82,11 +72,9 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
                 "anyValueNotInTabName" /* !!! This button does not have active state, use impossible tab value  !!! */
               }
               onClick={() => {
-                const isAiCommandBarVisible = !$isAiCommandBarVisible.get();
-                $isAiCommandBarVisible.set(isAiCommandBarVisible);
                 setClientSetting(
                   "isAiCommandBarVisible",
-                  isAiCommandBarVisible
+                  !clientSettings.isAiCommandBarVisible
                 );
               }}
             >

--- a/apps/builder/app/builder/shared/client-settings/settings.ts
+++ b/apps/builder/app/builder/shared/client-settings/settings.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 export const zSettings = z.object({
   navigatorLayout: z.enum(["docked", "undocked"]).default("undocked"),
   isAiMenuOpen: z.boolean().default(true),
+  isAiCommandBarVisible: z.boolean().default(true),
 });
 
 export type Settings = z.infer<typeof zSettings>;

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -327,5 +327,3 @@ export type DragAndDropState = {
 export const $dragAndDropState = atom<DragAndDropState>({
   isDragging: false,
 });
-
-export const $isAiCommandBarVisible = atom<boolean>(false);

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -328,4 +328,4 @@ export const $dragAndDropState = atom<DragAndDropState>({
   isDragging: false,
 });
 
-export const $isAiCommandBarVisible = atom<boolean>(true);
+export const $isAiCommandBarVisible = atom<boolean>(false);


### PR DESCRIPTION
## Description

When the user hides the AI bar and reloads, it should stay hidden. Some people won't be using it and having to hide it every time is going to be annoying.

## Steps for reproduction

1. hide AI bar
2. reload
3. see its still hidden
4. show AI bar
5. reload
6. see its visible

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
