### PR TITLE
fix: typo in .env.example

### DIFF
--- a/apps/builder/.env.example
+++ b/apps/builder/.env.example
@@ -32,7 +32,7 @@ ASSET_BASE_URL=/s/uploads/
 # PUBLISHER_TOKEN=
 
 # Base origin for accessing user-generated build (canvas / preview / etc)
-# Should contatin protocol and host (e.g. https://example.com)
+# Should contain protocol and host (e.g. https://example.com)
 # Will be detected automatically in development environments like localhost or preview deployment
 # BUILD_ORIGIN=https://wstd.live
 


### PR DESCRIPTION
## Fix typo 

fix: typographical error in [.env.example](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/.env.example)