### PR TITLE
feat: Quick settings dialog

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
@@ -76,7 +76,7 @@ export const CanvasTools = ({ publish }: CanvasToolsProps) => {
       {isPreviewMode === false && (
         <>
           <div className={containerStyle({ overflow: "hidden" })}>
-            <SelectedInstanceOutline />
+            <SelectedInstanceOutline publish={publish} />
             <HoveredInstanceOutline />
             <CollaborativeInstanceOutline />
           </div>

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/quick-settings.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/quick-settings.tsx
@@ -1,0 +1,107 @@
+import {
+  FloatingPanelPopover,
+  FloatingPanelPopoverContent,
+  FloatingPanelAnchor,
+  FloatingPanelPopoverTrigger,
+  theme,
+  FloatingPanelPopoverTitle,
+  type Rect,
+  Flex,
+  ScrollArea,
+} from "@webstudio-is/design-system";
+import { ItemIcon } from "@webstudio-is/icons";
+import type { Instance } from "@webstudio-is/sdk";
+import {
+  useState,
+  type ReactNode,
+  useRef,
+  useCallback,
+  type RefObject,
+} from "react";
+import { SettingsPanelContainer } from "~/builder/features/settings-panel";
+import type { Publish } from "~/shared/pubsub";
+
+const useCalcAlignOffset = (
+  triggerRef: RefObject<HTMLButtonElement | null>,
+  labelRect: Rect
+) => {
+  return useCallback(() => {
+    if (triggerRef.current === null) {
+      return 0;
+    }
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    return triggerRect.left - labelRect.left;
+  }, [labelRect.left]);
+};
+
+const QuickSettingsPanel = ({
+  children,
+  title,
+  labelRect,
+}: {
+  children: ReactNode;
+  title: string;
+  labelRect: Rect;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const calcAlignOffset = useCalcAlignOffset(triggerRef, labelRect);
+
+  return (
+    <FloatingPanelPopover modal open={isOpen} onOpenChange={setIsOpen}>
+      <FloatingPanelAnchor>
+        <FloatingPanelPopoverTrigger
+          asChild
+          ref={triggerRef}
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+        >
+          <ItemIcon />
+        </FloatingPanelPopoverTrigger>
+      </FloatingPanelAnchor>
+
+      <FloatingPanelPopoverContent
+        alignOffset={isOpen ? -calcAlignOffset() : 0}
+        align="start"
+        css={{
+          width: theme.spacing[30],
+        }}
+      >
+        <FloatingPanelPopoverTitle>{title}</FloatingPanelPopoverTitle>
+        {children}
+      </FloatingPanelPopoverContent>
+    </FloatingPanelPopover>
+  );
+};
+
+type QuickSettingsProps = {
+  labelRect: Rect;
+  instance?: Instance;
+  publish?: Publish;
+};
+
+export const QuickSettings = ({
+  labelRect,
+  instance,
+  publish,
+}: QuickSettingsProps) => {
+  if (publish === undefined || instance === undefined) {
+    return;
+  }
+  return (
+    <QuickSettingsPanel
+      title={`${instance.component} Settings`}
+      labelRect={labelRect}
+    >
+      <Flex direction={"column"}>
+        <ScrollArea>
+          <SettingsPanelContainer
+            publish={publish}
+            selectedInstance={instance}
+          />
+        </ScrollArea>
+      </Flex>
+    </QuickSettingsPanel>
+  );
+};

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
@@ -9,8 +9,9 @@ import { Outline } from "./outline";
 import { Label } from "./label";
 import { applyScale } from "./apply-scale";
 import { scaleStore } from "~/builder/shared/nano-states";
+import type { Publish } from "~/shared/pubsub";
 
-export const SelectedInstanceOutline = () => {
+export const SelectedInstanceOutline = ({ publish }: { publish: Publish }) => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
   const textEditingInstanceSelector = useStore(
     textEditingInstanceSelectorStore
@@ -30,7 +31,11 @@ export const SelectedInstanceOutline = () => {
   const rect = applyScale(outline.rect, scale);
   return (
     <Outline rect={rect}>
-      <Label instance={outline.instance} instanceRect={rect} />
+      <Label
+        instance={outline.instance}
+        instanceRect={rect}
+        publish={publish}
+      />
     </Outline>
   );
 };


### PR DESCRIPTION
## Description

We haven't discussed the design, so this is a quick experimental implementation to see how hard it is and what the questions are.

The reason we need this is for components like Link, Image and others where component needs to be immediately configured after insertion, its practical to discover the settings right away like WF does

<img width="1239" alt="Screenshot 2023-10-18 at 13 33 37" src="https://github.com/webstudio-is/webstudio/assets/52824/a5c77589-4aee-4657-a1e0-d52a32da58e6">

## Todo

- [ ] make a list of components which should have settings open automatically when instance is created
- [ ] decide how to express settings auto-show via meta
- [ ] decide on the exact layout we show
- [ ] decide on the properties we show (maintaining a separate list is impractical, most likely we will just show all the initialProps) 
- [ ] what if we show the entire settings panel, would it be bad? should we only show initial props? wouldn't it be practical to also see instance label and show?
- [ ] if we only show initial props, we should rename it to QuickPropsDialog
- [ ] decide how image picker would open up

## Steps for reproduction

1. add an instance
2. click the temp icon on the label

## Code Review

- [ ] hi @taylor, I need you to do
 - design review


- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
