### PR TITLE
fix: switch to controlled value in text prop

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/text.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text.tsx
@@ -59,7 +59,7 @@ const UniversalInput = ({
           ? { resize: "vertical" }
           : { resize: "none", whiteSpace: "nowrap", overflow: "hidden" }
       }
-      defaultValue={value}
+      value={value}
       onChange={(event) => {
         const { value } = event.target;
         handleChange(value);

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -104,7 +104,11 @@ const renderProperty = (
     prop,
     propName,
     deletable: deletable ?? false,
-    onDelete: () => logic.handleDelete({ prop, propName }),
+    onDelete: () => {
+      if (prop) {
+        logic.handleDelete(prop);
+      }
+    },
     onChange: (propValue, asset) => {
       logic.handleChange({ prop, propName }, propValue);
 


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/2505

For some reason text prop used uncotrolled defaultValue which broke history management.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
