### PR TITLE
refactor: Extract layer handling functions into individual helpers

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadow-layers.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadow-layers.tsx
@@ -1,4 +1,4 @@
-import type { LayersValue } from "@webstudio-is/css-engine";
+import type { LayersValue, StyleProperty } from "@webstudio-is/css-engine";
 import {
   CssValueListArrowFocus,
   Flex,
@@ -11,20 +11,22 @@ import {
   getLayerCount,
   hideLayer,
   swapLayers,
-  updateBoxShadowLayer,
-} from "./box-shadow-utils";
+  updateLayer,
+} from "../../style-layer-utils";
 import { useMemo } from "react";
 
 type BoxShadowLayerProperies = RenderCategoryProps & {
   layers: LayersValue;
 };
 
+const property: StyleProperty = "boxShadow";
+
 export const BoxShadowLayers = ({
   layers,
   currentStyle,
   createBatchUpdate,
 }: BoxShadowLayerProperies) => {
-  const layersCount = getLayerCount(currentStyle);
+  const layersCount = getLayerCount(property, currentStyle);
 
   const sortableItems = useMemo(
     () =>
@@ -38,20 +40,20 @@ export const BoxShadowLayers = ({
   const { dragItemId, placementIndicator, sortableRefCallback } = useSortable({
     items: sortableItems,
     onSort: (newIndex, oldIndex) => {
-      swapLayers(newIndex, oldIndex, currentStyle, createBatchUpdate);
+      swapLayers(property, newIndex, oldIndex, currentStyle, createBatchUpdate);
     },
   });
 
   const handleDeleteLayer = (index: number) => {
-    return deleteLayer(index, layers, createBatchUpdate);
+    return deleteLayer(property, index, layers, createBatchUpdate);
   };
 
   const handleHideLayer = (index: number) => {
-    return hideLayer(index, layers, createBatchUpdate);
+    return hideLayer(property, index, layers, createBatchUpdate);
   };
 
   const onEditLayer = (index: number, newLayers: LayersValue) => {
-    return updateBoxShadowLayer(newLayers, layers, index, createBatchUpdate);
+    return updateLayer(property, newLayers, layers, index, createBatchUpdate);
   };
 
   return (

--- a/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
@@ -4,6 +4,7 @@ import {
   SectionTitleLabel,
 } from "@webstudio-is/design-system";
 import { PlusIcon } from "@webstudio-is/icons";
+import type { StyleProperty } from "@webstudio-is/css-engine";
 import { CollapsibleSectionBase } from "~/builder/shared/collapsible-section";
 import { useState } from "react";
 import { getDots } from "../../shared/collapsible-section";
@@ -11,8 +12,10 @@ import { PropertyName } from "../../shared/property-name";
 import { getStyleSource } from "../../shared/style-info";
 import type { RenderCategoryProps } from "../../style-sections";
 import { BoxShadowLayers } from "./box-shadow-layers";
-import { addBoxShadow, property } from "./box-shadow-utils";
+import { addLayer } from "../../style-layer-utils";
+import { parseBoxShadow } from "@webstudio-is/css-data";
 
+const property: StyleProperty = "boxShadow";
 const label = "Box Shadows";
 
 export const BoxShadowsSection = (props: RenderCategoryProps) => {
@@ -34,9 +37,10 @@ export const BoxShadowsSection = (props: RenderCategoryProps) => {
             <SectionTitleButton
               prefix={<PlusIcon />}
               onClick={() => {
-                addBoxShadow(
+                addLayer(
+                  property,
                   // Just using some default shadow by default
-                  "0px 2px 5px 0px rgba(0, 0, 0, 0.2)",
+                  parseBoxShadow("0px 2px 5px 0px rgba(0, 0, 0, 0.2)"),
                   currentStyle,
                   props.createBatchUpdate
                 );

--- a/apps/builder/app/builder/features/style-panel/style-layer-utils.test.ts
+++ b/apps/builder/app/builder/features/style-panel/style-layer-utils.test.ts
@@ -5,19 +5,22 @@ import type {
   StyleValue,
   TupleValue,
 } from "@webstudio-is/css-engine";
-import type { CreateBatchUpdate } from "../../shared/use-style-data";
+import type { CreateBatchUpdate } from "./shared/use-style-data";
 import {
-  addBoxShadow,
+  addLayer,
   deleteLayer,
   hideLayer,
   swapLayers,
-  updateBoxShadowLayer,
-} from "./box-shadow-utils";
-import type { StyleInfo } from "../../shared/style-info";
+  updateLayer,
+} from "./style-layer-utils";
+import type { StyleInfo } from "./shared/style-info";
+import { parseBoxShadow } from "@webstudio-is/css-data";
 
 let styleInfo: StyleInfo = {};
 let published = false;
 const deletedProperties = new Set<string>();
+
+const property: StyleProperty = "boxShadow";
 
 afterEach(() => {
   styleInfo = {};
@@ -99,7 +102,7 @@ describe("boxShadowUtils", () => {
       ],
     };
 
-    deleteLayer(1, layers, createBatchUpdate);
+    deleteLayer(property, 1, layers, createBatchUpdate);
     const boxShadowValue = styleInfo["boxShadow"]?.value as LayersValue;
 
     expect(published).toBe(true);
@@ -159,7 +162,7 @@ describe("boxShadowUtils", () => {
       ],
     };
 
-    deleteLayer(0, layers, createBatchUpdate);
+    deleteLayer(property, 0, layers, createBatchUpdate);
     expect(published).toBe(true);
     expect(deletedProperties.has("boxShadow")).toBe(true);
   });
@@ -190,7 +193,7 @@ describe("boxShadowUtils", () => {
       ],
     };
 
-    hideLayer(0, layers, createBatchUpdate);
+    hideLayer(property, 0, layers, createBatchUpdate);
     const boxShadowValue = styleInfo["boxShadow"]?.value as LayersValue;
 
     expect(published).toBe(true);
@@ -200,8 +203,9 @@ describe("boxShadowUtils", () => {
   });
 
   test("adds layer to box-shadow proeprty", () => {
-    addBoxShadow(
-      `box-shadow: 10px 10px 10px 0px rgba(0, 0, 0, 0.75)`,
+    addLayer(
+      property,
+      parseBoxShadow(`box-shadow: 10px 10px 10px 0px rgba(0, 0, 0, 0.75)`),
       styleInfo,
       createBatchUpdate
     );
@@ -300,20 +304,23 @@ describe("boxShadowUtils", () => {
       ],
     };
 
-    updateBoxShadowLayer(newLayer, oldLayers, 0, createBatchUpdate);
+    updateLayer(property, newLayer, oldLayers, 0, createBatchUpdate);
     const boxShadow = styleInfo["boxShadow"]?.value as LayersValue;
     expect(boxShadow).toBeDefined();
     expect(boxShadow.value[0]).toBe(newLayer.value[0]);
   });
 
   test("swaps the layers using indexe's", () => {
-    addBoxShadow(
-      `box-shadow: 0 60px 80px rgba(0,0,0,0.60), 0 45px 26px rgba(0,0,0,0.14);`,
+    addLayer(
+      property,
+      parseBoxShadow(
+        `box-shadow: 0 60px 80px rgba(0,0,0,0.60), 0 45px 26px rgba(0,0,0,0.14);`
+      ),
       styleInfo,
       createBatchUpdate
     );
 
-    swapLayers(0, 1, styleInfo, createBatchUpdate);
+    swapLayers(property, 0, 1, styleInfo, createBatchUpdate);
     const boxShadow = styleInfo["boxShadow"]?.value as LayersValue;
 
     expect(boxShadow.value[0].value).toMatchInlineSnapshot(`

--- a/apps/builder/app/builder/features/style-panel/style-layer-utils.ts
+++ b/apps/builder/app/builder/features/style-panel/style-layer-utils.ts
@@ -1,12 +1,14 @@
-import type { LayersValue } from "@webstudio-is/css-engine";
-import { parseBoxShadow } from "@webstudio-is/css-data";
-import type { RenderCategoryProps } from "../../style-sections";
-import type { StyleInfo } from "../../shared/style-info";
-import type { CreateBatchUpdate } from "../../shared/use-style-data";
-
-export const property = "boxShadow";
+import type {
+  InvalidValue,
+  LayersValue,
+  StyleProperty,
+} from "@webstudio-is/css-engine";
+import type { RenderCategoryProps } from "./style-sections";
+import type { StyleInfo } from "./shared/style-info";
+import type { CreateBatchUpdate } from "./shared/use-style-data";
 
 export const deleteLayer = (
+  property: StyleProperty,
   index: number,
   layers: LayersValue,
   createBatchUpdate: RenderCategoryProps["createBatchUpdate"]
@@ -33,6 +35,7 @@ export const deleteLayer = (
 };
 
 export const hideLayer = (
+  property: StyleProperty,
   index: number,
   layers: LayersValue,
   createBatchUpdate: RenderCategoryProps["createBatchUpdate"]
@@ -56,14 +59,13 @@ export const hideLayer = (
   batch.publish();
 };
 
-export const addBoxShadow = (
-  shadow: string,
+export const addLayer = (
+  property: StyleProperty,
+  layerValue: LayersValue | InvalidValue,
   style: StyleInfo,
   createBatchUpdate: RenderCategoryProps["createBatchUpdate"]
 ) => {
-  const parsedLayers = parseBoxShadow(shadow);
-  // Will never be invalid, just a TS guard.
-  if (parsedLayers.type === "invalid") {
+  if (layerValue.type === "invalid") {
     return;
   }
 
@@ -72,15 +74,16 @@ export const addBoxShadow = (
   // Initially its none, so we can just set it.
   if (layers?.type === "layers") {
     // Adding layers we had before
-    parsedLayers.value = [...parsedLayers.value, ...layers.value];
+    layerValue.value = [...layerValue.value, ...layers.value];
   }
 
   const batch = createBatchUpdate();
-  batch.setProperty(property)(parsedLayers);
+  batch.setProperty(property)(layerValue);
   batch.publish();
 };
 
-export const updateBoxShadowLayer = (
+export const updateLayer = (
+  property: StyleProperty,
   newValue: LayersValue,
   layers: LayersValue,
   index: number,
@@ -102,25 +105,26 @@ export const updateBoxShadowLayer = (
   batch.publish();
 };
 
-export const getLayerCount = (style: StyleInfo) => {
+export const getLayerCount = (property: StyleProperty, style: StyleInfo) => {
   const value = style[property]?.value;
   const layers = value?.type === "layers" ? value : undefined;
   return layers?.value.length ?? 0;
 };
 
-export const getValue = (style: StyleInfo) => {
+export const getValue = (property: StyleProperty, style: StyleInfo) => {
   const value = style[property]?.value;
   return value?.type === "layers" && value.value.length > 0 ? value : undefined;
 };
 
 export const swapLayers = (
+  property: StyleProperty,
   newIndex: number,
   oldIndex: number,
   style: StyleInfo,
   createBatchUpdate: CreateBatchUpdate
 ) => {
   const batch = createBatchUpdate();
-  const value = getValue(style);
+  const value = getValue(property, style);
 
   if (value === undefined) {
     return;


### PR DESCRIPTION
## Description

I have a separate [branch](https://github.com/webstudio-is/webstudio/tree/add-css-transitions) going for the transitions section. But better to pull out the main changes that are needed, a lot of things go hand-in-hand for shadows and transitions as both are layers based. So, extracting common things out. Please let me know about the naming convention of the file and the location. This felt the best for me, but if needed changes.

Will be doing a series of small ones, by pulling out all the common changes that needed for the both. Next will do with the design components.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
 
- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
 

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document