### PR TITLE
refactor: render ephemeral styles with synced store

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -332,7 +332,7 @@ export const Builder = ({
           isPreviewMode={isPreviewMode}
           css={{ overflow: "hidden" }}
         >
-          <Inspector publish={publish} navigatorLayout={navigatorLayout} />
+          <Inspector navigatorLayout={navigatorLayout} />
         </SidePanel>
         {isPreviewMode === false && <Footer />}
         <BlockingAlerts />

--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -15,7 +15,6 @@ import {
   Flex,
   ScrollArea,
 } from "@webstudio-is/design-system";
-import type { Publish } from "~/shared/pubsub";
 import { StylePanel } from "~/builder/features/style-panel";
 import { SettingsPanelContainer } from "~/builder/features/settings-panel";
 import { FloatingPanelProvider } from "~/builder/shared/floating-panel";
@@ -56,7 +55,6 @@ const InstanceInfo = ({ instance }: { instance: Instance }) => {
 };
 
 type InspectorProps = {
-  publish: Publish;
   navigatorLayout: Settings["navigatorLayout"];
 };
 
@@ -68,7 +66,7 @@ const contentStyle = {
 
 const $isDragging = computed([$dragAndDropState], (state) => state.isDragging);
 
-export const Inspector = ({ publish, navigatorLayout }: InspectorProps) => {
+export const Inspector = ({ navigatorLayout }: InspectorProps) => {
   const selectedInstance = useStore(selectedInstanceStore);
   const tabsRef = useRef<HTMLDivElement>(null);
   const [tab, setTab] = useState("style");
@@ -122,16 +120,12 @@ export const Inspector = ({ publish, navigatorLayout }: InspectorProps) => {
             </PanelTabsList>
             <PanelTabsContent value="style" css={contentStyle} tabIndex={-1}>
               <InstanceInfo instance={selectedInstance} />
-              <StylePanel
-                publish={publish}
-                selectedInstance={selectedInstance}
-              />
+              <StylePanel selectedInstance={selectedInstance} />
             </PanelTabsContent>
             <PanelTabsContent value="settings" css={contentStyle} tabIndex={-1}>
               <ScrollArea>
                 <InstanceInfo instance={selectedInstance} />
                 <SettingsPanelContainer
-                  publish={publish}
                   key={
                     selectedInstance.id /* Re-render when instance changes */
                   }

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -14,7 +14,6 @@ import {
   InputField,
   NestedInputButton,
 } from "@webstudio-is/design-system";
-import type { Publish } from "~/shared/pubsub";
 import {
   dataSourceVariablesStore,
   propsIndexStore,
@@ -200,14 +199,11 @@ export const PropsSection = (props: PropsSectionProps) => {
 
 export const PropsSectionContainer = ({
   selectedInstance: instance,
-  publish,
 }: {
-  publish: Publish;
   selectedInstance: Instance;
 }) => {
   const { setProperty: setCssProperty } = useStyleData({
     selectedInstance: instance,
-    publish,
   });
   const { propsByInstanceId } = useStore(propsIndexStore);
 

--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -1,22 +1,16 @@
 import type { Instance } from "@webstudio-is/sdk";
-import type { Publish } from "~/shared/pubsub";
 import { SettingsSection } from "./settings-section/settings-section";
 import { PropsSectionContainer } from "./props-section/props-section";
 
 export const SettingsPanelContainer = ({
   selectedInstance,
-  publish,
 }: {
-  publish: Publish;
   selectedInstance: Instance;
 }) => {
   return (
     <>
       <SettingsSection />
-      <PropsSectionContainer
-        publish={publish}
-        selectedInstance={selectedInstance}
-      />
+      <PropsSectionContainer selectedInstance={selectedInstance} />
     </>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
@@ -16,7 +16,7 @@ import {
 } from "~/shared/nano-states";
 import { useStyleInfo } from "./style-info";
 import { serverSyncStore } from "~/shared/sync";
-import { $ephemeralStyles } from "~/canvas/shared/styles";
+import { $ephemeralStyles } from "~/canvas/stores";
 
 export type StyleUpdate =
   | {

--- a/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
@@ -6,7 +6,6 @@ import {
   getStyleDeclKey,
 } from "@webstudio-is/sdk";
 import type { StyleProperty, StyleValue } from "@webstudio-is/css-engine";
-import type { Publish } from "~/shared/pubsub";
 import {
   selectedBreakpointStore,
   selectedOrLastStyleSourceSelectorStore,
@@ -38,7 +37,6 @@ type StyleUpdates = {
 };
 
 type UseStyleData = {
-  publish: Publish;
   selectedInstance: Instance;
 };
 
@@ -62,7 +60,7 @@ export type CreateBatchUpdate = () => {
   publish: (options?: StyleUpdateOptions) => void;
 };
 
-export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
+export const useStyleData = ({ selectedInstance }: UseStyleData) => {
   const selectedBreakpoint = useStore(selectedBreakpointStore);
 
   const currentStyle = useStyleInfo();
@@ -144,7 +142,7 @@ export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
         }
       );
     },
-    [publish, selectedBreakpoint, selectedInstance]
+    [selectedBreakpoint, selectedInstance]
   );
 
   const setProperty = useCallback<SetProperty>(

--- a/apps/builder/app/builder/features/style-panel/style-panel.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-panel.tsx
@@ -7,7 +7,6 @@ import {
   ScrollArea,
 } from "@webstudio-is/design-system";
 import type { Instance } from "@webstudio-is/sdk";
-import type { Publish } from "~/shared/pubsub";
 
 import { useStyleData } from "./shared/use-style-data";
 import { StyleSettings } from "./style-settings";
@@ -17,15 +16,13 @@ import { selectedInstanceRenderStateStore } from "~/shared/nano-states";
 import { useStore } from "@nanostores/react";
 
 type StylePanelProps = {
-  publish: Publish;
   selectedInstance: Instance;
 };
 
-export const StylePanel = ({ selectedInstance, publish }: StylePanelProps) => {
+export const StylePanel = ({ selectedInstance }: StylePanelProps) => {
   const { currentStyle, setProperty, deleteProperty, createBatchUpdate } =
     useStyleData({
       selectedInstance,
-      publish,
     });
 
   const selectedInstanceRenderState = useStore(

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useMemo } from "react";
 import { useIsomorphicLayoutEffect } from "react-use";
-import { computed } from "nanostores";
+import { atom, computed } from "nanostores";
 import { useStore } from "@nanostores/react";
 import type { Assets, Instance, StyleDecl } from "@webstudio-is/sdk";
 import {
@@ -32,7 +32,6 @@ import {
   toValue,
   compareMedia,
 } from "@webstudio-is/css-engine";
-import { useSubscribe } from "~/shared/pubsub";
 
 const userCssEngine = createCssEngine({ name: "user-styles" });
 const helpersCssEngine = createCssEngine({ name: "helpers" });
@@ -113,9 +112,66 @@ const subscribePreviewMode = () => {
   };
 };
 
+export const $ephemeralStyles = atom<
+  Array<{
+    instanceId: Instance["id"];
+    breakpointId: StyleDecl["breakpointId"];
+    state: StyleDecl["state"];
+    property: StyleDecl["property"];
+    value: StyleDecl["value"];
+  }>
+>([]);
+
+const subscribeEphemeralStyle = (params: Params) => {
+  // track custom properties added on previous ephemeral styles change
+  const addedCustomProperties = new Set<string>();
+  return $ephemeralStyles.subscribe((ephemeralStyles) => {
+    // track custom properties not set on this change
+    const deletedCustomProperties = new Set(addedCustomProperties);
+
+    const assets = assetsStore.get();
+    const transformer = createImageValueTransformer(assets, {
+      assetBaseUrl: params.assetBaseUrl,
+    });
+    for (const styleDecl of ephemeralStyles) {
+      const { instanceId, breakpointId, state, property, value } = styleDecl;
+      const customProperty = `--${toVarNamespace(instanceId, property)}`;
+      document.body.style.setProperty(
+        customProperty,
+        toValue(value, transformer)
+      );
+      addedCustomProperties.add(customProperty);
+      deletedCustomProperties.delete(customProperty);
+
+      const rule = getOrCreateRule({
+        instanceId,
+        breakpointId,
+        state,
+        assets,
+        params,
+      });
+      // this is possible on newly created instances,
+      // properties are not yet defined in the style.
+      if (rule.styleMap.has(property) === false) {
+        const varValue = toVarValue(instanceId, property, value);
+        if (varValue) {
+          rule.styleMap.set(property, varValue);
+        }
+      }
+    }
+
+    for (const property of deletedCustomProperties) {
+      document.body.style.removeProperty(property);
+      addedCustomProperties.delete(property);
+    }
+
+    // rerender style rules if new vars added
+    userCssEngine.render();
+  });
+};
+
 export const useManageDesignModeStyles = (params: Params) => {
-  useUpdateStyle(params);
-  usePreviewStyle(params);
+  useEffect(() => subscribeEphemeralStyle(params), [params]);
   useEffect(subscribePreviewMode, []);
 };
 
@@ -313,72 +369,4 @@ export const useCssRules = ({
 
 const toVarNamespace = (id: string, property: string) => {
   return `${property}-${id}`;
-};
-
-const setCssVar = (
-  params: Params,
-  id: string,
-  property: string,
-  value?: StyleValue
-) => {
-  const customProperty = `--${toVarNamespace(id, property)}`;
-  if (value === undefined) {
-    document.body.style.removeProperty(customProperty);
-    return;
-  }
-
-  const assets = assetsStore.get();
-  const transformer = createImageValueTransformer(assets, {
-    assetBaseUrl: params.assetBaseUrl,
-  });
-
-  document.body.style.setProperty(customProperty, toValue(value, transformer));
-};
-
-const useUpdateStyle = (params: Params) => {
-  useSubscribe("updateStyle", ({ id, updates }) => {
-    const selectedInstanceSelector = selectedInstanceSelectorStore.get();
-    const selectedInstanceId = selectedInstanceSelector?.[0];
-    // Only update styles if they match the selected instance
-    // It can potentially happen that we selected a difference instance right after we changed the style in style panel.
-    if (id !== selectedInstanceId) {
-      return;
-    }
-
-    for (const update of updates) {
-      setCssVar(params, id, update.property, undefined);
-    }
-  });
-};
-
-const usePreviewStyle = (params: Params) => {
-  useSubscribe("previewStyle", ({ id, updates, breakpoint, state }) => {
-    const rule = getOrCreateRule({
-      instanceId: id,
-      breakpointId: breakpoint.id,
-      state,
-      assets: assetsStore.get(),
-      params,
-    });
-
-    for (const update of updates) {
-      if (update.operation === "set") {
-        // This is possible on newly created instances, properties are not yet defined in the style.
-        if (rule.styleMap.has(update.property) === false) {
-          const varValue = toVarValue(id, update.property, update.value);
-          if (varValue) {
-            rule.styleMap.set(update.property, varValue);
-          }
-        }
-
-        setCssVar(params, id, update.property, update.value);
-      }
-
-      if (update.operation === "delete") {
-        setCssVar(params, id, update.property, undefined);
-      }
-    }
-
-    userCssEngine.render();
-  });
 };

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useMemo } from "react";
 import { useIsomorphicLayoutEffect } from "react-use";
-import { atom, computed } from "nanostores";
+import { computed } from "nanostores";
 import { useStore } from "@nanostores/react";
 import type { Assets, Instance, StyleDecl } from "@webstudio-is/sdk";
 import {
@@ -32,6 +32,7 @@ import {
   toValue,
   compareMedia,
 } from "@webstudio-is/css-engine";
+import { $ephemeralStyles } from "../stores";
 
 const userCssEngine = createCssEngine({ name: "user-styles" });
 const helpersCssEngine = createCssEngine({ name: "helpers" });
@@ -111,16 +112,6 @@ const subscribePreviewMode = () => {
     isRendered = false;
   };
 };
-
-export const $ephemeralStyles = atom<
-  Array<{
-    instanceId: Instance["id"];
-    breakpointId: StyleDecl["breakpointId"];
-    state: StyleDecl["state"];
-    property: StyleDecl["property"];
-    value: StyleDecl["value"];
-  }>
->([]);
 
 const subscribeEphemeralStyle = (params: Params) => {
   // track custom properties added on previous ephemeral styles change

--- a/apps/builder/app/canvas/stores.ts
+++ b/apps/builder/app/canvas/stores.ts
@@ -1,0 +1,12 @@
+import { atom } from "nanostores";
+import type { Instance, StyleDecl } from "@webstudio-is/sdk";
+
+export const $ephemeralStyles = atom<
+  Array<{
+    instanceId: Instance["id"];
+    breakpointId: StyleDecl["breakpointId"];
+    state: StyleDecl["state"];
+    property: StyleDecl["property"];
+    value: StyleDecl["value"];
+  }>
+>([]);

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -32,7 +32,7 @@ import {
   dataSourceVariablesStore,
   $dragAndDropState,
 } from "~/shared/nano-states";
-import { $ephemeralStyles } from "~/canvas/shared/styles";
+import { $ephemeralStyles } from "~/canvas/stores";
 
 enableMapSet();
 

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -32,6 +32,7 @@ import {
   dataSourceVariablesStore,
   $dragAndDropState,
 } from "~/shared/nano-states";
+import { $ephemeralStyles } from "~/canvas/shared/styles";
 
 enableMapSet();
 
@@ -107,6 +108,7 @@ export const registerContainers = () => {
     selectedStyleSourceSelectorStore
   );
   clientStores.set("dragAndDropState", $dragAndDropState);
+  clientStores.set("ephemeralStyles", $ephemeralStyles);
   for (const [name, store] of synchronizedBreakpointsStores) {
     clientStores.set(name, store);
   }


### PR DESCRIPTION
Here replaced updateStyle and previewStyle pubsub events with synchronized $ephemeralStyles store to reduce pubsub spread across the codebase.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
