### PR TITLE
refactor: replace soft delete with delete and invalid state

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
@@ -10,6 +10,7 @@ export const BooleanControl = ({
   meta,
   prop,
   propName,
+  deletable,
   onChange,
   onDelete,
 }: ControlProps<"boolean", "boolean">) => {
@@ -18,7 +19,7 @@ export const BooleanControl = ({
   return (
     <Grid
       css={{
-        gridTemplateColumns: onDelete
+        gridTemplateColumns: deletable
           ? `1fr max-content max-content`
           : `1fr max-content`,
         minHeight: theme.spacing[13],
@@ -35,7 +36,7 @@ export const BooleanControl = ({
         checked={prop?.value ?? false}
         onCheckedChange={(value) => onChange({ type: "boolean", value })}
       />
-      {onDelete && <RemovePropButton onClick={onDelete} />}
+      {deletable && <RemovePropButton onClick={onDelete} />}
     </Grid>
   );
 };

--- a/apps/builder/app/builder/features/settings-panel/controls/check.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/check.tsx
@@ -26,6 +26,7 @@ export const CheckControl = ({
   meta,
   prop,
   propName,
+  deletable,
   onChange,
   onDelete,
 }: ControlProps<"check" | "inline-check" | "multi-select", "string[]">) => {
@@ -46,6 +47,7 @@ export const CheckControl = ({
           {getLabel(meta, propName)}
         </Label>
       }
+      deletable={deletable}
       onDelete={onDelete}
     >
       <Box css={{ paddingTop: theme.spacing[2] }}>

--- a/apps/builder/app/builder/features/settings-panel/controls/code.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/code.tsx
@@ -6,9 +6,9 @@ export const CodeControl = ({
   meta,
   prop,
   propName,
+  deletable,
   onChange,
   onDelete,
-  onSoftDelete,
 }: ControlProps<"code", "string">) => {
   return (
     <TextControl
@@ -19,6 +19,7 @@ export const CodeControl = ({
       }}
       prop={prop}
       propName={propName}
+      deletable={deletable}
       onChange={(value) => {
         if (value.type === "string") {
           // sanitize html before saving
@@ -33,7 +34,6 @@ export const CodeControl = ({
         }
       }}
       onDelete={onDelete}
-      onSoftDelete={onSoftDelete}
     />
   );
 };

--- a/apps/builder/app/builder/features/settings-panel/controls/color.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/color.tsx
@@ -15,6 +15,7 @@ export const ColorControl = ({
   meta,
   prop,
   propName,
+  deletable,
   onChange,
   onDelete,
 }: ControlProps<"color", "string">) => {
@@ -31,6 +32,7 @@ export const ColorControl = ({
           {getLabel(meta, propName)}
         </Label>
       }
+      deletable={deletable}
       onDelete={onDelete}
     >
       <InputField

--- a/apps/builder/app/builder/features/settings-panel/controls/file.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/file.tsx
@@ -43,9 +43,9 @@ export const FileControl = ({
   meta,
   prop,
   propName,
+  deletable,
   onChange,
   onDelete,
-  onSoftDelete,
 }: FileControlProps) => {
   const id = useId();
 
@@ -57,7 +57,7 @@ export const FileControl = ({
       if (value === undefined) {
         return;
       } else if (value === "") {
-        onSoftDelete();
+        onDelete();
       } else {
         onChange({ type: "string", value });
       }
@@ -71,6 +71,7 @@ export const FileControl = ({
           {getLabel(meta, propName)}
         </Label>
       }
+      deletable={deletable}
       onDelete={onDelete}
     >
       <Row>
@@ -81,7 +82,7 @@ export const FileControl = ({
           prop={prop?.type === "asset" ? prop : undefined}
           accept={meta.accept}
           onChange={onChange}
-          onSoftDelete={onSoftDelete}
+          onDelete={onDelete}
         />
       </Row>
     </VerticalLayout>

--- a/apps/builder/app/builder/features/settings-panel/controls/number.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/number.tsx
@@ -6,23 +6,25 @@ import {
   ResponsiveLayout,
   Label,
 } from "../shared";
+import { useState } from "react";
 
 export const NumberControl = ({
   meta,
   prop,
   propName,
   onChange,
+  deletable,
   onDelete,
-  onSoftDelete,
 }: ControlProps<"number", "number">) => {
   const id = useId();
 
+  const [isInvalid, setIsInvalid] = useState(false);
   const localValue = useLocalValue(prop ? prop.value : "", (value) => {
     if (typeof value === "number") {
       onChange({ type: "number", value });
     }
     if (value === "") {
-      onSoftDelete();
+      setIsInvalid(true);
     }
   });
 
@@ -33,15 +35,18 @@ export const NumberControl = ({
           {getLabel(meta, propName)}
         </Label>
       }
+      deletable={deletable}
       onDelete={onDelete}
     >
       <InputField
         id={id}
         type="number"
         value={localValue.value}
-        onChange={({ target: { valueAsNumber, value } }) =>
-          localValue.set(Number.isNaN(valueAsNumber) ? value : valueAsNumber)
-        }
+        color={isInvalid ? "error" : undefined}
+        onChange={({ target: { valueAsNumber, value } }) => {
+          localValue.set(Number.isNaN(valueAsNumber) ? value : valueAsNumber);
+          setIsInvalid(false);
+        }}
         onBlur={localValue.save}
         onKeyDown={(event) => {
           if (event.key === "Enter") {

--- a/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
@@ -13,6 +13,7 @@ export const RadioControl = ({
   meta,
   prop,
   propName,
+  deletable,
   onChange,
   onDelete,
 }: ControlProps<"radio" | "inline-radio", "string">) => {
@@ -31,6 +32,7 @@ export const RadioControl = ({
           {getLabel(meta, propName)}
         </Label>
       }
+      deletable={deletable}
       onDelete={onDelete}
     >
       <Box css={{ paddingTop: theme.spacing[2] }}>

--- a/apps/builder/app/builder/features/settings-panel/controls/select-asset.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/select-asset.tsx
@@ -29,15 +29,10 @@ type Props = {
   accept?: string;
   prop: AssetControlProps["prop"];
   onChange: AssetControlProps["onChange"];
-  onSoftDelete: AssetControlProps["onSoftDelete"];
+  onDelete: AssetControlProps["onDelete"];
 };
 
-export const SelectAsset = ({
-  prop,
-  onChange,
-  onSoftDelete,
-  accept,
-}: Props) => {
+export const SelectAsset = ({ prop, onChange, onDelete, accept }: Props) => {
   const assetStore = useMemo(
     () =>
       computed(assetsStore, (assets) =>
@@ -72,7 +67,7 @@ export const SelectAsset = ({
       {prop ? (
         <SmallIconButton
           icon={<TrashIcon />}
-          onClick={onSoftDelete}
+          onClick={onDelete}
           variant="destructive"
         />
       ) : null}

--- a/apps/builder/app/builder/features/settings-panel/controls/select.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/select.tsx
@@ -6,6 +6,7 @@ export const SelectControl = ({
   meta,
   prop,
   propName,
+  deletable,
   onChange,
   onDelete,
 }: ControlProps<"select", "string">) => {
@@ -24,6 +25,7 @@ export const SelectControl = ({
           {getLabel(meta, propName)}
         </Label>
       }
+      deletable={deletable}
       onDelete={onDelete}
     >
       <Flex css={{ py: theme.spacing[2] }}>

--- a/apps/builder/app/builder/features/settings-panel/controls/text.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text.tsx
@@ -101,6 +101,7 @@ export const TextControl = ({
   meta,
   prop,
   propName,
+  deletable,
   onChange,
   onDelete,
 }: ControlProps<"text", "string">) => {
@@ -131,6 +132,7 @@ export const TextControl = ({
             {label}
           </Label>
         }
+        deletable={deletable}
         onDelete={onDelete}
       >
         <Flex>{input}</Flex>
@@ -145,6 +147,7 @@ export const TextControl = ({
           {label}
         </Label>
       }
+      deletable={deletable}
       onDelete={onDelete}
     >
       <Flex css={{ py: theme.spacing[2] }}>{input}</Flex>

--- a/apps/builder/app/builder/features/settings-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/url.tsx
@@ -37,7 +37,7 @@ type BaseControlProps = {
   instanceId: string;
   prop: UrlControlProps["prop"];
   onChange: UrlControlProps["onChange"];
-  onSoftDelete: UrlControlProps["onSoftDelete"];
+  onDelete: UrlControlProps["onDelete"];
 };
 
 const Row = ({ children }: { children: ReactNode }) => (
@@ -334,12 +334,12 @@ const BasePage = ({ prop, onChange }: BaseControlProps) => {
   );
 };
 
-const BaseAttachment = ({ prop, onChange, onSoftDelete }: BaseControlProps) => (
+const BaseAttachment = ({ prop, onChange, onDelete }: BaseControlProps) => (
   <Row>
     <SelectAsset
       prop={prop?.type === "asset" ? prop : undefined}
       onChange={onChange}
-      onSoftDelete={onSoftDelete}
+      onDelete={onDelete}
     />
   </Row>
 );
@@ -387,9 +387,9 @@ export const UrlControl = ({
   meta,
   prop,
   propName,
+  deletable,
   onChange,
   onDelete,
-  onSoftDelete,
 }: UrlControlProps) => {
   const [mode, setMode] = useState<Mode>(propToMode(prop));
 
@@ -404,6 +404,7 @@ export const UrlControl = ({
           {getLabel(meta, propName)}
         </Label>
       }
+      deletable={deletable}
       onDelete={onDelete}
     >
       <Flex
@@ -437,7 +438,7 @@ export const UrlControl = ({
         instanceId={instanceId}
         prop={prop}
         onChange={onChange}
-        onSoftDelete={onSoftDelete}
+        onDelete={onDelete}
       />
     </VerticalLayout>
   );

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -104,10 +104,8 @@ const renderProperty = (
     meta,
     prop,
     propName,
-    onDelete: deletable
-      ? () => logic.handleDelete({ prop, propName })
-      : undefined,
-    onSoftDelete: () => prop && logic.handleSoftDelete(prop),
+    deletable: deletable ?? false,
+    onDelete: () => logic.handleDelete({ prop, propName }),
     onChange: (propValue, asset) => {
       logic.handleChange({ prop, propName }, propValue);
 

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -293,16 +293,10 @@ export const usePropsLogic = ({
     setAddedNames((prev) => prev.filter((name) => propName !== name));
   };
 
-  const handleSoftDelete = (prop: Prop) => {
-    deleteProp(prop.id);
-  };
-
   return {
     handleAdd,
     handleChange,
     handleDelete,
-    /** Delete the prop, but keep it in the list of added props */
-    handleSoftDelete,
     handleChangeByPropName,
     meta,
     /** Similar to Initial, but displayed as a separate group in UI etc.

--- a/apps/builder/app/builder/features/settings-panel/settings-section/settings-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-section/settings-section.tsx
@@ -26,7 +26,11 @@ export const SettingsSection = () => {
 
   return (
     <Row>
-      <HorizontalLayout label={<Label htmlFor={id}>Name</Label>}>
+      <HorizontalLayout
+        label={<Label htmlFor={id}>Name</Label>}
+        deletable={false}
+        onDelete={() => {}}
+      >
         <InputField
           id={id}
           /* Key is required, otherwise when label is undefined, previous value stayed */

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -46,12 +46,9 @@ export type ControlProps<Control, PropType> = {
   // and we don't want to show user something like a 0 for number when it's in fact not set to any value
   prop: PropByType<PropType> | undefined;
   propName: string;
+  deletable: boolean;
   onChange: (value: PropValue, asset?: Asset) => void;
-  onDelete?: () => void;
-
-  // Should be called when we want to delete the prop,
-  // but want to keep it in the list until panel is closed
-  onSoftDelete: () => void;
+  onDelete: () => void;
 };
 
 export const getLabel = (meta: { label?: string }, fallback: string) =>
@@ -178,15 +175,21 @@ export const useLocalValue = <Type,>(
 
 type LayoutProps = {
   label: ReturnType<typeof Label>;
-  onDelete?: () => void;
+  deletable: boolean;
+  onDelete: () => void;
   children: ReactNode;
 };
 
-export const VerticalLayout = ({ label, onDelete, children }: LayoutProps) => (
+export const VerticalLayout = ({
+  label,
+  deletable,
+  onDelete,
+  children,
+}: LayoutProps) => (
   <Box>
     <Grid
       css={{
-        gridTemplateColumns: onDelete ? `1fr max-content` : `1fr`,
+        gridTemplateColumns: deletable ? `1fr max-content` : `1fr`,
         justifyItems: "start",
       }}
       align="center"
@@ -194,7 +197,7 @@ export const VerticalLayout = ({ label, onDelete, children }: LayoutProps) => (
       justify="between"
     >
       {label}
-      {onDelete && <RemovePropButton onClick={onDelete} />}
+      {deletable && <RemovePropButton onClick={onDelete} />}
     </Grid>
     {children}
   </Box>
@@ -202,12 +205,13 @@ export const VerticalLayout = ({ label, onDelete, children }: LayoutProps) => (
 
 export const HorizontalLayout = ({
   label,
+  deletable,
   onDelete,
   children,
 }: LayoutProps) => (
   <Grid
     css={{
-      gridTemplateColumns: onDelete
+      gridTemplateColumns: deletable
         ? `${theme.spacing[19]} 1fr max-content`
         : `${theme.spacing[19]} 1fr`,
       minHeight: theme.spacing[13],
@@ -218,12 +222,13 @@ export const HorizontalLayout = ({
   >
     {label}
     {children}
-    {onDelete && <RemovePropButton onClick={onDelete} />}
+    {deletable && <RemovePropButton onClick={onDelete} />}
   </Grid>
 );
 
 export const ResponsiveLayout = ({
   label,
+  deletable,
   onDelete,
   children,
 }: LayoutProps) => {
@@ -231,13 +236,13 @@ export const ResponsiveLayout = ({
   // might not cover all cases though
   if (label.props.children.length <= 8) {
     return (
-      <HorizontalLayout label={label} onDelete={onDelete}>
+      <HorizontalLayout label={label} deletable={deletable} onDelete={onDelete}>
         {children}
       </HorizontalLayout>
     );
   }
   return (
-    <VerticalLayout label={label} onDelete={onDelete}>
+    <VerticalLayout label={label} deletable={deletable} onDelete={onDelete}>
       {children}
     </VerticalLayout>
   );

--- a/packages/design-system/src/components/input-field.tsx
+++ b/packages/design-system/src/components/input-field.tsx
@@ -72,6 +72,10 @@ const containerStyle = css({
   "&:has([data-input-field-input][data-color=error])": {
     borderColor: theme.colors.borderDestructiveMain,
   },
+  "&:has([data-input-field-input][data-color=error]:focus), &[data-color=error]:focus":
+    {
+      outlineColor: theme.colors.borderDestructiveMain,
+    },
 
   "&:has([data-input-field-input]:disabled)": {
     backgroundColor: theme.colors.backgroundInputDisabled,


### PR DESCRIPTION
Here dropped soft delete because it does not play well with history. Instead numbers now get invalid state when input is empty and other cases just delete prop.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
