### PR TITLE
refactor: move click canvas event to commands

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
@@ -21,7 +21,6 @@ import {
   PopoverMenuItemContainer,
   PopoverMenuItemRightSlot,
 } from "@webstudio-is/design-system";
-import { useSubscribe } from "~/shared/pubsub";
 import { BreakpointsEditor } from "./breakpoints-editor";
 import { BreakpointsPopoverToolbarButton } from "./breakpoints-popover-toolbar-button";
 import { WidthInput } from "./width-input";
@@ -51,10 +50,6 @@ export const BreakpointsPopover = () => {
   const selectedBreakpoint = useStore(selectedBreakpointStore);
   const scale = useStore(scaleStore);
   const setInitialCanvasWidth = useSetInitialCanvasWidth();
-
-  useSubscribe("clickCanvas", () => {
-    $breakpointsMenuView.set(undefined);
-  });
 
   if (selectedBreakpoint === undefined) {
     return null;

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -21,7 +21,6 @@ import {
   PlusIcon,
 } from "@webstudio-is/icons";
 import type { Page, Pages } from "@webstudio-is/sdk";
-import type { Publish } from "~/shared/pubsub";
 import type { TabName } from "../../types";
 import { CloseButton, Header } from "../../header";
 import { SettingsPanel } from "./settings-panel";
@@ -31,7 +30,6 @@ import { switchPage } from "~/shared/pages";
 
 type TabContentProps = {
   onSetActiveTab: (tabName: TabName) => void;
-  publish: Publish;
 };
 
 type PagesTreeNode =

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -18,6 +18,7 @@ import { AiIcon, BugIcon, HelpIcon } from "@webstudio-is/icons";
 import { HelpPopover } from "./help-popover";
 import { useStore } from "@nanostores/react";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
+import { $activeSidebarPanel } from "~/builder/shared/nano-states";
 
 const none = { TabContent: () => null };
 
@@ -27,16 +28,13 @@ type SidebarLeftProps = {
 
 export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
   const dragAndDropState = useStore($dragAndDropState);
-  const [activeTab, setActiveTab] = useState<TabName>("none");
+  const activeTab = useStore($activeSidebarPanel);
   const { TabContent } = activeTab === "none" ? none : panels[activeTab];
   const [helpIsOpen, setHelpIsOpen] = useState(false);
   const [clientSettings, setClientSetting] = useClientSettings();
 
-  useSubscribe("clickCanvas", () => {
-    setActiveTab("none");
-  });
   useSubscribe("dragEnd", () => {
-    setActiveTab("none");
+    $activeSidebarPanel.set("none");
   });
 
   const enabledPanels = (Object.keys(panels) as Array<TabName>).filter(
@@ -59,7 +57,9 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
               key={tabName}
               value={tabName}
               onClick={() => {
-                setActiveTab(activeTab !== tabName ? tabName : "none");
+                $activeSidebarPanel.set(
+                  activeTab !== tabName ? tabName : "none"
+                );
               }}
             >
               {tabName === "none" ? null : panels[tabName].icon}
@@ -134,7 +134,10 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
                 : "visible",
           }}
         >
-          <TabContent publish={publish} onSetActiveTab={setActiveTab} />
+          <TabContent
+            publish={publish}
+            onSetActiveTab={$activeSidebarPanel.set}
+          />
         </SidebarTabsContent>
       </SidebarTabs>
     </Flex>

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -16,6 +16,7 @@ import { deleteInstance } from "~/shared/instance-utils";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { serverSyncStore } from "~/shared/sync";
 import { $publisher } from "~/shared/pubsub";
+import { $activeSidebarPanel } from "./nano-states";
 
 const makeBreakpointCommand = <CommandName extends string>(
   name: CommandName,
@@ -89,6 +90,13 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       handler: () => {
         const { publish } = $publisher.get();
         publish?.({ type: "cancelCurrentDrag" });
+      },
+    },
+    {
+      name: "clickCanvas",
+      handler: () => {
+        $breakpointsMenuView.set(undefined);
+        $activeSidebarPanel.set("none");
       },
     },
 

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -1,5 +1,6 @@
 import { atom, computed, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
+import type { TabName } from "~/builder/features/sidebar-left/types";
 
 const useValue = <T>(atom: WritableAtom<T>) => {
   const value = useStore(atom);
@@ -34,3 +35,5 @@ export const scaleStore = computed(
     );
   }
 );
+
+export const $activeSidebarPanel = atom<TabName>("none");

--- a/apps/builder/app/canvas/instance-selection.ts
+++ b/apps/builder/app/canvas/instance-selection.ts
@@ -7,13 +7,7 @@ import {
   selectedStyleSourceSelectorStore,
 } from "~/shared/nano-states";
 import { textEditingInstanceSelectorStore } from "~/shared/nano-states";
-import { publish } from "~/shared/pubsub";
-
-declare module "~/shared/pubsub" {
-  export interface PubsubMap {
-    clickCanvas: undefined;
-  }
-}
+import { emitCommand } from "./shared/commands";
 
 export const subscribeInstanceSelection = () => {
   let pointerDownElement: undefined | Element = undefined;
@@ -49,7 +43,7 @@ export const subscribeInstanceSelection = () => {
     if (clickCount === 1) {
       // notify whole app about click on document
       // e.g. to hide the side panel
-      publish({ type: "clickCanvas" });
+      emitCommand("clickCanvas");
     }
 
     // prevent selecting instances inside text editor while editing text

--- a/apps/builder/app/canvas/shared/commands.ts
+++ b/apps/builder/app/canvas/shared/commands.ts
@@ -19,6 +19,7 @@ import {
 
 export const { emitCommand, subscribeCommands } = createCommandsEmitter({
   source: "canvas",
+  externalCommands: ["clickCanvas"],
   commands: [
     {
       name: "editInstanceText",


### PR DESCRIPTION
One less pubsub event replaced with clickCanvas.
Added store for sidebar active panel to manage from commands.

## Steps for reproduction

1. close breakpoints menu by clicking on canvas
2. close sidebar panel by clicking on canvas

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
