### PR TITLE
refactor: unify pubsub and support multiple iframes

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, type ReactNode } from "react";
 import { useStore } from "@nanostores/react";
 import { useUnmount } from "react-use";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
-import { usePublish, $publisher } from "~/shared/pubsub";
 import type { Asset } from "@webstudio-is/sdk";
 import type { Build } from "@webstudio-is/project-build";
 import type { Project } from "@webstudio-is/project";
@@ -261,12 +260,7 @@ export const Builder = ({
 
   useSyncPageUrl();
 
-  const [publish, publishRef] = usePublish();
-  useEffect(() => {
-    $publisher.set({ publish });
-  }, [publish]);
-
-  useBuilderStore(publish);
+  useBuilderStore();
   useSyncServer({
     buildId: build.id,
     projectId: project.id,
@@ -283,10 +277,9 @@ export const Builder = ({
   useSetWindowTitle();
   const iframeRefCallback = useCallback(
     (element: HTMLIFrameElement) => {
-      publishRef.current = element;
       onRefReadCanvas(element);
     },
-    [publishRef, onRefReadCanvas]
+    [onRefReadCanvas]
   );
 
   const navigatorLayout = useNavigatorLayout();
@@ -321,7 +314,7 @@ export const Builder = ({
           )}
         </Main>
         <SidePanel gridArea="sidebar" isPreviewMode={isPreviewMode}>
-          <SidebarLeft publish={publish} />
+          <SidebarLeft />
         </SidePanel>
         <NavigatorPanel
           isPreviewMode={isPreviewMode}

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -14,7 +14,6 @@ import {
   ScrollArea,
 } from "@webstudio-is/design-system";
 import { PlusIcon } from "@webstudio-is/icons";
-import type { Publish } from "~/shared/pubsub";
 import { CollapsibleSection } from "~/builder/shared/collapsible-section";
 import type { TabName } from "../../types";
 import { Header, CloseButton } from "../../header";
@@ -30,17 +29,15 @@ import { getInstanceLabel } from "~/shared/instance-utils";
 
 type TabContentProps = {
   onSetActiveTab: (tabName: TabName) => void;
-  publish: Publish;
 };
 
-export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
+export const TabContent = ({ onSetActiveTab }: TabContentProps) => {
   const metaByComponentName = useStore(registeredComponentMetasStore);
   const { metaByCategory, componentNamesByMeta } = useMemo(
     () => getMetaMaps(metaByComponentName),
     [metaByComponentName]
   );
   const { dragCard, handleInsert, draggableContainerRef } = useDraggable({
-    publish,
     metaByComponentName,
   });
   const { pressProps } = usePress({

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
@@ -17,7 +17,7 @@ import {
   selectedInstanceSelectorStore,
   selectedPageStore,
 } from "~/shared/nano-states";
-import { useSubscribe, type Publish } from "~/shared/pubsub";
+import { publish, useSubscribe } from "~/shared/pubsub";
 import { $canvasRect, scaleStore } from "~/builder/shared/nano-states";
 import {
   computeInstancesConstraints,
@@ -117,10 +117,8 @@ const formatInsertionError = (component: string, meta: WsComponentMeta) => {
 };
 
 export const useDraggable = ({
-  publish,
   metaByComponentName,
 }: {
-  publish: Publish;
   metaByComponentName: Map<string, WsComponentMeta>;
 }) => {
   const [dragComponent, setDragComponent] = useState<Instance["component"]>();

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -7,7 +7,7 @@ import {
   SidebarTabsTrigger,
   Tooltip,
 } from "@webstudio-is/design-system";
-import { useSubscribe, type Publish } from "~/shared/pubsub";
+import { useSubscribe } from "~/shared/pubsub";
 import { $dragAndDropState } from "~/shared/nano-states";
 import { panels } from "./panels";
 import type { TabName } from "./types";
@@ -22,11 +22,7 @@ import { $activeSidebarPanel } from "~/builder/shared/nano-states";
 
 const none = { TabContent: () => null };
 
-type SidebarLeftProps = {
-  publish: Publish;
-};
-
-export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
+export const SidebarLeft = () => {
   const dragAndDropState = useStore($dragAndDropState);
   const activeTab = useStore($activeSidebarPanel);
   const { TabContent } = activeTab === "none" ? none : panels[activeTab];
@@ -134,10 +130,7 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
                 : "visible",
           }}
         >
-          <TabContent
-            publish={publish}
-            onSetActiveTab={$activeSidebarPanel.set}
-          />
+          <TabContent onSetActiveTab={$activeSidebarPanel.set} />
         </SidebarTabsContent>
       </SidebarTabs>
     </Flex>

--- a/apps/builder/app/builder/features/workspace/canvas-iframe.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-iframe.tsx
@@ -1,9 +1,11 @@
-import { forwardRef, useEffect, useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import {
   type CSS,
   css,
   canvasPointerEventsPropertyName,
 } from "@webstudio-is/design-system";
+import { mergeRefs } from "@react-aria/utils";
+import { registerIframe } from "~/shared/pubsub";
 
 const iframeStyle = css({
   border: "none",
@@ -14,19 +16,34 @@ type CanvasIframeProps = {
   css: CSS;
 } & JSX.IntrinsicElements["iframe"];
 
-export const CanvasIframe = forwardRef<HTMLIFrameElement, CanvasIframeProps>(
+const PublishableIframe = forwardRef<HTMLIFrameElement, CanvasIframeProps>(
   ({ css, ...rest }, ref) => {
+    const publishIframeRef = useRef<HTMLIFrameElement>(null);
+    useEffect(() => {
+      const element = publishIframeRef.current;
+      if (element) {
+        return registerIframe(element);
+      }
+    }, []);
+    return (
+      <iframe
+        {...rest}
+        className={iframeStyle({ css })}
+        ref={mergeRefs(ref, publishIframeRef)}
+      />
+    );
+  }
+);
+
+export const CanvasIframe = forwardRef<HTMLIFrameElement, CanvasIframeProps>(
+  (props, ref) => {
     // initialize canvas after builder is rendered
     // and synchronizatio is initialized
     const [isInitialized, setInitialized] = useState(false);
     useEffect(() => {
       setInitialized(true);
     }, []);
-    return (
-      isInitialized && (
-        <iframe {...rest} ref={ref} className={iframeStyle({ css })} />
-      )
-    );
+    return isInitialized && <PublishableIframe {...props} ref={ref} />;
   }
 );
 

--- a/apps/builder/app/builder/features/workspace/canvas-iframe.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-iframe.tsx
@@ -35,6 +35,8 @@ const PublishableIframe = forwardRef<HTMLIFrameElement, CanvasIframeProps>(
   }
 );
 
+PublishableIframe.displayName = "PublishableIframe";
+
 export const CanvasIframe = forwardRef<HTMLIFrameElement, CanvasIframeProps>(
   (props, ref) => {
     // initialize canvas after builder is rendered

--- a/apps/builder/app/builder/shared/commands.test.ts
+++ b/apps/builder/app/builder/shared/commands.test.ts
@@ -23,6 +23,7 @@ const metas = new Map(Object.entries(baseMetas));
 
 globalThis.document = {
   addEventListener: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
 subscribeCommands();
 

--- a/apps/builder/app/builder/shared/commands.test.ts
+++ b/apps/builder/app/builder/shared/commands.test.ts
@@ -7,7 +7,7 @@ import {
   selectedInstanceSelectorStore,
 } from "~/shared/nano-states";
 import { registerContainers } from "~/shared/sync";
-import { emitCommand } from "./commands";
+import { emitCommand, subscribeCommands } from "./commands";
 
 registerContainers();
 
@@ -20,6 +20,11 @@ const createInstancePair = (
 };
 
 const metas = new Map(Object.entries(baseMetas));
+
+globalThis.document = {
+  addEventListener: () => {},
+} as any;
+subscribeCommands();
 
 describe("deleteInstance", () => {
   // body

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -15,7 +15,7 @@ import { onCopy, onPaste } from "~/shared/copy-paste/plugin-instance";
 import { deleteInstance } from "~/shared/instance-utils";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { serverSyncStore } from "~/shared/sync";
-import { $publisher } from "~/shared/pubsub";
+import { publish } from "~/shared/pubsub";
 import { $activeSidebarPanel } from "./nano-states";
 
 const makeBreakpointCommand = <CommandName extends string>(
@@ -88,8 +88,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "cancelCurrentDrag",
       defaultHotkeys: ["escape"],
       handler: () => {
-        const { publish } = $publisher.get();
-        publish?.({ type: "cancelCurrentDrag" });
+        publish({ type: "cancelCurrentDrag" });
       },
     },
     {

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -20,7 +20,6 @@ import * as radixComponents from "@webstudio-is/sdk-components-react-radix";
 import * as radixComponentMetas from "@webstudio-is/sdk-components-react-radix/metas";
 import * as radixComponentPropsMetas from "@webstudio-is/sdk-components-react-radix/props";
 import { hooks as radixComponentHooks } from "@webstudio-is/sdk-components-react-radix/hooks";
-import { $publisher, publish } from "~/shared/pubsub";
 import { registerContainers, useCanvasStore } from "~/shared/sync";
 import { useManageDesignModeStyles, GlobalStyles } from "./shared/styles";
 import {
@@ -168,7 +167,7 @@ export const Canvas = ({
   params,
   imageLoader,
 }: CanvasProps): JSX.Element | null => {
-  useCanvasStore(publish);
+  useCanvasStore();
   const isPreviewMode = useStore($isPreviewMode);
 
   useMount(() => {
@@ -194,10 +193,6 @@ export const Canvas = ({
   useEffect(subscribeComponentHooks, []);
 
   useEffect(subscribeCommands, []);
-
-  useEffect(() => {
-    $publisher.set({ publish });
-  }, []);
 
   const selectedPage = useStore(selectedPageStore);
 

--- a/apps/builder/app/shared/commands-emitter.ts
+++ b/apps/builder/app/shared/commands-emitter.ts
@@ -1,6 +1,6 @@
 import { isHotkeyPressed } from "react-hotkeys-hook";
 import { atom } from "nanostores";
-import { $publisher, subscribe } from "~/shared/pubsub";
+import { publish, subscribe } from "~/shared/pubsub";
 import { clientSyncStore } from "~/shared/sync";
 
 type CommandMeta<CommandName extends string> = {
@@ -99,20 +99,13 @@ export const createCommandsEmitter = <CommandName extends string>({
   }
 
   const emitCommand = (name: CommandName) => {
-    const { publish } = $publisher.get();
-    // continue to work without emitter
-    // for example in tests
-    if (publish) {
-      publish({
-        type: "command",
-        payload: {
-          source,
-          name,
-        },
-      });
-    } else {
-      commandHandlers.get(name)?.();
-    }
+    publish({
+      type: "command",
+      payload: {
+        source,
+        name,
+      },
+    });
   };
 
   /**

--- a/apps/builder/app/shared/pubsub/index.ts
+++ b/apps/builder/app/shared/pubsub/index.ts
@@ -9,4 +9,3 @@ export interface PubsubMap {
 
 export const { registerIframe, publish, useSubscribe, subscribe } =
   createPubsub<PubsubMap>();
-export type Publish = typeof publish;

--- a/apps/builder/app/shared/pubsub/index.ts
+++ b/apps/builder/app/shared/pubsub/index.ts
@@ -1,4 +1,3 @@
-import { atom } from "nanostores";
 import { createPubsub } from "./create";
 
 export interface PubsubMap {
@@ -8,9 +7,6 @@ export interface PubsubMap {
   };
 }
 
-export const { publish, usePublish, useSubscribe, subscribe } =
+export const { registerIframe, publish, useSubscribe, subscribe } =
   createPubsub<PubsubMap>();
 export type Publish = typeof publish;
-export type UsePublish = typeof usePublish;
-
-export const $publisher = atom<{ publish?: Publish }>({});

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -3,7 +3,7 @@ import { Store, type Change } from "immerhin";
 import { enableMapSet } from "immer";
 import type { WritableAtom } from "nanostores";
 import { useEffect } from "react";
-import { type Publish, subscribe } from "~/shared/pubsub";
+import { publish, subscribe } from "~/shared/pubsub";
 import {
   projectStore,
   pagesStore,
@@ -136,7 +136,7 @@ export const registerContainers = () => {
   }
 };
 
-const syncStoresChanges = (name: SyncEventSource, publish: Publish) => {
+const syncStoresChanges = (name: SyncEventSource) => {
   const unsubscribeRemoteChanges = subscribe(
     "sendStoreChanges",
     ({ source, namespace, changes }) => {
@@ -196,7 +196,7 @@ const syncStoresChanges = (name: SyncEventSource, publish: Publish) => {
   };
 };
 
-const syncStoresState = (name: SyncEventSource, publish: Publish) => {
+const syncStoresState = (name: SyncEventSource) => {
   const latestData = new Map<string, unknown>();
 
   const unsubscribeRemoteChanges = subscribe(
@@ -265,7 +265,7 @@ const syncStoresState = (name: SyncEventSource, publish: Publish) => {
   };
 };
 
-export const useCanvasStore = (publish: Publish) => {
+export const useCanvasStore = () => {
   useEffect(() => {
     // connect to builder to get latest changes
     publish({
@@ -294,8 +294,8 @@ export const useCanvasStore = (publish: Publish) => {
 
     // subscribe stores after connect even so builder is ready to receive
     // changes from immerhin queue
-    const unsubscribeStoresState = syncStoresState("canvas", publish);
-    const unsubscribeStoresChanges = syncStoresChanges("canvas", publish);
+    const unsubscribeStoresState = syncStoresState("canvas");
+    const unsubscribeStoresChanges = syncStoresChanges("canvas");
 
     return () => {
       publish({
@@ -305,10 +305,10 @@ export const useCanvasStore = (publish: Publish) => {
       unsubscribeStoresState();
       unsubscribeStoresChanges();
     };
-  }, [publish]);
+  }, []);
 };
 
-export const useBuilderStore = (publish: Publish) => {
+export const useBuilderStore = () => {
   useEffect(() => {
     let unsubscribeStoresState: undefined | (() => void);
     let unsubscribeStoresChanges: undefined | (() => void);
@@ -317,8 +317,8 @@ export const useBuilderStore = (publish: Publish) => {
       // changes from immerhin queue
       // @todo subscribe prematurely and compute initial changes
       // from current state whenever new app is connected
-      unsubscribeStoresState = syncStoresState("builder", publish);
-      unsubscribeStoresChanges = syncStoresChanges("builder", publish);
+      unsubscribeStoresState = syncStoresState("builder");
+      unsubscribeStoresChanges = syncStoresChanges("builder");
       // immerhin data is sent only initially so not part of syncStoresState
       // expect data to be populated by the time effect is called
       const data = [];

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -356,5 +356,5 @@ export const useBuilderStore = () => {
       unsubscribeStoresState?.();
       unsubscribeStoresChanges?.();
     };
-  }, [publish]);
+  }, []);
 };


### PR DESCRIPTION
Here refactored our pubsub. Now iframes are registered instead of bounding to specific usePublish. This let us broadcast actions to multiple plugins with global publish call.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
