### PR TITLE
refactor: split instances slice into separate utility

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -2,7 +2,6 @@ import { shallowEqual } from "shallow-equal";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { toast } from "@webstudio-is/design-system";
-import { findTreeInstanceIds } from "@webstudio-is/sdk";
 import {
   Asset,
   Breakpoint,
@@ -12,13 +11,11 @@ import {
   StyleDecl,
   StyleSource,
   StyleSourceSelection,
-  StyleSourceSelections,
 } from "@webstudio-is/sdk";
 import {
   encodeDataSourceVariable,
   validateExpression,
   decodeDataSourceVariable,
-  computeExpressionsDependencies,
 } from "@webstudio-is/react-sdk";
 import {
   propsStore,
@@ -33,7 +30,6 @@ import {
   projectStore,
   registeredComponentMetasStore,
   dataSourcesStore,
-  dataSourcesLogicStore,
 } from "../nano-states";
 import {
   type InstanceSelector,
@@ -50,9 +46,9 @@ import {
   computeInstancesConstraints,
   deleteInstance,
   findClosestDroppableTarget,
+  getInstancesSlice,
   isInstanceDetachable,
 } from "../instance-utils";
-import { getMapValuesBy, getMapValuesByKeysSet } from "../array-utils";
 import { serverSyncStore } from "../sync";
 
 const version = "@webstudio/instance/v0.1";
@@ -71,114 +67,6 @@ const InstanceData = z.object({
 
 type InstanceData = z.infer<typeof InstanceData>;
 
-const findTreeStyleSourceIds = (
-  styleSourceSelections: StyleSourceSelections,
-  treeInstanceIds: Set<Instance["id"]>
-) => {
-  const treeStyleSourceIds = new Set<StyleSource["id"]>();
-  for (const { instanceId, values } of styleSourceSelections.values()) {
-    // skip selections outside of tree
-    if (treeInstanceIds.has(instanceId) === false) {
-      continue;
-    }
-    for (const styleSourceId of values) {
-      treeStyleSourceIds.add(styleSourceId);
-    }
-  }
-  return treeStyleSourceIds;
-};
-
-const getAssetsUsedInStyle = (
-  style: StyleDecl[],
-  foundAssetsIds = new Set<Asset["id"]>()
-) => {
-  const fontFamilies = new Set<string>();
-
-  const processValues = (values: StyleDecl["value"][]) => {
-    for (const value of values) {
-      if (value.type === "fontFamily") {
-        for (const fontFamily of value.value) {
-          fontFamilies.add(fontFamily);
-        }
-        continue;
-      }
-      if (value.type === "image") {
-        if (value.value.type === "asset") {
-          foundAssetsIds.add(value.value.value);
-        }
-        continue;
-      }
-      if (value.type === "var") {
-        processValues(value.fallbacks);
-        continue;
-      }
-      if (value.type === "tuple" || value.type === "layers") {
-        processValues(value.value);
-        continue;
-      }
-      if (
-        value.type === "unit" ||
-        value.type === "keyword" ||
-        value.type === "unparsed" ||
-        value.type === "invalid" ||
-        value.type === "unset" ||
-        value.type === "rgb"
-      ) {
-        continue;
-      }
-      value satisfies never;
-    }
-  };
-
-  processValues(style.map(({ value }) => value));
-
-  for (const asset of assetsStore.get().values()) {
-    if (asset?.type === "font" && fontFamilies.has(asset.meta.family)) {
-      foundAssetsIds.add(asset.id);
-    }
-  }
-
-  return foundAssetsIds;
-};
-
-const getAssetsUsedInProps = (props: Prop[], foundAssetsIds = new Set()) => {
-  for (const prop of props) {
-    if (prop.type === "asset") {
-      foundAssetsIds.add(prop.value);
-      continue;
-    }
-    if (
-      prop.type === "number" ||
-      prop.type === "string" ||
-      prop.type === "boolean" ||
-      prop.type === "page" ||
-      prop.type === "string[]" ||
-      prop.type === "dataSource" ||
-      prop.type === "action"
-    ) {
-      continue;
-    }
-    prop satisfies never;
-  }
-  return foundAssetsIds;
-};
-
-const getPropTypeAndValue = (value: unknown) => {
-  if (typeof value === "boolean") {
-    return { type: "boolean", value } as const;
-  }
-  if (typeof value === "number") {
-    return { type: "number", value } as const;
-  }
-  if (typeof value === "string") {
-    return { type: "string", value } as const;
-  }
-  if (Array.isArray(value)) {
-    return { type: "string[]", value } as const;
-  }
-  throw Error(`Unexpected prop value ${value}`);
-};
-
 const getTreeData = (targetInstanceSelector: InstanceSelector) => {
   if (isInstanceDetachable(targetInstanceSelector) === false) {
     toast.error(
@@ -193,165 +81,10 @@ const getTreeData = (targetInstanceSelector: InstanceSelector) => {
   }
 
   const [targetInstanceId] = targetInstanceSelector;
-  const instances = instancesStore.get();
-  const treeInstanceIds = findTreeInstanceIds(instances, targetInstanceId);
-  const styleSourceSelections = styleSourceSelectionsStore.get();
-  const treeStyleSourceIds = findTreeStyleSourceIds(
-    styleSourceSelections,
-    treeInstanceIds
-  );
-
-  // first item is guaranteed root of copied tree
-  const treeInstances = getMapValuesByKeysSet(instances, treeInstanceIds);
-
-  const dataSources = dataSourcesStore.get();
-  const expressions = new Map<string, string>();
-  for (const dataSource of dataSources.values()) {
-    if (dataSource.type === "expression") {
-      expressions.set(encodeDataSourceVariable(dataSource.id), dataSource.code);
-    }
-  }
-  const dependencies = computeExpressionsDependencies(expressions);
-
-  const treeDataSources = getMapValuesBy(dataSources, (dataSource) => {
-    if (dataSource.type === "expression") {
-      const expressionDeps = dependencies.get(
-        encodeDataSourceVariable(dataSource.id)
-      );
-      if (expressionDeps) {
-        for (const dependency of expressionDeps) {
-          const dataSourceId = decodeDataSourceVariable(dependency);
-          if (dataSourceId === undefined) {
-            continue;
-          }
-          const dataSource = dataSources.get(dataSourceId);
-          if (dataSource === undefined) {
-            continue;
-          }
-          if (
-            dataSource.scopeInstanceId === undefined ||
-            treeInstanceIds.has(dataSource.scopeInstanceId) === false
-          ) {
-            return false;
-          }
-        }
-      }
-    }
-    return (
-      dataSource.scopeInstanceId !== undefined &&
-      treeInstanceIds.has(dataSource.scopeInstanceId)
-    );
-  });
-  const treeDataSourceIds = new Set(
-    treeDataSources.map((dataSource) => dataSource.id)
-  );
-
-  const dataSourcesLogic = dataSourcesLogicStore.get();
-  const treeProps = getMapValuesBy(propsStore.get(), (prop) =>
-    treeInstanceIds.has(prop.instanceId)
-  ).map((prop) => {
-    if (prop.type === "dataSource") {
-      const dataSourceId = prop.value;
-      // copy data source if scoped to one of copied instances
-      if (treeDataSourceIds.has(dataSourceId)) {
-        return prop;
-      }
-      // convert data source prop to typed prop
-      // when data source is not scoped to one of copied instances
-      const value = dataSourcesLogic.get(dataSourceId);
-      return {
-        id: prop.id,
-        instanceId: prop.instanceId,
-        name: prop.name,
-        ...getPropTypeAndValue(value),
-      } satisfies Prop;
-    }
-    if (prop.type === "action") {
-      return {
-        ...prop,
-        value: prop.value.flatMap((value) => {
-          if (value.type !== "execute") {
-            return [value];
-          }
-          let shouldKeepAction = true;
-          validateExpression(value.code, {
-            effectful: true,
-            transformIdentifier: (identifier) => {
-              if (value.args.includes(identifier)) {
-                return identifier;
-              }
-              const id = decodeDataSourceVariable(identifier);
-              if (id === undefined) {
-                return identifier;
-              }
-              if (treeDataSourceIds.has(id) === false) {
-                shouldKeepAction = false;
-                return identifier;
-              }
-              const identifierDeps = dependencies.get(id);
-              if (identifierDeps) {
-                for (const dependency of identifierDeps) {
-                  const id = decodeDataSourceVariable(dependency);
-                  if (id === undefined) {
-                    continue;
-                  }
-                  if (treeDataSourceIds.has(id) === false) {
-                    shouldKeepAction = false;
-                    return identifier;
-                  }
-                }
-              }
-              return identifier;
-            },
-          });
-          if (shouldKeepAction) {
-            return [value];
-          }
-          return [];
-        }),
-      };
-    }
-    return prop;
-  });
-
-  const treeStyleSourceSelections = getMapValuesByKeysSet(
-    styleSourceSelections,
-    treeInstanceIds
-  );
-
-  const treeStyleSources = getMapValuesByKeysSet(
-    styleSourcesStore.get(),
-    treeStyleSourceIds
-  );
-
-  const treeStyles = getMapValuesBy(stylesStore.get(), (styleDecl) =>
-    treeStyleSourceIds.has(styleDecl.styleSourceId)
-  );
-
-  const treeBreapointIds = new Set<Breakpoint["id"]>();
-  for (const styleDecl of treeStyles) {
-    treeBreapointIds.add(styleDecl.breakpointId);
-  }
-  const treeBreapoints = getMapValuesByKeysSet(
-    breakpointsStore.get(),
-    treeBreapointIds
-  );
-
-  const treeAssets = getMapValuesByKeysSet(
-    assetsStore.get(),
-    getAssetsUsedInProps(treeProps, getAssetsUsedInStyle(treeStyles))
-  );
 
   return {
     instanceSelector: targetInstanceSelector,
-    breakpoints: treeBreapoints,
-    instances: treeInstances,
-    styleSources: treeStyleSources,
-    dataSources: treeDataSources,
-    props: treeProps,
-    styleSourceSelections: treeStyleSourceSelections,
-    styles: treeStyles,
-    assets: treeAssets,
+    ...getInstancesSlice(targetInstanceId),
   };
 };
 


### PR DESCRIPTION
Split instances slicer into separate utility from copy paste plugin. Will be used to duplicate pages. Along with splitting added more tests to better cover behavior.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
