### PR TITLE
fix: mono text added to display code in cli

### DIFF
--- a/apps/builder/app/dashboard/header.tsx
+++ b/apps/builder/app/dashboard/header.tsx
@@ -48,7 +48,7 @@ const Menu = ({ user }: { user: User }) => {
           </Flex>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent>
+      <DropdownMenuContent align="end">
         <DropdownMenuLabel>{title}</DropdownMenuLabel>
         <DropdownMenuItem onSelect={() => navigate(logoutPath())}>
           Logout

--- a/packages/design-system/src/components/input-field.tsx
+++ b/packages/design-system/src/components/input-field.tsx
@@ -31,7 +31,7 @@ export const inputFieldColors = ["placeholder", "set", "error"] as const;
 
 const inputStyle = css({
   all: "unset",
-  ...textVariants.regular,
+  ...textVariants.mono,
   color: theme.colors.foregroundMain,
   flexGrow: 1,
   flexShrink: 1,


### PR DESCRIPTION
## Description

This PR fixes the issue number #2388 
I have added font mono to display text of cli

<img width="218" alt="Screenshot 2023-10-28 185213" src="https://github.com/webstudio-is/webstudio/assets/88244542/cbe624c4-edc2-409d-b1db-41cb7336b11e">

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
