### PR TITLE
feat: Add Twitter card support & exclude pages from search/index

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
@@ -60,7 +60,6 @@ import { ImageControl } from "~/builder/features/seo/image-control";
 import { ImageInfo } from "./image-info";
 import { SocialPreview } from "./social-preview";
 import { useEffectEvent } from "~/builder/features/ai/hooks/effect-event";
-import { getPublishedUrl } from "~/shared/router-utils";
 
 const fieldDefaultValues = {
   name: "Untitled",
@@ -228,7 +227,7 @@ const FormFields = ({
   const faviconUrl = faviconAsset?.type === "image" ? faviconAsset.name : "";
 
   const project = projectStore.get();
-  const publishedUrl = new URL(getPublishedUrl(project?.domain ?? ""));
+  const publishedUrl = new URL(`https://${project?.domain}`);
 
   const pageDomainAndPath = [publishedUrl.host, values?.path]
     .filter(Boolean)

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
@@ -177,13 +177,19 @@ const CopyPageDomainAndPathButton = ({
     >
       <Button
         color="ghost"
+        type="button"
         onPointerDown={(event) => {
-          navigator.clipboard.writeText("ddd");
+          navigator.clipboard.writeText(`https://${pageDomainAndPath}`);
           setPathIconState("checkmark");
           // Prevent tooltip to be closed
           event.stopPropagation();
         }}
-        prefix={pathIcon}
+        // Recreating Icon without pointer-events: none cause mouse leave/enter event to be fired again
+        prefix={
+          <Grid align="center" css={{ pointerEvents: "none" }}>
+            {pathIcon}
+          </Grid>
+        }
         css={{ justifySelf: "start" }}
         onMouseEnter={() => {
           setPathIconState("copy");

--- a/fixtures/webstudio-custom-template/app/extension.ts
+++ b/fixtures/webstudio-custom-template/app/extension.ts
@@ -1,0 +1,8 @@
+// @ts-ignore
+import { AppLoadContext } from "@remix-run/server-runtime";
+
+declare module "@remix-run/server-runtime" {
+  interface AppLoadContext {
+    EXCLUDE_FROM_SEARCH: string;
+  }
+}

--- a/fixtures/webstudio-custom-template/app/extension.ts
+++ b/fixtures/webstudio-custom-template/app/extension.ts
@@ -1,3 +1,4 @@
+// @eslint-ignore
 // @ts-ignore
 import { AppLoadContext } from "@remix-run/server-runtime";
 

--- a/fixtures/webstudio-custom-template/app/extension.ts
+++ b/fixtures/webstudio-custom-template/app/extension.ts
@@ -4,6 +4,6 @@ import { AppLoadContext } from "@remix-run/server-runtime";
 
 declare module "@remix-run/server-runtime" {
   interface AppLoadContext {
-    EXCLUDE_FROM_SEARCH: string;
+    EXCLUDE_FROM_SEARCH: boolean;
   }
 }

--- a/fixtures/webstudio-custom-template/app/extension.ts
+++ b/fixtures/webstudio-custom-template/app/extension.ts
@@ -1,4 +1,4 @@
-// @eslint-ignore
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { AppLoadContext } from "@remix-run/server-runtime";
 

--- a/fixtures/webstudio-custom-template/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[robots.txt].tsx
@@ -1,0 +1,26 @@
+import { ActionArgs } from "@remix-run/server-runtime";
+
+export const loader = (arg: ActionArgs) => {
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  return new Response(
+    `
+User-agent: *
+Disallow: /api/
+
+# Uncomment
+# Sitemap: https://${host}/sitemap.xml
+
+
+  `,
+    {
+      headers: {
+        "Content-Type": "text/plain",
+      },
+      status: 200,
+    }
+  );
+};

--- a/fixtures/webstudio-custom-template/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[robots.txt].tsx
@@ -1,6 +1,6 @@
-import { ActionArgs } from "@remix-run/server-runtime";
+import type { LoaderArgs } from "@remix-run/server-runtime";
 
-export const loader = (arg: ActionArgs) => {
+export const loader = (arg: LoaderArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -13,7 +13,6 @@ Disallow: /api/
 
 # Uncomment
 # Sitemap: https://${host}/sitemap.xml
-
 
   `,
     {

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -24,10 +24,6 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export interface AppLoadContext {
-  EXCLUDE_FROM_SEARCH: string;
-}
-
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -42,6 +38,9 @@ export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
+
+  // typecheck
+  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
 
   return json(
     {

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -40,13 +40,13 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   // typecheck
-  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
+  arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
   return json(
     {
       host,
       url: url.href,
-      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -24,6 +24,10 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
+export interface AppLoadContext {
+  EXCLUDE_FROM_SEARCH: string;
+}
+
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -40,7 +44,11 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   return json(
-    { host, url: url.href },
+    {
+      host,
+      url: url.href,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+    },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
     { headers: { "Cache-Control": "public, max-age=600" } }
@@ -90,6 +98,13 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         name: site.siteName,
         url: origin,
       },
+    });
+  }
+
+  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+    metas.push({
+      name: "robots",
+      content: "noindex",
     });
   }
 

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -103,7 +103,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
   if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
     metas.push({
       name: "robots",
-      content: "noindex",
+      content: "noindex, nofollow",
     });
   }
 

--- a/fixtures/webstudio-custom-template/remix.env.d.ts
+++ b/fixtures/webstudio-custom-template/remix.env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
+

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/extension.ts
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/extension.ts
@@ -1,0 +1,8 @@
+// @ts-ignore
+import { AppLoadContext } from "@remix-run/server-runtime";
+
+declare module "@remix-run/server-runtime" {
+  interface AppLoadContext {
+    EXCLUDE_FROM_SEARCH: string;
+  }
+}

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/extension.ts
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/extension.ts
@@ -1,3 +1,4 @@
+// @eslint-ignore
 // @ts-ignore
 import { AppLoadContext } from "@remix-run/server-runtime";
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/extension.ts
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/extension.ts
@@ -4,6 +4,6 @@ import { AppLoadContext } from "@remix-run/server-runtime";
 
 declare module "@remix-run/server-runtime" {
   interface AppLoadContext {
-    EXCLUDE_FROM_SEARCH: string;
+    EXCLUDE_FROM_SEARCH: boolean;
   }
 }

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/extension.ts
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/extension.ts
@@ -1,4 +1,4 @@
-// @eslint-ignore
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { AppLoadContext } from "@remix-run/server-runtime";
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[robots.txt].tsx
@@ -1,0 +1,26 @@
+import { ActionArgs } from "@remix-run/server-runtime";
+
+export const loader = (arg: ActionArgs) => {
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  return new Response(
+    `
+User-agent: *
+Disallow: /api/
+
+# Uncomment
+# Sitemap: https://${host}/sitemap.xml
+
+
+  `,
+    {
+      headers: {
+        "Content-Type": "text/plain",
+      },
+      status: 200,
+    }
+  );
+};

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[robots.txt].tsx
@@ -1,6 +1,6 @@
-import { ActionArgs } from "@remix-run/server-runtime";
+import type { LoaderArgs } from "@remix-run/server-runtime";
 
-export const loader = (arg: ActionArgs) => {
+export const loader = (arg: LoaderArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -13,7 +13,6 @@ Disallow: /api/
 
 # Uncomment
 # Sitemap: https://${host}/sitemap.xml
-
 
   `,
     {

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -24,10 +24,6 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export interface AppLoadContext {
-  EXCLUDE_FROM_SEARCH: string;
-}
-
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -42,6 +38,9 @@ export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
+
+  // typecheck
+  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
 
   return json(
     {

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -40,13 +40,13 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   // typecheck
-  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
+  arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
   return json(
     {
       host,
       url: url.href,
-      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -24,6 +24,10 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
+export interface AppLoadContext {
+  EXCLUDE_FROM_SEARCH: string;
+}
+
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -40,7 +44,11 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   return json(
-    { host, url: url.href },
+    {
+      host,
+      url: url.href,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+    },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
     { headers: { "Cache-Control": "public, max-age=600" } }
@@ -90,6 +98,13 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         name: site.siteName,
         url: origin,
       },
+    });
+  }
+
+  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+    metas.push({
+      name: "robots",
+      content: "noindex",
     });
   }
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -103,7 +103,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
   if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
     metas.push({
       name: "robots",
-      content: "noindex",
+      content: "noindex, nofollow",
     });
   }
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/remix.env.d.ts
+++ b/fixtures/webstudio-remix-netlify-edge-functions/remix.env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
+

--- a/fixtures/webstudio-remix-netlify-functions/app/extension.ts
+++ b/fixtures/webstudio-remix-netlify-functions/app/extension.ts
@@ -1,0 +1,8 @@
+// @ts-ignore
+import { AppLoadContext } from "@remix-run/server-runtime";
+
+declare module "@remix-run/server-runtime" {
+  interface AppLoadContext {
+    EXCLUDE_FROM_SEARCH: string;
+  }
+}

--- a/fixtures/webstudio-remix-netlify-functions/app/extension.ts
+++ b/fixtures/webstudio-remix-netlify-functions/app/extension.ts
@@ -1,3 +1,4 @@
+// @eslint-ignore
 // @ts-ignore
 import { AppLoadContext } from "@remix-run/server-runtime";
 

--- a/fixtures/webstudio-remix-netlify-functions/app/extension.ts
+++ b/fixtures/webstudio-remix-netlify-functions/app/extension.ts
@@ -4,6 +4,6 @@ import { AppLoadContext } from "@remix-run/server-runtime";
 
 declare module "@remix-run/server-runtime" {
   interface AppLoadContext {
-    EXCLUDE_FROM_SEARCH: string;
+    EXCLUDE_FROM_SEARCH: boolean;
   }
 }

--- a/fixtures/webstudio-remix-netlify-functions/app/extension.ts
+++ b/fixtures/webstudio-remix-netlify-functions/app/extension.ts
@@ -1,4 +1,4 @@
-// @eslint-ignore
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { AppLoadContext } from "@remix-run/server-runtime";
 

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[robots.txt].tsx
@@ -1,0 +1,26 @@
+import { ActionArgs } from "@remix-run/server-runtime";
+
+export const loader = (arg: ActionArgs) => {
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  return new Response(
+    `
+User-agent: *
+Disallow: /api/
+
+# Uncomment
+# Sitemap: https://${host}/sitemap.xml
+
+
+  `,
+    {
+      headers: {
+        "Content-Type": "text/plain",
+      },
+      status: 200,
+    }
+  );
+};

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[robots.txt].tsx
@@ -1,6 +1,6 @@
-import { ActionArgs } from "@remix-run/server-runtime";
+import type { LoaderArgs } from "@remix-run/server-runtime";
 
-export const loader = (arg: ActionArgs) => {
+export const loader = (arg: LoaderArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -13,7 +13,6 @@ Disallow: /api/
 
 # Uncomment
 # Sitemap: https://${host}/sitemap.xml
-
 
   `,
     {

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -24,10 +24,6 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export interface AppLoadContext {
-  EXCLUDE_FROM_SEARCH: string;
-}
-
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -42,6 +38,9 @@ export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
+
+  // typecheck
+  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
 
   return json(
     {

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -40,13 +40,13 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   // typecheck
-  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
+  arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
   return json(
     {
       host,
       url: url.href,
-      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -24,6 +24,10 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
+export interface AppLoadContext {
+  EXCLUDE_FROM_SEARCH: string;
+}
+
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -40,7 +44,11 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   return json(
-    { host, url: url.href },
+    {
+      host,
+      url: url.href,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+    },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
     { headers: { "Cache-Control": "public, max-age=600" } }
@@ -90,6 +98,13 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         name: site.siteName,
         url: origin,
       },
+    });
+  }
+
+  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+    metas.push({
+      name: "robots",
+      content: "noindex",
     });
   }
 

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -103,7 +103,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
   if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
     metas.push({
       name: "robots",
-      content: "noindex",
+      content: "noindex, nofollow",
     });
   }
 

--- a/fixtures/webstudio-remix-netlify-functions/remix.env.d.ts
+++ b/fixtures/webstudio-remix-netlify-functions/remix.env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
+

--- a/fixtures/webstudio-remix-vercel/app/extension.ts
+++ b/fixtures/webstudio-remix-vercel/app/extension.ts
@@ -1,0 +1,8 @@
+// @ts-ignore
+import { AppLoadContext } from "@remix-run/server-runtime";
+
+declare module "@remix-run/server-runtime" {
+  interface AppLoadContext {
+    EXCLUDE_FROM_SEARCH: string;
+  }
+}

--- a/fixtures/webstudio-remix-vercel/app/extension.ts
+++ b/fixtures/webstudio-remix-vercel/app/extension.ts
@@ -1,3 +1,4 @@
+// @eslint-ignore
 // @ts-ignore
 import { AppLoadContext } from "@remix-run/server-runtime";
 

--- a/fixtures/webstudio-remix-vercel/app/extension.ts
+++ b/fixtures/webstudio-remix-vercel/app/extension.ts
@@ -4,6 +4,6 @@ import { AppLoadContext } from "@remix-run/server-runtime";
 
 declare module "@remix-run/server-runtime" {
   interface AppLoadContext {
-    EXCLUDE_FROM_SEARCH: string;
+    EXCLUDE_FROM_SEARCH: boolean;
   }
 }

--- a/fixtures/webstudio-remix-vercel/app/extension.ts
+++ b/fixtures/webstudio-remix-vercel/app/extension.ts
@@ -1,4 +1,4 @@
-// @eslint-ignore
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { AppLoadContext } from "@remix-run/server-runtime";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -24,10 +24,6 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export interface AppLoadContext {
-  EXCLUDE_FROM_SEARCH: string;
-}
-
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -42,6 +38,9 @@ export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
+
+  // typecheck
+  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
 
   return json(
     {

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -40,13 +40,13 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   // typecheck
-  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
+  arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
   return json(
     {
       host,
       url: url.href,
-      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -24,6 +24,10 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
+export interface AppLoadContext {
+  EXCLUDE_FROM_SEARCH: string;
+}
+
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -40,7 +44,11 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   return json(
-    { host, url: url.href },
+    {
+      host,
+      url: url.href,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+    },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
     { headers: { "Cache-Control": "public, max-age=600" } }
@@ -90,6 +98,13 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         name: site.siteName,
         url: origin,
       },
+    });
+  }
+
+  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+    metas.push({
+      name: "robots",
+      content: "noindex",
     });
   }
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -103,7 +103,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
   if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
     metas.push({
       name: "robots",
-      content: "noindex",
+      content: "noindex, nofollow",
     });
   }
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -24,10 +24,6 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export interface AppLoadContext {
-  EXCLUDE_FROM_SEARCH: string;
-}
-
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -42,6 +38,9 @@ export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
+
+  // typecheck
+  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
 
   return json(
     {

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -40,13 +40,13 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   // typecheck
-  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
+  arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
   return json(
     {
       host,
       url: url.href,
-      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -24,6 +24,10 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
+export interface AppLoadContext {
+  EXCLUDE_FROM_SEARCH: string;
+}
+
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -40,7 +44,11 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   return json(
-    { host, url: url.href },
+    {
+      host,
+      url: url.href,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+    },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
     { headers: { "Cache-Control": "public, max-age=600" } }
@@ -90,6 +98,13 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         name: site.siteName,
         url: origin,
       },
+    });
+  }
+
+  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+    metas.push({
+      name: "robots",
+      content: "noindex",
     });
   }
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -103,7 +103,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
   if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
     metas.push({
       name: "robots",
-      content: "noindex",
+      content: "noindex, nofollow",
     });
   }
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -24,10 +24,6 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export interface AppLoadContext {
-  EXCLUDE_FROM_SEARCH: string;
-}
-
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -42,6 +38,9 @@ export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
+
+  // typecheck
+  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
 
   return json(
     {

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -40,13 +40,13 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   // typecheck
-  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
+  arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
   return json(
     {
       host,
       url: url.href,
-      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -24,6 +24,10 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
+export interface AppLoadContext {
+  EXCLUDE_FROM_SEARCH: string;
+}
+
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -40,7 +44,11 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   return json(
-    { host, url: url.href },
+    {
+      host,
+      url: url.href,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+    },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
     { headers: { "Cache-Control": "public, max-age=600" } }
@@ -90,6 +98,13 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         name: site.siteName,
         url: origin,
       },
+    });
+  }
+
+  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+    metas.push({
+      name: "robots",
+      content: "noindex",
     });
   }
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -103,7 +103,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
   if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
     metas.push({
       name: "robots",
-      content: "noindex",
+      content: "noindex, nofollow",
     });
   }
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -24,10 +24,6 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export interface AppLoadContext {
-  EXCLUDE_FROM_SEARCH: string;
-}
-
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -42,6 +38,9 @@ export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
+
+  // typecheck
+  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
 
   return json(
     {

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -40,13 +40,13 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   // typecheck
-  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
+  arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
   return json(
     {
       host,
       url: url.href,
-      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -24,6 +24,10 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
+export interface AppLoadContext {
+  EXCLUDE_FROM_SEARCH: string;
+}
+
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -40,7 +44,11 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   return json(
-    { host, url: url.href },
+    {
+      host,
+      url: url.href,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+    },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
     { headers: { "Cache-Control": "public, max-age=600" } }
@@ -90,6 +98,13 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         name: site.siteName,
         url: origin,
       },
+    });
+  }
+
+  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+    metas.push({
+      name: "robots",
+      content: "noindex",
     });
   }
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -103,7 +103,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
   if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
     metas.push({
       name: "robots",
-      content: "noindex",
+      content: "noindex, nofollow",
     });
   }
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[robots.txt].tsx
@@ -1,0 +1,26 @@
+import { ActionArgs } from "@remix-run/server-runtime";
+
+export const loader = (arg: ActionArgs) => {
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  return new Response(
+    `
+User-agent: *
+Disallow: /api/
+
+# Uncomment
+# Sitemap: https://${host}/sitemap.xml
+
+
+  `,
+    {
+      headers: {
+        "Content-Type": "text/plain",
+      },
+      status: 200,
+    }
+  );
+};

--- a/fixtures/webstudio-remix-vercel/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[robots.txt].tsx
@@ -1,6 +1,6 @@
-import { ActionArgs } from "@remix-run/server-runtime";
+import type { LoaderArgs } from "@remix-run/server-runtime";
 
-export const loader = (arg: ActionArgs) => {
+export const loader = (arg: LoaderArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -13,7 +13,6 @@ Disallow: /api/
 
 # Uncomment
 # Sitemap: https://${host}/sitemap.xml
-
 
   `,
     {

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -24,10 +24,6 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export interface AppLoadContext {
-  EXCLUDE_FROM_SEARCH: string;
-}
-
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -42,6 +38,9 @@ export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
+
+  // typecheck
+  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
 
   return json(
     {

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -40,13 +40,13 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   // typecheck
-  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
+  arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
   return json(
     {
       host,
       url: url.href,
-      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -24,6 +24,10 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
+export interface AppLoadContext {
+  EXCLUDE_FROM_SEARCH: string;
+}
+
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -40,7 +44,11 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   return json(
-    { host, url: url.href },
+    {
+      host,
+      url: url.href,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+    },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
     { headers: { "Cache-Control": "public, max-age=600" } }
@@ -90,6 +98,13 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         name: site.siteName,
         url: origin,
       },
+    });
+  }
+
+  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+    metas.push({
+      name: "robots",
+      content: "noindex",
     });
   }
 

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -103,7 +103,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
   if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
     metas.push({
       name: "robots",
-      content: "noindex",
+      content: "noindex, nofollow",
     });
   }
 

--- a/fixtures/webstudio-remix-vercel/remix.env.d.ts
+++ b/fixtures/webstudio-remix-vercel/remix.env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
+

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -214,6 +214,14 @@ export const prebuild = async (options: {
 
   spinner.text = "Generating files";
 
+  const appRoot = "app";
+
+  const generatedDir = join(appRoot, "__generated__");
+  await rm(generatedDir, { recursive: true, force: true });
+
+  const routesDir = join(appRoot, "routes");
+  await rm(routesDir, { recursive: true, force: true });
+
   await copyTemplates();
 
   if (options.template !== undefined) {
@@ -389,14 +397,6 @@ export const prebuild = async (options: {
   }
 
   spinner.text = "Generating routes and pages";
-
-  const appRoot = "app";
-
-  const generatedDir = join(appRoot, "__generated__");
-  await rm(generatedDir, { recursive: true, force: true });
-
-  const routesDir = join(appRoot, "routes");
-  await rm(routesDir, { recursive: true, force: true });
 
   const routeFileTemplate = await readFile(
     normalize(

--- a/packages/cli/templates/defaults/app/extension.ts
+++ b/packages/cli/templates/defaults/app/extension.ts
@@ -1,0 +1,8 @@
+// @ts-ignore
+import { AppLoadContext } from "@remix-run/server-runtime";
+
+declare module "@remix-run/server-runtime" {
+  interface AppLoadContext {
+    EXCLUDE_FROM_SEARCH: string;
+  }
+}

--- a/packages/cli/templates/defaults/app/extension.ts
+++ b/packages/cli/templates/defaults/app/extension.ts
@@ -1,3 +1,4 @@
+// @eslint-ignore
 // @ts-ignore
 import { AppLoadContext } from "@remix-run/server-runtime";
 

--- a/packages/cli/templates/defaults/app/extension.ts
+++ b/packages/cli/templates/defaults/app/extension.ts
@@ -4,6 +4,6 @@ import { AppLoadContext } from "@remix-run/server-runtime";
 
 declare module "@remix-run/server-runtime" {
   interface AppLoadContext {
-    EXCLUDE_FROM_SEARCH: string;
+    EXCLUDE_FROM_SEARCH: boolean;
   }
 }

--- a/packages/cli/templates/defaults/app/extension.ts
+++ b/packages/cli/templates/defaults/app/extension.ts
@@ -1,4 +1,4 @@
-// @eslint-ignore
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { AppLoadContext } from "@remix-run/server-runtime";
 

--- a/packages/cli/templates/defaults/app/routes/[robots.txt].tsx
+++ b/packages/cli/templates/defaults/app/routes/[robots.txt].tsx
@@ -1,6 +1,6 @@
 import { ActionArgs } from "@remix-run/server-runtime";
 
-export const actions = (arg: ActionArgs) => {
+export const loader = (arg: ActionArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -13,7 +13,6 @@ Disallow: /api/
 
 # Uncomment
 # Sitemap: https://${host}/sitemap.xml
-
 
   `,
     {

--- a/packages/cli/templates/defaults/app/routes/[robots.txt].tsx
+++ b/packages/cli/templates/defaults/app/routes/[robots.txt].tsx
@@ -1,6 +1,6 @@
-import { ActionArgs } from "@remix-run/server-runtime";
+import type { LoaderArgs } from "@remix-run/server-runtime";
 
-export const loader = (arg: ActionArgs) => {
+export const loader = (arg: LoaderArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||

--- a/packages/cli/templates/defaults/app/routes/robots.txt.ts
+++ b/packages/cli/templates/defaults/app/routes/robots.txt.ts
@@ -1,0 +1,26 @@
+import { ActionArgs } from "@remix-run/server-runtime";
+
+export const actions = (arg: ActionArgs) => {
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  return new Response(
+    `
+User-agent: *
+Disallow: /api/
+
+# Uncomment
+# Sitemap: https://${host}/sitemap.xml
+
+
+  `,
+    {
+      headers: {
+        "Content-Type": "text/plain",
+      },
+      status: 200,
+    }
+  );
+};

--- a/packages/cli/templates/defaults/remix.env.d.ts
+++ b/packages/cli/templates/defaults/remix.env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
+

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -24,10 +24,6 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export interface AppLoadContext {
-  EXCLUDE_FROM_SEARCH: string;
-}
-
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -42,6 +38,9 @@ export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
+
+  // typecheck
+  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
 
   return json(
     {

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -40,13 +40,13 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   // typecheck
-  arg.context.EXCLUDE_FROM_SEARCH satisfies string;
+  arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
   return json(
     {
       host,
       url: url.href,
-      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -24,6 +24,10 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
+export interface AppLoadContext {
+  EXCLUDE_FROM_SEARCH: string;
+}
+
 export type PageData = {
   site?: SiteMeta;
   page: PageType;
@@ -40,7 +44,11 @@ export const loader = async (arg: LoaderArgs) => {
   url.protocol = "https";
 
   return json(
-    { host, url: url.href },
+    {
+      host,
+      url: url.href,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH !== undefined,
+    },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
     { headers: { "Cache-Control": "public, max-age=600" } }
@@ -90,6 +98,13 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         name: site.siteName,
         url: origin,
       },
+    });
+  }
+
+  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+    metas.push({
+      name: "robots",
+      content: "noindex",
     });
   }
 

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -103,7 +103,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
   if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
     metas.push({
       name: "robots",
-      content: "noindex",
+      content: "noindex, nofollow",
     });
   }
 


### PR DESCRIPTION
## Description

ref #2544

Corresponding SAAS PR https://github.com/webstudio-is/webstudio-saas/pull/215

- Support of page property - `excludePageFromSearch`
- Introduced functionality to enable the meta robot noindex tag for the entire website.
- Implemented robots.txt support, which appears to be essential for Twitter meta cards functionality.

Needs corresponding PR in SAAS deploy.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
