### PR TITLE
feat: add basic code editor

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/code-editor.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/code-editor.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CodeEditor as CodeEditorComponent } from "./code-editor";
+
+export default {
+  title: "Builder/CodeEditor",
+  component: CodeEditorComponent,
+} satisfies Meta;
+
+const variables = new Map([
+  ["#1", "formState"],
+  ["#2", "formInitial"],
+  ["#3", "count"],
+  ["#4", "something"],
+  ["#5", "else"],
+  ["#6", "hello"],
+]);
+
+export const CodeEditor: StoryObj = {
+  render: () => (
+    <>
+      <p>Type $ to trigger variables completion</p>
+      <label>Editor with variable in the middle</label>
+      <CodeEditorComponent
+        variables={variables}
+        defaultValue={"Default variable is #3"}
+        onChange={(newCode) => console.info(newCode)}
+      />
+      <div style={{ height: 32 }}></div>
+      <label>Editor with variable at the beginning</label>
+      <CodeEditorComponent
+        variables={variables}
+        defaultValue={"#1 comes first and #2 comes second, and last same #1"}
+        onChange={(newCode) => console.info(newCode)}
+      />
+    </>
+  ),
+};

--- a/apps/builder/app/builder/features/settings-panel/code-editor.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/code-editor.stories.tsx
@@ -23,6 +23,7 @@ export const CodeEditor: StoryObj = {
       <CodeEditorComponent
         variables={variables}
         defaultValue={"Default variable is #3"}
+        // eslint-disable-next-line no-console
         onChange={(newCode) => console.info(newCode)}
       />
       <div style={{ height: 32 }}></div>
@@ -30,6 +31,7 @@ export const CodeEditor: StoryObj = {
       <CodeEditorComponent
         variables={variables}
         defaultValue={"#1 comes first and #2 comes second, and last same #1"}
+        // eslint-disable-next-line no-console
         onChange={(newCode) => console.info(newCode)}
       />
     </>

--- a/apps/builder/app/builder/features/settings-panel/code-editor.tsx
+++ b/apps/builder/app/builder/features/settings-panel/code-editor.tsx
@@ -1,0 +1,382 @@
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  type DOMConversionMap,
+  type DOMConversionOutput,
+  type DOMExportOutput,
+  type EditorConfig,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedTextNode,
+  $applyNodeReplacement,
+  TextNode,
+  $getRoot,
+  $isElementNode,
+  createEditor,
+  type LexicalEditor,
+} from "lexical";
+import { $generateNodesFromDOM } from "@lexical/html";
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
+import LexicalErrorBoundary from "@lexical/react/LexicalErrorBoundary";
+import {
+  LexicalTypeaheadMenuPlugin,
+  MenuOption,
+  useBasicTypeaheadTriggerMatch,
+} from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
+import {
+  MenuItemButton,
+  MenuList,
+  css,
+  textVariants,
+  theme,
+} from "@webstudio-is/design-system";
+
+// mention node is based on
+// https://github.com/facebook/lexical/blob/f15a17564b6267531732ba5cc824b8aaf45f5b54/packages/lexical-playground/src/nodes/MentionNode.ts
+
+const convertMentionElement = (
+  domNode: HTMLElement
+): DOMConversionOutput | null => {
+  const mentionText = domNode.getAttribute("data-mention-text");
+  const mentionId = domNode.getAttribute("data-mention-id");
+
+  if (mentionText !== null && mentionId !== null) {
+    const node = $createMentionNode(mentionText, mentionId);
+    return {
+      node,
+    };
+  }
+
+  return null;
+};
+
+const mentionStyle = "background-color: rgba(24, 119, 232, 0.2)";
+
+class MentionNode extends TextNode {
+  mentionText: string;
+  mentionId: string;
+
+  static getType(): string {
+    return "mention";
+  }
+
+  static clone(node: MentionNode): MentionNode {
+    return new MentionNode(node.mentionText, node.mentionId, node.__key);
+  }
+
+  static importJSON(): MentionNode {
+    throw Error("Unimplemented");
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      span: (domNode: HTMLElement) => {
+        if (!domNode.hasAttribute("data-lexical-mention")) {
+          return null;
+        }
+        return {
+          conversion: convertMentionElement,
+          priority: 1,
+        };
+      },
+    };
+  }
+
+  constructor(mentionText: string, mentionId: string, key?: NodeKey) {
+    super(mentionText, key);
+    this.mentionText = mentionText;
+    this.mentionId = mentionId;
+  }
+
+  exportJSON(): SerializedTextNode {
+    throw Error("Unimplemented");
+  }
+
+  createDOM(config: EditorConfig): HTMLElement {
+    const dom = super.createDOM(config);
+    dom.style.cssText = mentionStyle;
+    dom.className = "mention";
+    return dom;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("span");
+    element.setAttribute("data-lexical-mention", "true");
+    element.setAttribute("data-mention-text", this.mentionText);
+    element.setAttribute("data-mention-id", this.mentionId);
+    element.textContent = this.__text;
+    return { element };
+  }
+
+  isTextEntity(): true {
+    return true;
+  }
+
+  canInsertTextBefore(): boolean {
+    return false;
+  }
+
+  canInsertTextAfter(): boolean {
+    return false;
+  }
+}
+
+const $createMentionNode = (
+  mentionText: string,
+  mentionId: string
+): MentionNode => {
+  const mentionNode = new MentionNode(mentionText, mentionId);
+  mentionNode.setMode("segmented").toggleDirectionless();
+  return $applyNodeReplacement(mentionNode);
+};
+
+const $isMentionNode = (
+  node: LexicalNode | null | undefined
+): node is MentionNode => {
+  return node instanceof MentionNode;
+};
+
+const findAllSubstrings = (text: string, substrings: string[]) => {
+  const offsets = new Set<number>();
+  for (const substring of substrings) {
+    let index = text.indexOf(substring);
+    while (index !== -1) {
+      // add start and end offsets of each match
+      offsets.add(index);
+      offsets.add(index + substring.length);
+      index = text.indexOf(substring, index + 1);
+    }
+  }
+  return Array.from(offsets);
+};
+
+const VariableSuggestionsPlugin = ({
+  variables,
+}: {
+  variables: Map<string, string>;
+}) => {
+  const [editor] = useLexicalComposerContext();
+  const checkForMentionMatch = useBasicTypeaheadTriggerMatch("$", {
+    minLength: 0,
+  });
+
+  const [options, setOptions] = useState<MenuOption[]>([]);
+
+  const onQueryChange = useCallback(
+    (matchingString: string | null) => {
+      let matchedIds: string[] = [];
+      if (matchingString == null) {
+        matchedIds = Array.from(variables.keys());
+      } else {
+        matchedIds = Array.from(variables)
+          .filter(([_id, text]) =>
+            // make search case insensitive
+            text.toLowerCase().includes(matchingString.toLowerCase())
+          )
+          .map(([id]) => id);
+      }
+      setOptions(matchedIds.map((id) => new MenuOption(id)));
+    },
+    [variables]
+  );
+
+  const onSelectOption = useCallback(
+    (
+      selectedOption: MenuOption,
+      nodeToReplace: TextNode | null,
+      closeMenu: () => void
+    ) => {
+      editor.update(() => {
+        const mentionId = selectedOption.key;
+        const mentionText = variables.get(mentionId);
+        if (mentionText !== undefined) {
+          const mentionNode = $createMentionNode(mentionText, mentionId);
+          if (nodeToReplace) {
+            nodeToReplace.replace(mentionNode);
+          }
+          mentionNode.select();
+        }
+        closeMenu();
+      });
+    },
+    [editor, variables]
+  );
+
+  useEffect(() => {
+    return editor.registerNodeTransform(TextNode, (node) => {
+      const offsets = findAllSubstrings(
+        node.getTextContent(),
+        Array.from(variables.keys())
+      );
+      // stop before calling any lexical updates to avoid infinite loop
+      if (offsets.length === 0) {
+        return;
+      }
+      const nodes = node.splitText(...offsets);
+      for (node of nodes) {
+        const mentionId = node.getTextContent();
+        const mentionText = variables.get(mentionId);
+        if (mentionText !== undefined) {
+          const mentionNode = $createMentionNode(mentionText, mentionId);
+          node.replace(mentionNode);
+        }
+      }
+    });
+  }, [editor, variables]);
+
+  return (
+    <LexicalTypeaheadMenuPlugin<MenuOption>
+      triggerFn={checkForMentionMatch}
+      onQueryChange={onQueryChange}
+      onSelectOption={onSelectOption}
+      options={options}
+      menuRenderFn={(
+        anchorElementRef,
+        { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex }
+      ) => {
+        if (anchorElementRef.current === null || options.length === 0) {
+          return null;
+        }
+        return createPortal(
+          <MenuList
+            // put menu below cursor
+            css={{
+              minWidth: 160,
+              width: "max-content",
+              position: "absolute",
+              top: "100%",
+            }}
+          >
+            {options.map((option, index) => (
+              <MenuItemButton
+                key={option.key}
+                // show variable names without changes
+                css={{ textTransform: "none" }}
+                tabIndex={-1}
+                ref={option.setRefElement}
+                role="option"
+                aria-selected={selectedIndex === index}
+                onMouseEnter={() => {
+                  setHighlightedIndex(index);
+                }}
+                onClick={() => {
+                  setHighlightedIndex(index);
+                  selectOptionAndCleanUp(option);
+                }}
+              >
+                {variables.get(option.key)}
+              </MenuItemButton>
+            ))}
+          </MenuList>,
+          anchorElementRef.current
+        );
+      }}
+    />
+  );
+};
+
+const traverseNode = (
+  node: LexicalNode,
+  callback: (node: LexicalNode) => void
+) => {
+  callback(node);
+  if ($isElementNode(node)) {
+    for (const child of node.getChildren()) {
+      traverseNode(child, callback);
+    }
+  }
+};
+
+const onError = (error: unknown) => {
+  console.error(error);
+};
+
+const rootStyle = css({
+  ...textVariants.mono,
+  boxSizing: "border-box",
+  color: theme.colors.foregroundMain,
+  borderRadius: theme.borderRadius[4],
+  border: `1px solid ${theme.colors.borderMain}`,
+  background: theme.colors.backgroundControls,
+  paddingTop: 6,
+  paddingBottom: 4,
+  paddingRight: theme.spacing[2],
+  paddingLeft: theme.spacing[3],
+  "&:focus": {
+    borderColor: theme.colors.borderFocus,
+    outline: `1px solid ${theme.colors.borderFocus}`,
+  },
+});
+
+const paragraphStyle = css({
+  marginTop: 0,
+  marginBottom: 0,
+});
+
+/**
+ * The main feature of code editor is to provide completion
+ * with specified variables
+ *
+ * Could be used to edit css as well in the future.
+ */
+export const CodeEditor = ({
+  variables,
+  defaultValue,
+  onChange,
+  onBlur,
+}: {
+  variables: Map<string, string>;
+  defaultValue: string;
+  onChange: (newCode: string) => void;
+  onBlur?: () => void;
+}) => {
+  const initialConfig = {
+    namespace: "CodeEditor",
+    nodes: [MentionNode],
+    theme: {
+      root: rootStyle.toString(),
+      paragraph: paragraphStyle.toString(),
+    },
+    editorState: (editor: LexicalEditor) => {
+      const root = $getRoot();
+      const parser = new DOMParser();
+      const dom = parser.parseFromString(`<p>${defaultValue}</p>`, "text/html");
+      const nodes = $generateNodesFromDOM(editor, dom);
+      root.append(...nodes);
+    },
+    onError,
+  };
+
+  return (
+    <LexicalComposer initialConfig={initialConfig}>
+      <PlainTextPlugin
+        contentEditable={<ContentEditable onBlur={onBlur} />}
+        placeholder={null}
+        ErrorBoundary={LexicalErrorBoundary}
+      />
+      <HistoryPlugin />
+      <VariableSuggestionsPlugin variables={variables} />
+      <OnChangePlugin
+        onChange={(editorState) => {
+          const { editorState: _editorState, ...config } = initialConfig;
+          const updater = createEditor(config);
+          updater.setEditorState(editorState.clone());
+          updater.update(() => {
+            const root = $getRoot();
+            traverseNode(root, (node) => {
+              if ($isMentionNode(node)) {
+                node.setTextContent(node.mentionId);
+              }
+            });
+            onChange(root.getTextContent());
+          });
+        }}
+      />
+    </LexicalComposer>
+  );
+};

--- a/apps/builder/app/builder/features/settings-panel/code-editor.tsx
+++ b/apps/builder/app/builder/features/settings-panel/code-editor.tsx
@@ -293,6 +293,7 @@ const traverseNode = (
 };
 
 const onError = (error: unknown) => {
+  // eslint-disable-next-line no-console
   console.error(error);
 };
 

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -25,6 +25,7 @@
     "@fontsource-variable/manrope": "^5.0.15",
     "@fontsource/roboto-mono": "^5.0.13",
     "@lexical/headless": "^0.12.2",
+    "@lexical/html": "^0.12.2",
     "@lexical/link": "^0.12.2",
     "@lexical/react": "^0.12.2",
     "@lexical/selection": "^0.12.2",

--- a/packages/design-system/src/components/menu.tsx
+++ b/packages/design-system/src/components/menu.tsx
@@ -55,6 +55,8 @@ export const menuItemCss = css(textVariants.labelsTitleCase, {
   mx: itemMargin,
   padding: theme.spacing[3],
   borderRadius: theme.borderRadius[3],
+  // override button default styles
+  backgroundColor: "transparent",
   "&:focus, &[data-found], &[aria-selected=true], &[data-state=open]": {
     backgroundColor: theme.colors.backgroundItemMenuItemHover,
   },
@@ -108,6 +110,8 @@ export const menuCss = css({
     },
   },
 });
+
+export const MenuList = styled("div", menuCss);
 
 export const subMenuCss = css(menuCss, {
   // the goal is to align the top menu item in a sub menu

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -19,6 +19,7 @@ export * from "./components/dialog";
 export * from "./components/floating-panel-popover";
 export * from "./components/popover";
 export {
+  MenuList,
   MenuItemButton,
   MenuCheckedIcon,
   MenuItemIndicator,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@lexical/headless':
         specifier: ^0.12.2
         version: 0.12.2(lexical@0.12.2)
+      '@lexical/html':
+        specifier: ^0.12.2
+        version: 0.12.2(lexical@0.12.2)
       '@lexical/link':
         specifier: ^0.12.2
         version: 0.12.2(lexical@0.12.2)


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here added code editor with variables completion support for bindings UI. Simple textarea would not work because same names can be used for different variables
to support seamless dnd for user. `$` is used to trigger completion, in the future can be replaced with tab or something like this. Current implementation is mostly a copy paste from lexical playground.

<img width="536" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5635476/c33ebb71-85d8-41b3-8151-72eccae76129">

To test try CodeEditor component in storybook

## Use case

1. Our variables can have the same names for easier copy-pastability
To address specific variable they should be chosen from available list.

2. renaming variable should rename it everywhere to not break bindings.
So variables behave as symbol in text editor and removed completely on backspace.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
