### PR TITLE
fix: stop preventing escape for radix components

### DIFF
--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -87,6 +87,8 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
     {
       name: "cancelCurrentDrag",
       defaultHotkeys: ["escape"],
+      // radix check event.defaultPrevented before invoking callbacks
+      preventDefault: false,
       handler: () => {
         const { publish } = $publisher.get();
         publish?.({ type: "cancelCurrentDrag" });

--- a/apps/builder/app/shared/commands-emitter.ts
+++ b/apps/builder/app/shared/commands-emitter.ts
@@ -8,6 +8,8 @@ type CommandMeta<CommandName extends string> = {
   name: CommandName;
   /** default because hotkeys can be customized from ui */
   defaultHotkeys?: string[];
+  /** set to false when default browser or radix behavior is desired */
+  preventDefault?: boolean;
   /** listen hotkeys only locally without sharing with other apps */
   disableHotkeyOutsideApp?: boolean;
   /**
@@ -125,6 +127,7 @@ export const createCommandsEmitter = <CommandName extends string>({
     });
     const handleKeyDown = (event: KeyboardEvent) => {
       let emitted = false;
+      let preventDefault = true;
       for (const commandMeta of findCommandsMatchingHeaviestHotkeys()) {
         if (
           commandMeta.disableHotkeyOutsideApp &&
@@ -158,11 +161,15 @@ export const createCommandsEmitter = <CommandName extends string>({
           continue;
         }
         emitted = true;
+        if (commandMeta.preventDefault === false) {
+          preventDefault = false;
+        }
         emitCommand(commandMeta.name as CommandName);
       }
       // command can redefine browser hotkeys
-      // always prevent to avoid unexpected behavior
-      if (emitted) {
+      // prevent to avoid unexpected behavior
+      // unless at least one matching command disabled prevent default
+      if (emitted && preventDefault) {
         event.preventDefault();
       }
     };


### PR DESCRIPTION
Commands always prevent default to not conflict with any default bahavior. Escape is probably the only case which is manageed by radix too. Though it checks event.defaultPrevented so we need an additional flag with exception.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
