### PR TITLE
feat: Add custom metadata UI Component

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/custom-metadata.stories.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/custom-metadata.stories.tsx
@@ -2,7 +2,7 @@ import { Box } from "@webstudio-is/design-system";
 import { CustomMetadata } from "./custom-metadata";
 import { useState } from "react";
 
-export default { component: CustomMetadata };
+export default { component: CustomMetadata, title: "Pages/CustomMetadata" };
 
 export const Basic = () => {
   const [customMetas, setCustomMetas] = useState([

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/custom-metadata.stories.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/custom-metadata.stories.tsx
@@ -1,0 +1,20 @@
+import { Box } from "@webstudio-is/design-system";
+import { CustomMetadata } from "./custom-metadata";
+import { useState } from "react";
+
+export default { component: CustomMetadata };
+
+export const Basic = () => {
+  const [customMetas, setCustomMetas] = useState([
+    {
+      property: "og:title",
+      content: "My title",
+    },
+  ]);
+
+  return (
+    <Box css={{ width: 448, margin: 20 }}>
+      <CustomMetadata customMetas={customMetas} onChange={setCustomMetas} />
+    </Box>
+  );
+};

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/custom-metadata.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/custom-metadata.tsx
@@ -36,9 +36,9 @@ const PropertyContent = (props: {
       css={{
         gridTemplateColumns: `${theme.spacing[18]} 1fr 19px`,
         gridTemplateAreas: `
-      "property property-input button"
-      "content content-input button"
-    `,
+         "property property-input button"
+         "content  content-input  button"
+        `,
       }}
       align={"center"}
     >
@@ -160,8 +160,10 @@ export const CustomMetadata = (props: CustomMetadataProps) => {
           }}
           prefix={<PlusIcon />}
           onClick={() => {
-            const newCustomMetas = [...props.customMetas];
-            newCustomMetas.push({ property: "", content: "" });
+            const newCustomMetas = [
+              ...props.customMetas,
+              { property: "", content: "" },
+            ];
             props.onChange(newCustomMetas);
           }}
         >

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/custom-metadata.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/custom-metadata.tsx
@@ -1,0 +1,173 @@
+import {
+  Button,
+  Grid,
+  InputErrorsTooltip,
+  InputField,
+  Label,
+  SmallIconButton,
+  Text,
+  theme,
+} from "@webstudio-is/design-system";
+import { DeleteIcon, PlusIcon } from "@webstudio-is/icons";
+import { useId } from "react";
+
+type Meta = {
+  property: string;
+  content: string;
+};
+
+type CustomMetadataProps = {
+  customMetas: Meta[];
+  onChange: (value: Meta[]) => void;
+};
+
+const PropertyContent = (props: {
+  property: string;
+  content: string;
+  onDelete: () => void;
+  onChange: (property: string, content: string) => void;
+}) => {
+  const propertyId = useId();
+  const contentId = useId();
+
+  return (
+    <Grid
+      gap={2}
+      css={{
+        gridTemplateColumns: `${theme.spacing[18]} 1fr 19px`,
+        gridTemplateAreas: `
+      "property property-input button"
+      "content content-input button"
+    `,
+      }}
+      align={"center"}
+    >
+      <Label htmlFor={propertyId} css={{ gridArea: "property" }}>
+        Property
+      </Label>
+      <InputErrorsTooltip errors={undefined}>
+        <InputField
+          css={{ gridArea: "property-input" }}
+          tabIndex={1}
+          id={propertyId}
+          property="path"
+          value={props.property}
+          onChange={(event) => {
+            props.onChange(event.target.value, props.content);
+          }}
+        />
+      </InputErrorsTooltip>
+      <Label htmlFor={contentId} css={{ gridArea: "content" }}>
+        Content
+      </Label>
+      <InputErrorsTooltip errors={undefined}>
+        <InputField
+          css={{
+            gridArea: "content-input",
+          }}
+          tabIndex={1}
+          id={contentId}
+          property="path"
+          value={props.content}
+          onChange={(event) => {
+            props.onChange(props.property, event.target.value);
+          }}
+        />
+      </InputErrorsTooltip>
+      <Grid
+        css={{
+          gridArea: "button",
+          justifyItems: "center",
+          gap: "2px",
+          color: theme.colors.foregroundIconSecondary,
+        }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="19"
+          height="11"
+          viewBox="0 0 19 11"
+          fill="currentColor"
+        >
+          <path d="M10 10.05V6.05005C10 2.73634 7.31371 0.0500488 4 0.0500488H0V1.05005H4C6.76142 1.05005 9 3.28863 9 6.05005V10.05H10Z" />
+        </svg>
+
+        <SmallIconButton
+          variant="destructive"
+          icon={<DeleteIcon />}
+          onClick={props.onDelete}
+        />
+
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="19"
+          height="11"
+          viewBox="0 0 19 11"
+          fill="currentColor"
+        >
+          <path d="M-4.37114e-07 10.05L4 10.05C7.31371 10.05 10 7.36376 10 4.05005L10 0.0500488L9 0.0500488L9 4.05005C9 6.81147 6.76142 9.05005 4 9.05005L-3.93402e-07 9.05005L-4.37114e-07 10.05Z" />
+        </svg>
+      </Grid>
+    </Grid>
+  );
+};
+
+export const CustomMetadata = (props: CustomMetadataProps) => {
+  return (
+    <Grid gap={2} css={{ my: theme.spacing[5], mx: theme.spacing[8] }}>
+      <Label sectionTitle>Custom Metadata</Label>
+      <Text color="subtle">
+        Use this section to input metadata for the document, which will be used
+        to generate{" "}
+        <Text as="b" variant={"regularBold"}>
+          &lt;meta&gt;
+        </Text>{" "}
+        tags. Each pair consists of a{" "}
+        <Text as="b" variant={"regularBold"}>
+          property
+        </Text>{" "}
+        attribute, indicating the type of metadata, and a{" "}
+        <Text as="b" variant={"regularBold"}>
+          content
+        </Text>{" "}
+        attribute, specifying its value.
+      </Text>
+      <div />
+      <Grid gap={3}>
+        {props.customMetas.map((meta, index) => (
+          <PropertyContent
+            key={index}
+            property={meta.property}
+            content={meta.content}
+            onChange={(property, content) => {
+              const newCustomMetas = [...props.customMetas];
+              newCustomMetas[index] = { property, content };
+              props.onChange(newCustomMetas);
+            }}
+            onDelete={() => {
+              const newCustomMetas = [...props.customMetas];
+              newCustomMetas.splice(index, 1);
+              props.onChange(newCustomMetas);
+            }}
+          />
+        ))}
+
+        <Button
+          type="button"
+          color="neutral"
+          css={{
+            justifySelf: "center",
+          }}
+          prefix={<PlusIcon />}
+          onClick={() => {
+            const newCustomMetas = [...props.customMetas];
+            newCustomMetas.push({ property: "", content: "" });
+            props.onChange(newCustomMetas);
+          }}
+        >
+          Add another metadata pair
+        </Button>
+      </Grid>
+    </Grid>
+  );
+};


### PR DESCRIPTION
## Description

<img width="523" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/1af0726f-e337-4c97-9e4e-e626a888fcb7">

I have changed Field Labels and Subtle text, 
As all meta we support are `<meta property={} content={}`

cc @taylornowotny 

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
