### PR TITLE
feat: support binding props to variables

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/code-editor.tsx
+++ b/apps/builder/app/builder/features/settings-panel/code-editor.tsx
@@ -356,7 +356,7 @@ export const CodeEditor = ({
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <PlainTextPlugin
-        contentEditable={<ContentEditable onBlur={onBlur} />}
+        contentEditable={<ContentEditable spellCheck={false} onBlur={onBlur} />}
         placeholder={null}
         ErrorBoundary={LexicalErrorBoundary}
       />

--- a/apps/builder/app/builder/features/settings-panel/variables.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables.tsx
@@ -7,25 +7,34 @@ import {
   CssValueListArrowFocus,
   CssValueListItem,
   Flex,
+  FloatingPanelPopoverClose,
   FloatingPanelPopoverTitle,
   InputErrorsTooltip,
   InputField,
   Label,
   ScrollArea,
+  Separator,
   SmallIconButton,
   Text,
   Tooltip,
   theme,
 } from "@webstudio-is/design-system";
-import { MenuIcon, MinusIcon, PlusIcon } from "@webstudio-is/icons";
-import type { DataSource } from "@webstudio-is/sdk";
-import { validateExpression } from "@webstudio-is/react-sdk";
+import { MenuIcon, MinusIcon, PlusIcon, TrashIcon } from "@webstudio-is/icons";
+import type { DataSource, Prop } from "@webstudio-is/sdk";
+import {
+  PropMeta,
+  decodeDataSourceVariable,
+  encodeDataSourceVariable,
+  validateExpression,
+} from "@webstudio-is/react-sdk";
 import {
   dataSourcesStore,
+  propsStore,
   selectedInstanceSelectorStore,
 } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
 import { CodeEditor } from "./code-editor";
+import type { PropValue } from "./shared";
 
 type VariableDataSource = Extract<DataSource, { type: "variable" }>;
 
@@ -198,7 +207,7 @@ const VariablePanel = ({
   );
 };
 
-const selectedInstanceVariables = computed(
+const $selectedInstanceVariables = computed(
   [selectedInstanceSelectorStore, dataSourcesStore],
   (instanceSelector, dataSources) => {
     const matchedVariables: VariableDataSource[] = [];
@@ -233,6 +242,48 @@ const EmptyList = ({ onAdd }: { onAdd: () => void }) => {
   );
 };
 
+const $usedVariables = computed(
+  [dataSourcesStore, propsStore],
+  (dataSources, props) => {
+    const usedVariables = new Set<DataSource["id"]>();
+    for (const dataSource of dataSources.values()) {
+      if (dataSource.type !== "expression") {
+        continue;
+      }
+      try {
+        validateExpression(dataSource.code, {
+          transformIdentifier: (identifier) => {
+            const id = decodeDataSourceVariable(identifier);
+            if (id !== undefined) {
+              usedVariables.add(id);
+            }
+            return identifier;
+          },
+        });
+      } catch {
+        // empty block
+      }
+    }
+    for (const prop of props.values()) {
+      if (prop.type === "action") {
+        for (const value of prop.value) {
+          validateExpression(value.code, {
+            effectful: true,
+            transformIdentifier: (identifier) => {
+              const id = decodeDataSourceVariable(identifier);
+              if (id !== undefined) {
+                usedVariables.add(id);
+              }
+              return identifier;
+            },
+          });
+        }
+      }
+    }
+    return usedVariables;
+  }
+);
+
 const deleteVariable = (variable: VariableDataSource) => {
   // @todo prevent delete when variable is used
   serverSyncStore.createTransaction([dataSourcesStore], (dataSources) => {
@@ -242,13 +293,15 @@ const deleteVariable = (variable: VariableDataSource) => {
 
 const ListItem = ({
   index,
-  selectedId,
+  selected,
+  deletable,
   variable,
   onSelect,
   onEdit,
 }: {
   index: number;
-  selectedId: undefined | string;
+  selected: boolean;
+  deletable: boolean;
   variable: VariableDataSource;
   onSelect: (variableId: DataSource["id"]) => void;
   onEdit: (variable: VariableDataSource) => void;
@@ -262,7 +315,7 @@ const ListItem = ({
       }
       id={variable.id}
       index={index}
-      active={selectedId === variable.id}
+      active={selected}
       buttons={
         <>
           <Tooltip content="Edit variable" side="bottom">
@@ -276,6 +329,7 @@ const ListItem = ({
           <Tooltip content="Delete variable" side="bottom">
             <SmallIconButton
               tabIndex={-1}
+              disabled={deletable === false}
               aria-label="Delete variable"
               variant="destructive"
               icon={<MinusIcon />}
@@ -289,15 +343,106 @@ const ListItem = ({
   );
 };
 
+const getPropExpressionStore = (propId: undefined | string) => {
+  const $propDataSource = computed(
+    [propsStore, dataSourcesStore],
+    (props, dataSources) => {
+      if (propId === undefined) {
+        return;
+      }
+      const prop = props.get(propId);
+      if (prop?.type !== "dataSource") {
+        return;
+      }
+      const dataSourceId = prop.value;
+      return dataSources.get(dataSourceId);
+    }
+  );
+  const $propExpression = computed([$propDataSource], (dataSource) => {
+    // convert variable to expression
+    if (dataSource?.type === "variable") {
+      return encodeDataSourceVariable(dataSource.id);
+    }
+    if (dataSource?.type === "expression") {
+      return dataSource.code;
+    }
+    return "";
+  });
+  return $propExpression;
+};
+
+const getExpressionVariables = (expression: string) => {
+  const variableIds = new Set<VariableDataSource["id"]>();
+  if (expression === "") {
+    return variableIds;
+  }
+  validateExpression(expression, {
+    transformIdentifier: (identifier) => {
+      const id = decodeDataSourceVariable(identifier);
+      if (id !== undefined) {
+        variableIds.add(id);
+      }
+      return identifier;
+    },
+  });
+  return variableIds;
+};
+
 const ListPanel = ({
+  prop,
   onAdd,
   onEdit,
+  onChange,
 }: {
+  prop: undefined | Prop;
   onAdd: () => void;
   onEdit: (variable: VariableDataSource) => void;
+  onChange: (value: undefined | PropValue) => void;
 }) => {
-  const matchedVariables = useStore(selectedInstanceVariables);
-  const [selectedId, setSelectedId] = useState<undefined | string>(undefined);
+  const matchedVariables = useStore($selectedInstanceVariables);
+  const editorVariables = useMemo(() => {
+    const variables = new Map<string, string>();
+    for (const variable of matchedVariables) {
+      variables.set(encodeDataSourceVariable(variable.id), variable.name);
+    }
+    return variables;
+  }, [matchedVariables]);
+  const propId = prop?.id;
+  const propExpression = useStore(
+    useMemo(() => getPropExpressionStore(propId), [propId])
+  );
+  const exoressionVariables = useMemo(
+    () => getExpressionVariables(propExpression),
+    [propExpression]
+  );
+  const usedVariables = useStore($usedVariables);
+  const [expression, setExpression] = useState<undefined | string>();
+
+  const applyExpression = (expression: string) => {
+    // @todo replace data source expression into prop expression
+    // this pirce would become one liner
+    serverSyncStore.createTransaction([dataSourcesStore], (dataSources) => {
+      const dataSource =
+        prop?.type === "dataSource" ? dataSources.get(prop.value) : undefined;
+
+      // update existing expression without changing prop
+      if (dataSource?.type === "expression") {
+        dataSource.code = expression;
+        return;
+      }
+
+      // create new expression and bind to prop
+      const dataSourceId = nanoid();
+      dataSources.set(dataSourceId, {
+        id: dataSourceId,
+        type: "expression",
+        name: "expression",
+        code: expression,
+      });
+      onChange({ type: "dataSource", value: dataSourceId });
+    });
+  };
+
   return (
     <ScrollArea
       css={{
@@ -310,24 +455,79 @@ const ListPanel = ({
       {matchedVariables.length === 0 ? (
         <EmptyList onAdd={onAdd} />
       ) : (
-        <CssValueListArrowFocus>
-          {matchedVariables.map((variable, index) => (
-            <ListItem
-              key={variable.id}
-              index={index}
-              variable={variable}
-              selectedId={selectedId}
-              onSelect={setSelectedId}
-              onEdit={onEdit}
+        <>
+          <CssValueListArrowFocus>
+            {matchedVariables.map((variable, index) => (
+              <ListItem
+                key={variable.id}
+                index={index}
+                variable={variable}
+                // mark all variables used in expression as selected
+                selected={exoressionVariables.has(variable.id)}
+                deletable={usedVariables.has(variable.id) === false}
+                onSelect={() =>
+                  // convert variable to expression
+                  applyExpression(encodeDataSourceVariable(variable.id))
+                }
+                onEdit={onEdit}
+              />
+            ))}
+          </CssValueListArrowFocus>
+          <Separator />
+          <Flex
+            direction="column"
+            css={{
+              padding: `${theme.spacing[5]} ${theme.spacing[9]} ${theme.spacing[9]}`,
+              gap: theme.spacing[3],
+            }}
+          >
+            <Label>Name</Label>
+            <CodeEditor
+              // reset uncontrolled editor when saved expression is changed
+              key={propExpression}
+              variables={editorVariables}
+              defaultValue={expression ?? propExpression}
+              onChange={setExpression}
+              onBlur={() => {
+                // skip when expression is not changed
+                if (expression === undefined) {
+                  return;
+                }
+
+                if (expression.trim() === "") {
+                  onChange(undefined);
+                  setExpression(undefined);
+                  return;
+                }
+
+                try {
+                  validateExpression(expression);
+                } catch (error) {
+                  // @todo show errors
+                  (error as Error).message;
+                  return;
+                }
+
+                applyExpression(expression);
+                setExpression(undefined);
+              }}
             />
-          ))}
-        </CssValueListArrowFocus>
+          </Flex>
+        </>
       )}
     </ScrollArea>
   );
 };
 
-export const VariablesPanel = () => {
+export const VariablesPanel = ({
+  prop,
+  propMeta,
+  onChange,
+}: {
+  prop: undefined | Prop;
+  propMeta: PropMeta;
+  onChange: (value: PropValue) => void;
+}) => {
   const [view, setView] = useState<
     | { name: "list" }
     | { name: "add" }
@@ -342,6 +542,7 @@ export const VariablesPanel = () => {
       </>
     );
   }
+
   if (view.name === "edit") {
     return (
       <>
@@ -354,23 +555,64 @@ export const VariablesPanel = () => {
       </>
     );
   }
+
+  const removeBinding = () => {
+    // delete expression if exists
+    if (prop?.type === "dataSource") {
+      serverSyncStore.createTransaction([dataSourcesStore], (dataSources) => {
+        const dataSource = dataSources.get(prop.value);
+        if (dataSource?.type === "expression") {
+          dataSources.delete(dataSource.id);
+        }
+      });
+    }
+    // reset prop with initial value from meta
+    onChange({
+      type: propMeta.type,
+      value: propMeta.defaultValue,
+    } as PropValue);
+  };
+
   return (
     <>
       <ListPanel
+        prop={prop}
         onAdd={() => setView({ name: "add" })}
         onEdit={(variable) => setView({ name: "edit", variable })}
+        onChange={(value) => {
+          if (value === undefined) {
+            removeBinding();
+          } else {
+            onChange(value);
+          }
+        }}
       />
       {/* put after content to avoid auto focusing "New variable" button */}
       <FloatingPanelPopoverTitle
         actions={
-          <Tooltip content="New variable" side="bottom">
-            <Button
-              aria-label="New variable"
-              prefix={<PlusIcon />}
-              color="ghost"
-              onClick={() => setView({ name: "add" })}
-            />
-          </Tooltip>
+          <>
+            {prop?.type === "dataSource" && (
+              <Tooltip content="Remove binding" side="bottom">
+                {/* automatically close popover when remove binding */}
+                <FloatingPanelPopoverClose asChild>
+                  <Button
+                    aria-label="Remove binding"
+                    prefix={<TrashIcon />}
+                    color="ghost"
+                    onClick={removeBinding}
+                  />
+                </FloatingPanelPopoverClose>
+              </Tooltip>
+            )}
+            <Tooltip content="New variable" side="bottom">
+              <Button
+                aria-label="New variable"
+                prefix={<PlusIcon />}
+                color="ghost"
+                onClick={() => setView({ name: "add" })}
+              />
+            </Tooltip>
+          </>
         }
       >
         Variables

--- a/apps/builder/app/builder/features/settings-panel/variables.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables.tsx
@@ -267,16 +267,20 @@ const $usedVariables = computed(
     for (const prop of props.values()) {
       if (prop.type === "action") {
         for (const value of prop.value) {
-          validateExpression(value.code, {
-            effectful: true,
-            transformIdentifier: (identifier) => {
-              const id = decodeDataSourceVariable(identifier);
-              if (id !== undefined) {
-                usedVariables.add(id);
-              }
-              return identifier;
-            },
-          });
+          try {
+            validateExpression(value.code, {
+              effectful: true,
+              transformIdentifier: (identifier) => {
+                const id = decodeDataSourceVariable(identifier);
+                if (id !== undefined) {
+                  usedVariables.add(id);
+                }
+                return identifier;
+              },
+            });
+          } catch {
+            // empty block
+          }
         }
       }
     }


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here extended variables panel UI with expressions bound to props which may reference and compute from variables.

Expressions editor supports completion with `$` or can be auto generated by selecting variable from list.

<img width="267" alt="Screenshot 2023-11-03 at 00 54 25" src="https://github.com/webstudio-is/webstudio/assets/5635476/fed300da-d2ff-4bfc-bd2a-d11356494fd9">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
