### PR TITLE
feat: normalize variable names

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variables.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables.tsx
@@ -176,10 +176,8 @@ const VariablePanel = ({
           </Button>
           <Button
             onClick={() => {
-              if (/[a-zA-z_]+[a-zA-z0-9_]*/.test(name) === false) {
-                setNameErrors([
-                  `Variable names must start with letter or underscore (_) and can include numbers.`,
-                ]);
+              if (name.length === 0) {
+                setNameErrors([`Variable name is required`]);
                 return;
               }
               const result = saveVariable(variable?.id, name, value);

--- a/packages/sdk/src/scope.test.ts
+++ b/packages/sdk/src/scope.test.ts
@@ -15,3 +15,18 @@ test("allow to predefine already occupied identifiers", () => {
   expect(scope.getName("2", "anotherName")).toEqual("anotherName_1");
   expect(scope.getName("3", "newName")).toEqual("newName");
 });
+
+test("delete non-ascii characters from name", () => {
+  const scope = createScope(["_"]);
+  expect(scope.getName("1", "привет")).toEqual("__1");
+});
+
+test("delete spaces from name", () => {
+  const scope = createScope(["_"]);
+  expect(scope.getName("1", "My Variable")).toEqual("MyVariable");
+});
+
+test("prefix name starting with digit", () => {
+  const scope = createScope(["_"]);
+  expect(scope.getName("1", "123")).toEqual("_123");
+});

--- a/packages/sdk/src/scope.ts
+++ b/packages/sdk/src/scope.ts
@@ -7,6 +7,22 @@ export type Scope = {
   getName(id: string, preferredName: string): string;
 };
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers
+const normalizeName = (name: string) => {
+  // only letters, digits, underscores and dollar signs allowed in names
+  // delete everything else
+  name = name.replaceAll(/[^\w$]/g, "");
+  // put at least single underscore in name to avoid syntax error
+  if (name.length === 0) {
+    return "_";
+  }
+  // variable name can start with letter, underscore and dollar signs
+  if (/[A-Za-z_$]/.test(name[0]) === false) {
+    name = `_${name}`;
+  }
+  return name;
+};
+
 /**
  * Utility to maintain unique variable when generate code.
  * Single scope is shared for generated module for simplicity.
@@ -26,6 +42,7 @@ export const createScope = (occupiedIdentifiers: string[] = []): Scope => {
     if (cachedName !== undefined) {
       return cachedName;
     }
+    preferredName = normalizeName(preferredName);
     const index = freeIndexByPreferredName.get(preferredName);
     freeIndexByPreferredName.set(preferredName, (index ?? 0) + 1);
     let scopedName = preferredName;


### PR DESCRIPTION
Here added names normalizer to scope utility
to generate valid variable name from anything provided by user without unnecessary restrictions.

This will let us safely use prop name to reference expressions when those move to prop type.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
