### PR TITLE
refactor: move expressions to props in embed template

### DIFF
--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -224,14 +224,14 @@ test("generate data for embedding from props bound to data source variables", ()
         {
           type: "instance",
           component: "Box1",
-          dataSources: {
-            showOtherBoxDataSource: { type: "variable", initialValue: false },
+          variables: {
+            showOtherBoxDataSource: { initialValue: false },
           },
           props: [
             {
-              type: "dataSource",
+              type: "expression",
               name: "showOtherBox",
-              dataSourceName: "showOtherBoxDataSource",
+              code: "showOtherBoxDataSource",
             },
           ],
           children: [],
@@ -241,9 +241,9 @@ test("generate data for embedding from props bound to data source variables", ()
           component: "Box2",
           props: [
             {
-              type: "dataSource",
+              type: "expression",
               name: showAttribute,
-              dataSourceName: "showOtherBoxDataSource",
+              code: "showOtherBoxDataSource",
             },
           ],
           children: [],
@@ -288,6 +288,20 @@ test("generate data for embedding from props bound to data source variables", ()
           value: false,
         },
       },
+      {
+        id: expectString,
+        scopeInstanceId: expectString,
+        type: "expression",
+        name: "expression",
+        code: expect.stringMatching(/\$ws\$dataSource\$\w+/),
+      },
+      {
+        id: expectString,
+        scopeInstanceId: expectString,
+        type: "expression",
+        name: "expression",
+        code: expect.stringMatching(/\$ws\$dataSource\$\w+/),
+      },
     ],
     styleSourceSelections: [],
     styleSources: [],
@@ -302,18 +316,14 @@ test("generate data for embedding from props bound to data source expressions", 
         {
           type: "instance",
           component: "Box1",
-          dataSources: {
-            boxState: { type: "variable", initialValue: "initial" },
-            boxStateSuccess: {
-              type: "expression",
-              code: `boxState === 'success'`,
-            },
+          variables: {
+            boxState: { initialValue: "initial" },
           },
           props: [
             {
-              type: "dataSource",
+              type: "expression",
               name: "state",
-              dataSourceName: "boxState",
+              code: "boxState",
             },
           ],
           children: [],
@@ -323,9 +333,9 @@ test("generate data for embedding from props bound to data source expressions", 
           component: "Box2",
           props: [
             {
-              type: "dataSource",
+              type: "expression",
               name: showAttribute,
-              dataSourceName: "boxStateSuccess",
+              code: "boxState === 'success'",
             },
           ],
           children: [],
@@ -374,7 +384,14 @@ test("generate data for embedding from props bound to data source expressions", 
         type: "expression",
         id: expectString,
         scopeInstanceId: expectString,
-        name: "boxStateSuccess",
+        name: "expression",
+        code: expect.stringMatching(/\$ws\$dataSource\$\w+/),
+      },
+      {
+        type: "expression",
+        id: expectString,
+        scopeInstanceId: expectString,
+        name: "expression",
         code: expect.stringMatching(/\$ws\$dataSource\$\w+ === 'success'/),
       },
     ],
@@ -391,14 +408,14 @@ test("generate data for embedding from action props", () => {
         {
           type: "instance",
           component: "Box1",
-          dataSources: {
-            boxState: { type: "variable", initialValue: "initial" },
+          variables: {
+            boxState: { initialValue: "initial" },
           },
           props: [
             {
-              type: "dataSource",
+              type: "expression",
               name: "state",
-              dataSourceName: "boxState",
+              code: "boxState",
             },
           ],
           children: [
@@ -487,6 +504,13 @@ test("generate data for embedding from action props", () => {
           type: "string",
           value: "initial",
         },
+      },
+      {
+        id: expectString,
+        scopeInstanceId: expectString,
+        name: "expression",
+        type: "expression",
+        code: expect.stringMatching(/\$ws\$dataSource\$\w+/),
       },
     ],
     styleSourceSelections: [],

--- a/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
@@ -13,7 +13,8 @@ import {
 } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [accordionValue, set$accordionValue] = useState("0");
+  let [accordionValue, set$accordionValue] = useState<any>("0");
+  let expression = accordionValue;
   let onValueChange = (value: any) => {
     accordionValue = value;
     set$accordionValue(accordionValue);
@@ -24,25 +25,25 @@ const Page = (props: { scripts?: ReactNode }) => {
         data-ws-id="1"
         data-ws-component="Accordion"
         collapsible={true}
-        value={accordionValue}
+        value={expression}
         onValueChange={onValueChange}
       >
         <AccordionItem
-          data-ws-id="6"
+          data-ws-id="7"
           data-ws-component="AccordionItem"
           data-ws-index="0"
         >
-          <AccordionHeader data-ws-id="8" data-ws-component="AccordionHeader">
+          <AccordionHeader data-ws-id="9" data-ws-component="AccordionHeader">
             <AccordionTrigger
-              data-ws-id="10"
+              data-ws-id="11"
               data-ws-component="AccordionTrigger"
             >
-              <Text data-ws-id="12" data-ws-component="Text">
+              <Text data-ws-id="13" data-ws-component="Text">
                 {"Is it accessible?"}
               </Text>
-              <Box data-ws-id="13" data-ws-component="Box">
+              <Box data-ws-id="14" data-ws-component="Box">
                 <HtmlEmbed
-                  data-ws-id="15"
+                  data-ws-id="16"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
@@ -52,28 +53,28 @@ const Page = (props: { scripts?: ReactNode }) => {
             </AccordionTrigger>
           </AccordionHeader>
           <AccordionContent
-            data-ws-id="17"
+            data-ws-id="18"
             data-ws-component="AccordionContent"
           >
             {"Yes. It adheres to the WAI-ARIA design pattern."}
           </AccordionContent>
         </AccordionItem>
         <AccordionItem
-          data-ws-id="19"
+          data-ws-id="20"
           data-ws-component="AccordionItem"
           data-ws-index="1"
         >
-          <AccordionHeader data-ws-id="21" data-ws-component="AccordionHeader">
+          <AccordionHeader data-ws-id="22" data-ws-component="AccordionHeader">
             <AccordionTrigger
-              data-ws-id="23"
+              data-ws-id="24"
               data-ws-component="AccordionTrigger"
             >
-              <Text data-ws-id="25" data-ws-component="Text">
+              <Text data-ws-id="26" data-ws-component="Text">
                 {"Is it styled?"}
               </Text>
-              <Box data-ws-id="26" data-ws-component="Box">
+              <Box data-ws-id="27" data-ws-component="Box">
                 <HtmlEmbed
-                  data-ws-id="28"
+                  data-ws-id="29"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
@@ -83,7 +84,7 @@ const Page = (props: { scripts?: ReactNode }) => {
             </AccordionTrigger>
           </AccordionHeader>
           <AccordionContent
-            data-ws-id="30"
+            data-ws-id="31"
             data-ws-component="AccordionContent"
           >
             {
@@ -92,21 +93,21 @@ const Page = (props: { scripts?: ReactNode }) => {
           </AccordionContent>
         </AccordionItem>
         <AccordionItem
-          data-ws-id="32"
+          data-ws-id="33"
           data-ws-component="AccordionItem"
           data-ws-index="2"
         >
-          <AccordionHeader data-ws-id="34" data-ws-component="AccordionHeader">
+          <AccordionHeader data-ws-id="35" data-ws-component="AccordionHeader">
             <AccordionTrigger
-              data-ws-id="36"
+              data-ws-id="37"
               data-ws-component="AccordionTrigger"
             >
-              <Text data-ws-id="38" data-ws-component="Text">
+              <Text data-ws-id="39" data-ws-component="Text">
                 {"Is it animated?"}
               </Text>
-              <Box data-ws-id="39" data-ws-component="Box">
+              <Box data-ws-id="40" data-ws-component="Box">
                 <HtmlEmbed
-                  data-ws-id="41"
+                  data-ws-id="42"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
@@ -116,7 +117,7 @@ const Page = (props: { scripts?: ReactNode }) => {
             </AccordionTrigger>
           </AccordionHeader>
           <AccordionContent
-            data-ws-id="43"
+            data-ws-id="44"
             data-ws-component="AccordionContent"
           >
             {
@@ -312,15 +313,15 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="6"] {
+  [data-ws-id="7"] {
     border-bottom-width: 1px;
     border-bottom-style: solid;
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  [data-ws-id="8"] {
+  [data-ws-id="9"] {
     display: flex
   }
-  [data-ws-id="10"] {
+  [data-ws-id="11"] {
     display: flex;
     flex-grow: 1;
     flex-shrink: 1;
@@ -332,13 +333,13 @@ html {margin: 0; display: grid; min-height: 100%}
     font-weight: 500;
     --accordion-trigger-icon-transform: 0deg
   }
-  [data-ws-id="10"]:hover {
+  [data-ws-id="11"]:hover {
     text-decoration-line: underline
   }
-  [data-ws-id="10"][data-state=open] {
+  [data-ws-id="11"][data-state=open] {
     --accordion-trigger-icon-transform: 180deg
   }
-  [data-ws-id="13"] {
+  [data-ws-id="14"] {
     rotate: var(--accordion-trigger-icon-transform);
     height: 1rem;
     width: 1rem;
@@ -347,21 +348,21 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="17"] {
+  [data-ws-id="18"] {
     overflow: hidden;
     font-size: 0.875rem;
     line-height: 1.25rem;
     padding-bottom: 1rem
   }
-  [data-ws-id="19"] {
+  [data-ws-id="20"] {
     border-bottom-width: 1px;
     border-bottom-style: solid;
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  [data-ws-id="21"] {
+  [data-ws-id="22"] {
     display: flex
   }
-  [data-ws-id="23"] {
+  [data-ws-id="24"] {
     display: flex;
     flex-grow: 1;
     flex-shrink: 1;
@@ -373,13 +374,13 @@ html {margin: 0; display: grid; min-height: 100%}
     font-weight: 500;
     --accordion-trigger-icon-transform: 0deg
   }
-  [data-ws-id="23"]:hover {
+  [data-ws-id="24"]:hover {
     text-decoration-line: underline
   }
-  [data-ws-id="23"][data-state=open] {
+  [data-ws-id="24"][data-state=open] {
     --accordion-trigger-icon-transform: 180deg
   }
-  [data-ws-id="26"] {
+  [data-ws-id="27"] {
     rotate: var(--accordion-trigger-icon-transform);
     height: 1rem;
     width: 1rem;
@@ -388,21 +389,21 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="30"] {
+  [data-ws-id="31"] {
     overflow: hidden;
     font-size: 0.875rem;
     line-height: 1.25rem;
     padding-bottom: 1rem
   }
-  [data-ws-id="32"] {
+  [data-ws-id="33"] {
     border-bottom-width: 1px;
     border-bottom-style: solid;
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  [data-ws-id="34"] {
+  [data-ws-id="35"] {
     display: flex
   }
-  [data-ws-id="36"] {
+  [data-ws-id="37"] {
     display: flex;
     flex-grow: 1;
     flex-shrink: 1;
@@ -414,13 +415,13 @@ html {margin: 0; display: grid; min-height: 100%}
     font-weight: 500;
     --accordion-trigger-icon-transform: 0deg
   }
-  [data-ws-id="36"]:hover {
+  [data-ws-id="37"]:hover {
     text-decoration-line: underline
   }
-  [data-ws-id="36"][data-state=open] {
+  [data-ws-id="37"][data-state=open] {
     --accordion-trigger-icon-transform: 180deg
   }
-  [data-ws-id="39"] {
+  [data-ws-id="40"] {
     rotate: var(--accordion-trigger-icon-transform);
     height: 1rem;
     width: 1rem;
@@ -429,7 +430,7 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="43"] {
+  [data-ws-id="44"] {
     overflow: hidden;
     font-size: 0.875rem;
     line-height: 1.25rem;

--- a/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
@@ -11,7 +11,8 @@ import {
 } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [checkboxChecked, set$checkboxChecked] = useState(false);
+  let [checkboxChecked, set$checkboxChecked] = useState<any>(false);
+  let expression = checkboxChecked;
   let onCheckedChange = (checked: any) => {
     checkboxChecked = checked;
     set$checkboxChecked(checkboxChecked);
@@ -22,15 +23,15 @@ const Page = (props: { scripts?: ReactNode }) => {
         <Checkbox
           data-ws-id="3"
           data-ws-component="Checkbox"
-          checked={checkboxChecked}
+          checked={expression}
           onCheckedChange={onCheckedChange}
         >
           <CheckboxIndicator
-            data-ws-id="8"
+            data-ws-id="9"
             data-ws-component="CheckboxIndicator"
           >
             <HtmlEmbed
-              data-ws-id="10"
+              data-ws-id="11"
               data-ws-component="HtmlEmbed"
               code={
                 '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M11.957 5.043a1 1 0 0 1 0 1.414l-4.5 4.5a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L6.75 8.836l3.793-3.793a1 1 0 0 1 1.414 0Z" clip-rule="evenodd"/></svg>'
@@ -38,7 +39,7 @@ const Page = (props: { scripts?: ReactNode }) => {
             />
           </CheckboxIndicator>
         </Checkbox>
-        <Text data-ws-id="12" data-ws-component="Text" tag={"span"}>
+        <Text data-ws-id="13" data-ws-component="Text" tag={"span"}>
           {"Checkbox"}
         </Text>
       </Label>
@@ -253,7 +254,7 @@ html {margin: 0; display: grid; min-height: 100%}
     background-color: rgba(15, 23, 42, 1);
     color: rgba(248, 250, 252, 1)
   }
-  [data-ws-id="8"] {
+  [data-ws-id="9"] {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
@@ -11,7 +11,8 @@ import {
 } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [collapsibleOpen, set$collapsibleOpen] = useState(false);
+  let [collapsibleOpen, set$collapsibleOpen] = useState<any>(false);
+  let expression = collapsibleOpen;
   let onOpenChange = (open: any) => {
     collapsibleOpen = open;
     set$collapsibleOpen(collapsibleOpen);
@@ -21,22 +22,22 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Collapsible
         data-ws-id="1"
         data-ws-component="Collapsible"
-        open={collapsibleOpen}
+        open={expression}
         onOpenChange={onOpenChange}
       >
         <CollapsibleTrigger
-          data-ws-id="5"
+          data-ws-id="6"
           data-ws-component="CollapsibleTrigger"
         >
-          <Button data-ws-id="6" data-ws-component="Button">
+          <Button data-ws-id="7" data-ws-component="Button">
             {"Click to toggle content"}
           </Button>
         </CollapsibleTrigger>
         <CollapsibleContent
-          data-ws-id="8"
+          data-ws-id="9"
           data-ws-component="CollapsibleContent"
         >
-          <Text data-ws-id="9" data-ws-component="Text">
+          <Text data-ws-id="10" data-ws-component="Text">
             {"Collapsible Content"}
           </Text>
         </CollapsibleContent>
@@ -196,7 +197,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="6"] {
+  [data-ws-id="7"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -226,18 +227,18 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0.5rem;
     padding-bottom: 0.5rem
   }
-  [data-ws-id="6"]:focus-visible {
+  [data-ws-id="7"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="6"]:disabled {
+  [data-ws-id="7"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="6"]:hover {
+  [data-ws-id="7"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
@@ -16,7 +16,8 @@ import {
 } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [dialogOpen, set$dialogOpen] = useState(false);
+  let [dialogOpen, set$dialogOpen] = useState<any>(false);
+  let expression = dialogOpen;
   let onOpenChange = (open: any) => {
     dialogOpen = open;
     set$dialogOpen(dialogOpen);
@@ -26,33 +27,33 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Dialog
         data-ws-id="1"
         data-ws-component="Dialog"
-        open={dialogOpen}
+        open={expression}
         onOpenChange={onOpenChange}
       >
-        <DialogTrigger data-ws-id="5" data-ws-component="DialogTrigger">
-          <Button data-ws-id="6" data-ws-component="Button">
+        <DialogTrigger data-ws-id="6" data-ws-component="DialogTrigger">
+          <Button data-ws-id="7" data-ws-component="Button">
             {"Button"}
           </Button>
         </DialogTrigger>
-        <DialogOverlay data-ws-id="8" data-ws-component="DialogOverlay">
-          <DialogContent data-ws-id="10" data-ws-component="DialogContent">
-            <Box data-ws-id="12" data-ws-component="Box">
-              <DialogTitle data-ws-id="14" data-ws-component="DialogTitle">
+        <DialogOverlay data-ws-id="9" data-ws-component="DialogOverlay">
+          <DialogContent data-ws-id="11" data-ws-component="DialogContent">
+            <Box data-ws-id="13" data-ws-component="Box">
+              <DialogTitle data-ws-id="15" data-ws-component="DialogTitle">
                 {"Dialog Title"}
               </DialogTitle>
               <DialogDescription
-                data-ws-id="16"
+                data-ws-id="17"
                 data-ws-component="DialogDescription"
               >
                 {"Dialog description text you can edit"}
               </DialogDescription>
             </Box>
-            <Text data-ws-id="18" data-ws-component="Text">
+            <Text data-ws-id="19" data-ws-component="Text">
               {"The text you can edit"}
             </Text>
-            <DialogClose data-ws-id="19" data-ws-component="DialogClose">
+            <DialogClose data-ws-id="20" data-ws-component="DialogClose">
               <HtmlEmbed
-                data-ws-id="21"
+                data-ws-id="22"
                 data-ws-component="HtmlEmbed"
                 code={
                   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M13.566 2.434a.8.8 0 0 1 0 1.132L9.13 8l4.435 4.434a.8.8 0 0 1-1.132 1.132L8 9.13l-4.434 4.435a.8.8 0 0 1-1.132-1.132L6.87 8 2.434 3.566a.8.8 0 0 1 1.132-1.132L8 6.87l4.434-4.435a.8.8 0 0 1 1.132 0Z" clip-rule="evenodd"/></svg>'
@@ -262,7 +263,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="6"] {
+  [data-ws-id="7"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -292,22 +293,22 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0.5rem;
     padding-bottom: 0.5rem
   }
-  [data-ws-id="6"]:focus-visible {
+  [data-ws-id="7"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="6"]:disabled {
+  [data-ws-id="7"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="6"]:hover {
+  [data-ws-id="7"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="8"] {
+  [data-ws-id="9"] {
     position: fixed;
     left: 0px;
     right: 0px;
@@ -319,7 +320,7 @@ html {margin: 0; display: grid; min-height: 100%}
     display: flex;
     overflow: auto
   }
-  [data-ws-id="10"] {
+  [data-ws-id="11"] {
     width: 100%;
     z-index: 50;
     display: flex;
@@ -351,27 +352,27 @@ html {margin: 0; display: grid; min-height: 100%}
     box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
     position: relative
   }
-  [data-ws-id="12"] {
+  [data-ws-id="13"] {
     display: flex;
     flex-direction: column;
     row-gap: 0.25rem;
     column-gap: 0.25rem
   }
-  [data-ws-id="14"] {
+  [data-ws-id="15"] {
     margin-top: 0px;
     margin-bottom: 0px;
     line-height: 1.75rem;
     font-size: 1.125rem;
     letter-spacing: -0.025em
   }
-  [data-ws-id="16"] {
+  [data-ws-id="17"] {
     margin-top: 0px;
     margin-bottom: 0px;
     font-size: 0.875rem;
     line-height: 1.25rem;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="19"] {
+  [data-ws-id="20"] {
     position: absolute;
     right: 1rem;
     top: 1rem;
@@ -403,10 +404,10 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="19"]:hover {
+  [data-ws-id="20"]:hover {
     opacity: 1
   }
-  [data-ws-id="19"]:focus {
+  [data-ws-id="20"]:focus {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
@@ -18,7 +18,8 @@ import {
 } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [menuValue, set$menuValue] = useState("");
+  let [menuValue, set$menuValue] = useState<any>("");
+  let expression = menuValue;
   let onValueChange = (value: any) => {
     menuValue = value;
     set$menuValue(menuValue);
@@ -28,29 +29,29 @@ const Page = (props: { scripts?: ReactNode }) => {
       <NavigationMenu
         data-ws-id="1"
         data-ws-component="NavigationMenu"
-        value={menuValue}
+        value={expression}
         onValueChange={onValueChange}
       >
         <NavigationMenuList
-          data-ws-id="6"
+          data-ws-id="7"
           data-ws-component="NavigationMenuList"
         >
           <NavigationMenuItem
-            data-ws-id="8"
+            data-ws-id="9"
             data-ws-component="NavigationMenuItem"
             data-ws-index="0"
           >
             <NavigationMenuTrigger
-              data-ws-id="9"
+              data-ws-id="10"
               data-ws-component="NavigationMenuTrigger"
             >
-              <Button data-ws-id="10" data-ws-component="Button">
-                <Text data-ws-id="12" data-ws-component="Text">
+              <Button data-ws-id="11" data-ws-component="Button">
+                <Text data-ws-id="13" data-ws-component="Text">
                   {"About"}
                 </Text>
-                <Box data-ws-id="13" data-ws-component="Box">
+                <Box data-ws-id="14" data-ws-component="Box">
                   <HtmlEmbed
-                    data-ws-id="15"
+                    data-ws-id="16"
                     data-ws-component="HtmlEmbed"
                     code={
                       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
@@ -60,28 +61,28 @@ const Page = (props: { scripts?: ReactNode }) => {
               </Button>
             </NavigationMenuTrigger>
             <NavigationMenuContent
-              data-ws-id="17"
+              data-ws-id="18"
               data-ws-component="NavigationMenuContent"
               data-ws-index="0"
             >
-              <Box data-ws-id="19" data-ws-component="Box">
-                <Box data-ws-id="21" data-ws-component="Box">
+              <Box data-ws-id="20" data-ws-component="Box">
+                <Box data-ws-id="22" data-ws-component="Box">
                   {""}
                 </Box>
-                <Box data-ws-id="23" data-ws-component="Box">
+                <Box data-ws-id="24" data-ws-component="Box">
                   <NavigationMenuLink
-                    data-ws-id="25"
+                    data-ws-id="26"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="26"
+                      data-ws-id="27"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/sheet"}
                     >
-                      <Text data-ws-id="29" data-ws-component="Text">
+                      <Text data-ws-id="30" data-ws-component="Text">
                         {"Sheet"}
                       </Text>
-                      <Paragraph data-ws-id="31" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="32" data-ws-component="Paragraph">
                         {
                           "Extends the Dialog component to display content that complements the main content of the screen."
                         }
@@ -89,37 +90,37 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="33"
+                    data-ws-id="34"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="34"
+                      data-ws-id="35"
                       data-ws-component="Link"
                       href={
                         "https://ui.shadcn.com/docs/components/navigation-menu"
                       }
                     >
-                      <Text data-ws-id="37" data-ws-component="Text">
+                      <Text data-ws-id="38" data-ws-component="Text">
                         {"Navigation Menu"}
                       </Text>
-                      <Paragraph data-ws-id="39" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="40" data-ws-component="Paragraph">
                         {"A collection of links for navigating websites."}
                       </Paragraph>
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="41"
+                    data-ws-id="42"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="42"
+                      data-ws-id="43"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/tabs"}
                     >
-                      <Text data-ws-id="45" data-ws-component="Text">
+                      <Text data-ws-id="46" data-ws-component="Text">
                         {"Tabs"}
                       </Text>
-                      <Paragraph data-ws-id="47" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="48" data-ws-component="Paragraph">
                         {
                           "A set of layered sections of content—known as tab panels—that are displayed one at a time."
                         }
@@ -131,21 +132,21 @@ const Page = (props: { scripts?: ReactNode }) => {
             </NavigationMenuContent>
           </NavigationMenuItem>
           <NavigationMenuItem
-            data-ws-id="49"
+            data-ws-id="50"
             data-ws-component="NavigationMenuItem"
             data-ws-index="1"
           >
             <NavigationMenuTrigger
-              data-ws-id="50"
+              data-ws-id="51"
               data-ws-component="NavigationMenuTrigger"
             >
-              <Button data-ws-id="51" data-ws-component="Button">
-                <Text data-ws-id="53" data-ws-component="Text">
+              <Button data-ws-id="52" data-ws-component="Button">
+                <Text data-ws-id="54" data-ws-component="Text">
                   {"Components"}
                 </Text>
-                <Box data-ws-id="54" data-ws-component="Box">
+                <Box data-ws-id="55" data-ws-component="Box">
                   <HtmlEmbed
-                    data-ws-id="56"
+                    data-ws-id="57"
                     data-ws-component="HtmlEmbed"
                     code={
                       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
@@ -155,25 +156,25 @@ const Page = (props: { scripts?: ReactNode }) => {
               </Button>
             </NavigationMenuTrigger>
             <NavigationMenuContent
-              data-ws-id="58"
+              data-ws-id="59"
               data-ws-component="NavigationMenuContent"
               data-ws-index="1"
             >
-              <Box data-ws-id="60" data-ws-component="Box">
-                <Box data-ws-id="62" data-ws-component="Box">
+              <Box data-ws-id="61" data-ws-component="Box">
+                <Box data-ws-id="63" data-ws-component="Box">
                   <NavigationMenuLink
-                    data-ws-id="64"
+                    data-ws-id="65"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="65"
+                      data-ws-id="66"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/accordion"}
                     >
-                      <Text data-ws-id="68" data-ws-component="Text">
+                      <Text data-ws-id="69" data-ws-component="Text">
                         {"Accordion"}
                       </Text>
-                      <Paragraph data-ws-id="70" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="71" data-ws-component="Paragraph">
                         {
                           "A vertically stacked set of interactive headings that each reveal a section of content."
                         }
@@ -181,18 +182,18 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="72"
+                    data-ws-id="73"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="73"
+                      data-ws-id="74"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/dialog"}
                     >
-                      <Text data-ws-id="76" data-ws-component="Text">
+                      <Text data-ws-id="77" data-ws-component="Text">
                         {"Dialog"}
                       </Text>
-                      <Paragraph data-ws-id="78" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="79" data-ws-component="Paragraph">
                         {
                           "A window overlaid on either the primary window or another dialog window, rendering the content underneath inert."
                         }
@@ -200,18 +201,18 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="80"
+                    data-ws-id="81"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="81"
+                      data-ws-id="82"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/collapsible"}
                     >
-                      <Text data-ws-id="84" data-ws-component="Text">
+                      <Text data-ws-id="85" data-ws-component="Text">
                         {"Collapsible"}
                       </Text>
-                      <Paragraph data-ws-id="86" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="87" data-ws-component="Paragraph">
                         {
                           "An interactive component which expands/collapses a panel."
                         }
@@ -219,20 +220,20 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                 </Box>
-                <Box data-ws-id="88" data-ws-component="Box">
+                <Box data-ws-id="89" data-ws-component="Box">
                   <NavigationMenuLink
-                    data-ws-id="90"
+                    data-ws-id="91"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="91"
+                      data-ws-id="92"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/popover"}
                     >
-                      <Text data-ws-id="94" data-ws-component="Text">
+                      <Text data-ws-id="95" data-ws-component="Text">
                         {"Popover"}
                       </Text>
-                      <Paragraph data-ws-id="96" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="97" data-ws-component="Paragraph">
                         {
                           "Displays rich content in a portal, triggered by a button."
                         }
@@ -240,18 +241,18 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="98"
+                    data-ws-id="99"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="99"
+                      data-ws-id="100"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/tooltip"}
                     >
-                      <Text data-ws-id="102" data-ws-component="Text">
+                      <Text data-ws-id="103" data-ws-component="Text">
                         {"Tooltip"}
                       </Text>
-                      <Paragraph data-ws-id="104" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="105" data-ws-component="Paragraph">
                         {
                           "A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it."
                         }
@@ -259,18 +260,18 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="106"
+                    data-ws-id="107"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="107"
+                      data-ws-id="108"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/button"}
                     >
-                      <Text data-ws-id="110" data-ws-component="Text">
+                      <Text data-ws-id="111" data-ws-component="Text">
                         {"Button"}
                       </Text>
-                      <Paragraph data-ws-id="112" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="113" data-ws-component="Paragraph">
                         {
                           "Displays a button or a component that looks like a button."
                         }
@@ -282,23 +283,23 @@ const Page = (props: { scripts?: ReactNode }) => {
             </NavigationMenuContent>
           </NavigationMenuItem>
           <NavigationMenuItem
-            data-ws-id="114"
+            data-ws-id="115"
             data-ws-component="NavigationMenuItem"
             data-ws-index="2"
           >
             <NavigationMenuLink
-              data-ws-id="115"
+              data-ws-id="116"
               data-ws-component="NavigationMenuLink"
             >
-              <Link data-ws-id="116" data-ws-component="Link">
+              <Link data-ws-id="117" data-ws-component="Link">
                 {"Standalone"}
               </Link>
             </NavigationMenuLink>
           </NavigationMenuItem>
         </NavigationMenuList>
-        <Box data-ws-id="118" data-ws-component="Box">
+        <Box data-ws-id="119" data-ws-component="Box">
           <NavigationMenuViewport
-            data-ws-id="120"
+            data-ws-id="121"
             data-ws-component="NavigationMenuViewport"
           />
         </Box>
@@ -520,7 +521,7 @@ html {margin: 0; display: grid; min-height: 100%}
     position: relative;
     max-width: max-content
   }
-  [data-ws-id="6"] {
+  [data-ws-id="7"] {
     padding-left: 0px;
     padding-right: 0px;
     padding-top: 0px;
@@ -539,7 +540,7 @@ html {margin: 0; display: grid; min-height: 100%}
     row-gap: 0.25rem;
     column-gap: 0.25rem
   }
-  [data-ws-id="10"] {
+  [data-ws-id="11"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -568,25 +569,25 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-right: 0.75rem;
     --navigation-menu-trigger-icon-transform: 0deg
   }
-  [data-ws-id="10"]:focus-visible {
+  [data-ws-id="11"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="10"]:disabled {
+  [data-ws-id="11"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="10"]:hover {
+  [data-ws-id="11"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="10"][data-state=open] {
+  [data-ws-id="11"][data-state=open] {
     --navigation-menu-trigger-icon-transform: 180deg
   }
-  [data-ws-id="13"] {
+  [data-ws-id="14"] {
     margin-left: 0.25rem;
     rotate: var(--navigation-menu-trigger-icon-transform);
     height: 1rem;
@@ -596,7 +597,7 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="17"] {
+  [data-ws-id="18"] {
     left: 0px;
     top: 0px;
     position: absolute;
@@ -606,7 +607,7 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 1rem;
     padding-bottom: 1rem
   }
-  [data-ws-id="19"] {
+  [data-ws-id="20"] {
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
@@ -615,7 +616,7 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0.5rem;
     padding-bottom: 0.5rem
   }
-  [data-ws-id="21"] {
+  [data-ws-id="22"] {
     background-color: rgba(226, 232, 240, 1);
     padding-left: 1rem;
     padding-right: 1rem;
@@ -627,14 +628,14 @@ html {margin: 0; display: grid; min-height: 100%}
     border-bottom-right-radius: 0.375rem;
     border-bottom-left-radius: 0.375rem
   }
-  [data-ws-id="23"] {
+  [data-ws-id="24"] {
     width: 16rem;
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
     flex-direction: column
   }
-  [data-ws-id="26"] {
+  [data-ws-id="27"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -656,20 +657,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="26"]:hover {
+  [data-ws-id="27"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="26"]:focus {
+  [data-ws-id="27"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="29"] {
+  [data-ws-id="30"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="31"] {
+  [data-ws-id="32"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -682,7 +683,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="34"] {
+  [data-ws-id="35"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -704,20 +705,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="34"]:hover {
+  [data-ws-id="35"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="34"]:focus {
+  [data-ws-id="35"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="37"] {
+  [data-ws-id="38"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="39"] {
+  [data-ws-id="40"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -730,7 +731,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="42"] {
+  [data-ws-id="43"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -752,20 +753,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="42"]:hover {
+  [data-ws-id="43"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="42"]:focus {
+  [data-ws-id="43"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="45"] {
+  [data-ws-id="46"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="47"] {
+  [data-ws-id="48"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -778,7 +779,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="51"] {
+  [data-ws-id="52"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -807,25 +808,25 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-right: 0.75rem;
     --navigation-menu-trigger-icon-transform: 0deg
   }
-  [data-ws-id="51"]:focus-visible {
+  [data-ws-id="52"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="51"]:disabled {
+  [data-ws-id="52"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="51"]:hover {
+  [data-ws-id="52"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="51"][data-state=open] {
+  [data-ws-id="52"][data-state=open] {
     --navigation-menu-trigger-icon-transform: 180deg
   }
-  [data-ws-id="54"] {
+  [data-ws-id="55"] {
     margin-left: 0.25rem;
     rotate: var(--navigation-menu-trigger-icon-transform);
     height: 1rem;
@@ -835,7 +836,7 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="58"] {
+  [data-ws-id="59"] {
     left: 0px;
     top: 0px;
     position: absolute;
@@ -845,7 +846,7 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 1rem;
     padding-bottom: 1rem
   }
-  [data-ws-id="60"] {
+  [data-ws-id="61"] {
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
@@ -854,14 +855,14 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0px;
     padding-bottom: 0px
   }
-  [data-ws-id="62"] {
+  [data-ws-id="63"] {
     width: 16rem;
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
     flex-direction: column
   }
-  [data-ws-id="65"] {
+  [data-ws-id="66"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -883,20 +884,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="65"]:hover {
+  [data-ws-id="66"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="65"]:focus {
+  [data-ws-id="66"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="68"] {
+  [data-ws-id="69"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="70"] {
+  [data-ws-id="71"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -909,7 +910,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="73"] {
+  [data-ws-id="74"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -931,20 +932,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="73"]:hover {
+  [data-ws-id="74"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="73"]:focus {
+  [data-ws-id="74"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="76"] {
+  [data-ws-id="77"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="78"] {
+  [data-ws-id="79"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -957,7 +958,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="81"] {
+  [data-ws-id="82"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -979,20 +980,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="81"]:hover {
+  [data-ws-id="82"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="81"]:focus {
+  [data-ws-id="82"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="84"] {
+  [data-ws-id="85"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="86"] {
+  [data-ws-id="87"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -1005,14 +1006,14 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="88"] {
+  [data-ws-id="89"] {
     width: 16rem;
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
     flex-direction: column
   }
-  [data-ws-id="91"] {
+  [data-ws-id="92"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -1034,20 +1035,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="91"]:hover {
+  [data-ws-id="92"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="91"]:focus {
+  [data-ws-id="92"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="94"] {
+  [data-ws-id="95"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="96"] {
+  [data-ws-id="97"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -1060,7 +1061,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="99"] {
+  [data-ws-id="100"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -1082,20 +1083,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="99"]:hover {
+  [data-ws-id="100"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="99"]:focus {
+  [data-ws-id="100"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="102"] {
+  [data-ws-id="103"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="104"] {
+  [data-ws-id="105"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -1108,7 +1109,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="107"] {
+  [data-ws-id="108"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -1130,20 +1131,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="107"]:hover {
+  [data-ws-id="108"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="107"]:focus {
+  [data-ws-id="108"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="110"] {
+  [data-ws-id="111"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="112"] {
+  [data-ws-id="113"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -1156,7 +1157,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="116"] {
+  [data-ws-id="117"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -1186,29 +1187,29 @@ html {margin: 0; display: grid; min-height: 100%}
     text-decoration-line: none;
     color: currentColor
   }
-  [data-ws-id="116"]:focus-visible {
+  [data-ws-id="117"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="116"]:disabled {
+  [data-ws-id="117"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="116"]:hover {
+  [data-ws-id="117"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="118"] {
+  [data-ws-id="119"] {
     position: absolute;
     left: 0px;
     top: 100%;
     display: flex;
     justify-content: center
   }
-  [data-ws-id="120"] {
+  [data-ws-id="121"] {
     position: relative;
     margin-top: 0.375rem;
     overflow: hidden;

--- a/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
@@ -11,7 +11,8 @@ import {
 } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [popoverOpen, set$popoverOpen] = useState(false);
+  let [popoverOpen, set$popoverOpen] = useState<any>(false);
+  let expression = popoverOpen;
   let onOpenChange = (open: any) => {
     popoverOpen = open;
     set$popoverOpen(popoverOpen);
@@ -21,16 +22,16 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Popover
         data-ws-id="1"
         data-ws-component="Popover"
-        open={popoverOpen}
+        open={expression}
         onOpenChange={onOpenChange}
       >
-        <PopoverTrigger data-ws-id="5" data-ws-component="PopoverTrigger">
-          <Button data-ws-id="6" data-ws-component="Button">
+        <PopoverTrigger data-ws-id="6" data-ws-component="PopoverTrigger">
+          <Button data-ws-id="7" data-ws-component="Button">
             {"Button"}
           </Button>
         </PopoverTrigger>
-        <PopoverContent data-ws-id="8" data-ws-component="PopoverContent">
-          <Text data-ws-id="10" data-ws-component="Text">
+        <PopoverContent data-ws-id="9" data-ws-component="PopoverContent">
+          <Text data-ws-id="11" data-ws-component="Text">
             {"The text you can edit"}
           </Text>
         </PopoverContent>
@@ -182,7 +183,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="6"] {
+  [data-ws-id="7"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -212,22 +213,22 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0.5rem;
     padding-bottom: 0.5rem
   }
-  [data-ws-id="6"]:focus-visible {
+  [data-ws-id="7"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="6"]:disabled {
+  [data-ws-id="7"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="6"]:hover {
+  [data-ws-id="7"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="8"] {
+  [data-ws-id="9"] {
     z-index: 50;
     width: 18rem;
     border-top-left-radius: 0.375rem;

--- a/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
@@ -12,7 +12,8 @@ import {
 } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [radioGroupValue, set$radioGroupValue] = useState("");
+  let [radioGroupValue, set$radioGroupValue] = useState<any>("");
+  let expression = radioGroupValue;
   let onValueChange = (value: any) => {
     radioGroupValue = value;
     set$radioGroupValue(radioGroupValue);
@@ -22,21 +23,21 @@ const Page = (props: { scripts?: ReactNode }) => {
       <RadioGroup
         data-ws-id="1"
         data-ws-component="RadioGroup"
-        value={radioGroupValue}
+        value={expression}
         onValueChange={onValueChange}
       >
-        <Label data-ws-id="6" data-ws-component="Label">
+        <Label data-ws-id="7" data-ws-component="Label">
           <RadioGroupItem
-            data-ws-id="8"
+            data-ws-id="9"
             data-ws-component="RadioGroupItem"
             value={"default"}
           >
             <RadioGroupIndicator
-              data-ws-id="11"
+              data-ws-id="12"
               data-ws-component="RadioGroupIndicator"
             >
               <HtmlEmbed
-                data-ws-id="12"
+                data-ws-id="13"
                 data-ws-component="HtmlEmbed"
                 code={
                   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M8 5.35a2.65 2.65 0 1 0 0 5.3 2.65 2.65 0 0 0 0-5.3Z"/></svg>'
@@ -44,22 +45,22 @@ const Page = (props: { scripts?: ReactNode }) => {
               />
             </RadioGroupIndicator>
           </RadioGroupItem>
-          <Text data-ws-id="14" data-ws-component="Text">
+          <Text data-ws-id="15" data-ws-component="Text">
             {"Default"}
           </Text>
         </Label>
-        <Label data-ws-id="15" data-ws-component="Label">
+        <Label data-ws-id="16" data-ws-component="Label">
           <RadioGroupItem
-            data-ws-id="17"
+            data-ws-id="18"
             data-ws-component="RadioGroupItem"
             value={"comfortable"}
           >
             <RadioGroupIndicator
-              data-ws-id="20"
+              data-ws-id="21"
               data-ws-component="RadioGroupIndicator"
             >
               <HtmlEmbed
-                data-ws-id="21"
+                data-ws-id="22"
                 data-ws-component="HtmlEmbed"
                 code={
                   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M8 5.35a2.65 2.65 0 1 0 0 5.3 2.65 2.65 0 0 0 0-5.3Z"/></svg>'
@@ -67,22 +68,22 @@ const Page = (props: { scripts?: ReactNode }) => {
               />
             </RadioGroupIndicator>
           </RadioGroupItem>
-          <Text data-ws-id="23" data-ws-component="Text">
+          <Text data-ws-id="24" data-ws-component="Text">
             {"Comfortable"}
           </Text>
         </Label>
-        <Label data-ws-id="24" data-ws-component="Label">
+        <Label data-ws-id="25" data-ws-component="Label">
           <RadioGroupItem
-            data-ws-id="26"
+            data-ws-id="27"
             data-ws-component="RadioGroupItem"
             value={"compact"}
           >
             <RadioGroupIndicator
-              data-ws-id="29"
+              data-ws-id="30"
               data-ws-component="RadioGroupIndicator"
             >
               <HtmlEmbed
-                data-ws-id="30"
+                data-ws-id="31"
                 data-ws-component="HtmlEmbed"
                 code={
                   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M8 5.35a2.65 2.65 0 1 0 0 5.3 2.65 2.65 0 0 0 0-5.3Z"/></svg>'
@@ -90,7 +91,7 @@ const Page = (props: { scripts?: ReactNode }) => {
               />
             </RadioGroupIndicator>
           </RadioGroupItem>
-          <Text data-ws-id="32" data-ws-component="Text">
+          <Text data-ws-id="33" data-ws-component="Text">
             {"Compact"}
           </Text>
         </Label>
@@ -278,13 +279,13 @@ html {margin: 0; display: grid; min-height: 100%}
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="6"] {
+  [data-ws-id="7"] {
     display: flex;
     align-items: center;
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="8"] {
+  [data-ws-id="9"] {
     aspect-ratio: 1 / 1;
     height: 1rem;
     width: 1rem;
@@ -306,24 +307,24 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="8"]:focus-visible {
+  [data-ws-id="9"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="8"]:disabled {
+  [data-ws-id="9"]:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="15"] {
+  [data-ws-id="16"] {
     display: flex;
     align-items: center;
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="17"] {
+  [data-ws-id="18"] {
     aspect-ratio: 1 / 1;
     height: 1rem;
     width: 1rem;
@@ -345,24 +346,24 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="17"]:focus-visible {
+  [data-ws-id="18"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="17"]:disabled {
+  [data-ws-id="18"]:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="24"] {
+  [data-ws-id="25"] {
     display: flex;
     align-items: center;
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="26"] {
+  [data-ws-id="27"] {
     aspect-ratio: 1 / 1;
     height: 1rem;
     width: 1rem;
@@ -384,14 +385,14 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="26"]:focus-visible {
+  [data-ws-id="27"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="26"]:disabled {
+  [data-ws-id="27"]:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }

--- a/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
@@ -15,8 +15,10 @@ import {
 } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [selectValue, set$selectValue] = useState("");
-  let [selectOpen, set$selectOpen] = useState(false);
+  let [selectValue, set$selectValue] = useState<any>("");
+  let [selectOpen, set$selectOpen] = useState<any>(false);
+  let expression = selectValue;
+  let expression_1 = selectOpen;
   let onValueChange = (value: any) => {
     selectValue = value;
     set$selectValue(selectValue);
@@ -30,31 +32,31 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Select
         data-ws-id="1"
         data-ws-component="Select"
-        value={selectValue}
+        value={expression}
         onValueChange={onValueChange}
-        open={selectOpen}
+        open={expression_1}
         onOpenChange={onOpenChange}
       >
-        <SelectTrigger data-ws-id="8" data-ws-component="SelectTrigger">
+        <SelectTrigger data-ws-id="10" data-ws-component="SelectTrigger">
           <SelectValue
-            data-ws-id="10"
+            data-ws-id="12"
             data-ws-component="SelectValue"
             placeholder={"Theme"}
           />
         </SelectTrigger>
-        <SelectContent data-ws-id="12" data-ws-component="SelectContent">
-          <SelectViewport data-ws-id="14" data-ws-component="SelectViewport">
+        <SelectContent data-ws-id="14" data-ws-component="SelectContent">
+          <SelectViewport data-ws-id="16" data-ws-component="SelectViewport">
             <SelectItem
-              data-ws-id="16"
+              data-ws-id="18"
               data-ws-component="SelectItem"
               value={"light"}
             >
               <SelectItemIndicator
-                data-ws-id="19"
+                data-ws-id="21"
                 data-ws-component="SelectItemIndicator"
               >
                 <HtmlEmbed
-                  data-ws-id="21"
+                  data-ws-id="23"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M11.957 5.043a1 1 0 0 1 0 1.414l-4.5 4.5a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L6.75 8.836l3.793-3.793a1 1 0 0 1 1.414 0Z" clip-rule="evenodd"/></svg>'
@@ -62,23 +64,23 @@ const Page = (props: { scripts?: ReactNode }) => {
                 />
               </SelectItemIndicator>
               <SelectItemText
-                data-ws-id="23"
+                data-ws-id="25"
                 data-ws-component="SelectItemText"
               >
                 {"Light"}
               </SelectItemText>
             </SelectItem>
             <SelectItem
-              data-ws-id="24"
+              data-ws-id="26"
               data-ws-component="SelectItem"
               value={"dark"}
             >
               <SelectItemIndicator
-                data-ws-id="27"
+                data-ws-id="29"
                 data-ws-component="SelectItemIndicator"
               >
                 <HtmlEmbed
-                  data-ws-id="29"
+                  data-ws-id="31"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M11.957 5.043a1 1 0 0 1 0 1.414l-4.5 4.5a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L6.75 8.836l3.793-3.793a1 1 0 0 1 1.414 0Z" clip-rule="evenodd"/></svg>'
@@ -86,23 +88,23 @@ const Page = (props: { scripts?: ReactNode }) => {
                 />
               </SelectItemIndicator>
               <SelectItemText
-                data-ws-id="31"
+                data-ws-id="33"
                 data-ws-component="SelectItemText"
               >
                 {"Dark"}
               </SelectItemText>
             </SelectItem>
             <SelectItem
-              data-ws-id="32"
+              data-ws-id="34"
               data-ws-component="SelectItem"
               value={"system"}
             >
               <SelectItemIndicator
-                data-ws-id="35"
+                data-ws-id="37"
                 data-ws-component="SelectItemIndicator"
               >
                 <HtmlEmbed
-                  data-ws-id="37"
+                  data-ws-id="39"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M11.957 5.043a1 1 0 0 1 0 1.414l-4.5 4.5a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L6.75 8.836l3.793-3.793a1 1 0 0 1 1.414 0Z" clip-rule="evenodd"/></svg>'
@@ -110,7 +112,7 @@ const Page = (props: { scripts?: ReactNode }) => {
                 />
               </SelectItemIndicator>
               <SelectItemText
-                data-ws-id="39"
+                data-ws-id="41"
                 data-ws-component="SelectItemText"
               >
                 {"System"}
@@ -297,7 +299,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="8"] {
+  [data-ws-id="10"] {
     display: flex;
     height: 2.5rem;
     width: 100%;
@@ -327,21 +329,21 @@ html {margin: 0; display: grid; min-height: 100%}
     font-size: 0.875rem;
     line-height: 1.25rem
   }
-  [data-ws-id="8"]::placeholder {
+  [data-ws-id="10"]::placeholder {
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="8"]:focus {
+  [data-ws-id="10"]:focus {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="8"]:disabled {
+  [data-ws-id="10"]:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="12"] {
+  [data-ws-id="14"] {
     position: relative;
     z-index: 50;
     min-width: 8rem;
@@ -366,7 +368,7 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(2, 8, 23, 1);
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)
   }
-  [data-ws-id="14"] {
+  [data-ws-id="16"] {
     padding-left: 0.25rem;
     padding-right: 0.25rem;
     padding-top: 0.25rem;
@@ -375,7 +377,7 @@ html {margin: 0; display: grid; min-height: 100%}
     width: 100%;
     min-width: var(--radix-select-trigger-width)
   }
-  [data-ws-id="16"] {
+  [data-ws-id="18"] {
     position: relative;
     display: flex;
     width: 100%;
@@ -397,15 +399,15 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="16"]:focus {
+  [data-ws-id="18"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="16"][data-disabled] {
+  [data-ws-id="18"][data-disabled] {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="19"] {
+  [data-ws-id="21"] {
     position: absolute;
     left: 0.5rem;
     display: flex;
@@ -414,7 +416,7 @@ html {margin: 0; display: grid; min-height: 100%}
     align-items: center;
     justify-content: center
   }
-  [data-ws-id="24"] {
+  [data-ws-id="26"] {
     position: relative;
     display: flex;
     width: 100%;
@@ -436,15 +438,15 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="24"]:focus {
+  [data-ws-id="26"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="24"][data-disabled] {
+  [data-ws-id="26"][data-disabled] {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="27"] {
+  [data-ws-id="29"] {
     position: absolute;
     left: 0.5rem;
     display: flex;
@@ -453,7 +455,7 @@ html {margin: 0; display: grid; min-height: 100%}
     align-items: center;
     justify-content: center
   }
-  [data-ws-id="32"] {
+  [data-ws-id="34"] {
     position: relative;
     display: flex;
     width: 100%;
@@ -475,15 +477,15 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="32"]:focus {
+  [data-ws-id="34"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="32"][data-disabled] {
+  [data-ws-id="34"][data-disabled] {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="35"] {
+  [data-ws-id="37"] {
     position: absolute;
     left: 0.5rem;
     display: flex;

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
@@ -16,7 +16,8 @@ import {
 } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [sheetOpen, set$sheetOpen] = useState(false);
+  let [sheetOpen, set$sheetOpen] = useState<any>(false);
+  let expression = sheetOpen;
   let onOpenChange = (open: any) => {
     sheetOpen = open;
     set$sheetOpen(sheetOpen);
@@ -26,13 +27,13 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Dialog
         data-ws-id="1"
         data-ws-component="Dialog"
-        open={sheetOpen}
+        open={expression}
         onOpenChange={onOpenChange}
       >
-        <DialogTrigger data-ws-id="5" data-ws-component="DialogTrigger">
-          <Button data-ws-id="6" data-ws-component="Button">
+        <DialogTrigger data-ws-id="6" data-ws-component="DialogTrigger">
+          <Button data-ws-id="7" data-ws-component="Button">
             <HtmlEmbed
-              data-ws-id="8"
+              data-ws-id="9"
               data-ws-component="HtmlEmbed"
               code={
                 '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M2 5.998a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Zm0 5.5a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Zm0 5.5a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd"/></svg>'
@@ -40,32 +41,32 @@ const Page = (props: { scripts?: ReactNode }) => {
             />
           </Button>
         </DialogTrigger>
-        <DialogOverlay data-ws-id="10" data-ws-component="DialogOverlay">
-          <DialogContent data-ws-id="12" data-ws-component="DialogContent">
+        <DialogOverlay data-ws-id="11" data-ws-component="DialogOverlay">
+          <DialogContent data-ws-id="13" data-ws-component="DialogContent">
             <Box
-              data-ws-id="14"
+              data-ws-id="15"
               data-ws-component="Box"
               tag={"nav"}
               role={"navigation"}
             >
-              <Box data-ws-id="17" data-ws-component="Box">
-                <DialogTitle data-ws-id="19" data-ws-component="DialogTitle">
+              <Box data-ws-id="18" data-ws-component="Box">
+                <DialogTitle data-ws-id="20" data-ws-component="DialogTitle">
                   {"Sheet Title"}
                 </DialogTitle>
                 <DialogDescription
-                  data-ws-id="21"
+                  data-ws-id="22"
                   data-ws-component="DialogDescription"
                 >
                   {"Sheet description text you can edit"}
                 </DialogDescription>
               </Box>
-              <Text data-ws-id="23" data-ws-component="Text">
+              <Text data-ws-id="24" data-ws-component="Text">
                 {"The text you can edit"}
               </Text>
             </Box>
-            <DialogClose data-ws-id="24" data-ws-component="DialogClose">
+            <DialogClose data-ws-id="25" data-ws-component="DialogClose">
               <HtmlEmbed
-                data-ws-id="26"
+                data-ws-id="27"
                 data-ws-component="HtmlEmbed"
                 code={
                   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M13.566 2.434a.8.8 0 0 1 0 1.132L9.13 8l4.435 4.434a.8.8 0 0 1-1.132 1.132L8 9.13l-4.434 4.435a.8.8 0 0 1-1.132-1.132L6.87 8 2.434 3.566a.8.8 0 0 1 1.132-1.132L8 6.87l4.434-4.435a.8.8 0 0 1 1.132 0Z" clip-rule="evenodd"/></svg>'
@@ -275,7 +276,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="6"] {
+  [data-ws-id="7"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -302,22 +303,22 @@ html {margin: 0; display: grid; min-height: 100%}
     height: 2.5rem;
     width: 2.5rem
   }
-  [data-ws-id="6"]:focus-visible {
+  [data-ws-id="7"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="6"]:disabled {
+  [data-ws-id="7"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="6"]:hover {
+  [data-ws-id="7"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="10"] {
+  [data-ws-id="11"] {
     position: fixed;
     left: 0px;
     right: 0px;
@@ -330,7 +331,7 @@ html {margin: 0; display: grid; min-height: 100%}
     flex-direction: column;
     overflow: auto
   }
-  [data-ws-id="12"] {
+  [data-ws-id="13"] {
     width: 100%;
     z-index: 50;
     display: flex;
@@ -360,27 +361,27 @@ html {margin: 0; display: grid; min-height: 100%}
     max-width: 24rem;
     flex-grow: 1
   }
-  [data-ws-id="17"] {
+  [data-ws-id="18"] {
     display: flex;
     flex-direction: column;
     row-gap: 0.25rem;
     column-gap: 0.25rem
   }
-  [data-ws-id="19"] {
+  [data-ws-id="20"] {
     margin-top: 0px;
     margin-bottom: 0px;
     line-height: 1.75rem;
     font-size: 1.125rem;
     letter-spacing: -0.025em
   }
-  [data-ws-id="21"] {
+  [data-ws-id="22"] {
     margin-top: 0px;
     margin-bottom: 0px;
     font-size: 0.875rem;
     line-height: 1.25rem;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="24"] {
+  [data-ws-id="25"] {
     position: absolute;
     right: 1rem;
     top: 1rem;
@@ -412,10 +413,10 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="24"]:hover {
+  [data-ws-id="25"]:hover {
     opacity: 1
   }
-  [data-ws-id="24"]:focus {
+  [data-ws-id="25"]:focus {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
@@ -3,7 +3,8 @@ import { Box as Box } from "@webstudio-is/sdk-components-react";
 import { Switch as Switch, SwitchThumb as SwitchThumb } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [switchChecked, set$switchChecked] = useState(false);
+  let [switchChecked, set$switchChecked] = useState<any>(false);
+  let expression = switchChecked;
   let onCheckedChange = (checked: any) => {
     switchChecked = checked;
     set$switchChecked(switchChecked);
@@ -13,10 +14,10 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Switch
         data-ws-id="1"
         data-ws-component="Switch"
-        checked={switchChecked}
+        checked={expression}
         onCheckedChange={onCheckedChange}
       >
-        <SwitchThumb data-ws-id="6" data-ws-component="SwitchThumb" />
+        <SwitchThumb data-ws-id="7" data-ws-component="SwitchThumb" />
       </Switch>
       {props.scripts}
     </Box>
@@ -214,7 +215,7 @@ html {margin: 0; display: grid; min-height: 100%}
   [data-ws-id="1"][data-state=unchecked] {
     background-color: rgba(226, 232, 240, 1)
   }
-  [data-ws-id="6"] {
+  [data-ws-id="7"] {
     pointer-events: none;
     display: block;
     height: 1.25rem;
@@ -229,10 +230,10 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms
   }
-  [data-ws-id="6"][data-state=checked] {
+  [data-ws-id="7"][data-state=checked] {
     transform: translateX(20px)
   }
-  [data-ws-id="6"][data-state=unchecked] {
+  [data-ws-id="7"][data-state=unchecked] {
     transform: translateX(0px)
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
@@ -8,7 +8,8 @@ import {
 } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [tabsValue, set$tabsValue] = useState("0");
+  let [tabsValue, set$tabsValue] = useState<any>("0");
+  let expression = tabsValue;
   let onValueChange = (value: any) => {
     tabsValue = value;
     set$tabsValue(tabsValue);
@@ -18,19 +19,19 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Tabs
         data-ws-id="1"
         data-ws-component="Tabs"
-        value={tabsValue}
+        value={expression}
         onValueChange={onValueChange}
       >
-        <TabsList data-ws-id="5" data-ws-component="TabsList">
+        <TabsList data-ws-id="6" data-ws-component="TabsList">
           <TabsTrigger
-            data-ws-id="7"
+            data-ws-id="8"
             data-ws-component="TabsTrigger"
             data-ws-index="0"
           >
             {"Account"}
           </TabsTrigger>
           <TabsTrigger
-            data-ws-id="9"
+            data-ws-id="10"
             data-ws-component="TabsTrigger"
             data-ws-index="1"
           >
@@ -38,14 +39,14 @@ const Page = (props: { scripts?: ReactNode }) => {
           </TabsTrigger>
         </TabsList>
         <TabsContent
-          data-ws-id="11"
+          data-ws-id="12"
           data-ws-component="TabsContent"
           data-ws-index="0"
         >
           {"Make changes to your account here."}
         </TabsContent>
         <TabsContent
-          data-ws-id="13"
+          data-ws-id="14"
           data-ws-component="TabsContent"
           data-ws-index="1"
         >
@@ -220,7 +221,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="5"] {
+  [data-ws-id="6"] {
     display: inline-flex;
     height: 2.5rem;
     align-items: center;
@@ -236,7 +237,7 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-bottom: 0.25rem;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="7"] {
+  [data-ws-id="8"] {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -256,23 +257,23 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms
   }
-  [data-ws-id="7"]:focus-visible {
+  [data-ws-id="8"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="7"]:disabled {
+  [data-ws-id="8"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="7"][data-state=active] {
+  [data-ws-id="8"][data-state=active] {
     background-color: rgba(255, 255, 255, 0.8);
     color: rgba(2, 8, 23, 1);
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05)
   }
-  [data-ws-id="9"] {
+  [data-ws-id="10"] {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -292,36 +293,36 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms
   }
-  [data-ws-id="9"]:focus-visible {
+  [data-ws-id="10"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="9"]:disabled {
+  [data-ws-id="10"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="9"][data-state=active] {
+  [data-ws-id="10"][data-state=active] {
     background-color: rgba(255, 255, 255, 0.8);
     color: rgba(2, 8, 23, 1);
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05)
   }
-  [data-ws-id="11"] {
+  [data-ws-id="12"] {
     margin-top: 0.5rem
   }
-  [data-ws-id="11"]:focus-visible {
+  [data-ws-id="12"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="13"] {
+  [data-ws-id="14"] {
     margin-top: 0.5rem
   }
-  [data-ws-id="13"]:focus-visible {
+  [data-ws-id="14"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
@@ -11,7 +11,8 @@ import {
 } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
-  let [tooltipOpen, set$tooltipOpen] = useState(false);
+  let [tooltipOpen, set$tooltipOpen] = useState<any>(false);
+  let expression = tooltipOpen;
   let onOpenChange = (open: any) => {
     tooltipOpen = open;
     set$tooltipOpen(tooltipOpen);
@@ -21,16 +22,16 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Tooltip
         data-ws-id="1"
         data-ws-component="Tooltip"
-        open={tooltipOpen}
+        open={expression}
         onOpenChange={onOpenChange}
       >
-        <TooltipTrigger data-ws-id="5" data-ws-component="TooltipTrigger">
-          <Button data-ws-id="6" data-ws-component="Button">
+        <TooltipTrigger data-ws-id="6" data-ws-component="TooltipTrigger">
+          <Button data-ws-id="7" data-ws-component="Button">
             {"Button"}
           </Button>
         </TooltipTrigger>
-        <TooltipContent data-ws-id="8" data-ws-component="TooltipContent">
-          <Text data-ws-id="10" data-ws-component="Text">
+        <TooltipContent data-ws-id="9" data-ws-component="TooltipContent">
+          <Text data-ws-id="11" data-ws-component="Text">
             {"The text you can edit"}
           </Text>
         </TooltipContent>
@@ -182,7 +183,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="6"] {
+  [data-ws-id="7"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -212,22 +213,22 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0.5rem;
     padding-bottom: 0.5rem
   }
-  [data-ws-id="6"]:focus-visible {
+  [data-ws-id="7"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="6"]:disabled {
+  [data-ws-id="7"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="6"]:hover {
+  [data-ws-id="7"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="8"] {
+  [data-ws-id="9"] {
     z-index: 50;
     overflow: hidden;
     border-top-left-radius: 0.375rem;

--- a/packages/sdk-components-react-radix/src/accordion.ws.ts
+++ b/packages/sdk-components-react-radix/src/accordion.ws.ts
@@ -131,12 +131,12 @@ export const metaAccordion: WsComponentMeta = {
     {
       type: "instance",
       component: "Accordion",
-      dataSources: {
-        accordionValue: { type: "variable", initialValue: "0" },
+      variables: {
+        accordionValue: { initialValue: "0" },
       },
       props: [
         { type: "boolean", name: "collapsible", value: true },
-        { type: "dataSource", name: "value", dataSourceName: "accordionValue" },
+        { type: "expression", name: "value", code: "accordionValue" },
         {
           name: "onValueChange",
           type: "action",

--- a/packages/sdk-components-react-radix/src/checkbox.ws.ts
+++ b/packages/sdk-components-react-radix/src/checkbox.ws.ts
@@ -49,14 +49,14 @@ export const metaCheckbox: WsComponentMeta = {
         {
           type: "instance",
           component: "Checkbox",
-          dataSources: {
-            checkboxChecked: { type: "variable", initialValue: false },
+          variables: {
+            checkboxChecked: { initialValue: false },
           },
           props: [
             {
               name: "checked",
-              type: "dataSource",
-              dataSourceName: "checkboxChecked",
+              type: "expression",
+              code: "checkboxChecked",
             },
             {
               name: "onCheckedChange",

--- a/packages/sdk-components-react-radix/src/collapsible.ws.ts
+++ b/packages/sdk-components-react-radix/src/collapsible.ws.ts
@@ -32,14 +32,14 @@ export const metaCollapsible: WsComponentMeta = {
     {
       type: "instance",
       component: "Collapsible",
-      dataSources: {
-        collapsibleOpen: { type: "variable", initialValue: false },
+      variables: {
+        collapsibleOpen: { initialValue: false },
       },
       props: [
         {
-          type: "dataSource",
+          type: "expression",
           name: "open",
-          dataSourceName: "collapsibleOpen",
+          code: "collapsibleOpen",
         },
         {
           name: "onOpenChange",

--- a/packages/sdk-components-react-radix/src/dialog.ws.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.ws.tsx
@@ -109,14 +109,14 @@ export const metaDialog: WsComponentMeta = {
     {
       type: "instance",
       component: "Dialog",
-      dataSources: {
-        dialogOpen: { type: "variable", initialValue: false },
+      variables: {
+        dialogOpen: { initialValue: false },
       },
       props: [
         {
-          type: "dataSource",
+          type: "expression",
           name: "open",
-          dataSourceName: "dialogOpen",
+          code: "dialogOpen",
         },
         {
           name: "onOpenChange",

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -314,11 +314,11 @@ export const metaNavigationMenu: WsComponentMeta = {
     {
       type: "instance",
       component: "NavigationMenu",
-      dataSources: {
-        menuValue: { type: "variable", initialValue: "" },
+      variables: {
+        menuValue: { initialValue: "" },
       },
       props: [
-        { type: "dataSource", name: "value", dataSourceName: "menuValue" },
+        { type: "expression", name: "value", code: "menuValue" },
         {
           name: "onValueChange",
           type: "action",

--- a/packages/sdk-components-react-radix/src/popover.ws.tsx
+++ b/packages/sdk-components-react-radix/src/popover.ws.tsx
@@ -53,14 +53,14 @@ export const metaPopover: WsComponentMeta = {
     {
       type: "instance",
       component: "Popover",
-      dataSources: {
-        popoverOpen: { type: "variable", initialValue: false },
+      variables: {
+        popoverOpen: { initialValue: false },
       },
       props: [
         {
-          type: "dataSource",
+          type: "expression",
           name: "open",
-          dataSourceName: "popoverOpen",
+          code: "popoverOpen",
         },
         {
           name: "onOpenChange",

--- a/packages/sdk-components-react-radix/src/radio-group.ws.ts
+++ b/packages/sdk-components-react-radix/src/radio-group.ws.ts
@@ -109,16 +109,16 @@ export const metaRadioGroup: WsComponentMeta = {
     {
       type: "instance",
       component: "RadioGroup",
-      dataSources: {
-        radioGroupValue: { type: "variable", initialValue: "" },
+      variables: {
+        radioGroupValue: { initialValue: "" },
       },
       // grid gap-2
       styles: [tc.flex(), tc.flex("col"), tc.gap(2)].flat(),
       props: [
         {
-          type: "dataSource",
+          type: "expression",
           name: "value",
-          dataSourceName: "radioGroupValue",
+          code: "radioGroupValue",
         },
         {
           name: "onValueChange",

--- a/packages/sdk-components-react-radix/src/select.ws.ts
+++ b/packages/sdk-components-react-radix/src/select.ws.ts
@@ -114,15 +114,15 @@ export const metaSelect: WsComponentMeta = {
     {
       type: "instance",
       component: "Select",
-      dataSources: {
-        selectValue: { type: "variable", initialValue: "" },
-        selectOpen: { type: "variable", initialValue: false },
+      variables: {
+        selectValue: { initialValue: "" },
+        selectOpen: { initialValue: false },
       },
       props: [
         {
           name: "value",
-          type: "dataSource",
-          dataSourceName: "selectValue",
+          type: "expression",
+          code: "selectValue",
         },
         {
           name: "onValueChange",
@@ -133,8 +133,8 @@ export const metaSelect: WsComponentMeta = {
         },
         {
           name: "open",
-          type: "dataSource",
-          dataSourceName: "selectOpen",
+          type: "expression",
+          code: "selectOpen",
         },
         {
           name: "onOpenChange",

--- a/packages/sdk-components-react-radix/src/sheet.ws.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.ws.tsx
@@ -24,14 +24,14 @@ export const meta: WsComponentMeta = {
       type: "instance",
       component: "Dialog",
       label: "Sheet",
-      dataSources: {
-        sheetOpen: { type: "variable", initialValue: false },
+      variables: {
+        sheetOpen: { initialValue: false },
       },
       props: [
         {
-          type: "dataSource",
+          type: "expression",
           name: "open",
-          dataSourceName: "sheetOpen",
+          code: "sheetOpen",
         },
         {
           name: "onOpenChange",

--- a/packages/sdk-components-react-radix/src/switch.ws.ts
+++ b/packages/sdk-components-react-radix/src/switch.ws.ts
@@ -36,14 +36,14 @@ export const metaSwitch: WsComponentMeta = {
     {
       type: "instance",
       component: "Switch",
-      dataSources: {
-        switchChecked: { type: "variable", initialValue: false },
+      variables: {
+        switchChecked: { initialValue: false },
       },
       props: [
         {
           name: "checked",
-          type: "dataSource",
-          dataSourceName: "switchChecked",
+          type: "expression",
+          code: "switchChecked",
         },
         {
           name: "onCheckedChange",

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -79,11 +79,11 @@ export const metaTabs: WsComponentMeta = {
     {
       type: "instance",
       component: "Tabs",
-      dataSources: {
-        tabsValue: { type: "variable", initialValue: "0" },
+      variables: {
+        tabsValue: { initialValue: "0" },
       },
       props: [
-        { type: "dataSource", name: "value", dataSourceName: "tabsValue" },
+        { type: "expression", name: "value", code: "tabsValue" },
         {
           name: "onValueChange",
           type: "action",

--- a/packages/sdk-components-react-radix/src/tooltip.ws.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.tsx
@@ -54,14 +54,14 @@ export const metaTooltip: WsComponentMeta = {
     {
       type: "instance",
       component: "Tooltip",
-      dataSources: {
-        tooltipOpen: { type: "variable", initialValue: false },
+      variables: {
+        tooltipOpen: { initialValue: false },
       },
       props: [
         {
-          type: "dataSource",
+          type: "expression",
           name: "open",
-          dataSourceName: "tooltipOpen",
+          code: "tooltipOpen",
         },
         {
           name: "onOpenChange",

--- a/packages/sdk-components-react-remix/src/form.ws.tsx
+++ b/packages/sdk-components-react-remix/src/form.ws.tsx
@@ -33,14 +33,14 @@ export const meta: WsComponentMeta = {
     {
       type: "instance",
       component: "Form",
-      dataSources: {
-        formState: { type: "variable", initialValue: "initial" },
+      variables: {
+        formState: { initialValue: "initial" },
       },
       props: [
         {
-          type: "dataSource",
+          type: "expression",
           name: "state",
-          dataSourceName: "formState",
+          code: "formState",
         },
         {
           type: "action",
@@ -55,17 +55,11 @@ export const meta: WsComponentMeta = {
           type: "instance",
           label: "Form Content",
           component: "Box",
-          dataSources: {
-            formInitial: {
-              type: "expression",
-              code: `formState === 'initial' || formState === 'error'`,
-            },
-          },
           props: [
             {
-              type: "dataSource",
+              type: "expression",
               name: showAttribute,
-              dataSourceName: "formInitial",
+              code: "formState === 'initial' || formState === 'error'",
             },
           ],
           children: [
@@ -103,17 +97,11 @@ export const meta: WsComponentMeta = {
           type: "instance",
           label: "Success Message",
           component: "Box",
-          dataSources: {
-            formSuccess: {
-              type: "expression",
-              code: `formState === 'success'`,
-            },
-          },
           props: [
             {
-              type: "dataSource",
+              type: "expression",
               name: showAttribute,
-              dataSourceName: "formSuccess",
+              code: "formState === 'success'",
             },
           ],
           children: [
@@ -125,17 +113,11 @@ export const meta: WsComponentMeta = {
           type: "instance",
           label: "Error Message",
           component: "Box",
-          dataSources: {
-            formError: {
-              type: "expression",
-              code: `formState === 'error'`,
-            },
-          },
           props: [
             {
-              type: "dataSource",
+              type: "expression",
               name: showAttribute,
-              dataSourceName: "formError",
+              code: "formState === 'error'",
             },
           ],
           children: [{ type: "text", value: "Sorry, something went wrong." }],


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

We decided to treat expressions as props bindings
so it makes sense to move expression data to props as well. This will make expression and action simetrical and simplify data sources management.

As you can see all expressions have same "expression" name now. In another PR will change to prop name.

## Testing

1. check newly created Form states
2. Check all radix components states

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
