### PR TITLE
fix: Fix image ratelimiting

### DIFF
--- a/apps/builder/middleware.js
+++ b/apps/builder/middleware.js
@@ -312,7 +312,9 @@ app.use("*", async (ctx, next) => {
 
   ctx.set(
     "skipRateLimit",
-    url.pathname.startsWith("/build/") || url.pathname.endsWith(".ico")
+    url.pathname.startsWith("/assets/") ||
+      url.pathname.startsWith("/build/") ||
+      url.pathname.endsWith(".ico")
   );
   return next();
 });


### PR DESCRIPTION
## Description

Image were ratelimited as authorized calls

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
