### PR TITLE
fix: Project outdated when switching on preview and link hashes

### DIFF
--- a/apps/builder/app/builder/shared/sync/command-queue.ts
+++ b/apps/builder/app/builder/shared/sync/command-queue.ts
@@ -39,11 +39,6 @@ export const enqueue = (command: Command) => {
   projectCommandsQueue.push(command);
 };
 
-export const dequeue = () => {
-  const command = projectCommandsQueue.pop();
-  return command;
-};
-
 export const dequeueAll = () => {
   const commands = [...projectCommandsQueue];
   projectCommandsQueue.length = 0;

--- a/apps/builder/app/routes/builder.$projectId.tsx
+++ b/apps/builder/app/routes/builder.$projectId.tsx
@@ -127,6 +127,13 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
   // to not regenerate auth token and preserve canvas url
   currentUrlCopy.searchParams.delete("pageId");
   nextUrlCopy.searchParams.delete("pageId");
+
+  currentUrlCopy.searchParams.delete("mode");
+  nextUrlCopy.searchParams.delete("mode");
+
+  currentUrlCopy.searchParams.delete("pageHash");
+  nextUrlCopy.searchParams.delete("pageHash");
+
   return currentUrlCopy.href === nextUrlCopy.href
     ? false
     : defaultShouldRevalidate;


### PR DESCRIPTION
## Description

Fixing 
`The project is outdated. Synchronization was incomplete when the project was opened`
at least in case of preview clicks 

Trying to prevent 
https://github.com/webstudio-is/webstudio-builder/blob/a379a98c1f480397d1ddb0b1caffdc07d64b5d24/apps/builder/app/builder/shared/sync/sync-server.ts#L263

The issue is that data reload cause loading outdated version from the build

during ordinary user work


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
