### PR TITLE
feat: Add sitemap generation

### DIFF
--- a/fixtures/webstudio-custom-template/.webstudio/data.json
+++ b/fixtures/webstudio-custom-template/.webstudio/data.json
@@ -4,6 +4,7 @@
     "projectId": "0d856812-61d8-4014-a20a-82e01c0eb8ee",
     "version": 17,
     "createdAt": "2023-11-03T11:20:29.565Z",
+    "updatedAt": "2023-11-03T11:20:29.565Z",
     "pages": {
       "meta": {
         "siteName": "Fixture Site",

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml].ts
@@ -2,6 +2,7 @@ export const sitemap = {
   pages: [
     {
       path: "",
+      lastModified: "2023-11-03T11:20:29.565Z",
     },
   ],
 };

--- a/fixtures/webstudio-custom-template/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[robots.txt].tsx
@@ -11,8 +11,7 @@ export const loader = (arg: LoaderArgs) => {
 User-agent: *
 Disallow: /api/
 
-# Uncomment
-# Sitemap: https://${host}/sitemap.xml
+Sitemap: https://${host}/sitemap.xml
 
   `,
     {

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap.xml].tsx
@@ -10,8 +10,6 @@ export const loader = (arg: LoaderArgs) => {
   const urls = sitemap.pages.map((page) => {
     const url = new URL(`https://${host}${page.path}`);
 
-    console.log("===========", page);
-
     return `
   <url>
     <loc>${url.href}</loc>

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap.xml].tsx
@@ -1,4 +1,5 @@
 import type { LoaderArgs } from "@remix-run/server-runtime";
+import { sitemap } from "../__generated__/[sitemap.xml]";
 
 export const loader = (arg: LoaderArgs) => {
   const host =
@@ -6,13 +7,23 @@ export const loader = (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
+  const urls = sitemap.pages.map((page) => {
+    const url = new URL(`https://${host}${page.path}`);
+
+    console.log("===========", page);
+
+    return `
+  <url>
+    <loc>${url.href}</loc>
+    <lastmod>${page.lastModified.split("T")[0]}</lastmod>
+  </url>
+    `;
+  });
+
   return new Response(
     `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://${host}/</loc>
-    <lastmod>2023-11-05</lastmod>
-  </url>
+${urls.join("")}
 </urlset>
   `,
     {

--- a/fixtures/webstudio-remix-netlify-edge-functions/.webstudio/data.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/.webstudio/data.json
@@ -4,6 +4,7 @@
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",
     "version": 18,
     "createdAt": "2023-09-23T09:29:28.107Z",
+    "updatedAt": "2023-09-23T09:29:28.107Z",
     "pages": {
       "homePage": {
         "id": "9di_L14CzctvSruIoKVvE",

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/[sitemap.xml].ts
@@ -2,6 +2,7 @@ export const sitemap = {
   pages: [
     {
       path: "",
+      lastModified: "2023-09-23T09:29:28.107Z",
     },
   ],
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[robots.txt].tsx
@@ -11,8 +11,7 @@ export const loader = (arg: LoaderArgs) => {
 User-agent: *
 Disallow: /api/
 
-# Uncomment
-# Sitemap: https://${host}/sitemap.xml
+Sitemap: https://${host}/sitemap.xml
 
   `,
     {

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[sitemap.xml].tsx
@@ -10,8 +10,6 @@ export const loader = (arg: LoaderArgs) => {
   const urls = sitemap.pages.map((page) => {
     const url = new URL(`https://${host}${page.path}`);
 
-    console.log("===========", page);
-
     return `
   <url>
     <loc>${url.href}</loc>

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[sitemap.xml].tsx
@@ -1,4 +1,5 @@
 import type { LoaderArgs } from "@remix-run/server-runtime";
+import { sitemap } from "../__generated__/[sitemap.xml]";
 
 export const loader = (arg: LoaderArgs) => {
   const host =
@@ -6,13 +7,23 @@ export const loader = (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
+  const urls = sitemap.pages.map((page) => {
+    const url = new URL(`https://${host}${page.path}`);
+
+    console.log("===========", page);
+
+    return `
+  <url>
+    <loc>${url.href}</loc>
+    <lastmod>${page.lastModified.split("T")[0]}</lastmod>
+  </url>
+    `;
+  });
+
   return new Response(
     `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://${host}/</loc>
-    <lastmod>2023-11-05</lastmod>
-  </url>
+${urls.join("")}
 </urlset>
   `,
     {

--- a/fixtures/webstudio-remix-netlify-functions/.webstudio/data.json
+++ b/fixtures/webstudio-remix-netlify-functions/.webstudio/data.json
@@ -4,6 +4,7 @@
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",
     "version": 18,
     "createdAt": "2023-09-23T09:29:28.107Z",
+    "updatedAt": "2023-09-23T09:29:28.107Z",
     "pages": {
       "homePage": {
         "id": "9di_L14CzctvSruIoKVvE",

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/[sitemap.xml].ts
@@ -2,6 +2,7 @@ export const sitemap = {
   pages: [
     {
       path: "",
+      lastModified: "2023-09-23T09:29:28.107Z",
     },
   ],
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[robots.txt].tsx
@@ -11,8 +11,7 @@ export const loader = (arg: LoaderArgs) => {
 User-agent: *
 Disallow: /api/
 
-# Uncomment
-# Sitemap: https://${host}/sitemap.xml
+Sitemap: https://${host}/sitemap.xml
 
   `,
     {

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[sitemap.xml].tsx
@@ -10,8 +10,6 @@ export const loader = (arg: LoaderArgs) => {
   const urls = sitemap.pages.map((page) => {
     const url = new URL(`https://${host}${page.path}`);
 
-    console.log("===========", page);
-
     return `
   <url>
     <loc>${url.href}</loc>

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[sitemap.xml].tsx
@@ -1,4 +1,5 @@
 import type { LoaderArgs } from "@remix-run/server-runtime";
+import { sitemap } from "../__generated__/[sitemap.xml]";
 
 export const loader = (arg: LoaderArgs) => {
   const host =
@@ -6,13 +7,23 @@ export const loader = (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
+  const urls = sitemap.pages.map((page) => {
+    const url = new URL(`https://${host}${page.path}`);
+
+    console.log("===========", page);
+
+    return `
+  <url>
+    <loc>${url.href}</loc>
+    <lastmod>${page.lastModified.split("T")[0]}</lastmod>
+  </url>
+    `;
+  });
+
   return new Response(
     `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://${host}/</loc>
-    <lastmod>2023-11-05</lastmod>
-  </url>
+${urls.join("")}
 </urlset>
   `,
     {

--- a/fixtures/webstudio-remix-vercel/.webstudio/data.json
+++ b/fixtures/webstudio-remix-vercel/.webstudio/data.json
@@ -4,6 +4,7 @@
     "projectId": "cddc1d44-af37-4cb6-a430-d300cf6f932d",
     "version": 222,
     "createdAt": "2023-11-03T13:22:34.879Z",
+    "updatedAt": "2023-11-03T13:22:34.879Z",
     "pages": {
       "meta": {
         "siteName": "KittyGuardedZone",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml].ts
@@ -2,18 +2,23 @@ export const sitemap = {
   pages: [
     {
       path: "",
+      lastModified: "2023-11-03T13:22:34.879Z",
     },
     {
       path: "/radix",
+      lastModified: "2023-11-03T13:22:34.879Z",
     },
     {
       path: "/_route_with_symbols_",
+      lastModified: "2023-11-03T13:22:34.879Z",
     },
     {
       path: "/form",
+      lastModified: "2023-11-03T13:22:34.879Z",
     },
     {
       path: "/heading-with-id",
+      lastModified: "2023-11-03T13:22:34.879Z",
     },
   ],
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[robots.txt].tsx
@@ -11,8 +11,7 @@ export const loader = (arg: LoaderArgs) => {
 User-agent: *
 Disallow: /api/
 
-# Uncomment
-# Sitemap: https://${host}/sitemap.xml
+Sitemap: https://${host}/sitemap.xml
 
   `,
     {

--- a/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml].tsx
@@ -10,8 +10,6 @@ export const loader = (arg: LoaderArgs) => {
   const urls = sitemap.pages.map((page) => {
     const url = new URL(`https://${host}${page.path}`);
 
-    console.log("===========", page);
-
     return `
   <url>
     <loc>${url.href}</loc>

--- a/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml].tsx
@@ -1,4 +1,5 @@
 import type { LoaderArgs } from "@remix-run/server-runtime";
+import { sitemap } from "../__generated__/[sitemap.xml]";
 
 export const loader = (arg: LoaderArgs) => {
   const host =
@@ -6,13 +7,23 @@ export const loader = (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
+  const urls = sitemap.pages.map((page) => {
+    const url = new URL(`https://${host}${page.path}`);
+
+    console.log("===========", page);
+
+    return `
+  <url>
+    <loc>${url.href}</loc>
+    <lastmod>${page.lastModified.split("T")[0]}</lastmod>
+  </url>
+    `;
+  });
+
   return new Response(
     `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://${host}/</loc>
-    <lastmod>2023-11-05</lastmod>
-  </url>
+${urls.join("")}
 </urlset>
   `,
     {

--- a/packages/cli/templates/defaults/app/__generated__/[sitemap.xml].ts
+++ b/packages/cli/templates/defaults/app/__generated__/[sitemap.xml].ts
@@ -1,4 +1,11 @@
 /**
  * The only intent of this file is to support typings inside ../routes/[sitemap.xml].tsx for easier development.
  **/
-export const sitemap = {};
+export const sitemap = {
+  pages: [
+    {
+      path: "",
+      lastModified: "2021-10-13T12:00:00.000Z",
+    },
+  ],
+};

--- a/packages/cli/templates/defaults/app/routes/[robots.txt].tsx
+++ b/packages/cli/templates/defaults/app/routes/[robots.txt].tsx
@@ -11,8 +11,7 @@ export const loader = (arg: LoaderArgs) => {
 User-agent: *
 Disallow: /api/
 
-# Uncomment
-# Sitemap: https://${host}/sitemap.xml
+Sitemap: https://${host}/sitemap.xml
 
   `,
     {

--- a/packages/cli/templates/defaults/app/routes/[sitemap.xml].tsx
+++ b/packages/cli/templates/defaults/app/routes/[sitemap.xml].tsx
@@ -10,8 +10,6 @@ export const loader = (arg: LoaderArgs) => {
   const urls = sitemap.pages.map((page) => {
     const url = new URL(`https://${host}${page.path}`);
 
-    console.log("===========", page);
-
     return `
   <url>
     <loc>${url.href}</loc>

--- a/packages/cli/templates/defaults/app/routes/[sitemap.xml].tsx
+++ b/packages/cli/templates/defaults/app/routes/[sitemap.xml].tsx
@@ -1,4 +1,5 @@
 import type { LoaderArgs } from "@remix-run/server-runtime";
+import { sitemap } from "../__generated__/[sitemap.xml]";
 
 export const loader = (arg: LoaderArgs) => {
   const host =
@@ -6,13 +7,23 @@ export const loader = (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
+  const urls = sitemap.pages.map((page) => {
+    const url = new URL(`https://${host}${page.path}`);
+
+    console.log("===========", page);
+
+    return `
+  <url>
+    <loc>${url.href}</loc>
+    <lastmod>${page.lastModified.split("T")[0]}</lastmod>
+  </url>
+    `;
+  });
+
   return new Response(
     `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://${host}/</loc>
-    <lastmod>2023-11-05</lastmod>
-  </url>
+${urls.join("")}
 </urlset>
   `,
     {


### PR DESCRIPTION
## Description

Generates following sitemap.xml for published sites

```
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

  <url>
    <loc>https://localhost:3000/</loc>
    <lastmod>2023-11-03</lastmod>
  </url>
    
  <url>
    <loc>https://localhost:3000/radix</loc>
    <lastmod>2023-11-03</lastmod>
  </url>
    
  <url>
    <loc>https://localhost:3000/_route_with_symbols_</loc>
    <lastmod>2023-11-03</lastmod>
  </url>
    
  <url>
    <loc>https://localhost:3000/form</loc>
    <lastmod>2023-11-03</lastmod>
  </url>
    
  <url>
    <loc>https://localhost:3000/heading-with-id</loc>
    <lastmod>2023-11-03</lastmod>
  </url>
    
</urlset>
```  


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
