### PR TITLE
refactor: compile prop expressions

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -163,7 +163,8 @@ export const usePropsLogic = ({
     // convert data source prop to typed prop
     const dataSourceId = prop.value;
     const dataSource = dataSources.get(dataSourceId);
-    const dataSourceValue = dataSourcesLogic.get(dataSourceId);
+    const dataSourceValue =
+      dataSourcesLogic.get(prop.id) ?? dataSourcesLogic.get(dataSourceId);
     if (dataSource === undefined) {
       return [];
     }

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -165,7 +165,11 @@ const useInstanceProps = (instanceId: Instance["id"]) => {
           }
           if (prop.type === "dataSource") {
             const dataSourceId = prop.value;
-            const value = dataSourcesLogic.get(dataSourceId);
+            const value =
+              // access expression by prop id
+              dataSourcesLogic.get(prop.id) ??
+              // access variable by data source id
+              dataSourcesLogic.get(dataSourceId);
             if (value !== undefined) {
               instancePropsObject[prop.name] = value;
             }

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -697,7 +697,8 @@ export const getInstancesSlice = (rootInstanceId: string) => {
     if (prop.type === "dataSource") {
       const dataSourceId = prop.value;
       if (slicedDataSources.has(dataSourceId) === false) {
-        const value = dataSourcesLogic.get(dataSourceId);
+        const value =
+          dataSourcesLogic.get(prop.id) ?? dataSourcesLogic.get(dataSourceId);
         slicedProps.set(prop.id, {
           id: prop.id,
           instanceId: prop.instanceId,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -73,20 +73,20 @@ export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 const Page = (props: { scripts?: ReactNode }) => {
   let [formState, set$formState] = useState<any>("initial");
   let [formState_1, set$formState_1] = useState<any>("initial");
-  let formInitial = formState === "initial" || formState === "error";
-  let formSuccess = formState === "success";
-  let formError = formState === "error";
-  let formInitial_1 = formState_1 === "initial" || formState_1 === "error";
-  let formSuccess_1 = formState_1 === "success";
-  let formError_1 = formState_1 === "error";
   let onStateChange = (state: any) => {
     formState = state;
     set$formState(formState);
   };
+  let datawsshow = formState === "initial" || formState === "error";
+  let datawsshow_1 = formState === "success";
+  let datawsshow_2 = formState === "error";
   let onStateChange_1 = (state: any) => {
     formState_1 = state;
     set$formState_1(formState_1);
   };
+  let datawsshow_3 = formState_1 === "initial" || formState_1 === "error";
+  let datawsshow_4 = formState_1 === "success";
+  let datawsshow_5 = formState_1 === "error";
   return (
     <Body data-ws-id="a-4nDFkaWy4px1fn38XWJ" data-ws-component="Body">
       <Form
@@ -95,7 +95,7 @@ const Page = (props: { scripts?: ReactNode }) => {
         state={formState_1}
         onStateChange={onStateChange_1}
       >
-        {formInitial_1 && (
+        {datawsshow_3 && (
           <Box data-ws-id="qhnVrmYGlyrMZi3UzqSQA" data-ws-component="Box">
             <Heading
               data-ws-id="YdHHf4u3jrdbRIWpB_VfH"
@@ -128,12 +128,12 @@ const Page = (props: { scripts?: ReactNode }) => {
             </Button>
           </Box>
         )}
-        {formSuccess_1 && (
+        {datawsshow_4 && (
           <Box data-ws-id="966cjxuqP_T99N27-mqWE" data-ws-component="Box">
             {"Thank you for getting in touch!"}
           </Box>
         )}
-        {formError_1 && (
+        {datawsshow_5 && (
           <Box data-ws-id="SYG5hhOz31xFJUN_v9zq6" data-ws-component="Box">
             {"Sorry, something went wrong."}
           </Box>
@@ -147,7 +147,7 @@ const Page = (props: { scripts?: ReactNode }) => {
         method={"get"}
         action={"/custom"}
       >
-        {formInitial && (
+        {datawsshow && (
           <Box data-ws-id="a5YPRc19IJyhTrjjasA_R" data-ws-component="Box">
             <Heading
               data-ws-id="y4pceTmziuBRIDgUBQNLD"
@@ -180,12 +180,12 @@ const Page = (props: { scripts?: ReactNode }) => {
             </Button>
           </Box>
         )}
-        {formSuccess && (
+        {datawsshow_1 && (
           <Box data-ws-id="Gw-ta0R4FNFAGBTVRWKep" data-ws-component="Box">
             {"Thank you for getting in touch!"}
           </Box>
         )}
-        {formError && (
+        {datawsshow_2 && (
           <Box data-ws-id="ewk_WKpu4syHLPABMmvUz" data-ws-component="Box">
             {"Sorry, something went wrong."}
           </Box>

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -288,7 +288,7 @@ test("generate jsx element with data sources and action", () => {
       data-ws-id="box"
       data-ws-component="Box"
       variable={variableName}
-      expression={expressionName}
+      expression={expression}
       onClick={onClick}
       onChange={onChange} />
     `)

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -60,7 +60,12 @@ export const generateJsxElement = ({
         if (dataSource === undefined) {
           continue;
         }
-        conditionVariableName = scope.getName(dataSource.id, dataSource.name);
+        if (dataSource.type === "variable") {
+          conditionVariableName = scope.getName(dataSource.id, dataSource.name);
+        }
+        if (dataSource.type === "expression") {
+          conditionVariableName = scope.getName(prop.id, prop.name);
+        }
       }
       // ignore any other values
       continue;
@@ -84,8 +89,17 @@ export const generateJsxElement = ({
       if (dataSource === undefined) {
         continue;
       }
-      const dataSourceVariable = scope.getName(dataSource.id, dataSource.name);
-      generatedProps += `\n${prop.name}={${dataSourceVariable}}`;
+      if (dataSource.type === "variable") {
+        const dataSourceVariable = scope.getName(
+          dataSource.id,
+          dataSource.name
+        );
+        generatedProps += `\n${prop.name}={${dataSourceVariable}}`;
+      }
+      if (dataSource.type === "expression") {
+        const dataSourceVariable = scope.getName(prop.id, prop.name);
+        generatedProps += `\n${prop.name}={${dataSourceVariable}}`;
+      }
       continue;
     }
     if (prop.type === "action") {

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -234,7 +234,7 @@ test("generate variables with actions", () => {
   );
 });
 
-test("generate variables with sorted expressions", () => {
+test("generate variables with expressions", () => {
   const generated = generateDataSources({
     scope: createScope(),
     dataSources: new Map([
@@ -255,7 +255,7 @@ test("generate variables with sorted expressions", () => {
           scopeInstanceId: "instance1",
           type: "expression",
           name: "myExp",
-          code: `$ws$dataSource$dataSource3 + "Name"`,
+          code: `$ws$dataSource$dataSource1 + "Name"`,
         },
       ],
       [
@@ -269,11 +269,32 @@ test("generate variables with sorted expressions", () => {
         },
       ],
     ]),
-    props: new Map(),
+    props: new Map([
+      [
+        "prop1",
+        {
+          id: "prop1",
+          instanceId: "instance1",
+          type: "dataSource",
+          name: "exp",
+          value: "dataSource2",
+        },
+      ],
+      [
+        "prop2",
+        {
+          id: "prop2",
+          instanceId: "instance2",
+          type: "dataSource",
+          name: "exp",
+          value: "dataSource3",
+        },
+      ],
+    ]),
   });
   expect(generated.body).toMatchInlineSnapshot(`
-"let myExp = (myVar + "Value");
-let myExp_1 = (myExp + "Name");
+"let exp = (myVar + "Name");
+let exp_1 = (myVar + "Value");
 "
 `);
   expect(generated.variables).toEqual(
@@ -291,8 +312,8 @@ let myExp_1 = (myExp + "Name");
   expect(generated.output).toEqual(
     new Map([
       ["dataSource1", "myVar"],
-      ["dataSource2", "myExp_1"],
-      ["dataSource3", "myExp"],
+      ["prop1", "exp"],
+      ["prop2", "exp_1"],
     ])
   );
 });

--- a/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
@@ -14,7 +14,7 @@ import {
 
 const Page = (props: { scripts?: ReactNode }) => {
   let [accordionValue, set$accordionValue] = useState<any>("0");
-  let expression = accordionValue;
+  let value = accordionValue;
   let onValueChange = (value: any) => {
     accordionValue = value;
     set$accordionValue(accordionValue);
@@ -25,7 +25,7 @@ const Page = (props: { scripts?: ReactNode }) => {
         data-ws-id="1"
         data-ws-component="Accordion"
         collapsible={true}
-        value={expression}
+        value={value}
         onValueChange={onValueChange}
       >
         <AccordionItem

--- a/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
@@ -12,7 +12,7 @@ import {
 
 const Page = (props: { scripts?: ReactNode }) => {
   let [checkboxChecked, set$checkboxChecked] = useState<any>(false);
-  let expression = checkboxChecked;
+  let checked = checkboxChecked;
   let onCheckedChange = (checked: any) => {
     checkboxChecked = checked;
     set$checkboxChecked(checkboxChecked);
@@ -23,7 +23,7 @@ const Page = (props: { scripts?: ReactNode }) => {
         <Checkbox
           data-ws-id="3"
           data-ws-component="Checkbox"
-          checked={expression}
+          checked={checked}
           onCheckedChange={onCheckedChange}
         >
           <CheckboxIndicator

--- a/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
@@ -12,7 +12,7 @@ import {
 
 const Page = (props: { scripts?: ReactNode }) => {
   let [collapsibleOpen, set$collapsibleOpen] = useState<any>(false);
-  let expression = collapsibleOpen;
+  let open = collapsibleOpen;
   let onOpenChange = (open: any) => {
     collapsibleOpen = open;
     set$collapsibleOpen(collapsibleOpen);
@@ -22,7 +22,7 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Collapsible
         data-ws-id="1"
         data-ws-component="Collapsible"
-        open={expression}
+        open={open}
         onOpenChange={onOpenChange}
       >
         <CollapsibleTrigger

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
@@ -17,7 +17,7 @@ import {
 
 const Page = (props: { scripts?: ReactNode }) => {
   let [dialogOpen, set$dialogOpen] = useState<any>(false);
-  let expression = dialogOpen;
+  let open = dialogOpen;
   let onOpenChange = (open: any) => {
     dialogOpen = open;
     set$dialogOpen(dialogOpen);
@@ -27,7 +27,7 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Dialog
         data-ws-id="1"
         data-ws-component="Dialog"
-        open={expression}
+        open={open}
         onOpenChange={onOpenChange}
       >
         <DialogTrigger data-ws-id="6" data-ws-component="DialogTrigger">

--- a/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
@@ -19,7 +19,7 @@ import {
 
 const Page = (props: { scripts?: ReactNode }) => {
   let [menuValue, set$menuValue] = useState<any>("");
-  let expression = menuValue;
+  let value = menuValue;
   let onValueChange = (value: any) => {
     menuValue = value;
     set$menuValue(menuValue);
@@ -29,7 +29,7 @@ const Page = (props: { scripts?: ReactNode }) => {
       <NavigationMenu
         data-ws-id="1"
         data-ws-component="NavigationMenu"
-        value={expression}
+        value={value}
         onValueChange={onValueChange}
       >
         <NavigationMenuList

--- a/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
@@ -12,7 +12,7 @@ import {
 
 const Page = (props: { scripts?: ReactNode }) => {
   let [popoverOpen, set$popoverOpen] = useState<any>(false);
-  let expression = popoverOpen;
+  let open = popoverOpen;
   let onOpenChange = (open: any) => {
     popoverOpen = open;
     set$popoverOpen(popoverOpen);
@@ -22,7 +22,7 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Popover
         data-ws-id="1"
         data-ws-component="Popover"
-        open={expression}
+        open={open}
         onOpenChange={onOpenChange}
       >
         <PopoverTrigger data-ws-id="6" data-ws-component="PopoverTrigger">

--- a/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
@@ -13,7 +13,7 @@ import {
 
 const Page = (props: { scripts?: ReactNode }) => {
   let [radioGroupValue, set$radioGroupValue] = useState<any>("");
-  let expression = radioGroupValue;
+  let value = radioGroupValue;
   let onValueChange = (value: any) => {
     radioGroupValue = value;
     set$radioGroupValue(radioGroupValue);
@@ -23,7 +23,7 @@ const Page = (props: { scripts?: ReactNode }) => {
       <RadioGroup
         data-ws-id="1"
         data-ws-component="RadioGroup"
-        value={expression}
+        value={value}
         onValueChange={onValueChange}
       >
         <Label data-ws-id="7" data-ws-component="Label">

--- a/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
@@ -17,12 +17,12 @@ import {
 const Page = (props: { scripts?: ReactNode }) => {
   let [selectValue, set$selectValue] = useState<any>("");
   let [selectOpen, set$selectOpen] = useState<any>(false);
-  let expression = selectValue;
-  let expression_1 = selectOpen;
+  let value = selectValue;
   let onValueChange = (value: any) => {
     selectValue = value;
     set$selectValue(selectValue);
   };
+  let open = selectOpen;
   let onOpenChange = (open: any) => {
     selectOpen = open;
     set$selectOpen(selectOpen);
@@ -32,9 +32,9 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Select
         data-ws-id="1"
         data-ws-component="Select"
-        value={expression}
+        value={value}
         onValueChange={onValueChange}
-        open={expression_1}
+        open={open}
         onOpenChange={onOpenChange}
       >
         <SelectTrigger data-ws-id="10" data-ws-component="SelectTrigger">

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
@@ -17,7 +17,7 @@ import {
 
 const Page = (props: { scripts?: ReactNode }) => {
   let [sheetOpen, set$sheetOpen] = useState<any>(false);
-  let expression = sheetOpen;
+  let open = sheetOpen;
   let onOpenChange = (open: any) => {
     sheetOpen = open;
     set$sheetOpen(sheetOpen);
@@ -27,7 +27,7 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Dialog
         data-ws-id="1"
         data-ws-component="Dialog"
-        open={expression}
+        open={open}
         onOpenChange={onOpenChange}
       >
         <DialogTrigger data-ws-id="6" data-ws-component="DialogTrigger">

--- a/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
@@ -4,7 +4,7 @@ import { Switch as Switch, SwitchThumb as SwitchThumb } from "../components";
 
 const Page = (props: { scripts?: ReactNode }) => {
   let [switchChecked, set$switchChecked] = useState<any>(false);
-  let expression = switchChecked;
+  let checked = switchChecked;
   let onCheckedChange = (checked: any) => {
     switchChecked = checked;
     set$switchChecked(switchChecked);
@@ -14,7 +14,7 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Switch
         data-ws-id="1"
         data-ws-component="Switch"
-        checked={expression}
+        checked={checked}
         onCheckedChange={onCheckedChange}
       >
         <SwitchThumb data-ws-id="7" data-ws-component="SwitchThumb" />

--- a/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
@@ -9,7 +9,7 @@ import {
 
 const Page = (props: { scripts?: ReactNode }) => {
   let [tabsValue, set$tabsValue] = useState<any>("0");
-  let expression = tabsValue;
+  let value = tabsValue;
   let onValueChange = (value: any) => {
     tabsValue = value;
     set$tabsValue(tabsValue);
@@ -19,7 +19,7 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Tabs
         data-ws-id="1"
         data-ws-component="Tabs"
-        value={expression}
+        value={value}
         onValueChange={onValueChange}
       >
         <TabsList data-ws-id="6" data-ws-component="TabsList">

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
@@ -12,7 +12,7 @@ import {
 
 const Page = (props: { scripts?: ReactNode }) => {
   let [tooltipOpen, set$tooltipOpen] = useState<any>(false);
-  let expression = tooltipOpen;
+  let open = tooltipOpen;
   let onOpenChange = (open: any) => {
     tooltipOpen = open;
     set$tooltipOpen(tooltipOpen);
@@ -22,7 +22,7 @@ const Page = (props: { scripts?: ReactNode }) => {
       <Tooltip
         data-ws-id="1"
         data-ws-component="Tooltip"
-        open={expression}
+        open={open}
         onOpenChange={onOpenChange}
       >
         <TooltipTrigger data-ws-id="6" data-ws-component="TooltipTrigger">


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here changed accessing expression from data source id to prop id in builder and data source name to prop name in generated code.

This is another step to migrate expressions from data sources to props.

See generated output for clarification.

Note: review with hidden spaces

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
