### PR TITLE
feat: add variables to settings panel

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
@@ -1,10 +1,11 @@
-import { Grid, Switch, theme, useId } from "@webstudio-is/design-system";
+import { Box, Grid, Switch, theme, useId } from "@webstudio-is/design-system";
 import {
   type ControlProps,
   getLabel,
   Label,
   RemovePropButton,
 } from "../shared";
+import { VariablesButton } from "../variables";
 
 export const BooleanControl = ({
   meta,
@@ -28,9 +29,12 @@ export const BooleanControl = ({
       align="center"
       gap="2"
     >
-      <Label htmlFor={id} description={meta.description}>
-        {getLabel(meta, propName)}
-      </Label>
+      <Box css={{ position: "relative" }}>
+        <Label htmlFor={id} description={meta.description}>
+          {getLabel(meta, propName)}
+        </Label>
+        <VariablesButton prop={prop} propMeta={meta} onChange={onChange} />
+      </Box>
       <Switch
         id={id}
         checked={prop?.value ?? false}

--- a/apps/builder/app/builder/features/settings-panel/controls/check.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/check.tsx
@@ -7,6 +7,7 @@ import {
 } from "@webstudio-is/design-system";
 import { humanizeString } from "~/shared/string-utils";
 import { type ControlProps, getLabel, VerticalLayout, Label } from "../shared";
+import { VariablesButton } from "../variables";
 
 const add = (array: string[], item: string) => {
   if (array.includes(item)) {
@@ -43,9 +44,12 @@ export const CheckControl = ({
   return (
     <VerticalLayout
       label={
-        <Label htmlFor={`${id}:${options[0]}`} description={meta.description}>
-          {getLabel(meta, propName)}
-        </Label>
+        <Box css={{ position: "relative" }}>
+          <Label htmlFor={`${id}:${options[0]}`} description={meta.description}>
+            {getLabel(meta, propName)}
+          </Label>
+          <VariablesButton prop={prop} propMeta={meta} onChange={onChange} />
+        </Box>
       }
       deletable={deletable}
       onDelete={onDelete}

--- a/apps/builder/app/builder/features/settings-panel/controls/color.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/color.tsx
@@ -1,4 +1,4 @@
-import { InputField, useId } from "@webstudio-is/design-system";
+import { Box, InputField, useId } from "@webstudio-is/design-system";
 import {
   type ControlProps,
   getLabel,
@@ -6,6 +6,7 @@ import {
   ResponsiveLayout,
   Label,
 } from "../shared";
+import { VariablesButton } from "../variables";
 
 // @todo:
 //   use ColorPicker (need to refactor it first,
@@ -28,9 +29,12 @@ export const ColorControl = ({
   return (
     <ResponsiveLayout
       label={
-        <Label htmlFor={id} description={meta.description}>
-          {getLabel(meta, propName)}
-        </Label>
+        <Box css={{ position: "relative" }}>
+          <Label htmlFor={id} description={meta.description}>
+            {getLabel(meta, propName)}
+          </Label>
+          <VariablesButton prop={prop} propMeta={meta} onChange={onChange} />
+        </Box>
       }
       deletable={deletable}
       onDelete={onDelete}

--- a/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
@@ -183,6 +183,12 @@ export const renderControl = ({
       );
     }
 
+    if (prop.type === "json") {
+      throw new Error(
+        `Cannot render a fallback control for prop "${rest.propName}" with type json, because we don't know the available options for a multiselect control`
+      );
+    }
+
     prop satisfies never;
   }
 

--- a/apps/builder/app/builder/features/settings-panel/controls/file.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/file.tsx
@@ -1,5 +1,11 @@
 import { type ReactNode } from "react";
-import { Flex, InputField, theme, useId } from "@webstudio-is/design-system";
+import {
+  Box,
+  Flex,
+  InputField,
+  theme,
+  useId,
+} from "@webstudio-is/design-system";
 import {
   type ControlProps,
   getLabel,
@@ -8,6 +14,7 @@ import {
   Label,
 } from "../shared";
 import { SelectAsset } from "./select-asset";
+import { VariablesButton } from "../variables";
 
 type FileControlProps = ControlProps<"file", "asset" | "string">;
 
@@ -67,9 +74,12 @@ export const FileControl = ({
   return (
     <VerticalLayout
       label={
-        <Label htmlFor={id} description={meta.description}>
-          {getLabel(meta, propName)}
-        </Label>
+        <Box css={{ position: "relative" }}>
+          <Label htmlFor={id} description={meta.description}>
+            {getLabel(meta, propName)}
+          </Label>
+          <VariablesButton prop={prop} propMeta={meta} onChange={onChange} />
+        </Box>
       }
       deletable={deletable}
       onDelete={onDelete}

--- a/apps/builder/app/builder/features/settings-panel/controls/number.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/number.tsx
@@ -1,4 +1,4 @@
-import { InputField, useId } from "@webstudio-is/design-system";
+import { Box, InputField, useId } from "@webstudio-is/design-system";
 import {
   type ControlProps,
   getLabel,
@@ -7,6 +7,7 @@ import {
   Label,
 } from "../shared";
 import { useState } from "react";
+import { VariablesButton } from "../variables";
 
 export const NumberControl = ({
   meta,
@@ -31,9 +32,12 @@ export const NumberControl = ({
   return (
     <ResponsiveLayout
       label={
-        <Label htmlFor={id} description={meta.description}>
-          {getLabel(meta, propName)}
-        </Label>
+        <Box css={{ position: "relative" }}>
+          <Label htmlFor={id} description={meta.description}>
+            {getLabel(meta, propName)}
+          </Label>
+          <VariablesButton prop={prop} propMeta={meta} onChange={onChange} />
+        </Box>
       }
       deletable={deletable}
       onDelete={onDelete}

--- a/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
@@ -8,6 +8,7 @@ import {
 } from "@webstudio-is/design-system";
 import { humanizeString } from "~/shared/string-utils";
 import { type ControlProps, getLabel, VerticalLayout, Label } from "../shared";
+import { VariablesButton } from "../variables";
 
 export const RadioControl = ({
   meta,
@@ -28,9 +29,12 @@ export const RadioControl = ({
   return (
     <VerticalLayout
       label={
-        <Label htmlFor={id} description={meta.description}>
-          {getLabel(meta, propName)}
-        </Label>
+        <Box css={{ position: "relative" }}>
+          <Label htmlFor={id} description={meta.description}>
+            {getLabel(meta, propName)}
+          </Label>
+          <VariablesButton prop={prop} propMeta={meta} onChange={onChange} />
+        </Box>
       }
       deletable={deletable}
       onDelete={onDelete}

--- a/apps/builder/app/builder/features/settings-panel/controls/select.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/select.tsx
@@ -1,6 +1,7 @@
-import { Flex, theme, useId, Select } from "@webstudio-is/design-system";
+import { Flex, theme, useId, Select, Box } from "@webstudio-is/design-system";
 import { humanizeString } from "~/shared/string-utils";
 import { type ControlProps, getLabel, VerticalLayout, Label } from "../shared";
+import { VariablesButton } from "../variables";
 
 export const SelectControl = ({
   meta,
@@ -21,9 +22,12 @@ export const SelectControl = ({
   return (
     <VerticalLayout
       label={
-        <Label htmlFor={id} description={meta.description}>
-          {getLabel(meta, propName)}
-        </Label>
+        <Box css={{ position: "relative" }}>
+          <Label htmlFor={id} description={meta.description}>
+            {getLabel(meta, propName)}
+          </Label>
+          <VariablesButton prop={prop} propMeta={meta} onChange={onChange} />
+        </Box>
       }
       deletable={deletable}
       onDelete={onDelete}

--- a/apps/builder/app/builder/features/settings-panel/controls/text.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text.tsx
@@ -1,4 +1,4 @@
-import { Flex, theme, useId, TextArea } from "@webstudio-is/design-system";
+import { Flex, theme, useId, TextArea, Box } from "@webstudio-is/design-system";
 import {
   type ControlProps,
   getLabel,
@@ -7,6 +7,7 @@ import {
   ResponsiveLayout,
   Label,
 } from "../shared";
+import { VariablesButton } from "../variables";
 
 export const TextControl = ({
   meta,
@@ -38,14 +39,19 @@ export const TextControl = ({
     />
   );
 
+  const labelElement = (
+    <Box css={{ position: "relative" }}>
+      <Label htmlFor={id} description={meta.description}>
+        {label}
+      </Label>
+      <VariablesButton prop={prop} propMeta={meta} onChange={onChange} />
+    </Box>
+  );
+
   if (isTwoColumnLayout) {
     return (
       <ResponsiveLayout
-        label={
-          <Label htmlFor={id} description={meta.description}>
-            {label}
-          </Label>
-        }
+        label={labelElement}
         deletable={deletable}
         onDelete={onDelete}
       >
@@ -56,11 +62,7 @@ export const TextControl = ({
 
   return (
     <VerticalLayout
-      label={
-        <Label htmlFor={id} description={meta.description}>
-          {label}
-        </Label>
-      }
+      label={labelElement}
       deletable={deletable}
       onDelete={onDelete}
     >

--- a/apps/builder/app/builder/features/settings-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/url.tsx
@@ -10,6 +10,7 @@ import {
   ToggleGroupButton,
   Select,
   Tooltip,
+  Box,
 } from "@webstudio-is/design-system";
 import {
   AttachmentIcon,
@@ -29,6 +30,7 @@ import {
   Label,
 } from "../shared";
 import { SelectAsset } from "./select-asset";
+import { VariablesButton } from "../variables";
 
 type UrlControlProps = ControlProps<"url", "string" | "page" | "asset">;
 
@@ -400,9 +402,12 @@ export const UrlControl = ({
   return (
     <VerticalLayout
       label={
-        <Label htmlFor={id} description={meta.description}>
-          {getLabel(meta, propName)}
-        </Label>
+        <Box css={{ position: "relative" }}>
+          <Label htmlFor={id} description={meta.description}>
+            {getLabel(meta, propName)}
+          </Label>
+          <VariablesButton prop={prop} propMeta={meta} onChange={onChange} />
+        </Box>
       }
       deletable={deletable}
       onDelete={onDelete}

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -218,7 +218,8 @@ export const PropsSectionContainer = ({
       const props = propsStore.get();
       const prop = props.get(update.id);
       // update data source instead when real prop has data source type
-      if (prop?.type === "dataSource") {
+      // update the prop when new binding is added
+      if (prop?.type === "dataSource" && update.type !== "dataSource") {
         let dataSourceId = prop.value;
         const dataSources = dataSourcesStore.get();
         const dataSource = dataSources.get(dataSourceId);

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -88,6 +88,10 @@ const getDefaultMetaForType = (type: Prop["type"]): PropMeta => {
       throw new Error(
         "A prop with type string[] must have a meta, we can't provide a default one because we need a list of options"
       );
+    case "json":
+      throw new Error(
+        "A prop with type json must have a meta, we can't provide a default one because we need a list of options"
+      );
     case "dataSource":
       throw new Error(
         "A prop with type dataSource must have a meta, we can't provide a default one because we need a list of options"
@@ -136,7 +140,8 @@ const getPropTypeAndValue = (value: unknown) => {
   if (Array.isArray(value)) {
     return { type: "string[]", value } as const;
   }
-  throw Error(`Unexpected prop value ${value}`);
+  // fallback to empty string to not break UI
+  return { type: "string", value: "" } as const;
 };
 
 /** usePropsLogic expects that key={instanceId} is used on the ancestor component */

--- a/apps/builder/app/builder/features/settings-panel/variables.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
-import { useStore } from "@nanostores/react";
 import { CodeEditor as CodeEditorComponent } from "./code-editor";
 import {
   Button,
@@ -34,8 +33,6 @@ propsStore.set(new Map([[initialProp.id, initialProp]]));
 
 const VariablesPopover = () => {
   const [isOpen, setIsOpen] = useState(true);
-  const props = useStore(propsStore);
-  const myProp = props.get("my-prop");
   return (
     <FloatingPanelPopover open={isOpen} onOpenChange={setIsOpen}>
       <FloatingPanelPopoverTrigger asChild>
@@ -43,7 +40,7 @@ const VariablesPopover = () => {
       </FloatingPanelPopoverTrigger>
       <FloatingPanelPopoverContent align="start">
         <VariablesPanel
-          prop={myProp}
+          propId="my-prop"
           propMeta={{
             required: false,
             control: "text",

--- a/apps/builder/app/builder/features/settings-panel/variables.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables.tsx
@@ -12,7 +12,6 @@ import {
   FloatingPanelPopoverContent,
   FloatingPanelPopoverTitle,
   FloatingPanelPopoverTrigger,
-  IconButton,
   InputErrorsTooltip,
   InputField,
   Label,

--- a/apps/builder/app/builder/features/settings-panel/variables.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables.tsx
@@ -531,14 +531,28 @@ const ListPanel = ({
 };
 
 export const VariablesPanel = ({
-  prop,
+  propId,
   propMeta,
   onChange,
 }: {
-  prop: undefined | Prop;
+  propId: undefined | Prop["id"];
   propMeta: PropMeta;
   onChange: (value: PropValue) => void;
 }) => {
+  // compute prop instead of using passed one
+  // because data source props are converted into values
+  const prop = useStore(
+    useMemo(
+      () =>
+        computed(propsStore, (props) => {
+          if (propId) {
+            return props.get(propId);
+          }
+        }),
+      [propId]
+    )
+  );
+
   const [view, setView] = useState<
     | { name: "list" }
     | { name: "add" }
@@ -657,7 +671,11 @@ export const VariablesButton = ({
         />
       </FloatingPanelPopoverTrigger>
       <FloatingPanelPopoverContent side="left" align="start">
-        <VariablesPanel prop={prop} propMeta={propMeta} onChange={onChange} />
+        <VariablesPanel
+          propId={prop?.id}
+          propMeta={propMeta}
+          onChange={onChange}
+        />
       </FloatingPanelPopoverContent>
     </FloatingPanelPopover>
   );

--- a/apps/builder/app/builder/features/settings-panel/variables.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables.tsx
@@ -7,8 +7,12 @@ import {
   CssValueListArrowFocus,
   CssValueListItem,
   Flex,
+  FloatingPanelPopover,
   FloatingPanelPopoverClose,
+  FloatingPanelPopoverContent,
   FloatingPanelPopoverTitle,
+  FloatingPanelPopoverTrigger,
+  IconButton,
   InputErrorsTooltip,
   InputField,
   Label,
@@ -19,7 +23,13 @@ import {
   Tooltip,
   theme,
 } from "@webstudio-is/design-system";
-import { MenuIcon, MinusIcon, PlusIcon, TrashIcon } from "@webstudio-is/icons";
+import {
+  DotIcon,
+  MenuIcon,
+  MinusIcon,
+  PlusIcon,
+  TrashIcon,
+} from "@webstudio-is/icons";
 import type { DataSource, Prop } from "@webstudio-is/sdk";
 import {
   PropMeta,
@@ -35,6 +45,7 @@ import {
 import { serverSyncStore } from "~/shared/sync";
 import { CodeEditor } from "./code-editor";
 import type { PropValue } from "./shared";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 type VariableDataSource = Extract<DataSource, { type: "variable" }>;
 
@@ -482,7 +493,7 @@ const ListPanel = ({
               gap: theme.spacing[3],
             }}
           >
-            <Label>Name</Label>
+            <Label>Expression</Label>
             <CodeEditor
               // reset uncontrolled editor when saved expression is changed
               key={propExpression}
@@ -619,5 +630,36 @@ export const VariablesPanel = ({
         Variables
       </FloatingPanelPopoverTitle>
     </>
+  );
+};
+
+export const VariablesButton = ({
+  prop,
+  propMeta,
+  onChange,
+}: {
+  prop: undefined | Prop;
+  propMeta: PropMeta;
+  onChange: (value: PropValue) => void;
+}) => {
+  if (isFeatureEnabled("bindings") === false) {
+    return;
+  }
+  return (
+    <FloatingPanelPopover modal>
+      <FloatingPanelPopoverTrigger asChild>
+        <SmallIconButton
+          css={{
+            position: "absolute",
+            top: -10,
+            left: -10,
+          }}
+          icon={<DotIcon />}
+        />
+      </FloatingPanelPopoverTrigger>
+      <FloatingPanelPopoverContent side="left" align="start">
+        <VariablesPanel prop={prop} propMeta={propMeta} onChange={onChange} />
+      </FloatingPanelPopoverContent>
+    </FloatingPanelPopover>
   );
 };

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -6,3 +6,4 @@ export const adminRole = false;
 export const ai = true;
 export const aiRadixComponents = false;
 export const transitions = false;
+export const bindings = false;

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -74,7 +74,8 @@ export const generateJsxElement = ({
       prop.type === "string" ||
       prop.type === "number" ||
       prop.type === "boolean" ||
-      prop.type === "string[]"
+      prop.type === "string[]" ||
+      prop.type === "json"
     ) {
       generatedProps += `\n${prop.name}={${JSON.stringify(prop.value)}}`;
       continue;

--- a/packages/sdk/src/schema/props.ts
+++ b/packages/sdk/src/schema/props.ts
@@ -27,6 +27,11 @@ export const Prop = z.union([
   }),
   z.object({
     ...baseProp,
+    type: z.literal("json"),
+    value: z.unknown(),
+  }),
+  z.object({
+    ...baseProp,
     type: z.literal("asset"),
     value: z.string(), // asset id
   }),


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here integrated variables into props. Now it can be tested considering instances tree.

<img width="488" alt="Screenshot 2023-11-06 at 13 10 33" src="https://github.com/webstudio-is/webstudio/assets/5635476/5615478a-c762-4324-9e24-745cbd452ad0">

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @kof, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
