### PR TITLE
refactor: simplify data sources copying

### DIFF
--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from "@jest/globals";
 import {
   decodeDataSourceVariable,
   encodeDataSourceVariable,
-  computeExpressionsDependencies,
   validateExpression,
   generateDataSources,
 } from "./expression";
@@ -95,36 +94,6 @@ test("encode/decode variable names", () => {
     "my--id"
   );
   expect(decodeDataSourceVariable("myVarName")).toEqual(undefined);
-});
-
-test("compute expressions dependencies", () => {
-  const expressions = new Map([
-    ["exp1", `var1`],
-    ["exp2", `exp1 + exp1`],
-    ["exp3", `exp1 + exp2`],
-    ["exp4", `var1 + exp1`],
-  ]);
-  expect(computeExpressionsDependencies(expressions)).toEqual(
-    new Map([
-      ["exp4", new Set(["var1", "exp1"])],
-      ["exp3", new Set(["var1", "exp1", "exp2"])],
-      ["exp2", new Set(["var1", "exp1"])],
-      ["exp1", new Set(["var1"])],
-    ])
-  );
-});
-
-test("handle cyclic dependencies", () => {
-  const expressions = new Map([
-    ["exp1", `exp2 + var1`],
-    ["exp2", `exp1 + var1`],
-  ]);
-  expect(computeExpressionsDependencies(expressions)).toEqual(
-    new Map([
-      ["exp2", new Set(["var1", "exp1", "exp2"])],
-      ["exp1", new Set(["var1", "exp1", "exp2"])],
-    ])
-  );
 });
 
 test("generate variables with actions", () => {

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -161,50 +161,6 @@ export const validateExpression = (
   return generateCode(expression, true, effectful, transformIdentifier);
 };
 
-const computeExpressionDependencies = (
-  expressions: Map<string, string>,
-  expressionId: string,
-  dependencies: Map<string, Set<string>>
-) => {
-  // prevent recalculating expressions over again
-  const depsById = dependencies.get(expressionId);
-  if (depsById) {
-    return depsById;
-  }
-  const parentDeps = new Set<string>();
-  const code = expressions.get(expressionId);
-  if (code === undefined) {
-    return parentDeps;
-  }
-  // write before recursive call to avoid infinite cycle
-  dependencies.set(expressionId, parentDeps);
-  validateExpression(code, {
-    transformIdentifier: (id) => {
-      parentDeps.add(id);
-      const childDeps = computeExpressionDependencies(
-        expressions,
-        id,
-        dependencies
-      );
-      for (const depId of childDeps) {
-        parentDeps.add(depId);
-      }
-      return id;
-    },
-  });
-  return parentDeps;
-};
-
-export const computeExpressionsDependencies = (
-  expressions: Map<string, string>
-) => {
-  const dependencies = new Map<string, Set<string>>();
-  for (const id of expressions.keys()) {
-    computeExpressionDependencies(expressions, id, dependencies);
-  }
-  return dependencies;
-};
-
 const dataSourceVariablePrefix = "$ws$dataSource$";
 
 // data source id is generated with nanoid which has "-" in alphabeta

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -22,7 +22,6 @@ export {
 export { type Params, ReactSdkContext } from "./context";
 export {
   validateExpression,
-  computeExpressionsDependencies,
   encodeDataSourceVariable,
   decodeDataSourceVariable,
   generateDataSources,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

We are movinng away from expressions dependent on other expressions. So we can simplify copying a lot by checking only variables.

## Testing
- try to copy whole form and change state value
- try to copy error message and check its show prop work

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
