### PR TITLE
fix: Omit excluded pages from sitemap generation

### DIFF
--- a/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml].ts
@@ -5,10 +5,6 @@ export const sitemap = {
       lastModified: "2023-11-03T13:22:34.879Z",
     },
     {
-      path: "/radix",
-      lastModified: "2023-11-03T13:22:34.879Z",
-    },
-    {
       path: "/_route_with_symbols_",
       lastModified: "2023-11-03T13:22:34.879Z",
     },

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -566,10 +566,12 @@ ${utilsExport}
     `
       export const sitemap = ${JSON.stringify(
         {
-          pages: siteData.pages.map((page) => ({
-            path: page.path,
-            lastModified: siteData.build.updatedAt,
-          })),
+          pages: siteData.pages
+            .filter((page) => page.meta.excludePageFromSearch !== true)
+            .map((page) => ({
+              path: page.path,
+              lastModified: siteData.build.updatedAt,
+            })),
         },
         null,
         2


### PR DESCRIPTION
## Description

Omit excluded pages from sitemap generation

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
