### PR TITLE
feat: reuse variables on copy/paste within same tree

### DIFF
--- a/apps/builder/app/shared/instance-utils.test.ts
+++ b/apps/builder/app/shared/instance-utils.test.ts
@@ -754,7 +754,7 @@ describe("get instances slice", () => {
     ]);
   });
 
-  test("collect data sources within instances slice and convert others to value prop", () => {
+  test("collect data sources used in expressions within instances", () => {
     // body
     //   box1
     //     box2
@@ -793,28 +793,28 @@ describe("get instances slice", () => {
     propsStore.set(
       toMap([
         {
-          id: "box1$state",
+          id: "box1$stateProp",
           instanceId: "box1",
           type: "dataSource",
           name: "state",
           value: "box1$state",
         },
         {
-          id: "box2$state",
+          id: "box2$stateProp",
           instanceId: "box2",
           type: "dataSource",
           name: "state",
           value: "box1$state",
         },
         {
-          id: "box2$show",
+          id: "box2$showProp",
           instanceId: "box2",
           type: "dataSource",
           name: "show",
           value: "box2$stateInitial",
         },
         {
-          id: "box2$true",
+          id: "box2$trueProp",
           instanceId: "box2",
           type: "dataSource",
           name: "bool-prop",
@@ -822,34 +822,57 @@ describe("get instances slice", () => {
         },
       ])
     );
-    const { props } = getInstancesSlice("box2");
+    const { props, dataSources } = getInstancesSlice("box2");
 
-    expect(props).toEqual([
+    expect(dataSources).toEqual([
       {
-        id: "box2$state",
-        instanceId: "box2",
-        type: "string",
+        id: "box1$state",
+        scopeInstanceId: "box1",
+        type: "variable",
         name: "state",
-        value: "initial",
+        value: { type: "string", value: "initial" },
       },
       {
-        id: "box2$show",
-        instanceId: "box2",
-        type: "boolean",
-        name: "show",
-        value: true,
+        id: "box2$stateInitial",
+        scopeInstanceId: "box2",
+        type: "expression",
+        name: "stateInitial",
+        code: `$ws$dataSource$box1$state === 'initial'`,
       },
       {
         id: "box2$true",
+        scopeInstanceId: "box2",
+        type: "expression",
+        name: "trueValue",
+        code: `true`,
+      },
+    ]);
+    expect(props).toEqual([
+      {
+        id: "box2$stateProp",
         instanceId: "box2",
+        name: "state",
         type: "dataSource",
+        value: "box1$state",
+      },
+      {
+        id: "box2$showProp",
+        instanceId: "box2",
+        name: "show",
+        type: "dataSource",
+        value: "box2$stateInitial",
+      },
+      {
+        id: "box2$trueProp",
+        instanceId: "box2",
         name: "bool-prop",
+        type: "dataSource",
         value: "box2$true",
       },
     ]);
   });
 
-  test("clear actions which depend on data sources outside of instances slice", () => {
+  test("collect data sources used in actions within instances", () => {
     // body
     //   box1
     //     box2
@@ -908,15 +931,37 @@ describe("get instances slice", () => {
         },
       ])
     );
-    const { props } = getInstancesSlice("box2");
+    const { props, dataSources } = getInstancesSlice("box2");
 
+    expect(dataSources).toEqual([
+      {
+        id: "box1$state",
+        scopeInstanceId: "box1",
+        type: "variable",
+        name: "state",
+        value: { type: "string", value: "initial" },
+      },
+      {
+        id: "box2$state",
+        scopeInstanceId: "box2",
+        type: "variable",
+        name: "state",
+        value: { type: "string", value: "initial" },
+      },
+    ]);
     expect(props).toEqual([
       {
         id: "box2$onChange1",
         instanceId: "box2",
         type: "action",
         name: "onChange",
-        value: [],
+        value: [
+          {
+            args: ["value"],
+            code: "$ws$dataSource$box1$state = value",
+            type: "execute",
+          },
+        ],
       },
       {
         id: "box2$onChange2",

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from "@jest/globals";
 import {
   decodeDataSourceVariable,
   encodeDataSourceVariable,
-  computeExpressionsDependencies,
   validateExpression,
   generateDataSources,
 } from "./expression";
@@ -95,36 +94,6 @@ test("encode/decode variable names", () => {
     "my--id"
   );
   expect(decodeDataSourceVariable("myVarName")).toEqual(undefined);
-});
-
-test("compute expressions dependencies", () => {
-  const expressions = new Map([
-    ["exp1", `var1`],
-    ["exp2", `exp1 + exp1`],
-    ["exp3", `exp1 + exp2`],
-    ["exp4", `var1 + exp1`],
-  ]);
-  expect(computeExpressionsDependencies(expressions)).toEqual(
-    new Map([
-      ["exp4", new Set(["var1", "exp1"])],
-      ["exp3", new Set(["var1", "exp1", "exp2"])],
-      ["exp2", new Set(["var1", "exp1"])],
-      ["exp1", new Set(["var1"])],
-    ])
-  );
-});
-
-test("handle cyclic dependencies", () => {
-  const expressions = new Map([
-    ["exp1", `exp2 + var1`],
-    ["exp2", `exp1 + var1`],
-  ]);
-  expect(computeExpressionsDependencies(expressions)).toEqual(
-    new Map([
-      ["exp2", new Set(["var1", "exp1", "exp2"])],
-      ["exp1", new Set(["var1", "exp1", "exp2"])],
-    ])
-  );
 });
 
 test("generate variables with actions", () => {

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -161,50 +161,6 @@ export const validateExpression = (
   return generateCode(expression, true, effectful, transformIdentifier);
 };
 
-const computeExpressionDependencies = (
-  expressions: Map<string, string>,
-  expressionId: string,
-  dependencies: Map<string, Set<string>>
-) => {
-  // prevent recalculating expressions over again
-  const depsById = dependencies.get(expressionId);
-  if (depsById) {
-    return depsById;
-  }
-  const parentDeps = new Set<string>();
-  const code = expressions.get(expressionId);
-  if (code === undefined) {
-    return parentDeps;
-  }
-  // write before recursive call to avoid infinite cycle
-  dependencies.set(expressionId, parentDeps);
-  validateExpression(code, {
-    transformIdentifier: (id) => {
-      parentDeps.add(id);
-      const childDeps = computeExpressionDependencies(
-        expressions,
-        id,
-        dependencies
-      );
-      for (const depId of childDeps) {
-        parentDeps.add(depId);
-      }
-      return id;
-    },
-  });
-  return parentDeps;
-};
-
-export const computeExpressionsDependencies = (
-  expressions: Map<string, string>
-) => {
-  const dependencies = new Map<string, Set<string>>();
-  for (const id of expressions.keys()) {
-    computeExpressionDependencies(expressions, id, dependencies);
-  }
-  return dependencies;
-};
-
 const dataSourceVariablePrefix = "$ws$dataSource$";
 
 // data source id is generated with nanoid which has "-" in alphabeta

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -22,7 +22,6 @@ export {
 export { type Params, ReactSdkContext } from "./context";
 export {
   validateExpression,
-  computeExpressionsDependencies,
   encodeDataSourceVariable,
   decodeDataSourceVariable,
   generateDataSources,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here improved copy/paste behavior.

Before variables outside of copied tree were inlined. For example ErrorMessage were loosing its expression when duplicated within same form.

Now expressions and variables are preserved
and variables are inlined into expressions when paste target do not have such variable. For example ErrorMessage get `"initial" == "error"`. With upcoming UI it will be more obvious. The main idea here to not loose all expressions but only references to unavailable variables.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
