### PR TITLE
refactor: add expression prop

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
@@ -18,6 +18,9 @@ export const renderControl = ({
   if (prop?.type === "dataSource") {
     throw Error("Data source is not resolved");
   }
+  if (prop?.type === "expression") {
+    throw Error("Expression is not resolved");
+  }
 
   // @todo remove once ui for action is implemented
   if (prop?.type === "action") {

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -239,6 +239,22 @@ export const PropsSectionContainer = ({
         const dataSourceVariables = new Map(dataSourceVariablesStore.get());
         dataSourceVariables.set(dataSourceId, update.value);
         dataSourceVariablesStore.set(dataSourceVariables);
+        // update the variable when real prop has expression type
+        // update the prop when new binding is added
+      } else if (prop?.type === "expression" && update.type !== "expression") {
+        const dataSources = dataSourcesStore.get();
+        // when expression contains only reference to variable update that variable
+        // extract id without parsing expression
+        const potentialVariableId = decodeDataSourceVariable(prop.value);
+        if (
+          potentialVariableId !== undefined &&
+          dataSources.has(potentialVariableId)
+        ) {
+          const dataSourceId = potentialVariableId;
+          const dataSourceVariables = new Map(dataSourceVariablesStore.get());
+          dataSourceVariables.set(dataSourceId, update.value);
+          dataSourceVariablesStore.set(dataSourceVariables);
+        }
       } else {
         serverSyncStore.createTransaction([propsStore], (props) => {
           const istanceProps = propsByInstanceId.get(instance.id) ?? [];

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -175,6 +175,13 @@ const useInstanceProps = (instanceId: Instance["id"]) => {
             }
             continue;
           }
+          if (prop.type === "expression") {
+            const value = dataSourcesLogic.get(prop.id);
+            if (value !== undefined) {
+              instancePropsObject[prop.name] = value;
+            }
+            continue;
+          }
           if (prop.type === "action") {
             const action = dataSourcesLogic.get(prop.id);
             if (typeof action === "function") {

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -327,6 +327,16 @@ export const onPaste = (clipboardData: string): boolean => {
               return prop;
             }
           }
+
+          if (prop.type === "expression") {
+            return {
+              ...prop,
+              value: validateExpression(prop.value, {
+                transformIdentifier,
+              }),
+            };
+          }
+
           if (prop.type === "action") {
             return {
               ...prop,
@@ -346,6 +356,7 @@ export const onPaste = (clipboardData: string): boolean => {
               }),
             };
           }
+
           return prop;
         }),
         copiedInstanceIds,

--- a/apps/builder/app/shared/instance-utils.test.ts
+++ b/apps/builder/app/shared/instance-utils.test.ts
@@ -872,6 +872,96 @@ describe("get instances slice", () => {
     ]);
   });
 
+  test("collect data sources used in expressions within instances 2", () => {
+    // body
+    //   box1
+    //     box2
+    instancesStore.set(
+      toMap([
+        createInstance("body", "Body", [{ type: "id", value: "box1" }]),
+        createInstance("box1", "Box", [{ type: "id", value: "box2" }]),
+        createInstance("box2", "Box", []),
+      ])
+    );
+    dataSourcesStore.set(
+      toMap([
+        {
+          id: "box1$state",
+          scopeInstanceId: "box1",
+          type: "variable",
+          name: "state",
+          value: { type: "string", value: "initial" },
+        },
+      ])
+    );
+    propsStore.set(
+      toMap([
+        {
+          id: "box1$stateProp",
+          instanceId: "box1",
+          name: "state",
+          type: "expression",
+          value: "$ws$dataSource$box1$state",
+        },
+        {
+          id: "box2$stateProp",
+          instanceId: "box2",
+          name: "state",
+          type: "expression",
+          value: "$ws$dataSource$box1$state",
+        },
+        {
+          id: "box2$showProp",
+          instanceId: "box2",
+          name: "show",
+          type: "expression",
+          value: `$ws$dataSource$box1$state === 'initial'`,
+        },
+        {
+          id: "box2$trueProp",
+          instanceId: "box2",
+          name: "bool-prop",
+          type: "expression",
+          value: `true`,
+        },
+      ])
+    );
+    const { props, dataSources } = getInstancesSlice("box2");
+
+    expect(dataSources).toEqual([
+      {
+        id: "box1$state",
+        scopeInstanceId: "box1",
+        type: "variable",
+        name: "state",
+        value: { type: "string", value: "initial" },
+      },
+    ]);
+    expect(props).toEqual([
+      {
+        id: "box2$stateProp",
+        instanceId: "box2",
+        name: "state",
+        type: "expression",
+        value: "$ws$dataSource$box1$state",
+      },
+      {
+        id: "box2$showProp",
+        instanceId: "box2",
+        name: "show",
+        type: "expression",
+        value: `$ws$dataSource$box1$state === 'initial'`,
+      },
+      {
+        id: "box2$trueProp",
+        instanceId: "box2",
+        name: "bool-prop",
+        type: "expression",
+        value: `true`,
+      },
+    ]);
+  });
+
   test("collect data sources used in actions within instances", () => {
     // body
     //   box1

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -635,6 +635,18 @@ export const getInstancesSlice = (rootInstanceId: string) => {
       }
     }
 
+    if (prop.type === "expression") {
+      validateExpression(prop.value, {
+        transformIdentifier(identifier) {
+          const id = decodeDataSourceVariable(identifier);
+          if (id !== undefined) {
+            usedDataSourceIds.add(id);
+          }
+          return identifier;
+        },
+      });
+    }
+
     if (prop.type === "action") {
       for (const value of prop.value) {
         if (value.type === "execute") {

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -371,6 +371,39 @@ test("generate jsx element with condition based on show prop", () => {
       }
     `)
   );
+  expect(
+    generateJsxElement({
+      scope: createScope(),
+      instance: createInstance("box", "Box", []),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "box",
+          name: showAttribute,
+          type: "expression",
+          value: "$ws$dataSource$conditionId",
+        }),
+      ]),
+      dataSources: new Map([
+        createDataSourcePair({
+          type: "variable",
+          id: "conditionId",
+          name: "conditionName",
+          value: { type: "boolean", value: false },
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+      children: "",
+    })
+  ).toEqual(
+    clear(`
+      {datawsshow &&
+      <Box
+      data-ws-id="box"
+      data-ws-component="Box" />
+      }
+    `)
+  );
 });
 
 test("generate jsx element with index prop", () => {
@@ -547,6 +580,72 @@ test("generate page component with data sources", () => {
       data-ws-component="Input"
       data-ws-index="0"
       value={variableName}
+      onChange={onChange} />
+      {props.scripts}
+      </Body>
+      }
+    `)
+  );
+});
+
+test("generate page component with variables and actions", () => {
+  expect(
+    generatePageComponent({
+      scope: createScope(),
+      rootInstanceId: "body",
+      instances: new Map([
+        createInstancePair("body", "Body", [{ type: "id", value: "input" }]),
+        createInstancePair("input", "Input", []),
+      ]),
+      dataSources: new Map([
+        createDataSourcePair({
+          type: "variable",
+          id: "variableId",
+          name: "variableName",
+          value: { type: "string", value: "initial" },
+        }),
+      ]),
+      props: new Map([
+        createPropPair({
+          id: "1",
+          instanceId: "input",
+          name: "value",
+          type: "expression",
+          value: "$ws$dataSource$variableId",
+        }),
+        createPropPair({
+          id: "2",
+          instanceId: "input",
+          name: "onChange",
+          type: "action",
+          value: [
+            {
+              type: "execute",
+              args: ["value"],
+              code: `$ws$dataSource$variableId = value`,
+            },
+          ],
+        }),
+      ]),
+      indexesWithinAncestors: new Map([["input", 0]]),
+    })
+  ).toEqual(
+    clear(`
+      const Page = (props: { scripts?: ReactNode }) => {
+      let [variableName, set$variableName] = useState<any>("initial")
+      let value = (variableName);
+      let onChange = (value: any) => {
+      variableName = value
+      set$variableName(variableName)
+      }
+      return <Body
+      data-ws-id="body"
+      data-ws-component="Body">
+      <Input
+      data-ws-id="input"
+      data-ws-component="Input"
+      data-ws-index="0"
+      value={value}
       onChange={onChange} />
       {props.scripts}
       </Body>

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -67,6 +67,9 @@ export const generateJsxElement = ({
           conditionVariableName = scope.getName(prop.id, prop.name);
         }
       }
+      if (prop.type === "expression") {
+        conditionVariableName = scope.getName(prop.id, prop.name);
+      }
       // ignore any other values
       continue;
     }
@@ -101,6 +104,11 @@ export const generateJsxElement = ({
         const dataSourceVariable = scope.getName(prop.id, prop.name);
         generatedProps += `\n${prop.name}={${dataSourceVariable}}`;
       }
+      continue;
+    }
+    if (prop.type === "expression") {
+      const propVariable = scope.getName(prop.id, prop.name);
+      generatedProps += `\n${prop.name}={${propVariable}}`;
       continue;
     }
     if (prop.type === "action") {

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -265,16 +265,16 @@ test("generate data for embedding from props bound to data source variables", ()
       {
         id: expectString,
         instanceId: expectString,
-        type: "dataSource",
+        type: "expression",
         name: "showOtherBox",
-        value: expectString,
+        value: expect.stringMatching(/\$ws\$dataSource\$\w+/),
       },
       {
         id: expectString,
         instanceId: expectString,
-        type: "dataSource",
+        type: "expression",
         name: showAttribute,
-        value: expectString,
+        value: expect.stringMatching(/\$ws\$dataSource\$\w+/),
       },
     ],
     dataSources: [
@@ -288,20 +288,6 @@ test("generate data for embedding from props bound to data source variables", ()
           value: false,
         },
       },
-      {
-        id: expectString,
-        scopeInstanceId: expectString,
-        type: "expression",
-        name: "expression",
-        code: expect.stringMatching(/\$ws\$dataSource\$\w+/),
-      },
-      {
-        id: expectString,
-        scopeInstanceId: expectString,
-        type: "expression",
-        name: "expression",
-        code: expect.stringMatching(/\$ws\$dataSource\$\w+/),
-      },
     ],
     styleSourceSelections: [],
     styleSources: [],
@@ -309,7 +295,7 @@ test("generate data for embedding from props bound to data source variables", ()
   });
 });
 
-test("generate data for embedding from props bound to data source expressions", () => {
+test("generate data for embedding from props with complex expressions", () => {
   expect(
     generateDataFromEmbedTemplate(
       [
@@ -357,16 +343,16 @@ test("generate data for embedding from props bound to data source expressions", 
       {
         id: expectString,
         instanceId: expectString,
-        type: "dataSource",
+        type: "expression",
         name: "state",
-        value: expectString,
+        value: expect.stringMatching(/\$ws\$dataSource\$\w+/),
       },
       {
         id: expectString,
         instanceId: expectString,
-        type: "dataSource",
+        type: "expression",
         name: showAttribute,
-        value: expectString,
+        value: expect.stringMatching(/\$ws\$dataSource\$\w+ === 'success'/),
       },
     ],
     dataSources: [
@@ -379,20 +365,6 @@ test("generate data for embedding from props bound to data source expressions", 
           type: "string",
           value: "initial",
         },
-      },
-      {
-        type: "expression",
-        id: expectString,
-        scopeInstanceId: expectString,
-        name: "expression",
-        code: expect.stringMatching(/\$ws\$dataSource\$\w+/),
-      },
-      {
-        type: "expression",
-        id: expectString,
-        scopeInstanceId: expectString,
-        name: "expression",
-        code: expect.stringMatching(/\$ws\$dataSource\$\w+ === 'success'/),
       },
     ],
     styleSourceSelections: [],
@@ -463,9 +435,9 @@ test("generate data for embedding from action props", () => {
       {
         id: expectString,
         instanceId: expectString,
-        type: "dataSource",
+        type: "expression",
         name: "state",
-        value: expectString,
+        value: expect.stringMatching(/\$ws\$dataSource\$\w+/),
       },
       {
         id: expectString,
@@ -504,13 +476,6 @@ test("generate data for embedding from action props", () => {
           type: "string",
           value: "initial",
         },
-      },
-      {
-        id: expectString,
-        scopeInstanceId: expectString,
-        name: "expression",
-        type: "expression",
-        code: expect.stringMatching(/\$ws\$dataSource\$\w+/),
       },
     ],
     styleSourceSelections: [],

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -179,26 +179,18 @@ const createInstancesFromTemplate = (
           const propId = generateId();
 
           if (prop.type === "expression") {
-            const dataSource: DataSource = {
+            props.push({
+              id: propId,
+              instanceId,
+              name: prop.name,
               type: "expression",
-              id: generateId(),
-              scopeInstanceId: instanceId,
-              name: "expression",
               // replace all references with variable names
-              code: validateExpression(prop.code, {
+              value: validateExpression(prop.code, {
                 transformIdentifier: (ref) => {
                   const id = dataSourceByRef.get(ref)?.id ?? ref;
                   return encodeDataSourceVariable(id);
                 },
               }),
-            };
-            dataSourceByRef.set(propId, dataSource);
-            props.push({
-              id: propId,
-              instanceId,
-              type: "dataSource",
-              name: prop.name,
-              value: dataSource.id,
             });
             continue;
           }

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -268,7 +268,7 @@ test("generate variables with actions", () => {
   );
 });
 
-test("generate variables with expressions", () => {
+test("generate variables with data source expressions", () => {
   const generated = generateDataSources({
     scope: createScope(),
     dataSources: new Map([
@@ -322,6 +322,70 @@ test("generate variables with expressions", () => {
           type: "dataSource",
           name: "exp",
           value: "dataSource3",
+        },
+      ],
+    ]),
+  });
+  expect(generated.body).toMatchInlineSnapshot(`
+"let exp = (myVar + "Name");
+let exp_1 = (myVar + "Value");
+"
+`);
+  expect(generated.variables).toEqual(
+    new Map([
+      [
+        "dataSource1",
+        {
+          initialValue: "initial",
+          setterName: "set$myVar",
+          valueName: "myVar",
+        },
+      ],
+    ])
+  );
+  expect(generated.output).toEqual(
+    new Map([
+      ["dataSource1", "myVar"],
+      ["prop1", "exp"],
+      ["prop2", "exp_1"],
+    ])
+  );
+});
+
+test("generate variables witha prop expressions", () => {
+  const generated = generateDataSources({
+    scope: createScope(),
+    dataSources: new Map([
+      [
+        "dataSource1",
+        {
+          id: "dataSource1",
+          scopeInstanceId: "instance1",
+          type: "variable",
+          name: "myVar",
+          value: { type: "string", value: "initial" },
+        },
+      ],
+    ]),
+    props: new Map([
+      [
+        "prop1",
+        {
+          id: "prop1",
+          instanceId: "instance1",
+          type: "expression",
+          name: "exp",
+          value: `$ws$dataSource$dataSource1 + "Name"`,
+        },
+      ],
+      [
+        "prop2",
+        {
+          id: "prop2",
+          instanceId: "instance2",
+          type: "expression",
+          name: "exp",
+          value: `$ws$dataSource$dataSource1 + "Value"`,
         },
       ],
     ]),

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -273,6 +273,24 @@ export const generateDataSources = ({
       body += `let ${name} = (${code});\n`;
     }
 
+    if (prop.type === "expression") {
+      const name = scope.getName(prop.id, prop.name);
+      output.set(prop.id, name);
+      const code = validateExpression(prop.value, {
+        transformIdentifier: (identifier) => {
+          const depId = decodeDataSourceVariable(identifier);
+          const dep = depId ? dataSources.get(depId) : undefined;
+          if (dep) {
+            return scope.getName(dep.id, dep.name);
+          }
+          // eslint-disable-next-line no-console
+          console.error(`Unknown dependency "${identifier}"`);
+          return identifier;
+        },
+      });
+      body += `let ${name} = (${code});\n`;
+    }
+
     // generate actions assigning variables and invoking their setters
     if (prop.type === "action") {
       const name = scope.getName(prop.id, prop.name);

--- a/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
@@ -29,21 +29,21 @@ const Page = (props: { scripts?: ReactNode }) => {
         onValueChange={onValueChange}
       >
         <AccordionItem
-          data-ws-id="7"
+          data-ws-id="6"
           data-ws-component="AccordionItem"
           data-ws-index="0"
         >
-          <AccordionHeader data-ws-id="9" data-ws-component="AccordionHeader">
+          <AccordionHeader data-ws-id="8" data-ws-component="AccordionHeader">
             <AccordionTrigger
-              data-ws-id="11"
+              data-ws-id="10"
               data-ws-component="AccordionTrigger"
             >
-              <Text data-ws-id="13" data-ws-component="Text">
+              <Text data-ws-id="12" data-ws-component="Text">
                 {"Is it accessible?"}
               </Text>
-              <Box data-ws-id="14" data-ws-component="Box">
+              <Box data-ws-id="13" data-ws-component="Box">
                 <HtmlEmbed
-                  data-ws-id="16"
+                  data-ws-id="15"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
@@ -53,28 +53,28 @@ const Page = (props: { scripts?: ReactNode }) => {
             </AccordionTrigger>
           </AccordionHeader>
           <AccordionContent
-            data-ws-id="18"
+            data-ws-id="17"
             data-ws-component="AccordionContent"
           >
             {"Yes. It adheres to the WAI-ARIA design pattern."}
           </AccordionContent>
         </AccordionItem>
         <AccordionItem
-          data-ws-id="20"
+          data-ws-id="19"
           data-ws-component="AccordionItem"
           data-ws-index="1"
         >
-          <AccordionHeader data-ws-id="22" data-ws-component="AccordionHeader">
+          <AccordionHeader data-ws-id="21" data-ws-component="AccordionHeader">
             <AccordionTrigger
-              data-ws-id="24"
+              data-ws-id="23"
               data-ws-component="AccordionTrigger"
             >
-              <Text data-ws-id="26" data-ws-component="Text">
+              <Text data-ws-id="25" data-ws-component="Text">
                 {"Is it styled?"}
               </Text>
-              <Box data-ws-id="27" data-ws-component="Box">
+              <Box data-ws-id="26" data-ws-component="Box">
                 <HtmlEmbed
-                  data-ws-id="29"
+                  data-ws-id="28"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
@@ -84,7 +84,7 @@ const Page = (props: { scripts?: ReactNode }) => {
             </AccordionTrigger>
           </AccordionHeader>
           <AccordionContent
-            data-ws-id="31"
+            data-ws-id="30"
             data-ws-component="AccordionContent"
           >
             {
@@ -93,21 +93,21 @@ const Page = (props: { scripts?: ReactNode }) => {
           </AccordionContent>
         </AccordionItem>
         <AccordionItem
-          data-ws-id="33"
+          data-ws-id="32"
           data-ws-component="AccordionItem"
           data-ws-index="2"
         >
-          <AccordionHeader data-ws-id="35" data-ws-component="AccordionHeader">
+          <AccordionHeader data-ws-id="34" data-ws-component="AccordionHeader">
             <AccordionTrigger
-              data-ws-id="37"
+              data-ws-id="36"
               data-ws-component="AccordionTrigger"
             >
-              <Text data-ws-id="39" data-ws-component="Text">
+              <Text data-ws-id="38" data-ws-component="Text">
                 {"Is it animated?"}
               </Text>
-              <Box data-ws-id="40" data-ws-component="Box">
+              <Box data-ws-id="39" data-ws-component="Box">
                 <HtmlEmbed
-                  data-ws-id="42"
+                  data-ws-id="41"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
@@ -117,7 +117,7 @@ const Page = (props: { scripts?: ReactNode }) => {
             </AccordionTrigger>
           </AccordionHeader>
           <AccordionContent
-            data-ws-id="44"
+            data-ws-id="43"
             data-ws-component="AccordionContent"
           >
             {
@@ -313,15 +313,15 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="7"] {
+  [data-ws-id="6"] {
     border-bottom-width: 1px;
     border-bottom-style: solid;
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  [data-ws-id="9"] {
+  [data-ws-id="8"] {
     display: flex
   }
-  [data-ws-id="11"] {
+  [data-ws-id="10"] {
     display: flex;
     flex-grow: 1;
     flex-shrink: 1;
@@ -333,13 +333,13 @@ html {margin: 0; display: grid; min-height: 100%}
     font-weight: 500;
     --accordion-trigger-icon-transform: 0deg
   }
-  [data-ws-id="11"]:hover {
+  [data-ws-id="10"]:hover {
     text-decoration-line: underline
   }
-  [data-ws-id="11"][data-state=open] {
+  [data-ws-id="10"][data-state=open] {
     --accordion-trigger-icon-transform: 180deg
   }
-  [data-ws-id="14"] {
+  [data-ws-id="13"] {
     rotate: var(--accordion-trigger-icon-transform);
     height: 1rem;
     width: 1rem;
@@ -348,21 +348,21 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="18"] {
+  [data-ws-id="17"] {
     overflow: hidden;
     font-size: 0.875rem;
     line-height: 1.25rem;
     padding-bottom: 1rem
   }
-  [data-ws-id="20"] {
+  [data-ws-id="19"] {
     border-bottom-width: 1px;
     border-bottom-style: solid;
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  [data-ws-id="22"] {
+  [data-ws-id="21"] {
     display: flex
   }
-  [data-ws-id="24"] {
+  [data-ws-id="23"] {
     display: flex;
     flex-grow: 1;
     flex-shrink: 1;
@@ -374,13 +374,13 @@ html {margin: 0; display: grid; min-height: 100%}
     font-weight: 500;
     --accordion-trigger-icon-transform: 0deg
   }
-  [data-ws-id="24"]:hover {
+  [data-ws-id="23"]:hover {
     text-decoration-line: underline
   }
-  [data-ws-id="24"][data-state=open] {
+  [data-ws-id="23"][data-state=open] {
     --accordion-trigger-icon-transform: 180deg
   }
-  [data-ws-id="27"] {
+  [data-ws-id="26"] {
     rotate: var(--accordion-trigger-icon-transform);
     height: 1rem;
     width: 1rem;
@@ -389,21 +389,21 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="31"] {
+  [data-ws-id="30"] {
     overflow: hidden;
     font-size: 0.875rem;
     line-height: 1.25rem;
     padding-bottom: 1rem
   }
-  [data-ws-id="33"] {
+  [data-ws-id="32"] {
     border-bottom-width: 1px;
     border-bottom-style: solid;
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  [data-ws-id="35"] {
+  [data-ws-id="34"] {
     display: flex
   }
-  [data-ws-id="37"] {
+  [data-ws-id="36"] {
     display: flex;
     flex-grow: 1;
     flex-shrink: 1;
@@ -415,13 +415,13 @@ html {margin: 0; display: grid; min-height: 100%}
     font-weight: 500;
     --accordion-trigger-icon-transform: 0deg
   }
-  [data-ws-id="37"]:hover {
+  [data-ws-id="36"]:hover {
     text-decoration-line: underline
   }
-  [data-ws-id="37"][data-state=open] {
+  [data-ws-id="36"][data-state=open] {
     --accordion-trigger-icon-transform: 180deg
   }
-  [data-ws-id="40"] {
+  [data-ws-id="39"] {
     rotate: var(--accordion-trigger-icon-transform);
     height: 1rem;
     width: 1rem;
@@ -430,7 +430,7 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="44"] {
+  [data-ws-id="43"] {
     overflow: hidden;
     font-size: 0.875rem;
     line-height: 1.25rem;

--- a/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
@@ -27,11 +27,11 @@ const Page = (props: { scripts?: ReactNode }) => {
           onCheckedChange={onCheckedChange}
         >
           <CheckboxIndicator
-            data-ws-id="9"
+            data-ws-id="8"
             data-ws-component="CheckboxIndicator"
           >
             <HtmlEmbed
-              data-ws-id="11"
+              data-ws-id="10"
               data-ws-component="HtmlEmbed"
               code={
                 '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M11.957 5.043a1 1 0 0 1 0 1.414l-4.5 4.5a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L6.75 8.836l3.793-3.793a1 1 0 0 1 1.414 0Z" clip-rule="evenodd"/></svg>'
@@ -39,7 +39,7 @@ const Page = (props: { scripts?: ReactNode }) => {
             />
           </CheckboxIndicator>
         </Checkbox>
-        <Text data-ws-id="13" data-ws-component="Text" tag={"span"}>
+        <Text data-ws-id="12" data-ws-component="Text" tag={"span"}>
           {"Checkbox"}
         </Text>
       </Label>
@@ -254,7 +254,7 @@ html {margin: 0; display: grid; min-height: 100%}
     background-color: rgba(15, 23, 42, 1);
     color: rgba(248, 250, 252, 1)
   }
-  [data-ws-id="9"] {
+  [data-ws-id="8"] {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
@@ -26,18 +26,18 @@ const Page = (props: { scripts?: ReactNode }) => {
         onOpenChange={onOpenChange}
       >
         <CollapsibleTrigger
-          data-ws-id="6"
+          data-ws-id="5"
           data-ws-component="CollapsibleTrigger"
         >
-          <Button data-ws-id="7" data-ws-component="Button">
+          <Button data-ws-id="6" data-ws-component="Button">
             {"Click to toggle content"}
           </Button>
         </CollapsibleTrigger>
         <CollapsibleContent
-          data-ws-id="9"
+          data-ws-id="8"
           data-ws-component="CollapsibleContent"
         >
-          <Text data-ws-id="10" data-ws-component="Text">
+          <Text data-ws-id="9" data-ws-component="Text">
             {"Collapsible Content"}
           </Text>
         </CollapsibleContent>
@@ -197,7 +197,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="7"] {
+  [data-ws-id="6"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -227,18 +227,18 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0.5rem;
     padding-bottom: 0.5rem
   }
-  [data-ws-id="7"]:focus-visible {
+  [data-ws-id="6"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="7"]:disabled {
+  [data-ws-id="6"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="7"]:hover {
+  [data-ws-id="6"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
@@ -30,30 +30,30 @@ const Page = (props: { scripts?: ReactNode }) => {
         open={open}
         onOpenChange={onOpenChange}
       >
-        <DialogTrigger data-ws-id="6" data-ws-component="DialogTrigger">
-          <Button data-ws-id="7" data-ws-component="Button">
+        <DialogTrigger data-ws-id="5" data-ws-component="DialogTrigger">
+          <Button data-ws-id="6" data-ws-component="Button">
             {"Button"}
           </Button>
         </DialogTrigger>
-        <DialogOverlay data-ws-id="9" data-ws-component="DialogOverlay">
-          <DialogContent data-ws-id="11" data-ws-component="DialogContent">
-            <Box data-ws-id="13" data-ws-component="Box">
-              <DialogTitle data-ws-id="15" data-ws-component="DialogTitle">
+        <DialogOverlay data-ws-id="8" data-ws-component="DialogOverlay">
+          <DialogContent data-ws-id="10" data-ws-component="DialogContent">
+            <Box data-ws-id="12" data-ws-component="Box">
+              <DialogTitle data-ws-id="14" data-ws-component="DialogTitle">
                 {"Dialog Title"}
               </DialogTitle>
               <DialogDescription
-                data-ws-id="17"
+                data-ws-id="16"
                 data-ws-component="DialogDescription"
               >
                 {"Dialog description text you can edit"}
               </DialogDescription>
             </Box>
-            <Text data-ws-id="19" data-ws-component="Text">
+            <Text data-ws-id="18" data-ws-component="Text">
               {"The text you can edit"}
             </Text>
-            <DialogClose data-ws-id="20" data-ws-component="DialogClose">
+            <DialogClose data-ws-id="19" data-ws-component="DialogClose">
               <HtmlEmbed
-                data-ws-id="22"
+                data-ws-id="21"
                 data-ws-component="HtmlEmbed"
                 code={
                   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M13.566 2.434a.8.8 0 0 1 0 1.132L9.13 8l4.435 4.434a.8.8 0 0 1-1.132 1.132L8 9.13l-4.434 4.435a.8.8 0 0 1-1.132-1.132L6.87 8 2.434 3.566a.8.8 0 0 1 1.132-1.132L8 6.87l4.434-4.435a.8.8 0 0 1 1.132 0Z" clip-rule="evenodd"/></svg>'
@@ -263,7 +263,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="7"] {
+  [data-ws-id="6"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -293,22 +293,22 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0.5rem;
     padding-bottom: 0.5rem
   }
-  [data-ws-id="7"]:focus-visible {
+  [data-ws-id="6"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="7"]:disabled {
+  [data-ws-id="6"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="7"]:hover {
+  [data-ws-id="6"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="9"] {
+  [data-ws-id="8"] {
     position: fixed;
     left: 0px;
     right: 0px;
@@ -320,7 +320,7 @@ html {margin: 0; display: grid; min-height: 100%}
     display: flex;
     overflow: auto
   }
-  [data-ws-id="11"] {
+  [data-ws-id="10"] {
     width: 100%;
     z-index: 50;
     display: flex;
@@ -352,27 +352,27 @@ html {margin: 0; display: grid; min-height: 100%}
     box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
     position: relative
   }
-  [data-ws-id="13"] {
+  [data-ws-id="12"] {
     display: flex;
     flex-direction: column;
     row-gap: 0.25rem;
     column-gap: 0.25rem
   }
-  [data-ws-id="15"] {
+  [data-ws-id="14"] {
     margin-top: 0px;
     margin-bottom: 0px;
     line-height: 1.75rem;
     font-size: 1.125rem;
     letter-spacing: -0.025em
   }
-  [data-ws-id="17"] {
+  [data-ws-id="16"] {
     margin-top: 0px;
     margin-bottom: 0px;
     font-size: 0.875rem;
     line-height: 1.25rem;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="20"] {
+  [data-ws-id="19"] {
     position: absolute;
     right: 1rem;
     top: 1rem;
@@ -404,10 +404,10 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="20"]:hover {
+  [data-ws-id="19"]:hover {
     opacity: 1
   }
-  [data-ws-id="20"]:focus {
+  [data-ws-id="19"]:focus {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
@@ -33,25 +33,25 @@ const Page = (props: { scripts?: ReactNode }) => {
         onValueChange={onValueChange}
       >
         <NavigationMenuList
-          data-ws-id="7"
+          data-ws-id="6"
           data-ws-component="NavigationMenuList"
         >
           <NavigationMenuItem
-            data-ws-id="9"
+            data-ws-id="8"
             data-ws-component="NavigationMenuItem"
             data-ws-index="0"
           >
             <NavigationMenuTrigger
-              data-ws-id="10"
+              data-ws-id="9"
               data-ws-component="NavigationMenuTrigger"
             >
-              <Button data-ws-id="11" data-ws-component="Button">
-                <Text data-ws-id="13" data-ws-component="Text">
+              <Button data-ws-id="10" data-ws-component="Button">
+                <Text data-ws-id="12" data-ws-component="Text">
                   {"About"}
                 </Text>
-                <Box data-ws-id="14" data-ws-component="Box">
+                <Box data-ws-id="13" data-ws-component="Box">
                   <HtmlEmbed
-                    data-ws-id="16"
+                    data-ws-id="15"
                     data-ws-component="HtmlEmbed"
                     code={
                       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
@@ -61,28 +61,28 @@ const Page = (props: { scripts?: ReactNode }) => {
               </Button>
             </NavigationMenuTrigger>
             <NavigationMenuContent
-              data-ws-id="18"
+              data-ws-id="17"
               data-ws-component="NavigationMenuContent"
               data-ws-index="0"
             >
-              <Box data-ws-id="20" data-ws-component="Box">
-                <Box data-ws-id="22" data-ws-component="Box">
+              <Box data-ws-id="19" data-ws-component="Box">
+                <Box data-ws-id="21" data-ws-component="Box">
                   {""}
                 </Box>
-                <Box data-ws-id="24" data-ws-component="Box">
+                <Box data-ws-id="23" data-ws-component="Box">
                   <NavigationMenuLink
-                    data-ws-id="26"
+                    data-ws-id="25"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="27"
+                      data-ws-id="26"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/sheet"}
                     >
-                      <Text data-ws-id="30" data-ws-component="Text">
+                      <Text data-ws-id="29" data-ws-component="Text">
                         {"Sheet"}
                       </Text>
-                      <Paragraph data-ws-id="32" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="31" data-ws-component="Paragraph">
                         {
                           "Extends the Dialog component to display content that complements the main content of the screen."
                         }
@@ -90,37 +90,37 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="34"
+                    data-ws-id="33"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="35"
+                      data-ws-id="34"
                       data-ws-component="Link"
                       href={
                         "https://ui.shadcn.com/docs/components/navigation-menu"
                       }
                     >
-                      <Text data-ws-id="38" data-ws-component="Text">
+                      <Text data-ws-id="37" data-ws-component="Text">
                         {"Navigation Menu"}
                       </Text>
-                      <Paragraph data-ws-id="40" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="39" data-ws-component="Paragraph">
                         {"A collection of links for navigating websites."}
                       </Paragraph>
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="42"
+                    data-ws-id="41"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="43"
+                      data-ws-id="42"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/tabs"}
                     >
-                      <Text data-ws-id="46" data-ws-component="Text">
+                      <Text data-ws-id="45" data-ws-component="Text">
                         {"Tabs"}
                       </Text>
-                      <Paragraph data-ws-id="48" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="47" data-ws-component="Paragraph">
                         {
                           "A set of layered sections of content—known as tab panels—that are displayed one at a time."
                         }
@@ -132,21 +132,21 @@ const Page = (props: { scripts?: ReactNode }) => {
             </NavigationMenuContent>
           </NavigationMenuItem>
           <NavigationMenuItem
-            data-ws-id="50"
+            data-ws-id="49"
             data-ws-component="NavigationMenuItem"
             data-ws-index="1"
           >
             <NavigationMenuTrigger
-              data-ws-id="51"
+              data-ws-id="50"
               data-ws-component="NavigationMenuTrigger"
             >
-              <Button data-ws-id="52" data-ws-component="Button">
-                <Text data-ws-id="54" data-ws-component="Text">
+              <Button data-ws-id="51" data-ws-component="Button">
+                <Text data-ws-id="53" data-ws-component="Text">
                   {"Components"}
                 </Text>
-                <Box data-ws-id="55" data-ws-component="Box">
+                <Box data-ws-id="54" data-ws-component="Box">
                   <HtmlEmbed
-                    data-ws-id="57"
+                    data-ws-id="56"
                     data-ws-component="HtmlEmbed"
                     code={
                       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
@@ -156,25 +156,25 @@ const Page = (props: { scripts?: ReactNode }) => {
               </Button>
             </NavigationMenuTrigger>
             <NavigationMenuContent
-              data-ws-id="59"
+              data-ws-id="58"
               data-ws-component="NavigationMenuContent"
               data-ws-index="1"
             >
-              <Box data-ws-id="61" data-ws-component="Box">
-                <Box data-ws-id="63" data-ws-component="Box">
+              <Box data-ws-id="60" data-ws-component="Box">
+                <Box data-ws-id="62" data-ws-component="Box">
                   <NavigationMenuLink
-                    data-ws-id="65"
+                    data-ws-id="64"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="66"
+                      data-ws-id="65"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/accordion"}
                     >
-                      <Text data-ws-id="69" data-ws-component="Text">
+                      <Text data-ws-id="68" data-ws-component="Text">
                         {"Accordion"}
                       </Text>
-                      <Paragraph data-ws-id="71" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="70" data-ws-component="Paragraph">
                         {
                           "A vertically stacked set of interactive headings that each reveal a section of content."
                         }
@@ -182,18 +182,18 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="73"
+                    data-ws-id="72"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="74"
+                      data-ws-id="73"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/dialog"}
                     >
-                      <Text data-ws-id="77" data-ws-component="Text">
+                      <Text data-ws-id="76" data-ws-component="Text">
                         {"Dialog"}
                       </Text>
-                      <Paragraph data-ws-id="79" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="78" data-ws-component="Paragraph">
                         {
                           "A window overlaid on either the primary window or another dialog window, rendering the content underneath inert."
                         }
@@ -201,18 +201,18 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="81"
+                    data-ws-id="80"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="82"
+                      data-ws-id="81"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/collapsible"}
                     >
-                      <Text data-ws-id="85" data-ws-component="Text">
+                      <Text data-ws-id="84" data-ws-component="Text">
                         {"Collapsible"}
                       </Text>
-                      <Paragraph data-ws-id="87" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="86" data-ws-component="Paragraph">
                         {
                           "An interactive component which expands/collapses a panel."
                         }
@@ -220,20 +220,20 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                 </Box>
-                <Box data-ws-id="89" data-ws-component="Box">
+                <Box data-ws-id="88" data-ws-component="Box">
                   <NavigationMenuLink
-                    data-ws-id="91"
+                    data-ws-id="90"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="92"
+                      data-ws-id="91"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/popover"}
                     >
-                      <Text data-ws-id="95" data-ws-component="Text">
+                      <Text data-ws-id="94" data-ws-component="Text">
                         {"Popover"}
                       </Text>
-                      <Paragraph data-ws-id="97" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="96" data-ws-component="Paragraph">
                         {
                           "Displays rich content in a portal, triggered by a button."
                         }
@@ -241,18 +241,18 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="99"
+                    data-ws-id="98"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="100"
+                      data-ws-id="99"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/tooltip"}
                     >
-                      <Text data-ws-id="103" data-ws-component="Text">
+                      <Text data-ws-id="102" data-ws-component="Text">
                         {"Tooltip"}
                       </Text>
-                      <Paragraph data-ws-id="105" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="104" data-ws-component="Paragraph">
                         {
                           "A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it."
                         }
@@ -260,18 +260,18 @@ const Page = (props: { scripts?: ReactNode }) => {
                     </Link>
                   </NavigationMenuLink>
                   <NavigationMenuLink
-                    data-ws-id="107"
+                    data-ws-id="106"
                     data-ws-component="NavigationMenuLink"
                   >
                     <Link
-                      data-ws-id="108"
+                      data-ws-id="107"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/button"}
                     >
-                      <Text data-ws-id="111" data-ws-component="Text">
+                      <Text data-ws-id="110" data-ws-component="Text">
                         {"Button"}
                       </Text>
-                      <Paragraph data-ws-id="113" data-ws-component="Paragraph">
+                      <Paragraph data-ws-id="112" data-ws-component="Paragraph">
                         {
                           "Displays a button or a component that looks like a button."
                         }
@@ -283,23 +283,23 @@ const Page = (props: { scripts?: ReactNode }) => {
             </NavigationMenuContent>
           </NavigationMenuItem>
           <NavigationMenuItem
-            data-ws-id="115"
+            data-ws-id="114"
             data-ws-component="NavigationMenuItem"
             data-ws-index="2"
           >
             <NavigationMenuLink
-              data-ws-id="116"
+              data-ws-id="115"
               data-ws-component="NavigationMenuLink"
             >
-              <Link data-ws-id="117" data-ws-component="Link">
+              <Link data-ws-id="116" data-ws-component="Link">
                 {"Standalone"}
               </Link>
             </NavigationMenuLink>
           </NavigationMenuItem>
         </NavigationMenuList>
-        <Box data-ws-id="119" data-ws-component="Box">
+        <Box data-ws-id="118" data-ws-component="Box">
           <NavigationMenuViewport
-            data-ws-id="121"
+            data-ws-id="120"
             data-ws-component="NavigationMenuViewport"
           />
         </Box>
@@ -521,7 +521,7 @@ html {margin: 0; display: grid; min-height: 100%}
     position: relative;
     max-width: max-content
   }
-  [data-ws-id="7"] {
+  [data-ws-id="6"] {
     padding-left: 0px;
     padding-right: 0px;
     padding-top: 0px;
@@ -540,7 +540,7 @@ html {margin: 0; display: grid; min-height: 100%}
     row-gap: 0.25rem;
     column-gap: 0.25rem
   }
-  [data-ws-id="11"] {
+  [data-ws-id="10"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -569,25 +569,25 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-right: 0.75rem;
     --navigation-menu-trigger-icon-transform: 0deg
   }
-  [data-ws-id="11"]:focus-visible {
+  [data-ws-id="10"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="11"]:disabled {
+  [data-ws-id="10"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="11"]:hover {
+  [data-ws-id="10"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="11"][data-state=open] {
+  [data-ws-id="10"][data-state=open] {
     --navigation-menu-trigger-icon-transform: 180deg
   }
-  [data-ws-id="14"] {
+  [data-ws-id="13"] {
     margin-left: 0.25rem;
     rotate: var(--navigation-menu-trigger-icon-transform);
     height: 1rem;
@@ -597,7 +597,7 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="18"] {
+  [data-ws-id="17"] {
     left: 0px;
     top: 0px;
     position: absolute;
@@ -607,7 +607,7 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 1rem;
     padding-bottom: 1rem
   }
-  [data-ws-id="20"] {
+  [data-ws-id="19"] {
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
@@ -616,7 +616,7 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0.5rem;
     padding-bottom: 0.5rem
   }
-  [data-ws-id="22"] {
+  [data-ws-id="21"] {
     background-color: rgba(226, 232, 240, 1);
     padding-left: 1rem;
     padding-right: 1rem;
@@ -628,14 +628,14 @@ html {margin: 0; display: grid; min-height: 100%}
     border-bottom-right-radius: 0.375rem;
     border-bottom-left-radius: 0.375rem
   }
-  [data-ws-id="24"] {
+  [data-ws-id="23"] {
     width: 16rem;
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
     flex-direction: column
   }
-  [data-ws-id="27"] {
+  [data-ws-id="26"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -657,20 +657,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="27"]:hover {
+  [data-ws-id="26"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="27"]:focus {
+  [data-ws-id="26"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="30"] {
+  [data-ws-id="29"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="32"] {
+  [data-ws-id="31"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -683,7 +683,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="35"] {
+  [data-ws-id="34"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -705,20 +705,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="35"]:hover {
+  [data-ws-id="34"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="35"]:focus {
+  [data-ws-id="34"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="38"] {
+  [data-ws-id="37"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="40"] {
+  [data-ws-id="39"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -731,7 +731,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="43"] {
+  [data-ws-id="42"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -753,20 +753,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="43"]:hover {
+  [data-ws-id="42"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="43"]:focus {
+  [data-ws-id="42"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="46"] {
+  [data-ws-id="45"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="48"] {
+  [data-ws-id="47"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -779,7 +779,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="52"] {
+  [data-ws-id="51"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -808,25 +808,25 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-right: 0.75rem;
     --navigation-menu-trigger-icon-transform: 0deg
   }
-  [data-ws-id="52"]:focus-visible {
+  [data-ws-id="51"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="52"]:disabled {
+  [data-ws-id="51"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="52"]:hover {
+  [data-ws-id="51"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="52"][data-state=open] {
+  [data-ws-id="51"][data-state=open] {
     --navigation-menu-trigger-icon-transform: 180deg
   }
-  [data-ws-id="55"] {
+  [data-ws-id="54"] {
     margin-left: 0.25rem;
     rotate: var(--navigation-menu-trigger-icon-transform);
     height: 1rem;
@@ -836,7 +836,7 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="59"] {
+  [data-ws-id="58"] {
     left: 0px;
     top: 0px;
     position: absolute;
@@ -846,7 +846,7 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 1rem;
     padding-bottom: 1rem
   }
-  [data-ws-id="61"] {
+  [data-ws-id="60"] {
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
@@ -855,14 +855,14 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0px;
     padding-bottom: 0px
   }
-  [data-ws-id="63"] {
+  [data-ws-id="62"] {
     width: 16rem;
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
     flex-direction: column
   }
-  [data-ws-id="66"] {
+  [data-ws-id="65"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -884,20 +884,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="66"]:hover {
+  [data-ws-id="65"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="66"]:focus {
+  [data-ws-id="65"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="69"] {
+  [data-ws-id="68"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="71"] {
+  [data-ws-id="70"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -910,7 +910,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="74"] {
+  [data-ws-id="73"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -932,20 +932,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="74"]:hover {
+  [data-ws-id="73"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="74"]:focus {
+  [data-ws-id="73"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="77"] {
+  [data-ws-id="76"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="79"] {
+  [data-ws-id="78"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -958,7 +958,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="82"] {
+  [data-ws-id="81"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -980,20 +980,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="82"]:hover {
+  [data-ws-id="81"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="82"]:focus {
+  [data-ws-id="81"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="85"] {
+  [data-ws-id="84"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="87"] {
+  [data-ws-id="86"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -1006,14 +1006,14 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="89"] {
+  [data-ws-id="88"] {
     width: 16rem;
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
     flex-direction: column
   }
-  [data-ws-id="92"] {
+  [data-ws-id="91"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -1035,20 +1035,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="92"]:hover {
+  [data-ws-id="91"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="92"]:focus {
+  [data-ws-id="91"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="95"] {
+  [data-ws-id="94"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="97"] {
+  [data-ws-id="96"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -1061,7 +1061,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="100"] {
+  [data-ws-id="99"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -1083,20 +1083,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="100"]:hover {
+  [data-ws-id="99"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="100"]:focus {
+  [data-ws-id="99"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="103"] {
+  [data-ws-id="102"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="105"] {
+  [data-ws-id="104"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -1109,7 +1109,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="108"] {
+  [data-ws-id="107"] {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -1131,20 +1131,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="108"]:hover {
+  [data-ws-id="107"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="108"]:focus {
+  [data-ws-id="107"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="111"] {
+  [data-ws-id="110"] {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="113"] {
+  [data-ws-id="112"] {
     margin-left: 0px;
     margin-right: 0px;
     margin-top: 0px;
@@ -1157,7 +1157,7 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.375;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="117"] {
+  [data-ws-id="116"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -1187,29 +1187,29 @@ html {margin: 0; display: grid; min-height: 100%}
     text-decoration-line: none;
     color: currentColor
   }
-  [data-ws-id="117"]:focus-visible {
+  [data-ws-id="116"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="117"]:disabled {
+  [data-ws-id="116"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="117"]:hover {
+  [data-ws-id="116"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="119"] {
+  [data-ws-id="118"] {
     position: absolute;
     left: 0px;
     top: 100%;
     display: flex;
     justify-content: center
   }
-  [data-ws-id="121"] {
+  [data-ws-id="120"] {
     position: relative;
     margin-top: 0.375rem;
     overflow: hidden;

--- a/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
@@ -25,13 +25,13 @@ const Page = (props: { scripts?: ReactNode }) => {
         open={open}
         onOpenChange={onOpenChange}
       >
-        <PopoverTrigger data-ws-id="6" data-ws-component="PopoverTrigger">
-          <Button data-ws-id="7" data-ws-component="Button">
+        <PopoverTrigger data-ws-id="5" data-ws-component="PopoverTrigger">
+          <Button data-ws-id="6" data-ws-component="Button">
             {"Button"}
           </Button>
         </PopoverTrigger>
-        <PopoverContent data-ws-id="9" data-ws-component="PopoverContent">
-          <Text data-ws-id="11" data-ws-component="Text">
+        <PopoverContent data-ws-id="8" data-ws-component="PopoverContent">
+          <Text data-ws-id="10" data-ws-component="Text">
             {"The text you can edit"}
           </Text>
         </PopoverContent>
@@ -183,7 +183,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="7"] {
+  [data-ws-id="6"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -213,22 +213,22 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0.5rem;
     padding-bottom: 0.5rem
   }
-  [data-ws-id="7"]:focus-visible {
+  [data-ws-id="6"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="7"]:disabled {
+  [data-ws-id="6"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="7"]:hover {
+  [data-ws-id="6"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="9"] {
+  [data-ws-id="8"] {
     z-index: 50;
     width: 18rem;
     border-top-left-radius: 0.375rem;

--- a/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
@@ -26,18 +26,18 @@ const Page = (props: { scripts?: ReactNode }) => {
         value={value}
         onValueChange={onValueChange}
       >
-        <Label data-ws-id="7" data-ws-component="Label">
+        <Label data-ws-id="6" data-ws-component="Label">
           <RadioGroupItem
-            data-ws-id="9"
+            data-ws-id="8"
             data-ws-component="RadioGroupItem"
             value={"default"}
           >
             <RadioGroupIndicator
-              data-ws-id="12"
+              data-ws-id="11"
               data-ws-component="RadioGroupIndicator"
             >
               <HtmlEmbed
-                data-ws-id="13"
+                data-ws-id="12"
                 data-ws-component="HtmlEmbed"
                 code={
                   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M8 5.35a2.65 2.65 0 1 0 0 5.3 2.65 2.65 0 0 0 0-5.3Z"/></svg>'
@@ -45,22 +45,22 @@ const Page = (props: { scripts?: ReactNode }) => {
               />
             </RadioGroupIndicator>
           </RadioGroupItem>
-          <Text data-ws-id="15" data-ws-component="Text">
+          <Text data-ws-id="14" data-ws-component="Text">
             {"Default"}
           </Text>
         </Label>
-        <Label data-ws-id="16" data-ws-component="Label">
+        <Label data-ws-id="15" data-ws-component="Label">
           <RadioGroupItem
-            data-ws-id="18"
+            data-ws-id="17"
             data-ws-component="RadioGroupItem"
             value={"comfortable"}
           >
             <RadioGroupIndicator
-              data-ws-id="21"
+              data-ws-id="20"
               data-ws-component="RadioGroupIndicator"
             >
               <HtmlEmbed
-                data-ws-id="22"
+                data-ws-id="21"
                 data-ws-component="HtmlEmbed"
                 code={
                   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M8 5.35a2.65 2.65 0 1 0 0 5.3 2.65 2.65 0 0 0 0-5.3Z"/></svg>'
@@ -68,22 +68,22 @@ const Page = (props: { scripts?: ReactNode }) => {
               />
             </RadioGroupIndicator>
           </RadioGroupItem>
-          <Text data-ws-id="24" data-ws-component="Text">
+          <Text data-ws-id="23" data-ws-component="Text">
             {"Comfortable"}
           </Text>
         </Label>
-        <Label data-ws-id="25" data-ws-component="Label">
+        <Label data-ws-id="24" data-ws-component="Label">
           <RadioGroupItem
-            data-ws-id="27"
+            data-ws-id="26"
             data-ws-component="RadioGroupItem"
             value={"compact"}
           >
             <RadioGroupIndicator
-              data-ws-id="30"
+              data-ws-id="29"
               data-ws-component="RadioGroupIndicator"
             >
               <HtmlEmbed
-                data-ws-id="31"
+                data-ws-id="30"
                 data-ws-component="HtmlEmbed"
                 code={
                   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M8 5.35a2.65 2.65 0 1 0 0 5.3 2.65 2.65 0 0 0 0-5.3Z"/></svg>'
@@ -91,7 +91,7 @@ const Page = (props: { scripts?: ReactNode }) => {
               />
             </RadioGroupIndicator>
           </RadioGroupItem>
-          <Text data-ws-id="33" data-ws-component="Text">
+          <Text data-ws-id="32" data-ws-component="Text">
             {"Compact"}
           </Text>
         </Label>
@@ -279,13 +279,13 @@ html {margin: 0; display: grid; min-height: 100%}
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="7"] {
+  [data-ws-id="6"] {
     display: flex;
     align-items: center;
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="9"] {
+  [data-ws-id="8"] {
     aspect-ratio: 1 / 1;
     height: 1rem;
     width: 1rem;
@@ -307,24 +307,24 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="9"]:focus-visible {
+  [data-ws-id="8"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="9"]:disabled {
+  [data-ws-id="8"]:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="16"] {
+  [data-ws-id="15"] {
     display: flex;
     align-items: center;
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="18"] {
+  [data-ws-id="17"] {
     aspect-ratio: 1 / 1;
     height: 1rem;
     width: 1rem;
@@ -346,24 +346,24 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="18"]:focus-visible {
+  [data-ws-id="17"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="18"]:disabled {
+  [data-ws-id="17"]:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="25"] {
+  [data-ws-id="24"] {
     display: flex;
     align-items: center;
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="27"] {
+  [data-ws-id="26"] {
     aspect-ratio: 1 / 1;
     height: 1rem;
     width: 1rem;
@@ -385,14 +385,14 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="27"]:focus-visible {
+  [data-ws-id="26"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="27"]:disabled {
+  [data-ws-id="26"]:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }

--- a/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
@@ -37,26 +37,26 @@ const Page = (props: { scripts?: ReactNode }) => {
         open={open}
         onOpenChange={onOpenChange}
       >
-        <SelectTrigger data-ws-id="10" data-ws-component="SelectTrigger">
+        <SelectTrigger data-ws-id="8" data-ws-component="SelectTrigger">
           <SelectValue
-            data-ws-id="12"
+            data-ws-id="10"
             data-ws-component="SelectValue"
             placeholder={"Theme"}
           />
         </SelectTrigger>
-        <SelectContent data-ws-id="14" data-ws-component="SelectContent">
-          <SelectViewport data-ws-id="16" data-ws-component="SelectViewport">
+        <SelectContent data-ws-id="12" data-ws-component="SelectContent">
+          <SelectViewport data-ws-id="14" data-ws-component="SelectViewport">
             <SelectItem
-              data-ws-id="18"
+              data-ws-id="16"
               data-ws-component="SelectItem"
               value={"light"}
             >
               <SelectItemIndicator
-                data-ws-id="21"
+                data-ws-id="19"
                 data-ws-component="SelectItemIndicator"
               >
                 <HtmlEmbed
-                  data-ws-id="23"
+                  data-ws-id="21"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M11.957 5.043a1 1 0 0 1 0 1.414l-4.5 4.5a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L6.75 8.836l3.793-3.793a1 1 0 0 1 1.414 0Z" clip-rule="evenodd"/></svg>'
@@ -64,23 +64,23 @@ const Page = (props: { scripts?: ReactNode }) => {
                 />
               </SelectItemIndicator>
               <SelectItemText
-                data-ws-id="25"
+                data-ws-id="23"
                 data-ws-component="SelectItemText"
               >
                 {"Light"}
               </SelectItemText>
             </SelectItem>
             <SelectItem
-              data-ws-id="26"
+              data-ws-id="24"
               data-ws-component="SelectItem"
               value={"dark"}
             >
               <SelectItemIndicator
-                data-ws-id="29"
+                data-ws-id="27"
                 data-ws-component="SelectItemIndicator"
               >
                 <HtmlEmbed
-                  data-ws-id="31"
+                  data-ws-id="29"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M11.957 5.043a1 1 0 0 1 0 1.414l-4.5 4.5a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L6.75 8.836l3.793-3.793a1 1 0 0 1 1.414 0Z" clip-rule="evenodd"/></svg>'
@@ -88,23 +88,23 @@ const Page = (props: { scripts?: ReactNode }) => {
                 />
               </SelectItemIndicator>
               <SelectItemText
-                data-ws-id="33"
+                data-ws-id="31"
                 data-ws-component="SelectItemText"
               >
                 {"Dark"}
               </SelectItemText>
             </SelectItem>
             <SelectItem
-              data-ws-id="34"
+              data-ws-id="32"
               data-ws-component="SelectItem"
               value={"system"}
             >
               <SelectItemIndicator
-                data-ws-id="37"
+                data-ws-id="35"
                 data-ws-component="SelectItemIndicator"
               >
                 <HtmlEmbed
-                  data-ws-id="39"
+                  data-ws-id="37"
                   data-ws-component="HtmlEmbed"
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M11.957 5.043a1 1 0 0 1 0 1.414l-4.5 4.5a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L6.75 8.836l3.793-3.793a1 1 0 0 1 1.414 0Z" clip-rule="evenodd"/></svg>'
@@ -112,7 +112,7 @@ const Page = (props: { scripts?: ReactNode }) => {
                 />
               </SelectItemIndicator>
               <SelectItemText
-                data-ws-id="41"
+                data-ws-id="39"
                 data-ws-component="SelectItemText"
               >
                 {"System"}
@@ -299,7 +299,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="10"] {
+  [data-ws-id="8"] {
     display: flex;
     height: 2.5rem;
     width: 100%;
@@ -329,21 +329,21 @@ html {margin: 0; display: grid; min-height: 100%}
     font-size: 0.875rem;
     line-height: 1.25rem
   }
-  [data-ws-id="10"]::placeholder {
+  [data-ws-id="8"]::placeholder {
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="10"]:focus {
+  [data-ws-id="8"]:focus {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="10"]:disabled {
+  [data-ws-id="8"]:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="14"] {
+  [data-ws-id="12"] {
     position: relative;
     z-index: 50;
     min-width: 8rem;
@@ -368,7 +368,7 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(2, 8, 23, 1);
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)
   }
-  [data-ws-id="16"] {
+  [data-ws-id="14"] {
     padding-left: 0.25rem;
     padding-right: 0.25rem;
     padding-top: 0.25rem;
@@ -377,7 +377,7 @@ html {margin: 0; display: grid; min-height: 100%}
     width: 100%;
     min-width: var(--radix-select-trigger-width)
   }
-  [data-ws-id="18"] {
+  [data-ws-id="16"] {
     position: relative;
     display: flex;
     width: 100%;
@@ -399,15 +399,15 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="18"]:focus {
+  [data-ws-id="16"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="18"][data-disabled] {
+  [data-ws-id="16"][data-disabled] {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="21"] {
+  [data-ws-id="19"] {
     position: absolute;
     left: 0.5rem;
     display: flex;
@@ -416,7 +416,7 @@ html {margin: 0; display: grid; min-height: 100%}
     align-items: center;
     justify-content: center
   }
-  [data-ws-id="26"] {
+  [data-ws-id="24"] {
     position: relative;
     display: flex;
     width: 100%;
@@ -438,15 +438,15 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="26"]:focus {
+  [data-ws-id="24"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="26"][data-disabled] {
+  [data-ws-id="24"][data-disabled] {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="29"] {
+  [data-ws-id="27"] {
     position: absolute;
     left: 0.5rem;
     display: flex;
@@ -455,7 +455,7 @@ html {margin: 0; display: grid; min-height: 100%}
     align-items: center;
     justify-content: center
   }
-  [data-ws-id="34"] {
+  [data-ws-id="32"] {
     position: relative;
     display: flex;
     width: 100%;
@@ -477,15 +477,15 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="34"]:focus {
+  [data-ws-id="32"]:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="34"][data-disabled] {
+  [data-ws-id="32"][data-disabled] {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="37"] {
+  [data-ws-id="35"] {
     position: absolute;
     left: 0.5rem;
     display: flex;

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
@@ -30,10 +30,10 @@ const Page = (props: { scripts?: ReactNode }) => {
         open={open}
         onOpenChange={onOpenChange}
       >
-        <DialogTrigger data-ws-id="6" data-ws-component="DialogTrigger">
-          <Button data-ws-id="7" data-ws-component="Button">
+        <DialogTrigger data-ws-id="5" data-ws-component="DialogTrigger">
+          <Button data-ws-id="6" data-ws-component="Button">
             <HtmlEmbed
-              data-ws-id="9"
+              data-ws-id="8"
               data-ws-component="HtmlEmbed"
               code={
                 '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M2 5.998a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Zm0 5.5a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Zm0 5.5a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd"/></svg>'
@@ -41,32 +41,32 @@ const Page = (props: { scripts?: ReactNode }) => {
             />
           </Button>
         </DialogTrigger>
-        <DialogOverlay data-ws-id="11" data-ws-component="DialogOverlay">
-          <DialogContent data-ws-id="13" data-ws-component="DialogContent">
+        <DialogOverlay data-ws-id="10" data-ws-component="DialogOverlay">
+          <DialogContent data-ws-id="12" data-ws-component="DialogContent">
             <Box
-              data-ws-id="15"
+              data-ws-id="14"
               data-ws-component="Box"
               tag={"nav"}
               role={"navigation"}
             >
-              <Box data-ws-id="18" data-ws-component="Box">
-                <DialogTitle data-ws-id="20" data-ws-component="DialogTitle">
+              <Box data-ws-id="17" data-ws-component="Box">
+                <DialogTitle data-ws-id="19" data-ws-component="DialogTitle">
                   {"Sheet Title"}
                 </DialogTitle>
                 <DialogDescription
-                  data-ws-id="22"
+                  data-ws-id="21"
                   data-ws-component="DialogDescription"
                 >
                   {"Sheet description text you can edit"}
                 </DialogDescription>
               </Box>
-              <Text data-ws-id="24" data-ws-component="Text">
+              <Text data-ws-id="23" data-ws-component="Text">
                 {"The text you can edit"}
               </Text>
             </Box>
-            <DialogClose data-ws-id="25" data-ws-component="DialogClose">
+            <DialogClose data-ws-id="24" data-ws-component="DialogClose">
               <HtmlEmbed
-                data-ws-id="27"
+                data-ws-id="26"
                 data-ws-component="HtmlEmbed"
                 code={
                   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path fill-rule="evenodd" d="M13.566 2.434a.8.8 0 0 1 0 1.132L9.13 8l4.435 4.434a.8.8 0 0 1-1.132 1.132L8 9.13l-4.434 4.435a.8.8 0 0 1-1.132-1.132L6.87 8 2.434 3.566a.8.8 0 0 1 1.132-1.132L8 6.87l4.434-4.435a.8.8 0 0 1 1.132 0Z" clip-rule="evenodd"/></svg>'
@@ -276,7 +276,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="7"] {
+  [data-ws-id="6"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -303,22 +303,22 @@ html {margin: 0; display: grid; min-height: 100%}
     height: 2.5rem;
     width: 2.5rem
   }
-  [data-ws-id="7"]:focus-visible {
+  [data-ws-id="6"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="7"]:disabled {
+  [data-ws-id="6"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="7"]:hover {
+  [data-ws-id="6"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="11"] {
+  [data-ws-id="10"] {
     position: fixed;
     left: 0px;
     right: 0px;
@@ -331,7 +331,7 @@ html {margin: 0; display: grid; min-height: 100%}
     flex-direction: column;
     overflow: auto
   }
-  [data-ws-id="13"] {
+  [data-ws-id="12"] {
     width: 100%;
     z-index: 50;
     display: flex;
@@ -361,27 +361,27 @@ html {margin: 0; display: grid; min-height: 100%}
     max-width: 24rem;
     flex-grow: 1
   }
-  [data-ws-id="18"] {
+  [data-ws-id="17"] {
     display: flex;
     flex-direction: column;
     row-gap: 0.25rem;
     column-gap: 0.25rem
   }
-  [data-ws-id="20"] {
+  [data-ws-id="19"] {
     margin-top: 0px;
     margin-bottom: 0px;
     line-height: 1.75rem;
     font-size: 1.125rem;
     letter-spacing: -0.025em
   }
-  [data-ws-id="22"] {
+  [data-ws-id="21"] {
     margin-top: 0px;
     margin-bottom: 0px;
     font-size: 0.875rem;
     line-height: 1.25rem;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="25"] {
+  [data-ws-id="24"] {
     position: absolute;
     right: 1rem;
     top: 1rem;
@@ -413,10 +413,10 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-color: transparent;
     outline-offset: 2px
   }
-  [data-ws-id="25"]:hover {
+  [data-ws-id="24"]:hover {
     opacity: 1
   }
-  [data-ws-id="25"]:focus {
+  [data-ws-id="24"]:focus {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
@@ -17,7 +17,7 @@ const Page = (props: { scripts?: ReactNode }) => {
         checked={checked}
         onCheckedChange={onCheckedChange}
       >
-        <SwitchThumb data-ws-id="7" data-ws-component="SwitchThumb" />
+        <SwitchThumb data-ws-id="6" data-ws-component="SwitchThumb" />
       </Switch>
       {props.scripts}
     </Box>
@@ -215,7 +215,7 @@ html {margin: 0; display: grid; min-height: 100%}
   [data-ws-id="1"][data-state=unchecked] {
     background-color: rgba(226, 232, 240, 1)
   }
-  [data-ws-id="7"] {
+  [data-ws-id="6"] {
     pointer-events: none;
     display: block;
     height: 1.25rem;
@@ -230,10 +230,10 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms
   }
-  [data-ws-id="7"][data-state=checked] {
+  [data-ws-id="6"][data-state=checked] {
     transform: translateX(20px)
   }
-  [data-ws-id="7"][data-state=unchecked] {
+  [data-ws-id="6"][data-state=unchecked] {
     transform: translateX(0px)
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
@@ -22,16 +22,16 @@ const Page = (props: { scripts?: ReactNode }) => {
         value={value}
         onValueChange={onValueChange}
       >
-        <TabsList data-ws-id="6" data-ws-component="TabsList">
+        <TabsList data-ws-id="5" data-ws-component="TabsList">
           <TabsTrigger
-            data-ws-id="8"
+            data-ws-id="7"
             data-ws-component="TabsTrigger"
             data-ws-index="0"
           >
             {"Account"}
           </TabsTrigger>
           <TabsTrigger
-            data-ws-id="10"
+            data-ws-id="9"
             data-ws-component="TabsTrigger"
             data-ws-index="1"
           >
@@ -39,14 +39,14 @@ const Page = (props: { scripts?: ReactNode }) => {
           </TabsTrigger>
         </TabsList>
         <TabsContent
-          data-ws-id="12"
+          data-ws-id="11"
           data-ws-component="TabsContent"
           data-ws-index="0"
         >
           {"Make changes to your account here."}
         </TabsContent>
         <TabsContent
-          data-ws-id="14"
+          data-ws-id="13"
           data-ws-component="TabsContent"
           data-ws-index="1"
         >
@@ -221,7 +221,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="6"] {
+  [data-ws-id="5"] {
     display: inline-flex;
     height: 2.5rem;
     align-items: center;
@@ -237,7 +237,7 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-bottom: 0.25rem;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="8"] {
+  [data-ws-id="7"] {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -257,23 +257,23 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms
   }
-  [data-ws-id="8"]:focus-visible {
+  [data-ws-id="7"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="8"]:disabled {
+  [data-ws-id="7"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="8"][data-state=active] {
+  [data-ws-id="7"][data-state=active] {
     background-color: rgba(255, 255, 255, 0.8);
     color: rgba(2, 8, 23, 1);
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05)
   }
-  [data-ws-id="10"] {
+  [data-ws-id="9"] {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -293,36 +293,36 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms
   }
-  [data-ws-id="10"]:focus-visible {
+  [data-ws-id="9"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="10"]:disabled {
+  [data-ws-id="9"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="10"][data-state=active] {
+  [data-ws-id="9"][data-state=active] {
     background-color: rgba(255, 255, 255, 0.8);
     color: rgba(2, 8, 23, 1);
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05)
   }
-  [data-ws-id="12"] {
+  [data-ws-id="11"] {
     margin-top: 0.5rem
   }
-  [data-ws-id="12"]:focus-visible {
+  [data-ws-id="11"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="14"] {
+  [data-ws-id="13"] {
     margin-top: 0.5rem
   }
-  [data-ws-id="14"]:focus-visible {
+  [data-ws-id="13"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
@@ -25,13 +25,13 @@ const Page = (props: { scripts?: ReactNode }) => {
         open={open}
         onOpenChange={onOpenChange}
       >
-        <TooltipTrigger data-ws-id="6" data-ws-component="TooltipTrigger">
-          <Button data-ws-id="7" data-ws-component="Button">
+        <TooltipTrigger data-ws-id="5" data-ws-component="TooltipTrigger">
+          <Button data-ws-id="6" data-ws-component="Button">
             {"Button"}
           </Button>
         </TooltipTrigger>
-        <TooltipContent data-ws-id="9" data-ws-component="TooltipContent">
-          <Text data-ws-id="11" data-ws-component="Text">
+        <TooltipContent data-ws-id="8" data-ws-component="TooltipContent">
+          <Text data-ws-id="10" data-ws-component="Text">
             {"The text you can edit"}
           </Text>
         </TooltipContent>
@@ -183,7 +183,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="7"] {
+  [data-ws-id="6"] {
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -213,22 +213,22 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-top: 0.5rem;
     padding-bottom: 0.5rem
   }
-  [data-ws-id="7"]:focus-visible {
+  [data-ws-id="6"]:focus-visible {
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="7"]:disabled {
+  [data-ws-id="6"]:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="7"]:hover {
+  [data-ws-id="6"]:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="9"] {
+  [data-ws-id="8"] {
     z-index: 50;
     overflow: hidden;
     border-top-left-radius: 0.375rem;

--- a/packages/sdk/src/schema/props.ts
+++ b/packages/sdk/src/schema/props.ts
@@ -59,6 +59,11 @@ export const Prop = z.union([
   }),
   z.object({
     ...baseProp,
+    type: z.literal("expression"),
+    value: z.string(),
+  }),
+  z.object({
+    ...baseProp,
     type: z.literal("action"),
     value: z.array(
       z.object({


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

On the last discussion about bindings we agreed expression are always bound to single prop and cannot be reused.

Here added new prop.type = 'expression' as a replacement to dataSource.type = 'expression'.

This will let us unify expression/variable reference and avoid deep dependencies. Expressions and actions become similar.

For now both expression prop and legacy expression data source are supported until we migrate completely in db.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
