### PR TITLE
feat: Report deployment url at *.prs.webstudio.is

### DIFF
--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -29,6 +29,8 @@ jobs:
             console.log('branch', branch);
             console.log('context.repo', JSON.stringify(context.repo));
 
+            const sha = context.payload.pull_request?.head?.sha ?? context.sha;
+
             const status = {
               state: 'success',
               target_url: 'http://example.com',
@@ -38,12 +40,12 @@ jobs:
 
             console.log(JSON.stringify(
               {...context.repo,
-                sha: context.sha,
+                sha,
               ...status
               }));
 
             github.rest.repos.createCommitStatus({
               ...context.repo,
-              sha: context.sha,
+              sha,
               ...status
             });

--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -1,0 +1,42 @@
+name: Main workflow
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  checks:
+    timeout-minutes: 20
+
+    env:
+      DATABASE_URL: postgres://
+      AUTH_SECRET: test
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add URL to vercel deployment through *.prs.webstudio.is
+        uses: actions/github-script@v6
+        with:
+          script: |
+
+            console.log('context.payload.ref', context.payload.ref, 'context.payload.pull_request.head.ref', context.payload.pull_request.head.ref);
+            console.log('context.repo', context.repo);
+
+            const status = {
+              state: 'success',
+              target_url: 'http://example.com',
+              description: 'Description of the status',
+              context: 'Context of the status'
+            };
+
+            github.repos.createCommitStatus({
+              ...context.repo,
+              sha: context.sha,
+              ...status
+            });

--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -1,4 +1,4 @@
-name: Main workflow
+name: Add status to commit
 
 on:
   push:

--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -26,7 +26,7 @@ jobs:
           script: |
 
             console.log('context.payload.ref', context.payload.ref, 'context.payload.pull_request.head.ref', context.payload.pull_request.head.ref);
-            console.log('context.repo', context.repo);
+            console.log('context.repo', JSON.stringify(context.repo));
 
             const status = {
               state: 'success',
@@ -35,9 +35,7 @@ jobs:
               context: 'Context of the status'
             };
 
-            console.log('github.repos.createCommitStatus', github.repos.createCommitStatus);
-
-            github.repos.createCommitStatus({
+            github.rest.repos.createCommitStatus({
               ...context.repo,
               sha: context.sha,
               ...status

--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  statuses: write # to fetch code (actions/checkout)
 
 jobs:
   checks:
@@ -35,7 +35,7 @@ jobs:
               context: 'Context of the status'
             };
 
-            github.rest.repos.createCommitStatus({
+            github.repos.createCommitStatus({
               ...context.repo,
               sha: context.sha,
               ...status

--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -26,23 +26,14 @@ jobs:
           script: |
 
             const branch = context.payload.ref ?? context.payload.pull_request.head.ref;
-            console.log('branch', branch);
-            console.log('context.repo', JSON.stringify(context.repo));
-
             const sha = context.payload.pull_request?.head?.sha ?? context.sha;
 
             const status = {
               state: 'success',
-              target_url: 'http://example.com',
-              description: 'Description of the status',
-              context: '🟠 Context of the status'
+              target_url: `${branch.toLowerCase().replace(/[^a-z0-9-]+/g, '')}.prs.webstudio.is`,
+              description: 'click details to see the deployment',
+              context: '⭐ Apps Webstudio URL'
             };
-
-            console.log(JSON.stringify(
-              {...context.repo,
-                sha,
-              ...status
-              }));
 
             github.rest.repos.createCommitStatus({
               ...context.repo,

--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -25,7 +25,8 @@ jobs:
         with:
           script: |
 
-            console.log('context.payload.ref', context.payload.ref, 'context.payload.pull_request.head.ref', context.payload.pull_request.head.ref);
+            const branch = context.payload.ref ?? context.payload.pull_request.head.ref;
+            console.log('branch', branch);
             console.log('context.repo', JSON.stringify(context.repo));
 
             const status = {
@@ -35,7 +36,13 @@ jobs:
               context: 'Context of the status'
             };
 
-            await github.rest.repos.createCommitStatus({
+            console.log(JSON.stringify(
+              {...context.repo,
+                sha: context.sha,
+              ...status
+              }));
+
+            github.rest.repos.createCommitStatus({
               ...context.repo,
               sha: context.sha,
               ...status

--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -30,7 +30,7 @@ jobs:
 
             const status = {
               state: 'success',
-              target_url: `${branch.toLowerCase().replace(/[^a-z0-9-]+/g, '')}.prs.webstudio.is`,
+              target_url: `https://${branch.toLowerCase().replace(/[^a-z0-9-]+/g, '')}.prs.webstudio.is`,
               description: 'click details to see the deployment',
               context: '⭐ Apps Webstudio URL'
             };

--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -35,7 +35,7 @@ jobs:
               state: 'success',
               target_url: 'http://example.com',
               description: 'Description of the status',
-              context: 'Context of the status'
+              context: '🟠 Context of the status'
             };
 
             console.log(JSON.stringify(

--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -35,7 +35,7 @@ jobs:
               context: 'Context of the status'
             };
 
-            github.repos.createCommitStatus({
+            await github.rest.repos.createCommitStatus({
               ...context.repo,
               sha: context.sha,
               ...status

--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -35,6 +35,8 @@ jobs:
               context: 'Context of the status'
             };
 
+            console.log('github.repos.createCommitStatus', github.repos.createCommitStatus);
+
             github.repos.createCommitStatus({
               ...context.repo,
               sha: context.sha,

--- a/apps/builder/app/env/env.public.server.ts
+++ b/apps/builder/app/env/env.public.server.ts
@@ -14,7 +14,6 @@ const env = {
   FEATURES: process.env.FEATURES,
   BUILDER_HOST: process.env.BUILDER_HOST,
   PUBLISHER_HOST: process.env.PUBLISHER_HOST || null,
-  BUILD_REQUIRE_SUBDOMAIN: process.env.BUILD_REQUIRE_SUBDOMAIN === "true",
 
   IMAGE_BASE_URL: serverEnv.IMAGE_BASE_URL,
   ASSET_BASE_URL: serverEnv.ASSET_BASE_URL,


### PR DESCRIPTION
## Description

To have ability to test some cloudflare worker issues we are now have *.prs.webstudio.is domains. 
Builder app now can be accessed through such urls.

Here we add prs.webstudio app url at the end of status list

<img width="973" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/5e716b07-bee5-41bd-9db6-deae01df89cd">

Known issues:
will not work if branch names exceed 24 chars,

Gonna not fix for now.


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
