### PR TITLE
fix: Wrong branch name used on main push

### DIFF
--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           script: |
 
-            const branch = context.payload.ref ?? context.payload.pull_request.head.ref;
+            const branch = context.payload.pull_request?.head?.ref ?? context.payload.ref?.replace('refs/heads/', '')
             const sha = context.payload.pull_request?.head?.sha ?? context.sha;
 
             const status = {


### PR DESCRIPTION
## Description

`refs/heads/` must be omited

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
