### PR TITLE
fix: Fix image loader paths

### DIFF
--- a/apps/builder/app/builder/features/seo/site-settings.tsx
+++ b/apps/builder/app/builder/features/seo/site-settings.tsx
@@ -57,7 +57,7 @@ const SiteSettingsContent = (props: Props) => {
   const favIconUrl = asset ? `${asset.name}` : undefined;
 
   const imageLoader = createImageLoader({
-    imageBaseUrl: env.ASSET_BASE_URL,
+    imageBaseUrl: env.IMAGE_BASE_URL,
   });
 
   return (

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/social-preview.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/social-preview.tsx
@@ -34,7 +34,7 @@ export const SocialPreview = ({
   ogUrl,
 }: SocialPreviewProps) => {
   const imageLoader = createImageLoader({
-    imageBaseUrl: env.ASSET_BASE_URL,
+    imageBaseUrl: env.IMAGE_BASE_URL,
   });
 
   return (

--- a/apps/builder/app/env/env.server.ts
+++ b/apps/builder/app/env/env.server.ts
@@ -38,7 +38,7 @@ const env = {
    * Base url or base path for any asset with ending slash.
    * Possible values are
    * /s/uploads/
-   * /asset/file/
+   * /cgi/asset/
    * https://assets-dev.webstudio.is/
    * https://assets.webstudio.is/
    */
@@ -46,7 +46,7 @@ const env = {
     process.env.ASSET_BASE_URL ??
     process.env.ASSET_CDN_URL ??
     process.env.ASSET_PUBLIC_PATH ??
-    "/",
+    "/cgi/asset/",
 
   // Local assets
   FILE_UPLOAD_PATH: process.env.FILE_UPLOAD_PATH,


### PR DESCRIPTION
## Description

Also add default asset path to remove env variables from setup

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
