### PR TITLE
feat: support generating collection

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
@@ -19,6 +19,11 @@ export const renderControl = ({
     throw Error("Expression is not resolved");
   }
 
+  // never render parameter props
+  if (prop?.type === "parameter") {
+    return;
+  }
+
   // @todo remove once ui for action is implemented
   if (prop?.type === "action") {
     return;

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -96,6 +96,10 @@ const getDefaultMetaForType = (type: Prop["type"]): PropMeta => {
       throw new Error(
         "A prop with type expression must have a meta, we can't provide a default one because we need a list of options"
       );
+    case "parameter":
+      throw new Error(
+        "A prop with type parameter must have a meta, we can't provide a default one because we need a list of options"
+      );
     default:
       throw new Error(`Usupported data type: ${type satisfies never}`);
   }

--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -1,0 +1,1 @@
+export const collectionComponent = "ws:component";

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -249,6 +249,11 @@ export const generateDataSources = ({
   }
 
   for (const prop of props.values()) {
+    // prevent generating parameter variables as component state
+    if (prop.type === "parameter") {
+      output.delete(prop.value);
+      variables.delete(prop.value);
+    }
     // generate actions assigning variables and invoking their setters
     if (prop.type === "action") {
       const name = scope.getName(prop.id, prop.name);

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./css/index";
 export * from "./tree/index";
 export * from "./app/index";
+export * from "./core-components";
 export * from "./components/components-utils";
 export { PropMeta } from "./prop-meta";
 export {

--- a/packages/sdk/src/schema/props.ts
+++ b/packages/sdk/src/schema/props.ts
@@ -53,7 +53,14 @@ export const Prop = z.union([
   }),
   z.object({
     ...baseProp,
+    type: z.literal("parameter"),
+    // data source id
+    value: z.string(),
+  }),
+  z.object({
+    ...baseProp,
     type: z.literal("expression"),
+    // expression code
     value: z.string(),
   }),
   z.object({


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here first part for collection support. Collections are generated as

```tsx
list.map((item, index) => <Fragment key={index}></Fragment>)
```

Added new "parameter" prop type to represent "item" which always refers to variable. "parameter" reflects same semantics as js functions where in function call it is argument `fn(1, 2, 3)` and in function definition it is parameter `function fn(a, b, c) {}`.

Collection children are always wrapped with fragment to let having more than one child and always pass key to avoid react warnings.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
