### PR TITLE
fix: Blurry canvas on windows

### DIFF
--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -27,7 +27,6 @@ const workspaceStyle = css({
 
 const canvasContainerStyle = css({
   position: "absolute",
-  //transformStyle: "preserve-3d",
   transformOrigin: "0 0",
 });
 
@@ -93,17 +92,7 @@ const getCanvasStyle = (
     height: canvasHeight ?? "100%",
     maxWidth,
     left: "50%",
-    // Chrome on Windows has a bug and makes everything slightly blurry if scale(1) is used together with translateX.
-    // We have done a lot of comparisons between various fixes and they were producing slightly different sharpness,
-    // using scale 0.9999 with opacity 0.9999 works best.
-    // User Agent Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36
-    // Edition    Windows 11 Home
-    // Version    22H2
-    // Installed on    ‎10/‎18/‎2022
-    // OS build    22621.1848
-    // Experience    Windows Feature Experience Pack 1000.22642.1000.0
     transform: `scale(${scale}%) translateX(-50%)`,
-    //opacity: 0.9999,
   };
 };
 

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -102,7 +102,7 @@ const getCanvasStyle = (
     // Installed on    ‎10/‎18/‎2022
     // OS build    22621.1848
     // Experience    Windows Feature Experience Pack 1000.22642.1000.0
-    transform: `scale(${scale === 1 ? 0.9999 : scale}%) translateX(-50%)`,
+    transform: `scale(${scale}%) translateX(-50%)`,
     //opacity: 0.9999,
   };
 };

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -27,7 +27,7 @@ const workspaceStyle = css({
 
 const canvasContainerStyle = css({
   position: "absolute",
-  transformStyle: "preserve-3d",
+  //transformStyle: "preserve-3d",
   transformOrigin: "0 0",
 });
 
@@ -103,7 +103,7 @@ const getCanvasStyle = (
     // OS build    22621.1848
     // Experience    Windows Feature Experience Pack 1000.22642.1000.0
     transform: `scale(${scale === 1 ? 0.9999 : scale}%) translateX(-50%)`,
-    opacity: 0.9999,
+    //opacity: 0.9999,
   };
 };
 


### PR DESCRIPTION
## Description

We have experimented quite a bit before and now apparently on windows the canvas is still blurry and removing all the hacks apparently solves it. All of this is according to @itsNintu because he is the only one with windows on the team, I don't see a good way to test it, because the blur is very subtle and you won't clearly see it remote browsers.

## Steps for reproduction

1. open builder, resize canvas within workspace (100% scale)
2. resize canvas bigger than workspace, so that scale is lower than 100%
3. see that at no point in time canvas is blurry

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
