### PR TITLE
feat: N8N support

### DIFF
--- a/apps/builder/app/env/env.server.ts
+++ b/apps/builder/app/env/env.server.ts
@@ -90,6 +90,9 @@ const env = {
   OPENAI_ORG: process.env.OPENAI_ORG,
 
   PEXELS_API_KEY: process.env.PEXELS_API_KEY,
+
+  N8N_WEBHOOK_URL: process.env.N8N_WEBHOOK_URL,
+  N8N_WEBHOOK_TOKEN: process.env.N8N_WEBHOOK_TOKEN,
 };
 
 export type ServerEnv = typeof env;

--- a/apps/builder/app/routes/n8n.$.tsx
+++ b/apps/builder/app/routes/n8n.$.tsx
@@ -48,7 +48,10 @@ export const loader = async ({ request, params }: LoaderArgs) => {
   const webhookEnv = webhookEnvParsed.data;
 
   const n8nWebhookUrl = new URL(webhookEnv.N8N_WEBHOOK_URL);
-  n8nWebhookUrl.pathname = `${params["*"]}`;
+  n8nWebhookUrl.pathname = `${n8nWebhookUrl.pathname}/${params["*"]}`
+    .split("/")
+    .filter(Boolean)
+    .join("/");
   n8nWebhookUrl.search = new URL(request.url).search;
 
   const response = await fetch(n8nWebhookUrl.href, {

--- a/apps/builder/app/routes/n8n.$.tsx
+++ b/apps/builder/app/routes/n8n.$.tsx
@@ -37,7 +37,14 @@ export const loader = async ({ request, params }: LoaderArgs) => {
     );
   }
 
-  const webhookEnv = zWebhookEnv.parse(env);
+  const webhookEnvParsed = zWebhookEnv.safeParse(env);
+  if (webhookEnvParsed.success === false) {
+    throw new Response(webhookEnvParsed.error.message, {
+      status: 400,
+    });
+  }
+
+  const webhookEnv = webhookEnvParsed.data;
 
   const response = await fetch(`${webhookEnv.N8N_WEBHOOK_URL}/${params["*"]}`, {
     method: "POST",
@@ -65,7 +72,15 @@ export const loader = async ({ request, params }: LoaderArgs) => {
     );
   }
   const responseJson = await response.json();
-  const { title, description } = zN8NResponse.parse(responseJson);
+  const n8nResponseParsed = zN8NResponse.safeParse(responseJson);
+
+  if (n8nResponseParsed.success === false) {
+    throw new Response(n8nResponseParsed.error.message, {
+      status: 400,
+    });
+  }
+
+  const { title, description } = n8nResponseParsed.data;
 
   return json({ user, title, description });
 };

--- a/apps/builder/app/routes/n8n.$.tsx
+++ b/apps/builder/app/routes/n8n.$.tsx
@@ -1,0 +1,77 @@
+import { redirect } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { z } from "zod";
+import { findAuthenticatedUser } from "~/services/auth.server";
+import { loginPath } from "~/shared/router-utils";
+import env from "~/env/env.server";
+import {
+  // eslint-disable-next-line camelcase
+  type V2_ServerRuntimeMetaFunction,
+  type LoaderArgs,
+  json,
+} from "@remix-run/server-runtime";
+
+const zN8NResponse = z.object({
+  title: z.string(),
+  description: z.string(),
+});
+
+const zWebhookEnv = z.object({
+  N8N_WEBHOOK_URL: z.string(),
+  N8N_WEBHOOK_TOKEN: z.string(),
+});
+
+export const loader = async ({ request, params }: LoaderArgs) => {
+  const user = await findAuthenticatedUser(request);
+
+  if (user === null) {
+    const url = new URL(request.url);
+    throw redirect(
+      loginPath({
+        returnTo: url.pathname,
+      })
+    );
+  }
+
+  const webhookEnv = zWebhookEnv.parse(env);
+
+  const response = await fetch(`${webhookEnv.N8N_WEBHOOK_URL}/${params["*"]}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${webhookEnv.N8N_WEBHOOK_TOKEN}`,
+    },
+    body: JSON.stringify({
+      userId: user.id,
+      query: Object.fromEntries(new URL(request.url).searchParams),
+    }),
+  });
+
+  if (response.ok === false) {
+    const text = await response.text();
+
+    throw new Error(
+      `Fetch error status="${response.status}" text="${text.slice(0, 1000)}"`
+    );
+  }
+  const responseJson = await response.json();
+  const { title, description } = zN8NResponse.parse(responseJson);
+
+  return json({ user, title, description });
+};
+
+// eslint-disable-next-line camelcase
+export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
+  return [
+    {
+      title: data?.title,
+    },
+  ];
+};
+
+const N8NResponse = () => {
+  const data = useLoaderData<typeof loader>();
+  return <div dangerouslySetInnerHTML={{ __html: data.description }} />;
+};
+
+export default N8NResponse;

--- a/apps/builder/app/routes/n8n.$.tsx
+++ b/apps/builder/app/routes/n8n.$.tsx
@@ -4,11 +4,7 @@ import { z } from "zod";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import { loginPath } from "~/shared/router-utils";
 import env from "~/env/env.server";
-import {
-  // eslint-disable-next-line camelcase
-  type LoaderArgs,
-  json,
-} from "@remix-run/server-runtime";
+import { type LoaderArgs, json } from "@remix-run/server-runtime";
 
 const zN8NResponse = z.union([
   z.object({

--- a/apps/builder/app/routes/n8n.$.tsx
+++ b/apps/builder/app/routes/n8n.$.tsx
@@ -47,7 +47,11 @@ export const loader = async ({ request, params }: LoaderArgs) => {
 
   const webhookEnv = webhookEnvParsed.data;
 
-  const response = await fetch(`${webhookEnv.N8N_WEBHOOK_URL}/${params["*"]}`, {
+  const n8nWebhookUrl = new URL(webhookEnv.N8N_WEBHOOK_URL);
+  n8nWebhookUrl.pathname = `${params["*"]}`;
+  n8nWebhookUrl.search = new URL(request.url).search;
+
+  const response = await fetch(n8nWebhookUrl.href, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -55,7 +59,6 @@ export const loader = async ({ request, params }: LoaderArgs) => {
     },
     body: JSON.stringify({
       userId: user.id,
-      query: Object.fromEntries(new URL(request.url).searchParams),
     }),
   });
 

--- a/apps/builder/app/routes/n8n.tsx
+++ b/apps/builder/app/routes/n8n.tsx
@@ -1,0 +1,20 @@
+import type {
+  LoaderArgs,
+  V2_MetaFunction as MetaFunction,
+} from "@remix-run/node";
+import { Root } from "~/shared/remix";
+import env from "~/env/env.public.server";
+import { getThemeData } from "~/shared/theme";
+
+export const loader = async ({ request }: LoaderArgs) => {
+  return {
+    env,
+    theme: await getThemeData(request),
+  };
+};
+
+export const meta: MetaFunction = () => {
+  return [{ title: "Webstudio" }];
+};
+
+export default Root;


### PR DESCRIPTION
## Description

Link to `apps.webstudio.is/n8n/anything` solves 2 things.

1. Login user if it's not logged in
2. Executes schema in n8n passing userId and all query parameters inside.

Example:

```
https://n8n.prs.webstudio.is/n8n/buy/stripe/com?link=test_dR67uJ0bu3fS2Zi4gh
```

Will execute [dev schema](https://webstudio.app.n8n.cloud/workflow/mdNfsFIIwnoMsz6N) hook


`${N8N_WEBHOOK_URL}/buy/stripe/com?link=test_dR67uJ0bu3fS2Zi4gh`

```env
N8N_WEBHOOK_URL="https://webstudio.app.n8n.cloud/webhook-test/"
```

Schema after work will respond or with error or with redirect.



## Steps for reproduction

Open [n8n dev schema](https://webstudio.app.n8n.cloud/workflow/mdNfsFIIwnoMsz6N)
Execute in Dev Mode (at bottom)
Open URL [https://n8n.prs.webstudio.is/n8n/buy/stripe/com?link=test_dR67uJ0bu3fS2Zi4gh](https://n8n.prs.webstudio.is/n8n/buy/stripe/com?link=test_dR67uJ0bu3fS2Zi4gh)
See it works

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
