### PR TITLE
fix: generate empty function for cleared actions

### DIFF
--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -267,3 +267,29 @@ test("generate variables with actions", () => {
     ])
   );
 });
+
+test("generate function for empty action", () => {
+  const generated = generateDataSources({
+    scope: createScope(),
+    dataSources: new Map(),
+    props: new Map([
+      [
+        "prop1",
+        {
+          id: "prop1",
+          instanceId: "instance1",
+          type: "action",
+          name: "onChange",
+          value: [],
+        },
+      ],
+    ]),
+  });
+  expect(generated.body).toMatchInlineSnapshot(`
+    "let onChange = () => {
+    }
+    "
+  `);
+  expect(generated.variables).toEqual(new Map());
+  expect(generated.output).toEqual(new Map([["prop1", "onChange"]]));
+});

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -259,7 +259,8 @@ export const generateDataSources = ({
       const name = scope.getName(prop.id, prop.name);
       output.set(prop.id, name);
       const setters = new Set<DataSourceId>();
-      let args: undefined | string[] = undefined;
+      // important to fallback to empty argumets to render empty function
+      let args: string[] = [];
       let newCode = "";
       for (const value of prop.value) {
         args = value.args;
@@ -285,9 +286,6 @@ export const generateDataSources = ({
           },
         });
         newCode += `\n`;
-      }
-      if (args === undefined) {
-        continue;
       }
       if (typed) {
         args = args.map((arg) => `${arg}: any`);


### PR DESCRIPTION
Fixes https://discord.com/channels/955905230107738152/1174291886878490656

Actions are cleared on copy paste though here we get runtime error because output expects function to be defined.

Here always generate at least empty function.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
