### PR TITLE
feat: Add client references table

### DIFF
--- a/packages/prisma-client/prisma/migrations/20231115205820_client-references/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20231115205820_client-references/migration.sql
@@ -1,0 +1,21 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- CreateTable
+CREATE TABLE "ClientReferences" (
+    "id" TEXT NOT NULL DEFAULT uuid_generate_v4(),
+    "reference" TEXT NOT NULL DEFAULT uuid_generate_v4(),
+    "service" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "ClientReferences_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ClientReferences_userId_service_key" ON "ClientReferences"("userId", "service");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ClientReferences_reference_service_key" ON "ClientReferences"("reference", "service");
+
+-- AddForeignKey
+ALTER TABLE "ClientReferences" ADD CONSTRAINT "ClientReferences_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -50,15 +50,31 @@ model Asset {
 }
 
 model User {
-  id        String    @id @default(uuid())
-  email     String?   @unique
-  provider  String?
-  image     String?
-  username  String?
-  createdAt DateTime  @default(now())
-  team      Team?     @relation(fields: [teamId], references: [id])
-  teamId    String?
-  projects  Project[]
+  id               String             @id @default(uuid())
+  email            String?            @unique
+  provider         String?
+  image            String?
+  username         String?
+  createdAt        DateTime           @default(now())
+  team             Team?              @relation(fields: [teamId], references: [id])
+  teamId           String?
+  projects         Project[]
+  clientReferences ClientReferences[]
+}
+
+// User client references in external services like stripe etc
+model ClientReferences {
+  id        String   @id @default(uuid())
+  // userId    String
+  //user      User     @relation(fields: [userId], references: [id])
+  reference String   @default(uuid())
+  service   String
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+
+  @@unique([userId, service])
+  @@unique([reference, service])
 }
 
 model Project {


### PR DESCRIPTION
## Description

Table "ClientRefernces" allows to hold 3rd party client references per user and service.
Like client_reference_id in stripe

Following constraints

```
  @@unique([userId, service])
  @@unique([reference, service])
```

As  `@@unique([userId, reference, service)` is not enough




Would need to change existing postgres node in n8n schema https://webstudio.app.n8n.cloud/workflow/mdNfsFIIwnoMsz6N

onto

<img width="398" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/bf456ede-d211-4fd1-8f88-45038dd824c1">

```
INSERT INTO "ClientReferences"("userId", "service") 
VALUES ($1, 'stripe') 
ON CONFLICT ("userId", "service") DO UPDATE SET "userId"=$1 
RETURNING *;
```

## Steps for reproduction

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
