### PR TITLE
fix: Transaction log, add preview/production/local to hooks

### DIFF
--- a/apps/builder/app/routes/n8n.$.tsx
+++ b/apps/builder/app/routes/n8n.$.tsx
@@ -44,7 +44,9 @@ export const loader = async ({ request, params }: LoaderArgs) => {
   const webhookEnv = webhookEnvParsed.data;
 
   const n8nWebhookUrl = new URL(webhookEnv.N8N_WEBHOOK_URL);
-  n8nWebhookUrl.pathname = `${n8nWebhookUrl.pathname}/${params["*"]}`
+  n8nWebhookUrl.pathname = `${n8nWebhookUrl.pathname}/${
+    env.DEPLOYMENT_ENVIRONMENT ?? "local"
+  }/${params["*"]}`
     .split("/")
     .filter(Boolean)
     .join("/");

--- a/packages/prisma-client/prisma/migrations/20231116174151_transaction/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20231116174151_transaction/migration.sql
@@ -1,3 +1,0 @@
--- AlterTable
-ALTER TABLE "TransactionLog" DROP CONSTRAINT "TransactionLog_pkey",
-DROP COLUMN "id";

--- a/packages/prisma-client/prisma/migrations/20231117094001_transaction/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20231117094001_transaction/migration.sql
@@ -1,0 +1,25 @@
+-- AlterTable
+ALTER TABLE "ClientReferences" ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "reference" DROP DEFAULT;
+
+-- CreateTable
+CREATE TABLE "TransactionLog" (
+    "eventId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TransactionLog_eventId_productId_key" ON "TransactionLog"("eventId", "productId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TransactionLog_sessionId_productId_key" ON "TransactionLog"("sessionId", "productId");
+
+-- AddForeignKey
+ALTER TABLE "TransactionLog" ADD CONSTRAINT "TransactionLog_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TransactionLog" ADD CONSTRAINT "TransactionLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/prisma-client/prisma/migrations/20231117095612_transaction/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20231117095612_transaction/migration.sql
@@ -1,6 +1,10 @@
+-- DropIndex
+DROP INDEX "ClientReferences_userId_service_key";
+
 -- AlterTable
-ALTER TABLE "ClientReferences" ALTER COLUMN "id" DROP DEFAULT,
-ALTER COLUMN "reference" DROP DEFAULT;
+ALTER TABLE "ClientReferences" DROP CONSTRAINT "ClientReferences_pkey",
+DROP COLUMN "id",
+ADD CONSTRAINT "ClientReferences_pkey" PRIMARY KEY ("userId", "service");
 
 -- CreateTable
 CREATE TABLE "TransactionLog" (

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -65,16 +65,13 @@ model User {
 
 // User client references in external services like stripe etc
 model ClientReferences {
-  id        String   @id @default(uuid())
-  // userId    String
-  //user      User     @relation(fields: [userId], references: [id])
-  reference String   @default(uuid())
+  reference String   @default(dbgenerated())
   service   String
   createdAt DateTime @default(now())
   user      User     @relation(fields: [userId], references: [id])
   userId    String
 
-  @@unique([userId, service])
+  @@id([userId, service])
   @@unique([reference, service])
 }
 


### PR DESCRIPTION
## Description

- Prisma way of creating migrations comparing local db with schema model is super error prone
- Adding 'preview' | 'production' or 'local' to n8n webhooks otherway no way to host hooks together

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
