### PR TITLE
refactor: compute props contextually

### DIFF
--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -9,10 +9,8 @@ import {
   selectedInstanceRenderStateStore,
   stylesIndexStore,
   instancesStore,
-  propsStore,
-  dataSourcesLogicStore,
   selectedInstanceSelectorStore,
-  dataSourceVariablesStore,
+  $propValuesByInstanceSelector,
 } from "~/shared/nano-states";
 import htmlTags, { type htmlTags as HtmlTags } from "html-tags";
 import {
@@ -227,12 +225,8 @@ const subscribeSelectedInstance = (
 
   const unsubscribeStylesIndexStore = stylesIndexStore.subscribe(update);
   const unsubscribeInstancesStore = instancesStore.subscribe(update);
-  const unsubscribePropsStore = propsStore.subscribe(update);
-  const unsubscribeDataSourcesLogicStore =
-    dataSourcesLogicStore.subscribe(update);
-
-  const unsubscribeDataSourceVariablesStore =
-    dataSourceVariablesStore.subscribe(update);
+  const unsubscribePropValuesStore =
+    $propValuesByInstanceSelector.subscribe(update);
 
   const unsubscribeIsResizingCanvas = isResizingCanvasStore.subscribe(
     (isResizing) => {
@@ -275,9 +269,7 @@ const subscribeSelectedInstance = (
     unsubscribeWindowResize();
     unsubscribeStylesIndexStore();
     unsubscribeInstancesStore();
-    unsubscribePropsStore();
-    unsubscribeDataSourcesLogicStore();
-    unsubscribeDataSourceVariablesStore();
+    unsubscribePropValuesStore();
   };
 };
 

--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -14,7 +14,6 @@ const isAbsoluteUrl = (href: string) => {
 const handleLinkClick = (element: HTMLAnchorElement) => {
   const pages = pagesStore.get();
   const href = element.getAttribute("href");
-  console.log(href);
   if (href === null || pages === undefined) {
     return;
   }

--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -14,6 +14,7 @@ const isAbsoluteUrl = (href: string) => {
 const handleLinkClick = (element: HTMLAnchorElement) => {
   const pages = pagesStore.get();
   const href = element.getAttribute("href");
+  console.log(href);
   if (href === null || pages === undefined) {
     return;
   }

--- a/apps/builder/app/canvas/stores.ts
+++ b/apps/builder/app/canvas/stores.ts
@@ -1,5 +1,6 @@
 import { atom } from "nanostores";
 import type { Instance, StyleDecl } from "@webstudio-is/sdk";
+import type { Params } from "@webstudio-is/react-sdk";
 
 export const $ephemeralStyles = atom<
   Array<{
@@ -10,3 +11,5 @@ export const $ephemeralStyles = atom<
     value: StyleDecl["value"];
   }>
 >([]);
+
+export const $params = atom<undefined | Params>();

--- a/apps/builder/app/shared/array-utils.test.ts
+++ b/apps/builder/app/shared/array-utils.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@jest/globals";
 import {
   getMapValuesBy,
   getMapValuesByKeysSet,
+  groupBy,
   removeByMutable,
 } from "./array-utils";
 
@@ -61,4 +62,13 @@ test("getMapValuesBy", () => {
   expect(
     getMapValuesBy(map, (value) => value.includes("3") || value.includes("5"))
   ).toEqual(["value3", "value5"]);
+});
+
+test("groupBy", () => {
+  expect(groupBy([1, 2, 3, 4, 5], (item) => item % 2)).toEqual(
+    new Map([
+      [0, [2, 4]],
+      [1, [1, 3, 5]],
+    ])
+  );
 });

--- a/apps/builder/app/shared/array-utils.ts
+++ b/apps/builder/app/shared/array-utils.ts
@@ -38,3 +38,21 @@ export const getMapValuesBy = <Key, Value>(
   }
   return values;
 };
+
+// @todo replace with builtin Map.groupBy when support
+export const groupBy = <Item, Key>(
+  array: Item[] | IterableIterator<Item>,
+  getKey: (item: Item) => Key
+) => {
+  const groups = new Map<Key, Item[]>();
+  for (const item of array) {
+    const key = getKey(item);
+    let group = groups.get(key);
+    if (group === undefined) {
+      group = [];
+      groups.set(key, group);
+    }
+    group.push(item);
+  }
+  return groups;
+};

--- a/apps/builder/app/shared/nano-states/index.ts
+++ b/apps/builder/app/shared/nano-states/index.ts
@@ -1,6 +1,7 @@
 export * from "./nano-states";
 export * from "./breakpoints";
 export * from "./instances";
+export * from "./props";
 export * from "./canvas";
 export * from "./pages";
 export * from "./components";

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -15,6 +15,7 @@ export const textEditingInstanceSelectorStore = atom<
 >();
 
 export const instancesStore = atom<Instances>(new Map());
+export const $instances = instancesStore;
 
 export const selectedInstanceStore = computed(
   [instancesStore, selectedInstanceSelectorStore],

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -4,24 +4,19 @@ import { useStore } from "@nanostores/react";
 import { nanoid } from "nanoid";
 import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
 import type { ItemDropTarget, Placement } from "@webstudio-is/design-system";
-import {
-  createScope,
-  type Assets,
-  type DataSource,
-  type DataSources,
-  type Instance,
-  type Prop,
-  type Props,
-  type StyleDecl,
-  type Styles,
-  type StyleSource,
-  type StyleSources,
-  type StyleSourceSelections,
+import type {
+  Assets,
+  DataSource,
+  DataSources,
+  Instance,
+  Prop,
+  Props,
+  StyleDecl,
+  Styles,
+  StyleSource,
+  StyleSources,
+  StyleSourceSelections,
 } from "@webstudio-is/sdk";
-import {
-  encodeDataSourceVariable,
-  generateDataSources,
-} from "@webstudio-is/react-sdk";
 import type { Style } from "@webstudio-is/css-engine";
 import type { DragStartPayload } from "~/canvas/shared/use-drag-drop";
 import { shallowComputed } from "../store-utils";
@@ -47,11 +42,14 @@ export const rootInstanceStore = computed(
 );
 
 export const dataSourcesStore = atom<DataSources>(new Map());
+export const $dataSources = dataSourcesStore;
 export const dataSourceVariablesStore = atom<Map<DataSource["id"], unknown>>(
   new Map()
 );
+export const $dataSourceVariables = dataSourceVariablesStore;
 
 export const propsStore = atom<Props>(new Map());
+export const $props = propsStore;
 export const propsIndexStore = computed(propsStore, (props) => {
   const propsByInstanceId = new Map<Instance["id"], Prop[]>();
   for (const prop of props.values()) {
@@ -67,76 +65,6 @@ export const propsIndexStore = computed(propsStore, (props) => {
     propsByInstanceId,
   };
 });
-
-// result of executing generated code
-// includes variables, computed expressions and action callbacks
-export const dataSourcesLogicStore = computed(
-  [dataSourcesStore, dataSourceVariablesStore, propsStore],
-  (dataSources, dataSourceVariables, props) => {
-    const { variables, body, output } = generateDataSources({
-      scope: createScope(["_getVariable", "_setVariable", "_output"]),
-      dataSources,
-      props,
-    });
-    let generatedCode = "";
-    for (const [dataSourceId, variable] of variables) {
-      const { valueName, setterName } = variable;
-      const initialValue = JSON.stringify(variable.initialValue);
-      generatedCode += `let ${valueName} = _getVariable("${dataSourceId}") ?? ${initialValue};\n`;
-      generatedCode += `let ${setterName} = (value) => _setVariable("${dataSourceId}", value);\n`;
-    }
-    generatedCode += body;
-    generatedCode += `let _output = new Map();\n`;
-    for (const [dataSourceId, variableName] of output) {
-      generatedCode += `_output.set('${dataSourceId}', ${variableName})\n`;
-    }
-    generatedCode += `return _output\n`;
-
-    try {
-      const executeFn = new Function(
-        "_getVariable",
-        "_setVariable",
-        generatedCode
-      );
-      const getVariable = (id: string) => {
-        return dataSourceVariables.get(id);
-      };
-      const setVariable = (id: string, value: unknown) => {
-        const dataSourceVariables = new Map(dataSourceVariablesStore.get());
-        dataSourceVariables.set(id, value);
-        dataSourceVariablesStore.set(dataSourceVariables);
-      };
-      return executeFn(getVariable, setVariable);
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(error);
-    }
-    return new Map();
-  }
-);
-
-export const computeExpression = (
-  expression: string,
-  variables: Map<DataSource["id"], unknown>
-) => {
-  let code = "";
-  for (const [id, value] of variables) {
-    // @todo pass dedicated map of variables without actions
-    // skip actions
-    if (typeof value === "function") {
-      continue;
-    }
-    const identifier = encodeDataSourceVariable(id);
-    code += `const ${identifier} = ${JSON.stringify(value)};\n`;
-  }
-  code += `return (${expression})`;
-  try {
-    const result = new Function(code)();
-    return result;
-  } catch {
-    // empty block
-  }
-};
 
 export const stylesStore = atom<Styles>(new Map());
 
@@ -211,6 +139,7 @@ export const stylesIndexStore = computed(
 );
 
 export const assetsStore = atom<Assets>(new Map());
+export const $assets = assetsStore;
 
 export const selectedInstanceBrowserStyleStore = atom<undefined | Style>();
 

--- a/apps/builder/app/shared/nano-states/pages.ts
+++ b/apps/builder/app/shared/nano-states/pages.ts
@@ -2,8 +2,10 @@ import { atom, computed } from "nanostores";
 import type { Page, Pages } from "@webstudio-is/sdk";
 
 export const pagesStore = atom<undefined | Pages>(undefined);
+export const $pages = pagesStore;
 
 export const selectedPageIdStore = atom<undefined | Page["id"]>(undefined);
+export const $selectedPageId = selectedPageIdStore;
 export const selectedPageHashStore = atom<string>("");
 
 export const selectedPageStore = computed(
@@ -18,3 +20,4 @@ export const selectedPageStore = computed(
     return pages.pages.find((page) => page.id === selectedPageId);
   }
 );
+export const $selectedPage = selectedPageStore;

--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -1,0 +1,254 @@
+import { expect, test } from "@jest/globals";
+import { cleanStores } from "nanostores";
+import type { Instance, Page } from "@webstudio-is/sdk";
+import { $instances } from "./instances";
+import { $propValuesByInstanceSelector } from "./props";
+import { $pages, $selectedPageId } from "./pages";
+import {
+  $assets,
+  $dataSourceVariables,
+  $dataSources,
+  $props,
+} from "./nano-states";
+import { $params } from "~/canvas/stores";
+
+const getIdValuePair = <T extends { id: string }>(item: T) =>
+  [item.id, item] as const;
+
+const toMap = <T extends { id: string }>(list: T[]) =>
+  new Map(list.map(getIdValuePair));
+
+const setBoxInstance = (id: Instance["id"]) => {
+  $instances.set(
+    toMap([{ id, type: "instance", component: "Box", children: [] }])
+  );
+};
+
+const selectPageRoot = (rootInstanceId: Instance["id"]) => {
+  $pages.set({
+    homePage: { id: "pageId", rootInstanceId, path: "/my-page" } as Page,
+    pages: [],
+  });
+  $selectedPageId.set("pageId");
+};
+
+test("collect prop values", () => {
+  setBoxInstance("box");
+  selectPageRoot("box");
+  $dataSources.set(new Map());
+  $props.set(
+    toMap([
+      {
+        id: "prop1",
+        name: "first",
+        instanceId: "box",
+        type: "number",
+        value: 0,
+      },
+      {
+        id: "prop2",
+        name: "second",
+        instanceId: "box",
+        type: "json",
+        value: { name: "John" },
+      },
+    ])
+  );
+  expect(
+    $propValuesByInstanceSelector.get().get(JSON.stringify(["box"]))
+  ).toEqual(
+    new Map<string, unknown>([
+      ["first", 0],
+      ["second", { name: "John" }],
+    ])
+  );
+
+  cleanStores($propValuesByInstanceSelector);
+});
+
+test("compute expression prop values", () => {
+  setBoxInstance("box");
+  selectPageRoot("box");
+  $dataSources.set(
+    toMap([
+      {
+        id: "var1",
+        type: "variable",
+        name: "",
+        value: { type: "number", value: 1 },
+      },
+      {
+        id: "var2",
+        type: "variable",
+        name: "",
+        value: { type: "string", value: "Hello" },
+      },
+    ])
+  );
+  $props.set(
+    toMap([
+      {
+        id: "prop1",
+        name: "first",
+        instanceId: "box",
+        type: "expression",
+        value: `$ws$dataSource$var1 + 2`,
+      },
+      {
+        id: "prop2",
+        name: "second",
+        instanceId: "box",
+        type: "expression",
+        value: `$ws$dataSource$var2 + ' World!'`,
+      },
+    ])
+  );
+  expect(
+    $propValuesByInstanceSelector.get().get(JSON.stringify(["box"]))
+  ).toEqual(
+    new Map<string, unknown>([
+      ["first", 3],
+      ["second", "Hello World!"],
+    ])
+  );
+
+  $dataSourceVariables.set(new Map([["var1", 4]]));
+  expect(
+    $propValuesByInstanceSelector.get().get(JSON.stringify(["box"]))
+  ).toEqual(
+    new Map<string, unknown>([
+      ["first", 6],
+      ["second", "Hello World!"],
+    ])
+  );
+
+  cleanStores($propValuesByInstanceSelector);
+});
+
+test("generate action prop callbacks", () => {
+  setBoxInstance("box");
+  selectPageRoot("box");
+  $dataSources.set(
+    toMap([
+      {
+        id: "var",
+        type: "variable",
+        name: "",
+        value: { type: "number", value: 1 },
+      },
+    ])
+  );
+  $props.set(
+    toMap([
+      {
+        id: "valueId",
+        name: "value",
+        instanceId: "box",
+        type: "expression",
+        value: `$ws$dataSource$var`,
+      },
+      {
+        id: "actionId",
+        name: "onChange",
+        instanceId: "box",
+        type: "action",
+        value: [
+          {
+            type: "execute",
+            args: [],
+            code: `$ws$dataSource$var = $ws$dataSource$var + 1`,
+          },
+        ],
+      },
+    ])
+  );
+  const values1 = $propValuesByInstanceSelector
+    .get()
+    .get(JSON.stringify(["box"]));
+  expect(values1?.get("value")).toEqual(1);
+
+  (values1?.get("onChange") as Function)();
+  const values2 = $propValuesByInstanceSelector
+    .get()
+    .get(JSON.stringify(["box"]));
+  expect(values2?.get("value")).toEqual(2);
+
+  cleanStores($propValuesByInstanceSelector);
+});
+
+test("resolve asset prop values when params is provided", () => {
+  setBoxInstance("box");
+  selectPageRoot("box");
+  $dataSources.set(new Map());
+  $params.set(undefined);
+  $assets.set(
+    toMap([
+      {
+        id: "assetId",
+        type: "image",
+        name: "my-file.jpg",
+        format: "jpeg",
+        size: 0,
+        projectId: "",
+        createdAt: "",
+        meta: { width: 0, height: 0 },
+        description: "",
+      },
+    ])
+  );
+  $props.set(
+    toMap([
+      {
+        id: "propId",
+        name: "myAsset",
+        instanceId: "box",
+        type: "asset",
+        value: "assetId",
+      },
+    ])
+  );
+  expect(
+    $propValuesByInstanceSelector.get().get(JSON.stringify(["box"]))
+  ).toEqual(new Map());
+
+  $params.set({
+    assetBaseUrl: "/asset/",
+    imageBaseUrl: "/image/",
+  });
+  expect(
+    $propValuesByInstanceSelector.get().get(JSON.stringify(["box"]))
+  ).toEqual(new Map<string, unknown>([["myAsset", "/asset/my-file.jpg"]]));
+
+  cleanStores($propValuesByInstanceSelector);
+});
+
+test("resolve page prop values when params is provided", () => {
+  setBoxInstance("box");
+  selectPageRoot("box");
+  $params.set(undefined);
+  $dataSources.set(new Map());
+  $props.set(
+    toMap([
+      {
+        id: "propId",
+        name: "myPage",
+        instanceId: "box",
+        type: "page",
+        value: "pageId",
+      },
+    ])
+  );
+  expect(
+    $propValuesByInstanceSelector.get().get(JSON.stringify(["box"]))
+  ).toEqual(new Map());
+
+  $params.set({
+    assetBaseUrl: "/asset/",
+    imageBaseUrl: "/image/",
+  });
+  expect(
+    $propValuesByInstanceSelector.get().get(JSON.stringify(["box"]))
+  ).toEqual(new Map<string, unknown>([["myPage", "/my-page"]]));
+
+  cleanStores($propValuesByInstanceSelector);
+});

--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -167,7 +167,7 @@ test("generate action prop callbacks", () => {
     .get(JSON.stringify(["box"]));
   expect(values1?.get("value")).toEqual(1);
 
-  (values1?.get("onChange") as Function)();
+  (values1?.get("onChange") as () => void)();
   const values2 = $propValuesByInstanceSelector
     .get()
     .get(JSON.stringify(["box"]));

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -1,0 +1,201 @@
+import { computed } from "nanostores";
+import {
+  createScope,
+  type DataSource,
+  type Instance,
+  type Page,
+  type Prop,
+} from "@webstudio-is/sdk";
+import {
+  encodeDataSourceVariable,
+  generateDataSources,
+  normalizeProps,
+} from "@webstudio-is/react-sdk";
+import { $instances } from "./instances";
+import {
+  $dataSourceVariables,
+  $dataSources,
+  $props,
+  $assets,
+} from "./nano-states";
+import { $selectedPage, $pages } from "./pages";
+import { groupBy } from "../array-utils";
+import type { InstanceSelector } from "../tree-utils";
+import { $params } from "~/canvas/stores";
+
+// result of executing generated code
+// includes variables, computed expressions and action callbacks
+const $dataSourcesLogic = computed(
+  [$dataSources, $dataSourceVariables, $props],
+  (dataSources, dataSourceVariables, props) => {
+    const { variables, body, output } = generateDataSources({
+      scope: createScope(["_getVariable", "_setVariable", "_output"]),
+      dataSources,
+      props,
+    });
+    let generatedCode = "";
+    for (const [dataSourceId, variable] of variables) {
+      const { valueName, setterName } = variable;
+      const initialValue = JSON.stringify(variable.initialValue);
+      generatedCode += `let ${valueName} = _getVariable("${dataSourceId}") ?? ${initialValue};\n`;
+      generatedCode += `let ${setterName} = (value) => _setVariable("${dataSourceId}", value);\n`;
+    }
+    generatedCode += body;
+    generatedCode += `let _output = new Map();\n`;
+    for (const [dataSourceId, variableName] of output) {
+      generatedCode += `_output.set('${dataSourceId}', ${variableName})\n`;
+    }
+    generatedCode += `return _output\n`;
+
+    try {
+      const executeFn = new Function(
+        "_getVariable",
+        "_setVariable",
+        generatedCode
+      );
+      const getVariable = (id: string) => {
+        return dataSourceVariables.get(id);
+      };
+      const setVariable = (id: string, value: unknown) => {
+        const dataSourceVariables = new Map($dataSourceVariables.get());
+        dataSourceVariables.set(id, value);
+        $dataSourceVariables.set(dataSourceVariables);
+      };
+      return executeFn(getVariable, setVariable);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+    return new Map();
+  }
+);
+
+const computeExpression = (
+  expression: string,
+  variables: Map<DataSource["id"], unknown>
+) => {
+  let code = "";
+  for (const [id, value] of variables) {
+    // @todo pass dedicated map of variables without actions
+    // skip actions
+    if (typeof value === "function") {
+      continue;
+    }
+    const identifier = encodeDataSourceVariable(id);
+    code += `const ${identifier} = ${JSON.stringify(value)};\n`;
+  }
+  code += `return (${expression})`;
+  try {
+    const result = new Function(code)();
+    return result;
+  } catch {
+    // empty block
+  }
+};
+
+const $pagesMap = computed($pages, (pages): Map<string, Page> => {
+  if (pages === undefined) {
+    return new Map();
+  }
+  return new Map(
+    [pages.homePage, ...pages.pages].map((page) => [page.id, page])
+  );
+});
+
+/**
+ * compute prop values within context of instance ancestors
+ * like a dry-run of rendering and accessing react contexts deep in the tree
+ * essential to support collections which provide different values in each item
+ * for same variables
+ */
+export const $propValuesByInstanceSelector = computed(
+  [
+    $instances,
+    $props,
+    $selectedPage,
+    $dataSourcesLogic,
+    $params,
+    $pagesMap,
+    $assets,
+  ],
+  (instances, props, page, dataSourcesLogic, params, pages, assets) => {
+    const values = new Map<string, unknown>(dataSourcesLogic);
+
+    // collect props and group by instances
+    const propsByInstanceId = groupBy(
+      props.values(),
+      (prop) => prop.instanceId
+    );
+
+    // traverse instances tree and compute props within each instance
+    const propValuesByInstanceSelector = new Map<
+      Instance["id"],
+      Map<Prop["name"], unknown>
+    >();
+    if (page === undefined) {
+      return propValuesByInstanceSelector;
+    }
+    const traverseInstances = (instanceSelector: InstanceSelector) => {
+      const [instanceId] = instanceSelector;
+      const instance = instances.get(instanceId);
+      if (instance === undefined) {
+        return;
+      }
+
+      const propValues = new Map<Prop["name"], unknown>();
+      let props = propsByInstanceId.get(instanceId);
+      // @todo store parameters to update with core components later
+      const parameters = new Map<Prop["name"], DataSource["id"]>();
+      if (props) {
+        // ignore asset and page props when params is not provided
+        // important to resolve only in canvas
+        if (params) {
+          props = normalizeProps({
+            props,
+            assetBaseUrl: params.assetBaseUrl,
+            assets,
+            pages,
+          });
+        }
+        for (const prop of props) {
+          // at this point asset and page either already converted to string
+          // or can be ignored
+          if (prop.type === "asset" || prop.type === "page") {
+            continue;
+          }
+          if (prop.type === "expression") {
+            const value = computeExpression(prop.value, values);
+            if (value !== undefined) {
+              propValues.set(prop.name, value);
+            }
+            continue;
+          }
+          if (prop.type === "action") {
+            const action = values.get(prop.id);
+            if (typeof action === "function") {
+              propValues.set(prop.name, action);
+            }
+            continue;
+          }
+          if (prop.type === "parameter") {
+            parameters.set(prop.name, prop.value);
+            continue;
+          }
+          propValues.set(prop.name, prop.value);
+        }
+      }
+
+      propValuesByInstanceSelector.set(
+        JSON.stringify(instanceSelector),
+        propValues
+      );
+      for (const child of instance.children) {
+        if (child.type === "id") {
+          traverseInstances([child.value, ...instanceSelector]);
+        }
+      }
+    };
+    traverseInstances([page.rootInstanceId]);
+    return propValuesByInstanceSelector;
+  }
+);

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -1,6 +1,4 @@
-import type { Instance, Page, Prop, Props, Assets } from "@webstudio-is/sdk";
-
-export type PropsByInstanceId = Map<Instance["id"], Prop[]>;
+import type { Page, Prop, Assets } from "@webstudio-is/sdk";
 
 export type Pages = Map<Page["id"], Page>;
 
@@ -71,19 +69,6 @@ export const normalizeProps = ({
     newProps.push(prop);
   }
   return newProps;
-};
-
-export const getPropsByInstanceId = (props: Props) => {
-  const propsByInstanceId: PropsByInstanceId = new Map();
-  for (const prop of props.values()) {
-    let instanceProps = propsByInstanceId.get(prop.instanceId);
-    if (instanceProps === undefined) {
-      instanceProps = [];
-      propsByInstanceId.set(prop.instanceId, instanceProps);
-    }
-    instanceProps.push(prop);
-  }
-  return propsByInstanceId;
 };
 
 export const idAttribute = "data-ws-id" as const;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here refactored props values computing to reuse in both canvas and settings panel and support future collections which need to provide different values for same variables.

Grouped whole logic and covered with tests.

## Testing

- check image src is working
- check link switch page in preview

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
