### PR TITLE
fix: breakpoints are not registered for undo/redo

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/breakpoints-popover-toolbar-button.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-popover-toolbar-button.tsx
@@ -30,14 +30,14 @@ export const BreakpointsPopoverToolbarButton = forwardRef<
   const scale = useStore(scaleStore);
   const breakpoint = useStore(selectedBreakpointStore);
   const [canvasWidth] = useCanvasWidth();
-  if (breakpoint === undefined || canvasWidth === undefined) {
+  if (breakpoint === undefined || canvasWidth?.value === undefined) {
     return null;
   }
   const roundedScale = Math.round(scale);
   return (
     <button ref={ref} {...props}>
       <Value unit="PX" minWidth={55}>
-        {Math.round(canvasWidth)}
+        {Math.round(canvasWidth.value)}
       </Value>
       {roundedScale !== 100 && (
         <Value unit="%" minWidth={30}>

--- a/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
@@ -37,8 +37,8 @@ import {
   isBaseBreakpoint,
   minCanvasWidth,
 } from "~/shared/breakpoints";
-import { scaleStore } from "~/builder/shared/nano-states";
-import { setInitialCanvasWidth } from "./use-set-initial-canvas-width";
+import { canvasWidthStore, scaleStore } from "~/builder/shared/nano-states";
+import { setInitialCanvasWidthAsTransaction } from "./use-set-initial-canvas-width";
 import { serverSyncStore } from "~/shared/sync";
 
 export const BreakpointsPopover = () => {
@@ -75,8 +75,13 @@ export const BreakpointsPopover = () => {
       const breakpointsArray = Array.from(breakpoints.values());
       const base =
         breakpointsArray.find(isBaseBreakpoint) ?? breakpointsArray[0];
-      selectedBreakpointIdStore.set(base.id);
-      setInitialCanvasWidth(base.id);
+      serverSyncStore.createTransaction(
+        [selectedBreakpointIdStore, canvasWidthStore],
+        (selectedBreakpointIdStore, canvasWidthStore) => {
+          selectedBreakpointIdStore.value = base.id;
+          setInitialCanvasWidthAsTransaction(canvasWidthStore, base.id);
+        }
+      );
     }
     setBreakpointToDelete(undefined);
     $breakpointsMenuView.set("editor");
@@ -148,8 +153,16 @@ export const BreakpointsPopover = () => {
                         <ListItem
                           asChild
                           onSelect={() => {
-                            selectedBreakpointIdStore.set(breakpoint.id);
-                            setInitialCanvasWidth(breakpoint.id);
+                            serverSyncStore.createTransaction(
+                              [selectedBreakpointIdStore, canvasWidthStore],
+                              (selectedBreakpointIdStore, canvasWidthStore) => {
+                                selectedBreakpointIdStore.value = breakpoint.id;
+                                setInitialCanvasWidthAsTransaction(
+                                  canvasWidthStore,
+                                  breakpoint.id
+                                );
+                              }
+                            );
                           }}
                           index={index}
                           key={breakpoint.id}

--- a/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
@@ -11,7 +11,9 @@ import { BpStarOffIcon, BpStarOnIcon } from "@webstudio-is/icons";
 import { CascadeIndicator } from "./cascade-indicator";
 import { selectedBreakpointIdStore } from "~/shared/nano-states";
 import { groupBreakpoints, isBaseBreakpoint } from "~/shared/breakpoints";
-import { setInitialCanvasWidth } from "./use-set-initial-canvas-width";
+import { setInitialCanvasWidthAsTransaction } from "./use-set-initial-canvas-width";
+import { serverSyncStore } from "~/shared/sync";
+import { canvasWidthStore } from "~/builder/shared/nano-states";
 
 const getTooltipContent = (breakpoint: Breakpoint) => {
   if (isBaseBreakpoint(breakpoint)) {
@@ -69,8 +71,16 @@ export const BreakpointsSelector = ({
           if (breakpoints.has(breakpointId) === false) {
             return;
           }
-          selectedBreakpointIdStore.set(breakpointId);
-          setInitialCanvasWidth(breakpointId);
+          serverSyncStore.createTransaction(
+            [selectedBreakpointIdStore, canvasWidthStore],
+            (selectedBreakpointIdStore, canvasWidthStore) => {
+              selectedBreakpointIdStore.value = breakpointId;
+              setInitialCanvasWidthAsTransaction(
+                canvasWidthStore,
+                breakpointId
+              );
+            }
+          );
         }}
         css={{ position: "relative" }}
       >

--- a/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
@@ -12,7 +12,10 @@ import { findInitialWidth } from "./find-initial-width";
 
 // Fixes initial canvas width jump on wide screens.
 // Calculate canvas width during SSR based on known initial width for wide screens.
-export const setInitialCanvasWidth = (breakpointId: Breakpoint["id"]) => {
+export const setInitialCanvasWidthAsTransaction = (
+  canvasWidthStore: { value: number | undefined },
+  breakpointId: Breakpoint["id"]
+) => {
   const workspaceRect = workspaceRectStore.get();
   const breakpoints = breakpointsStore.get();
   const breakpoint = breakpoints.get(breakpointId);
@@ -25,8 +28,7 @@ export const setInitialCanvasWidth = (breakpointId: Breakpoint["id"]) => {
     breakpoint,
     workspaceRect.width
   );
-
-  canvasWidthStore.set(width);
+  canvasWidthStore.value = width;
   return true;
 };
 
@@ -52,7 +54,7 @@ export const useSetCanvasWidth = () => {
           selectedBreakpoint,
           workspaceRect.width
         );
-        canvasWidthStore.set(width);
+        canvasWidthStore.set({ value: width });
       }
     };
 

--- a/apps/builder/app/builder/features/breakpoints/width-input.tsx
+++ b/apps/builder/app/builder/features/breakpoints/width-input.tsx
@@ -23,6 +23,7 @@ import {
   type KeyboardEvent,
   useEffect,
 } from "react";
+import { serverSyncStore } from "~/shared/sync";
 
 const useEnhancedInput = ({
   onChange,
@@ -86,13 +87,18 @@ export const WidthInput = ({ min }: { min: number }) => {
   const breakpoints = useStore(breakpointsStore);
 
   const onChange = (value: number) => {
-    setCanvasWidth(value);
+    setCanvasWidth({ value });
     const applicableBreakpoint = findApplicableMedia(
       Array.from(breakpoints.values()),
       value
     );
     if (applicableBreakpoint) {
-      selectedBreakpointIdStore.set(applicableBreakpoint.id);
+      serverSyncStore.createTransaction(
+        [selectedBreakpointIdStore],
+        (selectedBreakpointIdStore) => {
+          selectedBreakpointIdStore.value = applicableBreakpoint.id;
+        }
+      );
     }
     if (isResizingCanvasStore.get() === false) {
       isResizingCanvasStore.set(true);
@@ -115,13 +121,13 @@ export const WidthInput = ({ min }: { min: number }) => {
   }, []);
 
   const inputProps = useEnhancedInput({
-    value: canvasWidth ?? 0,
+    value: canvasWidth.value ?? 0,
     onChange,
     onChangeComplete,
     min,
   });
 
-  if (canvasWidth === undefined || selectedBreakpoint === undefined) {
+  if (canvasWidth?.value === undefined || selectedBreakpoint === undefined) {
     return null;
   }
 

--- a/apps/builder/app/builder/features/workspace/canvas-tools/resize-handles.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/resize-handles.tsx
@@ -14,6 +14,7 @@ import {
   isResizingCanvasStore,
   selectedBreakpointIdStore,
 } from "~/shared/nano-states";
+import { serverSyncStore } from "~/shared/sync";
 
 const handlesContainerStyle = css({
   position: "absolute",
@@ -89,7 +90,12 @@ const updateBreakpoint = (width: number) => {
     width
   );
   if (applicableBreakpoint) {
-    selectedBreakpointIdStore.set(applicableBreakpoint.id);
+    serverSyncStore.createTransaction(
+      [selectedBreakpointIdStore],
+      (selectedBreakpointIdStore) => {
+        selectedBreakpointIdStore.value = applicableBreakpoint.id;
+      }
+    );
   }
 };
 
@@ -105,7 +111,7 @@ const useScrub = ({ side }: { side: "right" | "left" }) => {
 
     const disposeScrubControl = numericScrubControl(ref.current, {
       getInitialValue() {
-        return canvasWidthStore.get();
+        return canvasWidthStore.get().value;
       },
       getValue(state, movement) {
         const value =
@@ -128,7 +134,7 @@ const useScrub = ({ side }: { side: "right" | "left" }) => {
         isResizingCanvasStore.set(false);
       },
       onValueInput(event) {
-        canvasWidthStore.set(event.value);
+        canvasWidthStore.set({ value: event.value });
         updateBreakpoint(event.value);
       },
     });

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -103,7 +103,12 @@ const useCanvasStyle = (
   const workspaceRect = useStore(workspaceRectStore);
   const [canvasWidth] = useCanvasWidth();
 
-  return getCanvasStyle(initialBreakpoints, scale, workspaceRect, canvasWidth);
+  return getCanvasStyle(
+    initialBreakpoints,
+    scale,
+    workspaceRect,
+    canvasWidth?.value
+  );
 };
 
 const useOutlineStyle = (
@@ -116,14 +121,16 @@ const useOutlineStyle = (
     initialBreakpoints,
     100,
     workspaceRect,
-    canvasWidth
+    canvasWidth?.value
   );
 
   return {
     ...style,
     pointerEvents: "none",
     width:
-      canvasWidth === undefined ? "100%" : (canvasWidth ?? 0) * (scale / 100),
+      canvasWidth === undefined
+        ? "100%"
+        : (canvasWidth?.value ?? 0) * (scale / 100),
   } as const;
 };
 

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -13,7 +13,9 @@ export const useIsShareDialogOpen = () => useValue(isShareDialogOpenStore);
 const isPublishDialogOpenStore = atom<boolean>(false);
 export const useIsPublishDialogOpen = () => useValue(isPublishDialogOpenStore);
 
-export const canvasWidthStore = atom<number | undefined>();
+export const canvasWidthStore = atom<{ value: number | undefined }>({
+  value: undefined,
+});
 export const useCanvasWidth = () => useValue(canvasWidthStore);
 
 export const $canvasRect = atom<DOMRect | undefined>();
@@ -24,14 +26,14 @@ export const scaleStore = computed(
   [canvasWidthStore, workspaceRectStore],
   (canvasWidth, workspaceRect) => {
     if (
-      canvasWidth === undefined ||
+      canvasWidth?.value === undefined ||
       workspaceRect === undefined ||
-      canvasWidth <= workspaceRect.width
+      canvasWidth.value <= workspaceRect.width
     ) {
       return 100;
     }
     return Number.parseFloat(
-      ((workspaceRect.width / canvasWidth) * 100).toFixed(2)
+      ((workspaceRect.width / canvasWidth.value) * 100).toFixed(2)
     );
   }
 );

--- a/apps/builder/app/shared/breakpoints/select-breakpoint-by-order.ts
+++ b/apps/builder/app/shared/breakpoints/select-breakpoint-by-order.ts
@@ -1,6 +1,8 @@
 import { groupBreakpoints } from "./group-breakpoints";
 import { selectedBreakpointIdStore, breakpointsStore } from "../nano-states";
-import { setInitialCanvasWidth } from "~/builder/features/breakpoints";
+import { setInitialCanvasWidthAsTransaction } from "~/builder/features/breakpoints";
+import { serverSyncStore } from "~/shared/sync";
+import { canvasWidthStore } from "~/builder/shared/nano-states";
 
 /**
  * Order number starts with 1 and covers all existing breakpoints
@@ -12,7 +14,12 @@ export const selectBreakpointByOrder = (orderNumber: number) => {
     index
   );
   if (breakpoint) {
-    selectedBreakpointIdStore.set(breakpoint.id);
-    setInitialCanvasWidth(breakpoint.id);
+    serverSyncStore.createTransaction(
+      [selectedBreakpointIdStore, canvasWidthStore],
+      (selectedBreakpointIdStore, canvasWidthStore) => {
+        selectedBreakpointIdStore.value = breakpoint.id;
+        setInitialCanvasWidthAsTransaction(canvasWidthStore, breakpoint.id);
+      }
+    );
   }
 };

--- a/apps/builder/app/shared/nano-states/breakpoints.ts
+++ b/apps/builder/app/shared/nano-states/breakpoints.ts
@@ -4,17 +4,17 @@ import { isBaseBreakpoint } from "../breakpoints";
 
 export const breakpointsStore = atom<Breakpoints>(new Map());
 
-export const selectedBreakpointIdStore = atom<undefined | Breakpoint["id"]>(
-  undefined
-);
+export const selectedBreakpointIdStore = atom<{
+  value: undefined | Breakpoint["id"];
+}>({ value: undefined });
 
 export const selectedBreakpointStore = computed(
   [breakpointsStore, selectedBreakpointIdStore],
   (breakpoints, selectedBreakpointId) => {
     const selectedBreakpoint =
-      selectedBreakpointId === undefined
+      selectedBreakpointId?.value === undefined
         ? undefined
-        : breakpoints.get(selectedBreakpointId);
+        : breakpoints.get(selectedBreakpointId.value);
 
     if (breakpoints.size === 0) {
       return;

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -31,8 +31,10 @@ import {
   synchronizedComponentsMetaStores,
   dataSourceVariablesStore,
   $dragAndDropState,
+  selectedBreakpointIdStore,
 } from "~/shared/nano-states";
 import { $ephemeralStyles } from "~/canvas/stores";
+import { canvasWidthStore } from "~/builder/shared/nano-states";
 
 enableMapSet();
 
@@ -79,6 +81,11 @@ export const registerContainers = () => {
   serverSyncStore.register("props", propsStore);
   serverSyncStore.register("dataSources", dataSourcesStore);
   serverSyncStore.register("assets", assetsStore);
+  serverSyncStore.register(
+    "selectedBreakpointIdStore",
+    selectedBreakpointIdStore
+  );
+  serverSyncStore.register("canvasWidthStore", canvasWidthStore);
   // synchronize whole states
   clientStores.set("project", projectStore);
   clientStores.set("dataSourceVariables", dataSourceVariablesStore);


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)
https://github.com/webstudio-is/webstudio/issues/2613

## Steps for reproduction

1. change the breakpoint.
2. try to undo/redo. 

## Code Review

- [x] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
