### PR TITLE
feat: Add fields to transaction log,  add userPlanSettings

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -47,6 +47,7 @@ import { useMount } from "~/shared/hook-utils/use-mount";
 import { subscribeCommands } from "~/builder/shared/commands";
 import { AiCommandBar } from "./features/ai/ai-command-bar";
 import { SiteSettings } from "./features/seo/site-settings";
+import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 
 registerContainers();
 
@@ -225,6 +226,7 @@ export type BuilderProps = {
   assets: [Asset["id"], Asset][];
   authToken?: string;
   authPermit: AuthPermit;
+  userPlanFeatures: UserPlanFeatures;
 };
 
 export const Builder = ({
@@ -234,6 +236,7 @@ export const Builder = ({
   assets,
   authToken,
   authPermit,
+  userPlanFeatures,
 }: BuilderProps) => {
   useMount(() => {
     // additional data stores
@@ -301,7 +304,11 @@ export const Builder = ({
     <TooltipProvider>
       <ChromeWrapper isPreviewMode={isPreviewMode}>
         <SiteSettings />
-        <Topbar gridArea="header" project={project} />
+        <Topbar
+          gridArea="header"
+          project={project}
+          hasProPlan={userPlanFeatures.hasProPlan}
+        />
         <Main>
           <Workspace
             onTransitionEnd={onTransitionEnd}

--- a/apps/builder/app/builder/features/topbar/share.tsx
+++ b/apps/builder/app/builder/features/topbar/share.tsx
@@ -15,7 +15,13 @@ import { ShareProjectContainer } from "~/shared/share-project";
 import { $authPermit } from "~/shared/nano-states";
 import { useIsShareDialogOpen } from "~/builder/shared/nano-states";
 
-export const ShareButton = ({ projectId }: { projectId: Project["id"] }) => {
+export const ShareButton = ({
+  projectId,
+  hasProPlan,
+}: {
+  projectId: Project["id"];
+  hasProPlan: boolean;
+}) => {
   const [isShareOpen, setIsShareOpen] = useIsShareDialogOpen();
   const authPermit = useStore($authPermit);
 
@@ -45,7 +51,7 @@ export const ShareButton = ({ projectId }: { projectId: Project["id"] }) => {
           marginRight: theme.spacing[3],
         }}
       >
-        <ShareProjectContainer projectId={projectId} />
+        <ShareProjectContainer projectId={projectId} hasProPlan={hasProPlan} />
         <FloatingPanelPopoverTitle>Share</FloatingPanelPopoverTitle>
       </FloatingPanelPopoverContent>
     </FloatingPanelPopover>

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -32,9 +32,10 @@ const topbarContainerStyle = css({
 type TopbarProps = {
   gridArea: string;
   project: Project;
+  hasProPlan: boolean;
 };
 
-export const Topbar = ({ gridArea, project }: TopbarProps) => {
+export const Topbar = ({ gridArea, project, hasProPlan }: TopbarProps) => {
   const page = useStore(selectedPageStore);
 
   return (
@@ -68,7 +69,7 @@ export const Topbar = ({ gridArea, project }: TopbarProps) => {
           <ViewMode />
           <SyncStatus />
           <PreviewButton />
-          <ShareButton projectId={project.id} />
+          <ShareButton projectId={project.id} hasProPlan={hasProPlan} />
           <PublishButton projectId={project.id} />
         </ToolbarToggleGroup>
       </Toolbar>

--- a/apps/builder/app/dashboard/dashboard.stories.tsx
+++ b/apps/builder/app/dashboard/dashboard.stories.tsx
@@ -25,9 +25,21 @@ const createRouter = (element: JSX.Element) =>
     },
   ]);
 
+const userPlanFeatures = {
+  hasProPlan: false,
+  hasSubscription: false,
+  allowShareAdminLinks: false,
+  maxDomainsAllowedPerUser: 5,
+};
+
 export const Empty: ComponentStory<typeof Dashboard> = () => {
   const router = createRouter(
-    <Dashboard user={user} projects={[]} projectTemplates={[]} />
+    <Dashboard
+      user={user}
+      projects={[]}
+      projectTemplates={[]}
+      userPlanFeatures={userPlanFeatures}
+    />
   );
   return <RouterProvider router={router} />;
 };
@@ -46,7 +58,12 @@ export const WithProjects: ComponentStory<typeof Dashboard> = () => {
     },
   ];
   const router = createRouter(
-    <Dashboard user={user} projects={projects} projectTemplates={projects} />
+    <Dashboard
+      user={user}
+      projects={projects}
+      projectTemplates={projects}
+      userPlanFeatures={userPlanFeatures}
+    />
   );
   return <RouterProvider router={router} />;
 };

--- a/apps/builder/app/dashboard/dashboard.tsx
+++ b/apps/builder/app/dashboard/dashboard.tsx
@@ -4,6 +4,7 @@ import { Projects } from "./projects";
 import type { User } from "~/shared/db/user.server";
 import type { DashboardProject } from "@webstudio-is/dashboard";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
+import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 
 const globalStyles = globalCss({
   body: {
@@ -16,17 +17,19 @@ type DashboardProps = {
   user: User;
   projects: Array<DashboardProject>;
   projectTemplates: Array<DashboardProject>;
+  userPlanFeatures: UserPlanFeatures;
 };
 
 export const Dashboard = ({
   user,
   projects,
   projectTemplates,
+  userPlanFeatures,
 }: DashboardProps) => {
   globalStyles();
   return (
     <TooltipProvider>
-      <Header user={user} />
+      <Header user={user} userPlanFeatures={userPlanFeatures} />
       <main>
         <Flex justify="center" as="section" css={{ minWidth: "min-content" }}>
           <Projects projects={projects} projectTemplates={projectTemplates} />

--- a/apps/builder/app/dashboard/dashboard.tsx
+++ b/apps/builder/app/dashboard/dashboard.tsx
@@ -32,7 +32,11 @@ export const Dashboard = ({
       <Header user={user} userPlanFeatures={userPlanFeatures} />
       <main>
         <Flex justify="center" as="section" css={{ minWidth: "min-content" }}>
-          <Projects projects={projects} projectTemplates={projectTemplates} />
+          <Projects
+            projects={projects}
+            projectTemplates={projectTemplates}
+            hasProPlan={userPlanFeatures.hasProPlan}
+          />
         </Flex>
       </main>
     </TooltipProvider>

--- a/apps/builder/app/dashboard/header.tsx
+++ b/apps/builder/app/dashboard/header.tsx
@@ -13,8 +13,9 @@ import {
   Button,
 } from "@webstudio-is/design-system";
 import { useNavigate } from "@remix-run/react";
-import { logoutPath } from "~/shared/router-utils";
+import { logoutPath, userPlanSubscriptionPath } from "~/shared/router-utils";
 import type { User } from "~/shared/db/user.server";
+import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 
 const containerStyle = css({
   px: theme.spacing[13],
@@ -27,7 +28,13 @@ const getAvatarLetter = (title?: string) => {
   return (title || "X").charAt(0).toLocaleUpperCase();
 };
 
-const Menu = ({ user }: { user: User }) => {
+const Menu = ({
+  user,
+  userPlanFeatures,
+}: {
+  user: User;
+  userPlanFeatures: UserPlanFeatures;
+}) => {
   const navigate = useNavigate();
   const title = user?.username ?? user?.email ?? undefined;
   return (
@@ -53,12 +60,26 @@ const Menu = ({ user }: { user: User }) => {
         <DropdownMenuItem onSelect={() => navigate(logoutPath())}>
           Logout
         </DropdownMenuItem>
+
+        {userPlanFeatures.hasSubscription && (
+          <DropdownMenuItem
+            onSelect={() => navigate(userPlanSubscriptionPath())}
+          >
+            Subscriptions
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );
 };
 
-export const Header = ({ user }: { user: User }) => {
+export const Header = ({
+  user,
+  userPlanFeatures,
+}: {
+  user: User;
+  userPlanFeatures: UserPlanFeatures;
+}) => {
   return (
     <Flex
       as="header"
@@ -68,7 +89,7 @@ export const Header = ({ user }: { user: User }) => {
     >
       <WebstudioIcon width={30} height={23} />
       <Flex gap="1" align="center">
-        <Menu user={user} />
+        <Menu user={user} userPlanFeatures={userPlanFeatures} />
       </Flex>
     </Flex>
   );

--- a/apps/builder/app/dashboard/header.tsx
+++ b/apps/builder/app/dashboard/header.tsx
@@ -93,29 +93,31 @@ export const Header = ({
       <WebstudioIcon width={30} height={23} />
       <Flex gap="1" align="center" css={{ position: "relative" }}>
         <Menu user={user} userPlanFeatures={userPlanFeatures} />
-        <Flex
-          css={{
-            position: "absolute",
-            left: theme.spacing[6],
-            top: -4,
-            width: 0,
-          }}
-          align={"center"}
-          justify={"center"}
-        >
-          <Box
+        {userPlanFeatures.hasProPlan && (
+          <Flex
             css={{
-              backgroundColor: theme.colors.primary,
-              minWidth: "fit-content",
-              py: theme.spacing[1],
-              px: theme.spacing[3],
-              borderRadius: theme.borderRadius[3],
-              color: theme.colors.white,
+              position: "absolute",
+              left: theme.spacing[6],
+              top: -4,
+              width: 0,
             }}
+            align={"center"}
+            justify={"center"}
           >
-            <Text variant={"small"}>Pro</Text>
-          </Box>
-        </Flex>
+            <Box
+              css={{
+                backgroundColor: theme.colors.primary,
+                minWidth: "fit-content",
+                py: theme.spacing[1],
+                px: theme.spacing[3],
+                borderRadius: theme.borderRadius[3],
+                color: theme.colors.white,
+              }}
+            >
+              <Text variant={"small"}>Pro</Text>
+            </Box>
+          </Flex>
+        )}
       </Flex>
     </Flex>
   );

--- a/apps/builder/app/dashboard/header.tsx
+++ b/apps/builder/app/dashboard/header.tsx
@@ -11,6 +11,8 @@ import {
   rawTheme,
   theme,
   Button,
+  Box,
+  Text,
 } from "@webstudio-is/design-system";
 import { useNavigate } from "@remix-run/react";
 import { logoutPath, userPlanSubscriptionPath } from "~/shared/router-utils";
@@ -47,6 +49,7 @@ const Menu = ({
               fallback={getAvatarLetter(title)}
               alt={title || "User Avatar"}
             />
+
             <ChevronDownIcon
               width={15}
               height={15}
@@ -88,8 +91,31 @@ export const Header = ({
       className={containerStyle()}
     >
       <WebstudioIcon width={30} height={23} />
-      <Flex gap="1" align="center">
+      <Flex gap="1" align="center" css={{ position: "relative" }}>
         <Menu user={user} userPlanFeatures={userPlanFeatures} />
+        <Flex
+          css={{
+            position: "absolute",
+            left: theme.spacing[6],
+            top: -4,
+            width: 0,
+          }}
+          align={"center"}
+          justify={"center"}
+        >
+          <Box
+            css={{
+              backgroundColor: theme.colors.primary,
+              minWidth: "fit-content",
+              py: theme.spacing[1],
+              px: theme.spacing[3],
+              borderRadius: theme.borderRadius[3],
+              color: theme.colors.white,
+            }}
+          >
+            <Text variant={"small"}>Pro</Text>
+          </Box>
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/apps/builder/app/dashboard/projects/project-card.tsx
+++ b/apps/builder/app/dashboard/projects/project-card.tsx
@@ -175,13 +175,14 @@ const useProjectCard = () => {
 type ProjectCardProps = Pick<
   DashboardProject,
   "id" | "title" | "domain" | "isPublished"
->;
+> & { hasProPlan: boolean };
 
 export const ProjectCard = ({
   id,
   title,
   domain,
   isPublished,
+  hasProPlan,
 }: ProjectCardProps) => {
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -258,6 +259,7 @@ export const ProjectCard = ({
         isOpen={isShareDialogOpen}
         onOpenChange={setIsShareDialogOpen}
         projectId={id}
+        hasProPlan={hasProPlan}
       />
     </Box>
   );
@@ -268,7 +270,7 @@ export const ProjectTemplateCard = ({
   title,
   domain,
   isPublished,
-}: ProjectCardProps) => {
+}: Omit<ProjectCardProps, "hasProPlan">) => {
   const { thumbnailRef, handleKeyDown } = useProjectCard();
   const [isDuplicateDialogOpen, setIsDuplicateDialogOpen] = useState(false);
 

--- a/apps/builder/app/dashboard/projects/project-dialogs.tsx
+++ b/apps/builder/app/dashboard/projects/project-dialogs.tsx
@@ -404,14 +404,16 @@ export const ShareProjectDialog = ({
   isOpen,
   onOpenChange,
   projectId,
+  hasProPlan,
 }: {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
   projectId: DashboardProject["id"];
+  hasProPlan: boolean;
 }) => {
   return (
     <Dialog title="Share Project" isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ShareProjectContainer projectId={projectId} />
+      <ShareProjectContainer hasProPlan={hasProPlan} projectId={projectId} />
     </Dialog>
   );
 };

--- a/apps/builder/app/dashboard/projects/projects.tsx
+++ b/apps/builder/app/dashboard/projects/projects.tsx
@@ -11,9 +11,14 @@ import { useState } from "react";
 type ProjectsProps = {
   projects: Array<DashboardProject>;
   projectTemplates: Array<DashboardProject>;
+  hasProPlan: boolean;
 };
 
-export const Projects = ({ projects, projectTemplates }: ProjectsProps) => {
+export const Projects = ({
+  projects,
+  projectTemplates,
+  hasProPlan,
+}: ProjectsProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -45,7 +50,13 @@ export const Projects = ({ projects, projectTemplates }: ProjectsProps) => {
           }}
         >
           {projects.map((project) => {
-            return <ProjectCard {...project} key={project.id} />;
+            return (
+              <ProjectCard
+                {...project}
+                key={project.id}
+                hasProPlan={hasProPlan}
+              />
+            );
           })}
         </Grid>
       </Flex>

--- a/apps/builder/app/routes/builder.$projectId.tsx
+++ b/apps/builder/app/routes/builder.$projectId.tsx
@@ -78,6 +78,11 @@ export const loader = async ({
 
     const authToken = url.searchParams.get("authToken") ?? undefined;
 
+    const { userPlanFeatures } = context;
+    if (userPlanFeatures === undefined) {
+      throw new Error("User plan features are not defined");
+    }
+
     return {
       project,
       domains,
@@ -85,6 +90,7 @@ export const loader = async ({
       assets: assets.map((asset) => [asset.id, asset]),
       authToken,
       authPermit,
+      userPlanFeatures,
     };
   } catch (error) {
     if (error instanceof AuthorizationError) {

--- a/apps/builder/app/routes/dashboard._index.tsx
+++ b/apps/builder/app/routes/dashboard._index.tsx
@@ -40,7 +40,18 @@ export const loader = async ({
       projectIds,
     });
 
-  return { user, projects, projectTemplates };
+  const { userPlanFeatures } = context;
+
+  if (userPlanFeatures === undefined) {
+    throw new Error("User plan features are not defined");
+  }
+
+  return {
+    user,
+    projects,
+    projectTemplates,
+    userPlanFeatures,
+  };
 };
 
 export const ErrorBoundary = () => {

--- a/apps/builder/app/shared/context.server.ts
+++ b/apps/builder/app/shared/context.server.ts
@@ -3,6 +3,7 @@ import env from "~/env/env.server";
 import { authenticator } from "~/services/auth.server";
 import { trpcClient } from "~/services/trpc.server";
 import { entryApi } from "./entri/entri-api.server";
+import { getUserPlanFeatures } from "./db/user-plan-features.server";
 
 const createAuthorizationContext = async (
   request: Request
@@ -56,6 +57,12 @@ const createEntriContext = () => {
   };
 };
 
+const createUserPlanContext = async (request: Request) => {
+  const user = await authenticator.isAuthenticated(request);
+  const planFeatures = user?.id ? getUserPlanFeatures(user.id) : undefined;
+  return planFeatures;
+};
+
 /**
  * argument buildEnv==="prod" only if we are loading project with production build
  */
@@ -64,10 +71,12 @@ export const createContext = async (request: Request): Promise<AppContext> => {
   const domain = createDomainContext(request);
   const deployment = createDeploymentContext(request);
   const entri = createEntriContext();
+  const userPlanFeatures = await createUserPlanContext(request);
   return {
     authorization,
     domain,
     deployment,
     entri,
+    userPlanFeatures,
   };
 };

--- a/apps/builder/app/shared/db/user-plan-features.server.ts
+++ b/apps/builder/app/shared/db/user-plan-features.server.ts
@@ -7,6 +7,7 @@ export type UserPlanFeatures = {
   allowShareAdminLinks: boolean;
   maxDomainsAllowedPerUser: number;
   hasSubscription: boolean;
+  hasProPlan: boolean;
 };
 
 // No strings - no secrets
@@ -50,6 +51,7 @@ export const getUserPlanFeatures = async (
       allowShareAdminLinks: true,
       maxDomainsAllowedPerUser: Number.MAX_SAFE_INTEGER,
       hasSubscription,
+      hasProPlan: true,
     };
   }
 
@@ -57,5 +59,6 @@ export const getUserPlanFeatures = async (
     allowShareAdminLinks: false,
     maxDomainsAllowedPerUser: 5,
     hasSubscription: false,
+    hasProPlan: false,
   };
 };

--- a/apps/builder/app/shared/db/user-plan-features.server.ts
+++ b/apps/builder/app/shared/db/user-plan-features.server.ts
@@ -1,0 +1,61 @@
+import { prisma } from "@webstudio-is/prisma-client";
+
+/**
+ * Plan features are available on the client, do not use any secrets, 3rd party ids etc
+ **/
+export type UserPlanFeatures = {
+  allowShareAdminLinks: boolean;
+  maxDomainsAllowedPerUser: number;
+  hasSubscription: boolean;
+};
+
+// No strings - no secrets
+({}) as UserPlanFeatures satisfies Record<string, boolean | number>;
+
+export const getUserPlanFeatures = async (
+  userId: string
+): Promise<UserPlanFeatures> => {
+  const transactionLog = await prisma.transactionLog.findMany({
+    where: { userId },
+    orderBy: {
+      createdAt: "desc",
+    },
+    select: {
+      eventId: true,
+      sessionId: true,
+      createdAt: true,
+      customerId: true,
+      subscriptionId: true,
+      product: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          features: true,
+          meta: true,
+          images: true,
+        },
+      },
+    },
+  });
+
+  // This is fast and dirty implementation
+  // @todo: implement this using products meta, custom table with aggregated transaction info
+  if (transactionLog.length > 0) {
+    const hasSubscription = transactionLog.some(
+      (log) => log.subscriptionId !== null
+    );
+
+    return {
+      allowShareAdminLinks: true,
+      maxDomainsAllowedPerUser: Number.MAX_SAFE_INTEGER,
+      hasSubscription,
+    };
+  }
+
+  return {
+    allowShareAdminLinks: false,
+    maxDomainsAllowedPerUser: 5,
+    hasSubscription: false,
+  };
+};

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -87,6 +87,13 @@ export const loginPath = (params: {
 
 export const logoutPath = () => "/logout";
 
+export const userPlanSubscriptionPath = () => {
+  const urlSearchParams = new URLSearchParams();
+  urlSearchParams.set("return_url", window.location.href);
+
+  return `/n8n/billing_portal/sessions?${urlSearchParams.toString()}`;
+};
+
 export const authCallbackPath = ({
   provider,
 }: {

--- a/apps/builder/app/shared/share-project/share-project-container.tsx
+++ b/apps/builder/app/shared/share-project/share-project-container.tsx
@@ -86,13 +86,17 @@ const useShareProjectContainer = (projectId: Project["id"]) => {
 
 type ShareButtonProps = {
   projectId: Project["id"];
+  hasProPlan: boolean;
 };
 
 /**
  * we place the logic inside Popover so that the fetcher does not exist outside of it.
  * Then remix will not call `trpc.findMany.useQuery` if Popover is closed
  */
-export const ShareProjectContainer = ({ projectId }: ShareButtonProps) => {
+export const ShareProjectContainer = ({
+  projectId,
+  hasProPlan,
+}: ShareButtonProps) => {
   const {
     links,
     handleChangeDebounced,
@@ -103,6 +107,7 @@ export const ShareProjectContainer = ({ projectId }: ShareButtonProps) => {
 
   return (
     <ShareProject
+      hasProPlan={hasProPlan}
       links={links}
       onChange={handleChangeDebounced}
       onDelete={handleDelete}

--- a/apps/builder/app/shared/share-project/share-project.stories.tsx
+++ b/apps/builder/app/shared/share-project/share-project.stories.tsx
@@ -85,6 +85,7 @@ export const Empty: ComponentStory<typeof ShareProject> = () => {
       <FloatingPanelPopoverContent>
         <ShareProject
           {...props}
+          hasProPlan={false}
           isPending={false}
           builderUrl={({ authToken, mode }) =>
             `https://blabla.com/${authToken}/${mode}`
@@ -106,6 +107,7 @@ export const WithLinks: ComponentStory<typeof ShareProject> = () => {
       <FloatingPanelPopoverContent>
         <ShareProject
           {...props}
+          hasProPlan={false}
           isPending={false}
           builderUrl={({ authToken, mode }) =>
             `https://blabla.com/${authToken}/${mode}`
@@ -127,6 +129,7 @@ export const WithAsyncLinks: ComponentStory<typeof ShareProject> = () => {
       <FloatingPanelPopoverContent>
         <ShareProject
           {...props}
+          hasProPlan={false}
           isPending={false}
           builderUrl={({ authToken, mode }) =>
             `https://blabla.com/${authToken}/${mode}`

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -21,7 +21,6 @@ import {
 } from "@webstudio-is/design-system";
 import { CopyIcon, MenuIcon, PlusIcon, HelpIcon } from "@webstudio-is/icons";
 import { Fragment, useState, type ComponentProps } from "react";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 const Item = (props: ComponentProps<typeof Flex>) => (
   <Flex
@@ -67,12 +66,14 @@ const Permission = ({
 type MenuProps = {
   relation: Relation;
   name: string;
+  hasProPlan: boolean;
   onChangePermission: (relation: Relation) => void;
   onChangeName: (name: string) => void;
   onDelete: () => void;
 };
 
 const Menu = ({
+  hasProPlan,
   relation,
   name,
   onChangePermission,
@@ -146,7 +147,7 @@ const Menu = ({
               info="Recipients can make any changes but can not publish the site."
             />
 
-            {isFeatureEnabled("adminRole") && (
+            {hasProPlan && (
               <Permission
                 onCheckedChange={handleCheckedChange("administrators")}
                 checked={relation === "administrators"}
@@ -198,6 +199,7 @@ type SharedLinkItemType = LinkOptions & {
     authToken: string;
     mode: "preview" | "edit";
   }) => string;
+  hasProPlan: boolean;
 };
 
 const SharedLinkItem = ({
@@ -208,6 +210,7 @@ const SharedLinkItem = ({
   onChangeName,
   onDelete,
   builderUrl,
+  hasProPlan,
 }: SharedLinkItemType) => {
   const [currentName, setCurrentName] = useState(name);
 
@@ -236,6 +239,7 @@ const SharedLinkItem = ({
           onChangeName(name);
         }}
         onDelete={onDelete}
+        hasProPlan={hasProPlan}
       />
     </Box>
   );
@@ -248,6 +252,7 @@ type ShareProjectProps = {
   onCreate: () => void;
   builderUrl: SharedLinkItemType["builderUrl"];
   isPending: boolean;
+  hasProPlan: boolean;
 };
 
 const animateCollapsibleHeight = keyframes({
@@ -274,11 +279,11 @@ export const ShareProject = ({
   onCreate,
   builderUrl,
   isPending,
+  hasProPlan,
 }: ShareProjectProps) => {
   const items = links.map((link) => (
     <Fragment key={link.token}>
       <SharedLinkItem
-        {...link}
         onChangeRelation={(relation) => {
           onChange({ ...link, relation });
         }}
@@ -289,6 +294,10 @@ export const ShareProject = ({
           onDelete(link);
         }}
         builderUrl={builderUrl}
+        name={link.name}
+        relation={link.relation}
+        token={link.token}
+        hasProPlan={hasProPlan}
       />
       <Separator />
     </Fragment>

--- a/apps/builder/docker-compose.yaml
+++ b/apps/builder/docker-compose.yaml
@@ -6,6 +6,8 @@ volumes:
 services:
   db:
     image: postgres
+    # Uncomment to log all queries
+    # command: ["postgres", "-c", "log_statement=all"]
     restart: always
     environment:
       # postgresql://user:pass@localhost:5432/webstudio

--- a/packages/domain/src/trpc/domain.ts
+++ b/packages/domain/src/trpc/domain.ts
@@ -121,11 +121,16 @@ export const domainRouter = router({
     )
     .mutation(async ({ input, ctx }) => {
       try {
+        const { userPlanFeatures } = ctx;
+        if (userPlanFeatures === undefined) {
+          throw new Error("Missing userPlanFeatures");
+        }
+
         return await db.create(
           {
             projectId: input.projectId,
             domain: input.domain,
-            maxDomainsAllowedPerUser: 5,
+            maxDomainsAllowedPerUser: userPlanFeatures.maxDomainsAllowedPerUser,
           },
           ctx
         );

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -1,8 +1,6 @@
 export const dark = false;
 export const unsupportedBrowsers = false;
 export const displayContents = false;
-// @todo this should be pro users check
-export const adminRole = false;
 export const ai = true;
 export const aiRadixComponents = false;
 export const transitions = false;

--- a/packages/prisma-client/prisma/migrations/20231119153806_transaction-customer-subscription/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20231119153806_transaction-customer-subscription/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "TransactionLog" ADD COLUMN     "customerId" TEXT,
+ADD COLUMN     "subscriptionId" TEXT,
+ADD COLUMN     "customerEmail" TEXT;

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -100,6 +100,11 @@ model TransactionLog {
   status    String
   createdAt DateTime @default(now())
 
+  // Helper fields we can use for faster api calls and to have additional information for debugging purposes
+  customerId     String?
+  subscriptionId String?
+  customerEmail  String?
+
   @@unique([eventId, productId])
   @@unique([sessionId, productId])
 }

--- a/packages/trpc-interface/src/context/context.server.ts
+++ b/packages/trpc-interface/src/context/context.server.ts
@@ -50,6 +50,12 @@ type DeploymentContext = {
   };
 };
 
+type UserPlanFeatures = {
+  allowShareAdminLinks: boolean;
+  maxDomainsAllowedPerUser: number;
+  hasSubscription: boolean;
+};
+
 /**
  * AppContext is a global context that is passed to all trpc/api queries/mutations
  * "authorization" is made inside the namespace because eventually there will be
@@ -60,4 +66,5 @@ export type AppContext = {
   domain: DomainContext;
   deployment: DeploymentContext;
   entri: EntriContext;
+  userPlanFeatures: UserPlanFeatures | undefined;
 };

--- a/packages/trpc-interface/src/context/context.server.ts
+++ b/packages/trpc-interface/src/context/context.server.ts
@@ -54,6 +54,7 @@ type UserPlanFeatures = {
   allowShareAdminLinks: boolean;
   maxDomainsAllowedPerUser: number;
   hasSubscription: boolean;
+  hasProPlan: boolean;
 };
 
 /**


### PR DESCRIPTION
## Description

Add additional fields to transaction log, so we can create billing portal for users to unsubscribe/change etc of subscriptions

Plus:
- [x] Allow unlimited domains to all "pro" users
- [x] Add subscriptions link to users with subscriptions (created by n8n schema on click)
<img width="213" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/08d40835-3273-4ca9-a0e3-8a4f7614da93">

- [x] Allow admin link sharing

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
