### PR TITLE
refactor: use selectors in all tree callbacks

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -210,13 +210,13 @@ const PagesPanel = ({
           onSelect={selectTreeNode}
           itemData={pagesTree}
           renderItem={renderItem}
-          getItemChildren={(nodeId) => {
+          getItemChildren={([nodeId]) => {
             if (nodeId === pagesTree.id && pagesTree.type === "folder") {
               return pagesTree.children;
             }
             return [];
           }}
-          isItemHidden={(itemId) => itemId === pagesTree.id}
+          isItemHidden={([itemId]) => itemId === pagesTree.id}
           getIsExpanded={() => true}
         />
       </Box>

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from "react";
 import { useStore } from "@nanostores/react";
 import { shallowEqual } from "shallow-equal";
 import { toast } from "@webstudio-is/design-system";
-import type { Instance } from "@webstudio-is/sdk";
 import {
   hoveredInstanceSelectorStore,
   instancesStore,
@@ -86,7 +85,7 @@ export const NavigatorTree = () => {
   );
 
   const isItemHidden = useCallback(
-    (instanceId: Instance["id"]) =>
+    ([instanceId]: InstanceSelector) =>
       // fragment is internal component to group other instances
       // for example to support multiple children in slots
       instances.get(instanceId)?.component === "Fragment",

--- a/apps/builder/app/builder/shared/tree/index.tsx
+++ b/apps/builder/app/builder/shared/tree/index.tsx
@@ -19,6 +19,7 @@ import { MetaIcon } from "../meta-icon";
 import { useContentEditable } from "~/shared/dom-hooks";
 import { getInstanceLabel } from "~/shared/instance-utils";
 import { serverSyncStore } from "~/shared/sync";
+import type { InstanceSelector } from "~/shared/tree-utils";
 
 export const InstanceTree = (
   props: Omit<
@@ -31,7 +32,7 @@ export const InstanceTree = (
   const editingItemId = useStore(editingItemIdStore);
 
   const canLeaveParent = useCallback(
-    (instanceId: Instance["id"]) => {
+    ([instanceId]: InstanceSelector) => {
       const instance = instances.get(instanceId);
       if (instance === undefined) {
         return false;
@@ -43,7 +44,7 @@ export const InstanceTree = (
   );
 
   const getItemChildren = useCallback(
-    (instanceId: Instance["id"]) => {
+    ([instanceId]: InstanceSelector) => {
       const instance = instances.get(instanceId);
       const children: Instance[] = [];
       if (instance === undefined) {

--- a/packages/design-system/src/components/tree/horizontal-shift.test.ts
+++ b/packages/design-system/src/components/tree/horizontal-shift.test.ts
@@ -114,9 +114,9 @@ const render = (
         (findItemById(tree, itemSelector[0])?.children.length ?? 0) > 0,
       canAcceptChild: (itemSelector: ItemSelector) =>
         findItemById(tree, itemSelector[0])?.canAcceptChildren ?? false,
-      getItemChildren: (itemId: ItemId) =>
-        findItemById(tree, itemId)?.children ?? [],
-      isItemHidden: (_itemId: ItemId) => false,
+      getItemChildren: (itemSelector: ItemSelector) =>
+        findItemById(tree, itemSelector[0])?.children ?? [],
+      isItemHidden: ([_itemId]: ItemSelector) => false,
     },
   });
 

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -392,8 +392,8 @@ export const TreeItemLabel = forwardRef(TreeItemLabelBase);
 
 export type TreeNodeProps<Data extends { id: ItemId }> = {
   itemData: Data;
-  getItemChildren: (itemId: ItemId) => Data[];
-  isItemHidden: (itemId: ItemId) => boolean;
+  getItemChildren: (itemSelector: ItemSelector) => Data[];
+  isItemHidden: (itemSelector: ItemSelector) => boolean;
   renderItem: (props: TreeItemRenderProps<Data>) => React.ReactNode;
 
   getIsExpanded: (itemSelector: ItemSelector) => boolean;
@@ -433,11 +433,11 @@ export const TreeNode = <Data extends { id: string }>({
     isItemHidden,
   } = commonProps;
 
-  const itemChildren = getItemChildren(itemData.id);
-
   const itemSelector = [itemData.id, ...(parentSelector ?? [])];
 
-  const itemIsHidden = isItemHidden(itemData.id);
+  const itemChildren = getItemChildren(itemSelector);
+
+  const itemIsHidden = isItemHidden(itemSelector);
   // hidden items and root are always expanded
   const isAlwaysExpanded = itemIsHidden || level === 0;
 

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -95,7 +95,9 @@ export const StressTest = () => {
           });
         }}
         canLeaveParent={() => true}
-        getItemChildren={(itemId) => findItemById(root, itemId)?.children ?? []}
+        getItemChildren={(itemSelector) =>
+          findItemById(root, itemSelector[0])?.children ?? []
+        }
         isItemHidden={(itemSelector) =>
           findItemById(root, itemSelector[0])?.isHidden ?? false
         }

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -30,10 +30,10 @@ export type TreeProps<Data extends { id: string }> = {
   dragItemSelector: undefined | ItemSelector;
   dropTarget: undefined | ItemDropTarget;
 
-  canLeaveParent: (itemId: ItemId) => boolean;
+  canLeaveParent: (itemSelector: ItemSelector) => boolean;
   findClosestDroppableIndex: (itemSelector: ItemSelector) => number;
-  getItemChildren: (itemId: ItemId) => Data[];
-  isItemHidden: (itemId: ItemId) => boolean;
+  getItemChildren: (itemSelector: ItemSelector) => Data[];
+  isItemHidden: (itemSelector: ItemSelector) => boolean;
   renderItem: (props: TreeItemRenderProps<Data>) => React.ReactNode;
 
   onSelect?: (itemSelector: ItemSelector) => void;
@@ -211,8 +211,7 @@ export const Tree = <Data extends { id: string }>({
         return false;
       }
 
-      const [dragItemId] = dragItemSelector;
-      if (canLeaveParent(dragItemId) === false) {
+      if (canLeaveParent(dragItemSelector) === false) {
         return false;
       }
 
@@ -336,8 +335,8 @@ const useKeyboardNavigation = <Data extends { id: string }>({
 }: {
   root: Data;
   selectedItemSelector: undefined | ItemSelector;
-  getItemChildren: (itemId: ItemId) => Data[];
-  isItemHidden: (itemId: ItemId) => boolean;
+  getItemChildren: (itemSelector: ItemSelector) => Data[];
+  isItemHidden: (itemSelector: ItemSelector) => boolean;
   getIsExpanded: (itemSelector: ItemSelector) => boolean;
   setIsExpanded: (
     itemSelector: ItemSelector,
@@ -350,12 +349,11 @@ const useKeyboardNavigation = <Data extends { id: string }>({
   const flatCurrentlyExpandedTree = useMemo(() => {
     const result: ItemSelector[] = [];
     const traverse = (itemSelector: ItemSelector) => {
-      const [itemId] = itemSelector;
-      if (isItemHidden(itemId) === false) {
+      if (isItemHidden(itemSelector) === false) {
         result.push(itemSelector);
       }
       if (getIsExpanded(itemSelector)) {
-        for (const child of getItemChildren(itemId)) {
+        for (const child of getItemChildren(itemSelector)) {
           traverse([child.id, ...itemSelector]);
         }
       }
@@ -495,7 +493,7 @@ const useExpandState = <Data extends { id: string }>({
   getItemChildren,
 }: {
   selectedItemSelector: undefined | ItemSelector;
-  getItemChildren: (itemId: string) => Data[];
+  getItemChildren: (itemSelector: ItemSelector) => Data[];
 }) => {
   const [record, setRecord] = useState<Record<string, boolean>>({});
 
@@ -548,7 +546,7 @@ const useExpandState = <Data extends { id: string }>({
         if (all) {
           const newRecord = { ...record };
           const addChildren = (parentSelector: string[]) => {
-            for (const child of getItemChildren(parentSelector[0])) {
+            for (const child of getItemChildren(parentSelector)) {
               const itemSelector = [child.id, ...parentSelector];
               newRecord[itemSelector.join()] = value;
               addChildren(itemSelector);


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Selectors in tree are necessary to easily access data of ancestors while manipulaating navigator tree.

Required to support collections.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
