### PR TITLE
fix: show active style states as remote

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -202,7 +202,8 @@ test("compute inherited styles", () => {
       ]),
 
       cascadedBreakpointIds,
-      selectedBreakpointId
+      selectedBreakpointId,
+      new Set()
     )
   ).toMatchInlineSnapshot(`
     {
@@ -307,7 +308,8 @@ test("compute styles from previous sources", () => {
       stylesByInstanceId,
       selectedInstanceSelector,
       selectedStyleSourceSelector,
-      "bp"
+      "bp",
+      new Set()
     )
   ).toMatchInlineSnapshot(`
     {
@@ -374,7 +376,8 @@ test("compute styles from next sources", () => {
       stylesByInstanceId,
       selectedInstanceSelector,
       selectedStyleSourceSelector,
-      "bp"
+      "bp",
+      new Set()
     )
   ).toMatchInlineSnapshot(`
     {

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "@jest/globals";
-import { renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react-hooks";
 import * as defaultMetas from "@webstudio-is/sdk-components-react/metas";
 import {
   getStyleDeclKey,
@@ -7,8 +7,11 @@ import {
   type Instance,
   type Instances,
   type StyleDecl,
+  StyleSourceSelection,
 } from "@webstudio-is/sdk";
 import {
+  $selectedBreakpointId,
+  $selectedInstanceStates,
   breakpointsStore,
   instancesStore,
   registeredComponentMetasStore,
@@ -25,8 +28,18 @@ import {
   getInheritedInfo,
   getNextSourceInfo,
   getPreviousSourceInfo,
+  getStyleSource,
   useStyleInfo,
 } from "./style-info";
+
+const toMap = <T extends { id: string }>(list: T[]) =>
+  new Map(list.map((item) => [item.id, item]));
+
+const toStyleSourceSelectionsMap = (list: StyleSourceSelection[]) =>
+  new Map(list.map((item) => [item.instanceId, item]));
+
+const toStylesMap = (list: StyleDecl[]) =>
+  new Map(list.map((item) => [getStyleDeclKey(item), item]));
 
 const metas = new Map(Object.entries(defaultMetas));
 
@@ -150,7 +163,8 @@ test("compute cascaded styles", () => {
     getCascadedInfo(
       cascadingStylesByInstanceId,
       selectedInstanceSelector[0],
-      cascadedBreakpointIds
+      cascadedBreakpointIds,
+      new Set()
     )
   ).toMatchInlineSnapshot(`
     {
@@ -386,6 +400,7 @@ const resetStores = () => {
   selectedInstanceSelectorStore.set(undefined);
   selectedInstanceIntanceToTagStore.set(new Map());
   selectedStyleSourceSelectorStore.set(undefined);
+  $selectedInstanceStates.set(new Set());
 };
 
 describe("color and currentColor", () => {
@@ -565,6 +580,368 @@ describe("color and currentColor", () => {
     expect(result.current.color?.currentColor).toEqual({
       type: "keyword",
       value: "black",
+    });
+  });
+});
+
+describe("active states", () => {
+  test("show stateless style as remote when state is selected", () => {
+    resetStores();
+    instancesStore.set(
+      toMap([{ type: "instance", id: "box", component: "Box", children: [] }])
+    );
+    breakpointsStore.set(toMap([{ id: "base", label: "" }]));
+    styleSourcesStore.set(toMap([{ id: "box.local", type: "local" }]));
+    styleSourceSelectionsStore.set(
+      toStyleSourceSelectionsMap([{ instanceId: "box", values: ["box.local"] }])
+    );
+    stylesStore.set(
+      toStylesMap([
+        {
+          styleSourceId: "box.local",
+          breakpointId: "base",
+          property: "color",
+          value: { type: "keyword", value: "green" },
+        },
+      ])
+    );
+    selectedInstanceSelectorStore.set(["box"]);
+    selectedStyleSourceSelectorStore.set({ styleSourceId: "box.local" });
+
+    const { result } = renderHook(() => useStyleInfo());
+    expect(getStyleSource(result.current.color)).toEqual("local");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "green",
+    });
+
+    act(() => {
+      selectedStyleSourceSelectorStore.set({
+        styleSourceId: "box.local",
+        state: ":hover",
+      });
+    });
+    expect(getStyleSource(result.current.color)).toEqual("remote");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "green",
+    });
+  });
+
+  test("show active state style as local when selected", () => {
+    resetStores();
+    instancesStore.set(
+      toMap([{ type: "instance", id: "box", component: "Box", children: [] }])
+    );
+    breakpointsStore.set(toMap([{ id: "base", label: "" }]));
+    styleSourcesStore.set(toMap([{ id: "box.local", type: "local" }]));
+    styleSourceSelectionsStore.set(
+      toStyleSourceSelectionsMap([{ instanceId: "box", values: ["box.local"] }])
+    );
+    stylesStore.set(
+      toStylesMap([
+        {
+          styleSourceId: "box.local",
+          breakpointId: "base",
+          state: ":hover",
+          property: "color",
+          value: { type: "keyword", value: "green" },
+        },
+      ])
+    );
+    selectedInstanceSelectorStore.set(["box"]);
+    selectedStyleSourceSelectorStore.set({ styleSourceId: "box.local" });
+    $selectedInstanceStates.set(new Set([":hover"]));
+
+    const { result } = renderHook(() => useStyleInfo());
+    expect(getStyleSource(result.current.color)).toEqual("remote");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "green",
+    });
+
+    act(() => {
+      selectedStyleSourceSelectorStore.set({
+        styleSourceId: "box.local",
+        state: ":hover",
+      });
+    });
+    expect(getStyleSource(result.current.color)).toEqual("local");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "green",
+    });
+  });
+
+  test("show active state from another breakpoint as remote", () => {
+    resetStores();
+    instancesStore.set(
+      toMap([{ type: "instance", id: "box", component: "Box", children: [] }])
+    );
+    breakpointsStore.set(
+      toMap([
+        { id: "base", label: "" },
+        { id: "small", label: "", minWidth: 768 },
+      ])
+    );
+    styleSourcesStore.set(toMap([{ id: "box.local", type: "local" }]));
+    styleSourceSelectionsStore.set(
+      toStyleSourceSelectionsMap([{ instanceId: "box", values: ["box.local"] }])
+    );
+    stylesStore.set(
+      toStylesMap([
+        {
+          styleSourceId: "box.local",
+          breakpointId: "base",
+          state: ":hover",
+          property: "color",
+          value: { type: "keyword", value: "green" },
+        },
+        // check stateless declaration does not override state
+        {
+          styleSourceId: "box.local",
+          breakpointId: "base",
+          property: "color",
+          value: { type: "keyword", value: "red" },
+        },
+      ])
+    );
+    selectedInstanceSelectorStore.set(["box"]);
+    selectedStyleSourceSelectorStore.set({ styleSourceId: "box.local" });
+    $selectedBreakpointId.set("small");
+
+    const { result } = renderHook(() => useStyleInfo());
+    expect(getStyleSource(result.current.color)).toEqual("remote");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "red",
+    });
+
+    act(() => {
+      $selectedInstanceStates.set(new Set([":hover"]));
+    });
+    expect(getStyleSource(result.current.color)).toEqual("remote");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "green",
+    });
+  });
+
+  test("show active state inherited from parent as remote", () => {
+    resetStores();
+    instancesStore.set(
+      toMap([
+        {
+          type: "instance",
+          id: "body",
+          component: "Body",
+          children: [{ type: "id", value: "box" }],
+        },
+        { type: "instance", id: "box", component: "Box", children: [] },
+      ])
+    );
+    breakpointsStore.set(toMap([{ id: "base", label: "" }]));
+    styleSourcesStore.set(toMap([{ id: "body.local", type: "local" }]));
+    styleSourceSelectionsStore.set(
+      toStyleSourceSelectionsMap([
+        { instanceId: "body", values: ["body.local"] },
+      ])
+    );
+    stylesStore.set(
+      toStylesMap([
+        {
+          styleSourceId: "body.local",
+          breakpointId: "base",
+          state: ":hover",
+          property: "color",
+          value: { type: "keyword", value: "green" },
+        },
+        // check stateless declaration does not override state
+        {
+          styleSourceId: "body.local",
+          breakpointId: "base",
+          property: "color",
+          value: { type: "keyword", value: "red" },
+        },
+      ])
+    );
+    selectedInstanceSelectorStore.set(["box", "body"]);
+
+    const { result } = renderHook(() => useStyleInfo());
+    expect(getStyleSource(result.current.color)).toEqual("remote");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "red",
+    });
+
+    act(() => {
+      $selectedInstanceStates.set(new Set([":hover"]));
+    });
+    expect(getStyleSource(result.current.color)).toEqual("remote");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "green",
+    });
+  });
+
+  test("show active state from the previous token as remote", () => {
+    resetStores();
+    instancesStore.set(
+      toMap([{ type: "instance", id: "box", component: "Box", children: [] }])
+    );
+    breakpointsStore.set(toMap([{ id: "base", label: "" }]));
+    styleSourcesStore.set(
+      toMap([
+        { id: "box.token", type: "token", name: "" },
+        { id: "box.local", type: "local" },
+      ])
+    );
+    styleSourceSelectionsStore.set(
+      toStyleSourceSelectionsMap([
+        { instanceId: "box", values: ["box.token", "box.local"] },
+      ])
+    );
+    stylesStore.set(
+      toStylesMap([
+        {
+          styleSourceId: "box.token",
+          breakpointId: "base",
+          state: ":hover",
+          property: "color",
+          value: { type: "keyword", value: "green" },
+        },
+        // check stateless declaration does not override state
+        {
+          styleSourceId: "box.token",
+          breakpointId: "base",
+          property: "color",
+          value: { type: "keyword", value: "red" },
+        },
+      ])
+    );
+    selectedInstanceSelectorStore.set(["box"]);
+    selectedStyleSourceSelectorStore.set({ styleSourceId: "box.local" });
+
+    const { result } = renderHook(() => useStyleInfo());
+    expect(getStyleSource(result.current.color)).toEqual("remote");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "red",
+    });
+
+    act(() => {
+      $selectedInstanceStates.set(new Set([":hover"]));
+    });
+    expect(getStyleSource(result.current.color)).toEqual("remote");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "green",
+    });
+  });
+
+  test("show active state from the next token as overwritten", () => {
+    resetStores();
+    instancesStore.set(
+      toMap([{ type: "instance", id: "box", component: "Box", children: [] }])
+    );
+    breakpointsStore.set(toMap([{ id: "base", label: "" }]));
+    styleSourcesStore.set(
+      toMap([
+        { id: "box.first", type: "token", name: "" },
+        { id: "box.second", type: "token", name: "" },
+        { id: "box.third", type: "token", name: "" },
+      ])
+    );
+    styleSourceSelectionsStore.set(
+      toStyleSourceSelectionsMap([
+        { instanceId: "box", values: ["box.first", "box.second", "box.third"] },
+      ])
+    );
+    stylesStore.set(
+      toStylesMap([
+        {
+          styleSourceId: "box.third",
+          breakpointId: "base",
+          state: ":hover",
+          property: "color",
+          value: { type: "keyword", value: "green" },
+        },
+        // check stateless declaration does not override state
+        {
+          styleSourceId: "box.second",
+          breakpointId: "base",
+          state: ":hover",
+          property: "color",
+          value: { type: "keyword", value: "blue" },
+        },
+      ])
+    );
+    selectedInstanceSelectorStore.set(["box"]);
+    selectedStyleSourceSelectorStore.set({ styleSourceId: "box.first" });
+    $selectedInstanceStates.set(new Set([":hover"]));
+
+    const { result } = renderHook(() => useStyleInfo());
+    expect(getStyleSource(result.current.color)).toEqual("remote");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "green",
+    });
+
+    act(() => {
+      selectedStyleSourceSelectorStore.set({ styleSourceId: "box.second" });
+    });
+    expect(getStyleSource(result.current.color)).toEqual("overwritten");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "blue",
+    });
+  });
+
+  test("show active state from preset", () => {
+    resetStores();
+    instancesStore.set(
+      toMap([{ type: "instance", id: "box", component: "Box", children: [] }])
+    );
+    breakpointsStore.set(toMap([{ id: "base", label: "" }]));
+    styleSourcesStore.set(toMap([{ id: "box.local", type: "local" }]));
+    styleSourceSelectionsStore.set(
+      toStyleSourceSelectionsMap([{ instanceId: "box", values: ["box.local"] }])
+    );
+    stylesStore.set(new Map());
+    registeredComponentMetasStore.set(
+      new Map([
+        [
+          "Box",
+          {
+            type: "container",
+            icon: "",
+            presetStyle: {
+              div: [
+                {
+                  state: ":hover",
+                  property: "color",
+                  value: { type: "keyword", value: "green" },
+                },
+                {
+                  property: "color",
+                  value: { type: "keyword", value: "red" },
+                },
+              ],
+            },
+          },
+        ],
+      ])
+    );
+    selectedInstanceSelectorStore.set(["box"]);
+    $selectedInstanceStates.set(new Set([":hover"]));
+    selectedStyleSourceSelectorStore.set({ styleSourceId: "box.local" });
+    selectedInstanceIntanceToTagStore.set(new Map([["box", "div"]]));
+
+    const { result } = renderHook(() => useStyleInfo());
+    expect(getStyleSource(result.current.color)).toEqual("preset");
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "green",
     });
   });
 });

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -27,6 +27,7 @@ import {
   breakpointsStore,
   styleSourceSelectionsStore,
   registeredComponentMetasStore,
+  $selectedInstanceStates,
 } from "~/shared/nano-states";
 import { selectedBreakpointStore } from "~/shared/nano-states";
 import type { InstanceSelector } from "~/shared/tree-utils";
@@ -71,7 +72,11 @@ const CUSTOM_DEFAULT_VALUES: Partial<Record<StyleProperty, StyleValue>> = {
 
 export type StyleValueInfo = {
   value: StyleValue;
+  // either stateful and local exist or stateless and local or just local
+  // @todo improve with more clear structure
+  stateful?: StyleValue;
   local?: StyleValue;
+  stateless?: StyleValue;
   previousSource?: SourceValueInfo;
   nextSource?: SourceValueInfo;
   cascaded?: CascadedValueInfo;
@@ -109,7 +114,12 @@ export const getStyleSource = (
   // show source to use if at least one of control properties matches
   // so user could see if something is set or something is inherited
   for (const info of styleValueInfos) {
-    if (info?.nextSource && info.local) {
+    if (info?.nextSource && (info.local || info.stateful)) {
+      return "overwritten";
+    }
+  }
+  for (const info of styleValueInfos) {
+    if (info?.stateful && info.local) {
       return "overwritten";
     }
   }
@@ -119,26 +129,27 @@ export const getStyleSource = (
     }
   }
   for (const info of styleValueInfos) {
-    if (
-      info?.previousSource !== undefined ||
-      info?.nextSource !== undefined ||
-      info?.cascaded !== undefined
-    ) {
+    if (info?.stateless || info?.stateful) {
       return "remote";
     }
   }
   for (const info of styleValueInfos) {
-    if (info?.preset !== undefined) {
+    if (info?.previousSource || info?.nextSource || info?.cascaded) {
+      return "remote";
+    }
+  }
+  for (const info of styleValueInfos) {
+    if (info?.preset) {
       return "preset";
     }
   }
   for (const info of styleValueInfos) {
-    if (info?.htmlValue !== undefined) {
+    if (info?.htmlValue) {
       return "default";
     }
   }
   for (const info of styleValueInfos) {
-    if (info?.inherited !== undefined) {
+    if (info?.inherited) {
       return "remote";
     }
   }
@@ -153,36 +164,41 @@ for (const [property, value] of Object.entries(properties)) {
   }
 }
 
-const getSelectedStyle = (
+const getLocalStyles = (
   stylesByStyleSourceId: Map<StyleSourceType["id"], StyleDecl[]>,
   breakpointId: string,
-  styleSourceSelector: StyleSourceSelector
+  styleSourceSelector: StyleSourceSelector,
+  activeStates: Set<string>
 ) => {
-  const style: Style = {};
+  const statelessStyles = new Map<StyleProperty, StyleValue>();
+  const localStyles = new Map<StyleProperty, StyleValue>();
+  const statefulStyles = new Map<StyleProperty, StyleValue>();
   const instanceStyles = stylesByStyleSourceId.get(
     styleSourceSelector.styleSourceId
   );
   if (instanceStyles === undefined) {
-    return style;
+    return { statelessStyles, localStyles, statefulStyles };
   }
   for (const styleDecl of instanceStyles) {
-    // @todo consider making stateless styles remote when state is selected
-    if (
-      styleDecl.breakpointId === breakpointId &&
-      styleDecl.state === undefined
-    ) {
-      style[styleDecl.property] = styleDecl.value;
+    if (styleDecl.breakpointId !== breakpointId) {
+      continue;
+    }
+    if (styleDecl.state === undefined) {
+      if (styleSourceSelector.state === undefined) {
+        localStyles.set(styleDecl.property, styleDecl.value);
+      } else {
+        statelessStyles.set(styleDecl.property, styleDecl.value);
+      }
+    }
+    if (styleDecl.state && activeStates.has(styleDecl.state)) {
+      if (styleDecl.state === styleSourceSelector.state) {
+        localStyles.set(styleDecl.property, styleDecl.value);
+      } else {
+        statefulStyles.set(styleDecl.property, styleDecl.value);
+      }
     }
   }
-  for (const styleDecl of instanceStyles) {
-    if (
-      styleDecl.breakpointId === breakpointId &&
-      styleDecl.state === styleSourceSelector.state
-    ) {
-      style[styleDecl.property] = styleDecl.value;
-    }
-  }
-  return style;
+  return { statelessStyles, localStyles, statefulStyles };
 };
 
 /**
@@ -210,7 +226,8 @@ export const getCascadedBreakpointIds = (
 export const getCascadedInfo = (
   stylesByInstanceId: Map<Instance["id"], StyleDecl[]>,
   instanceId: string,
-  cascadedBreakpointIds: string[]
+  cascadedBreakpointIds: string[],
+  activeStates: Set<string>
 ) => {
   const cascadedStyle: CascadedProperties = {};
   const instanceStyles = stylesByInstanceId.get(instanceId);
@@ -222,6 +239,18 @@ export const getCascadedInfo = (
       if (
         styleDecl.breakpointId === breakpointId &&
         styleDecl.state === undefined
+      ) {
+        cascadedStyle[styleDecl.property] = {
+          breakpointId,
+          value: styleDecl.value,
+        };
+      }
+    }
+    for (const styleDecl of instanceStyles) {
+      if (
+        styleDecl.breakpointId === breakpointId &&
+        styleDecl.state &&
+        activeStates.has(styleDecl.state)
       ) {
         cascadedStyle[styleDecl.property] = {
           breakpointId,
@@ -250,7 +279,7 @@ export const getInstanceComponent = (
 export const getPresetStyleRule = (
   meta: undefined | WsComponentMeta,
   tagName: HtmlTags,
-  styleSourceSelector?: StyleSourceSelector
+  activeStates: Set<string>
 ) => {
   const presetStyles = meta?.presetStyle?.[tagName];
   if (presetStyles === undefined) {
@@ -258,11 +287,12 @@ export const getPresetStyleRule = (
   }
   const presetStyle: Style = {};
   for (const styleDecl of presetStyles) {
-    // @todo consider making stateless styles remote when state is selected
     if (styleDecl.state === undefined) {
       presetStyle[styleDecl.property] = styleDecl.value;
     }
-    if (styleDecl.state === styleSourceSelector?.state) {
+  }
+  for (const styleDecl of presetStyles) {
+    if (styleDecl.state && activeStates.has(styleDecl.state)) {
       presetStyle[styleDecl.property] = styleDecl.value;
     }
   }
@@ -280,7 +310,8 @@ export const getInheritedInfo = (
   instanceSelector: InstanceSelector,
   selectedInstanceIntanceToTag: Map<Instance["id"], HtmlTags>,
   cascadedBreakpointIds: string[],
-  selectedBreakpointId: string
+  selectedBreakpointId: string,
+  activeStates: Set<string>
 ) => {
   const inheritedStyle: InheritedProperties = {};
   // skip current instance and start with root til parent
@@ -324,8 +355,22 @@ export const getInheritedInfo = (
       for (const styleDecl of ancestorInstanceStyles) {
         if (
           styleDecl.breakpointId === breakpointId &&
-          styleDecl.state === undefined &&
-          inheritableProperties.has(styleDecl.property)
+          inheritableProperties.has(styleDecl.property) &&
+          styleDecl.state === undefined
+        ) {
+          inheritedStyle[styleDecl.property] = {
+            instanceId: ancestorInstance.id,
+            styleSourceId: styleDecl.styleSourceId,
+            value: styleDecl.value,
+          };
+        }
+      }
+      for (const styleDecl of ancestorInstanceStyles) {
+        if (
+          styleDecl.breakpointId === breakpointId &&
+          inheritableProperties.has(styleDecl.property) &&
+          styleDecl.state &&
+          activeStates.has(styleDecl.state)
         ) {
           inheritedStyle[styleDecl.property] = {
             instanceId: ancestorInstance.id,
@@ -344,7 +389,8 @@ export const getPreviousSourceInfo = (
   stylesByInstanceId: Map<Instance["id"], StyleDecl[]>,
   selectedInstanceSelector: InstanceSelector,
   selectedStyleSourceSelector: StyleSourceSelector,
-  breakpointId: Breakpoint["id"]
+  breakpointId: Breakpoint["id"],
+  activeStates: Set<string>
 ) => {
   const previousSourceStyle: SourceProperties = {};
   const [selectedInstanceId] = selectedInstanceSelector;
@@ -362,7 +408,21 @@ export const getPreviousSourceInfo = (
   for (const styleDecl of instanceStyles) {
     if (
       styleDecl.breakpointId === breakpointId &&
-      previousSourceIds.includes(styleDecl.styleSourceId)
+      previousSourceIds.includes(styleDecl.styleSourceId) &&
+      styleDecl.state === undefined
+    ) {
+      previousSourceStyle[styleDecl.property] = {
+        styleSourceId: styleDecl.styleSourceId,
+        value: styleDecl.value,
+      };
+    }
+  }
+  for (const styleDecl of instanceStyles) {
+    if (
+      styleDecl.breakpointId === breakpointId &&
+      previousSourceIds.includes(styleDecl.styleSourceId) &&
+      styleDecl.state &&
+      activeStates.has(styleDecl.state)
     ) {
       previousSourceStyle[styleDecl.property] = {
         styleSourceId: styleDecl.styleSourceId,
@@ -378,7 +438,8 @@ export const getNextSourceInfo = (
   stylesByInstanceId: Map<Instance["id"], StyleDecl[]>,
   selectedInstanceSelector: InstanceSelector,
   selectedStyleSourceSelector: StyleSourceSelector,
-  breakpointId: Breakpoint["id"]
+  breakpointId: Breakpoint["id"],
+  activeStates: Set<string>
 ) => {
   const nextSourceStyle: SourceProperties = {};
   const [selectedInstanceId] = selectedInstanceSelector;
@@ -396,7 +457,21 @@ export const getNextSourceInfo = (
   for (const styleDecl of instanceStyles) {
     if (
       styleDecl.breakpointId === breakpointId &&
-      nextSourceIds.includes(styleDecl.styleSourceId)
+      nextSourceIds.includes(styleDecl.styleSourceId) &&
+      styleDecl.state === undefined
+    ) {
+      nextSourceStyle[styleDecl.property] = {
+        styleSourceId: styleDecl.styleSourceId,
+        value: styleDecl.value,
+      };
+    }
+  }
+  for (const styleDecl of instanceStyles) {
+    if (
+      styleDecl.breakpointId === breakpointId &&
+      nextSourceIds.includes(styleDecl.styleSourceId) &&
+      styleDecl.state &&
+      activeStates.has(styleDecl.state)
     ) {
       nextSourceStyle[styleDecl.property] = {
         styleSourceId: styleDecl.styleSourceId,
@@ -427,20 +502,42 @@ const useStyleInfoByInstanceAndStyleSource = (
   const { stylesByInstanceId, stylesByStyleSourceId } =
     useStore(stylesIndexStore);
   const styleSourceSelections = useStore(styleSourceSelectionsStore);
+  const selectedInstanceStates = useStore($selectedInstanceStates);
+  const activeStates = useMemo(() => {
+    const activeStates = new Set(selectedInstanceStates);
+    if (styleSourceSelector?.state !== undefined) {
+      activeStates.add(styleSourceSelector.state);
+    }
+    return activeStates;
+  }, [styleSourceSelector, selectedInstanceStates]);
 
-  const selectedStyle = useMemo(() => {
+  const selectedStyle = useMemo((): {
+    statelessStyles: Map<StyleProperty, StyleValue>;
+    localStyles: Map<StyleProperty, StyleValue>;
+    statefulStyles: Map<StyleProperty, StyleValue>;
+  } => {
     if (
       selectedBreakpointId === undefined ||
       styleSourceSelector === undefined
     ) {
-      return {};
+      return {
+        statelessStyles: new Map(),
+        localStyles: new Map(),
+        statefulStyles: new Map(),
+      };
     }
-    return getSelectedStyle(
+    return getLocalStyles(
       stylesByStyleSourceId,
       selectedBreakpointId,
-      styleSourceSelector
+      styleSourceSelector,
+      activeStates
     );
-  }, [stylesByStyleSourceId, selectedBreakpointId, styleSourceSelector]);
+  }, [
+    stylesByStyleSourceId,
+    selectedBreakpointId,
+    activeStates,
+    styleSourceSelector,
+  ]);
 
   const cascadedBreakpointIds = useMemo(
     () => getCascadedBreakpointIds(breakpoints, selectedBreakpointId),
@@ -462,7 +559,8 @@ const useStyleInfoByInstanceAndStyleSource = (
       instanceSelector,
       instanceToTag,
       cascadedBreakpointIds,
-      selectedBreakpointId
+      selectedBreakpointId,
+      activeStates
     );
   }, [
     instances,
@@ -472,6 +570,7 @@ const useStyleInfoByInstanceAndStyleSource = (
     selectedBreakpointId,
     instanceSelector,
     instanceToTag,
+    activeStates,
   ]);
 
   const cascadedInfo = useMemo(() => {
@@ -481,9 +580,15 @@ const useStyleInfoByInstanceAndStyleSource = (
     return getCascadedInfo(
       stylesByInstanceId,
       instanceSelector[0],
-      cascadedBreakpointIds
+      cascadedBreakpointIds,
+      activeStates
     );
-  }, [stylesByInstanceId, instanceSelector, cascadedBreakpointIds]);
+  }, [
+    stylesByInstanceId,
+    instanceSelector,
+    cascadedBreakpointIds,
+    activeStates,
+  ]);
 
   const previousSourceInfo = useMemo(() => {
     if (
@@ -498,7 +603,8 @@ const useStyleInfoByInstanceAndStyleSource = (
       stylesByInstanceId,
       instanceSelector,
       styleSourceSelector,
-      selectedBreakpointId
+      selectedBreakpointId,
+      activeStates
     );
   }, [
     styleSourceSelections,
@@ -506,6 +612,7 @@ const useStyleInfoByInstanceAndStyleSource = (
     instanceSelector,
     styleSourceSelector,
     selectedBreakpointId,
+    activeStates,
   ]);
 
   const nextSourceInfo = useMemo(() => {
@@ -521,7 +628,8 @@ const useStyleInfoByInstanceAndStyleSource = (
       stylesByInstanceId,
       instanceSelector,
       styleSourceSelector,
-      selectedBreakpointId
+      selectedBreakpointId,
+      activeStates
     );
   }, [
     styleSourceSelections,
@@ -529,6 +637,7 @@ const useStyleInfoByInstanceAndStyleSource = (
     instanceSelector,
     styleSourceSelector,
     selectedBreakpointId,
+    activeStates,
   ]);
 
   const presetStyle = useMemo(() => {
@@ -541,12 +650,15 @@ const useStyleInfoByInstanceAndStyleSource = (
     if (tagName === undefined || component === undefined) {
       return;
     }
-    return getPresetStyleRule(
-      metas.get(component),
-      tagName,
-      styleSourceSelector
-    );
-  }, [instances, metas, instanceSelector, instanceToTag, styleSourceSelector]);
+    return getPresetStyleRule(metas.get(component), tagName, activeStates);
+  }, [
+    instances,
+    metas,
+    instanceSelector,
+    instanceToTag,
+    activeStates,
+    styleSourceSelector,
+  ]);
 
   const htmlStyle = useMemo(() => {
     const instanceId = instanceSelector?.[0];
@@ -581,9 +693,14 @@ const useStyleInfoByInstanceAndStyleSource = (
       const cascaded = cascadedInfo[property];
       const previousSource = previousSourceInfo[property];
       const nextSource = nextSourceInfo[property];
-      const local = selectedStyle?.[property];
+      const { statelessStyles, localStyles, statefulStyles } = selectedStyle;
+      const stateful = statefulStyles.get(property);
+      const local = localStyles.get(property);
+      const stateless = statelessStyles.get(property);
       const ownValue =
         local ??
+        stateful ??
+        stateless ??
         nextSource?.value ??
         previousSource?.value ??
         cascaded?.value ??
@@ -607,7 +724,9 @@ const useStyleInfoByInstanceAndStyleSource = (
           const currentColor = ownColor ?? inheritedColor ?? defaultValue;
           styleInfoData[property] = {
             value,
+            stateful,
             local,
+            stateless,
             nextSource,
             previousSource,
             cascaded,
@@ -619,7 +738,9 @@ const useStyleInfoByInstanceAndStyleSource = (
         } else {
           styleInfoData[property] = {
             value,
+            stateful,
             local,
+            stateless,
             nextSource,
             previousSource,
             cascaded,

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -70,11 +70,13 @@ const CUSTOM_DEFAULT_VALUES: Partial<Record<StyleProperty, StyleValue>> = {
   outlineWidth: { value: 0, type: "unit", unit: "px" },
 };
 
+type StatefulValue = { state: string; value: StyleValue };
+
 export type StyleValueInfo = {
   value: StyleValue;
   // either stateful and local exist or stateless and local or just local
   // @todo improve with more clear structure
-  stateful?: StyleValue;
+  stateful?: StatefulValue;
   local?: StyleValue;
   stateless?: StyleValue;
   previousSource?: SourceValueInfo;
@@ -172,7 +174,7 @@ const getLocalStyles = (
 ) => {
   const statelessStyles = new Map<StyleProperty, StyleValue>();
   const localStyles = new Map<StyleProperty, StyleValue>();
-  const statefulStyles = new Map<StyleProperty, StyleValue>();
+  const statefulStyles = new Map<StyleProperty, StatefulValue>();
   const instanceStyles = stylesByStyleSourceId.get(
     styleSourceSelector.styleSourceId
   );
@@ -194,7 +196,10 @@ const getLocalStyles = (
       if (styleDecl.state === styleSourceSelector.state) {
         localStyles.set(styleDecl.property, styleDecl.value);
       } else {
-        statefulStyles.set(styleDecl.property, styleDecl.value);
+        statefulStyles.set(styleDecl.property, {
+          state: styleDecl.state,
+          value: styleDecl.value,
+        });
       }
     }
   }
@@ -514,7 +519,7 @@ const useStyleInfoByInstanceAndStyleSource = (
   const selectedStyle = useMemo((): {
     statelessStyles: Map<StyleProperty, StyleValue>;
     localStyles: Map<StyleProperty, StyleValue>;
-    statefulStyles: Map<StyleProperty, StyleValue>;
+    statefulStyles: Map<StyleProperty, StatefulValue>;
   } => {
     if (
       selectedBreakpointId === undefined ||
@@ -699,7 +704,7 @@ const useStyleInfoByInstanceAndStyleSource = (
       const stateless = statelessStyles.get(property);
       const ownValue =
         local ??
-        stateful ??
+        stateful?.value ??
         stateless ??
         nextSource?.value ??
         previousSource?.value ??

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-badge.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-badge.tsx
@@ -15,6 +15,9 @@ export const StyleSourceBadge = styled(Text, {
   textOverflow: "ellipsis",
   variants: {
     source: {
+      local: {
+        backgroundColor: theme.colors.backgroundStyleSourceLocal,
+      },
       token: {
         backgroundColor: theme.colors.backgroundStyleSourceToken,
       },

--- a/apps/builder/app/canvas/collapsed.ts
+++ b/apps/builder/app/canvas/collapsed.ts
@@ -78,13 +78,15 @@ const getInstanceSize = (instanceId: string, tagName: HtmlTags | undefined) => {
   const component = getInstanceComponent(instances, instanceId);
   const presetStyle =
     tagName !== undefined && component !== undefined
-      ? getPresetStyleRule(metas.get(component), tagName)
+      ? getPresetStyleRule(metas.get(component), tagName, new Set())
       : undefined;
 
-  const cascadedStyle = getCascadedInfo(stylesByInstanceId, instanceId, [
-    ...cascadedBreakpointIds,
-    selectedBreakpointId,
-  ]);
+  const cascadedStyle = getCascadedInfo(
+    stylesByInstanceId,
+    instanceId,
+    [...cascadedBreakpointIds, selectedBreakpointId],
+    new Set()
+  );
 
   const widthStyle = cascadedStyle?.width?.value ?? presetStyle?.width;
   const heightStyle = cascadedStyle?.height?.value ?? presetStyle?.height;

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -11,6 +11,9 @@ import {
   instancesStore,
   selectedInstanceSelectorStore,
   $propValuesByInstanceSelector,
+  $styles,
+  $selectedInstanceStates,
+  styleSourceSelectionsStore,
 } from "~/shared/nano-states";
 import htmlTags, { type htmlTags as HtmlTags } from "html-tags";
 import {
@@ -135,7 +138,7 @@ const subscribeSelectedInstance = (
       return;
     }
 
-    const element = elements[0];
+    const [element] = elements;
     // trigger style recomputing every time instance styles are changed
     selectedInstanceBrowserStyleStore.set(getBrowserStyle(element));
 
@@ -158,6 +161,27 @@ const subscribeSelectedInstance = (
 
     const unitSizes = calculateUnitSizes(element);
     selectedInstanceUnitSizesStore.set(unitSizes);
+
+    const availableStates = new Set<string>();
+    const instanceStyleSourceIds = new Set(
+      styleSourceSelectionsStore.get().get(instanceId)?.values
+    );
+    const styles = $styles.get();
+    for (const styleDecl of styles.values()) {
+      if (
+        instanceStyleSourceIds.has(styleDecl.styleSourceId) &&
+        styleDecl.state
+      ) {
+        availableStates.add(styleDecl.state);
+      }
+    }
+    const activeStates = new Set<string>();
+    for (const state of availableStates) {
+      if (element.matches(state)) {
+        activeStates.add(state);
+      }
+    }
+    $selectedInstanceStates.set(activeStates);
   };
 
   let updateStoreTimeouHandle: undefined | ReturnType<typeof setTimeout>;

--- a/apps/builder/app/shared/nano-states/breakpoints.ts
+++ b/apps/builder/app/shared/nano-states/breakpoints.ts
@@ -7,6 +7,7 @@ export const breakpointsStore = atom<Breakpoints>(new Map());
 export const selectedBreakpointIdStore = atom<undefined | Breakpoint["id"]>(
   undefined
 );
+export const $selectedBreakpointId = selectedBreakpointIdStore;
 
 export const selectedBreakpointStore = computed(
   [breakpointsStore, selectedBreakpointIdStore],

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -67,6 +67,7 @@ export const propsIndexStore = computed(propsStore, (props) => {
 });
 
 export const stylesStore = atom<Styles>(new Map());
+export const $styles = stylesStore;
 
 export const useInstanceStyles = (instanceId: undefined | Instance["id"]) => {
   const instanceStylesStore = useMemo(() => {
@@ -263,6 +264,13 @@ export const selectedStyleSourceStore = computed(
     );
   }
 );
+export const $selectedStyleSource = selectedStyleSourceStore;
+
+/**
+ * Store the list of active states inferred from dom element
+ * to display style values as remote
+ */
+export const $selectedInstanceStates = atom(new Set<string>());
 
 export const hoveredInstanceSelectorStore = atom<undefined | InstanceSelector>(
   undefined

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -31,6 +31,7 @@ import {
   synchronizedComponentsMetaStores,
   dataSourceVariablesStore,
   $dragAndDropState,
+  $selectedInstanceStates,
 } from "~/shared/nano-states";
 import { $ephemeralStyles } from "~/canvas/stores";
 
@@ -109,6 +110,8 @@ export const registerContainers = () => {
   );
   clientStores.set("dragAndDropState", $dragAndDropState);
   clientStores.set("ephemeralStyles", $ephemeralStyles);
+  clientStores.set("selectedInstanceStates", $selectedInstanceStates);
+
   for (const [name, store] of synchronizedBreakpointsStores) {
     clientStores.set(name, store);
   }


### PR DESCRIPTION
Succeeds https://github.com/webstudio-is/webstudio/pull/2136 in more simple way. Active states are preresolved for everything except local styles. And local styles shown as overwritten when defined state is active.

Fixes https://discord.com/channels/955905230107738152/1177028091227418654

## Steps for reproduction

1. create form component
2. choose error state
3. set background red
4. go to error state in style source menu
5. should be "remote" label
6. set background green
7. go to stateless style source
8. reset background color
9. should be "overwritten" label

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
