### PR TITLE
fix: Display error messages when a template is not passed for building a project

### DIFF
--- a/fixtures/webstudio-remix-vercel/package.json
+++ b/fixtures/webstudio-remix-vercel/package.json
@@ -6,7 +6,7 @@
     "typecheck": "tsc",
     "fixtures:link": "webstudio link --link 'https://webstudio-builder-git-main-getwebstudio.vercel.app/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview'",
     "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "webstudio build --preview && pnpm prettier --write ./app/ ./package.json"
+    "fixtures:build": "webstudio build --template vercel --preview && pnpm prettier --write ./app/ ./package.json"
   },
   "private": true,
   "sideEffects": false,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,7 @@ import { initFlow } from "./commands/init-flow";
 import makeCLI from "yargs";
 import packageJson from "../package.json" assert { type: "json" };
 import type { CommonYargsArgv } from "./commands/yargs-types";
+import yargs from "yargs";
 
 export const main = async () => {
   try {
@@ -45,7 +46,17 @@ export const main = async () => {
 
     cmd.version(packageJson.version).alias("v", "version");
 
-    cmd.command(["build"], "Build the project", buildOptions, build);
+    cmd.command(
+      ["build"],
+      "Build the project",
+      (yargs: CommonYargsArgv) => {
+        return buildOptions(yargs).demandOption(
+          "template",
+          "Please specify a template to use for the build"
+        );
+      },
+      build
+    );
     cmd.command(["link"], "Link the project with the cloud", linkOptions, link);
     cmd.command(["sync"], "Sync your project", syncOptions, sync);
     cmd.command(["$0", "init"], "Setup the project", buildOptions, initFlow);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,7 +10,6 @@ import { initFlow } from "./commands/init-flow";
 import makeCLI from "yargs";
 import packageJson from "../package.json" assert { type: "json" };
 import type { CommonYargsArgv } from "./commands/yargs-types";
-import yargs from "yargs";
 
 export const main = async () => {
   try {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -20,14 +20,14 @@ export const buildOptions = (yargs: CommonYargsArgv) =>
     })
     .option("template", {
       type: "string",
-      describe: `Template to use for the build [choices: ${PROJECT_TEMPALTES.toString()}]`,
+      describe: `Template to use for the build [choices: ${PROJECT_TEMPALTES.join(
+        ", "
+      )}]`,
     });
 
 // @todo: use options.assets to define if we need to download assets
 export const build = async (
-  options: StrictYargsOptionsToInterface<typeof buildOptions> & {
-    template: string;
-  }
+  options: StrictYargsOptionsToInterface<typeof buildOptions>
 ) => {
   try {
     await access(LOCAL_DATA_FILE);

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -25,7 +25,9 @@ export const buildOptions = (yargs: CommonYargsArgv) =>
 
 // @todo: use options.assets to define if we need to download assets
 export const build = async (
-  options: StrictYargsOptionsToInterface<typeof buildOptions>
+  options: StrictYargsOptionsToInterface<typeof buildOptions> & {
+    template: string;
+  }
 ) => {
   try {
     await access(LOCAL_DATA_FILE);

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -20,7 +20,6 @@ export const buildOptions = (yargs: CommonYargsArgv) =>
     })
     .option("template", {
       type: "string",
-      default: "vercel",
       describe: `[Experimental] Template to use for the build [choices: ${PROJECT_TEMPALTES.toString()}]`,
     });
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -20,7 +20,7 @@ export const buildOptions = (yargs: CommonYargsArgv) =>
     })
     .option("template", {
       type: "string",
-      describe: `[Experimental] Template to use for the build [choices: ${PROJECT_TEMPALTES.toString()}]`,
+      describe: `Template to use for the build [choices: ${PROJECT_TEMPALTES.toString()}]`,
     });
 
 // @todo: use options.assets to define if we need to download assets

--- a/packages/cli/src/commands/init-flow.ts
+++ b/packages/cli/src/commands/init-flow.ts
@@ -82,6 +82,26 @@ export const initFlow = async (
 
   await sync({ buildId: undefined, origin: undefined, authToken: undefined });
 
+  /*
+    If a project is already linked, we sync direclty without asking for deploy target.
+    We need to request for deploy target here as the current flow is running in a existing project.
+  */
+
+  if (projectTemplate === undefined) {
+    const { deployTarget } = await prompt({
+      type: "select",
+      name: "deployTarget",
+      message: "Where would you like to deploy your project?",
+      choices: PROJECT_TEMPALTES.map((template) => {
+        return {
+          title: titleCase(template),
+          value: template,
+        };
+      }),
+    });
+    projectTemplate = deployTarget;
+  }
+
   await build({
     ...options,
     ...(projectTemplate && { template: projectTemplate }),

--- a/packages/cli/src/commands/init-flow.ts
+++ b/packages/cli/src/commands/init-flow.ts
@@ -58,27 +58,18 @@ export const initFlow = async (
     }
     await link({ link: projectLink });
 
-    const { shouldSetupDeployTarget } = await prompt({
-      type: "confirm",
-      name: "shouldSetupDeployTarget",
-      message: "Would you like to setup a deploy target?",
-      initial: false,
+    const { deployTarget } = await prompt({
+      type: "select",
+      name: "deployTarget",
+      message: "Where would you like to deploy your project?",
+      choices: PROJECT_TEMPALTES.map((template) => {
+        return {
+          title: titleCase(template),
+          value: template,
+        };
+      }),
     });
-
-    if (shouldSetupDeployTarget === true) {
-      const { deployTarget } = await prompt({
-        type: "select",
-        name: "deployTarget",
-        message: "Where would you like to deploy your project?",
-        choices: PROJECT_TEMPALTES.map((template) => {
-          return {
-            title: titleCase(template),
-            value: template,
-          };
-        }),
-      });
-      projectTemplate = deployTarget;
-    }
+    projectTemplate = deployTarget;
 
     const { installDeps } = await prompt({
       type: "confirm",

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -53,6 +53,7 @@ export const jsonToGlobalConfig = (json: unknown) => {
 export type GlobalConfig = z.infer<typeof zGlobalConfig>;
 
 export const PROJECT_TEMPALTES = [
+  "vanilla",
   "vercel",
   "netlify-functions",
   "netlify-edge-functions",

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -197,10 +197,9 @@ export const prebuild = async (options: {
   /**
    * Template to use for the build in addition to defaults template
    **/
-  template?: string;
+  template: string;
 }) => {
   if (
-    options.template !== undefined &&
     (await isCliTemplate(options.template)) === false &&
     options.template.startsWith(".") === false
   ) {

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -197,9 +197,16 @@ export const prebuild = async (options: {
   /**
    * Template to use for the build in addition to defaults template
    **/
-  template: string;
+  template?: string;
 }) => {
+  if (options.template === undefined) {
+    throw new Error(
+      `\n Template is not provided \n Please check webstudio --help for more details`
+    );
+  }
+
   if (
+    options.template !== "vanilla" &&
     (await isCliTemplate(options.template)) === false &&
     options.template.startsWith(".") === false
   ) {
@@ -223,7 +230,7 @@ export const prebuild = async (options: {
 
   await copyTemplates();
 
-  if (options.template !== undefined) {
+  if (options.template !== "vanilla") {
     await copyTemplates(options.template);
   }
 


### PR DESCRIPTION
## Description

fixes #2538 and #2615

Don't use `vercel` as default template while exporting from cli

## Code Review

- [ ] hi @istarkov , I need you to do
  - detailed review (read every line)
  
## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document