### PR TITLE
refactor: reimplement duplicating instances

### DIFF
--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -1,4 +1,6 @@
+import { nanoid } from "nanoid";
 import { toast } from "@webstudio-is/design-system";
+import { equalMedia, type StyleValue } from "@webstudio-is/css-engine";
 import {
   type Instance,
   type Instances,
@@ -13,6 +15,8 @@ import {
   DataSources,
   Props,
   DataSource,
+  Prop,
+  Breakpoint,
 } from "@webstudio-is/sdk";
 import { findTreeInstanceIdsExcludingSlotDescendants } from "@webstudio-is/sdk";
 import {
@@ -21,6 +25,8 @@ import {
   type EmbedTemplateData,
   decodeDataSourceVariable,
   validateExpression,
+  encodeDataSourceVariable,
+  portalComponent,
 } from "@webstudio-is/react-sdk";
 import {
   propsStore,
@@ -34,6 +40,15 @@ import {
   registeredComponentMetasStore,
   dataSourcesStore,
   assetsStore,
+  $instances,
+  $assets,
+  $project,
+  $dataSources,
+  $props,
+  $breakpoints,
+  $styleSources,
+  $styles,
+  $styleSourceSelections,
 } from "./nano-states";
 import {
   type DroppableTarget,
@@ -48,7 +63,6 @@ import { removeByMutable } from "./array-utils";
 import { isBaseBreakpoint } from "./breakpoints";
 import { humanizeString } from "./string-utils";
 import { serverSyncStore } from "./sync";
-import type { StyleValue } from "@webstudio-is/css-engine";
 
 const getLabelFromComponentName = (component: Instance["component"]) => {
   if (component.includes(":")) {
@@ -533,6 +547,17 @@ const traverseStyleValue = (
   value satisfies never;
 };
 
+type InstancesSlice = {
+  instances: Instance[];
+  styleSourceSelections: StyleSourceSelection[];
+  styleSources: StyleSource[];
+  breakpoints: Breakpoint[];
+  styles: StyleDecl[];
+  dataSources: DataSource[];
+  props: Prop[];
+  assets: Asset[];
+};
+
 export const getInstancesSlice = (rootInstanceId: string) => {
   const assets = assetsStore.get();
   const instances = instancesStore.get();
@@ -686,4 +711,453 @@ export const getInstancesSlice = (rootInstanceId: string) => {
     props: Array.from(slicedProps.values()),
     assets: slicedAssets,
   };
+};
+
+export const findAvailableDataSources = (
+  dataSources: DataSources,
+  instanceSelector: InstanceSelector
+) => {
+  const instanceIds = new Set(instanceSelector);
+  const availableDataSources = new Set<DataSource["id"]>();
+  for (const { id, scopeInstanceId } of dataSources.values()) {
+    if (scopeInstanceId && instanceIds.has(scopeInstanceId)) {
+      availableDataSources.add(id);
+    }
+  }
+  return availableDataSources;
+};
+
+const inlineUnavailableDataSources = ({
+  code,
+  availableDataSources,
+  dataSources,
+}: {
+  code: string;
+  availableDataSources: Set<DataSource["id"]>;
+  dataSources: DataSources;
+}) => {
+  let isDiscarded = false;
+  const newCode = validateExpression(code, {
+    effectful: true,
+    transformIdentifier: (identifier, assignee) => {
+      const dataSourceId = decodeDataSourceVariable(identifier);
+      if (
+        dataSourceId === undefined ||
+        availableDataSources.has(dataSourceId)
+      ) {
+        return identifier;
+      }
+      // left operand of assign operator cannot be inlined
+      if (assignee) {
+        isDiscarded = true;
+      }
+      const dataSource = dataSources.get(dataSourceId);
+      // inline variable not scoped to portal content instances
+      if (dataSource?.type === "variable") {
+        return JSON.stringify(dataSource.value.value);
+      }
+      dataSource?.type satisfies undefined;
+      return identifier;
+    },
+  });
+  return { code: newCode, isDiscarded };
+};
+
+const replaceDataSources = (
+  code: string,
+  replacements: Map<DataSource["id"], DataSource["id"]>
+) => {
+  return validateExpression(code, {
+    effectful: true,
+    transformIdentifier: (identifier) => {
+      const dataSourceId = decodeDataSourceVariable(identifier);
+      if (dataSourceId === undefined) {
+        return identifier;
+      }
+      return encodeDataSourceVariable(
+        replacements.get(dataSourceId) ?? dataSourceId
+      );
+    },
+  });
+};
+
+export const insertInstancesSliceCopy = ({
+  slice,
+  availableDataSources,
+  beforeTransactionEnd,
+}: {
+  slice: InstancesSlice;
+  availableDataSources: Set<DataSource["id"]>;
+  beforeTransactionEnd?: (
+    rootInstanceI: Instance["id"],
+    draft: { instances: Instances }
+  ) => void;
+}) => {
+  const projectId = $project.get()?.id;
+  if (projectId === undefined) {
+    return;
+  }
+
+  const sliceInstances: Instances = new Map();
+  const portalContentIds = new Set<Instance["id"]>();
+  for (const instance of slice.instances) {
+    sliceInstances.set(instance.id, instance);
+    if (instance.component === portalComponent) {
+      for (const child of instance.children) {
+        if (child.type === "id") {
+          portalContentIds.add(child.value);
+        }
+      }
+    }
+  }
+
+  const sliceDataSources: DataSources = new Map();
+  for (const dataSource of slice.dataSources) {
+    sliceDataSources.set(dataSource.id, dataSource);
+  }
+
+  serverSyncStore.createTransaction(
+    [
+      $assets,
+      $instances,
+      $dataSources,
+      $props,
+      $breakpoints,
+      $styleSources,
+      $styles,
+      $styleSourceSelections,
+    ],
+    (
+      assets,
+      instances,
+      dataSources,
+      props,
+      breakpoints,
+      styleSources,
+      styles,
+      styleSourceSelections
+    ) => {
+      /**
+       * insert reusables without changing their ids to not bloat data
+       * and catch up with user changes
+       * - assets
+       * - breakpoints
+       * - token styles
+       * - portals
+       *
+       * breakpoints behave slightly differently and merged with existing ones
+       * and those ids are used instead
+       */
+
+      // insert assets
+
+      for (const asset of slice.assets) {
+        // asset can be already present if pasting to the same project
+        if (assets.has(asset.id) === false) {
+          // we use the same asset.id so the references are preserved
+          assets.set(asset.id, { ...asset, projectId });
+        }
+      }
+
+      // merge breakpoints
+
+      const mergedBreakpointIds = new Map<Breakpoint["id"], Breakpoint["id"]>();
+      for (const newBreakpoint of slice.breakpoints) {
+        let matched = false;
+        for (const breakpoint of breakpoints.values()) {
+          if (equalMedia(breakpoint, newBreakpoint)) {
+            matched = true;
+            mergedBreakpointIds.set(newBreakpoint.id, breakpoint.id);
+            break;
+          }
+        }
+        if (matched === false) {
+          breakpoints.set(newBreakpoint.id, newBreakpoint);
+        }
+      }
+
+      // insert tokens with their styles
+
+      const tokenStyleSourceIds = new Set<StyleSource["id"]>();
+      for (const styleSource of slice.styleSources) {
+        // prevent inserting styles when token is already present
+        if (styleSource.type === "local" || styleSources.has(styleSource.id)) {
+          continue;
+        }
+        styleSource.type satisfies "token";
+        tokenStyleSourceIds.add(styleSource.id);
+        styleSources.set(styleSource.id, styleSource);
+      }
+      for (const styleDecl of slice.styles) {
+        if (tokenStyleSourceIds.has(styleDecl.styleSourceId)) {
+          const { breakpointId } = styleDecl;
+          const newStyleDecl: StyleDecl = {
+            ...styleDecl,
+            breakpointId: mergedBreakpointIds.get(breakpointId) ?? breakpointId,
+          };
+          styles.set(getStyleDeclKey(newStyleDecl), newStyleDecl);
+        }
+      }
+
+      // insert portal contents
+      // - instances
+      // - data sources
+      // - props
+      // - local styles
+      for (const rootInstanceId of portalContentIds) {
+        // prevent reinserting portals which could be already changed by user
+        if (instances.has(rootInstanceId)) {
+          continue;
+        }
+
+        const instanceIds = findTreeInstanceIdsExcludingSlotDescendants(
+          sliceInstances,
+          rootInstanceId
+        );
+        for (const instance of slice.instances) {
+          if (instanceIds.has(instance.id)) {
+            instances.set(instance.id, instance);
+          }
+        }
+
+        const availablePortalDataSources = new Set(availableDataSources);
+        for (const dataSource of slice.dataSources) {
+          // insert only data sources within portal content
+          if (
+            dataSource.scopeInstanceId &&
+            instanceIds.has(dataSource.scopeInstanceId)
+          ) {
+            availablePortalDataSources.add(dataSource.id);
+            dataSources.set(dataSource.id, dataSource);
+          }
+        }
+
+        for (let prop of slice.props) {
+          if (instanceIds.has(prop.instanceId) === false) {
+            continue;
+          }
+          // inline data sources not available in scope into expressions
+          if (prop.type === "expression") {
+            const { code } = inlineUnavailableDataSources({
+              code: prop.value,
+              availableDataSources: availablePortalDataSources,
+              dataSources: sliceDataSources,
+            });
+            prop = { ...prop, value: code };
+          }
+          if (prop.type === "action") {
+            prop = {
+              ...prop,
+              value: prop.value.flatMap((value) => {
+                if (value.type !== "execute") {
+                  return [value];
+                }
+                const { code, isDiscarded } = inlineUnavailableDataSources({
+                  code: value.code,
+                  availableDataSources: availablePortalDataSources,
+                  dataSources: sliceDataSources,
+                });
+                if (isDiscarded) {
+                  return [];
+                }
+                return [{ ...value, code }];
+              }),
+            };
+          }
+          props.set(prop.id, prop);
+        }
+
+        // insert local style sources with their styles
+
+        const instanceStyleSourceIds = new Set<StyleSource["id"]>();
+        for (const styleSourceSelection of slice.styleSourceSelections) {
+          const { instanceId } = styleSourceSelection;
+          if (instanceIds.has(instanceId) === false) {
+            continue;
+          }
+          styleSourceSelections.set(instanceId, styleSourceSelection);
+          for (const styleSourceId of styleSourceSelection.values) {
+            instanceStyleSourceIds.add(styleSourceId);
+          }
+        }
+        const localStyleSourceIds = new Set<StyleSource["id"]>();
+        for (const styleSource of slice.styleSources) {
+          if (
+            styleSource.type === "local" &&
+            instanceStyleSourceIds.has(styleSource.id)
+          ) {
+            localStyleSourceIds.add(styleSource.id);
+            styleSources.set(styleSource.id, styleSource);
+          }
+        }
+        for (const styleDecl of slice.styles) {
+          if (localStyleSourceIds.has(styleDecl.styleSourceId)) {
+            const { breakpointId } = styleDecl;
+            const newStyleDecl: StyleDecl = {
+              ...styleDecl,
+              breakpointId:
+                mergedBreakpointIds.get(breakpointId) ?? breakpointId,
+            };
+            styles.set(getStyleDeclKey(newStyleDecl), newStyleDecl);
+          }
+        }
+      }
+
+      /**
+       * inserting unique content is structurally similar to inserting portal content
+       * but all ids are regenerated to support duplicating existing content
+       * - instances
+       * - data sources
+       * - props
+       * - local styles
+       */
+
+      // generate new ids only instances outside of portals
+      const sliceInstanceIds = findTreeInstanceIdsExcludingSlotDescendants(
+        sliceInstances,
+        slice.instances[0].id
+      );
+      const newInstanceIds = new Map<Instance["id"], Instance["id"]>();
+      for (const instanceId of sliceInstanceIds) {
+        newInstanceIds.set(instanceId, nanoid());
+      }
+      for (const instance of slice.instances) {
+        if (sliceInstanceIds.has(instance.id)) {
+          const newId = newInstanceIds.get(instance.id) ?? instance.id;
+          instances.set(newId, {
+            ...instance,
+            id: newId,
+            children: instance.children.map((child) => {
+              if (child.type === "id") {
+                return {
+                  type: "id",
+                  value: newInstanceIds.get(child.value) ?? child.value,
+                };
+              }
+              return child;
+            }),
+          });
+        }
+      }
+
+      const availablePortalDataSources = new Set(availableDataSources);
+      const newDataSourceIds = new Map<DataSource["id"], DataSource["id"]>();
+      for (const dataSource of slice.dataSources) {
+        const { scopeInstanceId } = dataSource;
+        // insert only data sources within portal content
+        if (scopeInstanceId && sliceInstanceIds.has(scopeInstanceId)) {
+          availablePortalDataSources.add(dataSource.id);
+          const newId = nanoid();
+          newDataSourceIds.set(dataSource.id, newId);
+          dataSources.set(newId, {
+            ...dataSource,
+            id: newId,
+            scopeInstanceId: newInstanceIds.get(scopeInstanceId),
+          });
+        }
+      }
+
+      for (let prop of slice.props) {
+        if (sliceInstanceIds.has(prop.instanceId) === false) {
+          continue;
+        }
+        // inline data sources not available in scope into expressions
+        if (prop.type === "expression") {
+          const { code } = inlineUnavailableDataSources({
+            code: prop.value,
+            availableDataSources: availablePortalDataSources,
+            dataSources: sliceDataSources,
+          });
+          prop = { ...prop, value: replaceDataSources(code, newDataSourceIds) };
+        }
+        if (prop.type === "action") {
+          prop = {
+            ...prop,
+            value: prop.value.flatMap((value) => {
+              if (value.type !== "execute") {
+                return [value];
+              }
+              const { code, isDiscarded } = inlineUnavailableDataSources({
+                code: value.code,
+                availableDataSources: availablePortalDataSources,
+                dataSources: sliceDataSources,
+              });
+              if (isDiscarded) {
+                return [];
+              }
+              return [
+                { ...value, code: replaceDataSources(code, newDataSourceIds) },
+              ];
+            }),
+          };
+        }
+        const newId = nanoid();
+        props.set(newId, {
+          ...prop,
+          id: newId,
+          instanceId: newInstanceIds.get(prop.instanceId) ?? prop.instanceId,
+        });
+      }
+
+      // insert local styles with new ids
+
+      const instanceStyleSourceIds = new Set<StyleSource["id"]>();
+      for (const styleSourceSelection of slice.styleSourceSelections) {
+        if (sliceInstanceIds.has(styleSourceSelection.instanceId) === false) {
+          continue;
+        }
+        for (const styleSourceId of styleSourceSelection.values) {
+          instanceStyleSourceIds.add(styleSourceId);
+        }
+      }
+      const newLocalStyleSourceIds = new Map<
+        StyleSource["id"],
+        StyleSource["id"]
+      >();
+      for (const styleSource of slice.styleSources) {
+        if (
+          styleSource.type === "local" &&
+          instanceStyleSourceIds.has(styleSource.id)
+        ) {
+          const newId = nanoid();
+          newLocalStyleSourceIds.set(styleSource.id, newId);
+          styleSources.set(newId, { ...styleSource, id: newId });
+        }
+      }
+      for (const styleSourceSelection of slice.styleSourceSelections) {
+        const { instanceId, values } = styleSourceSelection;
+        if (sliceInstanceIds.has(instanceId) === false) {
+          continue;
+        }
+        const newInstanceId = newInstanceIds.get(instanceId) ?? instanceId;
+        styleSourceSelections.set(newInstanceId, {
+          instanceId: newInstanceId,
+          values: values.map(
+            (styleSourceId) =>
+              newLocalStyleSourceIds.get(styleSourceId) ?? styleSourceId
+          ),
+        });
+        for (const styleSourceId of styleSourceSelection.values) {
+          instanceStyleSourceIds.add(styleSourceId);
+        }
+      }
+      for (const styleDecl of slice.styles) {
+        const { breakpointId, styleSourceId } = styleDecl;
+        if (newLocalStyleSourceIds.has(styleDecl.styleSourceId)) {
+          const newStyleDecl: StyleDecl = {
+            ...styleDecl,
+            styleSourceId:
+              newLocalStyleSourceIds.get(styleSourceId) ?? styleSourceId,
+            breakpointId: mergedBreakpointIds.get(breakpointId) ?? breakpointId,
+          };
+          styles.set(getStyleDeclKey(newStyleDecl), newStyleDecl);
+        }
+      }
+
+      // invoke callback to allow additional changes within same transaction
+      const rootInstanceId =
+        newInstanceIds.get(slice.instances[0].id) ?? slice.instances[0].id;
+      beforeTransactionEnd?.(rootInstanceId, { instances });
+    }
+  );
 };

--- a/apps/builder/app/shared/nano-states/breakpoints.ts
+++ b/apps/builder/app/shared/nano-states/breakpoints.ts
@@ -3,6 +3,7 @@ import type { Breakpoint, Breakpoints } from "@webstudio-is/sdk";
 import { isBaseBreakpoint } from "../breakpoints";
 
 export const breakpointsStore = atom<Breakpoints>(new Map());
+export const $breakpoints = breakpointsStore;
 
 export const selectedBreakpointIdStore = atom<undefined | Breakpoint["id"]>(
   undefined

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -28,6 +28,7 @@ import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-
 import type { Project } from "@webstudio-is/project";
 
 export const projectStore = atom<Project | undefined>();
+export const $project = projectStore;
 
 export const $domains = atom<string[]>([]);
 
@@ -83,10 +84,12 @@ export const useInstanceStyles = (instanceId: undefined | Instance["id"]) => {
 };
 
 export const styleSourcesStore = atom<StyleSources>(new Map());
+export const $styleSources = styleSourcesStore;
 
 export const styleSourceSelectionsStore = atom<StyleSourceSelections>(
   new Map()
 );
+export const $styleSourceSelections = styleSourceSelectionsStore;
 
 export type StyleSourceSelector = {
   styleSourceId: StyleSource["id"];

--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -1,1 +1,3 @@
+export const portalComponent = "Slot";
+
 export const collectionComponent = "ws:component";


### PR DESCRIPTION
Part of https://github.com/webstudio-is/webstudio/issues/2516

Here added new copy implementation. There are 2 differences

- it does not change existing instances and not change their children, we will need this to copy pages
- it handles cross-project copy of portals (slots) properly, now each portal content is inserted separately if the root does not exist and skips otherwise
- much better covered with tests

## Steps for reproduction

1. try duplicating form and change form state prop
2. try duplicating form error message and change form state prop

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
