### PR TITLE
feat: support duplicating pages

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -269,6 +269,10 @@ export const TabContent = ({ onSetActiveTab }: TabContentProps) => {
                 switchPage();
               }
             }}
+            onDuplicate={(newPageId) => {
+              setEditingPageId(undefined);
+              switchPage(newPageId);
+            }}
             pageId={editingPageId}
             key={editingPageId}
           />

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.stories.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.stories.tsx
@@ -80,7 +80,12 @@ export const PageSettingsEdit = () => {
         borderRadius: theme.borderRadius[4],
       }}
     >
-      <PageSettings onClose={() => {}} onDelete={() => {}} pageId="pageId" />
+      <PageSettings
+        onClose={() => {}}
+        onDuplicate={() => {}}
+        onDelete={() => {}}
+        pageId="pageId"
+      />
     </Grid>
   );
 };

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
@@ -43,7 +43,11 @@ import {
 } from "@webstudio-is/icons";
 import { useIds } from "~/shared/form-utils";
 import { Header, HeaderSuffixSpacer } from "../../header";
-import { deleteInstance } from "~/shared/instance-utils";
+import {
+  deleteInstance,
+  getInstancesSlice,
+  insertInstancesSliceCopy,
+} from "~/shared/instance-utils";
 import {
   assetsStore,
   $domains,
@@ -634,7 +638,7 @@ const NewPageSettingsView = ({
 }: {
   onSubmit: () => void;
   isSubmitting: boolean;
-  onClose?: () => void;
+  onClose: () => void;
 } & ComponentProps<typeof FormFields>) => {
   return (
     <>
@@ -771,13 +775,50 @@ const deletePage = (pageId: Page["id"]) => {
   });
 };
 
+const duplicatePage = (pageId: Page["id"]) => {
+  const pages = pagesStore.get();
+  const page =
+    pages?.homePage.id === pageId
+      ? pages.homePage
+      : pages?.pages.find((page) => page.id === pageId);
+  if (page === undefined) {
+    return;
+  }
+
+  const newPageId = nanoid();
+  const { name = page.name, indexString } =
+    // parse "name" or "name (indexString)"
+    page.name.match(/^(?<name>.+) \((?<indexString>\d+)\)$/)?.groups ?? {};
+  const index = Number(indexString ?? "0") + 1;
+  const newName = `${name} (${index})`;
+
+  const slice = getInstancesSlice(page.rootInstanceId);
+  insertInstancesSliceCopy({
+    slice,
+    availableDataSources: new Set(),
+    beforeTransactionEnd: (rootInstanceId, draft) => {
+      const newPage = {
+        ...page,
+        id: newPageId,
+        rootInstanceId,
+        name: newName,
+        path: nameToPath(pages, newName),
+      };
+      draft.pages?.pages.push(newPage);
+    },
+  });
+  return newPageId;
+};
+
 export const PageSettings = ({
   onClose,
+  onDuplicate,
   onDelete,
   pageId,
 }: {
-  onClose?: () => void;
-  onDelete?: () => void;
+  onClose: () => void;
+  onDuplicate: (newPageId: string) => void;
+  onDelete: () => void;
   pageId: string;
 }) => {
   const pages = useStore(pagesStore);
@@ -832,7 +873,7 @@ export const PageSettings = ({
 
   const hanldeDelete = () => {
     deletePage(pageId);
-    onDelete?.();
+    onDelete();
   };
 
   if (page === undefined) {
@@ -843,6 +884,12 @@ export const PageSettings = ({
     <PageSettingsView
       onClose={onClose}
       onDelete={hanldeDelete}
+      onDuplicate={() => {
+        const newPageId = duplicatePage(pageId);
+        if (newPageId !== undefined) {
+          onDuplicate(newPageId);
+        }
+      }}
       errors={errors}
       values={values}
       onChange={handleChange}
@@ -852,11 +899,13 @@ export const PageSettings = ({
 
 const PageSettingsView = ({
   onDelete,
+  onDuplicate,
   onClose,
   ...formFieldsProps
 }: {
   onDelete: () => void;
-  onClose?: () => void;
+  onDuplicate: () => void;
+  onClose: () => void;
 } & ComponentProps<typeof FormFields>) => {
   return (
     <>
@@ -875,6 +924,15 @@ const PageSettingsView = ({
                 />
               </Tooltip>
             )}
+            <Tooltip content="Duplicate page" side="bottom">
+              <Button
+                color="ghost"
+                prefix={<CopyIcon />}
+                onClick={onDuplicate}
+                aria-label="Duplicate page"
+                tabIndex={2}
+              />
+            </Tooltip>
             {onClose && (
               <Tooltip content="Close page settings" side="bottom">
                 <Button

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
@@ -786,11 +786,10 @@ const duplicatePage = (pageId: Page["id"]) => {
   }
 
   const newPageId = nanoid();
-  const { name = page.name, indexString } =
-    // parse "name" or "name (indexString)"
-    page.name.match(/^(?<name>.+) \((?<indexString>\d+)\)$/)?.groups ?? {};
-  const index = Number(indexString ?? "0") + 1;
-  const newName = `${name} (${index})`;
+  const { name = page.name, copyNumber } =
+    // extract a number from "name (copyNumber)"
+    page.name.match(/^(?<name>.+) \((?<copyNumber>\d+)\)$/)?.groups ?? {};
+  const newName = `${name} (${Number(copyNumber ?? "0") + 1})`;
 
   const slice = getInstancesSlice(page.rootInstanceId);
   insertInstancesSliceCopy({

--- a/apps/builder/app/shared/instance-utils.test.ts
+++ b/apps/builder/app/shared/instance-utils.test.ts
@@ -11,6 +11,7 @@ import type {
   Asset,
   Instance,
   Instances,
+  Page,
   Prop,
   StyleDecl,
   StyleDeclKey,
@@ -33,6 +34,7 @@ import {
   $breakpoints,
   $dataSources,
   $instances,
+  $pages,
   $project,
   $props,
   $styleSourceSelections,
@@ -1038,6 +1040,7 @@ describe("insert instances slice copy", () => {
   };
 
   beforeEach(() => {
+    $pages.set({ homePage: { id: "" } as Page, pages: [] });
     $project.set({ id: "current_project" } as Project);
     $assets.set(new Map());
     $breakpoints.set(new Map());

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -17,6 +17,7 @@ import {
   DataSource,
   Prop,
   Breakpoint,
+  Pages,
 } from "@webstudio-is/sdk";
 import { findTreeInstanceIdsExcludingSlotDescendants } from "@webstudio-is/sdk";
 import {
@@ -50,6 +51,7 @@ import {
   $styleSources,
   $styles,
   $styleSourceSelections,
+  $pages,
 } from "./nano-states";
 import {
   type DroppableTarget,
@@ -800,7 +802,7 @@ export const insertInstancesSliceCopy = ({
   availableDataSources: Set<DataSource["id"]>;
   beforeTransactionEnd?: (
     rootInstanceI: Instance["id"],
-    draft: { instances: Instances }
+    draft: { instances: Instances; pages: undefined | Pages }
   ) => void;
 }) => {
   const projectId = $project.get()?.id;
@@ -836,6 +838,7 @@ export const insertInstancesSliceCopy = ({
       $styleSources,
       $styles,
       $styleSourceSelections,
+      $pages,
     ],
     (
       assets,
@@ -845,7 +848,8 @@ export const insertInstancesSliceCopy = ({
       breakpoints,
       styleSources,
       styles,
-      styleSourceSelections
+      styleSourceSelections,
+      pages
     ) => {
       /**
        * insert reusables without changing their ids to not bloat data
@@ -1173,7 +1177,7 @@ export const insertInstancesSliceCopy = ({
       // invoke callback to allow additional changes within same transaction
       const rootInstanceId =
         newInstanceIds.get(slice.instances[0].id) ?? slice.instances[0].id;
-      beforeTransactionEnd?.(rootInstanceId, { instances });
+      beforeTransactionEnd?.(rootInstanceId, { instances, pages });
     }
   );
 };


### PR DESCRIPTION
Fix https://github.com/webstudio-is/webstudio/issues/2516

Here added "duplicate" button to page settings and implemented logic based on recent instances slice utilities.

## Steps for reproduction

1. open pages
2. click on page
3. click "copy" button

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
