### PR TITLE
feat: disable props bound to complex expressions

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/code-editor.tsx
+++ b/apps/builder/app/builder/features/settings-panel/code-editor.tsx
@@ -326,11 +326,13 @@ const paragraphStyle = css({
  * Could be used to edit css as well in the future.
  */
 export const CodeEditor = ({
+  readOnly = false,
   variables,
   defaultValue,
   onChange,
   onBlur,
 }: {
+  readOnly?: boolean;
   variables: Map<string, string>;
   defaultValue: string;
   onChange: (newCode: string) => void;
@@ -338,6 +340,7 @@ export const CodeEditor = ({
 }) => {
   const initialConfig = {
     namespace: "CodeEditor",
+    editable: readOnly === false,
     nodes: [MentionNode],
     theme: {
       root: rootStyle.toString(),

--- a/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
@@ -12,6 +12,7 @@ export const BooleanControl = ({
   prop,
   propName,
   deletable,
+  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"boolean", "boolean">) => {
@@ -30,7 +31,7 @@ export const BooleanControl = ({
       gap="2"
     >
       <Box css={{ position: "relative" }}>
-        <Label htmlFor={id} description={meta.description}>
+        <Label htmlFor={id} description={meta.description} readOnly={readOnly}>
           {getLabel(meta, propName)}
         </Label>
         <VariablesButton
@@ -41,6 +42,7 @@ export const BooleanControl = ({
       </Box>
       <Switch
         id={id}
+        disabled={readOnly}
         checked={prop?.value ?? false}
         onCheckedChange={(value) => onChange({ type: "boolean", value })}
       />

--- a/apps/builder/app/builder/features/settings-panel/controls/check.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/check.tsx
@@ -28,6 +28,7 @@ export const CheckControl = ({
   prop,
   propName,
   deletable,
+  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"check" | "inline-check" | "multi-select", "string[]">) => {
@@ -45,7 +46,11 @@ export const CheckControl = ({
     <VerticalLayout
       label={
         <Box css={{ position: "relative" }}>
-          <Label htmlFor={`${id}:${options[0]}`} description={meta.description}>
+          <Label
+            htmlFor={`${id}:${options[0]}`}
+            description={meta.description}
+            readOnly={readOnly}
+          >
             {getLabel(meta, propName)}
           </Label>
           <VariablesButton
@@ -62,6 +67,7 @@ export const CheckControl = ({
         {options.map((option) => (
           <CheckboxAndLabel key={option}>
             <Checkbox
+              disabled={readOnly}
               checked={value.includes(option)}
               onCheckedChange={(checked) => {
                 onChange({

--- a/apps/builder/app/builder/features/settings-panel/controls/code.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/code.tsx
@@ -7,6 +7,7 @@ export const CodeControl = ({
   prop,
   propName,
   deletable,
+  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"code", "string">) => {
@@ -19,6 +20,7 @@ export const CodeControl = ({
       }}
       prop={prop}
       propName={propName}
+      readOnly={readOnly}
       deletable={deletable}
       onChange={(value) => {
         if (value.type === "string") {

--- a/apps/builder/app/builder/features/settings-panel/controls/color.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/color.tsx
@@ -17,6 +17,7 @@ export const ColorControl = ({
   prop,
   propName,
   deletable,
+  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"color", "string">) => {
@@ -30,7 +31,11 @@ export const ColorControl = ({
     <ResponsiveLayout
       label={
         <Box css={{ position: "relative" }}>
-          <Label htmlFor={id} description={meta.description}>
+          <Label
+            htmlFor={id}
+            description={meta.description}
+            readOnly={readOnly}
+          >
             {getLabel(meta, propName)}
           </Label>
           <VariablesButton
@@ -45,6 +50,7 @@ export const ColorControl = ({
     >
       <InputField
         id={id}
+        disabled={readOnly}
         value={localValue.value}
         onChange={(event) => localValue.set(event.target.value)}
         onBlur={localValue.save}

--- a/apps/builder/app/builder/features/settings-panel/controls/json.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/json.tsx
@@ -16,6 +16,7 @@ export const JsonControl = ({
   prop,
   propName,
   deletable,
+  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"json", "json">) => {
@@ -35,7 +36,9 @@ export const JsonControl = ({
     <VerticalLayout
       label={
         <Box css={{ position: "relative" }}>
-          <Label description={meta.description}>{label}</Label>
+          <Label description={meta.description} readOnly={readOnly}>
+            {label}
+          </Label>
           <VariablesButton
             propId={prop?.id}
             propName={propName}
@@ -50,6 +53,7 @@ export const JsonControl = ({
         <CodeEditor
           // reset editor every time value is changed
           key={valueString}
+          readOnly={readOnly}
           variables={emptyVariables}
           defaultValue={localValue.value}
           onChange={localValue.set}

--- a/apps/builder/app/builder/features/settings-panel/controls/number.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/number.tsx
@@ -15,6 +15,7 @@ export const NumberControl = ({
   propName,
   onChange,
   deletable,
+  readOnly,
   onDelete,
 }: ControlProps<"number", "number">) => {
   const id = useId();
@@ -33,7 +34,11 @@ export const NumberControl = ({
     <ResponsiveLayout
       label={
         <Box css={{ position: "relative" }}>
-          <Label htmlFor={id} description={meta.description}>
+          <Label
+            htmlFor={id}
+            description={meta.description}
+            readOnly={readOnly}
+          >
             {getLabel(meta, propName)}
           </Label>
           <VariablesButton
@@ -48,6 +53,7 @@ export const NumberControl = ({
     >
       <InputField
         id={id}
+        disabled={readOnly}
         type="number"
         value={localValue.value}
         color={isInvalid ? "error" : undefined}

--- a/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
@@ -15,6 +15,7 @@ export const RadioControl = ({
   prop,
   propName,
   deletable,
+  disabled,
   onChange,
   onDelete,
 }: ControlProps<"radio" | "inline-radio", "string">) => {
@@ -45,6 +46,7 @@ export const RadioControl = ({
     >
       <Box css={{ paddingTop: theme.spacing[2] }}>
         <RadioGroup
+          disabled={disabled}
           name="value"
           value={prop?.value}
           onValueChange={(value) => onChange({ type: "string", value })}

--- a/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
@@ -15,7 +15,7 @@ export const RadioControl = ({
   prop,
   propName,
   deletable,
-  disabled,
+  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"radio" | "inline-radio", "string">) => {
@@ -31,7 +31,11 @@ export const RadioControl = ({
     <VerticalLayout
       label={
         <Box css={{ position: "relative" }}>
-          <Label htmlFor={id} description={meta.description}>
+          <Label
+            htmlFor={id}
+            description={meta.description}
+            readOnly={readOnly}
+          >
             {getLabel(meta, propName)}
           </Label>
           <VariablesButton
@@ -46,7 +50,7 @@ export const RadioControl = ({
     >
       <Box css={{ paddingTop: theme.spacing[2] }}>
         <RadioGroup
-          disabled={disabled}
+          disabled={readOnly}
           name="value"
           value={prop?.value}
           onValueChange={(value) => onChange({ type: "string", value })}

--- a/apps/builder/app/builder/features/settings-panel/controls/select.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/select.tsx
@@ -8,6 +8,7 @@ export const SelectControl = ({
   prop,
   propName,
   deletable,
+  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"select", "string">) => {
@@ -23,7 +24,11 @@ export const SelectControl = ({
     <VerticalLayout
       label={
         <Box css={{ position: "relative" }}>
-          <Label htmlFor={id} description={meta.description}>
+          <Label
+            htmlFor={id}
+            description={meta.description}
+            readOnly={readOnly}
+          >
             {getLabel(meta, propName)}
           </Label>
           <VariablesButton
@@ -39,6 +44,7 @@ export const SelectControl = ({
       <Flex css={{ py: theme.spacing[2] }}>
         <Select
           id={id}
+          disabled={readOnly}
           value={prop?.value}
           options={options}
           getLabel={humanizeString}

--- a/apps/builder/app/builder/features/settings-panel/controls/text.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text.tsx
@@ -14,6 +14,7 @@ export const TextControl = ({
   prop,
   propName,
   deletable,
+  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"text", "string">) => {
@@ -28,6 +29,7 @@ export const TextControl = ({
   const input = (
     <TextArea
       id={id}
+      disabled={readOnly}
       autoGrow
       value={localValue.value}
       rows={meta.rows ?? 1}
@@ -41,7 +43,7 @@ export const TextControl = ({
 
   const labelElement = (
     <Box css={{ position: "relative" }}>
-      <Label htmlFor={id} description={meta.description}>
+      <Label htmlFor={id} description={meta.description} readOnly={readOnly}>
         {label}
       </Label>
       <VariablesButton propId={prop?.id} propName={propName} propMeta={meta} />

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -98,7 +98,7 @@ const renderProperty = (
     component,
     instanceId,
   }: PropsSectionProps,
-  { prop, propName, meta }: PropAndMeta,
+  { prop, propName, meta, readOnly }: PropAndMeta,
   deletable?: boolean
 ) => (
   // fix the issue with changing type while binding expression
@@ -111,6 +111,7 @@ const renderProperty = (
       meta,
       prop,
       propName,
+      readOnly,
       deletable: deletable ?? false,
       onDelete: () => {
         if (prop) {
@@ -209,20 +210,6 @@ export const PropsSection = (props: PropsSectionProps) => {
   );
 };
 
-const getPropTypeAndValue = (value: unknown) => {
-  if (typeof value === "boolean") {
-    return { type: "boolean", value } as const;
-  }
-  if (typeof value === "number") {
-    return { type: "number", value } as const;
-  }
-  if (typeof value === "string") {
-    return { type: "string", value } as const;
-  }
-  // fallback to json
-  return { type: "json", value } as const;
-};
-
 export const PropsSectionContainer = ({
   selectedInstance: instance,
 }: {
@@ -240,17 +227,8 @@ export const PropsSectionContainer = ({
 
   const logic = usePropsLogic({
     instance,
-
-    // compute expression prop values before rendering props section
-    // to always show already computed values
-    props:
-      propsByInstanceId.get(instance.id)?.map((prop) => {
-        if (prop.type !== "expression") {
-          return prop;
-        }
-        const propValue = propValues?.get(prop.name);
-        return { ...prop, ...getPropTypeAndValue(propValue) };
-      }) ?? [],
+    props: propsByInstanceId.get(instance.id) ?? [],
+    propValues,
 
     updateProp: (update) => {
       const props = propsStore.get();

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -132,7 +132,7 @@ export const Label = ({
       {readOnly && (
         <Tooltip
           content={
-            "The property's value is controlled by complex expression and cannot be changed"
+            "The value is controlled by an expression and cannot be changed."
           }
           variant="wrapped"
         >

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -8,7 +8,7 @@ import {
 import equal from "fast-deep-equal";
 import type { PropMeta } from "@webstudio-is/react-sdk";
 import type { Prop, Asset } from "@webstudio-is/sdk";
-import { SubtractIcon } from "@webstudio-is/icons";
+import { HelpIcon, SubtractIcon } from "@webstudio-is/icons";
 import {
   SmallIconButton,
   Label as BaseLabel,
@@ -20,6 +20,7 @@ import {
   Text,
   theme,
   type CSS,
+  rawTheme,
 } from "@webstudio-is/design-system";
 import { humanizeString } from "~/shared/string-utils";
 
@@ -52,6 +53,7 @@ export type ControlProps<Control, PropType> = {
   prop: PropByType<PropType> | undefined;
   propName: string;
   deletable: boolean;
+  readOnly: boolean;
   onChange: (value: PropValue, asset?: Asset) => void;
   onDelete: () => void;
 };
@@ -84,6 +86,7 @@ type LabelProps = ComponentPropsWithoutRef<typeof BaseLabel> & {
   children: string;
   description?: string;
   openOnClick?: boolean;
+  readOnly?: boolean;
 };
 
 export const Label = ({
@@ -91,29 +94,52 @@ export const Label = ({
   children,
   description,
   openOnClick = false,
+  readOnly,
   ...rest
 }: LabelProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
+  let label: ReactNode;
+
   if (description == null) {
-    return <SimpleLabel htmlFor={htmlFor}>{children}</SimpleLabel>;
+    label = <SimpleLabel htmlFor={htmlFor}>{children}</SimpleLabel>;
+  } else {
+    label = (
+      <Tooltip
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        content={
+          <Flex
+            direction="column"
+            gap="2"
+            css={{ maxWidth: theme.spacing[28] }}
+          >
+            <Text variant="titles">{children}</Text>
+            <Text>{description}</Text>
+          </Flex>
+        }
+      >
+        <BaseLabel truncate htmlFor={htmlFor} {...rest}>
+          {children}
+        </BaseLabel>
+      </Tooltip>
+    );
   }
 
   return (
-    <Tooltip
-      open={isOpen}
-      onOpenChange={setIsOpen}
-      content={
-        <Flex direction="column" gap="2" css={{ maxWidth: theme.spacing[28] }}>
-          <Text variant="titles">{children}</Text>
-          <Text>{description}</Text>
-        </Flex>
-      }
-    >
-      <BaseLabel truncate htmlFor={htmlFor} {...rest}>
-        {children}
-      </BaseLabel>
-    </Tooltip>
+    <Flex align="center" css={{ gap: theme.spacing[3] }}>
+      {label}
+      {readOnly && (
+        <Tooltip
+          content={
+            "The property's value is controlled by complex expression and cannot be changed"
+          }
+          variant="wrapped"
+        >
+          <HelpIcon color={rawTheme.colors.foregroundSubtle} tabIndex={0} />
+        </Tooltip>
+      )}
+    </Flex>
   );
 };
 


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here added logic to disable props controlled by complex expressions like `formState === 'success'` where we cannot change variable value.

Added icon with tooltip near label to clarify why it is disabled.

<img width="312" alt="Screenshot 2023-12-03 at 13 46 47" src="https://github.com/webstudio-is/webstudio/assets/5635476/ce5680d4-8e9c-4467-ac6a-5971d3ce99ab">
<img width="308" alt="Screenshot 2023-12-03 at 13 36 56" src="https://github.com/webstudio-is/webstudio/assets/5635476/ecc20bd5-cfab-43a9-bc20-a762cd6d37b2">


## Steps for reproduction

1. create form
2. select success message
3. check "show" prop
4. create collection
5. go to html embed and change "code" expression to `collectionItem + " pie"`
6. check code prop

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
