### PR TITLE
fix: create temporary files within assets directory

### DIFF
--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -93,8 +93,6 @@ export const downloadAsset = async (
   // Error: EXDEV: cross-device link not permitted
   const tempAssetPath = `${assetPath}.tmp`;
 
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-
   try {
     await access(assetPath);
   } catch {


### PR DESCRIPTION
Fixes https://discord.com/channels/955905230107738152/1133337749856989316/1181798549982302329

This fixes linux issue when tmp and cwd are on different mounts or drives.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
