### PR TITLE
refactor: support parameter data source for collection item

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
@@ -30,6 +30,10 @@ export const renderControl = ({
     return;
   }
 
+  if (meta.control === "json" && (prop === undefined || prop.type === "json")) {
+    return <JsonControl meta={meta} prop={prop} {...rest} />;
+  }
+
   if (
     meta.control === "text" &&
     (prop === undefined || prop.type === "string")

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -199,7 +199,7 @@ export const usePropsLogic = ({
     const potentialVariableId = decodeDataSourceVariable(prop.value);
     return (
       potentialVariableId === undefined ||
-      dataSources.has(potentialVariableId) === false
+      dataSources.get(potentialVariableId)?.type !== "variable"
     );
   };
 

--- a/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
@@ -371,7 +371,7 @@ describe("data sources", () => {
     );
   });
 
-  test("copy parameter prop with new data source", () => {
+  test.only("copy parameter prop with new data source", () => {
     const instances: Instances = toMap([
       createInstance("body", "Body", [{ type: "id", value: "list" }]),
       createInstance("list", collectionComponent, []),
@@ -380,9 +380,8 @@ describe("data sources", () => {
       {
         id: "itemDataSource",
         scopeInstanceId: "list",
-        type: "variable",
+        type: "parameter",
         name: "item",
-        value: { type: "json", value: {} },
       },
     ] satisfies DataSource[]);
     const props: Props = toMap([
@@ -427,9 +426,8 @@ describe("data sources", () => {
           {
             id: itemDataSourceId,
             scopeInstanceId: collectionId,
-            type: "variable",
+            type: "parameter",
             name: "item",
-            value: { type: "json", value: {} },
           },
         ],
       ])

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -768,8 +768,7 @@ const inlineUnavailableDataSources = ({
       if (dataSource?.type === "variable") {
         return JSON.stringify(dataSource.value.value);
       }
-      dataSource?.type satisfies undefined;
-      return identifier;
+      return "";
     },
   });
   return { code: newCode, isDiscarded };

--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -276,9 +276,8 @@ test("compute expression from collection items", () => {
     toMap([
       {
         id: "itemId",
-        type: "variable",
+        type: "parameter",
         name: "item",
-        value: { type: "json", value: {} },
       },
     ])
   );

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -640,9 +640,8 @@ test("avoid generating collection parameter variable as state", () => {
         createDataSourcePair({
           id: "dataSourceItem",
           scopeInstanceId: "list",
-          type: "variable",
+          type: "parameter",
           name: "element",
-          value: { type: "json", value: `` },
         }),
       ]),
       props: new Map([

--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -18,9 +18,6 @@ const collectionMeta: WsComponentMeta = {
     {
       type: "instance",
       component: collectionComponent,
-      variables: {
-        collectionItem: { initialValue: "" },
-      },
       props: [
         {
           name: "data",

--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -14,6 +14,7 @@ const collectionMeta: WsComponentMeta = {
   type: "container",
   label: "Collection",
   icon: ListIcon,
+  stylable: false,
   template: [
     {
       type: "instance",

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -490,9 +490,6 @@ test("generate data for embedding from parameter props", () => {
       {
         type: "instance",
         component: "Box",
-        variables: {
-          parameterName: { initialValue: "" },
-        },
         props: [
           {
             type: "parameter",
@@ -529,11 +526,10 @@ test("generate data for embedding from parameter props", () => {
     ],
     dataSources: [
       {
-        type: "variable",
+        type: "parameter",
         id: variableId,
         scopeInstanceId: instanceId,
         name: "parameterName",
-        value: { type: "string", value: "" },
       },
     ],
     styleSourceSelections: [],

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -230,10 +230,14 @@ const createInstancesFromTemplate = (
           }
 
           if (prop.type === "parameter") {
-            const dataSourceId = dataSourceByRef.get(prop.variableName)?.id;
-            if (dataSourceId === undefined) {
-              continue;
-            }
+            const dataSourceId = generateId();
+            // generate data sources implicitly
+            dataSourceByRef.set(prop.variableName, {
+              type: "parameter",
+              id: dataSourceId,
+              scopeInstanceId: instanceId,
+              name: prop.variableName,
+            });
             props.push({
               id: propId,
               instanceId,

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -7,6 +7,9 @@ import {
 } from "./expression";
 import { createScope } from "@webstudio-is/sdk";
 
+const toMap = <T extends { id: string }>(list: T[]) =>
+  new Map(list.map((item) => [item.id, item]));
+
 test("allow literals and array expressions", () => {
   expect(
     validateExpression(`["", '', 0, true, false, null, undefined]`)
@@ -292,4 +295,30 @@ test("generate function for empty action", () => {
   `);
   expect(generated.variables).toEqual(new Map());
   expect(generated.output).toEqual(new Map([["prop1", "onChange"]]));
+});
+
+test("prevent generating parameter variables", () => {
+  const generated = generateDataSources({
+    scope: createScope(),
+    dataSources: toMap([
+      {
+        id: "dataSourceid",
+        scopeInstanceId: "instanceId",
+        type: "parameter",
+        name: "myParameter",
+      },
+    ]),
+    props: toMap([
+      {
+        id: "propId",
+        instanceId: "instanceId",
+        type: "expression",
+        name: "value",
+        value: "$ws$dataSource$dataSourceId",
+      },
+    ]),
+  });
+  expect(generated.body).toEqual("");
+  expect(generated.variables).toEqual(new Map());
+  expect(generated.output).toEqual(new Map());
 });

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -249,11 +249,6 @@ export const generateDataSources = ({
   }
 
   for (const prop of props.values()) {
-    // prevent generating parameter variables as component state
-    if (prop.type === "parameter") {
-      output.delete(prop.value);
-      variables.delete(prop.value);
-    }
     // generate actions assigning variables and invoking their setters
     if (prop.type === "action") {
       const name = scope.getName(prop.id, prop.name);

--- a/packages/sdk/src/schema/data-sources.ts
+++ b/packages/sdk/src/schema/data-sources.ts
@@ -34,7 +34,12 @@ export const DataSource = z.union([
     name: z.string(),
     value: DataSourceVariableValue,
   }),
-  z.never(),
+  z.object({
+    type: z.literal("parameter"),
+    id: DataSourceId,
+    scopeInstanceId: z.optional(z.string()),
+    name: z.string(),
+  }),
 ]);
 
 export type DataSource = z.infer<typeof DataSource>;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here added dataSource.type = 'parameter' without initial value because value is always provided by context. It let us fix a few issues with variables without complicating logic.

- prevent deleting parameter variable (collection item) in variables panel
- allow changing only name of parameter variable
- show only name in the list of variables
- fix removing expression from collection data
- hide item parameter from collection variable list
- prevent editing parameter value from props
- make collection unstylable

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
