### PR TITLE
feat: validate page path

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
@@ -389,7 +389,7 @@ const FormFields = ({
                   Path
                   <Tooltip
                     content={
-                      "Path may contain dynamic parameters '/:name/rest' or wildcard with the rest of url in the end '/*' or '/:name*'"
+                      "The path can include dynamic parameters like :name, which could be made optional using :name?, or have a wildcard such as /* or /:name* to store whole remaining part at the end of the URL."
                     }
                     variant="wrapped"
                   >

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
@@ -35,6 +35,8 @@ import {
   Separator,
   Text,
   ScrollArea,
+  rawTheme,
+  Flex,
 } from "@webstudio-is/design-system";
 import {
   ChevronDoubleLeftIcon,
@@ -43,6 +45,7 @@ import {
   CheckMarkIcon,
   LinkIcon,
   HomeIcon,
+  HelpIcon,
 } from "@webstudio-is/icons";
 import { useIds } from "~/shared/form-utils";
 import { Header, HeaderSuffixSpacer } from "../../header";
@@ -72,7 +75,11 @@ import { SocialPreview } from "./social-preview";
 import { useEffectEvent } from "~/builder/features/ai/hooks/effect-event";
 import { CustomMetadata } from "./custom-metadata";
 import env from "~/shared/env";
-import { compilePathnamePattern, parsePathnamePattern } from "./url-pattern";
+import {
+  compilePathnamePattern,
+  parsePathnamePattern,
+  validatePathnamePattern,
+} from "./url-pattern";
 
 const fieldDefaultValues = {
   name: "Untitled",
@@ -171,13 +178,16 @@ const validateValues = (
   if (parsedResult.success === false) {
     return parsedResult.error.formErrors.fieldErrors;
   }
-  if (
-    pages !== undefined &&
-    values.path !== undefined &&
-    isPathUnique(pages, pageId, values.path) === false
-  ) {
-    errors.path = errors.path ?? [];
-    errors.path.push("All paths must be unique");
+  if (pages !== undefined && values.path !== undefined) {
+    if (isPathUnique(pages, pageId, values.path) === false) {
+      errors.path = errors.path ?? [];
+      errors.path.push("All paths must be unique");
+    }
+    const messages = validatePathnamePattern(values.path);
+    if (messages.length > 0) {
+      errors.path = errors.path ?? [];
+      errors.path.push(...messages);
+    }
   }
   return errors;
 };
@@ -374,7 +384,22 @@ const FormFields = ({
 
           {values.isHomePage === false && (
             <Grid gap={1}>
-              <Label htmlFor={fieldIds.path}>Path</Label>
+              <Label htmlFor={fieldIds.path}>
+                <Flex align="center" css={{ gap: theme.spacing[3] }}>
+                  Path
+                  <Tooltip
+                    content={
+                      "Path may contain dynamic parameters '/:name/rest' or wildcard with the rest of url in the end '/*' or '/:name*'"
+                    }
+                    variant="wrapped"
+                  >
+                    <HelpIcon
+                      color={rawTheme.colors.foregroundSubtle}
+                      tabIndex={0}
+                    />
+                  </Tooltip>
+                </Flex>
+              </Label>
               <InputErrorsTooltip errors={errors.path}>
                 <InputField
                   tabIndex={1}

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/url-pattern.test.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/url-pattern.test.ts
@@ -89,54 +89,54 @@ test("validate named groups with optional modifier", () => {
 
 test('validate "one or more" named group modifier', () => {
   expect(validatePathnamePattern("/:name+/:slug+")).toEqual([
-    "+ modifier is not allowed at ':name+', ':slug+'",
+    "Dynamic parameters ':name+', ':slug+' shouldn't have the + modifier.",
   ]);
 });
 
 test('validate "zero or more" named group modifier', () => {
   expect(validatePathnamePattern("/:name*")).toEqual([]);
   expect(validatePathnamePattern("/:name*/:another*/:slug*")).toEqual([
-    "* modifier is not allowed at ':name*', ':another*' and can be used only in the end",
+    "':name*', ':another*' should end the path.",
   ]);
 });
 
 test("validate wildcard groups", () => {
   expect(validatePathnamePattern("/*")).toEqual([]);
   expect(validatePathnamePattern("/*?/*?")).toEqual([
-    `? modifier is not allowed on wildcard group at '*?'`,
+    `Optional wildcard '*?' is not allowed.`,
   ]);
   expect(validatePathnamePattern("/*/*")).toEqual([
-    `Wildcard group '*' is allowed only in the end`,
+    `Wildcard '*' should end the path.`,
   ]);
   expect(validatePathnamePattern("/*/last")).toEqual([
-    `Wildcard group '*' is allowed only in the end`,
+    `Wildcard '*' should end the path.`,
   ]);
   expect(validatePathnamePattern("/*?/*/last")).toEqual([
-    `? modifier is not allowed on wildcard group at '*?'`,
-    `Wildcard group '*' is allowed only in the end`,
+    `Optional wildcard '*?' is not allowed.`,
+    `Wildcard '*' should end the path.`,
   ]);
 });
 
 test("forbid wildcard group with static parts before", () => {
   expect(validatePathnamePattern("/blog-*")).toEqual([
-    `Cannot use wildcard at 'blog-*'`,
+    `Static parts cannot be mixed with dynamic parameters at 'blog-*'.`,
   ]);
 });
 
 test(`forbid named group with "zero or more" modifier and static parts before`, () => {
   expect(validatePathnamePattern("/blog-:slug*")).toEqual([
-    `Cannot use named group at 'blog-:slug*'`,
+    `Static parts cannot be mixed with dynamic parameters at 'blog-:slug*'.`,
   ]);
 });
 
 test(`forbid named group with static parts before or after`, () => {
   expect(validatePathnamePattern("/prefix-:id")).toEqual([
-    `Cannot use named group at 'prefix-:id'`,
+    `Static parts cannot be mixed with dynamic parameters at 'prefix-:id'.`,
   ]);
   expect(validatePathnamePattern("/:id-suffix")).toEqual([
-    `Cannot use named group at ':id-suffix'`,
+    `Static parts cannot be mixed with dynamic parameters at ':id-suffix'.`,
   ]);
   expect(validatePathnamePattern("/prefix-:id-suffix")).toEqual([
-    `Cannot use named group at 'prefix-:id-suffix'`,
+    `Static parts cannot be mixed with dynamic parameters at 'prefix-:id-suffix'.`,
   ]);
 });

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/url-pattern.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/url-pattern.ts
@@ -15,7 +15,6 @@ export const parsePathnamePattern = (pathname: string) => {
 
 const indexRegex = /^\d+$/;
 
-// @todo prevent replacing with empty strigs
 export const compilePathnamePattern = (
   pathname: string,
   values: Record<string, string>
@@ -37,4 +36,78 @@ export const compilePathnamePattern = (
     }
   }
   return pathname;
+};
+
+export const validatePathnamePattern = (pathname: string) => {
+  try {
+    new URLPattern(pathname, baseUrl);
+  } catch {
+    return [`Invalid path pattern '${pathname}'`];
+  }
+
+  const messages: string[] = [];
+
+  // allowed syntax
+  // :name - group without modifiers
+  // :name? - group with optional modifier
+  // :name* - group with zero or more modifier in the end
+  // * - wildcard group in the end
+
+  // fobid :name+ everywhere
+  const namedGroupsWithPlus = Array.from(pathname.matchAll(/:\w+\+/g)).flat();
+  if (namedGroupsWithPlus.length > 0) {
+    const list = namedGroupsWithPlus.map((item) => `'${item}'`).join(", ");
+    messages.push(`+ modifier is not allowed at ${list}`);
+  }
+
+  // :name* in the middle
+  const namedGroupsWithAsterisk = Array.from(
+    // skip matching in the end of string
+    pathname.matchAll(/:\w+\*(?!$)/g)
+  ).flat();
+  if (namedGroupsWithAsterisk.length > 0) {
+    const list = namedGroupsWithAsterisk.map((item) => `'${item}'`).join(", ");
+    messages.push(
+      `* modifier is not allowed at ${list} and can be used only in the end`
+    );
+  }
+
+  // *? everywhere
+  const wildcardGroupsWithQuestion = Array.from(
+    pathname.matchAll(/\*\?/g)
+  ).flat();
+  if (wildcardGroupsWithQuestion.length > 0) {
+    messages.push(`? modifier is not allowed on wildcard group at '*?'`);
+  }
+
+  // * in the middle
+  const wildcardGroups = Array.from(
+    // skip matching with :name before *
+    // skip matching with ? after *
+    // skip matching with * in the end
+    pathname.matchAll(/(?<!:\w+)\*(?!\?)(?!$)/g)
+  ).flat();
+  if (wildcardGroups.length > 0) {
+    messages.push(`Wildcard group '*' is allowed only in the end`);
+  }
+
+  // show segment errors only when syntax is valid
+  if (messages.length > 0) {
+    return messages;
+  }
+
+  for (const segment of pathname.split("/")) {
+    const group = segment.match(/(?<group>:\w+(\*|\?)?)/)?.groups?.group;
+    if (group) {
+      if (group.length !== segment.length) {
+        messages.push(`Cannot use named group at '${segment}'`);
+      }
+    } else if (segment.includes("*")) {
+      if (segment.length > 1) {
+        messages.push(`Cannot use wildcard at '${segment}'`);
+      }
+    }
+  }
+
+  return messages;
 };

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/url-pattern.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/url-pattern.ts
@@ -57,7 +57,7 @@ export const validatePathnamePattern = (pathname: string) => {
   const namedGroupsWithPlus = Array.from(pathname.matchAll(/:\w+\+/g)).flat();
   if (namedGroupsWithPlus.length > 0) {
     const list = namedGroupsWithPlus.map((item) => `'${item}'`).join(", ");
-    messages.push(`+ modifier is not allowed at ${list}`);
+    messages.push(`Dynamic parameters ${list} shouldn't have the + modifier.`);
   }
 
   // :name* in the middle
@@ -67,9 +67,7 @@ export const validatePathnamePattern = (pathname: string) => {
   ).flat();
   if (namedGroupsWithAsterisk.length > 0) {
     const list = namedGroupsWithAsterisk.map((item) => `'${item}'`).join(", ");
-    messages.push(
-      `* modifier is not allowed at ${list} and can be used only in the end`
-    );
+    messages.push(`${list} should end the path.`);
   }
 
   // *? everywhere
@@ -77,7 +75,7 @@ export const validatePathnamePattern = (pathname: string) => {
     pathname.matchAll(/\*\?/g)
   ).flat();
   if (wildcardGroupsWithQuestion.length > 0) {
-    messages.push(`? modifier is not allowed on wildcard group at '*?'`);
+    messages.push(`Optional wildcard '*?' is not allowed.`);
   }
 
   // * in the middle
@@ -88,7 +86,7 @@ export const validatePathnamePattern = (pathname: string) => {
     pathname.matchAll(/(?<!:\w+)\*(?!\?)(?!$)/g)
   ).flat();
   if (wildcardGroups.length > 0) {
-    messages.push(`Wildcard group '*' is allowed only in the end`);
+    messages.push(`Wildcard '*' should end the path.`);
   }
 
   // show segment errors only when syntax is valid
@@ -100,11 +98,15 @@ export const validatePathnamePattern = (pathname: string) => {
     const group = segment.match(/(?<group>:\w+(\*|\?)?)/)?.groups?.group;
     if (group) {
       if (group.length !== segment.length) {
-        messages.push(`Cannot use named group at '${segment}'`);
+        messages.push(
+          `Static parts cannot be mixed with dynamic parameters at '${segment}'.`
+        );
       }
     } else if (segment.includes("*")) {
       if (segment.length > 1) {
-        messages.push(`Cannot use wildcard at '${segment}'`);
+        messages.push(
+          `Static parts cannot be mixed with dynamic parameters at '${segment}'.`
+        );
       }
     }
   }

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -52,8 +52,8 @@ export const PagePath = z
   .refine((path) => path.endsWith("/") === false, "Can't end with a /")
   .refine((path) => path.includes("//") === false, "Can't contain repeating /")
   .refine(
-    (path) => /^[-_a-z0-9*:\\/]*$/.test(path),
-    "Only a-z, 0-9, -, _, /, : and * are allowed"
+    (path) => /^[-_a-z0-9*:?\\/]*$/.test(path),
+    "Only a-z, 0-9, -, _, /, :, ? and * are allowed"
   )
   .refine(
     // We use /s for our system stuff like /s/css or /s/uploads


### PR DESCRIPTION
Here added description tooltip and additional validation to constrain UrlPattern syntax to fit most framework abilities.

<img width="765" alt="Screenshot 2023-12-13 at 15 58 11" src="https://github.com/webstudio-is/webstudio/assets/5635476/f4124e66-a483-4228-b576-99b9d57afc31">
<img width="528" alt="Screenshot 2023-12-13 at 15 56 45" src="https://github.com/webstudio-is/webstudio/assets/5635476/e3241ebe-bfb1-4e79-9ade-691700b9e08b">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
