### PR TITLE
feat: support page path params in site compiler

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -43,7 +43,8 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="ibXgMoi9_ipHx1gVrvii0" data-ws-component="Body">
       <Heading data-ws-id="7pwqBSgrfuuOfk1JblWcL" data-ws-component="Heading">
@@ -54,6 +55,10 @@ const Page = () => {
 };
 
 export { Page };
+
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
+};
 
 export const pagesPaths = new Set([""]);
 

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -7,6 +7,7 @@ import {
   type LoaderArgs,
   json,
 } from "@remix-run/server-runtime";
+import { useLoaderData } from "@remix-run/react";
 import type { Page as PageType, SiteMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
@@ -19,6 +20,7 @@ import {
   formsProperties,
   Page,
   imageAssets,
+  getRemixParams,
 } from "../__generated__/_index.tsx";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
@@ -29,6 +31,8 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const params = getRemixParams(arg.params);
+
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -46,6 +50,7 @@ export const loader = async (arg: LoaderArgs) => {
       host,
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
+      params,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -282,6 +287,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
+  const { params } = useLoaderData();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -291,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -27,7 +27,8 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="MMimeobf_zi4ZkRGXapju" data-ws-component="Body">
       <Heading data-ws-id="MYDt0guk1-vzc7yzqyN6A" data-ws-component="Heading">
@@ -41,6 +42,10 @@ const Page = () => {
 };
 
 export { Page };
+
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
+};
 
 export const pagesPaths = new Set([""]);
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -7,6 +7,7 @@ import {
   type LoaderArgs,
   json,
 } from "@remix-run/server-runtime";
+import { useLoaderData } from "@remix-run/react";
 import type { Page as PageType, SiteMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
@@ -19,6 +20,7 @@ import {
   formsProperties,
   Page,
   imageAssets,
+  getRemixParams,
 } from "../__generated__/_index.tsx";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
@@ -29,6 +31,8 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const params = getRemixParams(arg.params);
+
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -46,6 +50,7 @@ export const loader = async (arg: LoaderArgs) => {
       host,
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
+      params,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -282,6 +287,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
+  const { params } = useLoaderData();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -291,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -27,7 +27,8 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="MMimeobf_zi4ZkRGXapju" data-ws-component="Body">
       <Heading data-ws-id="MYDt0guk1-vzc7yzqyN6A" data-ws-component="Heading">
@@ -41,6 +42,10 @@ const Page = () => {
 };
 
 export { Page };
+
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
+};
 
 export const pagesPaths = new Set([""]);
 

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -7,6 +7,7 @@ import {
   type LoaderArgs,
   json,
 } from "@remix-run/server-runtime";
+import { useLoaderData } from "@remix-run/react";
 import type { Page as PageType, SiteMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
@@ -19,6 +20,7 @@ import {
   formsProperties,
   Page,
   imageAssets,
+  getRemixParams,
 } from "../__generated__/_index.tsx";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
@@ -29,6 +31,8 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const params = getRemixParams(arg.params);
+
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -46,6 +50,7 @@ export const loader = async (arg: LoaderArgs) => {
       host,
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
+      params,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -282,6 +287,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
+  const { params } = useLoaderData();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -291,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -63,7 +63,8 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="EDEfpMPRqDejthtwkH7ws" data-ws-component="Body">
       <Image
@@ -76,6 +77,10 @@ const Page = () => {
 };
 
 export { Page };
+
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
+};
 
 export const pagesPaths = new Set([
   "",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -72,7 +72,8 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [formState, set$formState] = useState<any>("initial");
   let [formState_1, set$formState_1] = useState<any>("initial");
   let onStateChange = (state: any) => {
@@ -192,6 +193,10 @@ const Page = () => {
 };
 
 export { Page };
+
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
+};
 
 export const pagesPaths = new Set([
   "",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -63,7 +63,8 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="O-ljaGZQ0iRNTlEshMkgE" data-ws-component="Body">
       <Heading
@@ -78,6 +79,10 @@ const Page = () => {
 };
 
 export { Page };
+
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
+};
 
 export const pagesPaths = new Set([
   "",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -79,7 +79,8 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [accordionValue, set$accordionValue] = useState<any>("0");
   let onValueChange = (value: any) => {
     accordionValue = value;
@@ -206,6 +207,10 @@ const Page = () => {
 };
 
 export { Page };
+
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
+};
 
 export const pagesPaths = new Set([
   "",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -77,7 +77,8 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="On9cvWCxr5rdZtY9O1Bv0" data-ws-component="Body">
       <Heading data-ws-id="nVMWvMsaLCcb0o1wuNQgg" data-ws-component="Heading">
@@ -151,6 +152,10 @@ const Page = () => {
 };
 
 export { Page };
+
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
+};
 
 export const pagesPaths = new Set([
   "",

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -7,6 +7,7 @@ import {
   type LoaderArgs,
   json,
 } from "@remix-run/server-runtime";
+import { useLoaderData } from "@remix-run/react";
 import type { Page as PageType, SiteMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
@@ -19,6 +20,7 @@ import {
   formsProperties,
   Page,
   imageAssets,
+  getRemixParams,
 } from "../__generated__/[_route_with_symbols_]._index.tsx";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
@@ -29,6 +31,8 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const params = getRemixParams(arg.params);
+
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -46,6 +50,7 @@ export const loader = async (arg: LoaderArgs) => {
       host,
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
+      params,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -282,6 +287,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
+  const { params } = useLoaderData();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -291,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -7,6 +7,7 @@ import {
   type LoaderArgs,
   json,
 } from "@remix-run/server-runtime";
+import { useLoaderData } from "@remix-run/react";
 import type { Page as PageType, SiteMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
@@ -19,6 +20,7 @@ import {
   formsProperties,
   Page,
   imageAssets,
+  getRemixParams,
 } from "../__generated__/[form]._index.tsx";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
@@ -29,6 +31,8 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const params = getRemixParams(arg.params);
+
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -46,6 +50,7 @@ export const loader = async (arg: LoaderArgs) => {
       host,
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
+      params,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -282,6 +287,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
+  const { params } = useLoaderData();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -291,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -7,6 +7,7 @@ import {
   type LoaderArgs,
   json,
 } from "@remix-run/server-runtime";
+import { useLoaderData } from "@remix-run/react";
 import type { Page as PageType, SiteMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
@@ -19,6 +20,7 @@ import {
   formsProperties,
   Page,
   imageAssets,
+  getRemixParams,
 } from "../__generated__/[heading-with-id]._index.tsx";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
@@ -29,6 +31,8 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const params = getRemixParams(arg.params);
+
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -46,6 +50,7 @@ export const loader = async (arg: LoaderArgs) => {
       host,
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
+      params,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -282,6 +287,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
+  const { params } = useLoaderData();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -291,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -7,6 +7,7 @@ import {
   type LoaderArgs,
   json,
 } from "@remix-run/server-runtime";
+import { useLoaderData } from "@remix-run/react";
 import type { Page as PageType, SiteMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
@@ -19,6 +20,7 @@ import {
   formsProperties,
   Page,
   imageAssets,
+  getRemixParams,
 } from "../__generated__/[radix]._index.tsx";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
@@ -29,6 +31,8 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const params = getRemixParams(arg.params);
+
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -46,6 +50,7 @@ export const loader = async (arg: LoaderArgs) => {
       host,
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
+      params,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -282,6 +287,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
+  const { params } = useLoaderData();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -291,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -7,6 +7,7 @@ import {
   type LoaderArgs,
   json,
 } from "@remix-run/server-runtime";
+import { useLoaderData } from "@remix-run/react";
 import type { Page as PageType, SiteMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
@@ -19,6 +20,7 @@ import {
   formsProperties,
   Page,
   imageAssets,
+  getRemixParams,
 } from "../__generated__/_index.tsx";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
@@ -29,6 +31,8 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const params = getRemixParams(arg.params);
+
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -46,6 +50,7 @@ export const loader = async (arg: LoaderArgs) => {
       host,
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
+      params,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -282,6 +287,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
+  const { params } = useLoaderData();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -291,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/cli/__generated__/index.tsx
+++ b/packages/cli/__generated__/index.tsx
@@ -28,11 +28,16 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "project-id";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   return <></>;
 };
 
 export { Page };
+
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
+};
 
 export const pagesPaths = new Set<string>();
 

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -24,6 +24,8 @@ import {
   type Params,
   type WsComponentMeta,
   normalizeProps,
+  getRemixRoute,
+  generateRemixParams,
 } from "@webstudio-is/react-sdk";
 import type {
   Instance,
@@ -74,13 +76,6 @@ type SiteDataByPage = {
     params?: Params;
     pages: Array<Page>;
   };
-};
-
-type RemixRoutes = {
-  routes: Array<{
-    path: string;
-    file: string;
-  }>;
 };
 
 export const downloadAsset = async (
@@ -255,10 +250,6 @@ export const prebuild = async (options: {
     throw new Error(`Project domain is missing from the site data`);
   }
 
-  const remixRoutes: RemixRoutes = {
-    routes: [],
-  };
-
   const radixComponentNamespacedMetas = Object.entries(
     radixComponentMetas
   ).reduce(
@@ -287,16 +278,6 @@ export const prebuild = async (options: {
   const siteDataByPage: SiteDataByPage = {};
 
   for (const page of Object.values(siteData.pages)) {
-    const originPath = page.path;
-    const path = originPath === "" ? "index" : originPath.replace("/", "");
-
-    if (path !== "index") {
-      remixRoutes.routes.push({
-        path: originPath === "" ? "/" : originPath,
-        file: `routes/${path}.tsx`,
-      });
-    }
-
     const instanceMap = new Map(siteData.build.instances);
     const pageInstanceSet = findTreeInstanceIds(
       instanceMap,
@@ -330,7 +311,7 @@ export const prebuild = async (options: {
       }
     }
 
-    siteDataByPage[path] = {
+    siteDataByPage[page.path] = {
       build: {
         props,
         instances,
@@ -341,10 +322,10 @@ export const prebuild = async (options: {
       assets: siteData.assets,
     };
 
-    componentsByPage[path] = new Set();
+    componentsByPage[page.path] = new Set();
     for (const [_instanceId, instance] of instances) {
       if (instance.component) {
-        componentsByPage[path].add(instance.component);
+        componentsByPage[page.path].add(instance.component);
         const meta = metas.get(instance.component);
         if (meta) {
           projectMetas.set(instance.component, meta);
@@ -412,7 +393,7 @@ export const prebuild = async (options: {
     "utf8"
   );
 
-  for (const [pathName, pageComponents] of Object.entries(componentsByPage)) {
+  for (const [pathname, pageComponents] of Object.entries(componentsByPage)) {
     const scope = createScope([
       // manually maintained list of occupied identifiers
       "useState",
@@ -425,7 +406,7 @@ export const prebuild = async (options: {
       "projectId",
       "formsProperties",
       "Page",
-      "props",
+      "_props",
     ]);
     const namespaces = new Map<
       string,
@@ -468,7 +449,7 @@ export const prebuild = async (options: {
       componentImports += `import { ${specifiers} } from "${namespace}";\n`;
     }
 
-    const pageData = siteDataByPage[pathName];
+    const pageData = siteDataByPage[pathname];
     // serialize data only used in runtime
     const renderedPageData: PageData = {
       site: siteData.build.pages.meta,
@@ -485,7 +466,7 @@ export const prebuild = async (options: {
     });
     const pageComponent = generatePageComponent({
       scope,
-      rootInstanceId,
+      page: pageData.page,
       instances,
       props,
       dataSources,
@@ -514,6 +495,8 @@ ${pageComponent}
 
 export { Page }
 
+${generateRemixParams(pathname)}
+
 ${utilsExport}
 `;
 
@@ -529,13 +512,7 @@ ${utilsExport}
       https://remix.run/docs/en/main/file-conventions/route-files-v2#nested-urls-without-layout-nesting
     */
 
-    const fileName =
-      pathName === "main" || pathName === "index"
-        ? "_index.tsx"
-        : `${pathName
-            .split("/")
-            .map((route) => `[${route}]`)
-            .join(".")}._index.tsx`;
+    const fileName = getRemixRoute(pathname);
 
     const routeFileContent = routeFileTemplate.replace(
       "../__generated__/index",

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -24,7 +24,7 @@ import {
   type Params,
   type WsComponentMeta,
   normalizeProps,
-  getRemixRoute,
+  generateRemixRoute,
   generateRemixParams,
 } from "@webstudio-is/react-sdk";
 import type {
@@ -512,7 +512,7 @@ ${utilsExport}
       https://remix.run/docs/en/main/file-conventions/route-files-v2#nested-urls-without-layout-nesting
     */
 
-    const fileName = getRemixRoute(pathname);
+    const fileName = generateRemixRoute(pathname);
 
     const routeFileContent = routeFileTemplate.replace(
       "../__generated__/index",

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -7,6 +7,7 @@ import {
   type LoaderArgs,
   json,
 } from "@remix-run/server-runtime";
+import { useLoaderData } from "@remix-run/react";
 import type { Page as PageType, SiteMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
@@ -19,6 +20,7 @@ import {
   formsProperties,
   Page,
   imageAssets,
+  getRemixParams,
 } from "../__generated__/index";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
@@ -29,6 +31,8 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const params = getRemixParams(arg.params);
+
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
@@ -46,6 +50,7 @@ export const loader = async (arg: LoaderArgs) => {
       host,
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
+      params,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -282,6 +287,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
+  const { params } = useLoaderData();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -291,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./remix";
 export * from "./css/index";
 export * from "./tree/index";
 export * from "./app/index";

--- a/packages/react-sdk/src/remix.test.ts
+++ b/packages/react-sdk/src/remix.test.ts
@@ -1,32 +1,34 @@
 import { expect, test } from "@jest/globals";
-import { generateRemixParams, getRemixRoute } from "./remix";
+import { generateRemixParams, generateRemixRoute } from "./remix";
 
 test("convert home page to remix route", () => {
-  expect(getRemixRoute("")).toEqual("_index.tsx");
-  expect(getRemixRoute("/")).toEqual("_index.tsx");
+  expect(generateRemixRoute("")).toEqual("_index.tsx");
+  expect(generateRemixRoute("/")).toEqual("_index.tsx");
 });
 
 test("convert path to remix route", () => {
-  expect(getRemixRoute("/blog")).toEqual("[blog]._index.tsx");
-  expect(getRemixRoute("/blog/my-introduction")).toEqual(
+  expect(generateRemixRoute("/blog")).toEqual("[blog]._index.tsx");
+  expect(generateRemixRoute("/blog/my-introduction")).toEqual(
     "[blog].[my-introduction]._index.tsx"
   );
 });
 
 test("convert wildcard to remix route", () => {
-  expect(getRemixRoute("/blog/*")).toEqual("[blog].$.tsx");
+  expect(generateRemixRoute("/blog/*")).toEqual("[blog].$.tsx");
 });
 
 test("convert named group with * modifier to remix route", () => {
-  expect(getRemixRoute("/blog/:slug*")).toEqual("[blog].$.tsx");
+  expect(generateRemixRoute("/blog/:slug*")).toEqual("[blog].$.tsx");
 });
 
 test("convert named group with ? modifier to remix route", () => {
-  expect(getRemixRoute("/:id?/:slug?")).toEqual("($id).($slug)._index.tsx");
+  expect(generateRemixRoute("/:id?/:slug?")).toEqual(
+    "($id).($slug)._index.tsx"
+  );
 });
 
 test("convert named groups to remix route", () => {
-  expect(getRemixRoute("/blog/:id/:date")).toEqual(
+  expect(generateRemixRoute("/blog/:id/:date")).toEqual(
     "[blog].$id.$date._index.tsx"
   );
 });

--- a/packages/react-sdk/src/remix.test.ts
+++ b/packages/react-sdk/src/remix.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@jest/globals";
+import { generateRemixParams, getRemixRoute } from "./remix";
+
+test("convert home page to remix route", () => {
+  expect(getRemixRoute("")).toEqual("_index.tsx");
+  expect(getRemixRoute("/")).toEqual("_index.tsx");
+});
+
+test("convert path to remix route", () => {
+  expect(getRemixRoute("/blog")).toEqual("[blog]._index.tsx");
+  expect(getRemixRoute("/blog/my-introduction")).toEqual(
+    "[blog].[my-introduction]._index.tsx"
+  );
+});
+
+test("convert wildcard to remix route", () => {
+  expect(getRemixRoute("/blog/*")).toEqual("[blog].$.tsx");
+});
+
+test("convert named group with * modifier to remix route", () => {
+  expect(getRemixRoute("/blog/:slug*")).toEqual("[blog].$.tsx");
+});
+
+test("convert named group with ? modifier to remix route", () => {
+  expect(getRemixRoute("/:id?/:slug?")).toEqual("($id).($slug)._index.tsx");
+});
+
+test("convert named groups to remix route", () => {
+  expect(getRemixRoute("/blog/:id/:date")).toEqual(
+    "[blog].$id.$date._index.tsx"
+  );
+});
+
+test("generate remix params for static pathname", () => {
+  expect("\n" + generateRemixParams("/blog/my-post")).toEqual(`
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params
+}
+`);
+});
+
+test("generate remix params converter with wildcard", () => {
+  expect("\n" + generateRemixParams("/blog/*")).toEqual(`
+export const getRemixParams = ({ ...params }: Params): Params => {
+  params[0] = params["*"]
+  delete params["*"]
+  return params
+}
+`);
+});
+
+test("generate remix params converter with named group and * modifier", () => {
+  expect("\n" + generateRemixParams("/blog/:name*")).toEqual(`
+export const getRemixParams = ({ ...params }: Params): Params => {
+  params["name"] = params["*"]
+  delete params["*"]
+  return params
+}
+`);
+});

--- a/packages/react-sdk/src/remix.ts
+++ b/packages/react-sdk/src/remix.ts
@@ -2,6 +2,10 @@ const getRemixSegment = (segment: string) => {
   if (segment === "*") {
     return "$";
   }
+  // matches following examples
+  // :name
+  // :name?
+  // :name*
   const match = segment.match(/^:(?<name>\w+)(?<modifier>\*|\?)?$/);
   const name = match?.groups?.name;
   const modifier = match?.groups?.modifier;
@@ -17,7 +21,16 @@ const getRemixSegment = (segment: string) => {
   return `[${segment}]`;
 };
 
-export const getRemixRoute = (pathname: string) => {
+/**
+ * transforms url pattern subset to remix route format
+ *
+ * /:name/ -> .$name. - named dynamic segment
+ * /:name?/ -> .($name). - optional dynamic segment
+ * /* -> .$ - splat in the end of pattern
+ * /:name* -> .$ - named splat which gets specified name at runtime
+ *
+ */
+export const generateRemixRoute = (pathname: string) => {
   if (pathname.startsWith("/")) {
     pathname = pathname.slice(1);
   }

--- a/packages/react-sdk/src/remix.ts
+++ b/packages/react-sdk/src/remix.ts
@@ -1,0 +1,47 @@
+const getRemixSegment = (segment: string) => {
+  if (segment === "*") {
+    return "$";
+  }
+  const match = segment.match(/^:(?<name>\w+)(?<modifier>\*|\?)?$/);
+  const name = match?.groups?.name;
+  const modifier = match?.groups?.modifier;
+  if (name) {
+    if (modifier === "*") {
+      return "$";
+    }
+    if (modifier === "?") {
+      return `($${name})`;
+    }
+    return `$${name}`;
+  }
+  return `[${segment}]`;
+};
+
+export const getRemixRoute = (pathname: string) => {
+  if (pathname.startsWith("/")) {
+    pathname = pathname.slice(1);
+  }
+  if (pathname === "") {
+    return `_index.tsx`;
+  }
+  const base = pathname.split("/").map(getRemixSegment).join(".");
+  const tail = pathname.endsWith("*") ? "" : "._index";
+  return `${base}${tail}.tsx`;
+};
+
+export const generateRemixParams = (pathname: string) => {
+  const name = pathname.match(/:(?<name>\w+)\*$/)?.groups?.name;
+  let generated = "";
+  generated += `export const getRemixParams = ({ ...params }: Params): Params => {\n`;
+  if (name) {
+    generated += `  params["${name}"] = params["*"]\n`;
+    generated += `  delete params["*"]\n`;
+  }
+  if (pathname.endsWith("/*")) {
+    generated += `  params[0] = params["*"]\n`;
+    generated += `  delete params["*"]\n`;
+  }
+  generated += `  return params\n`;
+  generated += `}\n`;
+  return generated;
+};

--- a/packages/react-sdk/src/remix.ts
+++ b/packages/react-sdk/src/remix.ts
@@ -42,6 +42,15 @@ export const generateRemixRoute = (pathname: string) => {
   return `${base}${tail}.tsx`;
 };
 
+/**
+ * generates a function to convert remix params to compatible with url pattern groups
+ *
+ * for /:name* pattern
+ * params["*"] is replaced with params["name"]
+ *
+ * for /* pattern
+ * params["*"] is replaced with params[0]
+ */
 export const generateRemixParams = (pathname: string) => {
   const name = pathname.match(/:(?<name>\w+)\*$/)?.groups?.name;
   let generated = "";

--- a/packages/sdk-cli/src/generate-stories.ts
+++ b/packages/sdk-cli/src/generate-stories.ts
@@ -8,6 +8,7 @@ import {
   createScope,
   parseComponentName,
   getStyleDeclKey,
+  type Page,
 } from "@webstudio-is/sdk";
 import {
   type WsComponentMeta,
@@ -160,7 +161,7 @@ export const generateStories = async () => {
     content += `\n`;
     content += generatePageComponent({
       scope,
-      rootInstanceId,
+      page: { rootInstanceId } as Page,
       instances,
       props: new Map(data.props.map((prop) => [prop.id, prop])),
       dataSources: new Map(data.dataSources.map((prop) => [prop.id, prop])),

--- a/packages/sdk-cli/src/generate-stories.ts
+++ b/packages/sdk-cli/src/generate-stories.ts
@@ -86,7 +86,7 @@ const Story = {
 ${css}
       \`}
       </style>
-      <Page />
+      <Page params={{}} />
     </>
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
@@ -438,7 +438,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
@@ -12,7 +12,8 @@ import {
   AccordionContent as AccordionContent,
 } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [accordionValue, set$accordionValue] = useState<any>("0");
   let onValueChange = (value: any) => {
     accordionValue = value;

--- a/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
@@ -262,7 +262,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
@@ -10,7 +10,8 @@ import {
   CheckboxIndicator as CheckboxIndicator,
 } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [checkboxChecked, set$checkboxChecked] = useState<any>(false);
   let onCheckedChange = (checked: any) => {
     checkboxChecked = checked;

--- a/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
@@ -244,7 +244,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
@@ -10,7 +10,8 @@ import {
   CollapsibleContent as CollapsibleContent,
 } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [collapsibleOpen, set$collapsibleOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     collapsibleOpen = open;

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
@@ -15,7 +15,8 @@ import {
   DialogClose as DialogClose,
 } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [dialogOpen, set$dialogOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     dialogOpen = open;

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
@@ -412,7 +412,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
@@ -1,7 +1,8 @@
 import { Box as Box } from "@webstudio-is/sdk-components-react";
 import { Label as Label } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   return (
     <Box data-ws-id="root" data-ws-component="Box">
       <Label data-ws-id="1" data-ws-component="Label">

--- a/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
@@ -138,7 +138,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
@@ -1237,7 +1237,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
@@ -17,7 +17,8 @@ import {
   NavigationMenuViewport as NavigationMenuViewport,
 } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [menuValue, set$menuValue] = useState<any>("");
   let onValueChange = (value: any) => {
     menuValue = value;

--- a/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
@@ -261,7 +261,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
@@ -10,7 +10,8 @@ import {
   PopoverContent as PopoverContent,
 } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [popoverOpen, set$popoverOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     popoverOpen = open;

--- a/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
@@ -11,7 +11,8 @@ import {
   RadioGroupIndicator as RadioGroupIndicator,
 } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [radioGroupValue, set$radioGroupValue] = useState<any>("");
   let onValueChange = (value: any) => {
     radioGroupValue = value;

--- a/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
@@ -398,7 +398,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
@@ -14,7 +14,8 @@ import {
   SelectItemText as SelectItemText,
 } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [selectValue, set$selectValue] = useState<any>("");
   let [selectOpen, set$selectOpen] = useState<any>(false);
   let onValueChange = (value: any) => {

--- a/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
@@ -495,7 +495,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
@@ -421,7 +421,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
@@ -15,7 +15,8 @@ import {
   DialogClose as DialogClose,
 } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [sheetOpen, set$sheetOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     sheetOpen = open;

--- a/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import { Box as Box } from "@webstudio-is/sdk-components-react";
 import { Switch as Switch, SwitchThumb as SwitchThumb } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [switchChecked, set$switchChecked] = useState<any>(false);
   let onCheckedChange = (checked: any) => {
     switchChecked = checked;

--- a/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
@@ -238,7 +238,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
@@ -331,7 +331,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
@@ -7,7 +7,8 @@ import {
   TabsContent as TabsContent,
 } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [tabsValue, set$tabsValue] = useState<any>("0");
   let onValueChange = (value: any) => {
     tabsValue = value;

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
@@ -259,7 +259,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
@@ -10,7 +10,8 @@ import {
   TooltipContent as TooltipContent,
 } from "../components";
 
-const Page = () => {
+type Params = Record<string, string | undefined>;
+const Page = (_props: { params: Params }) => {
   let [tooltipOpen, set$tooltipOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     tooltipOpen = open;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here remix route params are adapted to URLPattern format and passed to generate page component as prop.

For this added 2 remix specific utilities
- convert subset of url pattern to remix route
- generate utility to adapt remix params to URLPattern params for example for `/*` `params['*']` is replaced with `params[0]` and for `/:slug*` `params['*']` is replaced with `params['slug']`

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
