### PR TITLE
fix: Fix that status error prevented PR merge

### DIFF
--- a/.github/workflows/add-status.yml
+++ b/.github/workflows/add-status.yml
@@ -10,7 +10,7 @@ permissions:
   statuses: write # to fetch code (actions/checkout)
 
 jobs:
-  checks:
+  add-status:
     timeout-minutes: 20
 
     env:


### PR DESCRIPTION
## Description

github protection rules are based on job names

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
