### PR TITLE
fix: Broken chrome detection

### DIFF
--- a/apps/builder/app/builder/features/blocking-alerts/blocking-alerts.tsx
+++ b/apps/builder/app/builder/features/blocking-alerts/blocking-alerts.tsx
@@ -35,8 +35,9 @@ const useUnsupportedBrowser = () => {
   const [message, setMessage] = useState<ReactNode>();
   useEffect(() => {
     if ("chrome" in window || isFeatureEnabled("unsupportedBrowsers")) {
-      //return;
+      return;
     }
+
     setMessage(
       <>
         The Webstudio Builder UI currently supports any{" "}


### PR DESCRIPTION
## Description

seems like `// return` was commented for local testing

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
