### PR TITLE
feat: support resources in schema and compiler

### DIFF
--- a/apps/builder/app/routes/rest.patch.ts
+++ b/apps/builder/app/routes/rest.patch.ts
@@ -11,6 +11,7 @@ import {
   StyleSourceSelections,
   StyleSources,
   Styles,
+  Resources,
 } from "@webstudio-is/sdk";
 import type { Build } from "@webstudio-is/project-build";
 import {
@@ -30,6 +31,8 @@ import {
   serializeStyleSourceSelections,
   serializeStyles,
   serializeDataSources,
+  parseData,
+  serializeData,
 } from "@webstudio-is/project-build/index.server";
 import { patchAssets } from "@webstudio-is/asset-uploader/index.server";
 import type { Project } from "@webstudio-is/project";
@@ -102,6 +105,7 @@ export const action = async ({ request }: ActionArgs) => {
       instances?: Instances;
       props?: Props;
       dataSources?: DataSources;
+      resources?: Resources;
       styleSources?: StyleSources;
       styleSourceSelections?: StyleSourceSelections;
       styles?: Styles;
@@ -173,6 +177,12 @@ export const action = async ({ request }: ActionArgs) => {
           continue;
         }
 
+        if (namespace === "resources") {
+          const resources = buildData.resources ?? parseData(build.resources);
+          buildData.resources = applyPatches(resources, patches);
+          continue;
+        }
+
         if (namespace === "breakpoints") {
           const breakpoints =
             buildData.breakpoints ?? parseBreakpoints(build.breakpoints);
@@ -223,6 +233,12 @@ export const action = async ({ request }: ActionArgs) => {
     if (buildData.dataSources) {
       dbBuildData.dataSources = serializeDataSources(
         DataSources.parse(buildData.dataSources)
+      );
+    }
+
+    if (buildData.resources) {
+      dbBuildData.resources = serializeData(
+        Resources.parse(buildData.resources)
       );
     }
 

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -44,7 +44,8 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   return (
     <Body data-ws-id="ibXgMoi9_ipHx1gVrvii0" data-ws-component="Body">
       <Heading data-ws-id="7pwqBSgrfuuOfk1JblWcL" data-ws-component="Heading">

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -297,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} />
+      <Page params={params} resources={{}} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -28,7 +28,8 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   return (
     <Body data-ws-id="MMimeobf_zi4ZkRGXapju" data-ws-component="Body">
       <Heading data-ws-id="MYDt0guk1-vzc7yzqyN6A" data-ws-component="Heading">

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -297,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} />
+      <Page params={params} resources={{}} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -28,7 +28,8 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   return (
     <Body data-ws-id="MMimeobf_zi4ZkRGXapju" data-ws-component="Body">
       <Heading data-ws-id="MYDt0guk1-vzc7yzqyN6A" data-ws-component="Heading">

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -297,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} />
+      <Page params={params} resources={{}} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -64,7 +64,8 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   return (
     <Body data-ws-id="EDEfpMPRqDejthtwkH7ws" data-ws-component="Body">
       <Image

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -73,7 +73,8 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [formState, set$formState] = useState<any>("initial");
   let [formState_1, set$formState_1] = useState<any>("initial");
   let onStateChange = (state: any) => {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -64,7 +64,8 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   return (
     <Body data-ws-id="O-ljaGZQ0iRNTlEshMkgE" data-ws-component="Body">
       <Heading

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -80,7 +80,8 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [accordionValue, set$accordionValue] = useState<any>("0");
   let onValueChange = (value: any) => {
     accordionValue = value;

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -78,7 +78,8 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   return (
     <Body data-ws-id="On9cvWCxr5rdZtY9O1Bv0" data-ws-component="Body">
       <Heading data-ws-id="nVMWvMsaLCcb0o1wuNQgg" data-ws-component="Heading">

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -297,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} />
+      <Page params={params} resources={{}} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -297,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} />
+      <Page params={params} resources={{}} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -297,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} />
+      <Page params={params} resources={{}} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -297,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} />
+      <Page params={params} resources={{}} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -297,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} />
+      <Page params={params} resources={{}} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/cli/__generated__/index.tsx
+++ b/packages/cli/__generated__/index.tsx
@@ -1,8 +1,8 @@
 /**
  * The only intent of this file is to support typings inside ../templates/route-template for easier development.
  **/
-import type { PageData } from "../templates/route-template";
 import type { Asset, ImageAsset } from "@webstudio-is/sdk";
+import type { PageData } from "../templates/route-template";
 
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [];
@@ -29,7 +29,8 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "project-id";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   return <></>;
 };
 

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -297,7 +297,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} />
+      <Page params={params} resources={{}} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -7,6 +7,7 @@ import type {
   Page,
   Pages,
   Prop,
+  Resource,
   StyleDecl,
   StyleDeclKey,
   StyleSource,
@@ -30,6 +31,7 @@ export type Data = {
     props: [Prop["id"], Prop][];
     instances: [Instance["id"], Instance][];
     dataSources: [DataSource["id"], DataSource][];
+    resources: [Resource["id"], Resource][];
     deployment?: Deployment | undefined;
   };
   assets: Array<Asset>;

--- a/packages/prisma-client/prisma/migrations/20231211152313_build_resources/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20231211152313_build_resources/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Build" ADD COLUMN     "resources" TEXT NOT NULL DEFAULT '[]';

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -175,6 +175,7 @@ model Build {
   styleSourceSelections String @default("[]")
   props                 String @default("[]")
   dataSources           String @default("[]")
+  resources             String @default("[]")
   instances             String @default("[]")
 
   deployment    String?

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -12,7 +12,7 @@ import {
   type AppContext,
 } from "@webstudio-is/trpc-interface/index.server";
 import type { Build } from "../types";
-import { Pages, type Deployment } from "@webstudio-is/sdk";
+import { Pages, type Deployment, Resource } from "@webstudio-is/sdk";
 import {
   createInitialBreakpoints,
   parseBreakpoints,
@@ -26,6 +26,20 @@ import { parseDataSources } from "./data-sources";
 import { parseInstances, serializeInstances } from "./instances";
 import { parseDeployment, serializeDeployment } from "./deployment";
 import type { Data } from "@webstudio-is/http-client";
+
+export const parseData = <Type extends { id: string }>(
+  string: string
+): Map<Type["id"], Type> => {
+  const list = JSON.parse(string) as Type[];
+  return new Map(list.map((item) => [item.id, item]));
+};
+
+export const serializeData = <Type extends { id: string }>(
+  data: Map<Type["id"], Type>
+) => {
+  const dataSourcesList: Type[] = Array.from(data.values());
+  return JSON.stringify(dataSourcesList);
+};
 
 const parseBuild = async (build: DbBuild): Promise<Build> => {
   // eslint-disable-next-line no-console
@@ -57,6 +71,7 @@ const parseBuild = async (build: DbBuild): Promise<Build> => {
       styleSourceSelections,
       props,
       dataSources,
+      resources: Array.from(parseData<Resource>(build.resources)),
       instances,
       deployment,
     } satisfies Data["build"];

--- a/packages/project-build/src/types.ts
+++ b/packages/project-build/src/types.ts
@@ -9,6 +9,7 @@ import type {
   StyleSourceSelection,
   Deployment,
   DataSource,
+  Resource,
 } from "@webstudio-is/sdk";
 
 export type Build = {
@@ -25,5 +26,6 @@ export type Build = {
   props: [Prop["id"], Prop][];
   instances: [Instance["id"], Instance][];
   dataSources: [DataSource["id"], DataSource][];
+  resources: [Resource["id"], Resource][];
   deployment?: Deployment | undefined;
 };

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -601,7 +601,8 @@ test("generate page component with variables and actions", () => {
   ).toEqual(
     clear(`
       type Params = Record<string, string | undefined>
-      const Page = (_props: { params: Params }) => {
+      type Resources = Record<string, unknown>
+      const Page = (_props: { params: Params, resources: Resources }) => {
       let [variableName, set$variableName] = useState<any>("initial")
       let onChange = (value: any) => {
       variableName = value
@@ -667,7 +668,8 @@ test("avoid generating collection parameter variable as state", () => {
   ).toEqual(
     clear(`
     type Params = Record<string, string | undefined>
-    const Page = (_props: { params: Params }) => {
+    type Resources = Record<string, unknown>
+    const Page = (_props: { params: Params, resources: Resources }) => {
     let [data, set$data] = useState<any>(["apple","orange","mango"])
     return <Body
     data-ws-id="body"
@@ -710,12 +712,70 @@ test("generate params variable when present", () => {
   ).toEqual(
     clear(`
     type Params = Record<string, string | undefined>
-    const Page = (_props: { params: Params }) => {
+    type Resources = Record<string, unknown>
+    const Page = (_props: { params: Params, resources: Resources }) => {
     let params_1 = _props.params
     return <Body
     data-ws-id="body"
     data-ws-component="Body"
     data-slug={params_1?.slug} />
+    }
+    `)
+  );
+});
+
+test("generate resources loading", () => {
+  expect(
+    generatePageComponent({
+      scope: createScope(),
+      page: { rootInstanceId: "body" } as Page,
+      instances: new Map([createInstancePair("body", "Body", [])]),
+      dataSources: new Map([
+        createDataSourcePair({
+          id: "dataSourceDataId",
+          scopeInstanceId: "body",
+          type: "variable",
+          name: "data",
+          value: { type: "json", value: "data" },
+        }),
+        createDataSourcePair({
+          id: "dataSourceResourceId",
+          scopeInstanceId: "body",
+          type: "resource",
+          name: "data",
+          resourceId: "resourceId",
+        }),
+      ]),
+      props: new Map([
+        createPropPair({
+          id: "propDataId",
+          instanceId: "body",
+          name: "data-data",
+          type: "expression",
+          value: "$ws$dataSource$dataSourceDataId",
+        }),
+        createPropPair({
+          id: "propResourceId",
+          instanceId: "body",
+          name: "data-resource",
+          type: "expression",
+          value: "$ws$dataSource$dataSourceResourceId",
+        }),
+      ]),
+      indexesWithinAncestors: new Map(),
+    })
+  ).toEqual(
+    clear(`
+    type Params = Record<string, string | undefined>
+    type Resources = Record<string, unknown>
+    const Page = (_props: { params: Params, resources: Resources }) => {
+    let [data, set$data] = useState<any>("data")
+    let data_1 = _props.resources["data_2"]
+    return <Body
+    data-ws-id="body"
+    data-ws-component="Body"
+    data-data={data}
+    data-resource={data_1} />
     }
     `)
   );

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -273,6 +273,15 @@ export const generatePageComponent = ({
         generatedDataSources += `let ${valueName} = _props.params\n`;
       }
     }
+    if (dataSource.type === "resource") {
+      const valueName = scope.getName(dataSource.id, dataSource.name);
+      // call resource by bound variable name
+      const resourceName = scope.getName(
+        dataSource.resourceId,
+        dataSource.name
+      );
+      generatedDataSources += `let ${valueName} = _props.resources["${resourceName}"]\n`;
+    }
   }
 
   generatedDataSources += dataSourcesBody;
@@ -295,7 +304,8 @@ export const generatePageComponent = ({
 
   let generatedComponent = "";
   generatedComponent += `type Params = Record<string, string | undefined>\n`;
-  generatedComponent += `const Page = (_props: { params: Params }) => {\n`;
+  generatedComponent += `type Resources = Record<string, unknown>\n`;
+  generatedComponent += `const Page = (_props: { params: Params, resources: Resources }) => {\n`;
   generatedComponent += `${generatedDataSources}`;
   generatedComponent += `return ${generatedJsx}`;
   generatedComponent += `}\n`;

--- a/packages/sdk-cli/src/generate-stories.ts
+++ b/packages/sdk-cli/src/generate-stories.ts
@@ -86,7 +86,7 @@ const Story = {
 ${css}
       \`}
       </style>
-      <Page params={{}} />
+      <Page params={{}} resources={{}} />
     </>
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
@@ -13,7 +13,8 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [accordionValue, set$accordionValue] = useState<any>("0");
   let onValueChange = (value: any) => {
     accordionValue = value;
@@ -438,7 +439,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
@@ -11,7 +11,8 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [checkboxChecked, set$checkboxChecked] = useState<any>(false);
   let onCheckedChange = (checked: any) => {
     checkboxChecked = checked;
@@ -262,7 +263,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
@@ -11,7 +11,8 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [collapsibleOpen, set$collapsibleOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     collapsibleOpen = open;
@@ -244,7 +245,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
@@ -16,7 +16,8 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [dialogOpen, set$dialogOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     dialogOpen = open;
@@ -412,7 +413,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
@@ -2,7 +2,8 @@ import { Box as Box } from "@webstudio-is/sdk-components-react";
 import { Label as Label } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   return (
     <Box data-ws-id="root" data-ws-component="Box">
       <Label data-ws-id="1" data-ws-component="Label">
@@ -138,7 +139,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
@@ -18,7 +18,8 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [menuValue, set$menuValue] = useState<any>("");
   let onValueChange = (value: any) => {
     menuValue = value;
@@ -1237,7 +1238,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
@@ -11,7 +11,8 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [popoverOpen, set$popoverOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     popoverOpen = open;
@@ -261,7 +262,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
@@ -12,7 +12,8 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [radioGroupValue, set$radioGroupValue] = useState<any>("");
   let onValueChange = (value: any) => {
     radioGroupValue = value;
@@ -398,7 +399,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
@@ -15,7 +15,8 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [selectValue, set$selectValue] = useState<any>("");
   let [selectOpen, set$selectOpen] = useState<any>(false);
   let onValueChange = (value: any) => {
@@ -495,7 +496,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
@@ -16,7 +16,8 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [sheetOpen, set$sheetOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     sheetOpen = open;
@@ -421,7 +422,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
@@ -3,7 +3,8 @@ import { Box as Box } from "@webstudio-is/sdk-components-react";
 import { Switch as Switch, SwitchThumb as SwitchThumb } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [switchChecked, set$switchChecked] = useState<any>(false);
   let onCheckedChange = (checked: any) => {
     switchChecked = checked;
@@ -238,7 +239,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
@@ -8,7 +8,8 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [tabsValue, set$tabsValue] = useState<any>("0");
   let onValueChange = (value: any) => {
     tabsValue = value;
@@ -331,7 +332,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
@@ -11,7 +11,8 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+type Resources = Record<string, unknown>;
+const Page = (_props: { params: Params; resources: Resources }) => {
   let [tooltipOpen, set$tooltipOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     tooltipOpen = open;
@@ -259,7 +260,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Page params={{}} resources={{}} />
       </>
     );
   },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,6 +2,7 @@ export * from "./schema/assets";
 export * from "./schema/pages";
 export * from "./schema/instances";
 export * from "./schema/data-sources";
+export * from "./schema/resources";
 export * from "./schema/props";
 export * from "./schema/breakpoints";
 export * from "./schema/style-sources";

--- a/packages/sdk/src/schema/data-sources.ts
+++ b/packages/sdk/src/schema/data-sources.ts
@@ -40,6 +40,13 @@ export const DataSource = z.union([
     scopeInstanceId: z.optional(z.string()),
     name: z.string(),
   }),
+  z.object({
+    type: z.literal("resource"),
+    id: DataSourceId,
+    scopeInstanceId: z.optional(z.string()),
+    name: z.string(),
+    resourceId: z.string(),
+  }),
 ]);
 
 export type DataSource = z.infer<typeof DataSource>;

--- a/packages/sdk/src/schema/resources.ts
+++ b/packages/sdk/src/schema/resources.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+const ResourceId = z.string();
+
+export const Resource = z.union([
+  // !!! this is prototype only resource type
+  // build other resources before exposing to production
+  z.object({
+    type: z.literal("getjson"),
+    id: ResourceId,
+    instanceId: z.string(),
+    // expression
+    url: z.string(),
+  }),
+  z.never(),
+]);
+
+export type Resource = z.infer<typeof Resource>;
+
+export const Resources = z.map(ResourceId, Resource);
+
+export type Resources = z.infer<typeof Resources>;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here added new schema type "Resources" to contain configuration of requests to services. Their first use case is referencing from variable to store loaded data.

For now added only client side generation. Later add support for server code generation as part of remix loaders.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
