### PR TITLE
fix: generate link hash in preview

### DIFF
--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -142,11 +142,19 @@ export const $propValuesByInstanceSelector = computed(
   (instances, props, page, dataSourcesLogic, params, pages, assets) => {
     const values = new Map<string, unknown>(dataSourcesLogic);
 
+    let propsList = Array.from(props.values());
+    // ignore asset and page props when params is not provided
+    if (params) {
+      // use whole props list to let access hash props from other pages and instances
+      propsList = normalizeProps({
+        props: propsList,
+        assetBaseUrl: params.assetBaseUrl,
+        assets,
+        pages,
+      });
+    }
     // collect props and group by instances
-    const propsByInstanceId = groupBy(
-      props.values(),
-      (prop) => prop.instanceId
-    );
+    const propsByInstanceId = groupBy(propsList, (prop) => prop.instanceId);
 
     // traverse instances tree and compute props within each instance
     const propValuesByInstanceSelector = new Map<
@@ -167,16 +175,6 @@ export const $propValuesByInstanceSelector = computed(
       let props = propsByInstanceId.get(instanceId);
       const parameters = new Map<Prop["name"], DataSource["id"]>();
       if (props) {
-        // ignore asset and page props when params is not provided
-        // important to resolve only in canvas
-        if (params) {
-          props = normalizeProps({
-            props,
-            assetBaseUrl: params.assetBaseUrl,
-            assets,
-            pages,
-          });
-        }
         for (const prop of props) {
           // at this point asset and page either already converted to string
           // or can be ignored


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/2696

broke this when refactored props computing, normalizing props should always be called on whole props list to allow getting id prop from other pages and instances and copmute hash.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
