### PR TITLE
feat: generate resource loaders

### DIFF
--- a/fixtures/webstudio-custom-template/.webstudio/data.json
+++ b/fixtures/webstudio-custom-template/.webstudio/data.json
@@ -91,6 +91,7 @@
     ],
     "props": [],
     "dataSources": [],
+    "resources": [],
     "instances": [
       [
         "ibXgMoi9_ipHx1gVrvii0",

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
@@ -1,0 +1,5 @@
+type Params = Record<string, string | undefined>;
+export const loadResources = async (_props: { params: Params }) => {
+  const [] = await Promise.all([]);
+  return {} as Record<string, unknown>;
+};

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -21,7 +21,8 @@ import {
   Page,
   imageAssets,
   getRemixParams,
-} from "../__generated__/_index.tsx";
+} from "../__generated__/_index";
+import { loadResources } from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
@@ -32,6 +33,7 @@ export type PageData = {
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
+  const resources = await loadResources({ params });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -51,6 +53,7 @@ export const loader = async (arg: LoaderArgs) => {
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
+      resources,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -287,7 +290,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
-  const { params } = useLoaderData();
+  const { params, resources } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -297,7 +300,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} resources={{}} />
+      <Page params={params} resources={resources} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/.webstudio/data.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/.webstudio/data.json
@@ -119,6 +119,7 @@
     ],
     "props": [],
     "dataSources": [],
+    "resources": [],
     "instances": [
       [
         "MMimeobf_zi4ZkRGXapju",

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
@@ -1,0 +1,5 @@
+type Params = Record<string, string | undefined>;
+export const loadResources = async (_props: { params: Params }) => {
+  const [] = await Promise.all([]);
+  return {} as Record<string, unknown>;
+};

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -21,7 +21,8 @@ import {
   Page,
   imageAssets,
   getRemixParams,
-} from "../__generated__/_index.tsx";
+} from "../__generated__/_index";
+import { loadResources } from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
@@ -32,6 +33,7 @@ export type PageData = {
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
+  const resources = await loadResources({ params });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -51,6 +53,7 @@ export const loader = async (arg: LoaderArgs) => {
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
+      resources,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -287,7 +290,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
-  const { params } = useLoaderData();
+  const { params, resources } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -297,7 +300,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} resources={{}} />
+      <Page params={params} resources={resources} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-netlify-functions/.webstudio/data.json
+++ b/fixtures/webstudio-remix-netlify-functions/.webstudio/data.json
@@ -119,6 +119,7 @@
     ],
     "props": [],
     "dataSources": [],
+    "resources": [],
     "instances": [
       [
         "MMimeobf_zi4ZkRGXapju",

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
@@ -1,0 +1,5 @@
+type Params = Record<string, string | undefined>;
+export const loadResources = async (_props: { params: Params }) => {
+  const [] = await Promise.all([]);
+  return {} as Record<string, unknown>;
+};

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -21,7 +21,8 @@ import {
   Page,
   imageAssets,
   getRemixParams,
-} from "../__generated__/_index.tsx";
+} from "../__generated__/_index";
+import { loadResources } from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
@@ -32,6 +33,7 @@ export type PageData = {
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
+  const resources = await loadResources({ params });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -51,6 +53,7 @@ export const loader = async (arg: LoaderArgs) => {
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
+      resources,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -287,7 +290,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
-  const { params } = useLoaderData();
+  const { params, resources } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -297,7 +300,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} resources={{}} />
+      <Page params={params} resources={resources} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/.webstudio/data.json
+++ b/fixtures/webstudio-remix-vercel/.webstudio/data.json
@@ -2116,6 +2116,7 @@
         }
       ]
     ],
+    "resources": [],
     "instances": [
       [
         "On9cvWCxr5rdZtY9O1Bv0",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
@@ -1,0 +1,5 @@
+type Params = Record<string, string | undefined>;
+export const loadResources = async (_props: { params: Params }) => {
+  const [] = await Promise.all([]);
+  return {} as Record<string, unknown>;
+};

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
@@ -1,0 +1,5 @@
+type Params = Record<string, string | undefined>;
+export const loadResources = async (_props: { params: Params }) => {
+  const [] = await Promise.all([]);
+  return {} as Record<string, unknown>;
+};

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
@@ -1,0 +1,5 @@
+type Params = Record<string, string | undefined>;
+export const loadResources = async (_props: { params: Params }) => {
+  const [] = await Promise.all([]);
+  return {} as Record<string, unknown>;
+};

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
@@ -1,0 +1,5 @@
+type Params = Record<string, string | undefined>;
+export const loadResources = async (_props: { params: Params }) => {
+  const [] = await Promise.all([]);
+  return {} as Record<string, unknown>;
+};

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
@@ -1,0 +1,5 @@
+type Params = Record<string, string | undefined>;
+export const loadResources = async (_props: { params: Params }) => {
+  const [] = await Promise.all([]);
+  return {} as Record<string, unknown>;
+};

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -21,7 +21,8 @@ import {
   Page,
   imageAssets,
   getRemixParams,
-} from "../__generated__/[_route_with_symbols_]._index.tsx";
+} from "../__generated__/[_route_with_symbols_]._index";
+import { loadResources } from "../__generated__/[_route_with_symbols_]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
@@ -32,6 +33,7 @@ export type PageData = {
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
+  const resources = await loadResources({ params });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -51,6 +53,7 @@ export const loader = async (arg: LoaderArgs) => {
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
+      resources,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -287,7 +290,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
-  const { params } = useLoaderData();
+  const { params, resources } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -297,7 +300,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} resources={{}} />
+      <Page params={params} resources={resources} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -21,7 +21,8 @@ import {
   Page,
   imageAssets,
   getRemixParams,
-} from "../__generated__/[form]._index.tsx";
+} from "../__generated__/[form]._index";
+import { loadResources } from "../__generated__/[form]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
@@ -32,6 +33,7 @@ export type PageData = {
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
+  const resources = await loadResources({ params });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -51,6 +53,7 @@ export const loader = async (arg: LoaderArgs) => {
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
+      resources,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -287,7 +290,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
-  const { params } = useLoaderData();
+  const { params, resources } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -297,7 +300,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} resources={{}} />
+      <Page params={params} resources={resources} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -21,7 +21,8 @@ import {
   Page,
   imageAssets,
   getRemixParams,
-} from "../__generated__/[heading-with-id]._index.tsx";
+} from "../__generated__/[heading-with-id]._index";
+import { loadResources } from "../__generated__/[heading-with-id]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
@@ -32,6 +33,7 @@ export type PageData = {
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
+  const resources = await loadResources({ params });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -51,6 +53,7 @@ export const loader = async (arg: LoaderArgs) => {
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
+      resources,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -287,7 +290,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
-  const { params } = useLoaderData();
+  const { params, resources } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -297,7 +300,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} resources={{}} />
+      <Page params={params} resources={resources} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -21,7 +21,8 @@ import {
   Page,
   imageAssets,
   getRemixParams,
-} from "../__generated__/[radix]._index.tsx";
+} from "../__generated__/[radix]._index";
+import { loadResources } from "../__generated__/[radix]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
@@ -32,6 +33,7 @@ export type PageData = {
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
+  const resources = await loadResources({ params });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -51,6 +53,7 @@ export const loader = async (arg: LoaderArgs) => {
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
+      resources,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -287,7 +290,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
-  const { params } = useLoaderData();
+  const { params, resources } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -297,7 +300,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} resources={{}} />
+      <Page params={params} resources={resources} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -21,7 +21,8 @@ import {
   Page,
   imageAssets,
   getRemixParams,
-} from "../__generated__/_index.tsx";
+} from "../__generated__/_index";
+import { loadResources } from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
@@ -32,6 +33,7 @@ export type PageData = {
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
+  const resources = await loadResources({ params });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -51,6 +53,7 @@ export const loader = async (arg: LoaderArgs) => {
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
+      resources,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -287,7 +290,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
-  const { params } = useLoaderData();
+  const { params, resources } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -297,7 +300,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} resources={{}} />
+      <Page params={params} resources={resources} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/cli/__generated__/index.server.tsx
+++ b/packages/cli/__generated__/index.server.tsx
@@ -1,0 +1,5 @@
+type Params = Record<string, string | undefined>;
+export const loadResources = async (_props: { params: Params }) => {
+  const [] = await Promise.all([]);
+  return {} as Record<string, unknown>;
+};

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -26,6 +26,7 @@ import {
   normalizeProps,
   generateRemixRoute,
   generateRemixParams,
+  generateResourcesLoader,
 } from "@webstudio-is/react-sdk";
 import type {
   Instance,
@@ -36,6 +37,7 @@ import type {
   Asset,
   FontAsset,
   ImageAsset,
+  Resource,
 } from "@webstudio-is/sdk";
 import {
   createScope,
@@ -70,6 +72,7 @@ type SiteDataByPage = {
       props: [Prop["id"], Prop][];
       instances: [Instance["id"], Instance][];
       dataSources: [DataSource["id"], DataSource][];
+      resources: [Resource["id"], Resource][];
       deployment?: Deployment | undefined;
     };
     assets: Array<Asset>;
@@ -311,11 +314,19 @@ export const prebuild = async (options: {
       }
     }
 
+    const resources: [Resource["id"], Resource][] = [];
+    for (const [resourceId, resource] of siteData.build.resources ?? []) {
+      if (pageInstanceSet.has(resource.instanceId)) {
+        resources.push([resourceId, resource]);
+      }
+    }
+
     siteDataByPage[page.path] = {
       build: {
         props,
         instances,
         dataSources,
+        resources,
       },
       pages: siteData.pages,
       page,
@@ -460,6 +471,7 @@ export const prebuild = async (options: {
     const instances = new Map(pageData.build.instances);
     const props = new Map(pageData.build.props);
     const dataSources = new Map(pageData.build.dataSources);
+    const resources = new Map(pageData.build.resources);
     const utilsExport = generateUtilsExport({
       pages: siteData.build.pages,
       props,
@@ -512,15 +524,28 @@ ${utilsExport}
       https://remix.run/docs/en/main/file-conventions/route-files-v2#nested-urls-without-layout-nesting
     */
 
-    const fileName = generateRemixRoute(pathname);
+    const remixRoute = generateRemixRoute(pathname);
+    const fileName = `${remixRoute}.tsx`;
 
-    const routeFileContent = routeFileTemplate.replace(
-      "../__generated__/index",
-      `../__generated__/${fileName}`
-    );
+    const routeFileContent = routeFileTemplate
+      .replace('../__generated__/index"', `../__generated__/${remixRoute}\"`)
+      .replace(
+        '../__generated__/index.server"',
+        `../__generated__/${remixRoute}.server\"`
+      );
 
     await ensureFileInPath(join(routesDir, fileName), routeFileContent);
     await ensureFileInPath(join(generatedDir, fileName), pageExports);
+
+    await ensureFileInPath(
+      join(generatedDir, `${remixRoute}.server.tsx`),
+      generateResourcesLoader({
+        scope,
+        page: pageData.page,
+        dataSources,
+        resources,
+      })
+    );
   }
 
   spinner.text = "Generating css file";

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -528,10 +528,10 @@ ${utilsExport}
     const fileName = `${remixRoute}.tsx`;
 
     const routeFileContent = routeFileTemplate
-      .replace('../__generated__/index"', `../__generated__/${remixRoute}\"`)
+      .replace('../__generated__/index"', `../__generated__/${remixRoute}"`)
       .replace(
         '../__generated__/index.server"',
-        `../__generated__/${remixRoute}.server\"`
+        `../__generated__/${remixRoute}.server"`
       );
 
     await ensureFileInPath(join(routesDir, fileName), routeFileContent);

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -22,6 +22,7 @@ import {
   imageAssets,
   getRemixParams,
 } from "../__generated__/index";
+import { loadResources } from "../__generated__/index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
@@ -32,6 +33,7 @@ export type PageData = {
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
+  const resources = await loadResources({ params });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -51,6 +53,7 @@ export const loader = async (arg: LoaderArgs) => {
       url: url.href,
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
+      resources,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -287,7 +290,7 @@ export const action = async ({ request, context }: ActionArgs) => {
 };
 
 const Outlet = () => {
-  const { params } = useLoaderData();
+  const { params, resources } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -297,7 +300,7 @@ const Outlet = () => {
         pagesPaths,
       }}
     >
-      <Page params={params} resources={{}} />
+      <Page params={params} resources={resources} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -15,11 +15,7 @@ import {
   showAttribute,
 } from "./props";
 import { collectionComponent } from "./core-components";
-import {
-  decodeDataSourceVariable,
-  generateDataSources,
-  validateExpression,
-} from "./expression";
+import { generateExpression, generateDataSources } from "./expression";
 import type { IndexesWithinAncestors } from "./instance-utils";
 
 const generatePropValue = ({
@@ -54,17 +50,10 @@ const generatePropValue = ({
   }
   // inline expression to safely use collection item
   if (prop.type === "expression") {
-    return validateExpression(prop.value, {
-      // transpile to safely executable member expressions
-      optional: true,
-      transformIdentifier: (identifier) => {
-        const depId = decodeDataSourceVariable(identifier);
-        const dep = depId ? dataSources.get(depId) : undefined;
-        if (dep) {
-          return scope.getName(dep.id, dep.name);
-        }
-        return identifier;
-      },
+    return generateExpression({
+      expression: prop.value,
+      dataSources,
+      scope,
     });
   }
   if (prop.type === "action") {

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -185,6 +185,31 @@ export const decodeDataSourceVariable = (name: string) => {
   return;
 };
 
+export const generateExpression = ({
+  expression,
+  dataSources,
+  scope,
+}: {
+  expression: string;
+  dataSources: DataSources;
+  scope: Scope;
+}) => {
+  return validateExpression(expression, {
+    // parse any expression
+    effectful: true,
+    // transpile to safely executable member expressions
+    optional: true,
+    transformIdentifier: (identifier) => {
+      const depId = decodeDataSourceVariable(identifier);
+      const dep = depId ? dataSources.get(depId) : undefined;
+      if (dep) {
+        return scope.getName(dep.id, dep.name);
+      }
+      return identifier;
+    },
+  });
+};
+
 /*
 
 // header

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -31,3 +31,4 @@ export {
   generateJsxElement,
   generateJsxChildren,
 } from "./component-generator";
+export { generateResourcesLoader } from "./resources-generator";

--- a/packages/react-sdk/src/remix.test.ts
+++ b/packages/react-sdk/src/remix.test.ts
@@ -2,34 +2,32 @@ import { expect, test } from "@jest/globals";
 import { generateRemixParams, generateRemixRoute } from "./remix";
 
 test("convert home page to remix route", () => {
-  expect(generateRemixRoute("")).toEqual("_index.tsx");
-  expect(generateRemixRoute("/")).toEqual("_index.tsx");
+  expect(generateRemixRoute("")).toEqual("_index");
+  expect(generateRemixRoute("/")).toEqual("_index");
 });
 
 test("convert path to remix route", () => {
-  expect(generateRemixRoute("/blog")).toEqual("[blog]._index.tsx");
+  expect(generateRemixRoute("/blog")).toEqual("[blog]._index");
   expect(generateRemixRoute("/blog/my-introduction")).toEqual(
-    "[blog].[my-introduction]._index.tsx"
+    "[blog].[my-introduction]._index"
   );
 });
 
 test("convert wildcard to remix route", () => {
-  expect(generateRemixRoute("/blog/*")).toEqual("[blog].$.tsx");
+  expect(generateRemixRoute("/blog/*")).toEqual("[blog].$");
 });
 
 test("convert named group with * modifier to remix route", () => {
-  expect(generateRemixRoute("/blog/:slug*")).toEqual("[blog].$.tsx");
+  expect(generateRemixRoute("/blog/:slug*")).toEqual("[blog].$");
 });
 
 test("convert named group with ? modifier to remix route", () => {
-  expect(generateRemixRoute("/:id?/:slug?")).toEqual(
-    "($id).($slug)._index.tsx"
-  );
+  expect(generateRemixRoute("/:id?/:slug?")).toEqual("($id).($slug)._index");
 });
 
 test("convert named groups to remix route", () => {
   expect(generateRemixRoute("/blog/:id/:date")).toEqual(
-    "[blog].$id.$date._index.tsx"
+    "[blog].$id.$date._index"
   );
 });
 

--- a/packages/react-sdk/src/remix.ts
+++ b/packages/react-sdk/src/remix.ts
@@ -35,11 +35,11 @@ export const generateRemixRoute = (pathname: string) => {
     pathname = pathname.slice(1);
   }
   if (pathname === "") {
-    return `_index.tsx`;
+    return `_index`;
   }
   const base = pathname.split("/").map(getRemixSegment).join(".");
   const tail = pathname.endsWith("*") ? "" : "._index";
-  return `${base}${tail}.tsx`;
+  return `${base}${tail}`;
 };
 
 /**

--- a/packages/react-sdk/src/resources-generator.test.ts
+++ b/packages/react-sdk/src/resources-generator.test.ts
@@ -49,7 +49,7 @@ test("generate getjson resource loader", () => {
       const [
       resourceName,
       ] = await Promise.all([
-      _getjson(\"https://my-json.com\"),
+      _getjson("https://my-json.com"),
       ])
       return {
       resourceName,

--- a/packages/react-sdk/src/resources-generator.test.ts
+++ b/packages/react-sdk/src/resources-generator.test.ts
@@ -1,0 +1,142 @@
+import { expect, test } from "@jest/globals";
+import stripIndent from "strip-indent";
+import { createScope, type Page } from "@webstudio-is/sdk";
+import { generateResourcesLoader } from "./resources-generator";
+
+const clear = (input: string) =>
+  stripIndent(input).trimStart().replace(/ +$/, "");
+
+const toMap = <T extends { id: string }>(list: T[]) =>
+  new Map(list.map((item) => [item.id, item] as const));
+
+test("generate getjson resource loader", () => {
+  expect(
+    generateResourcesLoader({
+      scope: createScope(),
+      page: { rootInstanceId: "body" } as Page,
+      dataSources: toMap([
+        {
+          id: "variableResourceId",
+          scopeInstanceId: "body",
+          type: "resource",
+          name: "resourceName",
+          resourceId: "resourceId",
+        },
+      ]),
+      resources: toMap([
+        {
+          id: "resourceId",
+          instanceId: "body",
+          type: "getjson",
+          url: `"https://my-json.com"`,
+        },
+      ]),
+    })
+  ).toEqual(
+    clear(`
+      const _getjson = async (url: string) => {
+        const response = await fetch(url)
+        if (response.ok) {
+          const data = await response.json()
+          return data;
+        }
+        return {
+          error: await response.text()
+        }
+      }
+      type Params = Record<string, string | undefined>
+      export const loadResources = async (_props: { params: Params }) => {
+      const [
+      resourceName,
+      ] = await Promise.all([
+      _getjson(\"https://my-json.com\"),
+      ])
+      return {
+      resourceName,
+      } as Record<string, unknown>
+      }
+    `)
+  );
+});
+
+test("generate page params variable and use it resources", () => {
+  expect(
+    generateResourcesLoader({
+      scope: createScope(),
+      page: {
+        rootInstanceId: "body",
+        pathVariableId: "variableParamsId",
+      } as Page,
+      dataSources: toMap([
+        {
+          id: "variableResourceId",
+          scopeInstanceId: "body",
+          name: "resourceName",
+          type: "resource",
+          resourceId: "resourceId",
+        },
+        {
+          id: "variableParamsId",
+          scopeInstanceId: "body",
+          name: "Page params",
+          type: "parameter",
+        },
+      ]),
+      resources: toMap([
+        {
+          id: "resourceId",
+          instanceId: "body",
+          type: "getjson",
+          url: `"https://my-json.com/" + $ws$dataSource$variableParamsId.slug`,
+        },
+      ]),
+    })
+  ).toEqual(
+    clear(`
+      const _getjson = async (url: string) => {
+        const response = await fetch(url)
+        if (response.ok) {
+          const data = await response.json()
+          return data;
+        }
+        return {
+          error: await response.text()
+        }
+      }
+      type Params = Record<string, string | undefined>
+      export const loadResources = async (_props: { params: Params }) => {
+      const Pageparams = _props.params
+      const [
+      resourceName,
+      ] = await Promise.all([
+      _getjson("https://my-json.com/" + Pageparams?.slug),
+      ])
+      return {
+      resourceName,
+      } as Record<string, unknown>
+      }
+    `)
+  );
+});
+
+test("generate empty resources loader", () => {
+  expect(
+    generateResourcesLoader({
+      scope: createScope(),
+      page: { rootInstanceId: "body" } as Page,
+      dataSources: new Map(),
+      resources: new Map(),
+    })
+  ).toEqual(
+    clear(`
+      type Params = Record<string, string | undefined>
+      export const loadResources = async (_props: { params: Params }) => {
+      const [
+      ] = await Promise.all([
+      ])
+      return {
+      } as Record<string, unknown>
+      }
+    `)
+  );
+});

--- a/packages/react-sdk/src/resources-generator.ts
+++ b/packages/react-sdk/src/resources-generator.ts
@@ -1,0 +1,80 @@
+import type { DataSources, Page, Resources, Scope } from "@webstudio-is/sdk";
+import { generateExpression } from "./expression";
+
+const getjsonCode = `
+const _getjson = async (url: string) => {
+  const response = await fetch(url)
+  if (response.ok) {
+    const data = await response.json()
+    return data;
+  }
+  return {
+    error: await response.text()
+  }
+}
+`.trimStart();
+
+export const generateResourcesLoader = ({
+  scope,
+  page,
+  dataSources,
+  resources,
+}: {
+  scope: Scope;
+  page: Page;
+  dataSources: DataSources;
+  resources: Resources;
+}) => {
+  let generatedStores = "";
+  let generatedLoaders = "";
+  let hasGetjson = false;
+
+  for (const dataSource of dataSources.values()) {
+    if (dataSource.type !== "resource") {
+      continue;
+    }
+    const resource = resources.get(dataSource.resourceId);
+    if (resource === undefined) {
+      continue;
+    }
+    // call resource by bound variable name
+    const resourceName = scope.getName(resource.id, dataSource.name);
+    if (resource.type === "getjson") {
+      hasGetjson = true;
+      const url = generateExpression({
+        expression: resource.url,
+        dataSources,
+        scope,
+      });
+      generatedStores += `${resourceName},\n`;
+      generatedLoaders += `_getjson(${url}),\n`;
+    }
+  }
+
+  const paramsVariable = page.pathVariableId
+    ? dataSources.get(page.pathVariableId)
+    : undefined;
+  const paramsName = paramsVariable
+    ? scope.getName(paramsVariable.id, paramsVariable.name)
+    : undefined;
+
+  let generated = "";
+  if (hasGetjson) {
+    generated += getjsonCode;
+  }
+  generated += `type Params = Record<string, string | undefined>\n`;
+  generated += `export const loadResources = async (_props: { params: Params }) => {\n`;
+  if (paramsName !== undefined) {
+    generated += `const ${paramsName} = _props.params\n`;
+  }
+  generated += `const [\n`;
+  generated += generatedStores;
+  generated += `] = await Promise.all([\n`;
+  generated += generatedLoaders;
+  generated += `])\n`;
+  generated += `return {\n`;
+  generated += generatedStores;
+  generated += `} as Record<string, unknown>\n`;
+  generated += `}\n`;
+  return generated;
+};


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here added generation of server modules with resource loaders. These loaders are invoked in remix loader and result is passed to page component.

Check fixtures and tests.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
