### PR TITLE
feat: reimplement expression editor with codemirror

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/json.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/json.tsx
@@ -7,9 +7,10 @@ import {
   Label,
 } from "../shared";
 import { VariablesButton } from "../variables";
-import { CodeEditor } from "../code-editor";
-
-const emptyVariables = new Map();
+import {
+  ExpressionEditor,
+  formatValue,
+} from "~/builder/shared/expression-editor";
 
 export const JsonControl = ({
   meta,
@@ -20,7 +21,7 @@ export const JsonControl = ({
   onChange,
   onDelete,
 }: ControlProps<"json", "json">) => {
-  const valueString = JSON.stringify(prop?.value ?? "");
+  const valueString = formatValue(prop?.value ?? "");
   const localValue = useLocalValue(valueString, (value) => {
     try {
       // wrap into parens to treat object expression as value instead of block
@@ -50,14 +51,9 @@ export const JsonControl = ({
       onDelete={onDelete}
     >
       <Box css={{ py: theme.spacing[2] }}>
-        <CodeEditor
-          // reset editor every time value is changed
-          key={valueString}
+        <ExpressionEditor
           readOnly={readOnly}
-          variables={emptyVariables}
-          // actual local value is not important because code editor
-          // is uncontrolled and has own local value
-          defaultValue={valueString}
+          value={localValue.value}
           onChange={localValue.set}
           onBlur={localValue.save}
         />

--- a/apps/builder/app/builder/features/settings-panel/variables.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
-import { CodeEditor as CodeEditorComponent } from "./code-editor";
 import {
   Button,
   FloatingPanelPopover,
@@ -16,7 +15,7 @@ import { registerContainers } from "~/shared/sync";
 
 export default {
   title: "Builder/Variables",
-  component: CodeEditorComponent,
+  component: VariablesPanel,
 } satisfies Meta;
 
 registerContainers();

--- a/apps/builder/app/builder/features/settings-panel/variables.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables.tsx
@@ -48,6 +48,11 @@ import { serverSyncStore } from "~/shared/sync";
 import { CodeEditor } from "./code-editor";
 import type { PropValue } from "./shared";
 import { getStartingValue } from "./props-section/use-props-logic";
+import {
+  ExpressionEditor,
+  formatValue,
+  formatValuePreview,
+} from "~/builder/shared/expression-editor";
 
 /**
  * convert value expression to js value
@@ -137,12 +142,11 @@ const VariablePanel = ({
   onBack: () => void;
 }) => {
   // variable value cannot have an access to other variables
-  const variables = useMemo(() => new Map(), []);
   const nameId = useId();
   const [name, setName] = useState(variable?.name ?? "");
   const [nameErrors, setNameErrors] = useState<undefined | string[]>();
   const [value, setValue] = useState(
-    JSON.stringify(
+    formatValue(
       variable?.type === "variable" ? variable?.value.value ?? "" : ""
     )
   );
@@ -194,11 +198,7 @@ const VariablePanel = ({
             <Label>Value</Label>
             <InputErrorsTooltip errors={valueErrors}>
               <div>
-                <CodeEditor
-                  variables={variables}
-                  defaultValue={value}
-                  onChange={setValue}
-                />
+                <ExpressionEditor value={value} onChange={setValue} />
               </div>
             </InputErrorsTooltip>
           </Flex>
@@ -346,7 +346,7 @@ const ListItem = ({
       label={
         <Label truncate>
           {variable.type === "variable"
-            ? `${variable.name}: ${JSON.stringify(variable.value.value)}`
+            ? `${variable.name}: ${formatValuePreview(variable.value.value)}`
             : variable.name}
         </Label>
       }

--- a/apps/builder/app/builder/shared/expression-editor.stories.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.stories.tsx
@@ -37,7 +37,7 @@ export const ExpressionEditor: StoryObj = {
   render: () => (
     <>
       <p>
-        Start typing "h" or "o" or press "Tab" to start variables completion
+        {`Start typing "h" or "o" or press "Tab" to start variables completion`}
       </p>
       <ExpressionStory />
     </>

--- a/apps/builder/app/builder/shared/expression-editor.stories.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ExpressionEditor as ExpressionEditorComponent } from "./expression-editor";
+import { useState } from "react";
+
+export default {
+  title: "Builder/ExpressionEditor",
+  component: ExpressionEditorComponent,
+} satisfies Meta;
+
+const scope = {
+  $ws$dataSource$123: {
+    world: "!s fb skffsjdfksjdlkjslkkjlkj sjf lsdjsskljl kjsf",
+    hello: [],
+    aa: 0,
+    b: true,
+  },
+  $ws$dataSource$321: { my: "god" },
+};
+const aliases = new Map<string, string>([
+  ["$ws$dataSource$123", "Hello world"],
+  ["$ws$dataSource$321", "oh"],
+]);
+
+const ExpressionStory = () => {
+  const [value, setValue] = useState("$ws$dataSource$123.world");
+  return (
+    <ExpressionEditorComponent
+      scope={scope}
+      aliases={aliases}
+      value={value}
+      onChange={setValue}
+    />
+  );
+};
+
+export const ExpressionEditor: StoryObj = {
+  render: () => (
+    <>
+      <p>
+        Start typing "h" or "o" or press "Tab" to start variables completion
+      </p>
+      <ExpressionStory />
+    </>
+  ),
+};

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -1,0 +1,350 @@
+import { useEffect, useRef } from "react";
+import { matchSorter } from "match-sorter";
+import { Annotation, EditorState, Facet, StateEffect } from "@codemirror/state";
+import {
+  type DecorationSet,
+  type ViewUpdate,
+  MatchDecorator,
+  Decoration,
+  WidgetType,
+  ViewPlugin,
+  keymap,
+  drawSelection,
+  dropCursor,
+  EditorView,
+} from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import {
+  bracketMatching,
+  defaultHighlightStyle,
+  syntaxHighlighting,
+} from "@codemirror/language";
+import {
+  type Completion,
+  type CompletionSource,
+  autocompletion,
+  startCompletion,
+  closeBrackets,
+  closeBracketsKeymap,
+  completionKeymap,
+} from "@codemirror/autocomplete";
+import { completionPath, javascript } from "@codemirror/lang-javascript";
+import { theme, textVariants, css } from "@webstudio-is/design-system";
+
+export const formatValue = (value: unknown) => {
+  if (Array.isArray(value)) {
+    // format arrays as multiline
+    return JSON.stringify(value, null, 2);
+  }
+  if (typeof value === "object" && value !== null) {
+    // format objects with parentheses to enforce correct
+    // syntax highlighting as expression instead of block
+    return `(${JSON.stringify(value, null, 2)})`;
+  }
+  return JSON.stringify(value);
+};
+
+export const formatValuePreview = (value: unknown) => {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (Number.isNaN(value)) {
+    return "nan";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  if (typeof value === "number") {
+    return value.toString();
+  }
+  if (typeof value === "boolean") {
+    return value.toString();
+  }
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (value === null) {
+    return "null";
+  }
+  return typeof value;
+};
+
+const ExternalChange = Annotation.define<boolean>();
+
+type Scope = Record<string, unknown>;
+
+type Aliases = Map<string, string>;
+
+const VariablesData = Facet.define<{
+  scope: Scope;
+  aliases: Aliases;
+}>();
+
+// Defines a completion source that completes from the given scope
+// object (for example `globalThis`). Will enter properties
+// of the object when completing properties on a directly-named path.
+const scopeCompletionSource: CompletionSource = (context) => {
+  const [{ scope, aliases }] = context.state.facet(VariablesData);
+  const path = completionPath(context);
+  if (path === null) {
+    return null;
+  }
+  let target: any = scope;
+  for (const step of path.path) {
+    target = target[step];
+    if (target == null) {
+      return null;
+    }
+  }
+  let options: Completion[] = [];
+  if (typeof target === "object" && target !== null) {
+    options = Object.entries(target).map(([name, value]) => ({
+      label: name,
+      displayLabel: aliases.get(name),
+      detail: formatValuePreview(value),
+    }));
+    options = matchSorter(options, path.name, {
+      keys: [(option) => option.displayLabel ?? option.label],
+    });
+  }
+  return {
+    from: context.pos - path.name.length,
+    filter: false,
+    options,
+  };
+};
+
+/**
+ * Highlight variables and replace their $ws$dataSource$name like labels
+ * with user names
+ */
+
+class VariableWidget extends WidgetType {
+  constructor(readonly text: string) {
+    super();
+  }
+  toDOM(): HTMLElement {
+    const span = document.createElement("span");
+    span.style.backgroundColor = "rgba(24, 119, 232, 0.2)";
+    span.textContent = this.text;
+    return span;
+  }
+}
+
+const variableMatcher = new MatchDecorator({
+  regexp: /(\$ws\$dataSource\$\w+)/g,
+  decoration: (match, view) => {
+    const name = match[1];
+    const [data] = view.state.facet(VariablesData);
+    return Decoration.replace({
+      widget: new VariableWidget(data.aliases.get(name) ?? name),
+    });
+  },
+});
+
+const variables = ViewPlugin.fromClass(
+  class {
+    variables: DecorationSet;
+    constructor(view: EditorView) {
+      this.variables = variableMatcher.createDeco(view);
+    }
+    update(update: ViewUpdate) {
+      this.variables = variableMatcher.updateDeco(update, this.variables);
+    }
+  },
+  {
+    decorations: (instance) => instance.variables,
+    provide: (plugin) =>
+      EditorView.atomicRanges.of((view) => {
+        return view.plugin(plugin)?.variables || Decoration.none;
+      }),
+  }
+);
+
+const rootStyle = css({
+  ...textVariants.mono,
+  boxSizing: "border-box",
+  color: theme.colors.foregroundMain,
+  borderRadius: theme.borderRadius[4],
+  border: `1px solid ${theme.colors.borderMain}`,
+  background: theme.colors.backgroundControls,
+  paddingTop: 6,
+  paddingBottom: 4,
+  paddingRight: theme.spacing[2],
+  paddingLeft: theme.spacing[3],
+  "&:focus-within": {
+    borderColor: theme.colors.borderFocus,
+    outline: `1px solid ${theme.colors.borderFocus}`,
+  },
+  "& .cm-focused": {
+    outline: "none",
+  },
+  "& .cm-content": {
+    padding: 0,
+  },
+  "& .cm-line": {
+    padding: 0,
+  },
+  "& .cm-tooltip": {
+    border: "none",
+    backgroundColor: "transparent",
+  },
+  "& .cm-tooltip.cm-tooltip-autocomplete ul": {
+    minWidth: 160,
+    maxWidth: 260,
+    width: "max-content",
+    boxSizing: "border-box",
+    borderRadius: theme.borderRadius[6],
+    backgroundColor: theme.colors.backgroundMenu,
+    border: `1px solid ${theme.colors.borderMain}`,
+    boxShadow: `${theme.shadows.menuDropShadow}, inset 0 0 0 1px ${theme.colors.borderMenuInner}`,
+    padding: theme.spacing[3],
+    "& li": {
+      ...textVariants.labelsTitleCase,
+      textTransform: "none",
+      // outline: "none",
+      // cursor: "default",
+      position: "relative",
+      display: "flex",
+      alignItems: "center",
+      color: theme.colors.foregroundMain,
+      padding: theme.spacing[3],
+      borderRadius: theme.borderRadius[3],
+      "&[aria-selected]": {
+        color: theme.colors.foregroundMain,
+        backgroundColor: theme.colors.backgroundItemMenuItemHover,
+      },
+      "& .cm-completionIcon": {
+        display: "none",
+      },
+      "& .cm-completionLabel": {
+        flexGrow: 1,
+      },
+      "& .cm-completionDetail": {
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        fontStyle: "normal",
+        color: theme.colors.hint,
+      },
+    },
+  },
+});
+
+const emptyScope: Scope = {};
+const emptyAliases: Aliases = new Map();
+
+export const ExpressionEditor = ({
+  scope = emptyScope,
+  aliases = emptyAliases,
+  readOnly = false,
+  value,
+  onChange,
+  onBlur,
+}: {
+  /**
+   * object with variables and their data to autocomplete
+   */
+  scope?: Scope;
+  /**
+   * variable aliases to show instead of $ws$dataSource$id
+   */
+  aliases?: Aliases;
+  readOnly?: boolean;
+  value: string;
+  onChange: (newValue: string) => void;
+  onBlur?: () => void;
+}) => {
+  const editorRef = useRef<null | HTMLDivElement>(null);
+  const viewRef = useRef<undefined | EditorView>();
+
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const onBlurRef = useRef(onBlur);
+  onBlurRef.current = onBlur;
+
+  // setup editor
+
+  useEffect(() => {
+    if (editorRef.current === null) {
+      return;
+    }
+    const view = new EditorView({
+      doc: "",
+      parent: editorRef.current,
+    });
+    viewRef.current = view;
+    return () => {
+      view.destroy();
+    };
+  }, []);
+
+  // update extensions whenever variables data is changed
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (view === undefined) {
+      return;
+    }
+    view.dispatch({
+      effects: StateEffect.reconfigure.of([
+        history(),
+        drawSelection(),
+        dropCursor(),
+        bracketMatching(),
+        closeBrackets(),
+        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+        javascript({}),
+        VariablesData.of({ scope, aliases }),
+        autocompletion({ override: [scopeCompletionSource] }),
+        variables,
+        keymap.of([
+          ...closeBracketsKeymap,
+          ...defaultKeymap,
+          ...historyKeymap,
+          ...completionKeymap,
+          // use tab to trigger completion
+          { key: "Tab", run: startCompletion },
+        ]),
+        EditorView.editable.of(readOnly === false),
+        EditorState.readOnly.of(readOnly === true),
+        EditorView.updateListener.of((update) => {
+          if (
+            // prevent invoking callback when focus or selection is changed
+            update.docChanged &&
+            // prevent invoking callback when the change came from react value
+            update.transactions.some((trx) =>
+              trx.annotation(ExternalChange)
+            ) === false
+          ) {
+            onChangeRef.current(update.state.doc.toString());
+          }
+        }),
+        EditorView.domEventHandlers({
+          blur: () => {
+            onBlurRef.current?.();
+          },
+        }),
+      ]),
+    });
+  }, [scope, aliases, readOnly]);
+
+  // update editor with react value
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (view === undefined) {
+      return;
+    }
+    // prevent updating when editor has the same state
+    // and can be the source of new value
+    if (value === view.state.doc.toString()) {
+      return;
+    }
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: value },
+      annotations: [ExternalChange.of(true)],
+    });
+  }, [value]);
+
+  return <div className={rootStyle.toString()} ref={editorRef}></div>;
+};

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -89,9 +89,10 @@ const scopeCompletionSource: CompletionSource = (context) => {
   if (path === null) {
     return null;
   }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let target: any = scope;
   for (const step of path.path) {
-    target = target[step];
+    target = target?.[step];
     if (target == null) {
       return null;
     }

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -20,6 +20,12 @@
     "middleware:dev": "DOTENV_CONFIG_PATH=.env.preview tsx watch -r dotenv/config ./middleware.js"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.11.1",
+    "@codemirror/commands": "^6.3.2",
+    "@codemirror/lang-javascript": "^6.2.1",
+    "@codemirror/language": "^6.9.3",
+    "@codemirror/state": "^6.3.3",
+    "@codemirror/view": "^6.22.3",
     "@floating-ui/dom": "^1.5.3",
     "@fontsource-variable/inter": "^5.0.13",
     "@fontsource-variable/manrope": "^5.0.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,24 @@ importers:
 
   apps/builder:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.11.1
+        version: 6.11.1(@codemirror/language@6.9.3)(@codemirror/state@6.3.3)(@codemirror/view@6.22.3)(@lezer/common@1.1.2)
+      '@codemirror/commands':
+        specifier: ^6.3.2
+        version: 6.3.2
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.1
+        version: 6.2.1
+      '@codemirror/language':
+        specifier: ^6.9.3
+        version: 6.9.3
+      '@codemirror/state':
+        specifier: ^6.3.3
+        version: 6.3.3
+      '@codemirror/view':
+        specifier: ^6.22.3
+        version: 6.22.3
       '@floating-ui/dom':
         specifier: ^1.5.3
         version: 1.5.3
@@ -3276,6 +3294,72 @@ packages:
     resolution: {integrity: sha512-0FRcsz7Ea3jT+gc5gKPIYciykm1bbAaTpygdzpCwGt0RL+V83zWnYN30NWDW4rIHj/FHtz+MIuBKS61C8l7AzQ==}
     patched: true
 
+  /@codemirror/autocomplete@6.11.1(@codemirror/language@6.9.3)(@codemirror/state@6.3.3)(@codemirror/view@6.22.3)(@lezer/common@1.1.2):
+    resolution: {integrity: sha512-L5UInv8Ffd6BPw0P3EF7JLYAMeEbclY7+6Q11REt8vhih8RuLreKtPy/xk8wPxs4EQgYqzI7cdgpiYwWlbS/ow==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+      '@lezer/common': ^1.0.0
+    dependencies:
+      '@codemirror/language': 6.9.3
+      '@codemirror/state': 6.3.3
+      '@codemirror/view': 6.22.3
+      '@lezer/common': 1.1.2
+    dev: false
+
+  /@codemirror/commands@6.3.2:
+    resolution: {integrity: sha512-tjoi4MCWDNxgIpoLZ7+tezdS9OEB6pkiDKhfKx9ReJ/XBcs2G2RXIu+/FxXBlWsPTsz6C9q/r4gjzrsxpcnqCQ==}
+    dependencies:
+      '@codemirror/language': 6.9.3
+      '@codemirror/state': 6.3.3
+      '@codemirror/view': 6.22.3
+      '@lezer/common': 1.1.2
+    dev: false
+
+  /@codemirror/lang-javascript@6.2.1:
+    resolution: {integrity: sha512-jlFOXTejVyiQCW3EQwvKH0m99bUYIw40oPmFjSX2VS78yzfe0HELZ+NEo9Yfo1MkGRpGlj3Gnu4rdxV1EnAs5A==}
+    dependencies:
+      '@codemirror/autocomplete': 6.11.1(@codemirror/language@6.9.3)(@codemirror/state@6.3.3)(@codemirror/view@6.22.3)(@lezer/common@1.1.2)
+      '@codemirror/language': 6.9.3
+      '@codemirror/lint': 6.4.2
+      '@codemirror/state': 6.3.3
+      '@codemirror/view': 6.22.3
+      '@lezer/common': 1.1.2
+      '@lezer/javascript': 1.4.10
+    dev: false
+
+  /@codemirror/language@6.9.3:
+    resolution: {integrity: sha512-qq48pYzoi6ldYWV/52+Z9Ou6QouVI+8YwvxFbUypI33NbjG2UeRHKENRyhwljTTiOqjQ33FjyZj6EREQ9apAOQ==}
+    dependencies:
+      '@codemirror/state': 6.3.3
+      '@codemirror/view': 6.22.3
+      '@lezer/common': 1.1.2
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.3.14
+      style-mod: 4.1.0
+    dev: false
+
+  /@codemirror/lint@6.4.2:
+    resolution: {integrity: sha512-wzRkluWb1ptPKdzlsrbwwjYCPLgzU6N88YBAmlZi8WFyuiEduSd05MnJYNogzyc8rPK7pj6m95ptUApc8sHKVA==}
+    dependencies:
+      '@codemirror/state': 6.3.3
+      '@codemirror/view': 6.22.3
+      crelt: 1.0.6
+    dev: false
+
+  /@codemirror/state@6.3.3:
+    resolution: {integrity: sha512-0wufKcTw2dEwEaADajjHf6hBy1sh3M6V0e+q4JKIhLuiMSe5td5HOWpUdvKth1fT1M9VYOboajoBHpkCd7PG7A==}
+    dev: false
+
+  /@codemirror/view@6.22.3:
+    resolution: {integrity: sha512-rqnq+Zospwoi3x1vZ8BGV1MlRsaGljX+6qiGYmIpJ++M+LCC+wjfDaPklhwpWSgv7pr/qx29KiAKQBH5+DOn4w==}
+    dependencies:
+      '@codemirror/state': 6.3.3
+      style-mod: 4.1.0
+      w3c-keyname: 2.2.8
+    dev: false
+
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -4753,6 +4837,29 @@ packages:
       '@lexical/offset': 0.12.2(lexical@0.12.2)
       lexical: 0.12.2
       yjs: 13.5.52
+    dev: false
+
+  /@lezer/common@1.1.2:
+    resolution: {integrity: sha512-V+GqBsga5+cQJMfM0GdnHmg4DgWvLzgMWjbldBg0+jC3k9Gu6nJNZDLJxXEBT1Xj8KhRN4jmbC5CY7SIL++sVw==}
+    dev: false
+
+  /@lezer/highlight@1.2.0:
+    resolution: {integrity: sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==}
+    dependencies:
+      '@lezer/common': 1.1.2
+    dev: false
+
+  /@lezer/javascript@1.4.10:
+    resolution: {integrity: sha512-XJu3fZjHVVjJcRS7kHdwBO50irXc4H8rQwgm6SmT3Y8IHWk7WzpaLsaR2vdr/jSk/J4pQhXc1WLul7jVdxC+0Q==}
+    dependencies:
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.3.14
+    dev: false
+
+  /@lezer/lr@1.3.14:
+    resolution: {integrity: sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==}
+    dependencies:
+      '@lezer/common': 1.1.2
     dev: false
 
   /@mdx-js/react@2.3.0(react@18.2.0):
@@ -9625,6 +9732,10 @@ packages:
       - supports-color
       - ts-node
     dev: true
+
+  /crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+    dev: false
 
   /cron-schedule@3.0.6:
     resolution: {integrity: sha512-izfGgKyzzIyLaeb1EtZ3KbglkS6AKp9cv7LxmiyoOu+fXfol1tQDC0Cof0enVZGNtudTHW+3lfuW9ZkLQss4Wg==}
@@ -16230,6 +16341,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  /style-mod@4.1.0:
+    resolution: {integrity: sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==}
+    dev: false
+
   /style-to-object@0.4.1:
     resolution: {integrity: sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==}
     dependencies:
@@ -17214,6 +17329,10 @@ packages:
       '@vue/runtime-dom': 3.3.4
       '@vue/server-renderer': 3.3.4(vue@3.3.4)
       '@vue/shared': 3.3.4
+    dev: false
+
+  /w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
     dev: false
 
   /walker@1.0.8:


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here introduce the new expression editor as a replacement to code editor. It is implemented with codemirror and will improve DX of our bindings and cms usage.

- autocomplete now completes nested objects in variables
- javascript syntax is highlighted in expressions
- json values are formatted as multiline text
- autocomplete shows fields value/type

Additionally improved a couple of things

- json objects are wrapped with parentheses `({ param: "value" })` to be treated as object instead of block in highlighter
- objects and arrays are rendered as "object" and "array" in variables list for cleaner UI

Integrated in builder only for variable value and json prop value. Will require additional logic to integrate as expression editor.

<img width="559" alt="Screenshot 2023-12-19 at 12 13 28" src="https://github.com/webstudio-is/webstudio/assets/5635476/c3a3907a-9c08-4343-a1a7-ed12dbdb2404">
<img width="239" alt="Screenshot 2023-12-19 at 12 12 24" src="https://github.com/webstudio-is/webstudio/assets/5635476/777a2ac5-db79-46c7-8438-538f03edcbf7">


## Steps for reproduction

1. Play in storybook
2. check variable value field

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
