### PR TITLE
refactor: make resources universal

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
@@ -1,5 +1,4 @@
 type Params = Record<string, string | undefined>;
 export const loadResources = async (_props: { params: Params }) => {
-  const [] = await Promise.all([]);
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
@@ -1,5 +1,4 @@
 type Params = Record<string, string | undefined>;
 export const loadResources = async (_props: { params: Params }) => {
-  const [] = await Promise.all([]);
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
@@ -1,5 +1,4 @@
 type Params = Record<string, string | undefined>;
 export const loadResources = async (_props: { params: Params }) => {
-  const [] = await Promise.all([]);
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
@@ -1,5 +1,4 @@
 type Params = Record<string, string | undefined>;
 export const loadResources = async (_props: { params: Params }) => {
-  const [] = await Promise.all([]);
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
@@ -1,5 +1,4 @@
 type Params = Record<string, string | undefined>;
 export const loadResources = async (_props: { params: Params }) => {
-  const [] = await Promise.all([]);
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
@@ -1,5 +1,4 @@
 type Params = Record<string, string | undefined>;
 export const loadResources = async (_props: { params: Params }) => {
-  const [] = await Promise.all([]);
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
@@ -1,5 +1,4 @@
 type Params = Record<string, string | undefined>;
 export const loadResources = async (_props: { params: Params }) => {
-  const [] = await Promise.all([]);
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
@@ -1,5 +1,4 @@
 type Params = Record<string, string | undefined>;
 export const loadResources = async (_props: { params: Params }) => {
-  const [] = await Promise.all([]);
   return {} as Record<string, unknown>;
 };

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -305,18 +305,22 @@ export const prebuild = async (options: {
       }
     }
 
+    const resourceIds = new Set<Resource["id"]>();
     for (const [dataSourceId, dataSource] of siteData.build.dataSources) {
       if (
         dataSource.scopeInstanceId === undefined ||
         pageInstanceSet.has(dataSource.scopeInstanceId)
       ) {
         dataSources.push([dataSourceId, dataSource]);
+        if (dataSource.type === "resource") {
+          resourceIds.add(dataSource.resourceId);
+        }
       }
     }
 
     const resources: [Resource["id"], Resource][] = [];
     for (const [resourceId, resource] of siteData.build.resources ?? []) {
-      if (pageInstanceSet.has(resource.instanceId)) {
+      if (resourceIds.has(resourceId)) {
         resources.push([resourceId, resource]);
       }
     }

--- a/packages/react-sdk/src/resources-generator.test.ts
+++ b/packages/react-sdk/src/resources-generator.test.ts
@@ -9,7 +9,7 @@ const clear = (input: string) =>
 const toMap = <T extends { id: string }>(list: T[]) =>
   new Map(list.map((item) => [item.id, item] as const));
 
-test("generate getjson resource loader", () => {
+test("generate resources loader", () => {
   expect(
     generateResourcesLoader({
       scope: createScope(),
@@ -19,47 +19,47 @@ test("generate getjson resource loader", () => {
           id: "variableResourceId",
           scopeInstanceId: "body",
           type: "resource",
-          name: "resourceName",
+          name: "variableName",
           resourceId: "resourceId",
         },
       ]),
       resources: toMap([
         {
           id: "resourceId",
-          instanceId: "body",
-          type: "getjson",
+          name: "resourceName",
           url: `"https://my-json.com"`,
+          method: "post",
+          headers: [{ name: "Content-Type", value: `"application/json"` }],
+          body: `{ body: true }`,
         },
       ]),
     })
   ).toEqual(
     clear(`
-      const _getjson = async (url: string) => {
-        const response = await fetch(url)
-        if (response.ok) {
-          const data = await response.json()
-          return data;
-        }
-        return {
-          error: await response.text()
-        }
-      }
+      import { loadResource } from "@webstudio-is/sdk";
       type Params = Record<string, string | undefined>
       export const loadResources = async (_props: { params: Params }) => {
       const [
-      resourceName,
+      variableName,
       ] = await Promise.all([
-      _getjson("https://my-json.com"),
+      loadResource({
+      url: "https://my-json.com",
+      method: "post",
+      headers: [
+      { name: "Content-Type", value: "application/json" },
+      ],
+      body: {body: true},
+      }),
       ])
       return {
-      resourceName,
+      variableName,
       } as Record<string, unknown>
       }
     `)
   );
 });
 
-test("generate page params variable and use it resources", () => {
+test("generate variable and use in resources loader", () => {
   expect(
     generateResourcesLoader({
       scope: createScope(),
@@ -71,7 +71,73 @@ test("generate page params variable and use it resources", () => {
         {
           id: "variableResourceId",
           scopeInstanceId: "body",
+          name: "variableName",
+          type: "resource",
+          resourceId: "resourceId",
+        },
+        {
+          id: "variableTokenId",
+          scopeInstanceId: "body",
+          name: "Access Token",
+          type: "variable",
+          value: { type: "string", value: "my-token" },
+        },
+      ]),
+      resources: toMap([
+        {
+          id: "resourceId",
           name: "resourceName",
+          url: `"https://my-json.com/"`,
+          method: "post",
+          headers: [
+            {
+              name: "Authorization",
+              value: `"Token " + $ws$dataSource$variableTokenId`,
+            },
+          ],
+          body: `{ body: true }`,
+        },
+      ]),
+    })
+  ).toEqual(
+    clear(`
+      import { loadResource } from "@webstudio-is/sdk";
+      type Params = Record<string, string | undefined>
+      export const loadResources = async (_props: { params: Params }) => {
+      const AcessToken = "my-token"
+      const [
+      variableName,
+      ] = await Promise.all([
+      loadResource({
+      url: "https://my-json.com/",
+      method: "post",
+      headers: [
+      { name: "Authorization", value: "Token " + AccessToken },
+      ],
+      body: {body: true},
+      }),
+      ])
+      return {
+      variableName,
+      } as Record<string, unknown>
+      }
+    `)
+  );
+});
+
+test("generate page params variable and use in resources loader", () => {
+  expect(
+    generateResourcesLoader({
+      scope: createScope(),
+      page: {
+        rootInstanceId: "body",
+        pathVariableId: "variableParamsId",
+      } as Page,
+      dataSources: toMap([
+        {
+          id: "variableResourceId",
+          scopeInstanceId: "body",
+          name: "variableName",
           type: "resource",
           resourceId: "resourceId",
         },
@@ -85,34 +151,34 @@ test("generate page params variable and use it resources", () => {
       resources: toMap([
         {
           id: "resourceId",
-          instanceId: "body",
-          type: "getjson",
+          name: "resourceName",
           url: `"https://my-json.com/" + $ws$dataSource$variableParamsId.slug`,
+          method: "post",
+          headers: [{ name: "Content-Type", value: `"application/json"` }],
+          body: `{ body: true }`,
         },
       ]),
     })
   ).toEqual(
     clear(`
-      const _getjson = async (url: string) => {
-        const response = await fetch(url)
-        if (response.ok) {
-          const data = await response.json()
-          return data;
-        }
-        return {
-          error: await response.text()
-        }
-      }
+      import { loadResource } from "@webstudio-is/sdk";
       type Params = Record<string, string | undefined>
       export const loadResources = async (_props: { params: Params }) => {
       const Pageparams = _props.params
       const [
-      resourceName,
+      variableName,
       ] = await Promise.all([
-      _getjson("https://my-json.com/" + Pageparams?.slug),
+      loadResource({
+      url: "https://my-json.com/" + Pageparams?.slug,
+      method: "post",
+      headers: [
+      { name: "Content-Type", value: "application/json" },
+      ],
+      body: {body: true},
+      }),
       ])
       return {
-      resourceName,
+      variableName,
       } as Record<string, unknown>
       }
     `)
@@ -131,9 +197,6 @@ test("generate empty resources loader", () => {
     clear(`
       type Params = Record<string, string | undefined>
       export const loadResources = async (_props: { params: Params }) => {
-      const [
-      ] = await Promise.all([
-      ])
       return {
       } as Record<string, unknown>
       }

--- a/packages/react-sdk/src/resources-generator.test.ts
+++ b/packages/react-sdk/src/resources-generator.test.ts
@@ -104,7 +104,7 @@ test("generate variable and use in resources loader", () => {
       import { loadResource } from "@webstudio-is/sdk";
       type Params = Record<string, string | undefined>
       export const loadResources = async (_props: { params: Params }) => {
-      const AcessToken = "my-token"
+      let AccessToken = "my-token"
       const [
       variableName,
       ] = await Promise.all([

--- a/packages/react-sdk/src/resources-generator.ts
+++ b/packages/react-sdk/src/resources-generator.ts
@@ -53,7 +53,6 @@ export const generateResourcesLoader = ({
       if (resource.headers.length > 0) {
         generatedLoaders += `headers: [\n`;
         for (const header of resource.headers) {
-          header.name;
           const value = generateExpression({
             expression: header.value,
             dataSources,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,3 +12,4 @@ export * from "./schema/deployment";
 
 export * from "./instances-utils";
 export * from "./scope";
+export * from "./resource-loader";

--- a/packages/sdk/src/resource-loader.ts
+++ b/packages/sdk/src/resource-loader.ts
@@ -1,0 +1,32 @@
+import type { Resource } from "./schema/resources";
+
+export const loadResource = async (resourceData: Resource) => {
+  const { url, method, headers, body } = resourceData;
+  const requestHeaders = new Headers(
+    headers.map(({ name, value }) => [name, value])
+  );
+  const requestInit: RequestInit = {
+    method,
+    headers: requestHeaders,
+  };
+  if (method !== "get" && body !== undefined) {
+    requestInit.body = body;
+  }
+  const response = await fetch(url, requestInit);
+  let data;
+  if (
+    response.ok &&
+    // accept json by default and when specified explicitly
+    (requestHeaders.has("accept") === false ||
+      requestHeaders.get("accept") === "application/json")
+  ) {
+    data = await response.json();
+  } else {
+    data = await response.text();
+  }
+  return {
+    data,
+    status: response.status,
+    statusText: response.statusText,
+  };
+};

--- a/packages/sdk/src/resource-loader.ts
+++ b/packages/sdk/src/resource-loader.ts
@@ -3,7 +3,7 @@ import type { Resource } from "./schema/resources";
 export const loadResource = async (resourceData: Resource) => {
   const { url, method, headers, body } = resourceData;
   const requestHeaders = new Headers(
-    headers.map(({ name, value }) => [name, value])
+    headers.map(({ name, value }): [string, string] => [name, value])
   );
   const requestInit: RequestInit = {
     method,

--- a/packages/sdk/src/schema/resources.ts
+++ b/packages/sdk/src/schema/resources.ts
@@ -2,18 +2,29 @@ import { z } from "zod";
 
 const ResourceId = z.string();
 
-export const Resource = z.union([
-  // !!! this is prototype only resource type
-  // build other resources before exposing to production
-  z.object({
-    type: z.literal("getjson"),
-    id: ResourceId,
-    instanceId: z.string(),
-    // expression
-    url: z.string(),
-  }),
-  z.never(),
+const Method = z.union([
+  z.literal("get"),
+  z.literal("post"),
+  z.literal("put"),
+  z.literal("delete"),
 ]);
+
+const Header = z.object({
+  name: z.string(),
+  // expression
+  value: z.string(),
+});
+
+export const Resource = z.object({
+  id: ResourceId,
+  name: z.string(),
+  method: Method,
+  // expression
+  url: z.string(),
+  headers: z.array(Header),
+  // expression
+  body: z.optional(z.string()),
+});
 
 export type Resource = z.infer<typeof Resource>;
 


### PR DESCRIPTION
Refactored resources generator to use universal http resource which cover most cases.
- loadResource is imported from sdk
- accepts url (expression), method, headers (value is expression) and body (expression)
- all variables and page params parameter are available for loader expressions