### PR TITLE
fix: remove delay when showing spinner for openning projects

### DIFF
--- a/apps/builder/app/dashboard/projects/project-card.tsx
+++ b/apps/builder/app/dashboard/projects/project-card.tsx
@@ -207,7 +207,7 @@ export const ProjectCard = ({
       >
         <Grid className={thumbnailStyle()}>
           <ThumbnailLink title={title} to={linkPath} ref={thumbnailRef} />
-          {isTransitioning && <Spinner />}
+          {isTransitioning && <Spinner delay={0} />}
         </Grid>
 
         <Flex


### PR DESCRIPTION

## Description

Reason is we always see spinner, but with delay it feels less responsive

## Steps for reproduction

1. click project thumbnail
2. see spinner showing right away

## Code Review

- [ ] hi @try, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
