### PR TITLE
feat: load resources in builder

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -38,6 +38,7 @@ import {
   stylesStore,
   $domains,
   $resources,
+  subscribeResources,
 } from "~/shared/nano-states";
 import { type Settings, useClientSettings } from "./shared/client-settings";
 import { getBuildUrl } from "~/shared/router-utils";
@@ -261,6 +262,7 @@ export const Builder = ({
   });
 
   useEffect(subscribeCommands, []);
+  useEffect(subscribeResources, []);
 
   useUnmount(() => {
     pagesStore.set(undefined);

--- a/apps/builder/app/routes/rest.resources-loader.ts
+++ b/apps/builder/app/routes/rest.resources-loader.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import type { ActionArgs } from "@remix-run/node";
+import { loadResource, Resource } from "@webstudio-is/sdk";
+
+export const action = async ({ request }: ActionArgs) => {
+  const computedResources = z.array(Resource).parse(await request.json());
+  const responses = await Promise.all(computedResources.map(loadResource));
+  const output: [Resource["id"], unknown][] = [];
+  responses.forEach((response, index) => {
+    const request = computedResources[index];
+    output.push([request.id, response]);
+  });
+  return output;
+};

--- a/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
@@ -371,7 +371,7 @@ describe("data sources", () => {
     );
   });
 
-  test.only("copy parameter prop with new data source", () => {
+  test("copy parameter prop with new data source", () => {
     const instances: Instances = toMap([
       createInstance("body", "Body", [{ type: "id", value: "list" }]),
       createInstance("list", collectionComponent, []),

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -51,6 +51,7 @@ export const dataSourceVariablesStore = atom<Map<DataSource["id"], unknown>>(
 export const $dataSourceVariables = dataSourceVariablesStore;
 
 export const $resources = atom(new Map<Resource["id"], Resource>());
+export const $resourceValues = atom(new Map<Resource["id"], unknown>());
 
 export const propsStore = atom<Props>(new Map());
 export const $props = propsStore;

--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -13,6 +13,7 @@ import {
   $dataSourceVariables,
   $dataSources,
   $props,
+  $resourceValues,
 } from "./nano-states";
 import { $params } from "~/canvas/stores";
 
@@ -378,6 +379,45 @@ test("access parameter value from variables values", () => {
   cleanStores($propValuesByInstanceSelector);
 });
 
+test("compute props bound to resource variables", () => {
+  $instances.set(
+    toMap([{ id: "body", type: "instance", component: "Body", children: [] }])
+  );
+  selectPageRoot("body");
+  $dataSources.set(
+    toMap([
+      {
+        id: "resourceVariableId",
+        type: "resource",
+        name: "paramName",
+        resourceId: "resourceId",
+      },
+    ])
+  );
+  $resourceValues.set(new Map([["resourceId", "my-value"]]));
+  $props.set(
+    toMap([
+      {
+        id: "resourcePropId",
+        name: "resource",
+        instanceId: "body",
+        type: "expression",
+        value: "$ws$dataSource$resourceVariableId",
+      },
+    ])
+  );
+  expect($propValuesByInstanceSelector.get()).toEqual(
+    new Map([
+      [
+        JSON.stringify(["body"]),
+        new Map<string, unknown>([["resource", "my-value"]]),
+      ],
+    ])
+  );
+
+  cleanStores($propValuesByInstanceSelector);
+});
+
 test("compute variable values for root", () => {
   $instances.set(
     toMap([{ id: "body", type: "instance", component: "Body", children: [] }])
@@ -562,6 +602,37 @@ test("compute item values for collection", () => {
       [
         JSON.stringify(["collection"]),
         new Map<string, unknown>([["dataId", ["apple", "banana", "orange"]]]),
+      ],
+    ])
+  );
+
+  cleanStores($variableValuesByInstanceSelector);
+});
+
+test("compute resource variable values", () => {
+  $instances.set(
+    toMap([{ id: "body", type: "instance", component: "Body", children: [] }])
+  );
+  selectPageRoot("body");
+  $dataSources.set(
+    toMap([
+      {
+        id: "resourceVariableId",
+        scopeInstanceId: "body",
+        type: "resource",
+        name: "variableName",
+        resourceId: "resourceId",
+      },
+    ])
+  );
+  $resourceValues.set(new Map([["resourceId", "my-value"]]));
+  $props.set(new Map());
+
+  expect($variableValuesByInstanceSelector.get()).toEqual(
+    new Map([
+      [
+        JSON.stringify(["body"]),
+        new Map<string, unknown>([["resourceVariableId", "my-value"]]),
       ],
     ])
   );

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -1,6 +1,7 @@
 import { computed } from "nanostores";
 import {
   createScope,
+  type Resource,
   type DataSource,
   type Instance,
   type Page,
@@ -18,11 +19,14 @@ import {
   $dataSources,
   $props,
   $assets,
+  $resources,
+  $resourceValues,
 } from "./nano-states";
 import { $selectedPage, $pages } from "./pages";
 import { groupBy } from "../array-utils";
 import type { InstanceSelector } from "../tree-utils";
 import { $params } from "~/canvas/stores";
+import { restResourcesLoader } from "../router-utils";
 
 export const getIndexedInstanceId = (
   instanceId: Instance["id"],
@@ -32,27 +36,34 @@ export const getIndexedInstanceId = (
 // result of executing generated code
 // includes variables, computed expressions and action callbacks
 const $dataSourcesLogic = computed(
-  [$dataSources, $dataSourceVariables, $props],
-  (dataSources, dataSourceVariables, props) => {
+  [$dataSources, $dataSourceVariables, $resourceValues, $props],
+  (dataSources, dataSourceVariables, resourceValues, props) => {
     const scope = createScope(["_getVariable", "_setVariable", "_output"]);
-    const { variables, body, output } = generateDataSources({
+    const { body, output } = generateDataSources({
       scope,
       dataSources,
       props,
     });
     let generatedCode = "";
-    // render state variables
-    for (const [dataSourceId, variable] of variables) {
-      const { valueName, setterName } = variable;
-      const initialValue = JSON.stringify(variable.initialValue);
-      generatedCode += `let ${valueName} = _getVariable("${dataSourceId}") ?? ${initialValue};\n`;
-      generatedCode += `let ${setterName} = (value) => _setVariable("${dataSourceId}", value);\n`;
-    }
-    // render parameters
     for (const [dataSourceId, dataSource] of dataSources) {
+      if (dataSource.type === "variable") {
+        const initialValue = JSON.stringify(dataSource.value.value);
+        // save variables to generate header and footer depending on environment
+        const valueName = scope.getName(dataSourceId, dataSource.name);
+        const setterName = scope.getName(
+          `set$${dataSourceId}`,
+          `set$${dataSource.name}`
+        );
+        generatedCode += `let ${valueName} = _getVariable("${dataSourceId}") ?? ${initialValue};\n`;
+        generatedCode += `let ${setterName} = (value) => _setVariable("${dataSourceId}", value);\n`;
+      }
       if (dataSource.type === "parameter") {
         const variableName = scope.getName(dataSourceId, dataSource.name);
         generatedCode += `let ${variableName} = _getVariable("${dataSourceId}");\n`;
+      }
+      if (dataSource.type === "resource") {
+        const variableName = scope.getName(dataSourceId, dataSource.name);
+        generatedCode += `let ${variableName} = _getResource("${dataSource.resourceId}");\n`;
       }
     }
     generatedCode += body;
@@ -61,28 +72,30 @@ const $dataSourcesLogic = computed(
       generatedCode += `_output.set('${dataSourceId}', ${variableName})\n`;
     }
     for (const [dataSourceId, dataSource] of dataSources) {
-      if (dataSource.type === "parameter") {
-        const variableName = scope.getName(dataSourceId, dataSource.name);
-        generatedCode += `_output.set('${dataSourceId}', ${variableName})\n`;
-      }
+      const variableName = scope.getName(dataSourceId, dataSource.name);
+      generatedCode += `_output.set('${dataSourceId}', ${variableName})\n`;
     }
     generatedCode += `return _output\n`;
 
     try {
       const executeFn = new Function(
         "_getVariable",
+        "_getResource",
         "_setVariable",
         generatedCode
       );
       const getVariable = (id: string) => {
         return dataSourceVariables.get(id);
       };
+      const getResource = (id: string) => {
+        return resourceValues.get(id);
+      };
       const setVariable = (id: string, value: unknown) => {
         const dataSourceVariables = new Map($dataSourceVariables.get());
         dataSourceVariables.set(id, value);
         $dataSourceVariables.set(dataSourceVariables);
       };
-      return executeFn(getVariable, setVariable);
+      return executeFn(getVariable, getResource, setVariable);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error);
@@ -235,8 +248,22 @@ export const $propValuesByInstanceSelector = computed(
 );
 
 export const $variableValuesByInstanceSelector = computed(
-  [$instances, $props, $selectedPage, $dataSources, $dataSourceVariables],
-  (instances, props, page, dataSources, dataSourceVariables) => {
+  [
+    $instances,
+    $props,
+    $selectedPage,
+    $dataSources,
+    $dataSourceVariables,
+    $resourceValues,
+  ],
+  (
+    instances,
+    props,
+    page,
+    dataSources,
+    dataSourceVariables,
+    resourceValues
+  ) => {
     const propsByInstanceId = groupBy(
       props.values(),
       (prop) => prop.instanceId
@@ -273,11 +300,21 @@ export const $variableValuesByInstanceSelector = computed(
       const variables = variablesByInstanceId.get(instanceId);
       if (variables) {
         for (const variable of variables) {
-          const value = dataSourceVariables.get(variable.id);
           if (variable.type === "variable") {
+            const value = dataSourceVariables.get(variable.id);
             variableValues.set(variable.id, value ?? variable.value.value);
-          } else if (value !== undefined) {
-            variableValues.set(variable.id, value);
+          }
+          if (variable.type === "parameter") {
+            const value = dataSourceVariables.get(variable.id);
+            if (value !== undefined) {
+              variableValues.set(variable.id, value);
+            }
+          }
+          if (variable.type === "resource") {
+            const value = resourceValues.get(variable.resourceId);
+            if (value !== undefined) {
+              variableValues.set(variable.id, value);
+            }
           }
         }
       }
@@ -339,3 +376,119 @@ export const $variableValuesByInstanceSelector = computed(
     return variableValuesByInstanceSelector;
   }
 );
+
+// resource loader do not have an access to other resources
+const $loaderVariableValues = computed(
+  [$dataSources, $dataSourceVariables],
+  (dataSources, dataSourceVariables) => {
+    const variableValues = new Map<string, unknown>();
+    for (const variable of dataSources.values()) {
+      if (variable.type === "variable") {
+        const value = dataSourceVariables.get(variable.id);
+        variableValues.set(variable.id, value ?? variable.value.value);
+      }
+      if (variable.type === "parameter") {
+        const value = dataSourceVariables.get(variable.id);
+        variableValues.set(variable.id, value);
+      }
+    }
+    return variableValues;
+  }
+);
+
+const $computedResources = computed(
+  [$resources, $loaderVariableValues],
+  (resources, values) => {
+    const computedResources: Resource[] = [];
+    for (const resource of resources.values()) {
+      const data: Resource = {
+        id: resource.id,
+        name: resource.name,
+        url: computeExpression(resource.url, values),
+        method: resource.method,
+        headers: resource.headers.map(({ name, value }) => ({
+          name,
+          value: computeExpression(value, values),
+        })),
+      };
+      if (resource.body !== undefined) {
+        data.body = computeExpression(resource.body, values);
+      }
+      computedResources.push(data);
+    }
+    return computedResources;
+  }
+);
+
+let timeoutId: undefined | NodeJS.Timeout;
+const scheduleLoading = (callback: () => Promise<void>) => {
+  clearTimeout(timeoutId);
+  timeoutId = setTimeout(callback, 1000);
+};
+const loadResources = async (resourceRequests: Resource[]) => {
+  const response = await fetch(restResourcesLoader(), {
+    method: "POST",
+    body: JSON.stringify(resourceRequests),
+  });
+  if (response.ok === false) {
+    return;
+  }
+  const result: [Resource["id"], unknown][] = await response.json();
+  return result;
+};
+
+const cacheByKeys = new Map<string, unknown>();
+
+/**
+ * subscribe to all resources changes
+ * load them with currently available variable values
+ * and store in cache
+ */
+export const subscribeResources = () => {
+  return $computedResources.subscribe((computedResources) => {
+    const matched = new Map<Resource["id"], unknown>();
+    const missing = new Map<Resource["id"], Resource>();
+    for (const request of computedResources) {
+      const key = JSON.stringify(request);
+      if (cacheByKeys.has(key)) {
+        matched.set(request.id, request);
+      } else {
+        missing.set(request.id, request);
+      }
+    }
+
+    // update cached resource values
+    if (matched.size !== 0) {
+      const newResourceValues = new Map();
+      for (const [id, request] of matched) {
+        const response = cacheByKeys.get(JSON.stringify(request));
+        newResourceValues.set(id, response);
+      }
+      $resourceValues.set(newResourceValues);
+    }
+
+    if (missing.size === 0) {
+      return;
+    }
+
+    // load missing resource values
+    scheduleLoading(async () => {
+      // preset undefined to prevent loading already requested data
+      for (const request of missing.values()) {
+        cacheByKeys.set(JSON.stringify(request), undefined);
+      }
+      const result = await loadResources(Array.from(missing.values()));
+      if (result === undefined) {
+        return;
+      }
+      const newResourceValues = new Map($resourceValues.get());
+      for (const [id, response] of result) {
+        newResourceValues.set(id, response);
+        // save in cache
+        const request = missing.get(id);
+        cacheByKeys.set(JSON.stringify(request), response);
+      }
+      $resourceValues.set(newResourceValues);
+    });
+  });
+};

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -161,3 +161,5 @@ export const getPublishedUrl = (domain: string) => {
 
 export const restAi = (subEndpoint?: "detect" | "audio/transcriptions") =>
   typeof subEndpoint === "string" ? `/rest/ai/${subEndpoint}` : "/rest/ai";
+
+export const restResourcesLoader = () => `/rest/resources-loader`;

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -33,6 +33,7 @@ import {
   $dragAndDropState,
   $selectedInstanceStates,
   $resources,
+  $resourceValues,
 } from "~/shared/nano-states";
 import { $ephemeralStyles } from "~/canvas/stores";
 
@@ -85,6 +86,7 @@ export const registerContainers = () => {
   // synchronize whole states
   clientStores.set("project", projectStore);
   clientStores.set("dataSourceVariables", dataSourceVariablesStore);
+  clientStores.set("resourceValues", $resourceValues);
   clientStores.set("selectedPageId", selectedPageIdStore);
   clientStores.set("selectedPageHash", selectedPageHashStore);
   clientStores.set("selectedInstanceSelector", selectedInstanceSelectorStore);


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here improved resource management to load defined resources and store in variable values to allow preview data. Builder requests data from proxy route every time resources or their variables are changed.

<img width="1449" alt="Screenshot 2023-12-25 at 01 09 58" src="https://github.com/webstudio-is/webstudio/assets/5635476/6614a356-0170-4606-9b60-d39b1bc09837">

Data to test is here https://gist.githubusercontent.com/TrySound/56507c301ec85669db5f1541406a9259/raw/a49548730ab592c86b9e7781f5b29beec4765494/collection.json


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
