### PR TITLE
feat: add html editor

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/code.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/code.tsx
@@ -1,8 +1,15 @@
-import type { ControlProps } from "../shared";
-import { TextControl } from "./text";
+import { Box, theme } from "@webstudio-is/design-system";
+import {
+  useLocalValue,
+  type ControlProps,
+  getLabel,
+  VerticalLayout,
+  Label,
+} from "../shared";
+import { VariablesButton } from "../variables";
+import { HtmlEditor } from "~/builder/shared/html-editor";
 
 export const CodeControl = ({
-  instanceId,
   meta,
   prop,
   propName,
@@ -11,31 +18,46 @@ export const CodeControl = ({
   onChange,
   onDelete,
 }: ControlProps<"code", "string">) => {
+  const metaOverride = {
+    ...meta,
+    control: "text" as const,
+  };
+  const localValue = useLocalValue(prop?.value ?? "", (value) => {
+    // sanitize html before saving
+    // this is basically what browser does when innerHTML is set
+    // but isolated within temporary element
+    // so the result is correct markup
+    const div = document.createElement("div");
+    div.innerHTML = value;
+    onChange({ type: "string", value: div.innerHTML });
+  });
+  const label = getLabel(metaOverride, propName);
+
   return (
-    <TextControl
-      instanceId={instanceId}
-      meta={{
-        ...meta,
-        control: "text",
-      }}
-      prop={prop}
-      propName={propName}
-      readOnly={readOnly}
+    <VerticalLayout
+      label={
+        <Box css={{ position: "relative" }}>
+          <Label description={metaOverride.description} readOnly={readOnly}>
+            {label}
+          </Label>
+          <VariablesButton
+            propId={prop?.id}
+            propName={propName}
+            propMeta={metaOverride}
+          />
+        </Box>
+      }
       deletable={deletable}
-      onChange={(value) => {
-        if (value.type === "string") {
-          // sanitize html before saving
-          // this is basically what browser does when innerHTML is set
-          // but isolated within temporary element
-          // so the result is correct markup
-          const div = document.createElement("div");
-          div.innerHTML = value.value;
-          onChange({ type: "string", value: div.innerHTML });
-        } else {
-          onChange(value);
-        }
-      }}
       onDelete={onDelete}
-    />
+    >
+      <Box css={{ py: theme.spacing[2] }}>
+        <HtmlEditor
+          readOnly={readOnly}
+          value={localValue.value}
+          onChange={localValue.set}
+          onBlur={localValue.save}
+        />
+      </Box>
+    </VerticalLayout>
   );
 };

--- a/apps/builder/app/builder/shared/expression-editor.stories.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.stories.tsx
@@ -3,7 +3,7 @@ import { ExpressionEditor as ExpressionEditorComponent } from "./expression-edit
 import { useState } from "react";
 
 export default {
-  title: "Builder/ExpressionEditor",
+  title: "Builder/Expression Editor",
   component: ExpressionEditorComponent,
 } satisfies Meta;
 

--- a/apps/builder/app/builder/shared/html-editor.stories.tsx
+++ b/apps/builder/app/builder/shared/html-editor.stories.tsx
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { HtmlEditor as HtmlEditorComponent } from "./html-editor";
+
+export default {
+  title: "Builder/Html Editor",
+  component: HtmlEditorComponent,
+} satisfies Meta;
+
+const initialHtml = `
+<div>
+  <a href="#">Click me</a>
+</div>
+<script>
+  runMyJavascript()
+</script>
+`.trim();
+
+const HtmlStory = () => {
+  const [value, setValue] = useState(initialHtml);
+  return <HtmlEditorComponent value={value} onChange={setValue} />;
+};
+
+export const HtmlEditor: StoryObj = {
+  render: () => <HtmlStory />,
+};

--- a/apps/builder/app/builder/shared/html-editor.tsx
+++ b/apps/builder/app/builder/shared/html-editor.tsx
@@ -1,0 +1,128 @@
+import { useMemo } from "react";
+import {
+  keymap,
+  drawSelection,
+  dropCursor,
+  EditorView,
+  tooltips,
+  highlightSpecialChars,
+  highlightActiveLine,
+} from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import {
+  bracketMatching,
+  defaultHighlightStyle,
+  indentOnInput,
+  syntaxHighlighting,
+} from "@codemirror/language";
+import {
+  autocompletion,
+  closeBrackets,
+  closeBracketsKeymap,
+  completionKeymap,
+} from "@codemirror/autocomplete";
+import { html } from "@codemirror/lang-html";
+import { theme, textVariants, css } from "@webstudio-is/design-system";
+import { CodeEditor } from "./code-editor";
+
+const autocompletionStyle = css({
+  "&.cm-tooltip.cm-tooltip-autocomplete": {
+    ...textVariants.mono,
+    border: "none",
+    backgroundColor: "transparent",
+    "& ul": {
+      minWidth: 160,
+      maxWidth: 260,
+      width: "max-content",
+      boxSizing: "border-box",
+      borderRadius: theme.borderRadius[6],
+      backgroundColor: theme.colors.backgroundMenu,
+      border: `1px solid ${theme.colors.borderMain}`,
+      boxShadow: `${theme.shadows.menuDropShadow}, inset 0 0 0 1px ${theme.colors.borderMenuInner}`,
+      padding: theme.spacing[3],
+      "& li": {
+        ...textVariants.labelsTitleCase,
+        textTransform: "none",
+        position: "relative",
+        display: "flex",
+        alignItems: "center",
+        color: theme.colors.foregroundMain,
+        padding: theme.spacing[3],
+        borderRadius: theme.borderRadius[3],
+        "&[aria-selected]": {
+          color: theme.colors.foregroundMain,
+          backgroundColor: theme.colors.backgroundItemMenuItemHover,
+        },
+        "& .cm-completionLabel": {
+          flexGrow: 1,
+        },
+        "& .cm-completionDetail": {
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          fontStyle: "normal",
+          color: theme.colors.hint,
+        },
+      },
+    },
+  },
+});
+
+const wrapperStyle = css({
+  "& .cm-content": {
+    maxHeight: 200,
+  },
+});
+
+export const HtmlEditor = ({
+  readOnly = false,
+  value,
+  onChange,
+  onBlur,
+}: {
+  readOnly?: boolean;
+  value: string;
+  onChange: (newValue: string) => void;
+  onBlur?: () => void;
+}) => {
+  const extensions = useMemo(
+    () => [
+      highlightActiveLine(),
+      highlightSpecialChars(),
+      history(),
+      drawSelection(),
+      dropCursor(),
+      indentOnInput(),
+      EditorView.lineWrapping,
+      syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+      html({}),
+      bracketMatching(),
+      closeBrackets(),
+      // render autocomplete in body
+      // to prevent popover scroll overflow
+      tooltips({ parent: document.body }),
+      autocompletion({
+        icons: false,
+        tooltipClass: () => autocompletionStyle.toString(),
+      }),
+      keymap.of([
+        ...closeBracketsKeymap,
+        ...defaultKeymap,
+        ...historyKeymap,
+        ...completionKeymap,
+      ]),
+    ],
+    []
+  );
+
+  return (
+    <div className={wrapperStyle.toString()}>
+      <CodeEditor
+        extensions={extensions}
+        readOnly={readOnly}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+      />
+    </div>
+  );
+};

--- a/apps/builder/app/builder/shared/html-editor.tsx
+++ b/apps/builder/app/builder/shared/html-editor.tsx
@@ -69,7 +69,10 @@ const autocompletionStyle = css({
 
 const wrapperStyle = css({
   "& .cm-content": {
-    maxHeight: 200,
+    // 1 line is 16px
+    // set min 10 lines and max 20 lines
+    minHeight: 160,
+    maxHeight: 320,
   },
 });
 

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@codemirror/autocomplete": "^6.11.1",
     "@codemirror/commands": "^6.3.2",
+    "@codemirror/lang-html": "^6.4.7",
     "@codemirror/lang-javascript": "^6.2.1",
     "@codemirror/language": "^6.9.3",
     "@codemirror/state": "^6.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       '@codemirror/commands':
         specifier: ^6.3.2
         version: 6.3.2
+      '@codemirror/lang-html':
+        specifier: ^6.4.7
+        version: 6.4.7
       '@codemirror/lang-javascript':
         specifier: ^6.2.1
         version: 6.2.1
@@ -3317,6 +3320,32 @@ packages:
       '@lezer/common': 1.1.2
     dev: false
 
+  /@codemirror/lang-css@6.2.1(@codemirror/view@6.22.3):
+    resolution: {integrity: sha512-/UNWDNV5Viwi/1lpr/dIXJNWiwDxpw13I4pTUAsNxZdg6E0mI2kTQb0P2iHczg1Tu+H4EBgJR+hYhKiHKko7qg==}
+    dependencies:
+      '@codemirror/autocomplete': 6.11.1(@codemirror/language@6.9.3)(@codemirror/state@6.3.3)(@codemirror/view@6.22.3)(@lezer/common@1.1.2)
+      '@codemirror/language': 6.9.3
+      '@codemirror/state': 6.3.3
+      '@lezer/common': 1.1.2
+      '@lezer/css': 1.1.4
+    transitivePeerDependencies:
+      - '@codemirror/view'
+    dev: false
+
+  /@codemirror/lang-html@6.4.7:
+    resolution: {integrity: sha512-y9hWSSO41XlcL4uYwWyk0lEgTHcelWWfRuqmvcAmxfCs0HNWZdriWo/EU43S63SxEZpc1Hd50Itw7ktfQvfkUg==}
+    dependencies:
+      '@codemirror/autocomplete': 6.11.1(@codemirror/language@6.9.3)(@codemirror/state@6.3.3)(@codemirror/view@6.22.3)(@lezer/common@1.1.2)
+      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.22.3)
+      '@codemirror/lang-javascript': 6.2.1
+      '@codemirror/language': 6.9.3
+      '@codemirror/state': 6.3.3
+      '@codemirror/view': 6.22.3
+      '@lezer/common': 1.1.2
+      '@lezer/css': 1.1.4
+      '@lezer/html': 1.3.7
+    dev: false
+
   /@codemirror/lang-javascript@6.2.1:
     resolution: {integrity: sha512-jlFOXTejVyiQCW3EQwvKH0m99bUYIw40oPmFjSX2VS78yzfe0HELZ+NEo9Yfo1MkGRpGlj3Gnu4rdxV1EnAs5A==}
     dependencies:
@@ -4847,10 +4876,25 @@ packages:
     resolution: {integrity: sha512-V+GqBsga5+cQJMfM0GdnHmg4DgWvLzgMWjbldBg0+jC3k9Gu6nJNZDLJxXEBT1Xj8KhRN4jmbC5CY7SIL++sVw==}
     dev: false
 
+  /@lezer/css@1.1.4:
+    resolution: {integrity: sha512-CuUwjidrU7FOBokqASRJc72SmJ9g1PsHXDOWMoKg4md6+2u/Zxzwx5YsYrAFxRDsLrjLlsIyEF1rZHK3gFEJbw==}
+    dependencies:
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.3.14
+    dev: false
+
   /@lezer/highlight@1.2.0:
     resolution: {integrity: sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==}
     dependencies:
       '@lezer/common': 1.1.2
+    dev: false
+
+  /@lezer/html@1.3.7:
+    resolution: {integrity: sha512-Wo+rZ5UjLP0VqUTyXjzgmTYRW5bvTJUFn4Uw0K3HCQjX2/+f+zRo9GLN5BCAojwHQISPvaQk8BWSv2SSKx/UcQ==}
+    dependencies:
+      '@lezer/common': 1.1.2
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.3.14
     dev: false
 
   /@lezer/javascript@1.4.10:


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2359 https://github.com/webstudio-is/webstudio/issues/2388

Here added codemirror based html editor for html embed component. It supports basic autocomplete and highlights embedded css and js.

Splitted basic codemirror setup into CodeEditor component everything else can be customized around it.

<img width="245" alt="Screenshot 2023-12-27 at 15 30 57" src="https://github.com/webstudio-is/webstudio/assets/5635476/7bb7907a-0f5b-406b-8615-2029e6494839">
<img width="240" alt="Screenshot 2023-12-27 at 15 30 22" src="https://github.com/webstudio-is/webstudio/assets/5635476/bc826e52-0597-4998-a534-e7053f25fb26">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
