### PR TITLE
feat: add binding popover

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variables.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables.stories.tsx
@@ -8,10 +8,14 @@ import {
 } from "@webstudio-is/design-system";
 import { VariablesPanel } from "./variables";
 import {
-  propsStore,
-  selectedInstanceSelectorStore,
+  $pages,
+  $selectedInstanceSelector,
+  $selectedPageId,
+  $props,
+  $instances,
 } from "~/shared/nano-states";
 import { registerContainers } from "~/shared/sync";
+import type { Page } from "@webstudio-is/sdk";
 
 export default {
   title: "Builder/Variables",
@@ -19,7 +23,17 @@ export default {
 } satisfies Meta;
 
 registerContainers();
-selectedInstanceSelectorStore.set(["root"]);
+$selectedInstanceSelector.set(["root"]);
+$instances.set(
+  new Map([
+    ["root", { id: "root", type: "instance", component: "Box", children: [] }],
+  ])
+);
+$selectedPageId.set("home");
+$pages.set({
+  homePage: { id: "home", rootInstanceId: "root" } as Page,
+  pages: [],
+});
 
 const initialProp = {
   id: "my-prop",
@@ -28,7 +42,7 @@ const initialProp = {
   type: "string",
   value: "initial",
 } as const;
-propsStore.set(new Map([[initialProp.id, initialProp]]));
+$props.set(new Map([[initialProp.id, initialProp]]));
 
 const VariablesPopover = () => {
   const [isOpen, setIsOpen] = useState(true);

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -1,0 +1,296 @@
+import { forwardRef, useMemo, useRef, useState } from "react";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
+import { DotIcon, PlusIcon, TrashIcon } from "@webstudio-is/icons";
+import {
+  Box,
+  Button,
+  CssValueListArrowFocus,
+  CssValueListItem,
+  FloatingPanelPopover,
+  FloatingPanelPopoverClose,
+  FloatingPanelPopoverContent,
+  FloatingPanelPopoverTitle,
+  FloatingPanelPopoverTrigger,
+  InputErrorsTooltip,
+  Label,
+  ScrollArea,
+  SmallIconButton,
+  Tooltip,
+  theme,
+} from "@webstudio-is/design-system";
+import { validateExpression } from "@webstudio-is/react-sdk";
+import { ExpressionEditor, formatValuePreview } from "./expression-editor";
+
+export const evaluateExpressionWithinScope = (
+  expression: string,
+  scope: Record<string, unknown>
+) => {
+  let expressionWithScope = "";
+  for (const [name, value] of Object.entries(scope)) {
+    expressionWithScope += `const ${name} = ${JSON.stringify(value)};\n`;
+  }
+  expressionWithScope += `return (${expression})`;
+  try {
+    const fn = new Function(expressionWithScope);
+    return fn();
+  } catch {
+    //
+  }
+};
+
+/**
+ * execute valid expression without scope
+ * to check any variable usage
+ */
+export const isLiteralExpression = (expression: string) => {
+  try {
+    const fn = new Function(`return (${expression})`);
+    fn();
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const getUsedIdentifiers = (expression: string) => {
+  const identifiers = new Set<string>();
+  // prevent parsing empty expression
+  if (expression === "") {
+    return identifiers;
+  }
+  // avoid parsing error
+  try {
+    validateExpression(expression, {
+      transformIdentifier: (identifier) => {
+        identifiers.add(identifier);
+        return identifier;
+      },
+    });
+  } catch {
+    //
+  }
+  return identifiers;
+};
+
+const BindingPanel = ({
+  scope,
+  aliases,
+  error,
+  value,
+  onChange,
+  onPotentialErrorChange,
+  onValidate,
+}: {
+  scope: Record<string, unknown>;
+  aliases: Map<string, string>;
+  error: undefined | string;
+  value: string;
+  onChange: (newValue: string) => void;
+  onPotentialErrorChange: (error: string) => void;
+  onValidate: () => void;
+}) => {
+  const [expression, setExpression] = useState(value);
+  const usedIdentifiers = useMemo(() => getUsedIdentifiers(value), [value]);
+
+  const updateExpression = (newExpression: string) => {
+    setExpression(newExpression);
+    try {
+      if (newExpression.trim().length === 0) {
+        throw Error("Cannot use empty expression");
+      }
+      // update value only when expression is valid
+      validateExpression(newExpression, {
+        transformIdentifier: (identifier) => {
+          if (aliases.has(identifier) === false) {
+            throw Error(`Unknown variable "${identifier}"`);
+          }
+          return identifier;
+        },
+      });
+      onChange(newExpression);
+    } catch (error) {
+      onPotentialErrorChange((error as Error).message);
+    }
+  };
+
+  return (
+    <ScrollArea
+      css={{
+        display: "flex",
+        flexDirection: "column",
+        width: theme.spacing[30],
+      }}
+    >
+      <Box css={{ padding: `${theme.spacing[5]} 0` }}>
+        <CssValueListArrowFocus>
+          {Object.entries(scope).map(([identifier, value], index) => {
+            const name = aliases.get(identifier);
+            const label =
+              value === undefined
+                ? name
+                : `${name}: ${formatValuePreview(value)}`;
+            return (
+              <CssValueListItem
+                key={identifier}
+                id={identifier}
+                index={index}
+                label={<Label truncate>{label}</Label>}
+                // mark all variables used in expression as selected
+                active={usedIdentifiers.has(identifier)}
+                // convert variable to expression
+                onClick={() => {
+                  setExpression(identifier);
+                  onChange(identifier);
+                }}
+              />
+            );
+          })}
+        </CssValueListArrowFocus>
+      </Box>
+      <Box css={{ padding: `0 ${theme.spacing[9]} ${theme.spacing[9]}` }}>
+        <InputErrorsTooltip errors={error ? [error] : undefined}>
+          <div>
+            <ExpressionEditor
+              scope={scope}
+              aliases={aliases}
+              autoFocus={true}
+              value={expression}
+              onChange={updateExpression}
+              onBlur={onValidate}
+            />
+          </div>
+        </InputErrorsTooltip>
+      </Box>
+    </ScrollArea>
+  );
+};
+
+const BindingButton = forwardRef<HTMLButtonElement>((props, ref) => (
+  <SmallIconButton
+    ref={ref}
+    css={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      transform: "translate(-50%, -50%)",
+      width: 14,
+      height: 14,
+      borderRadius: "50%",
+      backgroundColor: "#834DF4",
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      "--dot-display": "block",
+      "--plus-display": "none",
+      "&:hover, &[aria-expanded=true]": {
+        width: 22,
+        height: 22,
+        "--dot-display": "none",
+        "--plus-display": "block",
+      },
+    }}
+    {...props}
+    icon={
+      <>
+        <DotIcon
+          size={14}
+          fill="white"
+          style={{ display: `var(--dot-display)` }}
+        />
+        <PlusIcon
+          size={18}
+          fill="white"
+          style={{ display: `var(--plus-display)` }}
+        />
+      </>
+    }
+  />
+));
+BindingButton.displayName = "BindingButton";
+
+export const BindingPopover = ({
+  scope,
+  aliases,
+  value,
+  onChange,
+}: {
+  scope: Record<string, unknown>;
+  aliases: Map<string, string>;
+  acceptableType?: "text" | "any";
+  value: string;
+  onChange: (newValue: string) => void;
+}) => {
+  const [open, onOpenChange] = useState(false);
+  const [error, setError] = useState<undefined | string>();
+  const potentialError = useRef<undefined | string>();
+
+  if (isFeatureEnabled("bindings") === false) {
+    return;
+  }
+  return (
+    <FloatingPanelPopover
+      modal
+      open={open}
+      onOpenChange={(newOpen) => {
+        if (potentialError.current) {
+          setError(potentialError.current);
+        } else {
+          onOpenChange(newOpen);
+        }
+      }}
+    >
+      <FloatingPanelPopoverTrigger asChild>
+        <BindingButton />
+      </FloatingPanelPopoverTrigger>
+      <FloatingPanelPopoverContent side="top" align="start">
+        <BindingPanel
+          scope={scope}
+          aliases={aliases}
+          error={error}
+          value={value}
+          onChange={(newValue) => {
+            potentialError.current = undefined;
+            setError(undefined);
+            onChange(newValue);
+          }}
+          onPotentialErrorChange={(error) => {
+            potentialError.current = error;
+          }}
+          onValidate={() => {
+            if (potentialError.current) {
+              setError(potentialError.current);
+            }
+          }}
+        />
+        {/* put after content to avoid auto focusing heading buttons */}
+        <FloatingPanelPopoverTitle
+          actions={
+            <Tooltip content="Reset binding" side="bottom">
+              {/* automatically close popover when remove expression */}
+              <FloatingPanelPopoverClose asChild>
+                <Button
+                  aria-label="Reset binding"
+                  prefix={<TrashIcon />}
+                  color="ghost"
+                  onClick={() => {
+                    // reset error, inline variables and close dialog
+                    potentialError.current = undefined;
+                    setError(undefined);
+                    const evaluatedValue = evaluateExpressionWithinScope(
+                      value,
+                      scope
+                    );
+                    onChange(JSON.stringify(evaluatedValue));
+                    onOpenChange(false);
+                  }}
+                />
+              </FloatingPanelPopoverClose>
+            </Tooltip>
+          }
+        >
+          Binding
+        </FloatingPanelPopoverTitle>
+      </FloatingPanelPopoverContent>
+    </FloatingPanelPopover>
+  );
+};

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -172,7 +172,6 @@ const BindingButton = forwardRef<HTMLButtonElement>((props, ref) => (
       position: "absolute",
       top: 0,
       left: 0,
-      transform: "translate(-50%, -50%)",
       width: 14,
       height: 14,
       borderRadius: "50%",
@@ -180,11 +179,12 @@ const BindingButton = forwardRef<HTMLButtonElement>((props, ref) => (
       display: "flex",
       justifyContent: "center",
       alignItems: "center",
+      transform: "translate(-50%, -50%) scale(1)",
+      transition: "transform 60ms",
       "--dot-display": "block",
       "--plus-display": "none",
       "&:hover, &[aria-expanded=true]": {
-        width: 22,
-        height: 22,
+        transform: `translate(-50%, -50%) scale(1.5)`,
         "--dot-display": "none",
         "--plus-display": "block",
       },
@@ -198,7 +198,7 @@ const BindingButton = forwardRef<HTMLButtonElement>((props, ref) => (
           style={{ display: `var(--dot-display)` }}
         />
         <PlusIcon
-          size={18}
+          size={10}
           fill="white"
           style={{ display: `var(--plus-display)` }}
         />

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -242,6 +242,7 @@ const emptyAliases: Aliases = new Map();
 export const ExpressionEditor = ({
   scope = emptyScope,
   aliases = emptyAliases,
+  autoFocus = false,
   readOnly = false,
   value,
   onChange,
@@ -255,6 +256,7 @@ export const ExpressionEditor = ({
    * variable aliases to show instead of $ws$dataSource$id
    */
   aliases?: Aliases;
+  autoFocus?: boolean;
   readOnly?: boolean;
   value: string;
   onChange: (newValue: string) => void;
@@ -278,11 +280,14 @@ export const ExpressionEditor = ({
       doc: "",
       parent: editorRef.current,
     });
+    if (autoFocus) {
+      view.focus();
+    }
     viewRef.current = view;
     return () => {
       view.destroy();
     };
-  }, []);
+  }, [autoFocus]);
 
   // update extensions whenever variables data is changed
 


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here added new binding popover as a replacement for variables popover. Integrated into resource fields and made button look like suggested by Mark and Taylor.

<img width="317" alt="Screenshot 2023-12-30 at 13 26 12" src="https://github.com/webstudio-is/webstudio/assets/5635476/141ea317-438f-428c-96a8-9f1919513e8c">
<img width="255" alt="Screenshot 2023-12-30 at 13 25 59" src="https://github.com/webstudio-is/webstudio/assets/5635476/f8a3b5c7-4928-46f2-8d86-5ee264150d13">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
