### PR TITLE
fix: Escape user-provided class

### DIFF
--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -638,7 +638,7 @@ test("add classes and merge classes", () => {
           instanceId: "body",
           name: "className",
           type: "string",
-          value: "cls2",
+          value: 'cls2 "cls3"',
         }),
       ]),
       indexesWithinAncestors: new Map(),
@@ -651,7 +651,7 @@ test("add classes and merge classes", () => {
     return <Body
     data-ws-id="body"
     data-ws-component="Body"
-    className="cls1 cls2" />
+    className="cls1 cls2 \\"cls3\\"" />
     }
     `)
   );

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -137,7 +137,7 @@ export const generateJsxElement = ({
   }
 
   if (classes.length !== 0) {
-    generatedProps += `\nclassName="${classes.join(" ")}"`;
+    generatedProps += `\nclassName=${JSON.stringify(classes.join(" "))}`;
   }
 
   let generatedElement = "";


### PR DESCRIPTION
## Description

Realized that user can put in a quote that will break the rendering

We also need an actual validation in the UI for class name, because its not just an arbitrary string.


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
