### PR TITLE
feat: add variables to settings panel

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -219,10 +219,10 @@ const $selectedInstanceVariables = computed(
 
 export const ResourcePanel = ({
   variable,
-  onCancel,
+  onClose,
 }: {
   variable?: DataSource;
-  onCancel: () => void;
+  onClose: () => void;
 }) => {
   const resources = useStore($resources);
   const resource =
@@ -346,7 +346,7 @@ export const ResourcePanel = ({
       )}
 
       <Flex justify="end" css={{ gap: theme.spacing[5] }}>
-        <Button color="neutral" onClick={onCancel}>
+        <Button color="neutral" onClick={onClose}>
           Cancel
         </Button>
         <Button
@@ -379,7 +379,7 @@ export const ResourcePanel = ({
                 resources.set(newResource.id, newResource);
               }
             );
-            onCancel();
+            onClose();
           }}
         >
           Save

--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -1,6 +1,8 @@
 import type { Instance } from "@webstudio-is/sdk";
 import { SettingsSection } from "./settings-section/settings-section";
 import { PropsSectionContainer } from "./props-section/props-section";
+import { VariablesSection } from "./variables-section";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 export const SettingsPanelContainer = ({
   selectedInstance,
@@ -11,6 +13,7 @@ export const SettingsPanelContainer = ({
     <>
       <SettingsSection />
       <PropsSectionContainer selectedInstance={selectedInstance} />
+      {isFeatureEnabled("bindings") && <VariablesSection />}
     </>
   );
 };

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -261,3 +261,5 @@ export const VariablePopoverTrigger = forwardRef<
     </FloatingPanelPopover>
   );
 });
+
+VariablePopoverTrigger.displayName = "VariablePopoverTrigger";

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -1,0 +1,263 @@
+import { nanoid } from "nanoid";
+import { forwardRef, useId, useState, type ReactNode } from "react";
+import {
+  Button,
+  Flex,
+  FloatingPanelPopover,
+  FloatingPanelPopoverContent,
+  FloatingPanelPopoverTitle,
+  FloatingPanelPopoverTrigger,
+  InputErrorsTooltip,
+  InputField,
+  Label,
+  PanelTabs,
+  PanelTabsContent,
+  PanelTabsList,
+  PanelTabsTrigger,
+  ScrollArea,
+  theme,
+} from "@webstudio-is/design-system";
+import { validateExpression } from "@webstudio-is/react-sdk";
+import type { DataSource } from "@webstudio-is/sdk";
+import {
+  ExpressionEditor,
+  formatValue,
+} from "~/builder/shared/expression-editor";
+import {
+  $dataSources,
+  $resources,
+  $selectedInstanceSelector,
+} from "~/shared/nano-states";
+import { serverSyncStore } from "~/shared/sync";
+import { ResourcePanel } from "./resource-panel";
+
+/**
+ * convert value expression to js value
+ * validating out accessing any identifier
+ */
+const parseVariableValue = (code: string) => {
+  const result: { value?: unknown; error?: string } = {};
+  const ids = new Set<string>();
+  try {
+    code = validateExpression(code, {
+      optional: true,
+      transformIdentifier: (id) => {
+        ids.add(id);
+        return id;
+      },
+    });
+  } catch (error) {
+    result.error = (error as Error).message;
+    return result;
+  }
+  if (ids.size === 0) {
+    try {
+      // wrap with parentheses to treat {} as object instead of block
+      result.value = eval(`(${code})`);
+    } catch (error) {
+      result.error = `Parse Error: ${(error as Error).message}`;
+    }
+  } else {
+    const idsList = Array.from(ids).join(", ");
+    result.error = `Cannot use variables ${idsList} as variable value`;
+  }
+  return result;
+};
+
+const renameVariable = (variable: DataSource, name: string) => {
+  serverSyncStore.createTransaction([$dataSources], (dataSources) => {
+    dataSources.set(variable.id, { ...variable, name });
+  });
+};
+
+const saveVariable = (
+  dataSource: undefined | DataSource,
+  name: string,
+  valueString: string
+): undefined | { error?: string } => {
+  const dataSourceId = dataSource?.id ?? nanoid();
+  const { value, error } = parseVariableValue(valueString);
+  if (error !== undefined) {
+    return { error };
+  }
+  const instanceSelector = $selectedInstanceSelector.get();
+  if (instanceSelector === undefined) {
+    return;
+  }
+  const [instanceId] = instanceSelector;
+  let variableValue: Extract<DataSource, { type: "variable" }>["value"] = {
+    type: "json",
+    value,
+  };
+  if (typeof value === "string") {
+    variableValue = { type: "string", value };
+  }
+  if (typeof value === "number") {
+    variableValue = { type: "number", value };
+  }
+  if (typeof value === "boolean") {
+    variableValue = { type: "boolean", value };
+  }
+  serverSyncStore.createTransaction(
+    [$dataSources, $resources],
+    (dataSources, resources) => {
+      // cleanup resource when value variable is set
+      if (dataSource?.type === "resource") {
+        resources.delete(dataSource.resourceId);
+      }
+      dataSources.set(dataSourceId, {
+        id: dataSourceId,
+        // preserve existing instance scope when edit
+        scopeInstanceId:
+          dataSources.get(dataSourceId)?.scopeInstanceId ?? instanceId,
+        name,
+        type: "variable",
+        value: variableValue,
+      });
+    }
+  );
+};
+
+const VariableValuePanel = ({
+  variable,
+  onClose,
+}: {
+  variable?: DataSource;
+  onClose: () => void;
+}) => {
+  // variable value cannot have an access to other variables
+  const nameId = useId();
+  const [name, setName] = useState(variable?.name ?? "");
+  const [nameErrors, setNameErrors] = useState<undefined | string[]>();
+  const [value, setValue] = useState(
+    formatValue(
+      variable?.type === "variable" ? variable?.value.value ?? "" : ""
+    )
+  );
+  const [valueErrors, setValueErrors] = useState<undefined | string[]>();
+
+  return (
+    <Flex
+      direction="column"
+      css={{
+        overflow: "hidden",
+        gap: theme.spacing[9],
+        px: theme.spacing[9],
+        pb: theme.spacing[9],
+      }}
+    >
+      <Flex direction="column" css={{ gap: theme.spacing[3] }}>
+        <Label htmlFor={nameId}>Name</Label>
+        <InputErrorsTooltip errors={nameErrors}>
+          <InputField
+            id={nameId}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+        </InputErrorsTooltip>
+      </Flex>
+      {/* resource variable can be replaced with value variable
+          parameters can change only name */}
+      {variable?.type !== "parameter" && (
+        <Flex direction="column" css={{ gap: theme.spacing[3] }}>
+          <Label>Value</Label>
+          <InputErrorsTooltip errors={valueErrors}>
+            <div>
+              <ExpressionEditor value={value} onChange={setValue} />
+            </div>
+          </InputErrorsTooltip>
+        </Flex>
+      )}
+      <Flex justify="end" css={{ gap: theme.spacing[5] }}>
+        <Button color="neutral" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => {
+            if (name.length === 0) {
+              setNameErrors([`Variable name is required`]);
+              return;
+            }
+            if (variable?.type === "parameter") {
+              renameVariable(variable, name);
+              onClose();
+            }
+            // save value variable and convert from resource variable if necessary
+            const result = saveVariable(variable, name, value);
+            if (result?.error !== undefined) {
+              setValueErrors([result.error]);
+              return;
+            }
+            onClose();
+          }}
+        >
+          Save
+        </Button>
+      </Flex>
+    </Flex>
+  );
+};
+
+const VariablePanel = ({
+  variable,
+  onClose,
+}: {
+  variable?: DataSource;
+  onClose: () => void;
+}) => {
+  const [tab, setTab] = useState(
+    variable?.type === "resource" ? "resource" : "value"
+  );
+
+  return (
+    <PanelTabs value={tab} onValueChange={setTab} asChild>
+      <Flex direction="column">
+        <ScrollArea
+          css={{
+            // flex fixes content overflowing artificial scroll area
+            display: "flex",
+            flexDirection: "column",
+            width: theme.spacing[30],
+          }}
+        >
+          {/* user can change only parameter name */}
+          {variable?.type !== "parameter" && (
+            <PanelTabsList>
+              <PanelTabsTrigger value="value">Value</PanelTabsTrigger>
+              <PanelTabsTrigger value="resource">Resource</PanelTabsTrigger>
+            </PanelTabsList>
+          )}
+          <PanelTabsContent value="value">
+            <VariableValuePanel variable={variable} onClose={onClose} />
+          </PanelTabsContent>
+          <PanelTabsContent value="resource">
+            <ResourcePanel variable={variable} onClose={onClose} />
+          </PanelTabsContent>
+        </ScrollArea>
+      </Flex>
+    </PanelTabs>
+  );
+};
+
+export const VariablePopoverTrigger = forwardRef<
+  HTMLButtonElement,
+  { variable?: DataSource; children: ReactNode }
+>(({ variable, children }, ref) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <FloatingPanelPopover modal open={open} onOpenChange={setOpen}>
+      <FloatingPanelPopoverTrigger ref={ref} asChild>
+        {children}
+      </FloatingPanelPopoverTrigger>
+      <FloatingPanelPopoverContent side="left" align="start">
+        <VariablePanel variable={variable} onClose={() => setOpen(false)} />
+        {/* put after content to avoid auto focusing "Close" button */}
+        {variable === undefined ? (
+          <FloatingPanelPopoverTitle>New Variable</FloatingPanelPopoverTitle>
+        ) : (
+          <FloatingPanelPopoverTitle>Edit Variable</FloatingPanelPopoverTitle>
+        )}
+      </FloatingPanelPopoverContent>
+    </FloatingPanelPopover>
+  );
+});

--- a/apps/builder/app/builder/features/settings-panel/variables-section.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { Page } from "@webstudio-is/sdk";
+import { Box } from "@webstudio-is/design-system";
+import { VariablesSection as VariablesSectionComponent } from "./variables-section";
+import {
+  $pages,
+  $selectedInstanceSelector,
+  $selectedPageId,
+  $instances,
+} from "~/shared/nano-states";
+import { registerContainers } from "~/shared/sync";
+
+export default {
+  title: "Builder/Variables Section",
+  component: VariablesSectionComponent,
+} satisfies Meta;
+
+registerContainers();
+$selectedInstanceSelector.set(["root"]);
+$instances.set(
+  new Map([
+    ["root", { id: "root", type: "instance", component: "Box", children: [] }],
+  ])
+);
+$selectedPageId.set("home");
+$pages.set({
+  homePage: { id: "home", rootInstanceId: "root" } as Page,
+  pages: [],
+});
+
+export const VariablesSection: StoryObj = {
+  render: () => (
+    <Box css={{ paddingLeft: 280 }}>
+      <VariablesSectionComponent />
+    </Box>
+  ),
+};

--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -1,0 +1,220 @@
+import { computed } from "nanostores";
+import { useStore } from "@nanostores/react";
+import {
+  Button,
+  CssValueListArrowFocus,
+  CssValueListItem,
+  Flex,
+  Label,
+  SectionTitle,
+  SectionTitleButton,
+  SectionTitleLabel,
+  SmallIconButton,
+  Text,
+  Tooltip,
+  theme,
+} from "@webstudio-is/design-system";
+import { MinusIcon, PlusIcon } from "@webstudio-is/icons";
+import type { DataSource } from "@webstudio-is/sdk";
+import {
+  decodeDataSourceVariable,
+  validateExpression,
+} from "@webstudio-is/react-sdk";
+import {
+  $dataSources,
+  $props,
+  $resources,
+  $selectedInstanceSelector,
+  $variableValuesByInstanceSelector,
+} from "~/shared/nano-states";
+import { serverSyncStore } from "~/shared/sync";
+import {
+  CollapsibleSectionBase,
+  useOpenState,
+} from "~/builder/shared/collapsible-section";
+import { formatValuePreview } from "~/builder/shared/expression-editor";
+import { VariablePopoverTrigger } from "./variable-popover";
+
+/**
+ * find variables defined specifically on this selected instance
+ */
+const $instanceVariables = computed(
+  [$selectedInstanceSelector, $dataSources],
+  (instanceSelector, dataSources) => {
+    const matchedVariables: DataSource[] = [];
+    if (instanceSelector === undefined) {
+      return matchedVariables;
+    }
+    const [instanceId] = instanceSelector;
+    for (const dataSource of dataSources.values()) {
+      if (instanceId === dataSource.scopeInstanceId) {
+        matchedVariables.push(dataSource);
+      }
+    }
+    return matchedVariables;
+  }
+);
+
+const $instanceVariableValues = computed(
+  [$selectedInstanceSelector, $variableValuesByInstanceSelector],
+  (instanceSelector, variableValuesByInstanceSelector) => {
+    const key = JSON.stringify(instanceSelector);
+    return variableValuesByInstanceSelector.get(key) ?? new Map();
+  }
+);
+
+/**
+ * find variables used in
+ *
+ * expression prop
+ * action prop
+ * url resource field
+ * header resource field
+ * body resource fiel
+ */
+const $usedVariables = computed([$props, $resources], (props, resources) => {
+  const usedVariables = new Set<DataSource["id"]>();
+  const collectExpressionVariables = (expression: string) => {
+    try {
+      validateExpression(expression, {
+        // parse any expression
+        effectful: true,
+        transformIdentifier: (identifier) => {
+          const id = decodeDataSourceVariable(identifier);
+          if (id !== undefined) {
+            usedVariables.add(id);
+          }
+          return identifier;
+        },
+      });
+    } catch {
+      // empty block
+    }
+  };
+  for (const resource of resources.values()) {
+    collectExpressionVariables(resource.url);
+    for (const { value } of resource.headers) {
+      collectExpressionVariables(value);
+    }
+    if (resource.body) {
+      collectExpressionVariables(resource.body);
+    }
+  }
+  for (const prop of props.values()) {
+    if (prop.type === "expression") {
+      collectExpressionVariables(prop.value);
+    }
+    if (prop.type === "action") {
+      for (const value of prop.value) {
+        collectExpressionVariables(value.code);
+      }
+    }
+  }
+  return usedVariables;
+});
+
+const deleteVariable = (variableId: DataSource["id"]) => {
+  serverSyncStore.createTransaction([$dataSources], (dataSources) => {
+    dataSources.delete(variableId);
+  });
+};
+
+const EmptyVariables = () => {
+  return (
+    <Flex direction="column" css={{ gap: theme.spacing[5] }}>
+      <Flex justify="center" align="center" css={{ height: theme.spacing[13] }}>
+        <Text variant="labelsSentenceCase">No variables yet</Text>
+      </Flex>
+      <Flex justify="center" align="center" css={{ height: theme.spacing[13] }}>
+        <VariablePopoverTrigger>
+          <Button prefix={<PlusIcon />}>Create variable</Button>
+        </VariablePopoverTrigger>
+      </Flex>
+    </Flex>
+  );
+};
+
+const VariablesList = () => {
+  const availableVariables = useStore($instanceVariables);
+  const variableValues = useStore($instanceVariableValues);
+  const usedVariables = useStore($usedVariables);
+
+  if (availableVariables.length === 0) {
+    return <EmptyVariables />;
+  }
+
+  return (
+    <CssValueListArrowFocus>
+      {availableVariables.map((variable, index) => {
+        const value = variableValues.get(variable.id);
+        const label =
+          value === undefined
+            ? variable.name
+            : `${variable.name}: ${formatValuePreview(value)}`;
+        // user should be able to create and delete
+        const deletable =
+          variable.type === "variable" || variable.type === "resource";
+        return (
+          <VariablePopoverTrigger key={variable.id} variable={variable}>
+            <CssValueListItem
+              id={variable.id}
+              index={index}
+              label={<Label truncate>{label}</Label>}
+              buttons={
+                <Tooltip content="Delete variable" side="bottom">
+                  <SmallIconButton
+                    tabIndex={-1}
+                    // allow to delete only unused variables
+                    disabled={
+                      deletable === false || usedVariables.has(variable.id)
+                    }
+                    aria-label="Delete variable"
+                    variant="destructive"
+                    icon={<MinusIcon />}
+                    onClick={() => deleteVariable(variable.id)}
+                  />
+                </Tooltip>
+              }
+            />
+          </VariablePopoverTrigger>
+        );
+      })}
+    </CssValueListArrowFocus>
+  );
+};
+
+export const VariablesSection = () => {
+  const [isOpen, setIsOpen] = useOpenState({
+    label: "variables",
+    isOpenDefault: true,
+  });
+  return (
+    <CollapsibleSectionBase
+      label="Variables"
+      fullWidth={true}
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      trigger={
+        <SectionTitle
+          suffix={
+            <VariablePopoverTrigger>
+              <SectionTitleButton
+                prefix={<PlusIcon />}
+                // open panel when add new varable
+                onClick={() => {
+                  if (isOpen === false) {
+                    setIsOpen(true);
+                  }
+                }}
+              />
+            </VariablePopoverTrigger>
+          }
+        >
+          <SectionTitleLabel>Variables</SectionTitleLabel>
+        </SectionTitle>
+      }
+    >
+      <VariablesList />
+    </CollapsibleSectionBase>
+  );
+};


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here added variables section to settings panel similar to props section. UI is slightly different from previous implementation.

- the list shows only variables defined specifically on current instance
- selecting item starts editing instead of "menu" button
- resource variables can be deleted when unused

<img width="519" alt="Screenshot 2023-12-31 at 18 01 35" src="https://github.com/webstudio-is/webstudio/assets/5635476/55763a49-a031-4696-bbf8-6c16ea0effbe">
<img width="253" alt="Screenshot 2023-12-31 at 18 01 48" src="https://github.com/webstudio-is/webstudio/assets/5635476/d6a768db-f8dd-4fe9-9820-8685dd991067">
<img width="519" alt="Screenshot 2023-12-31 at 18 01 35" src="https://github.com/webstudio-is/webstudio/assets/5635476/e7701edc-eaeb-44e8-beb3-5e2c9c01be03">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
