### PR TITLE
fix: Ensure user can't enter invalid canvas width value in breakpoints editor

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/width-input.tsx
+++ b/apps/builder/app/builder/features/breakpoints/width-input.tsx
@@ -52,7 +52,9 @@ const useEnhancedInput = ({
 
   const getValue = () => {
     const value = inputRef.current?.valueAsNumber;
-    return typeof value === "number" && isNaN(value) === false ? value : min;
+    return typeof value === "number" && Number.isNaN(value) === false
+      ? value
+      : min;
   };
 
   return {

--- a/apps/builder/app/builder/features/breakpoints/width-input.tsx
+++ b/apps/builder/app/builder/features/breakpoints/width-input.tsx
@@ -52,7 +52,7 @@ const useEnhancedInput = ({
 
   const getValue = () => {
     const value = inputRef.current?.valueAsNumber;
-    return typeof value !== "number" || isNaN(value) ? min : value;
+    return typeof value === "number" && isNaN(value) === false ? value : min;
   };
 
   return {

--- a/apps/builder/app/builder/features/breakpoints/width-input.tsx
+++ b/apps/builder/app/builder/features/breakpoints/width-input.tsx
@@ -17,12 +17,7 @@ import {
   selectedBreakpointIdStore,
   selectedBreakpointStore,
 } from "~/shared/nano-states";
-import {
-  useState,
-  type ChangeEvent,
-  type KeyboardEvent,
-  useEffect,
-} from "react";
+import { useState, type KeyboardEvent, useEffect } from "react";
 
 const useEnhancedInput = ({
   onChange,
@@ -55,15 +50,21 @@ const useEnhancedInput = ({
     onChangeComplete: handleChangeComplete,
   });
 
+  const getValue = () => {
+    const value = inputRef.current?.valueAsNumber;
+    return typeof value !== "number" || isNaN(value) ? min : value;
+  };
+
   return {
     ref: scrubRef,
     inputRef,
-    onChange(event: ChangeEvent<HTMLInputElement>) {
-      setIntermediateValue(event.target.valueAsNumber);
+    onChange() {
+      setIntermediateValue(getValue());
     },
     onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
       if (event.key === "Enter") {
-        return handleChangeComplete(event.currentTarget.valueAsNumber);
+        handleChangeComplete(getValue());
+        return;
       }
       const nextValue = handleNumericInputArrowKeys(currentValue, event);
       if (nextValue !== currentValue) {
@@ -72,7 +73,7 @@ const useEnhancedInput = ({
       }
     },
     onBlur() {
-      handleChangeComplete(inputRef.current?.valueAsNumber ?? 0);
+      handleChangeComplete(getValue());
     },
     type: "number" as const,
     value: currentValue,


### PR DESCRIPTION
## Description

User was able to delete the value and get a NaN error Ref https://github.com/webstudio-is/webstudio/issues/2734

## Steps for reproduction

1. delete the value
2. see the min width rendered

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
