### PR TITLE
feat: Add loading lazy/eager to vimeo

### DIFF
--- a/packages/sdk-components-react/src/__generated__/vimeo.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo.props.ts
@@ -550,6 +550,15 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     description: "Defines the language used in the element.",
   },
+  loading: {
+    description:
+      "Not a Vimeo attribute: Loading attribute for the iframe allows to eager or lazy load the source",
+    required: false,
+    control: "radio",
+    type: "string",
+    defaultValue: "lazy",
+    options: ["eager", "lazy"],
+  },
   loop: {
     description:
       "Whether to restart the video automatically after reaching the end.",
@@ -653,7 +662,7 @@ export const props: Record<string, PropMeta> = {
   },
   showPreview: {
     description:
-      "Whether the preview image should be loaded from Vimeo API. Ideally don't use it, because it will show up with some delay and will make your project feel slower.",
+      "Not a Vimeo attribute: Whether the preview image should be loaded from Vimeo API. Ideally don't use it, because it will show up with some delay and will make your project feel slower.",
     required: false,
     control: "boolean",
     type: "boolean",

--- a/packages/sdk-components-react/src/vimeo.tsx
+++ b/packages/sdk-components-react/src/vimeo.tsx
@@ -272,7 +272,7 @@ const useVimeo = ({
     return createPlayer(elementRef.current, stableOptions, { loading }, () => {
       setPlayerStatus("ready");
     });
-  }, [stableOptions, playerStatus]);
+  }, [stableOptions, playerStatus, loading]);
   return { previewImageUrl, playerStatus, setPlayerStatus, elementRef };
 };
 

--- a/packages/sdk-components-react/src/vimeo.tsx
+++ b/packages/sdk-components-react/src/vimeo.tsx
@@ -143,10 +143,11 @@ const warmConnections = () => {
 
 const createPlayer = (
   parent: Element,
-  options: VimeoPlayerOptions,
+  vimeoOptions: VimeoPlayerOptions,
+  extendedOptions: { loading: VimeoOptions["loading"] },
   callback: () => void
 ) => {
-  const url = getUrl(options);
+  const url = getUrl(vimeoOptions);
   if (url === undefined) {
     return;
   }
@@ -162,6 +163,9 @@ const createPlayer = (
     "style",
     "position: absolute; width: 100%; height: 100%; opacity: 0; transition: opacity 1s;"
   );
+  if (extendedOptions.loading) {
+    iframe.setAttribute("loading", extendedOptions.loading);
+  }
 
   // Show iframe only once it's loaded to avoid weird flashes.
   iframe.addEventListener(
@@ -219,9 +223,11 @@ const useVimeo = ({
   options,
   renderer,
   showPreview,
+  loading,
 }: {
   options: VimeoPlayerOptions;
   showPreview?: boolean;
+  loading: VimeoOptions["loading"];
   renderer: ContextType<typeof ReactSdkContext>["renderer"];
 }) => {
   const [playerStatus, setPlayerStatus] = useState<PlayerStatus>("initial");
@@ -263,7 +269,7 @@ const useVimeo = ({
     if (elementRef.current === null || playerStatus === "initial") {
       return;
     }
-    return createPlayer(elementRef.current, stableOptions, () => {
+    return createPlayer(elementRef.current, stableOptions, { loading }, () => {
       setPlayerStatus("ready");
     });
   }, [stableOptions, playerStatus]);
@@ -281,8 +287,10 @@ export type VimeoOptions = Omit<
   | "title"
   | "portrait"
 > & {
-  /** Whether the preview image should be loaded from Vimeo API. Ideally don't use it, because it will show up with some delay and will make your project feel slower. */
+  /** Not a Vimeo attribute: Whether the preview image should be loaded from Vimeo API. Ideally don't use it, because it will show up with some delay and will make your project feel slower. */
   showPreview?: boolean;
+  /** Not a Vimeo attribute: Loading attribute for the iframe allows to eager or lazy load the source */
+  loading?: "eager" | "lazy";
   /** Whether to prevent the player from tracking session data, including cookies. Keep in mind that setting this argument to true also blocks video stats. */
   doNotTrack?: VimeoPlayerOptions["dnt"];
   /** Key-value pairs representing dynamic parameters that are utilized on interactive videos with live elements, such as title=my-video,subtitle=interactive. */
@@ -310,6 +318,7 @@ export const Vimeo = forwardRef<Ref, Props>(
   (
     {
       url,
+      loading,
       autoplay = false,
       autopause = true,
       backgroundMode = false,
@@ -342,6 +351,7 @@ export const Vimeo = forwardRef<Ref, Props>(
       useVimeo({
         renderer,
         showPreview,
+        loading,
         options: {
           url,
           autoplay,

--- a/packages/sdk-components-react/src/vimeo.ws.ts
+++ b/packages/sdk-components-react/src/vimeo.ws.ts
@@ -318,6 +318,7 @@ const initialProps: Array<keyof ComponentProps<typeof Vimeo>> = [
   "quality",
   "showPreview",
   "autoplay",
+  "loading",
   "backgroundMode",
   "doNotTrack",
   "loop",


### PR DESCRIPTION
## Description

When video is off-screen and needs to be autoplayed, you can now put it to loading=lazy and it won't load until its in viewport.



https://github.com/webstudio-is/webstudio/assets/52824/3fa59ab8-1e19-44b4-969b-3eb99f12fccf


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
