### PR TITLE
feat: Support atomic CSS on build

### DIFF
--- a/fixtures/webstudio-custom-template/README.md
+++ b/fixtures/webstudio-custom-template/README.md
@@ -10,12 +10,11 @@ pnpm dev
 
 ```bash
 # Terminal 2
-pnpm webstudio link
-# add following link https://main.prs.webstudio.is/builder/0d856812-61d8-4014-a20a-82e01c0eb8ee?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f&mode=preview
+pnpm fixtures:link
 
-pnpm webstudio sync && pnpm prettier --write ./.webstudio/
+pnpm fixtures:sync
 # data.json generated
 
-pnpm webstudio build --preview --template ./custom-template && pnpm prettier --write ./app/ ./package.json
+pnpm fixtures:build
 # exec `pnpm run dev` to see result
 ```

--- a/fixtures/webstudio-custom-template/README.md
+++ b/fixtures/webstudio-custom-template/README.md
@@ -11,7 +11,7 @@ pnpm dev
 ```bash
 # Terminal 2
 pnpm webstudio link
-# add following link https://webstudio-builder-git-main-getwebstudio.vercel.app/builder/0d856812-61d8-4014-a20a-82e01c0eb8ee?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f&mode=preview
+# add following link https://main.prs.webstudio.is/builder/0d856812-61d8-4014-a20a-82e01c0eb8ee?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f&mode=preview
 
 pnpm webstudio sync && pnpm prettier --write ./.webstudio/
 # data.json generated

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -48,7 +48,11 @@ type Resources = Record<string, unknown>;
 const Page = (_props: { params: Params; resources: Resources }) => {
   return (
     <Body data-ws-id="ibXgMoi9_ipHx1gVrvii0" data-ws-component="Body">
-      <Heading data-ws-id="7pwqBSgrfuuOfk1JblWcL" data-ws-component="Heading">
+      <Heading
+        data-ws-id="7pwqBSgrfuuOfk1JblWcL"
+        data-ws-component="Heading"
+        className="c11x2bo2"
+      >
         {"DO NOT TOUCH THIS PROJECT, IT'S USED FOR FIXTURES"}
       </Heading>
     </Body>

--- a/fixtures/webstudio-custom-template/app/__generated__/index.css
+++ b/fixtures/webstudio-custom-template/app/__generated__/index.css
@@ -70,7 +70,7 @@ html {
   }
 }
 @media all {
-  [data-ws-id="7pwqBSgrfuuOfk1JblWcL"] {
+  .c11x2bo2 {
     font-size: 4em;
   }
 }

--- a/fixtures/webstudio-custom-template/package.json
+++ b/fixtures/webstudio-custom-template/package.json
@@ -7,7 +7,7 @@
     "start": "remix-serve build",
     "checks": "pnpm typecheck",
     "size-test": "rm -rf ./public && remix build && size-limit",
-    "fixtures:link": "webstudio link --link 'https://webstudio-builder-git-main-getwebstudio.vercel.app/builder/0d856812-61d8-4014-a20a-82e01c0eb8ee?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f'",
+    "fixtures:link": "webstudio link --link 'https://main.prs.webstudio.is/builder/0d856812-61d8-4014-a20a-82e01c0eb8ee?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f'",
     "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "webstudio build --template ./custom-template --preview && pnpm prettier --write ./app/ ./package.json"
   },

--- a/fixtures/webstudio-remix-netlify-edge-functions/.webstudio/data.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/.webstudio/data.json
@@ -1,11 +1,19 @@
 {
   "build": {
-    "id": "a298339d-fb81-44ef-a688-e5b1221f9532",
+    "id": "d194ee5e-772b-4455-bf5a-8d1b7d846518",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",
-    "version": 18,
-    "createdAt": "2023-09-23T09:29:28.107Z",
-    "updatedAt": "2023-09-23T09:29:28.107Z",
+    "version": 21,
+    "createdAt": "2024-01-08T07:32:44.126Z",
+    "updatedAt": "2024-01-08T07:32:44.126Z",
     "pages": {
+      "meta": {
+        "siteName": "",
+        "faviconAssetId": "",
+        "code": ""
+      },
+      "settings": {
+        "atomicStyles": false
+      },
       "homePage": {
         "id": "9di_L14CzctvSruIoKVvE",
         "name": "Home",

--- a/fixtures/webstudio-remix-netlify-edge-functions/README.md
+++ b/fixtures/webstudio-remix-netlify-edge-functions/README.md
@@ -10,12 +10,11 @@ pnpm dev
 
 ```bash
 # Terminal 2
-pnpm webstudio link
-# add following link https://main.prs.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93
+pnpm fixtures:link
 
-pnpm webstudio sync && pnpm prettier --write ./.webstudio/
+pnpm fixtures:sync
 # data.json generated
 
-pnpm webstudio build --preview && pnpm prettier --write ./app/ ./package.json
+pnpm fixtures:build
 # exec `pnpm run dev` to see result
 ```

--- a/fixtures/webstudio-remix-netlify-edge-functions/README.md
+++ b/fixtures/webstudio-remix-netlify-edge-functions/README.md
@@ -11,7 +11,7 @@ pnpm dev
 ```bash
 # Terminal 2
 pnpm webstudio link
-# add following link https://webstudio-builder-git-main-getwebstudio.vercel.app/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93
+# add following link https://main.prs.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93
 
 pnpm webstudio sync && pnpm prettier --write ./.webstudio/
 # data.json generated

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/[sitemap.xml].ts
@@ -2,7 +2,7 @@ export const sitemap = {
   pages: [
     {
       path: "",
-      lastModified: "2023-09-23T09:29:28.107Z",
+      lastModified: "2024-01-08T07:32:44.126Z",
     },
   ],
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -13,6 +13,7 @@ import {
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [];
 export const pageData: PageData = {
+  project: { siteName: "", faviconAssetId: "", code: "" },
   page: {
     id: "9di_L14CzctvSruIoKVvE",
     name: "Home",

--- a/fixtures/webstudio-remix-netlify-edge-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/package.json
@@ -5,7 +5,7 @@
     "build": "remix build",
     "dev": "remix dev",
     "typecheck": "tsc",
-    "fixtures:link": "webstudio link --link 'https://webstudio-builder-git-main-getwebstudio.vercel.app/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93&'",
+    "fixtures:link": "webstudio link --link 'https://main.prs.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93&'",
     "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "webstudio build --template netlify-edge-functions --preview && pnpm prettier --write ./app/ ./package.json"
   },

--- a/fixtures/webstudio-remix-netlify-functions/.webstudio/data.json
+++ b/fixtures/webstudio-remix-netlify-functions/.webstudio/data.json
@@ -1,11 +1,19 @@
 {
   "build": {
-    "id": "a298339d-fb81-44ef-a688-e5b1221f9532",
+    "id": "d194ee5e-772b-4455-bf5a-8d1b7d846518",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",
-    "version": 18,
-    "createdAt": "2023-09-23T09:29:28.107Z",
-    "updatedAt": "2023-09-23T09:29:28.107Z",
+    "version": 21,
+    "createdAt": "2024-01-08T07:32:44.126Z",
+    "updatedAt": "2024-01-08T07:32:44.126Z",
     "pages": {
+      "meta": {
+        "siteName": "",
+        "faviconAssetId": "",
+        "code": ""
+      },
+      "settings": {
+        "atomicStyles": false
+      },
       "homePage": {
         "id": "9di_L14CzctvSruIoKVvE",
         "name": "Home",

--- a/fixtures/webstudio-remix-netlify-functions/README.md
+++ b/fixtures/webstudio-remix-netlify-functions/README.md
@@ -10,12 +10,11 @@ pnpm dev
 
 ```bash
 # Terminal 2
-pnpm webstudio link
-# add following link https://main.prs.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93
+pnpm fixtures:link
 
-pnpm webstudio sync && pnpm prettier --write ./.webstudio/
+pnpm fixtures:sync
 # data.json generated
 
-pnpm webstudio build --preview && pnpm prettier --write ./app/ ./package.json
+pnpm fixtures:build
 # exec `pnpm run dev` to see result
 ```

--- a/fixtures/webstudio-remix-netlify-functions/README.md
+++ b/fixtures/webstudio-remix-netlify-functions/README.md
@@ -11,7 +11,7 @@ pnpm dev
 ```bash
 # Terminal 2
 pnpm webstudio link
-# add following link https://webstudio-builder-git-main-getwebstudio.vercel.app/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93
+# add following link https://main.prs.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93
 
 pnpm webstudio sync && pnpm prettier --write ./.webstudio/
 # data.json generated

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/[sitemap.xml].ts
@@ -2,7 +2,7 @@ export const sitemap = {
   pages: [
     {
       path: "",
-      lastModified: "2023-09-23T09:29:28.107Z",
+      lastModified: "2024-01-08T07:32:44.126Z",
     },
   ],
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -13,6 +13,7 @@ import {
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [];
 export const pageData: PageData = {
+  project: { siteName: "", faviconAssetId: "", code: "" },
   page: {
     id: "9di_L14CzctvSruIoKVvE",
     name: "Home",

--- a/fixtures/webstudio-remix-netlify-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-functions/package.json
@@ -5,7 +5,7 @@
     "build": "remix build",
     "dev": "remix dev",
     "typecheck": "tsc",
-    "fixtures:link": "webstudio link --link 'https://webstudio-builder-git-main-getwebstudio.vercel.app/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
+    "fixtures:link": "webstudio link --link 'https://main.prs.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
     "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "webstudio build --template netlify-functions --preview && pnpm prettier --write ./app/ ./package.json"
   },

--- a/fixtures/webstudio-remix-vercel/.webstudio/data.json
+++ b/fixtures/webstudio-remix-vercel/.webstudio/data.json
@@ -1,15 +1,18 @@
 {
   "build": {
-    "id": "c8c21b00-1c66-4fb1-903d-5fd207fe24a2",
+    "id": "28fd3af0-111a-4afa-9ed3-1978744b7fe6",
     "projectId": "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    "version": 228,
-    "createdAt": "2023-12-26T09:13:01.469Z",
-    "updatedAt": "2023-12-26T09:13:01.469Z",
+    "version": 231,
+    "createdAt": "2024-01-08T07:22:37.579Z",
+    "updatedAt": "2024-01-08T07:22:37.579Z",
     "pages": {
       "meta": {
         "siteName": "KittyGuardedZone",
         "faviconAssetId": "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
         "code": "<script>console.log('KittyGuardedZone')</script>\n"
+      },
+      "settings": {
+        "atomicStyles": true
       },
       "homePage": {
         "id": "7Db64ZXgYiRqKSQNR-qTQ",

--- a/fixtures/webstudio-remix-vercel/README.md
+++ b/fixtures/webstudio-remix-vercel/README.md
@@ -11,7 +11,7 @@ pnpm dev
 ```bash
 # Terminal 2
 pnpm webstudio-cli link
-# add following link https://webstudio-builder-git-main-getwebstudio.vercel.app/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview
+# add following link https://main.prs.webstudio.is/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview
 
 pnpm webstudio-cli sync && pnpm prettier --write ./.webstudio/
 # data.json generated

--- a/fixtures/webstudio-remix-vercel/README.md
+++ b/fixtures/webstudio-remix-vercel/README.md
@@ -10,12 +10,11 @@ pnpm dev
 
 ```bash
 # Terminal 2
-pnpm webstudio-cli link
-# add following link https://main.prs.webstudio.is/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview
+pnpm fixtures:link
 
-pnpm webstudio-cli sync && pnpm prettier --write ./.webstudio/
+pnpm fixtures:sync
 # data.json generated
 
-pnpm webstudio-cli build --preview && pnpm prettier --write ./app/ ./package.json
+pnpm fixtures:build
 # exec `pnpm run dev` to see result
 ```

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -72,6 +72,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         data-ws-id="AdXSAYCx4QDo5QN6nLoGs"
         data-ws-component="Image"
         src={"/assets/small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp"}
+        className="c1arp7pb"
       />
     </Body>
   );

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -100,19 +100,26 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           data-ws-id="zJ927zk9txwUbYycKB7QA"
           data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionItem"
           data-ws-index="0"
+          className="c1lk4dyo cpa46rs c1rs4a6c"
         >
           <AccordionHeader
             data-ws-id="sMxg7xT1hwYt05hbOvoPL"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionHeader"
+            className="ct8bqew"
           >
             <AccordionTrigger
               data-ws-id="qQSA4NoyKC88O68mBiQe2"
               data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionTrigger"
+              className="ct8bqew c4wr6vh c5exn1v c6th5p4 c8sklb9 cozm0zy crf2knr c16vf3pr c1u6bhyx cgivo88 c1px50mc cnog96r"
             >
               <Text data-ws-id="q-DVI4YTNrQ1LizmEyJHI" data-ws-component="Text">
                 {"Is it accessible?"}
               </Text>
-              <Box data-ws-id="RSk81lLj2IGXgchTuXF7V" data-ws-component="Box">
+              <Box
+                data-ws-id="RSk81lLj2IGXgchTuXF7V"
+                data-ws-component="Box"
+                className="c1chi4tu chkajpy cmhi6j0 c1bn66w8 cw6h46e c1mmsm3k c79adhm"
+              >
                 <HtmlEmbed
                   data-ws-id="d0sd_G-kHirxgjq6s6Uq1"
                   data-ws-component="HtmlEmbed"
@@ -126,6 +133,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           <AccordionContent
             data-ws-id="IUftdfjK-ilSzfOTdIx1u"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionContent"
+            className="c3kadi cl1n90y c11hmcmb c16vf3pr"
           >
             {"Yes. It adheres to the WAI-ARIA design pattern."}
           </AccordionContent>
@@ -134,19 +142,26 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           data-ws-id="C838wkvIcA1BQu30Xu2G8"
           data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionItem"
           data-ws-index="1"
+          className="c1lk4dyo cpa46rs c1rs4a6c"
         >
           <AccordionHeader
             data-ws-id="fYUOB_brm6s0Ky68lzMfU"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionHeader"
+            className="ct8bqew"
           >
             <AccordionTrigger
               data-ws-id="dfd4gonev_AX6BpuCsxjb"
               data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionTrigger"
+              className="ct8bqew c4wr6vh c5exn1v c6th5p4 c8sklb9 cozm0zy crf2knr c16vf3pr c1u6bhyx cgivo88 c1px50mc cnog96r"
             >
               <Text data-ws-id="lZ7sI6Kw_0VZkURriKscB" data-ws-component="Text">
                 {"Is it styled?"}
               </Text>
-              <Box data-ws-id="wRw75kuvFzl5NWD8IGJoI" data-ws-component="Box">
+              <Box
+                data-ws-id="wRw75kuvFzl5NWD8IGJoI"
+                data-ws-component="Box"
+                className="c1chi4tu chkajpy cmhi6j0 c1bn66w8 cw6h46e c1mmsm3k c79adhm"
+              >
                 <HtmlEmbed
                   data-ws-id="StPslEr81nfBISqBE2R-Y"
                   data-ws-component="HtmlEmbed"
@@ -160,6 +175,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           <AccordionContent
             data-ws-id="wNRVuu0L5E8TVufKdswp1"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionContent"
+            className="c3kadi cl1n90y c11hmcmb c16vf3pr"
           >
             {
               "Yes. It comes with default styles that matches the other components' aesthetic."
@@ -170,19 +186,26 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           data-ws-id="65djoTmSBGemZ2L5izQ5M"
           data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionItem"
           data-ws-index="2"
+          className="c1lk4dyo cpa46rs c1rs4a6c"
         >
           <AccordionHeader
             data-ws-id="UJYfe6kH7HqhH0YYeJwe7"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionHeader"
+            className="ct8bqew"
           >
             <AccordionTrigger
               data-ws-id="600nGddaNxGGdsuGgpxJR"
               data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionTrigger"
+              className="ct8bqew c4wr6vh c5exn1v c6th5p4 c8sklb9 cozm0zy crf2knr c16vf3pr c1u6bhyx cgivo88 c1px50mc cnog96r"
             >
               <Text data-ws-id="1iNKIMG91n83PzJnEdxq9" data-ws-component="Text">
                 {"Is it animated?"}
               </Text>
-              <Box data-ws-id="Ta70VqUb_fGJXBT_zsnxQ" data-ws-component="Box">
+              <Box
+                data-ws-id="Ta70VqUb_fGJXBT_zsnxQ"
+                data-ws-component="Box"
+                className="c1chi4tu chkajpy cmhi6j0 c1bn66w8 cw6h46e c1mmsm3k c79adhm"
+              >
                 <HtmlEmbed
                   data-ws-id="sO80m5u4f87jVGG91t6u8"
                   data-ws-component="HtmlEmbed"
@@ -196,6 +219,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           <AccordionContent
             data-ws-id="mOVPnIrlt6IwVAzI_i2Fc"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionContent"
+            className="c3kadi cl1n90y c11hmcmb c16vf3pr"
           >
             {
               "Yes. It's animated by default, but you can disable it if you prefer."

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml].ts
@@ -2,23 +2,23 @@ export const sitemap = {
   pages: [
     {
       path: "",
-      lastModified: "2023-12-26T09:13:01.469Z",
+      lastModified: "2024-01-08T07:22:37.579Z",
     },
     {
       path: "/_route_with_symbols_",
-      lastModified: "2023-12-26T09:13:01.469Z",
+      lastModified: "2024-01-08T07:22:37.579Z",
     },
     {
       path: "/form",
-      lastModified: "2023-12-26T09:13:01.469Z",
+      lastModified: "2024-01-08T07:22:37.579Z",
     },
     {
       path: "/heading-with-id",
-      lastModified: "2023-12-26T09:13:01.469Z",
+      lastModified: "2024-01-08T07:22:37.579Z",
     },
     {
       path: "/resources",
-      lastModified: "2023-12-26T09:13:01.469Z",
+      lastModified: "2024-01-08T07:22:37.579Z",
     },
   ],
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -81,12 +81,28 @@ type Params = Record<string, string | undefined>;
 type Resources = Record<string, unknown>;
 const Page = (_props: { params: Params; resources: Resources }) => {
   return (
-    <Body data-ws-id="On9cvWCxr5rdZtY9O1Bv0" data-ws-component="Body">
-      <Heading data-ws-id="nVMWvMsaLCcb0o1wuNQgg" data-ws-component="Heading">
+    <Body
+      data-ws-id="On9cvWCxr5rdZtY9O1Bv0"
+      data-ws-component="Body"
+      className="c1wfdiy8 cg4dwmz c1psdgn0 ciwrswx"
+    >
+      <Heading
+        data-ws-id="nVMWvMsaLCcb0o1wuNQgg"
+        data-ws-component="Heading"
+        className="cr3bcad"
+      >
         {"DO NOT TOUCH THIS PROJECT, IT'S USED FOR FIXTURES"}
       </Heading>
-      <Box data-ws-id="f0kF-WmL7DQg7MSyRvqY1" data-ws-component="Box">
-        <Box data-ws-id="5XDbqPrZDeCwq4YJ3CHsc" data-ws-component="Box">
+      <Box
+        data-ws-id="f0kF-WmL7DQg7MSyRvqY1"
+        data-ws-component="Box"
+        className="ct8bqew c18lita3 c1ac63p"
+      >
+        <Box
+          data-ws-id="5XDbqPrZDeCwq4YJ3CHsc"
+          data-ws-component="Box"
+          className="cdojbwh c4wr6vh cn27x24 cl3i1h5"
+        >
           <Heading
             data-ws-id="oLXYe1UQiVMhVnZGvJSMr"
             data-ws-component="Heading"
@@ -127,6 +143,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
             data-ws-id="9I4GRU1sev48hREkQcKQ-"
             data-ws-component="Link"
             href={"/_route_with_symbols_"}
+            className="cnpb7qg"
           >
             {"Symbols in path"}
           </Link>
@@ -134,17 +151,23 @@ const Page = (_props: { params: Params; resources: Resources }) => {
             data-ws-id="81ejLVXyFEV1SxiJrWhyw"
             data-ws-component="Link"
             href={"/heading-with-id#my-heading"}
+            className="cnpb7qg"
           >
             {"Link to instance"}
           </Link>
         </Box>
-        <Box data-ws-id="qPnkiFGDj8dITWb1kmpGl" data-ws-component="Box">
+        <Box
+          data-ws-id="qPnkiFGDj8dITWb1kmpGl"
+          data-ws-component="Box"
+          className="cdojbwh c4wr6vh cn27x24 cl3i1h5"
+        >
           <Image
             data-ws-id="pX1ovPI7NdC0HRjkw6Kpw"
             data-ws-component="Image"
             src={
               "/assets/_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg"
             }
+            className="c1arp7pb"
           />
         </Box>
       </Box>

--- a/fixtures/webstudio-remix-vercel/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/index.css
@@ -308,165 +308,115 @@ html {
   }
 }
 @media all {
-  [data-ws-id="nVMWvMsaLCcb0o1wuNQgg"] {
+  .cr3bcad {
     font-size: 4em;
   }
-  [data-ws-id="f0kF-WmL7DQg7MSyRvqY1"] {
+  .ct8bqew {
     display: flex;
+  }
+  .c18lita3 {
     justify-content: center;
+  }
+  .c1ac63p {
     align-items: start;
   }
-  [data-ws-id="5XDbqPrZDeCwq4YJ3CHsc"] {
+  .cdojbwh {
     min-width: 0px;
+  }
+  .c4wr6vh {
     flex-grow: 1;
+  }
+  .cn27x24 {
     flex-shrink: 0;
+  }
+  .cl3i1h5 {
     flex-basis: 0px;
   }
-  [data-ws-id="qPnkiFGDj8dITWb1kmpGl"] {
-    min-width: 0px;
-    flex-grow: 1;
-    flex-shrink: 0;
-    flex-basis: 0px;
-  }
-  [data-ws-id="pX1ovPI7NdC0HRjkw6Kpw"] {
+  .c1arp7pb {
     aspect-ratio: 1;
   }
-  [data-ws-id="On9cvWCxr5rdZtY9O1Bv0"] {
+  .c1wfdiy8 {
     padding-top: 16px;
+  }
+  .cg4dwmz {
     padding-right: 16px;
+  }
+  .c1psdgn0 {
     padding-left: 16px;
+  }
+  .ciwrswx {
     padding-bottom: 16px;
   }
-  [data-ws-id="zJ927zk9txwUbYycKB7QA"] {
+  .c1lk4dyo {
     border-bottom-width: 1px;
+  }
+  .cpa46rs {
     border-bottom-style: solid;
+  }
+  .c1rs4a6c {
     border-bottom-color: rgba(226, 232, 240, 1);
   }
-  [data-ws-id="sMxg7xT1hwYt05hbOvoPL"] {
-    display: flex;
-  }
-  [data-ws-id="qQSA4NoyKC88O68mBiQe2"] {
-    display: flex;
-    flex-grow: 1;
+  .c5exn1v {
     flex-shrink: 1;
+  }
+  .c6th5p4 {
     flex-basis: 0%;
+  }
+  .c8sklb9 {
     align-items: center;
+  }
+  .cozm0zy {
     justify-content: space-between;
+  }
+  .crf2knr {
     padding-top: 1rem;
+  }
+  .c16vf3pr {
     padding-bottom: 1rem;
+  }
+  .c1u6bhyx {
     font-weight: 500;
+  }
+  .cgivo88 {
     --accordion-trigger-icon-transform: 0deg;
   }
-  [data-ws-id="qQSA4NoyKC88O68mBiQe2"]:hover {
+  .c1px50mc:hover {
     text-decoration-line: underline;
   }
-  [data-ws-id="qQSA4NoyKC88O68mBiQe2"][data-state="open"] {
+  .cnog96r[data-state="open"] {
     --accordion-trigger-icon-transform: 180deg;
   }
-  [data-ws-id="RSk81lLj2IGXgchTuXF7V"] {
+  .c1chi4tu {
     rotate: var(--accordion-trigger-icon-transform);
+  }
+  .chkajpy {
     height: 1rem;
+  }
+  .cmhi6j0 {
     width: 1rem;
+  }
+  .c1bn66w8 {
     flex-grow: 0;
+  }
+  .cw6h46e {
     transition-property: all;
+  }
+  .c1mmsm3k {
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .c79adhm {
     transition-duration: 200ms;
   }
-  [data-ws-id="IUftdfjK-ilSzfOTdIx1u"] {
+  .c3kadi {
     overflow: hidden;
+  }
+  .cl1n90y {
     font-size: 0.875rem;
+  }
+  .c11hmcmb {
     line-height: 1.25rem;
-    padding-bottom: 1rem;
   }
-  [data-ws-id="C838wkvIcA1BQu30Xu2G8"] {
-    border-bottom-width: 1px;
-    border-bottom-style: solid;
-    border-bottom-color: rgba(226, 232, 240, 1);
-  }
-  [data-ws-id="fYUOB_brm6s0Ky68lzMfU"] {
-    display: flex;
-  }
-  [data-ws-id="dfd4gonev_AX6BpuCsxjb"] {
-    display: flex;
-    flex-grow: 1;
-    flex-shrink: 1;
-    flex-basis: 0%;
-    align-items: center;
-    justify-content: space-between;
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-    font-weight: 500;
-    --accordion-trigger-icon-transform: 0deg;
-  }
-  [data-ws-id="dfd4gonev_AX6BpuCsxjb"]:hover {
-    text-decoration-line: underline;
-  }
-  [data-ws-id="dfd4gonev_AX6BpuCsxjb"][data-state="open"] {
-    --accordion-trigger-icon-transform: 180deg;
-  }
-  [data-ws-id="wRw75kuvFzl5NWD8IGJoI"] {
-    rotate: var(--accordion-trigger-icon-transform);
-    height: 1rem;
-    width: 1rem;
-    flex-grow: 0;
-    transition-property: all;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: 200ms;
-  }
-  [data-ws-id="wNRVuu0L5E8TVufKdswp1"] {
-    overflow: hidden;
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-    padding-bottom: 1rem;
-  }
-  [data-ws-id="65djoTmSBGemZ2L5izQ5M"] {
-    border-bottom-width: 1px;
-    border-bottom-style: solid;
-    border-bottom-color: rgba(226, 232, 240, 1);
-  }
-  [data-ws-id="UJYfe6kH7HqhH0YYeJwe7"] {
-    display: flex;
-  }
-  [data-ws-id="600nGddaNxGGdsuGgpxJR"] {
-    display: flex;
-    flex-grow: 1;
-    flex-shrink: 1;
-    flex-basis: 0%;
-    align-items: center;
-    justify-content: space-between;
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-    font-weight: 500;
-    --accordion-trigger-icon-transform: 0deg;
-  }
-  [data-ws-id="600nGddaNxGGdsuGgpxJR"]:hover {
-    text-decoration-line: underline;
-  }
-  [data-ws-id="600nGddaNxGGdsuGgpxJR"][data-state="open"] {
-    --accordion-trigger-icon-transform: 180deg;
-  }
-  [data-ws-id="Ta70VqUb_fGJXBT_zsnxQ"] {
-    rotate: var(--accordion-trigger-icon-transform);
-    height: 1rem;
-    width: 1rem;
-    flex-grow: 0;
-    transition-property: all;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: 200ms;
-  }
-  [data-ws-id="mOVPnIrlt6IwVAzI_i2Fc"] {
-    overflow: hidden;
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-    padding-bottom: 1rem;
-  }
-  [data-ws-id="AdXSAYCx4QDo5QN6nLoGs"] {
-    aspect-ratio: 1;
-  }
-  [data-ws-id="9I4GRU1sev48hREkQcKQ-"] {
-    display: block;
-  }
-  [data-ws-id="81ejLVXyFEV1SxiJrWhyw"] {
+  .cnpb7qg {
     display: block;
   }
 }

--- a/fixtures/webstudio-remix-vercel/package.json
+++ b/fixtures/webstudio-remix-vercel/package.json
@@ -4,7 +4,7 @@
     "build": "remix build",
     "dev": "remix dev",
     "typecheck": "tsc",
-    "fixtures:link": "webstudio link --link 'https://webstudio-builder-git-main-getwebstudio.vercel.app/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview'",
+    "fixtures:link": "webstudio link --link 'https://main.prs.webstudio.is/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview'",
     "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "webstudio build --template vercel --preview && pnpm prettier --write ./app/ ./package.json"
   },

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -397,6 +397,7 @@ export const prebuild = async (options: {
   }
 
   spinner.text = "Generating css file";
+
   const { cssText, classesMap } = generateCss(
     {
       assets: siteData.assets,
@@ -408,8 +409,7 @@ export const prebuild = async (options: {
     },
     {
       assetBaseUrl,
-      // @todo switch to atomic depending on site settings
-      atomic: false,
+      atomic: siteData.build.pages.settings?.atomicStyles ?? true,
     }
   );
 


### PR DESCRIPTION
## Description

Logic was changed only in `prebuild.ts`. All other changes or README or autogenerated

Integrate atomic CSS support into CLI

The Vercel fixtures project now explicitly sets atomicStyles to true.
Netlify explicitly sets atomicStyles to false.
The custom template doesn't have a default setting, so atomicCss=true is used."

## Steps for reproduction

See fixtures.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
