### PR TITLE
feat: disable reset button for non-expression binding

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
@@ -65,6 +65,7 @@ export const BooleanControl = ({
               return `${label} expects a boolean value`;
             }
           }}
+          removable={prop?.type === "expression"}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/check.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/check.tsx
@@ -97,6 +97,7 @@ export const CheckControl = ({
               return `${label} expects an array of strings`;
             }
           }}
+          removable={prop?.type === "expression"}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/code.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/code.tsx
@@ -72,6 +72,7 @@ export const CodeControl = ({
               return `${label} expects a string value`;
             }
           }}
+          removable={prop?.type === "expression"}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/file.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/file.tsx
@@ -98,6 +98,7 @@ export const FileControl = ({
                 return `${label} expects a string value or file`;
               }
             }}
+            removable={prop?.type === "expression"}
             value={expression}
             onChange={(newExpression) =>
               onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/json.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/json.tsx
@@ -66,6 +66,7 @@ export const JsonControl = ({
         <BindingPopover
           scope={scope}
           aliases={aliases}
+          removable={prop?.type === "expression"}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/number.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/number.tsx
@@ -86,6 +86,7 @@ export const NumberControl = ({
               return `${label} expects a number value`;
             }
           }}
+          removable={prop?.type === "expression"}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
@@ -83,6 +83,7 @@ export const RadioControl = ({
               return `${label} expects one of ${options}`;
             }
           }}
+          removable={prop?.type === "expression"}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/select.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/select.tsx
@@ -80,6 +80,7 @@ export const SelectControl = ({
               return `${label} expects one of ${options}`;
             }
           }}
+          removable={prop?.type === "expression"}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/text.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text.tsx
@@ -63,6 +63,7 @@ export const TextControl = ({
             return `${label} expects a string value`;
           }
         }}
+        removable={prop?.type === "expression"}
         value={expression}
         onChange={(newExpression) =>
           onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/url.tsx
@@ -503,6 +503,7 @@ export const UrlControl = ({
               return `${label} expects a string value, page or file`;
             }
           }}
+          removable={prop?.type === "expression"}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -125,6 +125,7 @@ const HeaderPair = ({
           <BindingPopover
             scope={editorScope}
             aliases={editorAliases}
+            removable={isLiteralExpression(value) === false}
             value={value}
             onChange={(newValue) => {
               valueField.onChange(newValue);
@@ -384,6 +385,7 @@ export const ResourceForm = forwardRef<
           <BindingPopover
             scope={scope}
             aliases={aliases}
+            removable={isLiteralExpression(urlField.value) === false}
             value={urlField.value}
             onChange={(value) => {
               urlField.onChange(value);
@@ -439,6 +441,7 @@ export const ResourceForm = forwardRef<
             <BindingPopover
               scope={scope}
               aliases={aliases}
+              removable={isLiteralExpression(bodyField.value) === false}
               value={bodyField.value}
               onChange={(value) => {
                 bodyField.onChange(value);

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -285,6 +285,7 @@ export const BindingPopoverProvider = BindingPopoverContext.Provider;
 export const BindingPopover = ({
   scope,
   aliases,
+  removable = true,
   validate,
   value,
   onChange,
@@ -292,6 +293,7 @@ export const BindingPopover = ({
 }: {
   scope: Record<string, unknown>;
   aliases: Map<string, string>;
+  removable?: boolean;
   validate?: (value: unknown) => undefined | string;
   value: string;
   onChange: (newValue: string) => void;
@@ -369,6 +371,7 @@ export const BindingPopover = ({
                   aria-label="Reset binding"
                   prefix={<TrashIcon />}
                   color="ghost"
+                  disabled={removable === false}
                   onClick={(event) => {
                     event.preventDefault();
                     // inline variables and close dialog

--- a/packages/design-system/src/components/text-area.tsx
+++ b/packages/design-system/src/components/text-area.tsx
@@ -31,6 +31,9 @@ const gridStyle = css({
     borderColor: theme.colors.borderFocus,
     outline: `1px solid ${theme.colors.borderFocus}`,
   },
+  "&:has(textarea:disabled)": {
+    background: theme.colors.backgroundInputDisabled,
+  },
   variants: {
     autoGrow: {
       true: {
@@ -76,7 +79,6 @@ const commonStyle = css({
   },
   "&:disabled": {
     color: theme.colors.foregroundDisabled,
-    background: theme.colors.backgroundInputDisabled,
   },
   variants: {
     variant: {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

This prevents users from pointless resetting non-expression bindings.

Also fixed text controls style when binding is bound.

<img width="485" alt="Screenshot 2024-01-10 at 16 29 47" src="https://github.com/webstudio-is/webstudio/assets/5635476/8102a63f-7618-4a93-89a0-494219a8ef0a">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
