### PR TITLE
feat: delete resources along with variables

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -118,9 +118,19 @@ const $usedVariables = computed([$props, $resources], (props, resources) => {
 });
 
 const deleteVariable = (variableId: DataSource["id"]) => {
-  serverSyncStore.createTransaction([$dataSources], (dataSources) => {
-    dataSources.delete(variableId);
-  });
+  serverSyncStore.createTransaction(
+    [$dataSources, $resources],
+    (dataSources, resources) => {
+      const dataSource = dataSources.get(variableId);
+      if (dataSource === undefined) {
+        return;
+      }
+      dataSources.delete(variableId);
+      if (dataSource.type === "resource") {
+        resources.delete(dataSource.resourceId);
+      }
+    }
+  );
 };
 
 const EmptyVariables = () => {

--- a/apps/builder/app/shared/instance-utils.test.ts
+++ b/apps/builder/app/shared/instance-utils.test.ts
@@ -37,6 +37,7 @@ import {
   $pages,
   $project,
   $props,
+  $resources,
   $styleSourceSelections,
   $styleSources,
   $styles,
@@ -605,6 +606,46 @@ describe("delete instance", () => {
         createInstancePair("list", collectionComponent, []),
       ])
     );
+  });
+
+  test("delete resource along with variable", () => {
+    $instances.set(
+      toMap([
+        createInstance("body", "Body", [{ type: "id", value: "box" }]),
+        createInstance("box", "Box", []),
+      ])
+    );
+    $resources.set(
+      toMap([
+        {
+          id: "resourceId",
+          name: "My Resource",
+          url: `""`,
+          method: "get",
+          headers: [],
+        },
+      ])
+    );
+    $dataSources.set(
+      toMap([
+        {
+          id: "resourceVariableId",
+          scopeInstanceId: "box",
+          name: "My Resource Variable",
+          type: "resource",
+          resourceId: "resourceId",
+        },
+      ])
+    );
+    $registeredComponentMetas.set(createFakeComponentMetas({}));
+
+    deleteInstance(["box", "body"]);
+
+    expect($instances.get()).toEqual(
+      toMap([createInstance("body", "Body", [])])
+    );
+    expect($dataSources.get()).toEqual(new Map());
+    expect($resources.get()).toEqual(new Map());
   });
 });
 

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -44,6 +44,7 @@ import {
   $project,
   $breakpoints,
   $pages,
+  $resources,
 } from "./nano-states";
 import {
   type DroppableTarget,
@@ -430,6 +431,7 @@ export const deleteInstance = (instanceSelector: InstanceSelector) => {
       $styleSources,
       $styles,
       $dataSources,
+      $resources,
     ],
     (
       instances,
@@ -437,7 +439,8 @@ export const deleteInstance = (instanceSelector: InstanceSelector) => {
       styleSourceSelections,
       styleSources,
       styles,
-      dataSources
+      dataSources,
+      resources
     ) => {
       let targetInstanceId = instanceSelector[0];
       const parentInstanceId = instanceSelector[1];
@@ -498,6 +501,9 @@ export const deleteInstance = (instanceSelector: InstanceSelector) => {
           instanceIds.has(dataSource.scopeInstanceId)
         ) {
           dataSources.delete(dataSource.id);
+          if (dataSource.type === "resource") {
+            resources.delete(dataSource.resourceId);
+          }
         }
       }
       for (const instanceId of instanceIds) {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

- fixed deleting when delete in variables section
- fixed deleting when delete instance

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
