### PR TITLE
feat: hide variables outside of slots

### DIFF
--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -639,3 +639,72 @@ test("compute resource variable values", () => {
 
   cleanStores($variableValuesByInstanceSelector);
 });
+
+test("stop variables lookup outside of slots", () => {
+  $instances.set(
+    toMap([
+      {
+        id: "body",
+        type: "instance",
+        component: "Body",
+        children: [{ type: "id", value: "slot" }],
+      },
+      {
+        id: "slot",
+        type: "instance",
+        component: "Slot",
+        children: [{ type: "id", value: "box" }],
+      },
+      { id: "box", type: "instance", component: "Box", children: [] },
+    ])
+  );
+  selectPageRoot("body");
+  $dataSources.set(
+    toMap([
+      {
+        id: "bodyVariable",
+        scopeInstanceId: "body",
+        type: "variable",
+        name: "",
+        value: { type: "string", value: "body" },
+      },
+      {
+        id: "slotVariable",
+        scopeInstanceId: "slot",
+        type: "variable",
+        name: "",
+        value: { type: "string", value: "slot" },
+      },
+      {
+        id: "boxVariable",
+        scopeInstanceId: "box",
+        type: "variable",
+        name: "",
+        value: { type: "string", value: "box" },
+      },
+    ])
+  );
+  $props.set(new Map());
+
+  expect($variableValuesByInstanceSelector.get()).toEqual(
+    new Map([
+      [
+        JSON.stringify(["body"]),
+        new Map<string, unknown>([["bodyVariable", "body"]]),
+      ],
+      [
+        JSON.stringify(["slot", "body"]),
+        new Map<string, unknown>([
+          ["bodyVariable", "body"],
+          ["slotVariable", "slot"],
+        ]),
+      ],
+      [
+        JSON.stringify(["box", "slot", "body"]),
+        new Map<string, unknown>([["boxVariable", "box"]]),
+      ],
+    ])
+  );
+
+  cleanStores($variableValuesByInstanceSelector);
+});

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -12,6 +12,7 @@ import {
   encodeDataSourceVariable,
   generateDataSources,
   normalizeProps,
+  portalComponent,
 } from "@webstudio-is/react-sdk";
 import { $instances } from "./instances";
 import {
@@ -292,7 +293,7 @@ export const $variableValuesByInstanceSelector = computed(
         return;
       }
 
-      const variableValues = new Map<string, unknown>(parentVariableValues);
+      let variableValues = new Map<string, unknown>(parentVariableValues);
       variableValuesByInstanceSelector.set(
         JSON.stringify(instanceSelector),
         variableValues
@@ -365,6 +366,10 @@ export const $variableValuesByInstanceSelector = computed(
           });
         }
         return;
+      }
+      // reset values for slot children to let slots behave as isolated components
+      if (instance.component === portalComponent) {
+        variableValues = new Map();
       }
       for (const child of instance.children) {
         if (child.type === "id") {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Slots will eventually become components. And components cannot have direct access to page variables. Here added constraint to hide all variables outside of slot component.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
