### PR TITLE
fix: Add source and reset details in tooltips for flex gap

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../shared/css-value-input";
 import { theme } from "@webstudio-is/design-system";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
+import { TooltipContent } from "../../../style-panel/shared/property-name";
 
 const GapLinked = ({
   isLinked,
@@ -59,6 +60,7 @@ const GapInput = ({
   onIntermediateChange,
   onPreviewChange,
   onChange,
+  onReset,
 }: {
   icon: JSX.Element;
   style: StyleInfo;
@@ -67,14 +69,29 @@ const GapInput = ({
   onIntermediateChange: (value?: StyleValue | IntermediateStyleValue) => void;
   onPreviewChange: (value?: StyleValue) => void;
   onChange: (value: StyleValue) => void;
+  onReset: () => void;
 }) => {
   const { label, items } = styleConfigByName(property);
+
   return (
     <Box>
       <CssValueInput
         styleSource={getStyleSource(style[property])}
-        icon={<EnhancedTooltip content={label}>{icon}</EnhancedTooltip>}
-        property="columnGap"
+        icon={
+          <EnhancedTooltip
+            content={
+              <TooltipContent
+                title={label}
+                style={style}
+                properties={[property]}
+                onReset={onReset}
+              />
+            }
+          >
+            {icon}
+          </EnhancedTooltip>
+        }
+        property={property}
         value={style[property]?.value}
         intermediateValue={intermediateValue}
         keywords={items.map((item) => ({
@@ -168,6 +185,13 @@ const FlexGap = ({
               setIntermediateRowGap(value);
             }
           }}
+          onReset={() => {
+            batchUpdate.deleteProperty("columnGap");
+            if (isLinked) {
+              batchUpdate.deleteProperty("rowGap");
+            }
+            batchUpdate.publish();
+          }}
           onPreviewChange={(value) => {
             if (value === undefined) {
               batchUpdate.deleteProperty("columnGap");
@@ -228,6 +252,13 @@ const FlexGap = ({
             if (isLinked) {
               setIntermediateColumnGap(value);
             }
+          }}
+          onReset={() => {
+            batchUpdate.deleteProperty("rowGap");
+            if (isLinked) {
+              batchUpdate.deleteProperty("columnGap");
+            }
+            batchUpdate.publish();
           }}
           onPreviewChange={(value) => {
             if (value === undefined) {

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -125,7 +125,7 @@ const getDescription = (properties: StyleProperty[]) => {
   return propertyDescriptions[property as keyof typeof propertyDescriptions];
 };
 
-const TooltipContent = ({
+export const TooltipContent = ({
   title,
   description,
   scrollableContent,

--- a/packages/design-system/src/components/enhanced-tooltip.tsx
+++ b/packages/design-system/src/components/enhanced-tooltip.tsx
@@ -71,6 +71,12 @@ export const EnhancedTooltip = forwardRef(
      */
     const allowOpenRef = useRef(true);
 
+    const handleDisableOpen = () => {
+      allowOpenRef.current = false;
+      setOpen(false);
+      showTooltipDelayed.cancel();
+    };
+
     const showTooltipDelayed = useDebouncedCallback(
       () => {
         if (allowOpenRef.current) {
@@ -83,12 +89,18 @@ export const EnhancedTooltip = forwardRef(
 
     // We debounce blur/focus events in a single function, to skip fast `blur/focus` which can occur during select menu hovers
     const handleFocusEventsDebounced = useDebouncedCallback(
-      (eventType: "focus" | "blur") => {
+      (eventType: "focus" | "blur" | "mouseLeave") => {
         if (eventType === "blur") {
           isFocusedRef.current = false;
           allowOpenRef.current = true;
           setOpen(false);
           showTooltipDelayed.cancel();
+          return;
+        }
+
+        if (eventType === "mouseLeave") {
+          allowOpenRef.current = true;
+          isFocusedRef.current = true;
           return;
         }
 
@@ -109,6 +121,26 @@ export const EnhancedTooltip = forwardRef(
       },
       onBlur: (event: FocusEvent<HTMLElement>) => {
         handleFocusEventsDebounced("blur");
+        event.preventDefault();
+      },
+      onPointerDown: () => {
+        handleDisableOpen();
+      },
+      onKeyDown: () => {
+        handleDisableOpen();
+      },
+      /*
+        When onKeyDown or onPointerDown events occur, the tooltips are disabled.
+        Inorder not to show them when the drag operation is under progress.
+        However, there is a scenario in which users press keyDown,
+        drag the mouse, and leaves the icon and then leaves the drag on the input. (e.g., columnGap and rowGap handlers).
+        In this case, it is necessary to reset and enable the tooltips to appear again when
+        users hover over the icon after completing the drag operation. Without this reset,
+        the tooltips may not appear if the icon is revisited following a keyDown and drag operation.
+        Because showTooltipDelayed.cancel() is called in handleDisableOpen, or onKeyDown and onPointerDown events.
+      */
+      onMouseLeave: (event: React.MouseEvent<HTMLElement>) => {
+        handleFocusEventsDebounced("mouseLeave");
         event.preventDefault();
       },
     };

--- a/packages/design-system/src/components/enhanced-tooltip.tsx
+++ b/packages/design-system/src/components/enhanced-tooltip.tsx
@@ -71,12 +71,6 @@ export const EnhancedTooltip = forwardRef(
      */
     const allowOpenRef = useRef(true);
 
-    const handleDisableOpen = () => {
-      allowOpenRef.current = false;
-      setOpen(false);
-      showTooltipDelayed.cancel();
-    };
-
     const showTooltipDelayed = useDebouncedCallback(
       () => {
         if (allowOpenRef.current) {
@@ -116,12 +110,6 @@ export const EnhancedTooltip = forwardRef(
       onBlur: (event: FocusEvent<HTMLElement>) => {
         handleFocusEventsDebounced("blur");
         event.preventDefault();
-      },
-      onPointerDown: () => {
-        handleDisableOpen();
-      },
-      onKeyDown: () => {
-        handleDisableOpen();
       },
     };
 


### PR DESCRIPTION
## Description

fixes #2733 

Tooltips on FlexGap properties don't have details of `columnGap` or `rowGap`.  Now, on hover on these two properties will show the properties details and  able to reset the values from the tooltip

## Steps for reproduction

1. Hover on the flex-gap properties.
2. The property will show the details of the property and allows to reset.

## Code Review

- [ ] hi @kof, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
