### PR TITLE
fix: fallback to default value in computed props

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -104,7 +104,7 @@ const renderProperty = (
     instanceId,
     meta,
     prop,
-    computedValue: propValues.get(propName),
+    computedValue: propValues.get(propName) ?? meta.defaultValue,
     propName,
     readOnly,
     deletable: deletable ?? false,


### PR DESCRIPTION
This fixes the issue with "show" is false by default.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
