### PR TITLE
fix: hide page params with cms flag

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -137,7 +137,7 @@ const HomePageValues = z.object({
 
 const PageValues = z.object({
   name: PageName,
-  path: isFeatureEnabled("bindings") ? PagePath : LegacyPagePath,
+  path: isFeatureEnabled("cms") ? PagePath : LegacyPagePath,
   title: PageTitle,
   description: z.string().optional(),
 });

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -4,4 +4,5 @@ export const displayContents = false;
 export const ai = true;
 export const aiRadixComponents = false;
 export const bindings = false;
+export const cms = false;
 export const folders = false;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

We are launching bindings without page params
which will be part of cms launch.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
