### PR TITLE
fix: Better error message when user reaches max domains limit

### DIFF
--- a/packages/domain/src/db/domain.ts
+++ b/packages/domain/src/db/domain.ts
@@ -107,7 +107,7 @@ export const create = async (
     return {
       success: false,
       error:
-        "You have reached the maximum amount of domains allowed, please upgrade to Pro plan or higher.",
+        "You have reached the maximum number of allowed domains. Please upgrade to the Pro plan or higher.",
     };
   }
 

--- a/packages/domain/src/db/domain.ts
+++ b/packages/domain/src/db/domain.ts
@@ -106,7 +106,8 @@ export const create = async (
   if (projectDomainsCount >= props.maxDomainsAllowedPerUser) {
     return {
       success: false,
-      error: "You have reached the maximum amount of domains allowed",
+      error:
+        "You have reached the maximum amount of domains allowed, please upgrade to Pro plan or higher.",
     };
   }
 


### PR DESCRIPTION
## Description

Just message text

## Steps for reproduction

1. add more than 5 domains on a free account

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
