### PR TITLE
fix: Default link always underline

### DIFF
--- a/packages/design-system/src/components/link.stories.tsx
+++ b/packages/design-system/src/components/link.stories.tsx
@@ -40,7 +40,9 @@ const LinkStory = () => (
         <Link href="" underline="none">
           None
         </Link>
-        <Link href="">Hover</Link>
+        <Link href="" underline="hover">
+          Hover
+        </Link>
         <Link href="" underline="always">
           Always
         </Link>

--- a/packages/design-system/src/components/link.tsx
+++ b/packages/design-system/src/components/link.tsx
@@ -60,6 +60,6 @@ export const Link = styled("a", {
   defaultVariants: {
     variant: "regular",
     color: "main",
-    underline: "hover",
+    underline: "always",
   },
 });


### PR DESCRIPTION
## Description

Failed to check after last changes that the default link used most of the time and it should have underline=always by default, only rare cases have underline  hover or none

## Steps for reproduction

1. export dialog
2. blocking alert

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
