### PR TITLE
feat: support bound and overwritten binding button variants

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
@@ -11,6 +11,7 @@ import {
   RemovePropButton,
   $selectedInstanceScope,
   updateExpressionValue,
+  useBindingState,
 } from "../shared";
 
 export const BooleanControl = ({
@@ -19,7 +20,6 @@ export const BooleanControl = ({
   propName,
   computedValue,
   deletable,
-  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"boolean">) => {
@@ -28,6 +28,9 @@ export const BooleanControl = ({
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression =
     prop?.type === "expression" ? prop.value : JSON.stringify(computedValue);
+  const { overwritable, variant } = useBindingState(
+    prop?.type === "expression" ? prop.value : undefined
+  );
 
   return (
     <Grid
@@ -41,13 +44,17 @@ export const BooleanControl = ({
       align="center"
       gap="2"
     >
-      <Label htmlFor={id} description={meta.description} readOnly={readOnly}>
+      <Label
+        htmlFor={id}
+        description={meta.description}
+        readOnly={overwritable === false}
+      >
         {label}
       </Label>
       <BindingControl>
         <Switch
           id={id}
-          disabled={readOnly}
+          disabled={overwritable === false}
           checked={Boolean(computedValue ?? false)}
           onCheckedChange={(value) => {
             if (prop?.type === "expression") {
@@ -65,7 +72,7 @@ export const BooleanControl = ({
               return `${label} expects a boolean value`;
             }
           }}
-          removable={prop?.type === "expression"}
+          variant={variant}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/check.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/check.tsx
@@ -12,6 +12,7 @@ import {
   Label,
   $selectedInstanceScope,
   updateExpressionValue,
+  useBindingState,
 } from "../shared";
 
 const add = (array: string[], item: string) => {
@@ -34,7 +35,6 @@ export const CheckControl = ({
   propName,
   computedValue,
   deletable,
-  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"check" | "inline-check" | "multi-select">) => {
@@ -50,6 +50,9 @@ export const CheckControl = ({
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression =
     prop?.type === "expression" ? prop.value : JSON.stringify(computedValue);
+  const { overwritable, variant } = useBindingState(
+    prop?.type === "expression" ? prop.value : undefined
+  );
 
   return (
     <VerticalLayout
@@ -57,7 +60,7 @@ export const CheckControl = ({
         <Label
           htmlFor={`${id}:${options[0]}`}
           description={meta.description}
-          readOnly={readOnly}
+          readOnly={overwritable === false}
         >
           {label}
         </Label>
@@ -69,7 +72,7 @@ export const CheckControl = ({
         {options.map((option) => (
           <CheckboxAndLabel key={option}>
             <Checkbox
-              disabled={readOnly}
+              disabled={overwritable === false}
               checked={value.includes(option)}
               onCheckedChange={(checked) => {
                 const newValue = checked
@@ -97,7 +100,7 @@ export const CheckControl = ({
               return `${label} expects an array of strings`;
             }
           }}
-          removable={prop?.type === "expression"}
+          variant={variant}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/code.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/code.tsx
@@ -12,6 +12,7 @@ import {
   Label,
   updateExpressionValue,
   $selectedInstanceScope,
+  useBindingState,
 } from "../shared";
 
 export const CodeControl = ({
@@ -20,7 +21,6 @@ export const CodeControl = ({
   propName,
   computedValue,
   deletable,
-  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"code">) => {
@@ -46,11 +46,17 @@ export const CodeControl = ({
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression =
     prop?.type === "expression" ? prop.value : JSON.stringify(computedValue);
+  const { overwritable, variant } = useBindingState(
+    prop?.type === "expression" ? prop.value : undefined
+  );
 
   return (
     <VerticalLayout
       label={
-        <Label description={metaOverride.description} readOnly={readOnly}>
+        <Label
+          description={metaOverride.description}
+          readOnly={overwritable === false}
+        >
           {label}
         </Label>
       }
@@ -59,7 +65,7 @@ export const CodeControl = ({
     >
       <BindingControl>
         <HtmlEditor
-          readOnly={readOnly}
+          readOnly={overwritable === false}
           value={localValue.value}
           onChange={localValue.set}
           onBlur={localValue.save}
@@ -72,7 +78,7 @@ export const CodeControl = ({
               return `${label} expects a string value`;
             }
           }}
-          removable={prop?.type === "expression"}
+          variant={variant}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/file.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/file.tsx
@@ -13,6 +13,7 @@ import {
   Label,
   updateExpressionValue,
   $selectedInstanceScope,
+  useBindingState,
 } from "../shared";
 import { SelectAsset } from "./select-asset";
 
@@ -46,7 +47,6 @@ export const FileControl = ({
   prop,
   propName,
   computedValue,
-  readOnly,
   deletable,
   onChange,
   onDelete,
@@ -76,6 +76,9 @@ export const FileControl = ({
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression =
     prop?.type === "expression" ? prop.value : JSON.stringify(computedValue);
+  const { overwritable, variant } = useBindingState(
+    prop?.type === "expression" ? prop.value : undefined
+  );
 
   return (
     <VerticalLayout
@@ -89,7 +92,11 @@ export const FileControl = ({
     >
       <Flex css={{ gap: theme.spacing[3] }} direction="column" justify="center">
         <BindingControl>
-          <UrlInput id={id} readOnly={readOnly} localValue={localStringValue} />
+          <UrlInput
+            id={id}
+            readOnly={overwritable === false}
+            localValue={localStringValue}
+          />
           <BindingPopover
             scope={scope}
             aliases={aliases}
@@ -98,7 +105,7 @@ export const FileControl = ({
                 return `${label} expects a string value or file`;
               }
             }}
-            removable={prop?.type === "expression"}
+            variant={variant}
             value={expression}
             onChange={(newExpression) =>
               onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/json.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/json.tsx
@@ -7,6 +7,7 @@ import {
   Label,
   updateExpressionValue,
   $selectedInstanceScope,
+  useBindingState,
 } from "../shared";
 import {
   ExpressionEditor,
@@ -23,7 +24,6 @@ export const JsonControl = ({
   propName,
   computedValue,
   deletable,
-  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"json">) => {
@@ -45,11 +45,14 @@ export const JsonControl = ({
 
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression = prop?.type === "expression" ? prop.value : valueString;
+  const { overwritable, variant } = useBindingState(
+    prop?.type === "expression" ? prop.value : undefined
+  );
 
   return (
     <VerticalLayout
       label={
-        <Label description={meta.description} readOnly={readOnly}>
+        <Label description={meta.description} readOnly={overwritable === false}>
           {label}
         </Label>
       }
@@ -58,7 +61,7 @@ export const JsonControl = ({
     >
       <BindingControl>
         <ExpressionEditor
-          readOnly={readOnly}
+          readOnly={overwritable === false}
           value={localValue.value}
           onChange={localValue.set}
           onBlur={localValue.save}
@@ -66,7 +69,7 @@ export const JsonControl = ({
         <BindingPopover
           scope={scope}
           aliases={aliases}
-          removable={prop?.type === "expression"}
+          variant={variant}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/number.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/number.tsx
@@ -13,6 +13,7 @@ import {
   Label,
   updateExpressionValue,
   $selectedInstanceScope,
+  useBindingState,
 } from "../shared";
 
 export const NumberControl = ({
@@ -22,7 +23,6 @@ export const NumberControl = ({
   computedValue,
   onChange,
   deletable,
-  readOnly,
   onDelete,
 }: ControlProps<"number">) => {
   const id = useId();
@@ -49,11 +49,18 @@ export const NumberControl = ({
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression =
     prop?.type === "expression" ? prop.value : JSON.stringify(computedValue);
+  const { overwritable, variant } = useBindingState(
+    prop?.type === "expression" ? prop.value : undefined
+  );
 
   return (
     <ResponsiveLayout
       label={
-        <Label htmlFor={id} description={meta.description} readOnly={readOnly}>
+        <Label
+          htmlFor={id}
+          description={meta.description}
+          readOnly={overwritable === false}
+        >
           {label}
         </Label>
       }
@@ -63,7 +70,7 @@ export const NumberControl = ({
       <BindingControl>
         <InputField
           id={id}
-          disabled={readOnly}
+          disabled={overwritable === false}
           type="number"
           value={localValue.value}
           color={isInvalid ? "error" : undefined}
@@ -86,7 +93,7 @@ export const NumberControl = ({
               return `${label} expects a number value`;
             }
           }}
-          removable={prop?.type === "expression"}
+          variant={variant}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/radio.tsx
@@ -13,6 +13,7 @@ import {
   Label,
   $selectedInstanceScope,
   updateExpressionValue,
+  useBindingState,
 } from "../shared";
 
 export const RadioControl = ({
@@ -21,7 +22,6 @@ export const RadioControl = ({
   propName,
   computedValue,
   deletable,
-  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"radio" | "inline-radio">) => {
@@ -37,11 +37,18 @@ export const RadioControl = ({
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression =
     prop?.type === "expression" ? prop.value : JSON.stringify(computedValue);
+  const { overwritable, variant } = useBindingState(
+    prop?.type === "expression" ? prop.value : undefined
+  );
 
   return (
     <VerticalLayout
       label={
-        <Label htmlFor={id} description={meta.description} readOnly={readOnly}>
+        <Label
+          htmlFor={id}
+          description={meta.description}
+          readOnly={overwritable === false}
+        >
           {label}
         </Label>
       }
@@ -50,7 +57,7 @@ export const RadioControl = ({
     >
       <BindingControl>
         <RadioGroup
-          disabled={readOnly}
+          disabled={overwritable === false}
           name="value"
           value={value}
           onValueChange={(value) => {
@@ -83,7 +90,7 @@ export const RadioControl = ({
               return `${label} expects one of ${options}`;
             }
           }}
-          removable={prop?.type === "expression"}
+          variant={variant}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/select.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/select.tsx
@@ -13,6 +13,7 @@ import {
   Label,
   $selectedInstanceScope,
   updateExpressionValue,
+  useBindingState,
 } from "../shared";
 
 export const SelectControl = ({
@@ -21,7 +22,6 @@ export const SelectControl = ({
   propName,
   computedValue,
   deletable,
-  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"select">) => {
@@ -38,11 +38,18 @@ export const SelectControl = ({
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression =
     prop?.type === "expression" ? prop.value : JSON.stringify(computedValue);
+  const { overwritable, variant } = useBindingState(
+    prop?.type === "expression" ? prop.value : undefined
+  );
 
   return (
     <VerticalLayout
       label={
-        <Label htmlFor={id} description={meta.description} readOnly={readOnly}>
+        <Label
+          htmlFor={id}
+          description={meta.description}
+          readOnly={overwritable === false}
+        >
           {label}
         </Label>
       }
@@ -53,7 +60,7 @@ export const SelectControl = ({
         <Select
           fullWidth
           id={id}
-          disabled={readOnly}
+          disabled={overwritable === false}
           value={value}
           options={options}
           getLabel={humanizeString}
@@ -80,7 +87,7 @@ export const SelectControl = ({
               return `${label} expects one of ${options}`;
             }
           }}
-          removable={prop?.type === "expression"}
+          variant={variant}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/controls/text.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text.tsx
@@ -13,6 +13,7 @@ import {
   Label,
   updateExpressionValue,
   $selectedInstanceScope,
+  useBindingState,
 } from "../shared";
 
 export const TextControl = ({
@@ -21,7 +22,6 @@ export const TextControl = ({
   propName,
   deletable,
   computedValue,
-  readOnly,
   onChange,
   onDelete,
 }: ControlProps<"text">) => {
@@ -40,12 +40,15 @@ export const TextControl = ({
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression =
     prop?.type === "expression" ? prop.value : JSON.stringify(computedValue);
+  const { overwritable, variant } = useBindingState(
+    prop?.type === "expression" ? prop.value : undefined
+  );
 
   const input = (
     <BindingControl>
       <TextArea
         id={id}
-        disabled={readOnly}
+        disabled={overwritable === false}
         autoGrow
         value={localValue.value}
         rows={meta.rows ?? 1}
@@ -63,7 +66,7 @@ export const TextControl = ({
             return `${label} expects a string value`;
           }
         }}
-        removable={prop?.type === "expression"}
+        variant={variant}
         value={expression}
         onChange={(newExpression) =>
           onChange({ type: "expression", value: newExpression })
@@ -76,7 +79,11 @@ export const TextControl = ({
   );
 
   const labelElement = (
-    <Label htmlFor={id} description={meta.description} readOnly={readOnly}>
+    <Label
+      htmlFor={id}
+      description={meta.description}
+      readOnly={overwritable === false}
+    >
       {label}
     </Label>
   );

--- a/apps/builder/app/builder/features/settings-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/url.tsx
@@ -33,6 +33,7 @@ import {
   Label,
   updateExpressionValue,
   $selectedInstanceScope,
+  useBindingState,
 } from "../shared";
 import { SelectAsset } from "./select-asset";
 
@@ -428,7 +429,6 @@ export const UrlControl = ({
   prop,
   propName,
   computedValue,
-  readOnly,
   deletable,
   onChange,
   onDelete,
@@ -447,6 +447,9 @@ export const UrlControl = ({
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression =
     prop?.type === "expression" ? prop.value : JSON.stringify(computedValue);
+  const { overwritable, variant } = useBindingState(
+    prop?.type === "expression" ? prop.value : undefined
+  );
 
   return (
     <VerticalLayout
@@ -469,7 +472,7 @@ export const UrlControl = ({
       >
         <ToggleGroup
           type="single"
-          disabled={readOnly}
+          disabled={overwritable === false}
           value={mode}
           onValueChange={(value) => {
             // too tricky to prove to TS that value is a Mode
@@ -489,7 +492,7 @@ export const UrlControl = ({
         <BaseControl
           id={id}
           instanceId={instanceId}
-          readOnly={readOnly}
+          readOnly={overwritable === false}
           prop={prop}
           value={value}
           onChange={onChange}
@@ -503,7 +506,7 @@ export const UrlControl = ({
               return `${label} expects a string value, page or file`;
             }
           }}
-          removable={prop?.type === "expression"}
+          variant={variant}
           value={expression}
           onChange={(newExpression) =>
             onChange({ type: "expression", value: newExpression })

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -96,7 +96,7 @@ const renderProperty = (
     component,
     instanceId,
   }: PropsSectionProps,
-  { prop, propName, meta, readOnly }: PropAndMeta,
+  { prop, propName, meta }: PropAndMeta,
   deletable?: boolean
 ) =>
   renderControl({
@@ -106,7 +106,6 @@ const renderProperty = (
     prop,
     computedValue: propValues.get(propName) ?? meta.defaultValue,
     propName,
-    readOnly,
     deletable: deletable ?? false,
     onDelete: () => {
       if (prop) {

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -3,14 +3,12 @@ import type { Instance, Prop } from "@webstudio-is/sdk";
 import {
   type PropMeta,
   showAttribute,
-  decodeDataSourceVariable,
   textContentAttribute,
   collectionComponent,
 } from "@webstudio-is/react-sdk";
 import type { PropValue } from "../shared";
 import { useStore } from "@nanostores/react";
 import {
-  $dataSources,
   $registeredComponentMetas,
   $registeredComponentPropsMetas,
 } from "~/shared/nano-states";
@@ -20,7 +18,6 @@ export type PropAndMeta = {
   prop?: Prop;
   propName: string;
   meta: PropMeta;
-  readOnly: boolean;
 };
 export type NameAndLabel = { name: string; label?: string };
 
@@ -153,7 +150,6 @@ export const usePropsLogic = ({
     instance.component
   );
   const meta = useStore($registeredComponentPropsMetas).get(instance.component);
-  const dataSources = useStore($dataSources);
 
   if (meta === undefined) {
     throw new Error(`Could not get meta for component "${instance.component}"`);
@@ -169,20 +165,6 @@ export const usePropsLogic = ({
 
   const initialPropsNames = new Set(meta.initialProps ?? []);
 
-  /**
-   * make sure expression can be edited if consists only of single variable
-   */
-  const isReadOnly = (prop?: Prop) => {
-    if (prop?.type !== "expression") {
-      return false;
-    }
-    const potentialVariableId = decodeDataSourceVariable(prop.value);
-    return (
-      potentialVariableId === undefined ||
-      dataSources.get(potentialVariableId)?.type !== "variable"
-    );
-  };
-
   const systemProps: PropAndMeta[] = systemPropsMeta.map(({ name, meta }) => {
     let saved = getAndDelete<Prop>(unprocessedSaved, name);
     if (saved === undefined && meta.defaultValue !== undefined) {
@@ -194,7 +176,6 @@ export const usePropsLogic = ({
       prop: saved,
       propName: name,
       meta,
-      readOnly: isReadOnly(saved),
     };
   });
   const canHaveTextContent =
@@ -219,7 +200,6 @@ export const usePropsLogic = ({
         type: "string",
         defaultValue: "",
       },
-      readOnly: false,
     });
   }
 
@@ -255,7 +235,6 @@ export const usePropsLogic = ({
       prop,
       propName: name,
       meta: known,
-      readOnly: isReadOnly(prop),
     });
   }
 
@@ -280,7 +259,6 @@ export const usePropsLogic = ({
       prop,
       propName: prop.name,
       meta: known,
-      readOnly: isReadOnly(prop),
     });
   }
 

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -125,7 +125,7 @@ const HeaderPair = ({
           <BindingPopover
             scope={editorScope}
             aliases={editorAliases}
-            removable={isLiteralExpression(value) === false}
+            variant={isLiteralExpression(value) ? "default" : "bound"}
             value={value}
             onChange={(newValue) => {
               valueField.onChange(newValue);
@@ -385,7 +385,7 @@ export const ResourceForm = forwardRef<
           <BindingPopover
             scope={scope}
             aliases={aliases}
-            removable={isLiteralExpression(urlField.value) === false}
+            variant={isLiteralExpression(urlField.value) ? "default" : "bound"}
             value={urlField.value}
             onChange={(value) => {
               urlField.onChange(value);
@@ -441,7 +441,9 @@ export const ResourceForm = forwardRef<
             <BindingPopover
               scope={scope}
               aliases={aliases}
-              removable={isLiteralExpression(bodyField.value) === false}
+              variant={
+                isLiteralExpression(bodyField.value) ? "default" : "bound"
+              }
               value={bodyField.value}
               onChange={(value) => {
                 bodyField.onChange(value);


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

- added blue "bound" binding button
- added pink "overwritten" binding button
- added tooltip to reset overwriten binding

<img width="239" alt="Screenshot 2024-01-16 at 22 20 11" src="https://github.com/webstudio-is/webstudio/assets/5635476/e5c2b5df-470c-44af-b759-da905f8ec361">
<img width="279" alt="Screenshot 2024-01-16 at 22 20 05" src="https://github.com/webstudio-is/webstudio/assets/5635476/a5bd12e2-7e68-4068-bb20-c77ddce5f900">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
