### PR TITLE
fix: save latest value when close settings panel

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -181,8 +181,14 @@ export const useLocalValue = <Type,>(
 
   // onBlur will not trigger if control is unmounted when props panel is closed or similar.
   // So we're saving at the unmount
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => save, []);
+  // store save in ref to access latest saved value from render
+  // instead of stale one
+  const saveRef = useRef(save);
+  saveRef.current = save;
+  useEffect(() => {
+    // access ref in the moment of unmount
+    return () => saveRef.current();
+  }, []);
 
   useEffect(() => {
     // Update local value if saved value changes and control is not in edit mode.


### PR DESCRIPTION
Unmount got stale saved value because effect is run without dependencies.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
