### PR TITLE
feat: Allow selecting a nested path for link href

### DIFF
--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -1,4 +1,4 @@
-import { findPageByIdOrPath } from "@webstudio-is/project-build";
+import { findPageByIdOrPath } from "@webstudio-is/sdk";
 import { $isPreviewMode, $pages } from "~/shared/nano-states";
 import { switchPage } from "~/shared/pages";
 
@@ -24,7 +24,7 @@ const handleLinkClick = (element: HTMLAnchorElement) => {
   }
 
   const pageHref = new URL(href, "https://any-valid.url");
-  const page = findPageByIdOrPath(pages, pageHref.pathname);
+  const page = findPageByIdOrPath(pageHref.pathname, pages);
   if (page) {
     switchPage(page.id, pageHref.hash);
     return;

--- a/apps/builder/app/shared/db/canvas.server.ts
+++ b/apps/builder/app/shared/db/canvas.server.ts
@@ -2,7 +2,7 @@ import type { Data } from "@webstudio-is/http-client";
 import { loadBuildById } from "@webstudio-is/project-build/index.server";
 import { loadAssetsByProject } from "@webstudio-is/asset-uploader/index.server";
 import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
-import { findPageByIdOrPath } from "@webstudio-is/project-build";
+import { findPageByIdOrPath } from "@webstudio-is/sdk";
 import type { Build } from "@webstudio-is/prisma-client";
 import { db as domainDb } from "@webstudio-is/domain/index.server";
 
@@ -44,7 +44,7 @@ export const loadProductionCanvasData = async (
     )
   );
 
-  const page = findPageByIdOrPath(build.pages, "/");
+  const page = findPageByIdOrPath("/", build.pages);
 
   if (page === undefined) {
     throw new Error(`Page / not found`);

--- a/apps/builder/app/shared/nano-states/pages.ts
+++ b/apps/builder/app/shared/nano-states/pages.ts
@@ -1,5 +1,5 @@
 import { atom, computed } from "nanostores";
-import type { Page, Pages } from "@webstudio-is/sdk";
+import { findPageByIdOrPath, type Page, type Pages } from "@webstudio-is/sdk";
 
 export const $pages = atom<undefined | Pages>(undefined);
 
@@ -9,12 +9,9 @@ export const $selectedPageHash = atom<string>("");
 export const $selectedPage = computed(
   [$pages, $selectedPageId],
   (pages, selectedPageId) => {
-    if (pages === undefined) {
-      return undefined;
+    if (pages === undefined || selectedPageId === undefined) {
+      return;
     }
-    if (pages.homePage.id === selectedPageId) {
-      return pages.homePage;
-    }
-    return pages.pages.find((page) => page.id === selectedPageId);
+    return findPageByIdOrPath(selectedPageId, pages);
   }
 );

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -4,7 +4,6 @@ import {
   type Resource,
   type DataSource,
   type Instance,
-  type Page,
   type Prop,
 } from "@webstudio-is/sdk";
 import {
@@ -129,15 +128,6 @@ const computeExpression = (
   }
 };
 
-const $pagesMap = computed($pages, (pages): Map<string, Page> => {
-  if (pages === undefined) {
-    return new Map();
-  }
-  return new Map(
-    [pages.homePage, ...pages.pages].map((page) => [page.id, page])
-  );
-});
-
 /**
  * compute prop values within context of instance ancestors
  * like a dry-run of rendering and accessing react contexts deep in the tree
@@ -151,15 +141,16 @@ export const $propValuesByInstanceSelector = computed(
     $selectedPage,
     $dataSourcesLogic,
     $params,
-    $pagesMap,
+    $pages,
     $assets,
   ],
   (instances, props, page, dataSourcesLogic, params, pages, assets) => {
     const variableValues = new Map<string, unknown>(dataSourcesLogic);
 
     let propsList = Array.from(props.values());
+
     // ignore asset and page props when params is not provided
-    if (params) {
+    if (params && pages) {
       // use whole props list to let access hash props from other pages and instances
       propsList = normalizeProps({
         props: propsList,

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -1,8 +1,7 @@
 import { useEffect } from "react";
 import { useStore } from "@nanostores/react";
 import { useNavigate } from "@remix-run/react";
-import type { Page } from "@webstudio-is/sdk";
-import { findPageByIdOrPath } from "@webstudio-is/project-build";
+import { findPageByIdOrPath, type Page } from "@webstudio-is/sdk";
 import { useMount } from "~/shared/hook-utils/use-mount";
 import {
   $authToken,
@@ -23,7 +22,7 @@ export const switchPage = (pageId: Page["id"], pageHash: string = "") => {
     return;
   }
 
-  const page = findPageByIdOrPath(pages, pageId);
+  const page = findPageByIdOrPath(pageId, pages);
 
   if (page === undefined) {
     return;

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -297,7 +297,7 @@ export const prebuild = async (options: {
       props: siteData.build.props.map(([_id, prop]) => prop),
       assetBaseUrl,
       assets: new Map(siteData.assets.map((asset) => [asset.id, asset])),
-      pages: new Map(siteData.pages.map((page) => [page.id, page])),
+      pages: siteData.build.pages,
     });
 
     const props: [Prop["id"], Prop][] = [];

--- a/packages/project-build/src/shared/pages-utils.test.ts
+++ b/packages/project-build/src/shared/pages-utils.test.ts
@@ -1,49 +1,30 @@
-import { describe, test, expect } from "@jest/globals";
-import type { Page, Pages } from "@webstudio-is/sdk";
-import { findPageByIdOrPath } from "./pages-utils";
+import { test, expect } from "@jest/globals";
+import { createDefaultPages } from "./pages-utils";
 
-const pages = {
-  meta: {},
-  homePage: {
-    id: "home",
-    path: "/",
-    name: "Home",
-    title: "Home",
-    rootInstanceId: "instance-1",
+test("createDefaultPages", () => {
+  expect(
+    createDefaultPages({
+      rootInstanceId: "rootInstanceId",
+      homePageId: "homePageId",
+    })
+  ).toEqual({
     meta: {},
-  } satisfies Page,
-  pages: [
-    {
-      id: "page1",
-      path: "/page1",
-      name: "Page",
-      title: "Page",
-      rootInstanceId: "instance-1",
+    homePage: {
+      id: "homePageId",
+      name: "Home",
+      path: "",
+      title: "Home",
       meta: {},
-    } satisfies Page,
-  ],
-  folders: [],
-} satisfies Pages;
-
-describe("Find by id or path", () => {
-  test("home page by id", () => {
-    const page = findPageByIdOrPath(pages, "home");
-    expect(page).toEqual(pages.homePage);
-  });
-  test("home page by path /", () => {
-    const page = findPageByIdOrPath(pages, "/");
-    expect(page).toEqual(pages.homePage);
-  });
-  test("home page by empty path", () => {
-    const page = findPageByIdOrPath(pages, "");
-    expect(page).toEqual(pages.homePage);
-  });
-  test("find page by id", () => {
-    const page = findPageByIdOrPath(pages, "page1");
-    expect(page).toEqual(pages.pages[0]);
-  });
-  test("find page by path", () => {
-    const page = findPageByIdOrPath(pages, "/page1");
-    expect(page).toEqual(pages.pages[0]);
+      rootInstanceId: "rootInstanceId",
+    },
+    pages: [],
+    folders: [
+      {
+        id: "root",
+        name: "Root",
+        slug: "",
+        children: ["homePageId"],
+      },
+    ],
   });
 });

--- a/packages/project-build/src/shared/pages-utils.ts
+++ b/packages/project-build/src/shared/pages-utils.ts
@@ -1,18 +1,5 @@
-import type { Pages, Page, Folder } from "@webstudio-is/sdk";
+import type { Pages, Folder } from "@webstudio-is/sdk";
 import { nanoid } from "nanoid";
-
-// @todo path needs to support folders now
-export const findPageByIdOrPath = (
-  pages: Pages,
-  idOrPath: string
-): Page | undefined => {
-  if (idOrPath === "" || idOrPath === "/" || idOrPath === pages.homePage.id) {
-    return pages.homePage;
-  }
-  return pages.pages.find(
-    (page) => page.path === idOrPath || page.id === idOrPath
-  );
-};
 
 export const ROOT_FOLDER_ID = "root";
 

--- a/packages/react-sdk/src/props.test.ts
+++ b/packages/react-sdk/src/props.test.ts
@@ -2,6 +2,27 @@ import { test, expect } from "@jest/globals";
 import type { Prop } from "@webstudio-is/sdk";
 import { normalizeProps } from "./props";
 
+const pagesBase = {
+  meta: {},
+  homePage: {
+    id: "home",
+    path: "/",
+    name: "Home",
+    title: "Home",
+    rootInstanceId: "instance-1",
+    meta: {},
+  },
+  pages: [],
+  folders: [
+    {
+      id: "root",
+      name: "Root",
+      slug: "",
+      children: [],
+    },
+  ],
+};
+
 test("normalize asset prop into string", () => {
   expect(
     normalizeProps({
@@ -31,7 +52,7 @@ test("normalize asset prop into string", () => {
           },
         ],
       ]),
-      pages: new Map(),
+      pages: pagesBase,
     })
   ).toEqual([
     {
@@ -53,24 +74,25 @@ test("normalize page prop with path into string", () => {
           instanceId: "instance1",
           name: "href",
           type: "page",
-          value: "page1Id",
+          value: "page1",
         },
       ],
       assetBaseUrl: "",
       assets: new Map(),
-      pages: new Map([
-        [
-          "page1Id",
+      pages: {
+        ...pagesBase,
+        pages: [
           {
-            id: "page1Id",
-            path: "page1",
-            rootInstanceId: "",
-            name: "",
-            title: "",
+            id: "page1",
+            path: "/page1",
+            name: "Page",
+            title: "Page",
+            rootInstanceId: "instance-1",
             meta: {},
           },
         ],
-      ]),
+        folders: [],
+      },
     })
   ).toEqual([
     {
@@ -91,44 +113,57 @@ test("normalize page prop with path and hash into string", () => {
     type: "string",
     value: "my anchor",
   };
-  expect(
-    normalizeProps({
-      props: [
-        {
-          id: "prop1",
+  const result = normalizeProps({
+    props: [
+      {
+        id: "prop1",
+        instanceId: "instance1",
+        name: "href",
+        type: "page",
+        value: {
+          pageId: "page1",
           instanceId: "instance1",
-          name: "href",
-          type: "page",
-          value: {
-            pageId: "page1Id",
-            instanceId: "instance1",
-          },
         },
-        idProp,
+      },
+      idProp,
+    ],
+    assetBaseUrl: "",
+    assets: new Map(),
+    pages: {
+      ...pagesBase,
+      pages: [
+        {
+          id: "page1",
+          path: "/page1",
+          name: "Page",
+          title: "Page",
+          rootInstanceId: "instance-1",
+          meta: {},
+        },
       ],
-      assetBaseUrl: "",
-      assets: new Map(),
-      pages: new Map([
-        [
-          "page1Id",
-          {
-            id: "page1Id",
-            path: "page1",
-            rootInstanceId: "",
-            name: "",
-            title: "",
-            meta: {},
-          },
-        ],
-      ]),
-    })
-  ).toEqual([
+      folders: [
+        {
+          id: "root",
+          name: "Root",
+          slug: "",
+          children: ["folder"],
+        },
+        {
+          id: "folder",
+          name: "Folder",
+          slug: "folder",
+          children: ["page1"],
+        },
+      ],
+    },
+  });
+  expect(result).toEqual([
     {
       id: "prop1",
       instanceId: "instance1",
       name: "href",
       type: "string",
-      value: "/page1#my%20anchor",
+      value: "/folder/page1#my%20anchor",
     },
     idProp,
   ]);

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -1,6 +1,10 @@
-import type { Page, Prop, Assets } from "@webstudio-is/sdk";
-
-export type Pages = Map<Page["id"], Page>;
+import {
+  type Prop,
+  type Assets,
+  type Pages,
+  getPagePath,
+  findPageByIdOrPath,
+} from "@webstudio-is/sdk";
 
 export const normalizeProps = ({
   props,
@@ -33,22 +37,23 @@ export const normalizeProps = ({
     }
 
     if (prop.type === "page") {
-      let page: undefined | Page;
       let idProp: undefined | Prop;
-      if (typeof prop.value === "string") {
-        const pageId = prop.value;
-        page = pages.get(pageId);
-      } else {
-        const { pageId, instanceId } = prop.value;
-        page = pages.get(pageId);
+      const pageId =
+        typeof prop.value === "string" ? prop.value : prop.value.pageId;
+      const page = findPageByIdOrPath(pageId, pages);
+
+      if (page === undefined) {
+        continue;
+      }
+      if (typeof prop.value !== "string") {
+        const { instanceId } = prop.value;
         idProp = props.find(
           (prop) => prop.instanceId === instanceId && prop.name === "id"
         );
       }
-      if (page === undefined) {
-        continue;
-      }
-      const url = new URL(page.path, "https://any-valid.url");
+
+      const path = getPagePath(page.id, pages);
+      const url = new URL(path, "https://any-valid.url");
       let value = url.pathname;
       if (idProp?.type === "string") {
         const hash = idProp.value;

--- a/packages/sdk/src/page-utils.ts
+++ b/packages/sdk/src/page-utils.ts
@@ -1,5 +1,18 @@
 import type { Folder, Page, Pages } from "./schema/pages";
 
+// @todo path needs to support folders now
+export const findPageByIdOrPath = (
+  idOrPath: string,
+  pages: Pages
+): Page | undefined => {
+  if (idOrPath === "" || idOrPath === "/" || idOrPath === pages.homePage.id) {
+    return pages.homePage;
+  }
+  return pages.pages.find(
+    (page) => page.path === idOrPath || page.id === idOrPath
+  );
+};
+
 /**
  * Get a path from all folder slugs from root to the current folder or page.
  */
@@ -17,7 +30,8 @@ export const getPagePath = (id: Folder["id"] | Page["id"], pages: Pages) => {
   let currentId: undefined | string = id;
 
   // In case id is a page id
-  for (const page of pages.pages) {
+  const allPages = [pages.homePage, ...pages.pages];
+  for (const page of allPages) {
     if (page.id === id) {
       paths.push(page.path);
       currentId = childParentMap.get(page.id);

--- a/packages/sdk/src/page-utils.ts
+++ b/packages/sdk/src/page-utils.ts
@@ -1,6 +1,5 @@
 import type { Folder, Page, Pages } from "./schema/pages";
 
-// @todo path needs to support folders now
 export const findPageByIdOrPath = (
   idOrPath: string,
   pages: Pages
@@ -9,7 +8,7 @@ export const findPageByIdOrPath = (
     return pages.homePage;
   }
   return pages.pages.find(
-    (page) => page.path === idOrPath || page.id === idOrPath
+    (page) => page.id === idOrPath || getPagePath(page.id, pages) === idOrPath
   );
 };
 

--- a/packages/sdk/src/page-utilts.test.ts
+++ b/packages/sdk/src/page-utilts.test.ts
@@ -97,8 +97,11 @@ describe("findPageByIdOrPath", () => {
     const page = findPageByIdOrPath("page-1", pages);
     expect(page).toEqual(pages.pages[0]);
   });
-  test("find page by path", () => {
-    const page = findPageByIdOrPath("/page-1", pages);
+  test("find page by nested path", () => {
+    const page = findPageByIdOrPath(
+      "/folder-1/folder-1-1/folder-1-1-1/page-1",
+      pages
+    );
     expect(page).toEqual(pages.pages[0]);
   });
 });

--- a/packages/sdk/src/page-utilts.test.ts
+++ b/packages/sdk/src/page-utilts.test.ts
@@ -1,55 +1,59 @@
 import { describe, expect, test } from "@jest/globals";
 import type { Pages } from "./schema/pages";
-import { getPagePath } from "./page-utils";
+import { findPageByIdOrPath, getPagePath } from "./page-utils";
 
-describe("getPagePath", () => {
-  const pages = {
+const pages = {
+  meta: {},
+  homePage: {
+    id: "home",
+    path: "/",
+    name: "Home",
+    title: "Home",
+    rootInstanceId: "rootInstanceId",
     meta: {},
-    homePage: {
-      id: "home",
-      path: "/",
-      name: "Home",
-      title: "Home",
+  },
+  pages: [
+    {
+      id: "page-1",
+      path: "/page-1",
+      name: "Page",
+      title: "Page",
       rootInstanceId: "rootInstanceId",
       meta: {},
     },
-    pages: [
-      {
-        id: "page-1",
-        path: "/page-1",
-        name: "Page",
-        title: "Page",
-        rootInstanceId: "rootInstanceId",
-        meta: {},
-      },
-    ],
-    folders: [
-      {
-        id: "root",
-        name: "Root",
-        slug: "",
-        children: ["folderId-1"],
-      },
-      {
-        id: "folderId-1",
-        name: "Folder 1",
-        slug: "folder-1",
-        children: ["folderId-1-1"],
-      },
-      {
-        id: "folderId-1-1",
-        name: "Folder 1-1",
-        slug: "folder-1-1",
-        children: ["folderId-1-1-1"],
-      },
-      {
-        id: "folderId-1-1-1",
-        name: "Folder 1-1-1",
-        slug: "folder-1-1-1",
-        children: ["page-1"],
-      },
-    ],
-  } satisfies Pages;
+  ],
+  folders: [
+    {
+      id: "root",
+      name: "Root",
+      slug: "",
+      children: ["folderId-1"],
+    },
+    {
+      id: "folderId-1",
+      name: "Folder 1",
+      slug: "folder-1",
+      children: ["folderId-1-1"],
+    },
+    {
+      id: "folderId-1-1",
+      name: "Folder 1-1",
+      slug: "folder-1-1",
+      children: ["folderId-1-1-1"],
+    },
+    {
+      id: "folderId-1-1-1",
+      name: "Folder 1-1-1",
+      slug: "folder-1-1-1",
+      children: ["page-1"],
+    },
+  ],
+} satisfies Pages;
+
+describe("getPagePath", () => {
+  test("home page path", () => {
+    expect(getPagePath("home", pages)).toEqual("/");
+  });
 
   test("nesting level 0", () => {
     expect(getPagePath("root", pages)).toEqual("");
@@ -73,5 +77,28 @@ describe("getPagePath", () => {
     expect(getPagePath("page-1", pages)).toEqual(
       "/folder-1/folder-1-1/folder-1-1-1/page-1"
     );
+  });
+});
+
+describe("findPageByIdOrPath", () => {
+  test("home page by id", () => {
+    const page = findPageByIdOrPath("home", pages);
+    expect(page).toEqual(pages.homePage);
+  });
+  test("home page by path /", () => {
+    const page = findPageByIdOrPath("/", pages);
+    expect(page).toEqual(pages.homePage);
+  });
+  test("home page by empty path", () => {
+    const page = findPageByIdOrPath("", pages);
+    expect(page).toEqual(pages.homePage);
+  });
+  test("find page by id", () => {
+    const page = findPageByIdOrPath("page-1", pages);
+    expect(page).toEqual(pages.pages[0]);
+  });
+  test("find page by path", () => {
+    const page = findPageByIdOrPath("/page-1", pages);
+    expect(page).toEqual(pages.pages[0]);
   });
 });


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/404

## Description

- can select a nested path for link pages
- can click in preview to get to the page

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
