### PR TITLE
chore: Optimize findPageByIdOrPath

### DIFF
--- a/packages/sdk/src/page-utils.ts
+++ b/packages/sdk/src/page-utils.ts
@@ -7,24 +7,43 @@ export const findPageByIdOrPath = (
   if (idOrPath === "" || idOrPath === "/" || idOrPath === pages.homePage.id) {
     return pages.homePage;
   }
+  const cache = createCache(pages);
   return pages.pages.find(
-    (page) => page.id === idOrPath || getPagePath(page.id, pages) === idOrPath
+    (page) =>
+      page.id === idOrPath || getPagePath(page.id, pages, cache) === idOrPath
   );
+};
+
+type Cache = {
+  folderById: Map<Folder["id"], Folder>;
+  folderByChildId: Map<Folder["id"] | Page["id"], Folder>;
+};
+
+/**
+ * Reusable cache specialized for `getPagePath` so it can be used in a loop.
+ */
+const createCache = (pages: Pages): Cache => {
+  const folderById: Cache["folderById"] = new Map();
+  const folderByChildId: Cache["folderByChildId"] = new Map();
+  for (const folder of pages.folders) {
+    folderById.set(folder.id, folder);
+    for (const childId of folder.children) {
+      folderByChildId.set(childId, folder);
+    }
+  }
+
+  return { folderById, folderByChildId };
 };
 
 /**
  * Get a path from all folder slugs from root to the current folder or page.
  */
-export const getPagePath = (id: Folder["id"] | Page["id"], pages: Pages) => {
-  const foldersMap = new Map<Folder["id"], Folder>();
-  const childParentMap = new Map<Folder["id"] | Page["id"], Folder["id"]>();
-  for (const folder of pages.folders) {
-    foldersMap.set(folder.id, folder);
-    for (const childId of folder.children) {
-      childParentMap.set(childId, folder.id);
-    }
-  }
-
+export const getPagePath = (
+  id: Folder["id"] | Page["id"],
+  pages: Pages,
+  cache?: Cache
+) => {
+  cache || (cache = createCache(pages));
   const paths = [];
   let currentId: undefined | string = id;
 
@@ -33,18 +52,18 @@ export const getPagePath = (id: Folder["id"] | Page["id"], pages: Pages) => {
   for (const page of allPages) {
     if (page.id === id) {
       paths.push(page.path);
-      currentId = childParentMap.get(page.id);
+      currentId = cache.folderByChildId.get(page.id)?.id;
       break;
     }
   }
 
   while (currentId) {
-    const folder = foldersMap.get(currentId);
+    const folder = cache.folderById.get(currentId);
     if (folder === undefined) {
       break;
     }
     paths.push(folder.slug);
-    currentId = childParentMap.get(currentId);
+    currentId = cache.folderByChildId.get(currentId)?.id;
   }
 
   return paths.reverse().join("/").replace(/\/+/g, "/");


### PR DESCRIPTION
## Description

Added a reusable cache because we are going to be calling getPagePath() in findPageByIdOrPath() potentially as many times as there are pages and then we would create a lot of the same work, mapping out pages/folders.

Not sure if this is too early as an optimization.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
