### PR TITLE
refactor: pass resources to page with context

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -2,11 +2,12 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { PageData } from "~/routes/_index";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
+import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [
   {
@@ -44,8 +45,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="ibXgMoi9_ipHx1gVrvii0" data-ws-component="Body">
       <Heading

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -298,9 +298,10 @@ const Outlet = () => {
         assetBaseUrl,
         imageBaseUrl,
         pagesPaths,
+        resources,
       }}
     >
-      <Page params={params} resources={resources} />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -2,14 +2,15 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { PageData } from "~/routes/_index";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Heading as Heading,
   Text as Text,
 } from "@webstudio-is/sdk-components-react";
 
+import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [];
 export const pageData: PageData = {
@@ -29,8 +30,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="MMimeobf_zi4ZkRGXapju" data-ws-component="Body">
       <Heading data-ws-id="MYDt0guk1-vzc7yzqyN6A" data-ws-component="Heading">

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -298,9 +298,10 @@ const Outlet = () => {
         assetBaseUrl,
         imageBaseUrl,
         pagesPaths,
+        resources,
       }}
     >
-      <Page params={params} resources={resources} />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -2,14 +2,15 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { PageData } from "~/routes/_index";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Heading as Heading,
   Text as Text,
 } from "@webstudio-is/sdk-components-react";
 
+import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [];
 export const pageData: PageData = {
@@ -29,8 +30,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="MMimeobf_zi4ZkRGXapju" data-ws-component="Body">
       <Heading data-ws-id="MYDt0guk1-vzc7yzqyN6A" data-ws-component="Heading">

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -298,9 +298,10 @@ const Outlet = () => {
         assetBaseUrl,
         imageBaseUrl,
         pagesPaths,
+        resources,
       }}
     >
-      <Page params={params} resources={resources} />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -2,11 +2,12 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { PageData } from "~/routes/_index";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Image as Image } from "@webstudio-is/sdk-components-react";
 
+import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [
   {
@@ -64,8 +65,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="EDEfpMPRqDejthtwkH7ws" data-ws-component="Body">
       <Image

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -2,8 +2,8 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { PageData } from "~/routes/_index";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
   Form as Form,
@@ -16,6 +16,7 @@ import {
   Heading as Heading,
 } from "@webstudio-is/sdk-components-react";
 
+import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [
   {
@@ -73,8 +74,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [formState, set$formState] = useState<any>("initial");
   let [formState_1, set$formState_1] = useState<any>("initial");
   let onStateChange = (state: any) => {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -2,11 +2,12 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { PageData } from "~/routes/_index";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
+import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [
   {
@@ -64,8 +65,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="O-ljaGZQ0iRNTlEshMkgE" data-ws-component="Body">
       <Heading

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -2,11 +2,12 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { PageData } from "~/routes/_index";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
+import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [
   {
@@ -69,8 +70,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   return (
     <Body data-ws-id="L0ZXd5F9xk9Rsl9ORzIkJ" data-ws-component="Body">
       <Heading data-ws-id="VFPjLwt6Caq4l9PPJSiyI" data-ws-component="Heading">

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -2,8 +2,8 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { PageData } from "~/routes/_index";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Accordion as Accordion,
@@ -18,6 +18,7 @@ import {
   HtmlEmbed as HtmlEmbed,
 } from "@webstudio-is/sdk-components-react";
 
+import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [
   {
@@ -80,8 +81,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [accordionValue, set$accordionValue] = useState<any>("0");
   let onValueChange = (value: any) => {
     accordionValue = value;

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -2,14 +2,15 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { PageData } from "~/routes/_index";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Box as Box,
   HtmlEmbed as HtmlEmbed,
 } from "@webstudio-is/sdk-components-react";
 
+import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [
   {
@@ -72,9 +73,8 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
-  let list: any = _props.resources["list_1"];
+const Page = (_props: { params: Params }) => {
+  let list = useResource("list_1");
   return (
     <Body data-ws-id="AWY2qZfpbykoiWELeJhse" data-ws-component="Body">
       {list?.data?.map((collectionItem: any, index: number) => (

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -2,8 +2,8 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { PageData } from "~/routes/_index";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
   Link as Link,
@@ -16,6 +16,7 @@ import {
   Text as Text,
 } from "@webstudio-is/sdk-components-react";
 
+import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [
   {
@@ -78,8 +79,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   return (
     <Body
       data-ws-id="On9cvWCxr5rdZtY9O1Bv0"

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -298,9 +298,10 @@ const Outlet = () => {
         assetBaseUrl,
         imageBaseUrl,
         pagesPaths,
+        resources,
       }}
     >
-      <Page params={params} resources={resources} />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -298,9 +298,10 @@ const Outlet = () => {
         assetBaseUrl,
         imageBaseUrl,
         pagesPaths,
+        resources,
       }}
     >
-      <Page params={params} resources={resources} />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -298,9 +298,10 @@ const Outlet = () => {
         assetBaseUrl,
         imageBaseUrl,
         pagesPaths,
+        resources,
       }}
     >
-      <Page params={params} resources={resources} />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -298,9 +298,10 @@ const Outlet = () => {
         assetBaseUrl,
         imageBaseUrl,
         pagesPaths,
+        resources,
       }}
     >
-      <Page params={params} resources={resources} />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -298,9 +298,10 @@ const Outlet = () => {
         assetBaseUrl,
         imageBaseUrl,
         pagesPaths,
+        resources,
       }}
     >
-      <Page params={params} resources={resources} />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -298,9 +298,10 @@ const Outlet = () => {
         assetBaseUrl,
         imageBaseUrl,
         pagesPaths,
+        resources,
       }}
     >
-      <Page params={params} resources={resources} />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -298,9 +298,10 @@ const Outlet = () => {
         assetBaseUrl,
         imageBaseUrl,
         pagesPaths,
+        resources,
       }}
     >
-      <Page params={params} resources={resources} />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/cli/__generated__/index.tsx
+++ b/packages/cli/__generated__/index.tsx
@@ -29,8 +29,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "project-id";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   return <></>;
 };
 

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -435,6 +435,7 @@ export const prebuild = async (options: {
       // manually maintained list of occupied identifiers
       "useState",
       "Fragment",
+      "useResource",
       "PageData",
       "Asset",
       "fontAssets",
@@ -519,9 +520,10 @@ export const prebuild = async (options: {
     const pageExports = `/* eslint-disable */
 /* This is a auto generated file for building the project */ \n
 import { Fragment, useState } from "react";
-import type { PageData } from "~/routes/_index";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
 ${componentImports}
+import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = ${JSON.stringify(fontAssets)}
 export const imageAssets: ImageAsset[] = ${JSON.stringify(imageAssets)}
 export const pageData: PageData = ${JSON.stringify(renderedPageData)};

--- a/packages/cli/templates/route-template.tsx
+++ b/packages/cli/templates/route-template.tsx
@@ -298,9 +298,10 @@ const Outlet = () => {
         assetBaseUrl,
         imageBaseUrl,
         pagesPaths,
+        resources,
       }}
     >
-      <Page params={params} resources={resources} />
+      <Page params={params} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -629,8 +629,7 @@ test("generate page component with variables and actions", () => {
   ).toEqual(
     clear(`
       type Params = Record<string, string | undefined>
-      type Resources = Record<string, unknown>
-      const Page = (_props: { params: Params, resources: Resources }) => {
+      const Page = (_props: { params: Params }) => {
       let [variableName, set$variableName] = useState<any>("initial")
       let onChange = (value: any) => {
       variableName = value
@@ -673,8 +672,7 @@ test("add classes and merge classes", () => {
   ).toEqual(
     clear(`
     type Params = Record<string, string | undefined>
-    type Resources = Record<string, unknown>
-    const Page = (_props: { params: Params, resources: Resources }) => {
+    const Page = (_props: { params: Params }) => {
     return <Body
     data-ws-id="body"
     data-ws-component="Body"
@@ -730,8 +728,7 @@ test("avoid generating collection parameter variable as state", () => {
   ).toEqual(
     clear(`
     type Params = Record<string, string | undefined>
-    type Resources = Record<string, unknown>
-    const Page = (_props: { params: Params, resources: Resources }) => {
+    const Page = (_props: { params: Params }) => {
     let [data, set$data] = useState<any>(["apple","orange","mango"])
     return <Body
     data-ws-id="body"
@@ -775,8 +772,7 @@ test("generate params variable when present", () => {
   ).toEqual(
     clear(`
     type Params = Record<string, string | undefined>
-    type Resources = Record<string, unknown>
-    const Page = (_props: { params: Params, resources: Resources }) => {
+    const Page = (_props: { params: Params }) => {
     let params_1 = _props.params
     return <Body
     data-ws-id="body"
@@ -831,10 +827,9 @@ test("generate resources loading", () => {
   ).toEqual(
     clear(`
     type Params = Record<string, string | undefined>
-    type Resources = Record<string, unknown>
-    const Page = (_props: { params: Params, resources: Resources }) => {
+    const Page = (_props: { params: Params }) => {
     let [data, set$data] = useState<any>("data")
-    let data_1: any = _props.resources["data_2"]
+    let data_1 = useResource("data_2")
     return <Body
     data-ws-id="body"
     data-ws-component="Body"

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -301,7 +301,8 @@ export const generatePageComponent = ({
         dataSource.name
       );
       // cast to any to fix accessing fields from unknown error
-      generatedDataSources += `let ${valueName}: any = _props.resources["${resourceName}"]\n`;
+      const resourceNameString = JSON.stringify(resourceName);
+      generatedDataSources += `let ${valueName} = useResource(${resourceNameString})\n`;
     }
   }
 
@@ -327,8 +328,7 @@ export const generatePageComponent = ({
 
   let generatedComponent = "";
   generatedComponent += `type Params = Record<string, string | undefined>\n`;
-  generatedComponent += `type Resources = Record<string, unknown>\n`;
-  generatedComponent += `const Page = (_props: { params: Params, resources: Resources }) => {\n`;
+  generatedComponent += `const Page = (_props: { params: Params }) => {\n`;
   generatedComponent += `${generatedDataSources}`;
   generatedComponent += `return ${generatedJsx}`;
   generatedComponent += `}\n`;

--- a/packages/react-sdk/src/context.tsx
+++ b/packages/react-sdk/src/context.tsx
@@ -1,4 +1,4 @@
-import { createContext } from "react";
+import { createContext, useContext } from "react";
 import type { Page } from "@webstudio-is/sdk";
 import type { ImageLoader } from "@webstudio-is/image";
 
@@ -38,10 +38,17 @@ export const ReactSdkContext = createContext<
      * always empty for builder which handle anchor clicks globally
      */
     pagesPaths: Set<Page["path"]>;
+    resources: Record<string, any>;
   }
 >({
   assetBaseUrl: "/",
   imageBaseUrl: "/",
   imageLoader: ({ src }) => src,
   pagesPaths: new Set(),
+  resources: {},
 });
+
+export const useResource = (name: string) => {
+  const { resources } = useContext(ReactSdkContext);
+  return resources[name];
+};

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -16,7 +16,7 @@ export {
 } from "./components/component-meta";
 export * from "./embed-template";
 export * from "./props";
-export { type Params, ReactSdkContext } from "./context";
+export * from "./context";
 export {
   validateExpression,
   encodeDataSourceVariable,

--- a/packages/react-sdk/src/tree/create-elements-tree.tsx
+++ b/packages/react-sdk/src/tree/create-elements-tree.tsx
@@ -56,6 +56,7 @@ export const createElementsTree = ({
         pagesPaths: new Set(),
         assetBaseUrl,
         imageBaseUrl,
+        resources: {},
       }}
     >
       {root}

--- a/packages/sdk-cli/src/generate-stories.ts
+++ b/packages/sdk-cli/src/generate-stories.ts
@@ -86,7 +86,7 @@ const Story = {
 ${css}
       \`}
       </style>
-      <Page params={{}} resources={{}} />
+      <Page params={{}} />
     </>
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
@@ -13,8 +13,7 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [accordionValue, set$accordionValue] = useState<any>("0");
   let onValueChange = (value: any) => {
     accordionValue = value;
@@ -33,17 +32,17 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           data-ws-id="6"
           data-ws-component="AccordionItem"
           data-ws-index="0"
-          className="cjrlou9 c1uf7v01 c1x5uwe6"
+          className="caktpzb c17gos5d c102tttv"
         >
           <AccordionHeader
             data-ws-id="8"
             data-ws-component="AccordionHeader"
-            className="c6gk6ar"
+            className="c11xgi9i"
           >
             <AccordionTrigger
               data-ws-id="10"
               data-ws-component="AccordionTrigger"
-              className="c6gk6ar cn4ngym c1ee1pe1 c1xcrn9h c4v7k5r csg71e3 c1mdun74 c1bfvzwl cwry1sa cvfe049 clf46de c2xz4jt"
+              className="c11xgi9i c1yubncr c1iq6hwp cv7p8tf clo3r8o cqq29ax c17g8s4n c657y94 c1qjvju3 ceoyg4u cd7z43l c1f6k8wq"
             >
               <Text data-ws-id="12" data-ws-component="Text">
                 {"Is it accessible?"}
@@ -51,7 +50,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
               <Box
                 data-ws-id="13"
                 data-ws-component="Box"
-                className="c1h3z08b c18dp5gp clw3og8 c1qmz361 cu8n5i6 cqhjzs2 c1498b83"
+                className="c1tvigim c1pmpq0f c1yafs04 c11hichb cpr3ke2 c1wmnqxw c1aw50j7"
               >
                 <HtmlEmbed
                   data-ws-id="15"
@@ -66,7 +65,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           <AccordionContent
             data-ws-id="17"
             data-ws-component="AccordionContent"
-            className="c1e2gixt c1mfk609 c121vm9z c1bfvzwl"
+            className="c1p3lwwv c1qx3pju cut8gip c657y94"
           >
             {"Yes. It adheres to the WAI-ARIA design pattern."}
           </AccordionContent>
@@ -75,17 +74,17 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           data-ws-id="19"
           data-ws-component="AccordionItem"
           data-ws-index="1"
-          className="cjrlou9 c1uf7v01 c1x5uwe6"
+          className="caktpzb c17gos5d c102tttv"
         >
           <AccordionHeader
             data-ws-id="21"
             data-ws-component="AccordionHeader"
-            className="c6gk6ar"
+            className="c11xgi9i"
           >
             <AccordionTrigger
               data-ws-id="23"
               data-ws-component="AccordionTrigger"
-              className="c6gk6ar cn4ngym c1ee1pe1 c1xcrn9h c4v7k5r csg71e3 c1mdun74 c1bfvzwl cwry1sa cvfe049 clf46de c2xz4jt"
+              className="c11xgi9i c1yubncr c1iq6hwp cv7p8tf clo3r8o cqq29ax c17g8s4n c657y94 c1qjvju3 ceoyg4u cd7z43l c1f6k8wq"
             >
               <Text data-ws-id="25" data-ws-component="Text">
                 {"Is it styled?"}
@@ -93,7 +92,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
               <Box
                 data-ws-id="26"
                 data-ws-component="Box"
-                className="c1h3z08b c18dp5gp clw3og8 c1qmz361 cu8n5i6 cqhjzs2 c1498b83"
+                className="c1tvigim c1pmpq0f c1yafs04 c11hichb cpr3ke2 c1wmnqxw c1aw50j7"
               >
                 <HtmlEmbed
                   data-ws-id="28"
@@ -108,7 +107,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           <AccordionContent
             data-ws-id="30"
             data-ws-component="AccordionContent"
-            className="c1e2gixt c1mfk609 c121vm9z c1bfvzwl"
+            className="c1p3lwwv c1qx3pju cut8gip c657y94"
           >
             {
               "Yes. It comes with default styles that matches the other components' aesthetic."
@@ -119,17 +118,17 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           data-ws-id="32"
           data-ws-component="AccordionItem"
           data-ws-index="2"
-          className="cjrlou9 c1uf7v01 c1x5uwe6"
+          className="caktpzb c17gos5d c102tttv"
         >
           <AccordionHeader
             data-ws-id="34"
             data-ws-component="AccordionHeader"
-            className="c6gk6ar"
+            className="c11xgi9i"
           >
             <AccordionTrigger
               data-ws-id="36"
               data-ws-component="AccordionTrigger"
-              className="c6gk6ar cn4ngym c1ee1pe1 c1xcrn9h c4v7k5r csg71e3 c1mdun74 c1bfvzwl cwry1sa cvfe049 clf46de c2xz4jt"
+              className="c11xgi9i c1yubncr c1iq6hwp cv7p8tf clo3r8o cqq29ax c17g8s4n c657y94 c1qjvju3 ceoyg4u cd7z43l c1f6k8wq"
             >
               <Text data-ws-id="38" data-ws-component="Text">
                 {"Is it animated?"}
@@ -137,7 +136,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
               <Box
                 data-ws-id="39"
                 data-ws-component="Box"
-                className="c1h3z08b c18dp5gp clw3og8 c1qmz361 cu8n5i6 cqhjzs2 c1498b83"
+                className="c1tvigim c1pmpq0f c1yafs04 c11hichb cpr3ke2 c1wmnqxw c1aw50j7"
               >
                 <HtmlEmbed
                   data-ws-id="41"
@@ -152,7 +151,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           <AccordionContent
             data-ws-id="43"
             data-ws-component="AccordionContent"
-            className="c1e2gixt c1mfk609 c121vm9z c1bfvzwl"
+            className="c1p3lwwv c1qx3pju cut8gip c657y94"
           >
             {
               "Yes. It's animated by default, but you can disable it if you prefer."
@@ -345,247 +344,85 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-width: 1px
   }
 }@media all {
-  .cjrlou9 {
+  .caktpzb {
     border-bottom-width: 1px
   }
-  .c1uf7v01 {
+  .c17gos5d {
     border-bottom-style: solid
   }
-  .c1x5uwe6 {
+  .c102tttv {
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  .c6gk6ar {
+  .c11xgi9i {
     display: flex
   }
-  .c6gk6ar {
-    display: flex
-  }
-  .cn4ngym {
+  .c1yubncr {
     flex-grow: 1
   }
-  .c1ee1pe1 {
+  .c1iq6hwp {
     flex-shrink: 1
   }
-  .c1xcrn9h {
+  .cv7p8tf {
     flex-basis: 0%
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .csg71e3 {
+  .cqq29ax {
     justify-content: space-between
   }
-  .c1mdun74 {
+  .c17g8s4n {
     padding-top: 1rem
   }
-  .c1bfvzwl {
+  .c657y94 {
     padding-bottom: 1rem
   }
-  .cwry1sa {
+  .c1qjvju3 {
     font-weight: 500
   }
-  .cvfe049 {
+  .ceoyg4u {
     --accordion-trigger-icon-transform: 0deg
   }
-  .clf46de:hover {
+  .cd7z43l:hover {
     text-decoration-line: underline
   }
-  .c2xz4jt[data-state=open] {
+  .c1f6k8wq[data-state=open] {
     --accordion-trigger-icon-transform: 180deg
   }
-  .c1h3z08b {
+  .c1tvigim {
     rotate: var(--accordion-trigger-icon-transform)
   }
-  .c18dp5gp {
+  .c1pmpq0f {
     height: 1rem
   }
-  .clw3og8 {
+  .c1yafs04 {
     width: 1rem
   }
-  .c1qmz361 {
+  .c11hichb {
     flex-grow: 0
   }
-  .cu8n5i6 {
+  .cpr3ke2 {
     transition-property: all
   }
-  .cqhjzs2 {
+  .c1wmnqxw {
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1)
   }
-  .c1498b83 {
+  .c1aw50j7 {
     transition-duration: 200ms
   }
-  .c1e2gixt {
+  .c1p3lwwv {
     overflow: hidden
   }
-  .c1mfk609 {
+  .c1qx3pju {
     font-size: 0.875rem
   }
-  .c121vm9z {
+  .cut8gip {
     line-height: 1.25rem
-  }
-  .c1bfvzwl {
-    padding-bottom: 1rem
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .cn4ngym {
-    flex-grow: 1
-  }
-  .c1ee1pe1 {
-    flex-shrink: 1
-  }
-  .c1xcrn9h {
-    flex-basis: 0%
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .csg71e3 {
-    justify-content: space-between
-  }
-  .c1mdun74 {
-    padding-top: 1rem
-  }
-  .c1bfvzwl {
-    padding-bottom: 1rem
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .cvfe049 {
-    --accordion-trigger-icon-transform: 0deg
-  }
-  .clf46de:hover {
-    text-decoration-line: underline
-  }
-  .c2xz4jt[data-state=open] {
-    --accordion-trigger-icon-transform: 180deg
-  }
-  .c1h3z08b {
-    rotate: var(--accordion-trigger-icon-transform)
-  }
-  .c18dp5gp {
-    height: 1rem
-  }
-  .clw3og8 {
-    width: 1rem
-  }
-  .c1qmz361 {
-    flex-grow: 0
-  }
-  .cu8n5i6 {
-    transition-property: all
-  }
-  .cqhjzs2 {
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1)
-  }
-  .c1498b83 {
-    transition-duration: 200ms
-  }
-  .c1e2gixt {
-    overflow: hidden
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c121vm9z {
-    line-height: 1.25rem
-  }
-  .c1bfvzwl {
-    padding-bottom: 1rem
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .cn4ngym {
-    flex-grow: 1
-  }
-  .c1ee1pe1 {
-    flex-shrink: 1
-  }
-  .c1xcrn9h {
-    flex-basis: 0%
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .csg71e3 {
-    justify-content: space-between
-  }
-  .c1mdun74 {
-    padding-top: 1rem
-  }
-  .c1bfvzwl {
-    padding-bottom: 1rem
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .cvfe049 {
-    --accordion-trigger-icon-transform: 0deg
-  }
-  .clf46de:hover {
-    text-decoration-line: underline
-  }
-  .c2xz4jt[data-state=open] {
-    --accordion-trigger-icon-transform: 180deg
-  }
-  .c1h3z08b {
-    rotate: var(--accordion-trigger-icon-transform)
-  }
-  .c18dp5gp {
-    height: 1rem
-  }
-  .clw3og8 {
-    width: 1rem
-  }
-  .c1qmz361 {
-    flex-grow: 0
-  }
-  .cu8n5i6 {
-    transition-property: all
-  }
-  .cqhjzs2 {
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1)
-  }
-  .c1498b83 {
-    transition-duration: 200ms
-  }
-  .c1e2gixt {
-    overflow: hidden
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c121vm9z {
-    line-height: 1.25rem
-  }
-  .c1bfvzwl {
-    padding-bottom: 1rem
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
@@ -11,8 +11,7 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [checkboxChecked, set$checkboxChecked] = useState<any>(false);
   let onCheckedChange = (checked: any) => {
     checkboxChecked = checked;
@@ -23,19 +22,19 @@ const Page = (_props: { params: Params; resources: Resources }) => {
       <Label
         data-ws-id="1"
         data-ws-component="Label"
-        className="c6gk6ar cgt00fz cydvc77 c4v7k5r"
+        className="c11xgi9i c8prkzu c1edvzo4 clo3r8o"
       >
         <Checkbox
           data-ws-id="3"
           data-ws-component="Checkbox"
           checked={checkboxChecked}
           onCheckedChange={onCheckedChange}
-          className="c18dp5gp clw3og8 c1qmz361 c1d9pxa5 cnjyf56 c1jpjw0a c1lxvq7u c1inucbi c1dab7w1 c1uf7v01 czynn8e cuelx18 c17v08sn c1czmfdb c8nta89 cgassre c1ndsw6v cjrlou9 c945vvj c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l cegrmbm c1grhw0w ccop5vc c19tq2u"
+          className="c1pmpq0f c1yafs04 c11hichb c12e8ong c13c161l chzvexg c1s51a6q c17al2u0 c1ufcra4 c17gos5d cn4f13s c9mvxkx cu0p3ww c11i8aye ca1f4zs ck2qarh c1nxbatd caktpzb c1bm526f co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1oa7gr0 ce92j53 c1939zof c4lzij8"
         >
           <CheckboxIndicator
             data-ws-id="8"
             data-ws-component="CheckboxIndicator"
-            className="c6gk6ar c4v7k5r cvzkkb6 c2a7z25"
+            className="c11xgi9i clo3r8o cw9oyzl c1hdhil0"
           >
             <HtmlEmbed
               data-ws-id="10"
@@ -217,115 +216,112 @@ html {margin: 0; display: grid; min-height: 100%}
     min-height: 1em
   }
 }@media all {
-  .c6gk6ar {
+  .c11xgi9i {
     display: flex
   }
-  .cgt00fz {
+  .c8prkzu {
     row-gap: 0.5rem
   }
-  .cydvc77 {
+  .c1edvzo4 {
     column-gap: 0.5rem
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .c18dp5gp {
+  .c1pmpq0f {
     height: 1rem
   }
-  .clw3og8 {
+  .c1yafs04 {
     width: 1rem
   }
-  .c1qmz361 {
+  .c11hichb {
     flex-grow: 0
   }
-  .c1d9pxa5 {
+  .c12e8ong {
     border-top-left-radius: 0.125rem
   }
-  .cnjyf56 {
+  .c13c161l {
     border-top-right-radius: 0.125rem
   }
-  .c1jpjw0a {
+  .chzvexg {
     border-bottom-right-radius: 0.125rem
   }
-  .c1lxvq7u {
+  .c1s51a6q {
     border-bottom-left-radius: 0.125rem
   }
-  .c1inucbi {
+  .c17al2u0 {
     border-top-style: solid
   }
-  .c1dab7w1 {
+  .c1ufcra4 {
     border-right-style: solid
   }
-  .c1uf7v01 {
+  .c17gos5d {
     border-bottom-style: solid
   }
-  .czynn8e {
+  .cn4f13s {
     border-left-style: solid
   }
-  .cuelx18 {
+  .c9mvxkx {
     border-top-color: rgba(15, 23, 42, 1)
   }
-  .c17v08sn {
+  .cu0p3ww {
     border-right-color: rgba(15, 23, 42, 1)
   }
-  .c1czmfdb {
+  .c11i8aye {
     border-bottom-color: rgba(15, 23, 42, 1)
   }
-  .c8nta89 {
+  .ca1f4zs {
     border-left-color: rgba(15, 23, 42, 1)
   }
-  .cgassre {
+  .ck2qarh {
     border-top-width: 1px
   }
-  .c1ndsw6v {
+  .c1nxbatd {
     border-right-width: 1px
   }
-  .cjrlou9 {
+  .caktpzb {
     border-bottom-width: 1px
   }
-  .c945vvj {
+  .c1bm526f {
     border-left-width: 1px
   }
-  .c1t6bql4:focus-visible {
+  .co0lfwl:focus-visible {
     outline-width: 2px
   }
-  .czph7hf:focus-visible {
+  .c1kn3u98:focus-visible {
     outline-style: solid
   }
-  .cncn1ro:focus-visible {
+  .c2odgnt:focus-visible {
     outline-color: transparent
   }
-  .cb270vo:focus-visible {
+  .chlvjga:focus-visible {
     outline-offset: 2px
   }
-  .c1rgsd1l:focus-visible {
+  .c1jx7vpr:focus-visible {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  .cegrmbm:disabled {
+  .c1oa7gr0:disabled {
     cursor: not-allowed
   }
-  .c1grhw0w:disabled {
+  .ce92j53:disabled {
     opacity: 0.5
   }
-  .ccop5vc[data-state=checked] {
+  .c1939zof[data-state=checked] {
     background-color: rgba(15, 23, 42, 1)
   }
-  .c19tq2u[data-state=checked] {
+  .c4lzij8[data-state=checked] {
     color: rgba(248, 250, 252, 1)
   }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cvzkkb6 {
+  .cw9oyzl {
     justify-content: center
   }
-  .c2a7z25 {
+  .c1hdhil0 {
     color: currentColor
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
@@ -11,8 +11,7 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [collapsibleOpen, set$collapsibleOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     collapsibleOpen = open;
@@ -33,7 +32,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           <Button
             data-ws-id="6"
             data-ws-component="Button"
-            className="c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l cgassre c1ndsw6v cjrlou9 c945vvj c15mffxy c1mnuzt9 c4v7k5r cvzkkb6 cym38jd cqimob0 c2tr68t cjdtj3f c1mfk609 c121vm9z cwry1sa c1b8xvex c1y5f9qa cjw7gx9 c1peybss chh2z1n c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l c1srwcmr c1grhw0w c8xqq0k cjs8iie"
+            className="c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 ck2qarh c1nxbatd caktpzb c1bm526f c110hgy6 c1oai8p0 clo3r8o cw9oyzl cuqxbts cg19ih8 c1479lj6 comq4ym c1qx3pju cut8gip c1qjvju3 c18kkil c1c2uk29 c1x1m3cj cey1d5i cbnv1sn co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1jirpm3 ce92j53 c1dr421o c14ytp9r"
           >
             {"Click to toggle content"}
           </Button>
@@ -200,121 +199,121 @@ html {margin: 0; display: grid; min-height: 100%}
     min-height: 1em
   }
 }@media all {
-  .c1inucbi {
+  .c17al2u0 {
     border-top-style: solid
   }
-  .c1dab7w1 {
+  .c1ufcra4 {
     border-right-style: solid
   }
-  .c1uf7v01 {
+  .c17gos5d {
     border-bottom-style: solid
   }
-  .czynn8e {
+  .cn4f13s {
     border-left-style: solid
   }
-  .c6z96ps {
+  .c1wic2il {
     border-top-color: rgba(226, 232, 240, 1)
   }
-  .c9t5qyz {
+  .cdem58j {
     border-right-color: rgba(226, 232, 240, 1)
   }
-  .c1x5uwe6 {
+  .c102tttv {
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  .csnt51l {
+  .cb204z1 {
     border-left-color: rgba(226, 232, 240, 1)
   }
-  .cgassre {
+  .ck2qarh {
     border-top-width: 1px
   }
-  .c1ndsw6v {
+  .c1nxbatd {
     border-right-width: 1px
   }
-  .cjrlou9 {
+  .caktpzb {
     border-bottom-width: 1px
   }
-  .c945vvj {
+  .c1bm526f {
     border-left-width: 1px
   }
-  .c15mffxy {
+  .c110hgy6 {
     background-color: rgba(255, 255, 255, 0.8)
   }
-  .c1mnuzt9 {
+  .c1oai8p0 {
     display: inline-flex
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .cvzkkb6 {
+  .cw9oyzl {
     justify-content: center
   }
-  .cym38jd {
+  .cuqxbts {
     border-top-left-radius: 0.375rem
   }
-  .cqimob0 {
+  .cg19ih8 {
     border-top-right-radius: 0.375rem
   }
-  .c2tr68t {
+  .c1479lj6 {
     border-bottom-right-radius: 0.375rem
   }
-  .cjdtj3f {
+  .comq4ym {
     border-bottom-left-radius: 0.375rem
   }
-  .c1mfk609 {
+  .c1qx3pju {
     font-size: 0.875rem
   }
-  .c121vm9z {
+  .cut8gip {
     line-height: 1.25rem
   }
-  .cwry1sa {
+  .c1qjvju3 {
     font-weight: 500
   }
-  .c1b8xvex {
+  .c18kkil {
     height: 2.5rem
   }
-  .c1y5f9qa {
+  .c1c2uk29 {
     padding-left: 1rem
   }
-  .cjw7gx9 {
+  .c1x1m3cj {
     padding-right: 1rem
   }
-  .c1peybss {
+  .cey1d5i {
     padding-top: 0.5rem
   }
-  .chh2z1n {
+  .cbnv1sn {
     padding-bottom: 0.5rem
   }
-  .c1t6bql4:focus-visible {
+  .co0lfwl:focus-visible {
     outline-width: 2px
   }
-  .czph7hf:focus-visible {
+  .c1kn3u98:focus-visible {
     outline-style: solid
   }
-  .cncn1ro:focus-visible {
+  .c2odgnt:focus-visible {
     outline-color: transparent
   }
-  .cb270vo:focus-visible {
+  .chlvjga:focus-visible {
     outline-offset: 2px
   }
-  .c1rgsd1l:focus-visible {
+  .c1jx7vpr:focus-visible {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  .c1srwcmr:disabled {
+  .c1jirpm3:disabled {
     pointer-events: none
   }
-  .c1grhw0w:disabled {
+  .ce92j53:disabled {
     opacity: 0.5
   }
-  .c8xqq0k:hover {
+  .c1dr421o:hover {
     background-color: rgba(241, 245, 249, 0.9)
   }
-  .cjs8iie:hover {
+  .c14ytp9r:hover {
     color: rgba(15, 23, 42, 1)
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
@@ -16,8 +16,7 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [dialogOpen, set$dialogOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     dialogOpen = open;
@@ -35,7 +34,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           <Button
             data-ws-id="6"
             data-ws-component="Button"
-            className="c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l cgassre c1ndsw6v cjrlou9 c945vvj c15mffxy c1mnuzt9 c4v7k5r cvzkkb6 cym38jd cqimob0 c2tr68t cjdtj3f c1mfk609 c121vm9z cwry1sa c1b8xvex c1y5f9qa cjw7gx9 c1peybss chh2z1n c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l c1srwcmr c1grhw0w c8xqq0k cjs8iie"
+            className="c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 ck2qarh c1nxbatd caktpzb c1bm526f c110hgy6 c1oai8p0 clo3r8o cw9oyzl cuqxbts cg19ih8 c1479lj6 comq4ym c1qx3pju cut8gip c1qjvju3 c18kkil c1c2uk29 c1x1m3cj cey1d5i cbnv1sn co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1jirpm3 ce92j53 c1dr421o c14ytp9r"
           >
             {"Button"}
           </Button>
@@ -43,29 +42,29 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         <DialogOverlay
           data-ws-id="8"
           data-ws-component="DialogOverlay"
-          className="c1g0ebn8 c17k6ftv co2vb1i ci9y33x ckl9uqx c1wyidsg c15mffxy c1c159w3 c6gk6ar c19jsld4"
+          className="c15h1j27 cboqcgi cs5y8q6 ccq2s6t c3iotp8 c173yyao c110hgy6 c1x0vq2l c11xgi9i c1arpcws"
         >
           <DialogContent
             data-ws-id="10"
             data-ws-component="DialogContent"
-            className="c1i2mn37 c1wyidsg c6gk6ar c13wsd00 cb99ak4 ctl64vj c1ullep4 c1rj6y8a c1moepyh cxwv2s0 c12edzjb c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l cgassre c1ndsw6v cjrlou9 c945vvj c15mffxy cm3zvb4 c174435h c1xpn2dk c3vgloq cbzcu1y cnhoj7b"
+            className="c3elmho c173yyao c11xgi9i cfd715b ci4ea85 c13l7myj cakk94o cmty91p cukjqkn c12w8ig6 cqfb83m c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 ck2qarh c1nxbatd caktpzb c1bm526f c110hgy6 c1d23hgf cdv5i03 cog45sw c18egw0s c1ii9nza crmoyyg"
           >
             <Box
               data-ws-id="12"
               data-ws-component="Box"
-              className="c6gk6ar c13wsd00 cu0fd6l c8098d3"
+              className="c11xgi9i cfd715b csjyi15 c1xv9rff"
             >
               <DialogTitle
                 data-ws-id="14"
                 data-ws-component="DialogTitle"
-                className="c1u5xdcd cdf5ze5 c1ma6tz6 c1kjryeq cs0zr08"
+                className="cvrokas crk8tjo cx5cc56 c1o7k99s cck9swn"
               >
                 {"Dialog Title"}
               </DialogTitle>
               <DialogDescription
                 data-ws-id="16"
                 data-ws-component="DialogDescription"
-                className="c1u5xdcd cdf5ze5 c1mfk609 c121vm9z caa8yt3"
+                className="cvrokas crk8tjo c1qx3pju cut8gip c1pcz91e"
               >
                 {"Dialog description text you can edit"}
               </DialogDescription>
@@ -76,7 +75,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
             <DialogClose
               data-ws-id="19"
               data-ws-component="DialogClose"
-              className="c1kb88y7 caboyml c1y1em6x c1d9pxa5 cnjyf56 c1jpjw0a c1lxvq7u c1jcn3uk c6gk6ar c4v7k5r cvzkkb6 c18dp5gp clw3og8 c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l c1v4k4ip c2iozhh c1j5pqo1 cmqevnc cvxnx00 c601nqx c9i3lxo c1sz664l cm8bc7h c1m9udid c175y1wr"
+              className="ct2k8wg c1us255 c1hk37yi c12e8ong c13c161l chzvexg c1s51a6q c1qx8273 c11xgi9i clo3r8o cw9oyzl c1pmpq0f c1yafs04 c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 cok6gp c1ebb32d c1ed2n1f c1an30v3 ca60kt0 cxlxl0c c1gfzcg5 cohan28 c15roejc c1xy5yrr c192vyv4"
             >
               <HtmlEmbed
                 data-ws-id="21"
@@ -287,373 +286,280 @@ html {margin: 0; display: grid; min-height: 100%}
     text-transform: none
   }
 }@media all {
-  .c1inucbi {
+  .c17al2u0 {
     border-top-style: solid
   }
-  .c1dab7w1 {
+  .c1ufcra4 {
     border-right-style: solid
   }
-  .c1uf7v01 {
+  .c17gos5d {
     border-bottom-style: solid
   }
-  .czynn8e {
+  .cn4f13s {
     border-left-style: solid
   }
-  .c6z96ps {
+  .c1wic2il {
     border-top-color: rgba(226, 232, 240, 1)
   }
-  .c9t5qyz {
+  .cdem58j {
     border-right-color: rgba(226, 232, 240, 1)
   }
-  .c1x5uwe6 {
+  .c102tttv {
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  .csnt51l {
+  .cb204z1 {
     border-left-color: rgba(226, 232, 240, 1)
   }
-  .cgassre {
+  .ck2qarh {
     border-top-width: 1px
   }
-  .c1ndsw6v {
+  .c1nxbatd {
     border-right-width: 1px
   }
-  .cjrlou9 {
+  .caktpzb {
     border-bottom-width: 1px
   }
-  .c945vvj {
+  .c1bm526f {
     border-left-width: 1px
   }
-  .c15mffxy {
+  .c110hgy6 {
     background-color: rgba(255, 255, 255, 0.8)
   }
-  .c1mnuzt9 {
+  .c1oai8p0 {
     display: inline-flex
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .cvzkkb6 {
+  .cw9oyzl {
     justify-content: center
   }
-  .cym38jd {
+  .cuqxbts {
     border-top-left-radius: 0.375rem
   }
-  .cqimob0 {
+  .cg19ih8 {
     border-top-right-radius: 0.375rem
   }
-  .c2tr68t {
+  .c1479lj6 {
     border-bottom-right-radius: 0.375rem
   }
-  .cjdtj3f {
+  .comq4ym {
     border-bottom-left-radius: 0.375rem
   }
-  .c1mfk609 {
+  .c1qx3pju {
     font-size: 0.875rem
   }
-  .c121vm9z {
+  .cut8gip {
     line-height: 1.25rem
   }
-  .cwry1sa {
+  .c1qjvju3 {
     font-weight: 500
   }
-  .c1b8xvex {
+  .c18kkil {
     height: 2.5rem
   }
-  .c1y5f9qa {
+  .c1c2uk29 {
     padding-left: 1rem
   }
-  .cjw7gx9 {
+  .c1x1m3cj {
     padding-right: 1rem
   }
-  .c1peybss {
+  .cey1d5i {
     padding-top: 0.5rem
   }
-  .chh2z1n {
+  .cbnv1sn {
     padding-bottom: 0.5rem
   }
-  .c1t6bql4:focus-visible {
+  .co0lfwl:focus-visible {
     outline-width: 2px
   }
-  .czph7hf:focus-visible {
+  .c1kn3u98:focus-visible {
     outline-style: solid
   }
-  .cncn1ro:focus-visible {
+  .c2odgnt:focus-visible {
     outline-color: transparent
   }
-  .cb270vo:focus-visible {
+  .chlvjga:focus-visible {
     outline-offset: 2px
   }
-  .c1rgsd1l:focus-visible {
+  .c1jx7vpr:focus-visible {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  .c1srwcmr:disabled {
+  .c1jirpm3:disabled {
     pointer-events: none
   }
-  .c1grhw0w:disabled {
+  .ce92j53:disabled {
     opacity: 0.5
   }
-  .c8xqq0k:hover {
+  .c1dr421o:hover {
     background-color: rgba(241, 245, 249, 0.9)
   }
-  .cjs8iie:hover {
+  .c14ytp9r:hover {
     color: rgba(15, 23, 42, 1)
   }
-  .c1g0ebn8 {
+  .c15h1j27 {
     position: fixed
   }
-  .c17k6ftv {
+  .cboqcgi {
     left: 0px
   }
-  .co2vb1i {
+  .cs5y8q6 {
     right: 0px
   }
-  .ci9y33x {
+  .ccq2s6t {
     top: 0px
   }
-  .ckl9uqx {
+  .c3iotp8 {
     bottom: 0px
   }
-  .c1wyidsg {
+  .c173yyao {
     z-index: 50
   }
-  .c15mffxy {
-    background-color: rgba(255, 255, 255, 0.8)
-  }
-  .c1c159w3 {
+  .c1x0vq2l {
     backdrop-filter: blur(0 1px 2px 0 rgb(0 0 0 / 0.05))
   }
-  .c6gk6ar {
+  .c11xgi9i {
     display: flex
   }
-  .c19jsld4 {
+  .c1arpcws {
     overflow: auto
   }
-  .c1i2mn37 {
+  .c3elmho {
     width: 100%
   }
-  .c1wyidsg {
-    z-index: 50
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
+  .cfd715b {
     flex-direction: column
   }
-  .cb99ak4 {
+  .ci4ea85 {
     row-gap: 1rem
   }
-  .ctl64vj {
+  .c13l7myj {
     column-gap: 1rem
   }
-  .c1ullep4 {
+  .cakk94o {
     margin-left: auto
   }
-  .c1rj6y8a {
+  .cmty91p {
     margin-right: auto
   }
-  .c1moepyh {
+  .cukjqkn {
     margin-top: auto
   }
-  .cxwv2s0 {
+  .c12w8ig6 {
     margin-bottom: auto
   }
-  .c12edzjb {
+  .cqfb83m {
     max-width: 32rem
   }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .c6z96ps {
-    border-top-color: rgba(226, 232, 240, 1)
-  }
-  .c9t5qyz {
-    border-right-color: rgba(226, 232, 240, 1)
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .csnt51l {
-    border-left-color: rgba(226, 232, 240, 1)
-  }
-  .cgassre {
-    border-top-width: 1px
-  }
-  .c1ndsw6v {
-    border-right-width: 1px
-  }
-  .cjrlou9 {
-    border-bottom-width: 1px
-  }
-  .c945vvj {
-    border-left-width: 1px
-  }
-  .c15mffxy {
-    background-color: rgba(255, 255, 255, 0.8)
-  }
-  .cm3zvb4 {
+  .c1d23hgf {
     padding-left: 1.5rem
   }
-  .c174435h {
+  .cdv5i03 {
     padding-right: 1.5rem
   }
-  .c1xpn2dk {
+  .cog45sw {
     padding-top: 1.5rem
   }
-  .c3vgloq {
+  .c18egw0s {
     padding-bottom: 1.5rem
   }
-  .cbzcu1y {
+  .c1ii9nza {
     box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)
   }
-  .cnhoj7b {
+  .crmoyyg {
     position: relative
   }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .cu0fd6l {
+  .csjyi15 {
     row-gap: 0.25rem
   }
-  .c8098d3 {
+  .c1xv9rff {
     column-gap: 0.25rem
   }
-  .c1u5xdcd {
+  .cvrokas {
     margin-top: 0px
   }
-  .cdf5ze5 {
+  .crk8tjo {
     margin-bottom: 0px
   }
-  .c1ma6tz6 {
+  .cx5cc56 {
     line-height: 1.75rem
   }
-  .c1kjryeq {
+  .c1o7k99s {
     font-size: 1.125rem
   }
-  .cs0zr08 {
+  .cck9swn {
     letter-spacing: -0.025em
   }
-  .c1u5xdcd {
-    margin-top: 0px
-  }
-  .cdf5ze5 {
-    margin-bottom: 0px
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c121vm9z {
-    line-height: 1.25rem
-  }
-  .caa8yt3 {
+  .c1pcz91e {
     color: rgba(100, 116, 139, 1)
   }
-  .c1kb88y7 {
+  .ct2k8wg {
     position: absolute
   }
-  .caboyml {
+  .c1us255 {
     right: 1rem
   }
-  .c1y1em6x {
+  .c1hk37yi {
     top: 1rem
   }
-  .c1d9pxa5 {
+  .c12e8ong {
     border-top-left-radius: 0.125rem
   }
-  .cnjyf56 {
+  .c13c161l {
     border-top-right-radius: 0.125rem
   }
-  .c1jpjw0a {
+  .chzvexg {
     border-bottom-right-radius: 0.125rem
   }
-  .c1lxvq7u {
+  .c1s51a6q {
     border-bottom-left-radius: 0.125rem
   }
-  .c1jcn3uk {
+  .c1qx8273 {
     opacity: 0.7
   }
-  .c6gk6ar {
-    display: flex
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cvzkkb6 {
-    justify-content: center
-  }
-  .c18dp5gp {
+  .c1pmpq0f {
     height: 1rem
   }
-  .clw3og8 {
+  .c1yafs04 {
     width: 1rem
   }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .c6z96ps {
-    border-top-color: rgba(226, 232, 240, 1)
-  }
-  .c9t5qyz {
-    border-right-color: rgba(226, 232, 240, 1)
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .csnt51l {
-    border-left-color: rgba(226, 232, 240, 1)
-  }
-  .c1v4k4ip {
+  .cok6gp {
     border-top-width: 0px
   }
-  .c2iozhh {
+  .c1ebb32d {
     border-right-width: 0px
   }
-  .c1j5pqo1 {
+  .c1ed2n1f {
     border-bottom-width: 0px
   }
-  .cmqevnc {
+  .c1an30v3 {
     border-left-width: 0px
   }
-  .cvxnx00 {
+  .ca60kt0 {
     background-color: transparent
   }
-  .c601nqx {
+  .cxlxl0c {
     outline-width: 2px
   }
-  .c9i3lxo {
+  .c1gfzcg5 {
     outline-style: solid
   }
-  .c1sz664l {
+  .cohan28 {
     outline-color: transparent
   }
-  .cm8bc7h {
+  .c15roejc {
     outline-offset: 2px
   }
-  .c1m9udid:hover {
+  .c1xy5yrr:hover {
     opacity: 1
   }
-  .c175y1wr:focus {
+  .c192vyv4:focus {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
@@ -2,14 +2,13 @@ import { Box as Box } from "@webstudio-is/sdk-components-react";
 import { Label as Label } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   return (
     <Box data-ws-id="root" data-ws-component="Box">
       <Label
         data-ws-id="1"
         data-ws-component="Label"
-        className="c1mfk609 cvjxq2s cwry1sa"
+        className="c1qx3pju crxf9g c1qjvju3"
       >
         {"Form Label"}
       </Label>
@@ -134,19 +133,19 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-width: 1px
   }
 }@media all {
-  .c1mfk609 {
+  .c1qx3pju {
     font-size: 0.875rem
   }
-  .cvjxq2s {
+  .crxf9g {
     line-height: 1
   }
-  .cwry1sa {
+  .c1qjvju3 {
     font-weight: 500
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
@@ -18,8 +18,7 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [menuValue, set$menuValue] = useState<any>("");
   let onValueChange = (value: any) => {
     menuValue = value;
@@ -32,12 +31,12 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         data-ws-component="NavigationMenu"
         value={menuValue}
         onValueChange={onValueChange}
-        className="cnhoj7b c1a0z5in"
+        className="crmoyyg cvxi4jc"
       >
         <NavigationMenuList
           data-ws-id="6"
           data-ws-component="NavigationMenuList"
-          className="c1hxtwzc c1j0bzjz cbjj14v c15sjadq c3rzppk c17ybgbw c1u5xdcd cdf5ze5 c6gk6ar cn4ngym c1ee1pe1 c1xcrn9h csrd2h5 c4v7k5r cvzkkb6 cu0fd6l c8098d3"
+          className="c11ubft8 c19nnvu2 c6epq1b cniw9w8 cawkm6w clp87x0 cvrokas crk8tjo c11xgi9i c1yubncr c1iq6hwp cv7p8tf cq9q4za clo3r8o cw9oyzl csjyi15 c1xv9rff"
         >
           <NavigationMenuItem
             data-ws-id="8"
@@ -51,7 +50,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
               <Button
                 data-ws-id="10"
                 data-ws-component="Button"
-                className="c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l c1v4k4ip c2iozhh c1j5pqo1 cmqevnc cvxnx00 c1mnuzt9 c4v7k5r cvzkkb6 cym38jd cqimob0 c2tr68t cjdtj3f c1mfk609 c121vm9z cwry1sa c1b8xvex c1kc4g4w c1hi2fgx c1jrmp29 c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l c1srwcmr c1grhw0w c8xqq0k cjs8iie c157d2k6"
+                className="c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 cok6gp c1ebb32d c1ed2n1f c1an30v3 ca60kt0 c1oai8p0 clo3r8o cw9oyzl cuqxbts cg19ih8 c1479lj6 comq4ym c1qx3pju cut8gip c1qjvju3 c18kkil c16g5416 c111au61 c1uw27mb co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1jirpm3 ce92j53 c1dr421o c14ytp9r c1a713iq"
               >
                 <Text data-ws-id="12" data-ws-component="Text">
                   {"About"}
@@ -59,7 +58,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                 <Box
                   data-ws-id="13"
                   data-ws-component="Box"
-                  className="ck5mafm cm547tf c18dp5gp clw3og8 c1qmz361 cu8n5i6 cqhjzs2 c1498b83"
+                  className="c9je87j cwfkqjc c1pmpq0f c1yafs04 c11hichb cpr3ke2 c1wmnqxw c1aw50j7"
                 >
                   <HtmlEmbed
                     data-ws-id="15"
@@ -75,24 +74,24 @@ const Page = (_props: { params: Params; resources: Resources }) => {
               data-ws-id="17"
               data-ws-component="NavigationMenuContent"
               data-ws-index="0"
-              className="c17k6ftv ci9y33x c1kb88y7 cbgnvea c1y5f9qa cjw7gx9 c1mdun74 c1bfvzwl"
+              className="cboqcgi ccq2s6t ct2k8wg c12s9tcd c1c2uk29 c1x1m3cj c17g8s4n c657y94"
             >
               <Box
                 data-ws-id="19"
                 data-ws-component="Box"
-                className="c6gk6ar cb99ak4 ctl64vj cbxivag c18gyxfs c1peybss chh2z1n"
+                className="c11xgi9i ci4ea85 c13l7myj c1jmgbvo c1qmwsx9 cey1d5i cbnv1sn"
               >
                 <Box
                   data-ws-id="21"
                   data-ws-component="Box"
-                  className="c1af0hjb c1y5f9qa cjw7gx9 c1mdun74 c1bfvzwl c1187wgd cym38jd cqimob0 c2tr68t cjdtj3f"
+                  className="csvgwzp c1c2uk29 c1x1m3cj c17g8s4n c657y94 c1fd7x2o cuqxbts cg19ih8 c1479lj6 comq4ym"
                 >
                   {""}
                 </Box>
                 <Box
                   data-ws-id="23"
                   data-ws-component="Box"
-                  className="c88y2pm c6gk6ar cb99ak4 ctl64vj c13wsd00"
+                  className="c3e36dl c11xgi9i ci4ea85 c13l7myj cfd715b"
                 >
                   <NavigationMenuLink
                     data-ws-id="25"
@@ -102,19 +101,19 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                       data-ws-id="26"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/sheet"}
-                      className="c1wv658c c6gk6ar c13wsd00 c1hl4mbg cu0fd6l c8098d3 cym38jd cqimob0 c2tr68t cjdtj3f c1kc4g4w c1hi2fgx c16a2e8i c1y90k37 cvjxq2s chhysup c601nqx c9i3lxo c1sz664l cm8bc7h c8xqq0k cjs8iie cbt1ziu c1ci4uzu"
+                      className="c1lp1p2a c11xgi9i cfd715b cekw1i5 csjyi15 c1xv9rff cuqxbts cg19ih8 c1479lj6 comq4ym c16g5416 c111au61 c17g4cws ctolsm2 crxf9g c1gfew4a cxlxl0c c1gfzcg5 cohan28 c15roejc c1dr421o c14ytp9r c11eeprv c1rbq5ju"
                     >
                       <Text
                         data-ws-id="29"
                         data-ws-component="Text"
-                        className="c1mfk609 cvjxq2s cwry1sa"
+                        className="c1qx3pju crxf9g c1qjvju3"
                       >
                         {"Sheet"}
                       </Text>
                       <Paragraph
                         data-ws-id="31"
                         data-ws-component="Paragraph"
-                        className="c3rzppk c17ybgbw c1u5xdcd cdf5ze5 c1e2gixt c16sc1pt c78rgey c1mxykr c1mfk609 c18mq0f5 caa8yt3"
+                        className="cawkm6w clp87x0 cvrokas crk8tjo c1p3lwwv c1ldl5ci c1rc3t1c c69w97g c1qx3pju c1ls6yv2 c1pcz91e"
                       >
                         {
                           "Extends the Dialog component to display content that complements the main content of the screen."
@@ -132,19 +131,19 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                       href={
                         "https://ui.shadcn.com/docs/components/navigation-menu"
                       }
-                      className="c1wv658c c6gk6ar c13wsd00 c1hl4mbg cu0fd6l c8098d3 cym38jd cqimob0 c2tr68t cjdtj3f c1kc4g4w c1hi2fgx c16a2e8i c1y90k37 cvjxq2s chhysup c601nqx c9i3lxo c1sz664l cm8bc7h c8xqq0k cjs8iie cbt1ziu c1ci4uzu"
+                      className="c1lp1p2a c11xgi9i cfd715b cekw1i5 csjyi15 c1xv9rff cuqxbts cg19ih8 c1479lj6 comq4ym c16g5416 c111au61 c17g4cws ctolsm2 crxf9g c1gfew4a cxlxl0c c1gfzcg5 cohan28 c15roejc c1dr421o c14ytp9r c11eeprv c1rbq5ju"
                     >
                       <Text
                         data-ws-id="37"
                         data-ws-component="Text"
-                        className="c1mfk609 cvjxq2s cwry1sa"
+                        className="c1qx3pju crxf9g c1qjvju3"
                       >
                         {"Navigation Menu"}
                       </Text>
                       <Paragraph
                         data-ws-id="39"
                         data-ws-component="Paragraph"
-                        className="c3rzppk c17ybgbw c1u5xdcd cdf5ze5 c1e2gixt c16sc1pt c78rgey c1mxykr c1mfk609 c18mq0f5 caa8yt3"
+                        className="cawkm6w clp87x0 cvrokas crk8tjo c1p3lwwv c1ldl5ci c1rc3t1c c69w97g c1qx3pju c1ls6yv2 c1pcz91e"
                       >
                         {"A collection of links for navigating websites."}
                       </Paragraph>
@@ -158,19 +157,19 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                       data-ws-id="42"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/tabs"}
-                      className="c1wv658c c6gk6ar c13wsd00 c1hl4mbg cu0fd6l c8098d3 cym38jd cqimob0 c2tr68t cjdtj3f c1kc4g4w c1hi2fgx c16a2e8i c1y90k37 cvjxq2s chhysup c601nqx c9i3lxo c1sz664l cm8bc7h c8xqq0k cjs8iie cbt1ziu c1ci4uzu"
+                      className="c1lp1p2a c11xgi9i cfd715b cekw1i5 csjyi15 c1xv9rff cuqxbts cg19ih8 c1479lj6 comq4ym c16g5416 c111au61 c17g4cws ctolsm2 crxf9g c1gfew4a cxlxl0c c1gfzcg5 cohan28 c15roejc c1dr421o c14ytp9r c11eeprv c1rbq5ju"
                     >
                       <Text
                         data-ws-id="45"
                         data-ws-component="Text"
-                        className="c1mfk609 cvjxq2s cwry1sa"
+                        className="c1qx3pju crxf9g c1qjvju3"
                       >
                         {"Tabs"}
                       </Text>
                       <Paragraph
                         data-ws-id="47"
                         data-ws-component="Paragraph"
-                        className="c3rzppk c17ybgbw c1u5xdcd cdf5ze5 c1e2gixt c16sc1pt c78rgey c1mxykr c1mfk609 c18mq0f5 caa8yt3"
+                        className="cawkm6w clp87x0 cvrokas crk8tjo c1p3lwwv c1ldl5ci c1rc3t1c c69w97g c1qx3pju c1ls6yv2 c1pcz91e"
                       >
                         {
                           "A set of layered sections of content—known as tab panels—that are displayed one at a time."
@@ -194,7 +193,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
               <Button
                 data-ws-id="51"
                 data-ws-component="Button"
-                className="c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l c1v4k4ip c2iozhh c1j5pqo1 cmqevnc cvxnx00 c1mnuzt9 c4v7k5r cvzkkb6 cym38jd cqimob0 c2tr68t cjdtj3f c1mfk609 c121vm9z cwry1sa c1b8xvex c1kc4g4w c1hi2fgx c1jrmp29 c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l c1srwcmr c1grhw0w c8xqq0k cjs8iie c157d2k6"
+                className="c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 cok6gp c1ebb32d c1ed2n1f c1an30v3 ca60kt0 c1oai8p0 clo3r8o cw9oyzl cuqxbts cg19ih8 c1479lj6 comq4ym c1qx3pju cut8gip c1qjvju3 c18kkil c16g5416 c111au61 c1uw27mb co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1jirpm3 ce92j53 c1dr421o c14ytp9r c1a713iq"
               >
                 <Text data-ws-id="53" data-ws-component="Text">
                   {"Components"}
@@ -202,7 +201,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                 <Box
                   data-ws-id="54"
                   data-ws-component="Box"
-                  className="ck5mafm cm547tf c18dp5gp clw3og8 c1qmz361 cu8n5i6 cqhjzs2 c1498b83"
+                  className="c9je87j cwfkqjc c1pmpq0f c1yafs04 c11hichb cpr3ke2 c1wmnqxw c1aw50j7"
                 >
                   <HtmlEmbed
                     data-ws-id="56"
@@ -218,17 +217,17 @@ const Page = (_props: { params: Params; resources: Resources }) => {
               data-ws-id="58"
               data-ws-component="NavigationMenuContent"
               data-ws-index="1"
-              className="c17k6ftv ci9y33x c1kb88y7 cbgnvea c1y5f9qa cjw7gx9 c1mdun74 c1bfvzwl"
+              className="cboqcgi ccq2s6t ct2k8wg c12s9tcd c1c2uk29 c1x1m3cj c17g8s4n c657y94"
             >
               <Box
                 data-ws-id="60"
                 data-ws-component="Box"
-                className="c6gk6ar cb99ak4 ctl64vj c1hxtwzc c1j0bzjz cbjj14v c15sjadq"
+                className="c11xgi9i ci4ea85 c13l7myj c11ubft8 c19nnvu2 c6epq1b cniw9w8"
               >
                 <Box
                   data-ws-id="62"
                   data-ws-component="Box"
-                  className="c88y2pm c6gk6ar cb99ak4 ctl64vj c13wsd00"
+                  className="c3e36dl c11xgi9i ci4ea85 c13l7myj cfd715b"
                 >
                   <NavigationMenuLink
                     data-ws-id="64"
@@ -238,19 +237,19 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                       data-ws-id="65"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/accordion"}
-                      className="c1wv658c c6gk6ar c13wsd00 c1hl4mbg cu0fd6l c8098d3 cym38jd cqimob0 c2tr68t cjdtj3f c1kc4g4w c1hi2fgx c16a2e8i c1y90k37 cvjxq2s chhysup c601nqx c9i3lxo c1sz664l cm8bc7h c8xqq0k cjs8iie cbt1ziu c1ci4uzu"
+                      className="c1lp1p2a c11xgi9i cfd715b cekw1i5 csjyi15 c1xv9rff cuqxbts cg19ih8 c1479lj6 comq4ym c16g5416 c111au61 c17g4cws ctolsm2 crxf9g c1gfew4a cxlxl0c c1gfzcg5 cohan28 c15roejc c1dr421o c14ytp9r c11eeprv c1rbq5ju"
                     >
                       <Text
                         data-ws-id="68"
                         data-ws-component="Text"
-                        className="c1mfk609 cvjxq2s cwry1sa"
+                        className="c1qx3pju crxf9g c1qjvju3"
                       >
                         {"Accordion"}
                       </Text>
                       <Paragraph
                         data-ws-id="70"
                         data-ws-component="Paragraph"
-                        className="c3rzppk c17ybgbw c1u5xdcd cdf5ze5 c1e2gixt c16sc1pt c78rgey c1mxykr c1mfk609 c18mq0f5 caa8yt3"
+                        className="cawkm6w clp87x0 cvrokas crk8tjo c1p3lwwv c1ldl5ci c1rc3t1c c69w97g c1qx3pju c1ls6yv2 c1pcz91e"
                       >
                         {
                           "A vertically stacked set of interactive headings that each reveal a section of content."
@@ -266,19 +265,19 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                       data-ws-id="73"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/dialog"}
-                      className="c1wv658c c6gk6ar c13wsd00 c1hl4mbg cu0fd6l c8098d3 cym38jd cqimob0 c2tr68t cjdtj3f c1kc4g4w c1hi2fgx c16a2e8i c1y90k37 cvjxq2s chhysup c601nqx c9i3lxo c1sz664l cm8bc7h c8xqq0k cjs8iie cbt1ziu c1ci4uzu"
+                      className="c1lp1p2a c11xgi9i cfd715b cekw1i5 csjyi15 c1xv9rff cuqxbts cg19ih8 c1479lj6 comq4ym c16g5416 c111au61 c17g4cws ctolsm2 crxf9g c1gfew4a cxlxl0c c1gfzcg5 cohan28 c15roejc c1dr421o c14ytp9r c11eeprv c1rbq5ju"
                     >
                       <Text
                         data-ws-id="76"
                         data-ws-component="Text"
-                        className="c1mfk609 cvjxq2s cwry1sa"
+                        className="c1qx3pju crxf9g c1qjvju3"
                       >
                         {"Dialog"}
                       </Text>
                       <Paragraph
                         data-ws-id="78"
                         data-ws-component="Paragraph"
-                        className="c3rzppk c17ybgbw c1u5xdcd cdf5ze5 c1e2gixt c16sc1pt c78rgey c1mxykr c1mfk609 c18mq0f5 caa8yt3"
+                        className="cawkm6w clp87x0 cvrokas crk8tjo c1p3lwwv c1ldl5ci c1rc3t1c c69w97g c1qx3pju c1ls6yv2 c1pcz91e"
                       >
                         {
                           "A window overlaid on either the primary window or another dialog window, rendering the content underneath inert."
@@ -294,19 +293,19 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                       data-ws-id="81"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/collapsible"}
-                      className="c1wv658c c6gk6ar c13wsd00 c1hl4mbg cu0fd6l c8098d3 cym38jd cqimob0 c2tr68t cjdtj3f c1kc4g4w c1hi2fgx c16a2e8i c1y90k37 cvjxq2s chhysup c601nqx c9i3lxo c1sz664l cm8bc7h c8xqq0k cjs8iie cbt1ziu c1ci4uzu"
+                      className="c1lp1p2a c11xgi9i cfd715b cekw1i5 csjyi15 c1xv9rff cuqxbts cg19ih8 c1479lj6 comq4ym c16g5416 c111au61 c17g4cws ctolsm2 crxf9g c1gfew4a cxlxl0c c1gfzcg5 cohan28 c15roejc c1dr421o c14ytp9r c11eeprv c1rbq5ju"
                     >
                       <Text
                         data-ws-id="84"
                         data-ws-component="Text"
-                        className="c1mfk609 cvjxq2s cwry1sa"
+                        className="c1qx3pju crxf9g c1qjvju3"
                       >
                         {"Collapsible"}
                       </Text>
                       <Paragraph
                         data-ws-id="86"
                         data-ws-component="Paragraph"
-                        className="c3rzppk c17ybgbw c1u5xdcd cdf5ze5 c1e2gixt c16sc1pt c78rgey c1mxykr c1mfk609 c18mq0f5 caa8yt3"
+                        className="cawkm6w clp87x0 cvrokas crk8tjo c1p3lwwv c1ldl5ci c1rc3t1c c69w97g c1qx3pju c1ls6yv2 c1pcz91e"
                       >
                         {
                           "An interactive component which expands/collapses a panel."
@@ -318,7 +317,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                 <Box
                   data-ws-id="88"
                   data-ws-component="Box"
-                  className="c88y2pm c6gk6ar cb99ak4 ctl64vj c13wsd00"
+                  className="c3e36dl c11xgi9i ci4ea85 c13l7myj cfd715b"
                 >
                   <NavigationMenuLink
                     data-ws-id="90"
@@ -328,19 +327,19 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                       data-ws-id="91"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/popover"}
-                      className="c1wv658c c6gk6ar c13wsd00 c1hl4mbg cu0fd6l c8098d3 cym38jd cqimob0 c2tr68t cjdtj3f c1kc4g4w c1hi2fgx c16a2e8i c1y90k37 cvjxq2s chhysup c601nqx c9i3lxo c1sz664l cm8bc7h c8xqq0k cjs8iie cbt1ziu c1ci4uzu"
+                      className="c1lp1p2a c11xgi9i cfd715b cekw1i5 csjyi15 c1xv9rff cuqxbts cg19ih8 c1479lj6 comq4ym c16g5416 c111au61 c17g4cws ctolsm2 crxf9g c1gfew4a cxlxl0c c1gfzcg5 cohan28 c15roejc c1dr421o c14ytp9r c11eeprv c1rbq5ju"
                     >
                       <Text
                         data-ws-id="94"
                         data-ws-component="Text"
-                        className="c1mfk609 cvjxq2s cwry1sa"
+                        className="c1qx3pju crxf9g c1qjvju3"
                       >
                         {"Popover"}
                       </Text>
                       <Paragraph
                         data-ws-id="96"
                         data-ws-component="Paragraph"
-                        className="c3rzppk c17ybgbw c1u5xdcd cdf5ze5 c1e2gixt c16sc1pt c78rgey c1mxykr c1mfk609 c18mq0f5 caa8yt3"
+                        className="cawkm6w clp87x0 cvrokas crk8tjo c1p3lwwv c1ldl5ci c1rc3t1c c69w97g c1qx3pju c1ls6yv2 c1pcz91e"
                       >
                         {
                           "Displays rich content in a portal, triggered by a button."
@@ -356,19 +355,19 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                       data-ws-id="99"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/tooltip"}
-                      className="c1wv658c c6gk6ar c13wsd00 c1hl4mbg cu0fd6l c8098d3 cym38jd cqimob0 c2tr68t cjdtj3f c1kc4g4w c1hi2fgx c16a2e8i c1y90k37 cvjxq2s chhysup c601nqx c9i3lxo c1sz664l cm8bc7h c8xqq0k cjs8iie cbt1ziu c1ci4uzu"
+                      className="c1lp1p2a c11xgi9i cfd715b cekw1i5 csjyi15 c1xv9rff cuqxbts cg19ih8 c1479lj6 comq4ym c16g5416 c111au61 c17g4cws ctolsm2 crxf9g c1gfew4a cxlxl0c c1gfzcg5 cohan28 c15roejc c1dr421o c14ytp9r c11eeprv c1rbq5ju"
                     >
                       <Text
                         data-ws-id="102"
                         data-ws-component="Text"
-                        className="c1mfk609 cvjxq2s cwry1sa"
+                        className="c1qx3pju crxf9g c1qjvju3"
                       >
                         {"Tooltip"}
                       </Text>
                       <Paragraph
                         data-ws-id="104"
                         data-ws-component="Paragraph"
-                        className="c3rzppk c17ybgbw c1u5xdcd cdf5ze5 c1e2gixt c16sc1pt c78rgey c1mxykr c1mfk609 c18mq0f5 caa8yt3"
+                        className="cawkm6w clp87x0 cvrokas crk8tjo c1p3lwwv c1ldl5ci c1rc3t1c c69w97g c1qx3pju c1ls6yv2 c1pcz91e"
                       >
                         {
                           "A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it."
@@ -384,19 +383,19 @@ const Page = (_props: { params: Params; resources: Resources }) => {
                       data-ws-id="107"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/button"}
-                      className="c1wv658c c6gk6ar c13wsd00 c1hl4mbg cu0fd6l c8098d3 cym38jd cqimob0 c2tr68t cjdtj3f c1kc4g4w c1hi2fgx c16a2e8i c1y90k37 cvjxq2s chhysup c601nqx c9i3lxo c1sz664l cm8bc7h c8xqq0k cjs8iie cbt1ziu c1ci4uzu"
+                      className="c1lp1p2a c11xgi9i cfd715b cekw1i5 csjyi15 c1xv9rff cuqxbts cg19ih8 c1479lj6 comq4ym c16g5416 c111au61 c17g4cws ctolsm2 crxf9g c1gfew4a cxlxl0c c1gfzcg5 cohan28 c15roejc c1dr421o c14ytp9r c11eeprv c1rbq5ju"
                     >
                       <Text
                         data-ws-id="110"
                         data-ws-component="Text"
-                        className="c1mfk609 cvjxq2s cwry1sa"
+                        className="c1qx3pju crxf9g c1qjvju3"
                       >
                         {"Button"}
                       </Text>
                       <Paragraph
                         data-ws-id="112"
                         data-ws-component="Paragraph"
-                        className="c3rzppk c17ybgbw c1u5xdcd cdf5ze5 c1e2gixt c16sc1pt c78rgey c1mxykr c1mfk609 c18mq0f5 caa8yt3"
+                        className="cawkm6w clp87x0 cvrokas crk8tjo c1p3lwwv c1ldl5ci c1rc3t1c c69w97g c1qx3pju c1ls6yv2 c1pcz91e"
                       >
                         {
                           "Displays a button or a component that looks like a button."
@@ -420,7 +419,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
               <Link
                 data-ws-id="116"
                 data-ws-component="Link"
-                className="c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l c1v4k4ip c2iozhh c1j5pqo1 cmqevnc cvxnx00 c1mnuzt9 c4v7k5r cvzkkb6 cym38jd cqimob0 c2tr68t cjdtj3f c1mfk609 c121vm9z cwry1sa c1b8xvex c1kc4g4w c1hi2fgx chhysup c2a7z25 c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l c1srwcmr c1grhw0w c8xqq0k cjs8iie"
+                className="c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 cok6gp c1ebb32d c1ed2n1f c1an30v3 ca60kt0 c1oai8p0 clo3r8o cw9oyzl cuqxbts cg19ih8 c1479lj6 comq4ym c1qx3pju cut8gip c1qjvju3 c18kkil c16g5416 c111au61 c1gfew4a c1hdhil0 co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1jirpm3 ce92j53 c1dr421o c14ytp9r"
               >
                 {"Standalone"}
               </Link>
@@ -430,12 +429,12 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         <Box
           data-ws-id="118"
           data-ws-component="Box"
-          className="c1kb88y7 c17k6ftv cd2po1q c6gk6ar cvzkkb6"
+          className="ct2k8wg cboqcgi coe4ay6 c11xgi9i cw9oyzl"
         >
           <NavigationMenuViewport
             data-ws-id="120"
             data-ws-component="NavigationMenuViewport"
-            className="cnhoj7b c1t5p0zw c1e2gixt cym38jd cqimob0 c2tr68t cjdtj3f c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l cgassre c1ndsw6v cjrlou9 c945vvj c4mw8gp cj0w9yo cbzcu1y c1srbwx8 cr0e7oa"
+            className="crmoyyg cg2jhpq c1p3lwwv cuqxbts cg19ih8 c1479lj6 comq4ym c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 ck2qarh c1nxbatd caktpzb c1bm526f c1rt44f4 cwi0ez9 c1ii9nza c53wwee c1daganl"
           />
         </Box>
       </NavigationMenu>
@@ -650,1723 +649,340 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-width: 1px
   }
 }@media all {
-  .cnhoj7b {
+  .crmoyyg {
     position: relative
   }
-  .c1a0z5in {
+  .cvxi4jc {
     max-width: max-content
   }
-  .c1hxtwzc {
+  .c11ubft8 {
     padding-left: 0px
   }
-  .c1j0bzjz {
+  .c19nnvu2 {
     padding-right: 0px
   }
-  .cbjj14v {
+  .c6epq1b {
     padding-top: 0px
   }
-  .c15sjadq {
+  .cniw9w8 {
     padding-bottom: 0px
   }
-  .c3rzppk {
+  .cawkm6w {
     margin-left: 0px
   }
-  .c17ybgbw {
+  .clp87x0 {
     margin-right: 0px
   }
-  .c1u5xdcd {
+  .cvrokas {
     margin-top: 0px
   }
-  .cdf5ze5 {
+  .crk8tjo {
     margin-bottom: 0px
   }
-  .c6gk6ar {
+  .c11xgi9i {
     display: flex
   }
-  .cn4ngym {
+  .c1yubncr {
     flex-grow: 1
   }
-  .c1ee1pe1 {
+  .c1iq6hwp {
     flex-shrink: 1
   }
-  .c1xcrn9h {
+  .cv7p8tf {
     flex-basis: 0%
   }
-  .csrd2h5 {
+  .cq9q4za {
     list-style-type: none
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .cvzkkb6 {
+  .cw9oyzl {
     justify-content: center
   }
-  .cu0fd6l {
+  .csjyi15 {
     row-gap: 0.25rem
   }
-  .c8098d3 {
+  .c1xv9rff {
     column-gap: 0.25rem
   }
-  .c1inucbi {
+  .c17al2u0 {
     border-top-style: solid
   }
-  .c1dab7w1 {
+  .c1ufcra4 {
     border-right-style: solid
   }
-  .c1uf7v01 {
+  .c17gos5d {
     border-bottom-style: solid
   }
-  .czynn8e {
+  .cn4f13s {
     border-left-style: solid
   }
-  .c6z96ps {
+  .c1wic2il {
     border-top-color: rgba(226, 232, 240, 1)
   }
-  .c9t5qyz {
+  .cdem58j {
     border-right-color: rgba(226, 232, 240, 1)
   }
-  .c1x5uwe6 {
+  .c102tttv {
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  .csnt51l {
+  .cb204z1 {
     border-left-color: rgba(226, 232, 240, 1)
   }
-  .c1v4k4ip {
+  .cok6gp {
     border-top-width: 0px
   }
-  .c2iozhh {
+  .c1ebb32d {
     border-right-width: 0px
   }
-  .c1j5pqo1 {
+  .c1ed2n1f {
     border-bottom-width: 0px
   }
-  .cmqevnc {
+  .c1an30v3 {
     border-left-width: 0px
   }
-  .cvxnx00 {
+  .ca60kt0 {
     background-color: transparent
   }
-  .c1mnuzt9 {
+  .c1oai8p0 {
     display: inline-flex
   }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cvzkkb6 {
-    justify-content: center
-  }
-  .cym38jd {
+  .cuqxbts {
     border-top-left-radius: 0.375rem
   }
-  .cqimob0 {
+  .cg19ih8 {
     border-top-right-radius: 0.375rem
   }
-  .c2tr68t {
+  .c1479lj6 {
     border-bottom-right-radius: 0.375rem
   }
-  .cjdtj3f {
+  .comq4ym {
     border-bottom-left-radius: 0.375rem
   }
-  .c1mfk609 {
+  .c1qx3pju {
     font-size: 0.875rem
   }
-  .c121vm9z {
+  .cut8gip {
     line-height: 1.25rem
   }
-  .cwry1sa {
+  .c1qjvju3 {
     font-weight: 500
   }
-  .c1b8xvex {
+  .c18kkil {
     height: 2.5rem
   }
-  .c1kc4g4w {
+  .c16g5416 {
     padding-left: 0.75rem
   }
-  .c1hi2fgx {
+  .c111au61 {
     padding-right: 0.75rem
   }
-  .c1jrmp29 {
+  .c1uw27mb {
     --navigation-menu-trigger-icon-transform: 0deg
   }
-  .c1t6bql4:focus-visible {
+  .co0lfwl:focus-visible {
     outline-width: 2px
   }
-  .czph7hf:focus-visible {
+  .c1kn3u98:focus-visible {
     outline-style: solid
   }
-  .cncn1ro:focus-visible {
+  .c2odgnt:focus-visible {
     outline-color: transparent
   }
-  .cb270vo:focus-visible {
+  .chlvjga:focus-visible {
     outline-offset: 2px
   }
-  .c1rgsd1l:focus-visible {
+  .c1jx7vpr:focus-visible {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  .c1srwcmr:disabled {
+  .c1jirpm3:disabled {
     pointer-events: none
   }
-  .c1grhw0w:disabled {
+  .ce92j53:disabled {
     opacity: 0.5
   }
-  .c8xqq0k:hover {
+  .c1dr421o:hover {
     background-color: rgba(241, 245, 249, 0.9)
   }
-  .cjs8iie:hover {
+  .c14ytp9r:hover {
     color: rgba(15, 23, 42, 1)
   }
-  .c157d2k6[data-state=open] {
+  .c1a713iq[data-state=open] {
     --navigation-menu-trigger-icon-transform: 180deg
   }
-  .ck5mafm {
+  .c9je87j {
     margin-left: 0.25rem
   }
-  .cm547tf {
+  .cwfkqjc {
     rotate: var(--navigation-menu-trigger-icon-transform)
   }
-  .c18dp5gp {
+  .c1pmpq0f {
     height: 1rem
   }
-  .clw3og8 {
+  .c1yafs04 {
     width: 1rem
   }
-  .c1qmz361 {
+  .c11hichb {
     flex-grow: 0
   }
-  .cu8n5i6 {
+  .cpr3ke2 {
     transition-property: all
   }
-  .cqhjzs2 {
+  .c1wmnqxw {
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1)
   }
-  .c1498b83 {
+  .c1aw50j7 {
     transition-duration: 200ms
   }
-  .c17k6ftv {
+  .cboqcgi {
     left: 0px
   }
-  .ci9y33x {
+  .ccq2s6t {
     top: 0px
   }
-  .c1kb88y7 {
+  .ct2k8wg {
     position: absolute
   }
-  .cbgnvea {
+  .c12s9tcd {
     width: max-content
   }
-  .c1y5f9qa {
+  .c1c2uk29 {
     padding-left: 1rem
   }
-  .cjw7gx9 {
+  .c1x1m3cj {
     padding-right: 1rem
   }
-  .c1mdun74 {
+  .c17g8s4n {
     padding-top: 1rem
   }
-  .c1bfvzwl {
+  .c657y94 {
     padding-bottom: 1rem
   }
-  .c6gk6ar {
-    display: flex
-  }
-  .cb99ak4 {
+  .ci4ea85 {
     row-gap: 1rem
   }
-  .ctl64vj {
+  .c13l7myj {
     column-gap: 1rem
   }
-  .cbxivag {
+  .c1jmgbvo {
     padding-left: 0.5rem
   }
-  .c18gyxfs {
+  .c1qmwsx9 {
     padding-right: 0.5rem
   }
-  .c1peybss {
+  .cey1d5i {
     padding-top: 0.5rem
   }
-  .chh2z1n {
+  .cbnv1sn {
     padding-bottom: 0.5rem
   }
-  .c1af0hjb {
+  .csvgwzp {
     background-color: rgba(226, 232, 240, 1)
   }
-  .c1y5f9qa {
-    padding-left: 1rem
-  }
-  .cjw7gx9 {
-    padding-right: 1rem
-  }
-  .c1mdun74 {
-    padding-top: 1rem
-  }
-  .c1bfvzwl {
-    padding-bottom: 1rem
-  }
-  .c1187wgd {
+  .c1fd7x2o {
     width: 12rem
   }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c88y2pm {
+  .c3e36dl {
     width: 16rem
   }
-  .c6gk6ar {
-    display: flex
-  }
-  .cb99ak4 {
-    row-gap: 1rem
-  }
-  .ctl64vj {
-    column-gap: 1rem
-  }
-  .c13wsd00 {
+  .cfd715b {
     flex-direction: column
   }
-  .c1wv658c {
+  .c1lp1p2a {
     color: inherit
   }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .c1hl4mbg {
+  .cekw1i5 {
     user-select: none
   }
-  .cu0fd6l {
-    row-gap: 0.25rem
-  }
-  .c8098d3 {
-    column-gap: 0.25rem
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .c16a2e8i {
+  .c17g4cws {
     padding-top: 0.75rem
   }
-  .c1y90k37 {
+  .ctolsm2 {
     padding-bottom: 0.75rem
   }
-  .cvjxq2s {
+  .crxf9g {
     line-height: 1
   }
-  .chhysup {
+  .c1gfew4a {
     text-decoration-line: none
   }
-  .c601nqx {
+  .cxlxl0c {
     outline-width: 2px
   }
-  .c9i3lxo {
+  .c1gfzcg5 {
     outline-style: solid
   }
-  .c1sz664l {
+  .cohan28 {
     outline-color: transparent
   }
-  .cm8bc7h {
+  .c15roejc {
     outline-offset: 2px
   }
-  .c8xqq0k:hover {
+  .c11eeprv:focus {
     background-color: rgba(241, 245, 249, 0.9)
   }
-  .cjs8iie:hover {
+  .c1rbq5ju:focus {
     color: rgba(15, 23, 42, 1)
   }
-  .cbt1ziu:focus {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .c1ci4uzu:focus {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .c3rzppk {
-    margin-left: 0px
-  }
-  .c17ybgbw {
-    margin-right: 0px
-  }
-  .c1u5xdcd {
-    margin-top: 0px
-  }
-  .cdf5ze5 {
-    margin-bottom: 0px
-  }
-  .c1e2gixt {
+  .c1p3lwwv {
     overflow: hidden
   }
-  .c16sc1pt {
+  .c1ldl5ci {
     display: -webkit-box
   }
-  .c78rgey {
+  .c1rc3t1c {
     -webkit-box-orient: vertical
   }
-  .c1mxykr {
+  .c69w97g {
     -webkit-line-clamp: 2
   }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c18mq0f5 {
+  .c1ls6yv2 {
     line-height: 1.375
   }
-  .caa8yt3 {
+  .c1pcz91e {
     color: rgba(100, 116, 139, 1)
   }
-  .c1wv658c {
-    color: inherit
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .c1hl4mbg {
-    user-select: none
-  }
-  .cu0fd6l {
-    row-gap: 0.25rem
-  }
-  .c8098d3 {
-    column-gap: 0.25rem
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .c16a2e8i {
-    padding-top: 0.75rem
-  }
-  .c1y90k37 {
-    padding-bottom: 0.75rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .chhysup {
-    text-decoration-line: none
-  }
-  .c601nqx {
-    outline-width: 2px
-  }
-  .c9i3lxo {
-    outline-style: solid
-  }
-  .c1sz664l {
-    outline-color: transparent
-  }
-  .cm8bc7h {
-    outline-offset: 2px
-  }
-  .c8xqq0k:hover {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .cjs8iie:hover {
-    color: rgba(15, 23, 42, 1)
-  }
-  .cbt1ziu:focus {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .c1ci4uzu:focus {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .c3rzppk {
-    margin-left: 0px
-  }
-  .c17ybgbw {
-    margin-right: 0px
-  }
-  .c1u5xdcd {
-    margin-top: 0px
-  }
-  .cdf5ze5 {
-    margin-bottom: 0px
-  }
-  .c1e2gixt {
-    overflow: hidden
-  }
-  .c16sc1pt {
-    display: -webkit-box
-  }
-  .c78rgey {
-    -webkit-box-orient: vertical
-  }
-  .c1mxykr {
-    -webkit-line-clamp: 2
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c18mq0f5 {
-    line-height: 1.375
-  }
-  .caa8yt3 {
-    color: rgba(100, 116, 139, 1)
-  }
-  .c1wv658c {
-    color: inherit
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .c1hl4mbg {
-    user-select: none
-  }
-  .cu0fd6l {
-    row-gap: 0.25rem
-  }
-  .c8098d3 {
-    column-gap: 0.25rem
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .c16a2e8i {
-    padding-top: 0.75rem
-  }
-  .c1y90k37 {
-    padding-bottom: 0.75rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .chhysup {
-    text-decoration-line: none
-  }
-  .c601nqx {
-    outline-width: 2px
-  }
-  .c9i3lxo {
-    outline-style: solid
-  }
-  .c1sz664l {
-    outline-color: transparent
-  }
-  .cm8bc7h {
-    outline-offset: 2px
-  }
-  .c8xqq0k:hover {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .cjs8iie:hover {
-    color: rgba(15, 23, 42, 1)
-  }
-  .cbt1ziu:focus {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .c1ci4uzu:focus {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .c3rzppk {
-    margin-left: 0px
-  }
-  .c17ybgbw {
-    margin-right: 0px
-  }
-  .c1u5xdcd {
-    margin-top: 0px
-  }
-  .cdf5ze5 {
-    margin-bottom: 0px
-  }
-  .c1e2gixt {
-    overflow: hidden
-  }
-  .c16sc1pt {
-    display: -webkit-box
-  }
-  .c78rgey {
-    -webkit-box-orient: vertical
-  }
-  .c1mxykr {
-    -webkit-line-clamp: 2
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c18mq0f5 {
-    line-height: 1.375
-  }
-  .caa8yt3 {
-    color: rgba(100, 116, 139, 1)
-  }
-  .c1inucbi {
-    border-top-style: solid
-  }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .c6z96ps {
-    border-top-color: rgba(226, 232, 240, 1)
-  }
-  .c9t5qyz {
-    border-right-color: rgba(226, 232, 240, 1)
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .csnt51l {
-    border-left-color: rgba(226, 232, 240, 1)
-  }
-  .c1v4k4ip {
-    border-top-width: 0px
-  }
-  .c2iozhh {
-    border-right-width: 0px
-  }
-  .c1j5pqo1 {
-    border-bottom-width: 0px
-  }
-  .cmqevnc {
-    border-left-width: 0px
-  }
-  .cvxnx00 {
-    background-color: transparent
-  }
-  .c1mnuzt9 {
-    display: inline-flex
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cvzkkb6 {
-    justify-content: center
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c121vm9z {
-    line-height: 1.25rem
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .c1b8xvex {
-    height: 2.5rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .c1jrmp29 {
-    --navigation-menu-trigger-icon-transform: 0deg
-  }
-  .c1t6bql4:focus-visible {
-    outline-width: 2px
-  }
-  .czph7hf:focus-visible {
-    outline-style: solid
-  }
-  .cncn1ro:focus-visible {
-    outline-color: transparent
-  }
-  .cb270vo:focus-visible {
-    outline-offset: 2px
-  }
-  .c1rgsd1l:focus-visible {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
-  }
-  .c1srwcmr:disabled {
-    pointer-events: none
-  }
-  .c1grhw0w:disabled {
-    opacity: 0.5
-  }
-  .c8xqq0k:hover {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .cjs8iie:hover {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c157d2k6[data-state=open] {
-    --navigation-menu-trigger-icon-transform: 180deg
-  }
-  .ck5mafm {
-    margin-left: 0.25rem
-  }
-  .cm547tf {
-    rotate: var(--navigation-menu-trigger-icon-transform)
-  }
-  .c18dp5gp {
-    height: 1rem
-  }
-  .clw3og8 {
-    width: 1rem
-  }
-  .c1qmz361 {
-    flex-grow: 0
-  }
-  .cu8n5i6 {
-    transition-property: all
-  }
-  .cqhjzs2 {
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1)
-  }
-  .c1498b83 {
-    transition-duration: 200ms
-  }
-  .c17k6ftv {
-    left: 0px
-  }
-  .ci9y33x {
-    top: 0px
-  }
-  .c1kb88y7 {
-    position: absolute
-  }
-  .cbgnvea {
-    width: max-content
-  }
-  .c1y5f9qa {
-    padding-left: 1rem
-  }
-  .cjw7gx9 {
-    padding-right: 1rem
-  }
-  .c1mdun74 {
-    padding-top: 1rem
-  }
-  .c1bfvzwl {
-    padding-bottom: 1rem
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .cb99ak4 {
-    row-gap: 1rem
-  }
-  .ctl64vj {
-    column-gap: 1rem
-  }
-  .c1hxtwzc {
-    padding-left: 0px
-  }
-  .c1j0bzjz {
-    padding-right: 0px
-  }
-  .cbjj14v {
-    padding-top: 0px
-  }
-  .c15sjadq {
-    padding-bottom: 0px
-  }
-  .c88y2pm {
-    width: 16rem
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .cb99ak4 {
-    row-gap: 1rem
-  }
-  .ctl64vj {
-    column-gap: 1rem
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .c1wv658c {
-    color: inherit
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .c1hl4mbg {
-    user-select: none
-  }
-  .cu0fd6l {
-    row-gap: 0.25rem
-  }
-  .c8098d3 {
-    column-gap: 0.25rem
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .c16a2e8i {
-    padding-top: 0.75rem
-  }
-  .c1y90k37 {
-    padding-bottom: 0.75rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .chhysup {
-    text-decoration-line: none
-  }
-  .c601nqx {
-    outline-width: 2px
-  }
-  .c9i3lxo {
-    outline-style: solid
-  }
-  .c1sz664l {
-    outline-color: transparent
-  }
-  .cm8bc7h {
-    outline-offset: 2px
-  }
-  .c8xqq0k:hover {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .cjs8iie:hover {
-    color: rgba(15, 23, 42, 1)
-  }
-  .cbt1ziu:focus {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .c1ci4uzu:focus {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .c3rzppk {
-    margin-left: 0px
-  }
-  .c17ybgbw {
-    margin-right: 0px
-  }
-  .c1u5xdcd {
-    margin-top: 0px
-  }
-  .cdf5ze5 {
-    margin-bottom: 0px
-  }
-  .c1e2gixt {
-    overflow: hidden
-  }
-  .c16sc1pt {
-    display: -webkit-box
-  }
-  .c78rgey {
-    -webkit-box-orient: vertical
-  }
-  .c1mxykr {
-    -webkit-line-clamp: 2
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c18mq0f5 {
-    line-height: 1.375
-  }
-  .caa8yt3 {
-    color: rgba(100, 116, 139, 1)
-  }
-  .c1wv658c {
-    color: inherit
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .c1hl4mbg {
-    user-select: none
-  }
-  .cu0fd6l {
-    row-gap: 0.25rem
-  }
-  .c8098d3 {
-    column-gap: 0.25rem
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .c16a2e8i {
-    padding-top: 0.75rem
-  }
-  .c1y90k37 {
-    padding-bottom: 0.75rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .chhysup {
-    text-decoration-line: none
-  }
-  .c601nqx {
-    outline-width: 2px
-  }
-  .c9i3lxo {
-    outline-style: solid
-  }
-  .c1sz664l {
-    outline-color: transparent
-  }
-  .cm8bc7h {
-    outline-offset: 2px
-  }
-  .c8xqq0k:hover {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .cjs8iie:hover {
-    color: rgba(15, 23, 42, 1)
-  }
-  .cbt1ziu:focus {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .c1ci4uzu:focus {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .c3rzppk {
-    margin-left: 0px
-  }
-  .c17ybgbw {
-    margin-right: 0px
-  }
-  .c1u5xdcd {
-    margin-top: 0px
-  }
-  .cdf5ze5 {
-    margin-bottom: 0px
-  }
-  .c1e2gixt {
-    overflow: hidden
-  }
-  .c16sc1pt {
-    display: -webkit-box
-  }
-  .c78rgey {
-    -webkit-box-orient: vertical
-  }
-  .c1mxykr {
-    -webkit-line-clamp: 2
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c18mq0f5 {
-    line-height: 1.375
-  }
-  .caa8yt3 {
-    color: rgba(100, 116, 139, 1)
-  }
-  .c1wv658c {
-    color: inherit
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .c1hl4mbg {
-    user-select: none
-  }
-  .cu0fd6l {
-    row-gap: 0.25rem
-  }
-  .c8098d3 {
-    column-gap: 0.25rem
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .c16a2e8i {
-    padding-top: 0.75rem
-  }
-  .c1y90k37 {
-    padding-bottom: 0.75rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .chhysup {
-    text-decoration-line: none
-  }
-  .c601nqx {
-    outline-width: 2px
-  }
-  .c9i3lxo {
-    outline-style: solid
-  }
-  .c1sz664l {
-    outline-color: transparent
-  }
-  .cm8bc7h {
-    outline-offset: 2px
-  }
-  .c8xqq0k:hover {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .cjs8iie:hover {
-    color: rgba(15, 23, 42, 1)
-  }
-  .cbt1ziu:focus {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .c1ci4uzu:focus {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .c3rzppk {
-    margin-left: 0px
-  }
-  .c17ybgbw {
-    margin-right: 0px
-  }
-  .c1u5xdcd {
-    margin-top: 0px
-  }
-  .cdf5ze5 {
-    margin-bottom: 0px
-  }
-  .c1e2gixt {
-    overflow: hidden
-  }
-  .c16sc1pt {
-    display: -webkit-box
-  }
-  .c78rgey {
-    -webkit-box-orient: vertical
-  }
-  .c1mxykr {
-    -webkit-line-clamp: 2
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c18mq0f5 {
-    line-height: 1.375
-  }
-  .caa8yt3 {
-    color: rgba(100, 116, 139, 1)
-  }
-  .c88y2pm {
-    width: 16rem
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .cb99ak4 {
-    row-gap: 1rem
-  }
-  .ctl64vj {
-    column-gap: 1rem
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .c1wv658c {
-    color: inherit
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .c1hl4mbg {
-    user-select: none
-  }
-  .cu0fd6l {
-    row-gap: 0.25rem
-  }
-  .c8098d3 {
-    column-gap: 0.25rem
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .c16a2e8i {
-    padding-top: 0.75rem
-  }
-  .c1y90k37 {
-    padding-bottom: 0.75rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .chhysup {
-    text-decoration-line: none
-  }
-  .c601nqx {
-    outline-width: 2px
-  }
-  .c9i3lxo {
-    outline-style: solid
-  }
-  .c1sz664l {
-    outline-color: transparent
-  }
-  .cm8bc7h {
-    outline-offset: 2px
-  }
-  .c8xqq0k:hover {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .cjs8iie:hover {
-    color: rgba(15, 23, 42, 1)
-  }
-  .cbt1ziu:focus {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .c1ci4uzu:focus {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .c3rzppk {
-    margin-left: 0px
-  }
-  .c17ybgbw {
-    margin-right: 0px
-  }
-  .c1u5xdcd {
-    margin-top: 0px
-  }
-  .cdf5ze5 {
-    margin-bottom: 0px
-  }
-  .c1e2gixt {
-    overflow: hidden
-  }
-  .c16sc1pt {
-    display: -webkit-box
-  }
-  .c78rgey {
-    -webkit-box-orient: vertical
-  }
-  .c1mxykr {
-    -webkit-line-clamp: 2
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c18mq0f5 {
-    line-height: 1.375
-  }
-  .caa8yt3 {
-    color: rgba(100, 116, 139, 1)
-  }
-  .c1wv658c {
-    color: inherit
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .c1hl4mbg {
-    user-select: none
-  }
-  .cu0fd6l {
-    row-gap: 0.25rem
-  }
-  .c8098d3 {
-    column-gap: 0.25rem
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .c16a2e8i {
-    padding-top: 0.75rem
-  }
-  .c1y90k37 {
-    padding-bottom: 0.75rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .chhysup {
-    text-decoration-line: none
-  }
-  .c601nqx {
-    outline-width: 2px
-  }
-  .c9i3lxo {
-    outline-style: solid
-  }
-  .c1sz664l {
-    outline-color: transparent
-  }
-  .cm8bc7h {
-    outline-offset: 2px
-  }
-  .c8xqq0k:hover {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .cjs8iie:hover {
-    color: rgba(15, 23, 42, 1)
-  }
-  .cbt1ziu:focus {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .c1ci4uzu:focus {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .c3rzppk {
-    margin-left: 0px
-  }
-  .c17ybgbw {
-    margin-right: 0px
-  }
-  .c1u5xdcd {
-    margin-top: 0px
-  }
-  .cdf5ze5 {
-    margin-bottom: 0px
-  }
-  .c1e2gixt {
-    overflow: hidden
-  }
-  .c16sc1pt {
-    display: -webkit-box
-  }
-  .c78rgey {
-    -webkit-box-orient: vertical
-  }
-  .c1mxykr {
-    -webkit-line-clamp: 2
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c18mq0f5 {
-    line-height: 1.375
-  }
-  .caa8yt3 {
-    color: rgba(100, 116, 139, 1)
-  }
-  .c1wv658c {
-    color: inherit
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .c1hl4mbg {
-    user-select: none
-  }
-  .cu0fd6l {
-    row-gap: 0.25rem
-  }
-  .c8098d3 {
-    column-gap: 0.25rem
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .c16a2e8i {
-    padding-top: 0.75rem
-  }
-  .c1y90k37 {
-    padding-bottom: 0.75rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .chhysup {
-    text-decoration-line: none
-  }
-  .c601nqx {
-    outline-width: 2px
-  }
-  .c9i3lxo {
-    outline-style: solid
-  }
-  .c1sz664l {
-    outline-color: transparent
-  }
-  .cm8bc7h {
-    outline-offset: 2px
-  }
-  .c8xqq0k:hover {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .cjs8iie:hover {
-    color: rgba(15, 23, 42, 1)
-  }
-  .cbt1ziu:focus {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .c1ci4uzu:focus {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .cvjxq2s {
-    line-height: 1
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .c3rzppk {
-    margin-left: 0px
-  }
-  .c17ybgbw {
-    margin-right: 0px
-  }
-  .c1u5xdcd {
-    margin-top: 0px
-  }
-  .cdf5ze5 {
-    margin-bottom: 0px
-  }
-  .c1e2gixt {
-    overflow: hidden
-  }
-  .c16sc1pt {
-    display: -webkit-box
-  }
-  .c78rgey {
-    -webkit-box-orient: vertical
-  }
-  .c1mxykr {
-    -webkit-line-clamp: 2
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c18mq0f5 {
-    line-height: 1.375
-  }
-  .caa8yt3 {
-    color: rgba(100, 116, 139, 1)
-  }
-  .c1inucbi {
-    border-top-style: solid
-  }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .c6z96ps {
-    border-top-color: rgba(226, 232, 240, 1)
-  }
-  .c9t5qyz {
-    border-right-color: rgba(226, 232, 240, 1)
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .csnt51l {
-    border-left-color: rgba(226, 232, 240, 1)
-  }
-  .c1v4k4ip {
-    border-top-width: 0px
-  }
-  .c2iozhh {
-    border-right-width: 0px
-  }
-  .c1j5pqo1 {
-    border-bottom-width: 0px
-  }
-  .cmqevnc {
-    border-left-width: 0px
-  }
-  .cvxnx00 {
-    background-color: transparent
-  }
-  .c1mnuzt9 {
-    display: inline-flex
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cvzkkb6 {
-    justify-content: center
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c121vm9z {
-    line-height: 1.25rem
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .c1b8xvex {
-    height: 2.5rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .chhysup {
-    text-decoration-line: none
-  }
-  .c2a7z25 {
+  .c1hdhil0 {
     color: currentColor
   }
-  .c1t6bql4:focus-visible {
-    outline-width: 2px
-  }
-  .czph7hf:focus-visible {
-    outline-style: solid
-  }
-  .cncn1ro:focus-visible {
-    outline-color: transparent
-  }
-  .cb270vo:focus-visible {
-    outline-offset: 2px
-  }
-  .c1rgsd1l:focus-visible {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
-  }
-  .c1srwcmr:disabled {
-    pointer-events: none
-  }
-  .c1grhw0w:disabled {
-    opacity: 0.5
-  }
-  .c8xqq0k:hover {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .cjs8iie:hover {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1kb88y7 {
-    position: absolute
-  }
-  .c17k6ftv {
-    left: 0px
-  }
-  .cd2po1q {
+  .coe4ay6 {
     top: 100%
   }
-  .c6gk6ar {
-    display: flex
-  }
-  .cvzkkb6 {
-    justify-content: center
-  }
-  .c1t5p0zw {
+  .cg2jhpq {
     margin-top: 0.375rem
   }
-  .c1e2gixt {
-    overflow: hidden
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1inucbi {
-    border-top-style: solid
-  }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .c6z96ps {
-    border-top-color: rgba(226, 232, 240, 1)
-  }
-  .c9t5qyz {
-    border-right-color: rgba(226, 232, 240, 1)
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .csnt51l {
-    border-left-color: rgba(226, 232, 240, 1)
-  }
-  .cgassre {
+  .ck2qarh {
     border-top-width: 1px
   }
-  .c1ndsw6v {
+  .c1nxbatd {
     border-right-width: 1px
   }
-  .cjrlou9 {
+  .caktpzb {
     border-bottom-width: 1px
   }
-  .c945vvj {
+  .c1bm526f {
     border-left-width: 1px
   }
-  .c4mw8gp {
+  .c1rt44f4 {
     background-color: rgba(255, 255, 255, 1)
   }
-  .cj0w9yo {
+  .cwi0ez9 {
     color: rgba(2, 8, 23, 1)
   }
-  .cbzcu1y {
+  .c1ii9nza {
     box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)
   }
-  .c1srbwx8 {
+  .c53wwee {
     height: var(--radix-navigation-menu-viewport-height)
   }
-  .cr0e7oa {
+  .c1daganl {
     width: var(--radix-navigation-menu-viewport-width)
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
@@ -11,8 +11,7 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [popoverOpen, set$popoverOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     popoverOpen = open;
@@ -30,7 +29,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           <Button
             data-ws-id="6"
             data-ws-component="Button"
-            className="c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l cgassre c1ndsw6v cjrlou9 c945vvj c15mffxy c1mnuzt9 c4v7k5r cvzkkb6 cym38jd cqimob0 c2tr68t cjdtj3f c1mfk609 c121vm9z cwry1sa c1b8xvex c1y5f9qa cjw7gx9 c1peybss chh2z1n c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l c1srwcmr c1grhw0w c8xqq0k cjs8iie"
+            className="c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 ck2qarh c1nxbatd caktpzb c1bm526f c110hgy6 c1oai8p0 clo3r8o cw9oyzl cuqxbts cg19ih8 c1479lj6 comq4ym c1qx3pju cut8gip c1qjvju3 c18kkil c1c2uk29 c1x1m3cj cey1d5i cbnv1sn co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1jirpm3 ce92j53 c1dr421o c14ytp9r"
           >
             {"Button"}
           </Button>
@@ -38,7 +37,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         <PopoverContent
           data-ws-id="8"
           data-ws-component="PopoverContent"
-          className="c1wyidsg c1s33lcz cym38jd cqimob0 c2tr68t cjdtj3f c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l cgassre c1ndsw6v cjrlou9 c945vvj c4mw8gp c1y5f9qa cjw7gx9 c1mdun74 c1bfvzwl cj0w9yo ci3o5ma c601nqx c9i3lxo c1sz664l cm8bc7h"
+          className="c173yyao c1vgsbti cuqxbts cg19ih8 c1479lj6 comq4ym c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 ck2qarh c1nxbatd caktpzb c1bm526f c1rt44f4 c1c2uk29 c1x1m3cj c17g8s4n c657y94 cwi0ez9 cpbhzvr cxlxl0c c1gfzcg5 cohan28 c15roejc"
         >
           <Text data-ws-id="10" data-ws-component="Text">
             {"The text you can edit"}
@@ -190,205 +189,154 @@ html {margin: 0; display: grid; min-height: 100%}
     min-height: 1em
   }
 }@media all {
-  .c1inucbi {
+  .c17al2u0 {
     border-top-style: solid
   }
-  .c1dab7w1 {
+  .c1ufcra4 {
     border-right-style: solid
   }
-  .c1uf7v01 {
+  .c17gos5d {
     border-bottom-style: solid
   }
-  .czynn8e {
+  .cn4f13s {
     border-left-style: solid
   }
-  .c6z96ps {
+  .c1wic2il {
     border-top-color: rgba(226, 232, 240, 1)
   }
-  .c9t5qyz {
+  .cdem58j {
     border-right-color: rgba(226, 232, 240, 1)
   }
-  .c1x5uwe6 {
+  .c102tttv {
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  .csnt51l {
+  .cb204z1 {
     border-left-color: rgba(226, 232, 240, 1)
   }
-  .cgassre {
+  .ck2qarh {
     border-top-width: 1px
   }
-  .c1ndsw6v {
+  .c1nxbatd {
     border-right-width: 1px
   }
-  .cjrlou9 {
+  .caktpzb {
     border-bottom-width: 1px
   }
-  .c945vvj {
+  .c1bm526f {
     border-left-width: 1px
   }
-  .c15mffxy {
+  .c110hgy6 {
     background-color: rgba(255, 255, 255, 0.8)
   }
-  .c1mnuzt9 {
+  .c1oai8p0 {
     display: inline-flex
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .cvzkkb6 {
+  .cw9oyzl {
     justify-content: center
   }
-  .cym38jd {
+  .cuqxbts {
     border-top-left-radius: 0.375rem
   }
-  .cqimob0 {
+  .cg19ih8 {
     border-top-right-radius: 0.375rem
   }
-  .c2tr68t {
+  .c1479lj6 {
     border-bottom-right-radius: 0.375rem
   }
-  .cjdtj3f {
+  .comq4ym {
     border-bottom-left-radius: 0.375rem
   }
-  .c1mfk609 {
+  .c1qx3pju {
     font-size: 0.875rem
   }
-  .c121vm9z {
+  .cut8gip {
     line-height: 1.25rem
   }
-  .cwry1sa {
+  .c1qjvju3 {
     font-weight: 500
   }
-  .c1b8xvex {
+  .c18kkil {
     height: 2.5rem
   }
-  .c1y5f9qa {
+  .c1c2uk29 {
     padding-left: 1rem
   }
-  .cjw7gx9 {
+  .c1x1m3cj {
     padding-right: 1rem
   }
-  .c1peybss {
+  .cey1d5i {
     padding-top: 0.5rem
   }
-  .chh2z1n {
+  .cbnv1sn {
     padding-bottom: 0.5rem
   }
-  .c1t6bql4:focus-visible {
+  .co0lfwl:focus-visible {
     outline-width: 2px
   }
-  .czph7hf:focus-visible {
+  .c1kn3u98:focus-visible {
     outline-style: solid
   }
-  .cncn1ro:focus-visible {
+  .c2odgnt:focus-visible {
     outline-color: transparent
   }
-  .cb270vo:focus-visible {
+  .chlvjga:focus-visible {
     outline-offset: 2px
   }
-  .c1rgsd1l:focus-visible {
+  .c1jx7vpr:focus-visible {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  .c1srwcmr:disabled {
+  .c1jirpm3:disabled {
     pointer-events: none
   }
-  .c1grhw0w:disabled {
+  .ce92j53:disabled {
     opacity: 0.5
   }
-  .c8xqq0k:hover {
+  .c1dr421o:hover {
     background-color: rgba(241, 245, 249, 0.9)
   }
-  .cjs8iie:hover {
+  .c14ytp9r:hover {
     color: rgba(15, 23, 42, 1)
   }
-  .c1wyidsg {
+  .c173yyao {
     z-index: 50
   }
-  .c1s33lcz {
+  .c1vgsbti {
     width: 18rem
   }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .c6z96ps {
-    border-top-color: rgba(226, 232, 240, 1)
-  }
-  .c9t5qyz {
-    border-right-color: rgba(226, 232, 240, 1)
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .csnt51l {
-    border-left-color: rgba(226, 232, 240, 1)
-  }
-  .cgassre {
-    border-top-width: 1px
-  }
-  .c1ndsw6v {
-    border-right-width: 1px
-  }
-  .cjrlou9 {
-    border-bottom-width: 1px
-  }
-  .c945vvj {
-    border-left-width: 1px
-  }
-  .c4mw8gp {
+  .c1rt44f4 {
     background-color: rgba(255, 255, 255, 1)
   }
-  .c1y5f9qa {
-    padding-left: 1rem
-  }
-  .cjw7gx9 {
-    padding-right: 1rem
-  }
-  .c1mdun74 {
+  .c17g8s4n {
     padding-top: 1rem
   }
-  .c1bfvzwl {
+  .c657y94 {
     padding-bottom: 1rem
   }
-  .cj0w9yo {
+  .cwi0ez9 {
     color: rgba(2, 8, 23, 1)
   }
-  .ci3o5ma {
+  .cpbhzvr {
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)
   }
-  .c601nqx {
+  .cxlxl0c {
     outline-width: 2px
   }
-  .c9i3lxo {
+  .c1gfzcg5 {
     outline-style: solid
   }
-  .c1sz664l {
+  .cohan28 {
     outline-color: transparent
   }
-  .cm8bc7h {
+  .c15roejc {
     outline-offset: 2px
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
@@ -12,8 +12,7 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [radioGroupValue, set$radioGroupValue] = useState<any>("");
   let onValueChange = (value: any) => {
     radioGroupValue = value;
@@ -26,18 +25,18 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         data-ws-component="RadioGroup"
         value={radioGroupValue}
         onValueChange={onValueChange}
-        className="c6gk6ar c13wsd00 cgt00fz cydvc77"
+        className="c11xgi9i cfd715b c8prkzu c1edvzo4"
       >
         <Label
           data-ws-id="6"
           data-ws-component="Label"
-          className="c6gk6ar c4v7k5r cgt00fz cydvc77"
+          className="c11xgi9i clo3r8o c8prkzu c1edvzo4"
         >
           <RadioGroupItem
             data-ws-id="8"
             data-ws-component="RadioGroupItem"
             value={"default"}
-            className="c1rc9sce c18dp5gp clw3og8 c17f8p6x c15ce0qo c1yisi8r cpvsov c1inucbi c1dab7w1 c1uf7v01 czynn8e cuelx18 c17v08sn c1czmfdb c8nta89 cgassre c1ndsw6v cjrlou9 c945vvj c132tyaz c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l cegrmbm c1grhw0w"
+            className="c1t3sijk c1pmpq0f c1yafs04 c1o2cngd c1riwd65 ci2hmcl c1byz2lk c17al2u0 c1ufcra4 c17gos5d cn4f13s c9mvxkx cu0p3ww c11i8aye ca1f4zs ck2qarh c1nxbatd caktpzb c1bm526f c3i5k81 co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1oa7gr0 ce92j53"
           >
             <RadioGroupIndicator
               data-ws-id="11"
@@ -59,13 +58,13 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         <Label
           data-ws-id="15"
           data-ws-component="Label"
-          className="c6gk6ar c4v7k5r cgt00fz cydvc77"
+          className="c11xgi9i clo3r8o c8prkzu c1edvzo4"
         >
           <RadioGroupItem
             data-ws-id="17"
             data-ws-component="RadioGroupItem"
             value={"comfortable"}
-            className="c1rc9sce c18dp5gp clw3og8 c17f8p6x c15ce0qo c1yisi8r cpvsov c1inucbi c1dab7w1 c1uf7v01 czynn8e cuelx18 c17v08sn c1czmfdb c8nta89 cgassre c1ndsw6v cjrlou9 c945vvj c132tyaz c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l cegrmbm c1grhw0w"
+            className="c1t3sijk c1pmpq0f c1yafs04 c1o2cngd c1riwd65 ci2hmcl c1byz2lk c17al2u0 c1ufcra4 c17gos5d cn4f13s c9mvxkx cu0p3ww c11i8aye ca1f4zs ck2qarh c1nxbatd caktpzb c1bm526f c3i5k81 co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1oa7gr0 ce92j53"
           >
             <RadioGroupIndicator
               data-ws-id="20"
@@ -87,13 +86,13 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         <Label
           data-ws-id="24"
           data-ws-component="Label"
-          className="c6gk6ar c4v7k5r cgt00fz cydvc77"
+          className="c11xgi9i clo3r8o c8prkzu c1edvzo4"
         >
           <RadioGroupItem
             data-ws-id="26"
             data-ws-component="RadioGroupItem"
             value={"compact"}
-            className="c1rc9sce c18dp5gp clw3og8 c17f8p6x c15ce0qo c1yisi8r cpvsov c1inucbi c1dab7w1 c1uf7v01 czynn8e cuelx18 c17v08sn c1czmfdb c8nta89 cgassre c1ndsw6v cjrlou9 c945vvj c132tyaz c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l cegrmbm c1grhw0w"
+            className="c1t3sijk c1pmpq0f c1yafs04 c1o2cngd c1riwd65 ci2hmcl c1byz2lk c17al2u0 c1ufcra4 c17gos5d cn4f13s c9mvxkx cu0p3ww c11i8aye ca1f4zs ck2qarh c1nxbatd caktpzb c1bm526f c3i5k81 co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1oa7gr0 ce92j53"
           >
             <RadioGroupIndicator
               data-ws-id="29"
@@ -288,292 +287,106 @@ html {margin: 0; display: grid; min-height: 100%}
     min-height: 1em
   }
 }@media all {
-  .c6gk6ar {
+  .c11xgi9i {
     display: flex
   }
-  .c13wsd00 {
+  .cfd715b {
     flex-direction: column
   }
-  .cgt00fz {
+  .c8prkzu {
     row-gap: 0.5rem
   }
-  .cydvc77 {
+  .c1edvzo4 {
     column-gap: 0.5rem
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .cgt00fz {
-    row-gap: 0.5rem
-  }
-  .cydvc77 {
-    column-gap: 0.5rem
-  }
-  .c1rc9sce {
+  .c1t3sijk {
     aspect-ratio: 1 / 1
   }
-  .c18dp5gp {
+  .c1pmpq0f {
     height: 1rem
   }
-  .clw3og8 {
+  .c1yafs04 {
     width: 1rem
   }
-  .c17f8p6x {
+  .c1o2cngd {
     border-top-left-radius: 9999px
   }
-  .c15ce0qo {
+  .c1riwd65 {
     border-top-right-radius: 9999px
   }
-  .c1yisi8r {
+  .ci2hmcl {
     border-bottom-right-radius: 9999px
   }
-  .cpvsov {
+  .c1byz2lk {
     border-bottom-left-radius: 9999px
   }
-  .c1inucbi {
+  .c17al2u0 {
     border-top-style: solid
   }
-  .c1dab7w1 {
+  .c1ufcra4 {
     border-right-style: solid
   }
-  .c1uf7v01 {
+  .c17gos5d {
     border-bottom-style: solid
   }
-  .czynn8e {
+  .cn4f13s {
     border-left-style: solid
   }
-  .cuelx18 {
+  .c9mvxkx {
     border-top-color: rgba(15, 23, 42, 1)
   }
-  .c17v08sn {
+  .cu0p3ww {
     border-right-color: rgba(15, 23, 42, 1)
   }
-  .c1czmfdb {
+  .c11i8aye {
     border-bottom-color: rgba(15, 23, 42, 1)
   }
-  .c8nta89 {
+  .ca1f4zs {
     border-left-color: rgba(15, 23, 42, 1)
   }
-  .cgassre {
+  .ck2qarh {
     border-top-width: 1px
   }
-  .c1ndsw6v {
+  .c1nxbatd {
     border-right-width: 1px
   }
-  .cjrlou9 {
+  .caktpzb {
     border-bottom-width: 1px
   }
-  .c945vvj {
+  .c1bm526f {
     border-left-width: 1px
   }
-  .c132tyaz {
+  .c3i5k81 {
     color: rgba(15, 23, 42, 1)
   }
-  .c1t6bql4:focus-visible {
+  .co0lfwl:focus-visible {
     outline-width: 2px
   }
-  .czph7hf:focus-visible {
+  .c1kn3u98:focus-visible {
     outline-style: solid
   }
-  .cncn1ro:focus-visible {
+  .c2odgnt:focus-visible {
     outline-color: transparent
   }
-  .cb270vo:focus-visible {
+  .chlvjga:focus-visible {
     outline-offset: 2px
   }
-  .c1rgsd1l:focus-visible {
+  .c1jx7vpr:focus-visible {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  .cegrmbm:disabled {
+  .c1oa7gr0:disabled {
     cursor: not-allowed
   }
-  .c1grhw0w:disabled {
-    opacity: 0.5
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cgt00fz {
-    row-gap: 0.5rem
-  }
-  .cydvc77 {
-    column-gap: 0.5rem
-  }
-  .c1rc9sce {
-    aspect-ratio: 1 / 1
-  }
-  .c18dp5gp {
-    height: 1rem
-  }
-  .clw3og8 {
-    width: 1rem
-  }
-  .c17f8p6x {
-    border-top-left-radius: 9999px
-  }
-  .c15ce0qo {
-    border-top-right-radius: 9999px
-  }
-  .c1yisi8r {
-    border-bottom-right-radius: 9999px
-  }
-  .cpvsov {
-    border-bottom-left-radius: 9999px
-  }
-  .c1inucbi {
-    border-top-style: solid
-  }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .cuelx18 {
-    border-top-color: rgba(15, 23, 42, 1)
-  }
-  .c17v08sn {
-    border-right-color: rgba(15, 23, 42, 1)
-  }
-  .c1czmfdb {
-    border-bottom-color: rgba(15, 23, 42, 1)
-  }
-  .c8nta89 {
-    border-left-color: rgba(15, 23, 42, 1)
-  }
-  .cgassre {
-    border-top-width: 1px
-  }
-  .c1ndsw6v {
-    border-right-width: 1px
-  }
-  .cjrlou9 {
-    border-bottom-width: 1px
-  }
-  .c945vvj {
-    border-left-width: 1px
-  }
-  .c132tyaz {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1t6bql4:focus-visible {
-    outline-width: 2px
-  }
-  .czph7hf:focus-visible {
-    outline-style: solid
-  }
-  .cncn1ro:focus-visible {
-    outline-color: transparent
-  }
-  .cb270vo:focus-visible {
-    outline-offset: 2px
-  }
-  .c1rgsd1l:focus-visible {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
-  }
-  .cegrmbm:disabled {
-    cursor: not-allowed
-  }
-  .c1grhw0w:disabled {
-    opacity: 0.5
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cgt00fz {
-    row-gap: 0.5rem
-  }
-  .cydvc77 {
-    column-gap: 0.5rem
-  }
-  .c1rc9sce {
-    aspect-ratio: 1 / 1
-  }
-  .c18dp5gp {
-    height: 1rem
-  }
-  .clw3og8 {
-    width: 1rem
-  }
-  .c17f8p6x {
-    border-top-left-radius: 9999px
-  }
-  .c15ce0qo {
-    border-top-right-radius: 9999px
-  }
-  .c1yisi8r {
-    border-bottom-right-radius: 9999px
-  }
-  .cpvsov {
-    border-bottom-left-radius: 9999px
-  }
-  .c1inucbi {
-    border-top-style: solid
-  }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .cuelx18 {
-    border-top-color: rgba(15, 23, 42, 1)
-  }
-  .c17v08sn {
-    border-right-color: rgba(15, 23, 42, 1)
-  }
-  .c1czmfdb {
-    border-bottom-color: rgba(15, 23, 42, 1)
-  }
-  .c8nta89 {
-    border-left-color: rgba(15, 23, 42, 1)
-  }
-  .cgassre {
-    border-top-width: 1px
-  }
-  .c1ndsw6v {
-    border-right-width: 1px
-  }
-  .cjrlou9 {
-    border-bottom-width: 1px
-  }
-  .c945vvj {
-    border-left-width: 1px
-  }
-  .c132tyaz {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c1t6bql4:focus-visible {
-    outline-width: 2px
-  }
-  .czph7hf:focus-visible {
-    outline-style: solid
-  }
-  .cncn1ro:focus-visible {
-    outline-color: transparent
-  }
-  .cb270vo:focus-visible {
-    outline-offset: 2px
-  }
-  .c1rgsd1l:focus-visible {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
-  }
-  .cegrmbm:disabled {
-    cursor: not-allowed
-  }
-  .c1grhw0w:disabled {
+  .ce92j53:disabled {
     opacity: 0.5
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
@@ -15,8 +15,7 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [selectValue, set$selectValue] = useState<any>("");
   let [selectOpen, set$selectOpen] = useState<any>(false);
   let onValueChange = (value: any) => {
@@ -40,7 +39,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         <SelectTrigger
           data-ws-id="8"
           data-ws-component="SelectTrigger"
-          className="c6gk6ar c1b8xvex c1i2mn37 c4v7k5r csg71e3 cym38jd cqimob0 c2tr68t cjdtj3f c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l cgassre c1ndsw6v cjrlou9 c945vvj c15mffxy c1kc4g4w c1hi2fgx c1peybss chh2z1n c1mfk609 c121vm9z c13c0q0m c3jm2m1 c1tqca1w chqc64d cjfm7wi c175y1wr cegrmbm c1grhw0w"
+          className="c11xgi9i c18kkil c3elmho clo3r8o cqq29ax cuqxbts cg19ih8 c1479lj6 comq4ym c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 ck2qarh c1nxbatd caktpzb c1bm526f c110hgy6 c16g5416 c111au61 cey1d5i cbnv1sn c1qx3pju cut8gip cllerde c19s8l4l cvjgjoo cjdxik5 c1uf353 c192vyv4 c1oa7gr0 ce92j53"
         >
           <SelectValue
             data-ws-id="10"
@@ -51,23 +50,23 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         <SelectContent
           data-ws-id="12"
           data-ws-component="SelectContent"
-          className="cnhoj7b c1wyidsg c82b0cd c1e2gixt cym38jd cqimob0 c2tr68t cjdtj3f c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l cgassre c1ndsw6v cjrlou9 c945vvj c4mw8gp cj0w9yo ci3o5ma"
+          className="crmoyyg c173yyao c1ca5jk5 c1p3lwwv cuqxbts cg19ih8 c1479lj6 comq4ym c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 ck2qarh c1nxbatd caktpzb c1bm526f c1rt44f4 cwi0ez9 cpbhzvr"
         >
           <SelectViewport
             data-ws-id="14"
             data-ws-component="SelectViewport"
-            className="ckc6u2x cue5i4p c1wiz3di c1364qo7 cu1cnl4 c1i2mn37 c1lciyms"
+            className="c1tn9z53 c164ur30 c1ukzx8x c1wau4tj c1vx0yks c3elmho cav9kfy"
           >
             <SelectItem
               data-ws-id="16"
               data-ws-component="SelectItem"
               value={"light"}
-              className="cnhoj7b c6gk6ar c1i2mn37 ch0kuv9 c1hl4mbg c4v7k5r cym38jd cqimob0 c2tr68t cjdtj3f cs5tzic cl10cx8 c11bwakb c18gyxfs c1mfk609 c121vm9z c601nqx c9i3lxo c1sz664l cm8bc7h cbt1ziu c1ci4uzu c144pucd c4g4hty"
+              className="crmoyyg c11xgi9i c3elmho c17sljc0 cekw1i5 clo3r8o cuqxbts cg19ih8 c1479lj6 comq4ym ck4c8na c1mbhour c1dqbquh c1qmwsx9 c1qx3pju cut8gip cxlxl0c c1gfzcg5 cohan28 c15roejc c11eeprv c1rbq5ju cechooj c7yue4i"
             >
               <SelectItemIndicator
                 data-ws-id="19"
                 data-ws-component="SelectItemIndicator"
-                className="c1kb88y7 col5989 c6gk6ar cw8nk89 c192xk4i c4v7k5r cvzkkb6"
+                className="ct2k8wg cf4i3oe c11xgi9i c3jw7et c1kurney clo3r8o cw9oyzl"
               >
                 <HtmlEmbed
                   data-ws-id="21"
@@ -88,12 +87,12 @@ const Page = (_props: { params: Params; resources: Resources }) => {
               data-ws-id="24"
               data-ws-component="SelectItem"
               value={"dark"}
-              className="cnhoj7b c6gk6ar c1i2mn37 ch0kuv9 c1hl4mbg c4v7k5r cym38jd cqimob0 c2tr68t cjdtj3f cs5tzic cl10cx8 c11bwakb c18gyxfs c1mfk609 c121vm9z c601nqx c9i3lxo c1sz664l cm8bc7h cbt1ziu c1ci4uzu c144pucd c4g4hty"
+              className="crmoyyg c11xgi9i c3elmho c17sljc0 cekw1i5 clo3r8o cuqxbts cg19ih8 c1479lj6 comq4ym ck4c8na c1mbhour c1dqbquh c1qmwsx9 c1qx3pju cut8gip cxlxl0c c1gfzcg5 cohan28 c15roejc c11eeprv c1rbq5ju cechooj c7yue4i"
             >
               <SelectItemIndicator
                 data-ws-id="27"
                 data-ws-component="SelectItemIndicator"
-                className="c1kb88y7 col5989 c6gk6ar cw8nk89 c192xk4i c4v7k5r cvzkkb6"
+                className="ct2k8wg cf4i3oe c11xgi9i c3jw7et c1kurney clo3r8o cw9oyzl"
               >
                 <HtmlEmbed
                   data-ws-id="29"
@@ -114,12 +113,12 @@ const Page = (_props: { params: Params; resources: Resources }) => {
               data-ws-id="32"
               data-ws-component="SelectItem"
               value={"system"}
-              className="cnhoj7b c6gk6ar c1i2mn37 ch0kuv9 c1hl4mbg c4v7k5r cym38jd cqimob0 c2tr68t cjdtj3f cs5tzic cl10cx8 c11bwakb c18gyxfs c1mfk609 c121vm9z c601nqx c9i3lxo c1sz664l cm8bc7h cbt1ziu c1ci4uzu c144pucd c4g4hty"
+              className="crmoyyg c11xgi9i c3elmho c17sljc0 cekw1i5 clo3r8o cuqxbts cg19ih8 c1479lj6 comq4ym ck4c8na c1mbhour c1dqbquh c1qmwsx9 c1qx3pju cut8gip cxlxl0c c1gfzcg5 cohan28 c15roejc c11eeprv c1rbq5ju cechooj c7yue4i"
             >
               <SelectItemIndicator
                 data-ws-id="35"
                 data-ws-component="SelectItemIndicator"
-                className="c1kb88y7 col5989 c6gk6ar cw8nk89 c192xk4i c4v7k5r cvzkkb6"
+                className="ct2k8wg cf4i3oe c11xgi9i c3jw7et c1kurney clo3r8o cw9oyzl"
               >
                 <HtmlEmbed
                   data-ws-id="37"
@@ -315,469 +314,214 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-width: 1px
   }
 }@media all {
-  .c6gk6ar {
+  .c11xgi9i {
     display: flex
   }
-  .c1b8xvex {
+  .c18kkil {
     height: 2.5rem
   }
-  .c1i2mn37 {
+  .c3elmho {
     width: 100%
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .csg71e3 {
+  .cqq29ax {
     justify-content: space-between
   }
-  .cym38jd {
+  .cuqxbts {
     border-top-left-radius: 0.375rem
   }
-  .cqimob0 {
+  .cg19ih8 {
     border-top-right-radius: 0.375rem
   }
-  .c2tr68t {
+  .c1479lj6 {
     border-bottom-right-radius: 0.375rem
   }
-  .cjdtj3f {
+  .comq4ym {
     border-bottom-left-radius: 0.375rem
   }
-  .c1inucbi {
+  .c17al2u0 {
     border-top-style: solid
   }
-  .c1dab7w1 {
+  .c1ufcra4 {
     border-right-style: solid
   }
-  .c1uf7v01 {
+  .c17gos5d {
     border-bottom-style: solid
   }
-  .czynn8e {
+  .cn4f13s {
     border-left-style: solid
   }
-  .c6z96ps {
+  .c1wic2il {
     border-top-color: rgba(226, 232, 240, 1)
   }
-  .c9t5qyz {
+  .cdem58j {
     border-right-color: rgba(226, 232, 240, 1)
   }
-  .c1x5uwe6 {
+  .c102tttv {
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  .csnt51l {
+  .cb204z1 {
     border-left-color: rgba(226, 232, 240, 1)
   }
-  .cgassre {
+  .ck2qarh {
     border-top-width: 1px
   }
-  .c1ndsw6v {
+  .c1nxbatd {
     border-right-width: 1px
   }
-  .cjrlou9 {
+  .caktpzb {
     border-bottom-width: 1px
   }
-  .c945vvj {
+  .c1bm526f {
     border-left-width: 1px
   }
-  .c15mffxy {
+  .c110hgy6 {
     background-color: rgba(255, 255, 255, 0.8)
   }
-  .c1kc4g4w {
+  .c16g5416 {
     padding-left: 0.75rem
   }
-  .c1hi2fgx {
+  .c111au61 {
     padding-right: 0.75rem
   }
-  .c1peybss {
+  .cey1d5i {
     padding-top: 0.5rem
   }
-  .chh2z1n {
+  .cbnv1sn {
     padding-bottom: 0.5rem
   }
-  .c1mfk609 {
+  .c1qx3pju {
     font-size: 0.875rem
   }
-  .c121vm9z {
+  .cut8gip {
     line-height: 1.25rem
   }
-  .c13c0q0m::placeholder {
+  .cllerde::placeholder {
     color: rgba(100, 116, 139, 1)
   }
-  .c3jm2m1:focus {
+  .c19s8l4l:focus {
     outline-width: 2px
   }
-  .c1tqca1w:focus {
+  .cvjgjoo:focus {
     outline-style: solid
   }
-  .chqc64d:focus {
+  .cjdxik5:focus {
     outline-color: transparent
   }
-  .cjfm7wi:focus {
+  .c1uf353:focus {
     outline-offset: 2px
   }
-  .c175y1wr:focus {
+  .c192vyv4:focus {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  .cegrmbm:disabled {
+  .c1oa7gr0:disabled {
     cursor: not-allowed
   }
-  .c1grhw0w:disabled {
+  .ce92j53:disabled {
     opacity: 0.5
   }
-  .cnhoj7b {
+  .crmoyyg {
     position: relative
   }
-  .c1wyidsg {
+  .c173yyao {
     z-index: 50
   }
-  .c82b0cd {
+  .c1ca5jk5 {
     min-width: 8rem
   }
-  .c1e2gixt {
+  .c1p3lwwv {
     overflow: hidden
   }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1inucbi {
-    border-top-style: solid
-  }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .c6z96ps {
-    border-top-color: rgba(226, 232, 240, 1)
-  }
-  .c9t5qyz {
-    border-right-color: rgba(226, 232, 240, 1)
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .csnt51l {
-    border-left-color: rgba(226, 232, 240, 1)
-  }
-  .cgassre {
-    border-top-width: 1px
-  }
-  .c1ndsw6v {
-    border-right-width: 1px
-  }
-  .cjrlou9 {
-    border-bottom-width: 1px
-  }
-  .c945vvj {
-    border-left-width: 1px
-  }
-  .c4mw8gp {
+  .c1rt44f4 {
     background-color: rgba(255, 255, 255, 1)
   }
-  .cj0w9yo {
+  .cwi0ez9 {
     color: rgba(2, 8, 23, 1)
   }
-  .ci3o5ma {
+  .cpbhzvr {
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)
   }
-  .ckc6u2x {
+  .c1tn9z53 {
     padding-left: 0.25rem
   }
-  .cue5i4p {
+  .c164ur30 {
     padding-right: 0.25rem
   }
-  .c1wiz3di {
+  .c1ukzx8x {
     padding-top: 0.25rem
   }
-  .c1364qo7 {
+  .c1wau4tj {
     padding-bottom: 0.25rem
   }
-  .cu1cnl4 {
+  .c1vx0yks {
     height: var(--radix-select-trigger-height)
   }
-  .c1i2mn37 {
-    width: 100%
-  }
-  .c1lciyms {
+  .cav9kfy {
     min-width: var(--radix-select-trigger-width)
   }
-  .cnhoj7b {
-    position: relative
-  }
-  .c1i2mn37 {
-    width: 100%
-  }
-  .ch0kuv9 {
+  .c17sljc0 {
     cursor: default
   }
-  .c1hl4mbg {
+  .cekw1i5 {
     user-select: none
   }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .cs5tzic {
+  .ck4c8na {
     padding-top: 0.375rem
   }
-  .cl10cx8 {
+  .c1mbhour {
     padding-bottom: 0.375rem
   }
-  .c11bwakb {
+  .c1dqbquh {
     padding-left: 2rem
   }
-  .c18gyxfs {
+  .c1qmwsx9 {
     padding-right: 0.5rem
   }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c121vm9z {
-    line-height: 1.25rem
-  }
-  .c601nqx {
+  .cxlxl0c {
     outline-width: 2px
   }
-  .c9i3lxo {
+  .c1gfzcg5 {
     outline-style: solid
   }
-  .c1sz664l {
+  .cohan28 {
     outline-color: transparent
   }
-  .cm8bc7h {
+  .c15roejc {
     outline-offset: 2px
   }
-  .cbt1ziu:focus {
+  .c11eeprv:focus {
     background-color: rgba(241, 245, 249, 0.9)
   }
-  .c1ci4uzu:focus {
+  .c1rbq5ju:focus {
     color: rgba(15, 23, 42, 1)
   }
-  .c144pucd[data-disabled] {
+  .cechooj[data-disabled] {
     pointer-events: none
   }
-  .c4g4hty[data-disabled] {
+  .c7yue4i[data-disabled] {
     opacity: 0.5
   }
-  .c1kb88y7 {
+  .ct2k8wg {
     position: absolute
   }
-  .col5989 {
+  .cf4i3oe {
     left: 0.5rem
   }
-  .cw8nk89 {
+  .c3jw7et {
     height: 0.875rem
   }
-  .c192xk4i {
+  .c1kurney {
     width: 0.875rem
   }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cvzkkb6 {
-    justify-content: center
-  }
-  .cnhoj7b {
-    position: relative
-  }
-  .c1i2mn37 {
-    width: 100%
-  }
-  .ch0kuv9 {
-    cursor: default
-  }
-  .c1hl4mbg {
-    user-select: none
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .cs5tzic {
-    padding-top: 0.375rem
-  }
-  .cl10cx8 {
-    padding-bottom: 0.375rem
-  }
-  .c11bwakb {
-    padding-left: 2rem
-  }
-  .c18gyxfs {
-    padding-right: 0.5rem
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c121vm9z {
-    line-height: 1.25rem
-  }
-  .c601nqx {
-    outline-width: 2px
-  }
-  .c9i3lxo {
-    outline-style: solid
-  }
-  .c1sz664l {
-    outline-color: transparent
-  }
-  .cm8bc7h {
-    outline-offset: 2px
-  }
-  .cbt1ziu:focus {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .c1ci4uzu:focus {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c144pucd[data-disabled] {
-    pointer-events: none
-  }
-  .c4g4hty[data-disabled] {
-    opacity: 0.5
-  }
-  .c1kb88y7 {
-    position: absolute
-  }
-  .col5989 {
-    left: 0.5rem
-  }
-  .cw8nk89 {
-    height: 0.875rem
-  }
-  .c192xk4i {
-    width: 0.875rem
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cvzkkb6 {
-    justify-content: center
-  }
-  .cnhoj7b {
-    position: relative
-  }
-  .c1i2mn37 {
-    width: 100%
-  }
-  .ch0kuv9 {
-    cursor: default
-  }
-  .c1hl4mbg {
-    user-select: none
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .cs5tzic {
-    padding-top: 0.375rem
-  }
-  .cl10cx8 {
-    padding-bottom: 0.375rem
-  }
-  .c11bwakb {
-    padding-left: 2rem
-  }
-  .c18gyxfs {
-    padding-right: 0.5rem
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c121vm9z {
-    line-height: 1.25rem
-  }
-  .c601nqx {
-    outline-width: 2px
-  }
-  .c9i3lxo {
-    outline-style: solid
-  }
-  .c1sz664l {
-    outline-color: transparent
-  }
-  .cm8bc7h {
-    outline-offset: 2px
-  }
-  .cbt1ziu:focus {
-    background-color: rgba(241, 245, 249, 0.9)
-  }
-  .c1ci4uzu:focus {
-    color: rgba(15, 23, 42, 1)
-  }
-  .c144pucd[data-disabled] {
-    pointer-events: none
-  }
-  .c4g4hty[data-disabled] {
-    opacity: 0.5
-  }
-  .c1kb88y7 {
-    position: absolute
-  }
-  .col5989 {
-    left: 0.5rem
-  }
-  .cw8nk89 {
-    height: 0.875rem
-  }
-  .c192xk4i {
-    width: 0.875rem
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cvzkkb6 {
+  .cw9oyzl {
     justify-content: center
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
@@ -16,8 +16,7 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [sheetOpen, set$sheetOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     sheetOpen = open;
@@ -35,7 +34,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           <Button
             data-ws-id="6"
             data-ws-component="Button"
-            className="c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l c1v4k4ip c2iozhh c1j5pqo1 cmqevnc cvxnx00 c1mnuzt9 c4v7k5r cvzkkb6 cym38jd cqimob0 c2tr68t cjdtj3f c1mfk609 c121vm9z cwry1sa c1b8xvex c347ys1 c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l c1srwcmr c1grhw0w c8xqq0k cjs8iie"
+            className="c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 cok6gp c1ebb32d c1ed2n1f c1an30v3 ca60kt0 c1oai8p0 clo3r8o cw9oyzl cuqxbts cg19ih8 c1479lj6 comq4ym c1qx3pju cut8gip c1qjvju3 c18kkil cq7yq91 co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1jirpm3 ce92j53 c1dr421o c14ytp9r"
           >
             <HtmlEmbed
               data-ws-id="8"
@@ -49,12 +48,12 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         <DialogOverlay
           data-ws-id="10"
           data-ws-component="DialogOverlay"
-          className="c1g0ebn8 c17k6ftv co2vb1i ci9y33x ckl9uqx c1wyidsg c15mffxy c1c159w3 c6gk6ar c13wsd00 c19jsld4"
+          className="c15h1j27 cboqcgi cs5y8q6 ccq2s6t c3iotp8 c173yyao c110hgy6 c1x0vq2l c11xgi9i cfd715b c1arpcws"
         >
           <DialogContent
             data-ws-id="12"
             data-ws-component="DialogContent"
-            className="c1i2mn37 c1wyidsg c6gk6ar c13wsd00 cb99ak4 ctl64vj c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l cgassre c1ndsw6v cjrlou9 c945vvj c15mffxy cm3zvb4 c174435h c1xpn2dk c3vgloq cbzcu1y cnhoj7b c1rj6y8a cgfujm0 cn4ngym"
+            className="c3elmho c173yyao c11xgi9i cfd715b ci4ea85 c13l7myj c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 ck2qarh c1nxbatd caktpzb c1bm526f c110hgy6 c1d23hgf cdv5i03 cog45sw c18egw0s c1ii9nza crmoyyg cmty91p c1t1rwz c1yubncr"
           >
             <Box
               data-ws-id="14"
@@ -65,19 +64,19 @@ const Page = (_props: { params: Params; resources: Resources }) => {
               <Box
                 data-ws-id="17"
                 data-ws-component="Box"
-                className="c6gk6ar c13wsd00 cu0fd6l c8098d3"
+                className="c11xgi9i cfd715b csjyi15 c1xv9rff"
               >
                 <DialogTitle
                   data-ws-id="19"
                   data-ws-component="DialogTitle"
-                  className="c1u5xdcd cdf5ze5 c1ma6tz6 c1kjryeq cs0zr08"
+                  className="cvrokas crk8tjo cx5cc56 c1o7k99s cck9swn"
                 >
                   {"Sheet Title"}
                 </DialogTitle>
                 <DialogDescription
                   data-ws-id="21"
                   data-ws-component="DialogDescription"
-                  className="c1u5xdcd cdf5ze5 c1mfk609 c121vm9z caa8yt3"
+                  className="cvrokas crk8tjo c1qx3pju cut8gip c1pcz91e"
                 >
                   {"Sheet description text you can edit"}
                 </DialogDescription>
@@ -89,7 +88,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
             <DialogClose
               data-ws-id="24"
               data-ws-component="DialogClose"
-              className="c1kb88y7 caboyml c1y1em6x c1d9pxa5 cnjyf56 c1jpjw0a c1lxvq7u c1jcn3uk c6gk6ar c4v7k5r cvzkkb6 c18dp5gp clw3og8 c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l c1v4k4ip c2iozhh c1j5pqo1 cmqevnc cvxnx00 c601nqx c9i3lxo c1sz664l cm8bc7h c1m9udid c175y1wr"
+              className="ct2k8wg c1us255 c1hk37yi c12e8ong c13c161l chzvexg c1s51a6q c1qx8273 c11xgi9i clo3r8o cw9oyzl c1pmpq0f c1yafs04 c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 cok6gp c1ebb32d c1ed2n1f c1an30v3 ca60kt0 cxlxl0c c1gfzcg5 cohan28 c15roejc c1xy5yrr c192vyv4"
             >
               <HtmlEmbed
                 data-ws-id="26"
@@ -300,361 +299,265 @@ html {margin: 0; display: grid; min-height: 100%}
     text-transform: none
   }
 }@media all {
-  .c1inucbi {
+  .c17al2u0 {
     border-top-style: solid
   }
-  .c1dab7w1 {
+  .c1ufcra4 {
     border-right-style: solid
   }
-  .c1uf7v01 {
+  .c17gos5d {
     border-bottom-style: solid
   }
-  .czynn8e {
+  .cn4f13s {
     border-left-style: solid
   }
-  .c6z96ps {
+  .c1wic2il {
     border-top-color: rgba(226, 232, 240, 1)
   }
-  .c9t5qyz {
+  .cdem58j {
     border-right-color: rgba(226, 232, 240, 1)
   }
-  .c1x5uwe6 {
+  .c102tttv {
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  .csnt51l {
+  .cb204z1 {
     border-left-color: rgba(226, 232, 240, 1)
   }
-  .c1v4k4ip {
+  .cok6gp {
     border-top-width: 0px
   }
-  .c2iozhh {
+  .c1ebb32d {
     border-right-width: 0px
   }
-  .c1j5pqo1 {
+  .c1ed2n1f {
     border-bottom-width: 0px
   }
-  .cmqevnc {
+  .c1an30v3 {
     border-left-width: 0px
   }
-  .cvxnx00 {
+  .ca60kt0 {
     background-color: transparent
   }
-  .c1mnuzt9 {
+  .c1oai8p0 {
     display: inline-flex
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .cvzkkb6 {
+  .cw9oyzl {
     justify-content: center
   }
-  .cym38jd {
+  .cuqxbts {
     border-top-left-radius: 0.375rem
   }
-  .cqimob0 {
+  .cg19ih8 {
     border-top-right-radius: 0.375rem
   }
-  .c2tr68t {
+  .c1479lj6 {
     border-bottom-right-radius: 0.375rem
   }
-  .cjdtj3f {
+  .comq4ym {
     border-bottom-left-radius: 0.375rem
   }
-  .c1mfk609 {
+  .c1qx3pju {
     font-size: 0.875rem
   }
-  .c121vm9z {
+  .cut8gip {
     line-height: 1.25rem
   }
-  .cwry1sa {
+  .c1qjvju3 {
     font-weight: 500
   }
-  .c1b8xvex {
+  .c18kkil {
     height: 2.5rem
   }
-  .c347ys1 {
+  .cq7yq91 {
     width: 2.5rem
   }
-  .c1t6bql4:focus-visible {
+  .co0lfwl:focus-visible {
     outline-width: 2px
   }
-  .czph7hf:focus-visible {
+  .c1kn3u98:focus-visible {
     outline-style: solid
   }
-  .cncn1ro:focus-visible {
+  .c2odgnt:focus-visible {
     outline-color: transparent
   }
-  .cb270vo:focus-visible {
+  .chlvjga:focus-visible {
     outline-offset: 2px
   }
-  .c1rgsd1l:focus-visible {
+  .c1jx7vpr:focus-visible {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  .c1srwcmr:disabled {
+  .c1jirpm3:disabled {
     pointer-events: none
   }
-  .c1grhw0w:disabled {
+  .ce92j53:disabled {
     opacity: 0.5
   }
-  .c8xqq0k:hover {
+  .c1dr421o:hover {
     background-color: rgba(241, 245, 249, 0.9)
   }
-  .cjs8iie:hover {
+  .c14ytp9r:hover {
     color: rgba(15, 23, 42, 1)
   }
-  .c1g0ebn8 {
+  .c15h1j27 {
     position: fixed
   }
-  .c17k6ftv {
+  .cboqcgi {
     left: 0px
   }
-  .co2vb1i {
+  .cs5y8q6 {
     right: 0px
   }
-  .ci9y33x {
+  .ccq2s6t {
     top: 0px
   }
-  .ckl9uqx {
+  .c3iotp8 {
     bottom: 0px
   }
-  .c1wyidsg {
+  .c173yyao {
     z-index: 50
   }
-  .c15mffxy {
+  .c110hgy6 {
     background-color: rgba(255, 255, 255, 0.8)
   }
-  .c1c159w3 {
+  .c1x0vq2l {
     backdrop-filter: blur(0 1px 2px 0 rgb(0 0 0 / 0.05))
   }
-  .c6gk6ar {
+  .c11xgi9i {
     display: flex
   }
-  .c13wsd00 {
+  .cfd715b {
     flex-direction: column
   }
-  .c19jsld4 {
+  .c1arpcws {
     overflow: auto
   }
-  .c1i2mn37 {
+  .c3elmho {
     width: 100%
   }
-  .c1wyidsg {
-    z-index: 50
-  }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .cb99ak4 {
+  .ci4ea85 {
     row-gap: 1rem
   }
-  .ctl64vj {
+  .c13l7myj {
     column-gap: 1rem
   }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .c6z96ps {
-    border-top-color: rgba(226, 232, 240, 1)
-  }
-  .c9t5qyz {
-    border-right-color: rgba(226, 232, 240, 1)
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .csnt51l {
-    border-left-color: rgba(226, 232, 240, 1)
-  }
-  .cgassre {
+  .ck2qarh {
     border-top-width: 1px
   }
-  .c1ndsw6v {
+  .c1nxbatd {
     border-right-width: 1px
   }
-  .cjrlou9 {
+  .caktpzb {
     border-bottom-width: 1px
   }
-  .c945vvj {
+  .c1bm526f {
     border-left-width: 1px
   }
-  .c15mffxy {
-    background-color: rgba(255, 255, 255, 0.8)
-  }
-  .cm3zvb4 {
+  .c1d23hgf {
     padding-left: 1.5rem
   }
-  .c174435h {
+  .cdv5i03 {
     padding-right: 1.5rem
   }
-  .c1xpn2dk {
+  .cog45sw {
     padding-top: 1.5rem
   }
-  .c3vgloq {
+  .c18egw0s {
     padding-bottom: 1.5rem
   }
-  .cbzcu1y {
+  .c1ii9nza {
     box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)
   }
-  .cnhoj7b {
+  .crmoyyg {
     position: relative
   }
-  .c1rj6y8a {
+  .cmty91p {
     margin-right: auto
   }
-  .cgfujm0 {
+  .c1t1rwz {
     max-width: 24rem
   }
-  .cn4ngym {
+  .c1yubncr {
     flex-grow: 1
   }
-  .c6gk6ar {
-    display: flex
-  }
-  .c13wsd00 {
-    flex-direction: column
-  }
-  .cu0fd6l {
+  .csjyi15 {
     row-gap: 0.25rem
   }
-  .c8098d3 {
+  .c1xv9rff {
     column-gap: 0.25rem
   }
-  .c1u5xdcd {
+  .cvrokas {
     margin-top: 0px
   }
-  .cdf5ze5 {
+  .crk8tjo {
     margin-bottom: 0px
   }
-  .c1ma6tz6 {
+  .cx5cc56 {
     line-height: 1.75rem
   }
-  .c1kjryeq {
+  .c1o7k99s {
     font-size: 1.125rem
   }
-  .cs0zr08 {
+  .cck9swn {
     letter-spacing: -0.025em
   }
-  .c1u5xdcd {
-    margin-top: 0px
-  }
-  .cdf5ze5 {
-    margin-bottom: 0px
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c121vm9z {
-    line-height: 1.25rem
-  }
-  .caa8yt3 {
+  .c1pcz91e {
     color: rgba(100, 116, 139, 1)
   }
-  .c1kb88y7 {
+  .ct2k8wg {
     position: absolute
   }
-  .caboyml {
+  .c1us255 {
     right: 1rem
   }
-  .c1y1em6x {
+  .c1hk37yi {
     top: 1rem
   }
-  .c1d9pxa5 {
+  .c12e8ong {
     border-top-left-radius: 0.125rem
   }
-  .cnjyf56 {
+  .c13c161l {
     border-top-right-radius: 0.125rem
   }
-  .c1jpjw0a {
+  .chzvexg {
     border-bottom-right-radius: 0.125rem
   }
-  .c1lxvq7u {
+  .c1s51a6q {
     border-bottom-left-radius: 0.125rem
   }
-  .c1jcn3uk {
+  .c1qx8273 {
     opacity: 0.7
   }
-  .c6gk6ar {
-    display: flex
-  }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cvzkkb6 {
-    justify-content: center
-  }
-  .c18dp5gp {
+  .c1pmpq0f {
     height: 1rem
   }
-  .clw3og8 {
+  .c1yafs04 {
     width: 1rem
   }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .c6z96ps {
-    border-top-color: rgba(226, 232, 240, 1)
-  }
-  .c9t5qyz {
-    border-right-color: rgba(226, 232, 240, 1)
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .csnt51l {
-    border-left-color: rgba(226, 232, 240, 1)
-  }
-  .c1v4k4ip {
-    border-top-width: 0px
-  }
-  .c2iozhh {
-    border-right-width: 0px
-  }
-  .c1j5pqo1 {
-    border-bottom-width: 0px
-  }
-  .cmqevnc {
-    border-left-width: 0px
-  }
-  .cvxnx00 {
-    background-color: transparent
-  }
-  .c601nqx {
+  .cxlxl0c {
     outline-width: 2px
   }
-  .c9i3lxo {
+  .c1gfzcg5 {
     outline-style: solid
   }
-  .c1sz664l {
+  .cohan28 {
     outline-color: transparent
   }
-  .cm8bc7h {
+  .c15roejc {
     outline-offset: 2px
   }
-  .c1m9udid:hover {
+  .c1xy5yrr:hover {
     opacity: 1
   }
-  .c175y1wr:focus {
+  .c192vyv4:focus {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
@@ -3,8 +3,7 @@ import { Box as Box } from "@webstudio-is/sdk-components-react";
 import { Switch as Switch, SwitchThumb as SwitchThumb } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [switchChecked, set$switchChecked] = useState<any>(false);
   let onCheckedChange = (checked: any) => {
     switchChecked = checked;
@@ -17,12 +16,12 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         data-ws-component="Switch"
         checked={switchChecked}
         onCheckedChange={onCheckedChange}
-        className="c1mnuzt9 c1d1at8d c12hfef4 c1qmz361 c1c97wd6 c4v7k5r c17f8p6x c15ce0qo c1yisi8r cpvsov c1inucbi c1dab7w1 c1uf7v01 czynn8e cnwyako cthomhq c1rxblly c1chcr7b c1jdmvgd cro9q3k cunuc6r c1gtx6ev cu8n5i6 cqhjzs2 cxcp0y5 c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l cegrmbm c1grhw0w ccop5vc c10u8nhz"
+        className="c1oai8p0 cnd1wdj cuh3w30 c11hichb c95zj28 clo3r8o c1o2cngd c1riwd65 ci2hmcl c1byz2lk c17al2u0 c1ufcra4 c17gos5d cn4f13s c1cofqbt c85ds3m c1e8k408 c1uosf6b chxhflr cc4jebi c4zy9sv c18xqxv1 cpr3ke2 c1wmnqxw c1b503n2 co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1oa7gr0 ce92j53 c1939zof c14mirta"
       >
         <SwitchThumb
           data-ws-id="6"
           data-ws-component="SwitchThumb"
-          className="c18myu9o c13oituv ckaw9ej c16fb3rt c17f8p6x c15ce0qo c1yisi8r cpvsov c15mffxy cbzcu1y c119ylpf cqhjzs2 cxcp0y5 c166bn31 cgmn562"
+          className="c1qxqj1w c1say2x3 c1aacs57 c1u42gcv c1o2cngd c1riwd65 ci2hmcl c1byz2lk c110hgy6 c1ii9nza c89l9bb c1wmnqxw c1b503n2 c8w8p8q ck4sd1p"
         />
       </Switch>
     </Box>
@@ -175,157 +174,139 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-width: 1px
   }
 }@media all {
-  .c1mnuzt9 {
+  .c1oai8p0 {
     display: inline-flex
   }
-  .c1d1at8d {
+  .cnd1wdj {
     height: 24px
   }
-  .c12hfef4 {
+  .cuh3w30 {
     width: 44px
   }
-  .c1qmz361 {
+  .c11hichb {
     flex-grow: 0
   }
-  .c1c97wd6 {
+  .c95zj28 {
     cursor: pointer
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .c17f8p6x {
+  .c1o2cngd {
     border-top-left-radius: 9999px
   }
-  .c15ce0qo {
+  .c1riwd65 {
     border-top-right-radius: 9999px
   }
-  .c1yisi8r {
+  .ci2hmcl {
     border-bottom-right-radius: 9999px
   }
-  .cpvsov {
+  .c1byz2lk {
     border-bottom-left-radius: 9999px
   }
-  .c1inucbi {
+  .c17al2u0 {
     border-top-style: solid
   }
-  .c1dab7w1 {
+  .c1ufcra4 {
     border-right-style: solid
   }
-  .c1uf7v01 {
+  .c17gos5d {
     border-bottom-style: solid
   }
-  .czynn8e {
+  .cn4f13s {
     border-left-style: solid
   }
-  .cnwyako {
+  .c1cofqbt {
     border-top-color: transparent
   }
-  .cthomhq {
+  .c85ds3m {
     border-right-color: transparent
   }
-  .c1rxblly {
+  .c1e8k408 {
     border-bottom-color: transparent
   }
-  .c1chcr7b {
+  .c1uosf6b {
     border-left-color: transparent
   }
-  .c1jdmvgd {
+  .chxhflr {
     border-top-width: 2px
   }
-  .cro9q3k {
+  .cc4jebi {
     border-right-width: 2px
   }
-  .cunuc6r {
+  .c4zy9sv {
     border-bottom-width: 2px
   }
-  .c1gtx6ev {
+  .c18xqxv1 {
     border-left-width: 2px
   }
-  .cu8n5i6 {
+  .cpr3ke2 {
     transition-property: all
   }
-  .cqhjzs2 {
+  .c1wmnqxw {
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1)
   }
-  .cxcp0y5 {
+  .c1b503n2 {
     transition-duration: 150ms
   }
-  .c1t6bql4:focus-visible {
+  .co0lfwl:focus-visible {
     outline-width: 2px
   }
-  .czph7hf:focus-visible {
+  .c1kn3u98:focus-visible {
     outline-style: solid
   }
-  .cncn1ro:focus-visible {
+  .c2odgnt:focus-visible {
     outline-color: transparent
   }
-  .cb270vo:focus-visible {
+  .chlvjga:focus-visible {
     outline-offset: 2px
   }
-  .c1rgsd1l:focus-visible {
+  .c1jx7vpr:focus-visible {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  .cegrmbm:disabled {
+  .c1oa7gr0:disabled {
     cursor: not-allowed
   }
-  .c1grhw0w:disabled {
+  .ce92j53:disabled {
     opacity: 0.5
   }
-  .ccop5vc[data-state=checked] {
+  .c1939zof[data-state=checked] {
     background-color: rgba(15, 23, 42, 1)
   }
-  .c10u8nhz[data-state=unchecked] {
+  .c14mirta[data-state=unchecked] {
     background-color: rgba(226, 232, 240, 1)
   }
-  .c18myu9o {
+  .c1qxqj1w {
     pointer-events: none
   }
-  .c13oituv {
+  .c1say2x3 {
     display: block
   }
-  .ckaw9ej {
+  .c1aacs57 {
     height: 1.25rem
   }
-  .c16fb3rt {
+  .c1u42gcv {
     width: 1.25rem
   }
-  .c17f8p6x {
-    border-top-left-radius: 9999px
-  }
-  .c15ce0qo {
-    border-top-right-radius: 9999px
-  }
-  .c1yisi8r {
-    border-bottom-right-radius: 9999px
-  }
-  .cpvsov {
-    border-bottom-left-radius: 9999px
-  }
-  .c15mffxy {
+  .c110hgy6 {
     background-color: rgba(255, 255, 255, 0.8)
   }
-  .cbzcu1y {
+  .c1ii9nza {
     box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)
   }
-  .c119ylpf {
+  .c89l9bb {
     transition-property: transform
   }
-  .cqhjzs2 {
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1)
-  }
-  .cxcp0y5 {
-    transition-duration: 150ms
-  }
-  .c166bn31[data-state=checked] {
+  .c8w8p8q[data-state=checked] {
     transform: translateX(20px)
   }
-  .cgmn562[data-state=unchecked] {
+  .ck4sd1p[data-state=unchecked] {
     transform: translateX(0px)
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
@@ -8,8 +8,7 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [tabsValue, set$tabsValue] = useState<any>("0");
   let onValueChange = (value: any) => {
     tabsValue = value;
@@ -26,13 +25,13 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         <TabsList
           data-ws-id="5"
           data-ws-component="TabsList"
-          className="c1mnuzt9 c1b8xvex c4v7k5r cvzkkb6 cym38jd cqimob0 c2tr68t cjdtj3f cqcyl9r ckc6u2x cue5i4p c1wiz3di c1364qo7 caa8yt3"
+          className="c1oai8p0 c18kkil clo3r8o cw9oyzl cuqxbts cg19ih8 c1479lj6 comq4ym c1xf120q c1tn9z53 c164ur30 c1ukzx8x c1wau4tj c1pcz91e"
         >
           <TabsTrigger
             data-ws-id="7"
             data-ws-component="TabsTrigger"
             data-ws-index="0"
-            className="c1mnuzt9 c4v7k5r cvzkkb6 cwmcr0n cym38jd cqimob0 c2tr68t cjdtj3f c1kc4g4w c1hi2fgx cs5tzic cl10cx8 c1mfk609 c121vm9z cwry1sa cu8n5i6 cqhjzs2 cxcp0y5 c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l c1srwcmr c1grhw0w cz3we07 c18pp6i cww7dfg"
+            className="c1oai8p0 clo3r8o cw9oyzl c1kiukeb cuqxbts cg19ih8 c1479lj6 comq4ym c16g5416 c111au61 ck4c8na c1mbhour c1qx3pju cut8gip c1qjvju3 cpr3ke2 c1wmnqxw c1b503n2 co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1jirpm3 ce92j53 cvo3yl7 cec8597 c5vtmxr"
           >
             {"Account"}
           </TabsTrigger>
@@ -40,7 +39,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
             data-ws-id="9"
             data-ws-component="TabsTrigger"
             data-ws-index="1"
-            className="c1mnuzt9 c4v7k5r cvzkkb6 cwmcr0n cym38jd cqimob0 c2tr68t cjdtj3f c1kc4g4w c1hi2fgx cs5tzic cl10cx8 c1mfk609 c121vm9z cwry1sa cu8n5i6 cqhjzs2 cxcp0y5 c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l c1srwcmr c1grhw0w cz3we07 c18pp6i cww7dfg"
+            className="c1oai8p0 clo3r8o cw9oyzl c1kiukeb cuqxbts cg19ih8 c1479lj6 comq4ym c16g5416 c111au61 ck4c8na c1mbhour c1qx3pju cut8gip c1qjvju3 cpr3ke2 c1wmnqxw c1b503n2 co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1jirpm3 ce92j53 cvo3yl7 cec8597 c5vtmxr"
           >
             {"Password"}
           </TabsTrigger>
@@ -49,7 +48,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           data-ws-id="11"
           data-ws-component="TabsContent"
           data-ws-index="0"
-          className="c1culj6 c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l"
+          className="c1uybxzr co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr"
         >
           {"Make changes to your account here."}
         </TabsContent>
@@ -57,7 +56,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           data-ws-id="13"
           data-ws-component="TabsContent"
           data-ws-index="1"
-          className="c1culj6 c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l"
+          className="c1uybxzr co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr"
         >
           {"Change your password here."}
         </TabsContent>
@@ -228,250 +227,118 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-width: 1px
   }
 }@media all {
-  .c1mnuzt9 {
+  .c1oai8p0 {
     display: inline-flex
   }
-  .c1b8xvex {
+  .c18kkil {
     height: 2.5rem
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .cvzkkb6 {
+  .cw9oyzl {
     justify-content: center
   }
-  .cym38jd {
+  .cuqxbts {
     border-top-left-radius: 0.375rem
   }
-  .cqimob0 {
+  .cg19ih8 {
     border-top-right-radius: 0.375rem
   }
-  .c2tr68t {
+  .c1479lj6 {
     border-bottom-right-radius: 0.375rem
   }
-  .cjdtj3f {
+  .comq4ym {
     border-bottom-left-radius: 0.375rem
   }
-  .cqcyl9r {
+  .c1xf120q {
     background-color: rgba(241, 245, 249, 1)
   }
-  .ckc6u2x {
+  .c1tn9z53 {
     padding-left: 0.25rem
   }
-  .cue5i4p {
+  .c164ur30 {
     padding-right: 0.25rem
   }
-  .c1wiz3di {
+  .c1ukzx8x {
     padding-top: 0.25rem
   }
-  .c1364qo7 {
+  .c1wau4tj {
     padding-bottom: 0.25rem
   }
-  .caa8yt3 {
+  .c1pcz91e {
     color: rgba(100, 116, 139, 1)
   }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cvzkkb6 {
-    justify-content: center
-  }
-  .cwmcr0n {
+  .c1kiukeb {
     white-space: nowrap
   }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1kc4g4w {
+  .c16g5416 {
     padding-left: 0.75rem
   }
-  .c1hi2fgx {
+  .c111au61 {
     padding-right: 0.75rem
   }
-  .cs5tzic {
+  .ck4c8na {
     padding-top: 0.375rem
   }
-  .cl10cx8 {
+  .c1mbhour {
     padding-bottom: 0.375rem
   }
-  .c1mfk609 {
+  .c1qx3pju {
     font-size: 0.875rem
   }
-  .c121vm9z {
+  .cut8gip {
     line-height: 1.25rem
   }
-  .cwry1sa {
+  .c1qjvju3 {
     font-weight: 500
   }
-  .cu8n5i6 {
+  .cpr3ke2 {
     transition-property: all
   }
-  .cqhjzs2 {
+  .c1wmnqxw {
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1)
   }
-  .cxcp0y5 {
+  .c1b503n2 {
     transition-duration: 150ms
   }
-  .c1t6bql4:focus-visible {
+  .co0lfwl:focus-visible {
     outline-width: 2px
   }
-  .czph7hf:focus-visible {
+  .c1kn3u98:focus-visible {
     outline-style: solid
   }
-  .cncn1ro:focus-visible {
+  .c2odgnt:focus-visible {
     outline-color: transparent
   }
-  .cb270vo:focus-visible {
+  .chlvjga:focus-visible {
     outline-offset: 2px
   }
-  .c1rgsd1l:focus-visible {
+  .c1jx7vpr:focus-visible {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  .c1srwcmr:disabled {
+  .c1jirpm3:disabled {
     pointer-events: none
   }
-  .c1grhw0w:disabled {
+  .ce92j53:disabled {
     opacity: 0.5
   }
-  .cz3we07[data-state=active] {
+  .cvo3yl7[data-state=active] {
     background-color: rgba(255, 255, 255, 0.8)
   }
-  .c18pp6i[data-state=active] {
+  .cec8597[data-state=active] {
     color: rgba(2, 8, 23, 1)
   }
-  .cww7dfg[data-state=active] {
+  .c5vtmxr[data-state=active] {
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05)
   }
-  .c4v7k5r {
-    align-items: center
-  }
-  .cvzkkb6 {
-    justify-content: center
-  }
-  .cwmcr0n {
-    white-space: nowrap
-  }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1kc4g4w {
-    padding-left: 0.75rem
-  }
-  .c1hi2fgx {
-    padding-right: 0.75rem
-  }
-  .cs5tzic {
-    padding-top: 0.375rem
-  }
-  .cl10cx8 {
-    padding-bottom: 0.375rem
-  }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c121vm9z {
-    line-height: 1.25rem
-  }
-  .cwry1sa {
-    font-weight: 500
-  }
-  .cu8n5i6 {
-    transition-property: all
-  }
-  .cqhjzs2 {
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1)
-  }
-  .cxcp0y5 {
-    transition-duration: 150ms
-  }
-  .c1t6bql4:focus-visible {
-    outline-width: 2px
-  }
-  .czph7hf:focus-visible {
-    outline-style: solid
-  }
-  .cncn1ro:focus-visible {
-    outline-color: transparent
-  }
-  .cb270vo:focus-visible {
-    outline-offset: 2px
-  }
-  .c1rgsd1l:focus-visible {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
-  }
-  .c1srwcmr:disabled {
-    pointer-events: none
-  }
-  .c1grhw0w:disabled {
-    opacity: 0.5
-  }
-  .cz3we07[data-state=active] {
-    background-color: rgba(255, 255, 255, 0.8)
-  }
-  .c18pp6i[data-state=active] {
-    color: rgba(2, 8, 23, 1)
-  }
-  .cww7dfg[data-state=active] {
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05)
-  }
-  .c1culj6 {
+  .c1uybxzr {
     margin-top: 0.5rem
-  }
-  .c1t6bql4:focus-visible {
-    outline-width: 2px
-  }
-  .czph7hf:focus-visible {
-    outline-style: solid
-  }
-  .cncn1ro:focus-visible {
-    outline-color: transparent
-  }
-  .cb270vo:focus-visible {
-    outline-offset: 2px
-  }
-  .c1rgsd1l:focus-visible {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
-  }
-  .c1culj6 {
-    margin-top: 0.5rem
-  }
-  .c1t6bql4:focus-visible {
-    outline-width: 2px
-  }
-  .czph7hf:focus-visible {
-    outline-style: solid
-  }
-  .cncn1ro:focus-visible {
-    outline-color: transparent
-  }
-  .cb270vo:focus-visible {
-    outline-offset: 2px
-  }
-  .c1rgsd1l:focus-visible {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
@@ -11,8 +11,7 @@ import {
 } from "../components";
 
 type Params = Record<string, string | undefined>;
-type Resources = Record<string, unknown>;
-const Page = (_props: { params: Params; resources: Resources }) => {
+const Page = (_props: { params: Params }) => {
   let [tooltipOpen, set$tooltipOpen] = useState<any>(false);
   let onOpenChange = (open: any) => {
     tooltipOpen = open;
@@ -30,7 +29,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
           <Button
             data-ws-id="6"
             data-ws-component="Button"
-            className="c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l cgassre c1ndsw6v cjrlou9 c945vvj c15mffxy c1mnuzt9 c4v7k5r cvzkkb6 cym38jd cqimob0 c2tr68t cjdtj3f c1mfk609 c121vm9z cwry1sa c1b8xvex c1y5f9qa cjw7gx9 c1peybss chh2z1n c1t6bql4 czph7hf cncn1ro cb270vo c1rgsd1l c1srwcmr c1grhw0w c8xqq0k cjs8iie"
+            className="c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 ck2qarh c1nxbatd caktpzb c1bm526f c110hgy6 c1oai8p0 clo3r8o cw9oyzl cuqxbts cg19ih8 c1479lj6 comq4ym c1qx3pju cut8gip c1qjvju3 c18kkil c1c2uk29 c1x1m3cj cey1d5i cbnv1sn co0lfwl c1kn3u98 c2odgnt chlvjga c1jx7vpr c1jirpm3 ce92j53 c1dr421o c14ytp9r"
           >
             {"Button"}
           </Button>
@@ -38,7 +37,7 @@ const Page = (_props: { params: Params; resources: Resources }) => {
         <TooltipContent
           data-ws-id="8"
           data-ws-component="TooltipContent"
-          className="c1wyidsg c1e2gixt cym38jd cqimob0 c2tr68t cjdtj3f c1inucbi c1dab7w1 c1uf7v01 czynn8e c6z96ps c9t5qyz c1x5uwe6 csnt51l cgassre c1ndsw6v cjrlou9 c945vvj c4mw8gp c1kc4g4w c1hi2fgx cs5tzic cl10cx8 c1mfk609 c121vm9z cj0w9yo ci3o5ma"
+          className="c173yyao c1p3lwwv cuqxbts cg19ih8 c1479lj6 comq4ym c17al2u0 c1ufcra4 c17gos5d cn4f13s c1wic2il cdem58j c102tttv cb204z1 ck2qarh c1nxbatd caktpzb c1bm526f c1rt44f4 c16g5416 c111au61 ck4c8na c1mbhour c1qx3pju cut8gip cwi0ez9 cpbhzvr"
         >
           <Text data-ws-id="10" data-ws-component="Text">
             {"The text you can edit"}
@@ -190,199 +189,148 @@ html {margin: 0; display: grid; min-height: 100%}
     min-height: 1em
   }
 }@media all {
-  .c1inucbi {
+  .c17al2u0 {
     border-top-style: solid
   }
-  .c1dab7w1 {
+  .c1ufcra4 {
     border-right-style: solid
   }
-  .c1uf7v01 {
+  .c17gos5d {
     border-bottom-style: solid
   }
-  .czynn8e {
+  .cn4f13s {
     border-left-style: solid
   }
-  .c6z96ps {
+  .c1wic2il {
     border-top-color: rgba(226, 232, 240, 1)
   }
-  .c9t5qyz {
+  .cdem58j {
     border-right-color: rgba(226, 232, 240, 1)
   }
-  .c1x5uwe6 {
+  .c102tttv {
     border-bottom-color: rgba(226, 232, 240, 1)
   }
-  .csnt51l {
+  .cb204z1 {
     border-left-color: rgba(226, 232, 240, 1)
   }
-  .cgassre {
+  .ck2qarh {
     border-top-width: 1px
   }
-  .c1ndsw6v {
+  .c1nxbatd {
     border-right-width: 1px
   }
-  .cjrlou9 {
+  .caktpzb {
     border-bottom-width: 1px
   }
-  .c945vvj {
+  .c1bm526f {
     border-left-width: 1px
   }
-  .c15mffxy {
+  .c110hgy6 {
     background-color: rgba(255, 255, 255, 0.8)
   }
-  .c1mnuzt9 {
+  .c1oai8p0 {
     display: inline-flex
   }
-  .c4v7k5r {
+  .clo3r8o {
     align-items: center
   }
-  .cvzkkb6 {
+  .cw9oyzl {
     justify-content: center
   }
-  .cym38jd {
+  .cuqxbts {
     border-top-left-radius: 0.375rem
   }
-  .cqimob0 {
+  .cg19ih8 {
     border-top-right-radius: 0.375rem
   }
-  .c2tr68t {
+  .c1479lj6 {
     border-bottom-right-radius: 0.375rem
   }
-  .cjdtj3f {
+  .comq4ym {
     border-bottom-left-radius: 0.375rem
   }
-  .c1mfk609 {
+  .c1qx3pju {
     font-size: 0.875rem
   }
-  .c121vm9z {
+  .cut8gip {
     line-height: 1.25rem
   }
-  .cwry1sa {
+  .c1qjvju3 {
     font-weight: 500
   }
-  .c1b8xvex {
+  .c18kkil {
     height: 2.5rem
   }
-  .c1y5f9qa {
+  .c1c2uk29 {
     padding-left: 1rem
   }
-  .cjw7gx9 {
+  .c1x1m3cj {
     padding-right: 1rem
   }
-  .c1peybss {
+  .cey1d5i {
     padding-top: 0.5rem
   }
-  .chh2z1n {
+  .cbnv1sn {
     padding-bottom: 0.5rem
   }
-  .c1t6bql4:focus-visible {
+  .co0lfwl:focus-visible {
     outline-width: 2px
   }
-  .czph7hf:focus-visible {
+  .c1kn3u98:focus-visible {
     outline-style: solid
   }
-  .cncn1ro:focus-visible {
+  .c2odgnt:focus-visible {
     outline-color: transparent
   }
-  .cb270vo:focus-visible {
+  .chlvjga:focus-visible {
     outline-offset: 2px
   }
-  .c1rgsd1l:focus-visible {
+  .c1jx7vpr:focus-visible {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  .c1srwcmr:disabled {
+  .c1jirpm3:disabled {
     pointer-events: none
   }
-  .c1grhw0w:disabled {
+  .ce92j53:disabled {
     opacity: 0.5
   }
-  .c8xqq0k:hover {
+  .c1dr421o:hover {
     background-color: rgba(241, 245, 249, 0.9)
   }
-  .cjs8iie:hover {
+  .c14ytp9r:hover {
     color: rgba(15, 23, 42, 1)
   }
-  .c1wyidsg {
+  .c173yyao {
     z-index: 50
   }
-  .c1e2gixt {
+  .c1p3lwwv {
     overflow: hidden
   }
-  .cym38jd {
-    border-top-left-radius: 0.375rem
-  }
-  .cqimob0 {
-    border-top-right-radius: 0.375rem
-  }
-  .c2tr68t {
-    border-bottom-right-radius: 0.375rem
-  }
-  .cjdtj3f {
-    border-bottom-left-radius: 0.375rem
-  }
-  .c1dab7w1 {
-    border-right-style: solid
-  }
-  .c1uf7v01 {
-    border-bottom-style: solid
-  }
-  .czynn8e {
-    border-left-style: solid
-  }
-  .c6z96ps {
-    border-top-color: rgba(226, 232, 240, 1)
-  }
-  .c9t5qyz {
-    border-right-color: rgba(226, 232, 240, 1)
-  }
-  .c1x5uwe6 {
-    border-bottom-color: rgba(226, 232, 240, 1)
-  }
-  .csnt51l {
-    border-left-color: rgba(226, 232, 240, 1)
-  }
-  .cgassre {
-    border-top-width: 1px
-  }
-  .c1ndsw6v {
-    border-right-width: 1px
-  }
-  .cjrlou9 {
-    border-bottom-width: 1px
-  }
-  .c945vvj {
-    border-left-width: 1px
-  }
-  .c4mw8gp {
+  .c1rt44f4 {
     background-color: rgba(255, 255, 255, 1)
   }
-  .c1kc4g4w {
+  .c16g5416 {
     padding-left: 0.75rem
   }
-  .c1hi2fgx {
+  .c111au61 {
     padding-right: 0.75rem
   }
-  .cs5tzic {
+  .ck4c8na {
     padding-top: 0.375rem
   }
-  .cl10cx8 {
+  .c1mbhour {
     padding-bottom: 0.375rem
   }
-  .c1mfk609 {
-    font-size: 0.875rem
-  }
-  .c121vm9z {
-    line-height: 1.25rem
-  }
-  .cj0w9yo {
+  .cwi0ez9 {
     color: rgba(2, 8, 23, 1)
   }
-  .ci3o5ma {
+  .cpbhzvr {
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)
   }
 }
       `}
         </style>
-        <Page params={{}} resources={{}} />
+        <Page params={{}} />
       </>
     );
   },


### PR DESCRIPTION
Resources should not be part of component props.
Drilling resources to nested custom components
would be more complex so using context can
simplify this part and prepare for rendering
slots as separate components.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
