### PR TITLE
feat: inline variables outside current component/slot

### DIFF
--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -187,6 +187,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
           slice,
           availableDataSources: findAvailableDataSources(
             $dataSources.get(),
+            $instances.get(),
             parentInstanceSelector
           ),
           beforeTransactionEnd: (rootInstanceId, draft) => {

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -206,6 +206,7 @@ export const onPaste = (clipboardData: string): boolean => {
     slice: data,
     availableDataSources: findAvailableDataSources(
       $dataSources.get(),
+      $instances.get(),
       instanceSelector
     ),
     beforeTransactionEnd: (rootInstanceId, draft) => {

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -722,9 +722,18 @@ export const getInstancesSlice = (rootInstanceId: string) => {
 
 export const findAvailableDataSources = (
   dataSources: DataSources,
+  instances: Instances,
   instanceSelector: InstanceSelector
 ) => {
-  const instanceIds = new Set(instanceSelector);
+  // inline data sources not scoped to current portal
+  const instanceIds = new Set();
+  for (const instanceId of instanceSelector) {
+    const instance = instances.get(instanceId);
+    if (instance?.component === portalComponent) {
+      break;
+    }
+    instanceIds.add(instanceId);
+  }
   const availableDataSources = new Set<DataSource["id"]>();
   for (const { id, scopeInstanceId } of dataSources.values()) {
     if (scopeInstanceId && instanceIds.has(scopeInstanceId)) {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Important constrain on the way to custom components to not use data sources defined in other components when copy paste.

## Steps for reproduction

1. Test covers it

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
