### PR TITLE
refactor: generalize transferrable fragments

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -2,15 +2,9 @@ import { shallowEqual } from "shallow-equal";
 import { z } from "zod";
 import { toast } from "@webstudio-is/design-system";
 import {
-  Asset,
-  Breakpoint,
-  DataSource,
   Instance,
   Instances,
-  Prop,
-  StyleDecl,
-  StyleSource,
-  StyleSourceSelection,
+  WebstudioFragment,
   findTreeInstanceIdsExcludingSlotDescendants,
 } from "@webstudio-is/sdk";
 import {
@@ -40,16 +34,8 @@ import { portalComponent } from "@webstudio-is/react-sdk";
 
 const version = "@webstudio/instance/v0.1";
 
-const InstanceData = z.object({
+const InstanceData = WebstudioFragment.extend({
   instanceSelector: z.array(z.string()),
-  breakpoints: z.array(Breakpoint),
-  instances: z.array(Instance),
-  props: z.array(Prop),
-  dataSources: z.array(DataSource),
-  styleSourceSelections: z.array(StyleSourceSelection),
-  styleSources: z.array(StyleSource),
-  styles: z.array(StyleDecl),
-  assets: z.array(Asset),
 });
 
 type InstanceData = z.infer<typeof InstanceData>;

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.test.ts
@@ -10,6 +10,8 @@ describe("Plugin Markdown", () => {
   test("paragraph", () => {
     expect(parse("xyz", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -31,6 +33,7 @@ describe("Plugin Markdown", () => {
     },
   ],
   "props": [],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -41,6 +44,8 @@ describe("Plugin Markdown", () => {
   test("h1", () => {
     expect(parse("# heading", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -70,6 +75,7 @@ describe("Plugin Markdown", () => {
       "value": "h1",
     },
   ],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -80,6 +86,8 @@ describe("Plugin Markdown", () => {
   test("h6", () => {
     expect(parse("###### heading", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -109,6 +117,7 @@ describe("Plugin Markdown", () => {
       "value": "h6",
     },
   ],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -119,6 +128,8 @@ describe("Plugin Markdown", () => {
   test("bold 1", () => {
     expect(parse("__bold__", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -151,6 +162,7 @@ describe("Plugin Markdown", () => {
     },
   ],
   "props": [],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -161,6 +173,8 @@ describe("Plugin Markdown", () => {
   test("bold 2", () => {
     expect(parse("**bold**", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -193,6 +207,7 @@ describe("Plugin Markdown", () => {
     },
   ],
   "props": [],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -203,6 +218,8 @@ describe("Plugin Markdown", () => {
   test("italic 1", () => {
     expect(parse("_italic_", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -235,6 +252,7 @@ describe("Plugin Markdown", () => {
     },
   ],
   "props": [],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -245,6 +263,8 @@ describe("Plugin Markdown", () => {
   test("italic 2", () => {
     expect(parse("*italic*", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -277,6 +297,7 @@ describe("Plugin Markdown", () => {
     },
   ],
   "props": [],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -287,6 +308,8 @@ describe("Plugin Markdown", () => {
   test("link", () => {
     expect(parse('[link](/uri "Title")', options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -334,6 +357,7 @@ describe("Plugin Markdown", () => {
       "value": "Title",
     },
   ],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -344,6 +368,8 @@ describe("Plugin Markdown", () => {
   test("image", () => {
     expect(parse('![foo](/url "title")', options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -393,6 +419,7 @@ describe("Plugin Markdown", () => {
       "value": "foo",
     },
   ],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -409,6 +436,8 @@ describe("Plugin Markdown", () => {
       )
     ).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -434,6 +463,7 @@ describe("Plugin Markdown", () => {
     },
   ],
   "props": [],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -450,6 +480,8 @@ describe("Plugin Markdown", () => {
       )
     ).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -472,6 +504,7 @@ baz",
     },
   ],
   "props": [],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -482,6 +515,8 @@ baz",
   test("blockquote", () => {
     expect(parse("> bar", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -514,6 +549,7 @@ baz",
     },
   ],
   "props": [],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -524,6 +560,8 @@ baz",
   test("inline code", () => {
     expect(parse("`foo`", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -556,6 +594,7 @@ baz",
     },
   ],
   "props": [],
+  "resources": [],
   "styleSourceSelections": [
     {
       "instanceId": "123",
@@ -588,6 +627,8 @@ baz",
   test("code", () => {
     expect(parse("```js meta\nfoo\n```", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -617,6 +658,7 @@ baz",
       "value": "js",
     },
   ],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -627,6 +669,8 @@ baz",
   test("list unordered", () => {
     expect(parse("- one", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -678,6 +722,7 @@ baz",
       "value": false,
     },
   ],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -688,6 +733,8 @@ baz",
   test("list ordered", () => {
     expect(parse("3. one", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -746,6 +793,7 @@ baz",
       "value": 3,
     },
   ],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],
@@ -756,6 +804,8 @@ baz",
   test("thematic break | separator", () => {
     expect(parse("---", options)).toMatchInlineSnapshot(`
 {
+  "assets": [],
+  "breakpoints": [],
   "children": [
     {
       "type": "id",
@@ -772,6 +822,7 @@ baz",
     },
   ],
   "props": [],
+  "resources": [],
   "styleSourceSelections": [],
   "styleSources": [],
   "styles": [],

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.ts
@@ -2,8 +2,11 @@ import { nanoid } from "nanoid";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { gfmFromMarkdown } from "mdast-util-gfm";
 import { gfm } from "micromark-extension-gfm";
-import type { Breakpoint, Instance } from "@webstudio-is/sdk";
-import type { EmbedTemplateData } from "@webstudio-is/react-sdk";
+import type {
+  Breakpoint,
+  Instance,
+  WebstudioFragment,
+} from "@webstudio-is/sdk";
 import {
   computeInstancesConstraints,
   findClosestDroppableTarget,
@@ -49,7 +52,7 @@ type Options = { generateId?: typeof nanoid };
 type Root = ReturnType<typeof fromMarkdown>;
 
 const toInstanceData = (
-  data: EmbedTemplateData,
+  data: WebstudioFragment,
   breakpointId: Breakpoint["id"],
   ast: { children: Root["children"] },
   options: Options = {}
@@ -194,14 +197,17 @@ export const parse = (clipboardData: string, options?: Options) => {
   if (baseBreakpoint === undefined) {
     return;
   }
-  const data: EmbedTemplateData = {
+  const data: WebstudioFragment = {
     children: [],
     instances: [],
     props: [],
+    breakpoints: [],
     styles: [],
     styleSources: [],
     styleSourceSelections: [],
     dataSources: [],
+    resources: [],
+    assets: [],
   };
   data.children = toInstanceData(data, baseBreakpoint.id, ast, options);
   return data;

--- a/apps/builder/app/shared/instance-utils.test.ts
+++ b/apps/builder/app/shared/instance-utils.test.ts
@@ -471,6 +471,9 @@ test("insert template data with only new style sources", () => {
           value: { type: "keyword", value: "green" },
         },
       ],
+      assets: [],
+      resources: [],
+      breakpoints: [],
     },
     { parentSelector: ["body"], position: "end" }
   );
@@ -1053,6 +1056,7 @@ describe("get instances slice", () => {
 
 describe("insert instances slice copy", () => {
   const emptySlice = {
+    children: [],
     instances: [
       {
         id: "body",
@@ -1066,6 +1070,7 @@ describe("insert instances slice copy", () => {
     breakpoints: [],
     styles: [],
     dataSources: [],
+    resources: [],
     props: [],
     assets: [],
   };

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -15,15 +15,14 @@ import {
   DataSources,
   Props,
   DataSource,
-  Prop,
   Breakpoint,
   Pages,
+  type WebstudioFragment,
 } from "@webstudio-is/sdk";
 import { findTreeInstanceIdsExcludingSlotDescendants } from "@webstudio-is/sdk";
 import {
   type WsComponentMeta,
   generateDataFromEmbedTemplate,
-  type EmbedTemplateData,
   decodeDataSourceVariable,
   validateExpression,
   encodeDataSourceVariable,
@@ -301,7 +300,7 @@ export const findClosestDroppableTarget = (
 };
 
 export const insertTemplateData = (
-  templateData: EmbedTemplateData,
+  templateData: WebstudioFragment,
   dropTarget: DroppableTarget
 ) => {
   const {
@@ -554,18 +553,9 @@ const traverseStyleValue = (
   value satisfies never;
 };
 
-type InstancesSlice = {
-  instances: Instance[];
-  styleSourceSelections: StyleSourceSelection[];
-  styleSources: StyleSource[];
-  breakpoints: Breakpoint[];
-  styles: StyleDecl[];
-  dataSources: DataSource[];
-  props: Prop[];
-  assets: Asset[];
-};
-
-export const getInstancesSlice = (rootInstanceId: string) => {
+export const getInstancesSlice = (
+  rootInstanceId: string
+): WebstudioFragment => {
   const assets = $assets.get();
   const instances = $instances.get();
   const dataSources = $dataSources.get();
@@ -709,12 +699,14 @@ export const getInstancesSlice = (rootInstanceId: string) => {
   }
 
   return {
+    children: [{ type: "id", value: rootInstanceId }],
     instances: slicedInstances,
     styleSourceSelections: slicedStyleSourceSelections,
     styleSources: Array.from(slicedStyleSources.values()),
     breakpoints: Array.from(slicedBreapoints.values()),
     styles: slicedStyles,
     dataSources: Array.from(slicedDataSources.values()),
+    resources: [],
     props: Array.from(slicedProps.values()),
     assets: slicedAssets,
   };
@@ -801,7 +793,7 @@ export const insertInstancesSliceCopy = ({
   availableDataSources,
   beforeTransactionEnd,
 }: {
-  slice: InstancesSlice;
+  slice: WebstudioFragment;
   availableDataSources: Set<DataSource["id"]>;
   beforeTransactionEnd?: (
     rootInstanceId: Instance["id"],

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -51,6 +51,9 @@ test("generate data for embedding from instances and text", () => {
     styleSourceSelections: [],
     styleSources: [],
     styles: [],
+    assets: [],
+    breakpoints: [],
+    resources: [],
   });
 });
 
@@ -121,6 +124,9 @@ test("generate data for embedding from props", () => {
     styleSourceSelections: [],
     styleSources: [],
     styles: [],
+    assets: [],
+    breakpoints: [],
+    resources: [],
   });
 });
 
@@ -214,6 +220,9 @@ test("generate data for embedding from styles", () => {
         value: { type: "keyword", value: "black" },
       },
     ],
+    assets: [],
+    breakpoints: [],
+    resources: [],
   });
 });
 
@@ -292,6 +301,9 @@ test("generate data for embedding from props bound to data source variables", ()
     styleSourceSelections: [],
     styleSources: [],
     styles: [],
+    assets: [],
+    breakpoints: [],
+    resources: [],
   });
 });
 
@@ -332,6 +344,9 @@ test("generate variables with aliases instead of reference name", () => {
     styleSourceSelections: [],
     styleSources: [],
     styles: [],
+    assets: [],
+    breakpoints: [],
+    resources: [],
   });
 });
 
@@ -410,6 +425,9 @@ test("generate data for embedding from props with complex expressions", () => {
     styleSourceSelections: [],
     styleSources: [],
     styles: [],
+    assets: [],
+    breakpoints: [],
+    resources: [],
   });
 });
 
@@ -521,6 +539,9 @@ test("generate data for embedding from action props", () => {
     styleSourceSelections: [],
     styleSources: [],
     styles: [],
+    assets: [],
+    breakpoints: [],
+    resources: [],
   });
 });
 
@@ -595,6 +616,9 @@ test("generate data for embedding from parameter props", () => {
     styleSourceSelections: [],
     styleSources: [],
     styles: [],
+    assets: [],
+    breakpoints: [],
+    resources: [],
   });
 });
 
@@ -642,6 +666,9 @@ test("generate data for embedding from instance child bound to variables", () =>
     styleSourceSelections: [],
     styleSources: [],
     styles: [],
+    assets: [],
+    breakpoints: [],
+    resources: [],
   });
 });
 

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -10,6 +10,7 @@ import type {
   StyleDecl,
   Breakpoint,
   DataSource,
+  WebstudioFragment,
 } from "@webstudio-is/sdk";
 import { StyleValue, type StyleProperty } from "@webstudio-is/css-engine";
 import type { Simplify } from "type-fest";
@@ -379,7 +380,7 @@ export const generateDataFromEmbedTemplate = (
   metas: Map<Instance["component"], WsComponentMeta>,
   defaultBreakpointId: Breakpoint["id"],
   generateId: () => string = nanoid
-) => {
+): WebstudioFragment => {
   const instances: Instance[] = [];
   const props: Prop[] = [];
   const dataSourceByRef = new Map<string, DataSource>();
@@ -408,12 +409,11 @@ export const generateDataFromEmbedTemplate = (
     styleSourceSelections,
     styleSources,
     styles,
+    assets: [],
+    breakpoints: [],
+    resources: [],
   };
 };
-
-export type EmbedTemplateData = ReturnType<
-  typeof generateDataFromEmbedTemplate
->;
 
 const namespaceEmbedTemplateComponents = (
   template: WsEmbedTemplate,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,6 +9,7 @@ export * from "./schema/style-sources";
 export * from "./schema/style-source-selections";
 export * from "./schema/styles";
 export * from "./schema/deployment";
+export * from "./schema/webstudio";
 
 export * from "./instances-utils";
 export * from "./page-utils";

--- a/packages/sdk/src/schema/instances.ts
+++ b/packages/sdk/src/schema/instances.ts
@@ -21,12 +21,14 @@ export const ExpressionChild = z.object({
 });
 export type ExpressionChild = z.infer<typeof ExpressionChild>;
 
+export const InstanceChild = z.union([IdChild, TextChild, ExpressionChild]);
+
 export const Instance = z.object({
   type: z.literal("instance"),
   id: InstanceId,
   component: z.string(),
   label: z.string().optional(),
-  children: z.array(z.union([IdChild, TextChild, ExpressionChild])),
+  children: z.array(InstanceChild),
 });
 
 export type Instance = z.infer<typeof Instance>;

--- a/packages/sdk/src/schema/webstudio.ts
+++ b/packages/sdk/src/schema/webstudio.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { Asset, Assets } from "./assets";
+import { DataSource, DataSources } from "./data-sources";
+import { Resource, Resources } from "./resources";
+import { Instance, InstanceChild, Instances } from "./instances";
+import { Prop, Props } from "./props";
+import { Breakpoint, Breakpoints } from "./breakpoints";
+import {
+  StyleSourceSelection,
+  StyleSourceSelections,
+} from "./style-source-selections";
+import { StyleSource, StyleSources } from "./style-sources";
+import { StyleDecl, Styles } from "./styles";
+import { Pages } from "./pages";
+
+/**
+ * transferrable and insertable part of webstudio data
+ * may contain reusable parts like tokens and custom components
+ */
+export const WebstudioFragment = z.object({
+  children: z.array(InstanceChild),
+  instances: z.array(Instance),
+  assets: z.array(Asset),
+  dataSources: z.array(DataSource),
+  resources: z.array(Resource),
+  props: z.array(Prop),
+  breakpoints: z.array(Breakpoint),
+  styleSourceSelections: z.array(StyleSourceSelection),
+  styleSources: z.array(StyleSource),
+  styles: z.array(StyleDecl),
+});
+
+export type WebstudioFragment = z.infer<typeof WebstudioFragment>;
+
+/**
+ * all persisted webstudio data in normalized format
+ * should be used for composing parts of logic within
+ * single transaction
+ */
+export type WebstudioData = {
+  pages: Pages;
+  assets: Assets;
+  dataSources: DataSources;
+  resources: Resources;
+  instances: Instances;
+  props: Props;
+  breakpoints: Breakpoints;
+  styleSourceSelections: StyleSourceSelections;
+  styleSources: StyleSources;
+  styles: Styles;
+};


### PR DESCRIPTION
Here added two new types

WebstudioFragment - reusable fragment of webstudio data which can be generated (markdown, embed template), transferred (copied or stored in marketplace) and inserted.

WebstudioData - all available normalized data to allow composing multiple operations within single transaction like delete instance and then insert into other part of the page.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
