### PR TITLE
refactor: make delete instance composable

### DIFF
--- a/apps/builder/app/builder/features/ai/apply-operations.ts
+++ b/apps/builder/app/builder/features/ai/apply-operations.ts
@@ -3,8 +3,9 @@ import { generateDataFromEmbedTemplate } from "@webstudio-is/react-sdk";
 import { copywriter, type operations } from "@webstudio-is/ai";
 import { isBaseBreakpoint } from "~/shared/breakpoints";
 import {
-  deleteInstance as _deleteInstance,
+  deleteInstanceMutable,
   insertTemplateData,
+  updateWebstudioData,
 } from "~/shared/instance-utils";
 import {
   $breakpoints,
@@ -101,14 +102,16 @@ const deleteInstanceByOp = (
 ) => {
   const instanceSelector = computeSelectorForInstanceId(operation.wsId);
   if (instanceSelector) {
-    _deleteInstance(instanceSelector);
+    updateWebstudioData((data) => {
+      deleteInstanceMutable(data, instanceSelector);
+    });
   }
 };
 
 const applyStylesByOp = (operation: operations.editStylesWsOperation) => {
   serverSyncStore.createTransaction(
-    [$instances, $styleSourceSelections, $styleSources, $styles, $breakpoints],
-    (instances, styleSourceSelections, styleSources, styles, breakpoints) => {
+    [$styleSourceSelections, $styleSources, $styles, $breakpoints],
+    (styleSourceSelections, styleSources, styles, breakpoints) => {
       const newStyles = [...operation.styles.values()];
 
       const breakpointValues = Array.from(breakpoints.values());

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -48,9 +48,10 @@ import {
 import { useIds } from "~/shared/form-utils";
 import { Header, HeaderSuffixSpacer } from "../../header";
 import {
-  deleteInstance,
+  deleteInstanceMutable,
   getInstancesSlice,
   insertInstancesSliceCopy,
+  updateWebstudioData,
 } from "~/shared/instance-utils";
 import {
   $assets,
@@ -923,13 +924,12 @@ const deletePage = (pageId: Page["id"]) => {
     $selectedInstanceSelector.set(undefined);
   }
   const rootInstanceId = findPageByIdOrPath(pageId, pages)?.rootInstanceId;
-  if (rootInstanceId !== undefined) {
-    deleteInstance([rootInstanceId]);
+  if (rootInstanceId === undefined) {
+    return;
   }
-  serverSyncStore.createTransaction([$pages], (pages) => {
-    if (pages === undefined) {
-      return;
-    }
+  updateWebstudioData((data) => {
+    deleteInstanceMutable(data, [rootInstanceId]);
+    const { pages } = data;
     removeByMutable(pages.pages, (page) => page.id === pageId);
     cleanupChildRefsMutable(pageId, pages.folders);
   });

--- a/apps/builder/app/builder/shared/commands.test.ts
+++ b/apps/builder/app/builder/shared/commands.test.ts
@@ -3,11 +3,13 @@ import type { Instance } from "@webstudio-is/sdk";
 import * as baseMetas from "@webstudio-is/sdk-components-react/metas";
 import {
   $instances,
+  $pages,
   $registeredComponentMetas,
   $selectedInstanceSelector,
 } from "~/shared/nano-states";
 import { registerContainers } from "~/shared/sync";
 import { emitCommand } from "./commands";
+import { createDefaultPages } from "@webstudio-is/project-build";
 
 registerContainers();
 
@@ -20,6 +22,8 @@ const createInstancePair = (
 };
 
 const metas = new Map(Object.entries(baseMetas));
+
+$pages.set(createDefaultPages({ rootInstanceId: "" }));
 
 describe("deleteInstance", () => {
   // body

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -143,7 +143,8 @@ export const NavigatorTree = () => {
       onSelect={handleSelect}
       onHover={$hoveredInstanceSelector.set}
       onDragItemChange={(dragInstanceSelector) => {
-        if (isInstanceDetachable(dragInstanceSelector) === false) {
+        const instances = $instances.get();
+        if (isInstanceDetachable(instances, dragInstanceSelector) === false) {
           toast.error(
             "This instance can not be moved outside of its parent component."
           );

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -23,12 +23,13 @@ import {
 } from "../tree-utils";
 import {
   computeInstancesConstraints,
-  deleteInstance,
+  deleteInstanceMutable,
   findAvailableDataSources,
   findClosestDroppableTarget,
   getInstancesSlice,
   insertInstancesSliceCopy,
   isInstanceDetachable,
+  updateWebstudioData,
 } from "../instance-utils";
 import { portalComponent } from "@webstudio-is/react-sdk";
 
@@ -41,7 +42,8 @@ const InstanceData = WebstudioFragment.extend({
 type InstanceData = z.infer<typeof InstanceData>;
 
 const getTreeData = (targetInstanceSelector: InstanceSelector) => {
-  if (isInstanceDetachable(targetInstanceSelector) === false) {
+  const instances = $instances.get();
+  if (isInstanceDetachable(instances, targetInstanceSelector) === false) {
     toast.error(
       "This instance can not be moved outside of its parent component."
     );
@@ -253,7 +255,9 @@ export const onCut = () => {
   if (data === undefined) {
     return;
   }
-  deleteInstance(selectedInstanceSelector);
+  updateWebstudioData((data) => {
+    deleteInstanceMutable(data, selectedInstanceSelector);
+  });
   if (data === undefined) {
     return;
   }

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -18,6 +18,7 @@ import {
   Breakpoint,
   Pages,
   type WebstudioFragment,
+  type WebstudioData,
 } from "@webstudio-is/sdk";
 import { findTreeInstanceIdsExcludingSlotDescendants } from "@webstudio-is/sdk";
 import {
@@ -58,6 +59,53 @@ import { removeByMutable } from "./array-utils";
 import { isBaseBreakpoint } from "./breakpoints";
 import { humanizeString } from "./string-utils";
 import { serverSyncStore } from "./sync";
+
+export const updateWebstudioData = (mutate: (data: WebstudioData) => void) => {
+  serverSyncStore.createTransaction(
+    [
+      $pages,
+      $instances,
+      $props,
+      $breakpoints,
+      $styleSourceSelections,
+      $styleSources,
+      $styles,
+      $dataSources,
+      $resources,
+      $assets,
+    ],
+    (
+      pages,
+      instances,
+      props,
+      breakpoints,
+      styleSourceSelections,
+      styleSources,
+      styles,
+      dataSources,
+      resources,
+      assets
+    ) => {
+      // @todo normalize pages
+      if (pages === undefined) {
+        return;
+      }
+      mutate({
+        pages,
+        instances,
+        props,
+        dataSources,
+        resources,
+        breakpoints,
+        styleSourceSelections,
+        styleSources,
+        styles,
+        assets,
+      });
+      //
+    }
+  );
+};
 
 const getLabelFromComponentName = (component: Instance["component"]) => {
   if (component.includes(":")) {
@@ -135,8 +183,10 @@ export const findClosestDetachableInstanceSelector = (
   }
 };
 
-export const isInstanceDetachable = (instanceSelector: InstanceSelector) => {
-  const instances = $instances.get();
+export const isInstanceDetachable = (
+  instances: Instances,
+  instanceSelector: InstanceSelector
+) => {
   const metas = $registeredComponentMetas.get();
   const [instanceId] = instanceSelector;
   const instance = instances.get(instanceId);
@@ -411,113 +461,104 @@ export const reparentInstance = (
   $selectedStyleSourceSelector.set(undefined);
 };
 
-export const deleteInstance = (instanceSelector: InstanceSelector) => {
+export const deleteInstanceMutable = (
+  data: WebstudioData,
+  instanceSelector: InstanceSelector
+) => {
   // @todo tell user they can't delete root
   if (instanceSelector.length === 1) {
     return false;
   }
-  if (isInstanceDetachable(instanceSelector) === false) {
+  if (isInstanceDetachable(data.instances, instanceSelector) === false) {
     toast.error(
       "This instance can not be moved outside of its parent component."
     );
     return false;
   }
-  serverSyncStore.createTransaction(
-    [
-      $instances,
-      $props,
-      $styleSourceSelections,
-      $styleSources,
-      $styles,
-      $dataSources,
-      $resources,
-    ],
-    (
-      instances,
-      props,
-      styleSourceSelections,
-      styleSources,
-      styles,
-      dataSources,
-      resources
-    ) => {
-      let targetInstanceId = instanceSelector[0];
-      const parentInstanceId = instanceSelector[1];
-      let parentInstance =
-        parentInstanceId === undefined
-          ? undefined
-          : instances.get(parentInstanceId);
-      const grandparentInstanceId = instanceSelector[2];
-      const grandparentInstance = instances.get(grandparentInstanceId);
+  const {
+    instances,
+    props,
+    styleSourceSelections,
+    styleSources,
+    styles,
+    dataSources,
+    resources,
+  } = data;
+  let targetInstanceId = instanceSelector[0];
+  const parentInstanceId = instanceSelector[1];
+  let parentInstance =
+    parentInstanceId === undefined
+      ? undefined
+      : instances.get(parentInstanceId);
+  const grandparentInstanceId = instanceSelector[2];
+  const grandparentInstance = instances.get(grandparentInstanceId);
 
-      // delete parent fragment too if its last child is going to be deleted
-      // use case for slots: slot became empty and remove display: contents
-      // to be displayed properly on canvas
-      if (
-        parentInstance?.component === "Fragment" &&
-        parentInstance.children.length === 1 &&
-        grandparentInstance
-      ) {
-        targetInstanceId = parentInstance.id;
-        parentInstance = grandparentInstance;
-      }
+  // delete parent fragment too if its last child is going to be deleted
+  // use case for slots: slot became empty and remove display: contents
+  // to be displayed properly on canvas
+  if (
+    parentInstance?.component === "Fragment" &&
+    parentInstance.children.length === 1 &&
+    grandparentInstance
+  ) {
+    targetInstanceId = parentInstance.id;
+    parentInstance = grandparentInstance;
+  }
 
-      // skip parent fake "item" instance and use grandparent collection as parent
-      if (grandparentInstance?.component === collectionComponent) {
-        parentInstance = grandparentInstance;
-      }
+  // skip parent fake "item" instance and use grandparent collection as parent
+  if (grandparentInstance?.component === collectionComponent) {
+    parentInstance = grandparentInstance;
+  }
 
-      const instanceIds = findTreeInstanceIdsExcludingSlotDescendants(
-        instances,
-        targetInstanceId
-      );
-      const localStyleSourceIds = findLocalStyleSourcesWithinInstances(
-        styleSources.values(),
-        styleSourceSelections.values(),
-        instanceIds
-      );
+  const instanceIds = findTreeInstanceIdsExcludingSlotDescendants(
+    instances,
+    targetInstanceId
+  );
+  const localStyleSourceIds = findLocalStyleSourcesWithinInstances(
+    styleSources.values(),
+    styleSourceSelections.values(),
+    instanceIds
+  );
 
-      // may not exist when delete root
-      if (parentInstance) {
-        removeByMutable(
-          parentInstance.children,
-          (child) => child.type === "id" && child.value === targetInstanceId
-        );
-      }
+  // may not exist when delete root
+  if (parentInstance) {
+    removeByMutable(
+      parentInstance.children,
+      (child) => child.type === "id" && child.value === targetInstanceId
+    );
+  }
 
-      for (const instanceId of instanceIds) {
-        instances.delete(instanceId);
-      }
-      // delete props, data sources and styles of deleted instance and its descendants
-      for (const prop of props.values()) {
-        if (instanceIds.has(prop.instanceId)) {
-          props.delete(prop.id);
-        }
-      }
-      for (const dataSource of dataSources.values()) {
-        if (
-          dataSource.scopeInstanceId !== undefined &&
-          instanceIds.has(dataSource.scopeInstanceId)
-        ) {
-          dataSources.delete(dataSource.id);
-          if (dataSource.type === "resource") {
-            resources.delete(dataSource.resourceId);
-          }
-        }
-      }
-      for (const instanceId of instanceIds) {
-        styleSourceSelections.delete(instanceId);
-      }
-      for (const styleSourceId of localStyleSourceIds) {
-        styleSources.delete(styleSourceId);
-      }
-      for (const [styleDeclKey, styleDecl] of styles) {
-        if (localStyleSourceIds.has(styleDecl.styleSourceId)) {
-          styles.delete(styleDeclKey);
-        }
+  for (const instanceId of instanceIds) {
+    instances.delete(instanceId);
+  }
+  // delete props, data sources and styles of deleted instance and its descendants
+  for (const prop of props.values()) {
+    if (instanceIds.has(prop.instanceId)) {
+      props.delete(prop.id);
+    }
+  }
+  for (const dataSource of dataSources.values()) {
+    if (
+      dataSource.scopeInstanceId !== undefined &&
+      instanceIds.has(dataSource.scopeInstanceId)
+    ) {
+      dataSources.delete(dataSource.id);
+      if (dataSource.type === "resource") {
+        resources.delete(dataSource.resourceId);
       }
     }
-  );
+  }
+  for (const instanceId of instanceIds) {
+    styleSourceSelections.delete(instanceId);
+  }
+  for (const styleSourceId of localStyleSourceIds) {
+    styleSources.delete(styleSourceId);
+  }
+  for (const [styleDeclKey, styleDecl] of styles) {
+    if (localStyleSourceIds.has(styleDecl.styleSourceId)) {
+      styles.delete(styleDeclKey);
+    }
+  }
   return true;
 };
 


### PR DESCRIPTION
Here refactored delete instance to accept and mutate webstudio data instead of accessing data stores.
Now we can avoid double transaction when delete pages.

Note: review with hidden whitespaces

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
