### PR TITLE
refactor: make inserting fragments copy composable

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -953,31 +953,29 @@ const duplicatePage = (pageId: Page["id"]) => {
   const newName = `${name} (${Number(copyNumber ?? "0") + 1})`;
 
   const slice = getInstancesSlice(page.rootInstanceId);
-  insertInstancesSliceCopy({
-    slice,
-    availableDataSources: new Set(),
-    beforeTransactionEnd: (rootInstanceId, draft) => {
-      if (draft.pages === undefined) {
-        return;
-      }
-      const newPage = {
-        ...page,
-        id: newPageId,
-        rootInstanceId,
-        name: newName,
-        path: nameToPath(pages, newName),
-      } satisfies Page;
-      draft.pages.pages.push(newPage);
-      const currentFolder = findParentFolderByChildId(
-        pageId,
-        draft.pages.folders
-      );
-      registerFolderChildMutable(
-        draft.pages.folders,
-        newPageId,
-        currentFolder?.id
-      );
-    },
+  updateWebstudioData((data) => {
+    const rootInstanceId = insertInstancesSliceCopy({
+      data,
+      slice,
+      availableDataSources: new Set(),
+    });
+    if (rootInstanceId === undefined) {
+      return;
+    }
+    const newPage = {
+      ...page,
+      id: newPageId,
+      rootInstanceId,
+      name: newName,
+      path: nameToPath(pages, newName),
+    } satisfies Page;
+    data.pages.pages.push(newPage);
+    const currentFolder = findParentFolderByChildId(pageId, data.pages.folders);
+    registerFolderChildMutable(
+      data.pages.folders,
+      newPageId,
+      currentFolder?.id
+    );
   });
   return newPageId;
 };

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -1,6 +1,5 @@
 import { createCommandsEmitter, type Command } from "~/shared/commands-emitter";
 import {
-  $dataSources,
   $isPreviewMode,
   $editingItemId,
   $instances,
@@ -192,8 +191,8 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
             data,
             slice,
             availableDataSources: findAvailableDataSources(
-              $dataSources.get(),
-              instances,
+              data.dataSources,
+              data.instances,
               parentInstanceSelector
             ),
           });

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -187,33 +187,37 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
         const [targetInstanceId, parentInstanceId] = instanceSelector;
         const parentInstanceSelector = instanceSelector.slice(1);
         const slice = getInstancesSlice(targetInstanceId);
-        insertInstancesSliceCopy({
-          slice,
-          availableDataSources: findAvailableDataSources(
-            $dataSources.get(),
-            instances,
-            parentInstanceSelector
-          ),
-          beforeTransactionEnd: (rootInstanceId, draft) => {
-            const parentInstance = draft.instances.get(parentInstanceId);
-            if (parentInstance === undefined) {
-              return;
-            }
-            // put after current instance
-            const indexWithinChildren = parentInstance.children.findIndex(
-              (child) => child.type === "id" && child.value === targetInstanceId
-            );
-            const position = indexWithinChildren + 1;
-            parentInstance.children.splice(position, 0, {
-              type: "id",
-              value: rootInstanceId,
-            });
-            // select new instance
-            $selectedInstanceSelector.set([
-              rootInstanceId,
-              ...parentInstanceSelector,
-            ]);
-          },
+        updateWebstudioData((data) => {
+          const rootInstanceId = insertInstancesSliceCopy({
+            data,
+            slice,
+            availableDataSources: findAvailableDataSources(
+              $dataSources.get(),
+              instances,
+              parentInstanceSelector
+            ),
+          });
+          if (rootInstanceId === undefined) {
+            return;
+          }
+          const parentInstance = data.instances.get(parentInstanceId);
+          if (parentInstance === undefined) {
+            return;
+          }
+          // put after current instance
+          const indexWithinChildren = parentInstance.children.findIndex(
+            (child) => child.type === "id" && child.value === targetInstanceId
+          );
+          const position = indexWithinChildren + 1;
+          parentInstance.children.splice(position, 0, {
+            type: "id",
+            value: rootInstanceId,
+          });
+          // select new instance
+          $selectedInstanceSelector.set([
+            rootInstanceId,
+            ...parentInstanceSelector,
+          ]);
         });
       },
     },

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -167,14 +167,14 @@ const getPasteTarget = (
 };
 
 export const onPaste = (clipboardData: string): boolean => {
-  const data = parse(clipboardData);
+  const fragment = parse(clipboardData);
 
   const selectedPage = $selectedPage.get();
   const project = $project.get();
   const metas = $registeredComponentMetas.get();
 
   if (
-    data === undefined ||
+    fragment === undefined ||
     selectedPage === undefined ||
     project === undefined
   ) {
@@ -185,46 +185,50 @@ export const onPaste = (clipboardData: string): boolean => {
   const instanceSelector = $selectedInstanceSelector.get() ?? [
     selectedPage.rootInstanceId,
   ];
-  const pasteTarget = getPasteTarget(data, instanceSelector);
+  const pasteTarget = getPasteTarget(fragment, instanceSelector);
   if (pasteTarget === undefined) {
     return false;
   }
 
-  insertInstancesSliceCopy({
-    slice: data,
-    availableDataSources: findAvailableDataSources(
-      $dataSources.get(),
-      $instances.get(),
-      instanceSelector
-    ),
-    beforeTransactionEnd: (rootInstanceId, draft) => {
-      let dropTarget = pasteTarget;
-      dropTarget =
-        getInstanceOrCreateFragmentIfNecessary(draft.instances, dropTarget) ??
-        dropTarget;
-      dropTarget =
-        wrapEditableChildrenAroundDropTargetMutable(
-          draft.instances,
-          draft.props,
-          metas,
-          dropTarget
-        ) ?? dropTarget;
-      const [parentId] = dropTarget.parentSelector;
-      const parentInstance = draft.instances.get(parentId);
-      if (parentInstance === undefined) {
-        return;
-      }
-      const child: Instance["children"][number] = {
-        type: "id",
-        value: rootInstanceId,
-      };
-      const { position } = dropTarget;
-      if (position === "end") {
-        parentInstance.children.push(child);
-      } else {
-        parentInstance.children.splice(position, 0, child);
-      }
-    },
+  updateWebstudioData((data) => {
+    const rootInstanceId = insertInstancesSliceCopy({
+      data,
+      slice: fragment,
+      availableDataSources: findAvailableDataSources(
+        $dataSources.get(),
+        $instances.get(),
+        instanceSelector
+      ),
+    });
+    if (rootInstanceId === undefined) {
+      return;
+    }
+    let dropTarget = pasteTarget;
+    dropTarget =
+      getInstanceOrCreateFragmentIfNecessary(data.instances, dropTarget) ??
+      dropTarget;
+    dropTarget =
+      wrapEditableChildrenAroundDropTargetMutable(
+        data.instances,
+        data.props,
+        metas,
+        dropTarget
+      ) ?? dropTarget;
+    const [parentId] = dropTarget.parentSelector;
+    const parentInstance = data.instances.get(parentId);
+    if (parentInstance === undefined) {
+      return;
+    }
+    const child: Instance["children"][number] = {
+      type: "id",
+      value: rootInstanceId,
+    };
+    const { position } = dropTarget;
+    if (position === "end") {
+      parentInstance.children.push(child);
+    } else {
+      parentInstance.children.splice(position, 0, child);
+    }
   });
 
   return true;

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -13,7 +13,6 @@ import {
   $project,
   $registeredComponentMetas,
   $instances,
-  $dataSources,
 } from "../nano-states";
 import {
   type InstanceSelector,
@@ -195,8 +194,8 @@ export const onPaste = (clipboardData: string): boolean => {
       data,
       slice: fragment,
       availableDataSources: findAvailableDataSources(
-        $dataSources.get(),
-        $instances.get(),
+        data.dataSources,
+        data.instances,
         instanceSelector
       ),
     });

--- a/apps/builder/app/shared/instance-utils.test.ts
+++ b/apps/builder/app/shared/instance-utils.test.ts
@@ -9,6 +9,7 @@ import {
 import * as defaultMetas from "@webstudio-is/sdk-components-react/metas";
 import type {
   Asset,
+  Breakpoint,
   DataSource,
   Instance,
   Instances,
@@ -16,6 +17,7 @@ import type {
   Resource,
   StyleDecl,
   StyleDeclKey,
+  StyleSource,
   WebstudioData,
 } from "@webstudio-is/sdk";
 import type { StyleProperty, StyleValue } from "@webstudio-is/css-engine";
@@ -544,7 +546,7 @@ describe("reparent instance", () => {
   });
 });
 
-const getWebstudioData = (data: Partial<WebstudioData>): WebstudioData => ({
+const getWebstudioData = (data?: Partial<WebstudioData>): WebstudioData => ({
   pages: createDefaultPages({ rootInstanceId: "" }),
   assets: new Map(),
   dataSources: new Map(),
@@ -1081,9 +1083,10 @@ describe("insert instances slice copy", () => {
     assets: [],
   };
 
+  $project.set({ id: "current_project" } as Project);
+
   beforeEach(() => {
     $pages.set(createDefaultPages({ rootInstanceId: "" }));
-    $project.set({ id: "current_project" } as Project);
     $assets.set(new Map());
     $breakpoints.set(new Map());
     $styleSourceSelections.set(new Map());
@@ -1095,21 +1098,24 @@ describe("insert instances slice copy", () => {
   });
 
   test("insert assets with same ids if missing", () => {
+    const data = getWebstudioData();
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         assets: [createImageAsset("asset1", "name", "another_project")],
       },
       availableDataSources: new Set(),
     });
-    expect(Array.from($assets.get().values())).toEqual([
+    expect(Array.from(data.assets.values())).toEqual([
       createImageAsset("asset1", "name", "current_project"),
     ]);
 
-    $assets.set(
-      toMap([createImageAsset("asset1", "changed_name", "current_project")])
-    );
+    data.assets = toMap([
+      createImageAsset("asset1", "changed_name", "current_project"),
+    ]);
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         assets: [
@@ -1119,7 +1125,7 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(),
     });
-    expect(Array.from($assets.get().values())).toEqual([
+    expect(Array.from(data.assets.values())).toEqual([
       // preserve any user changes
       createImageAsset("asset1", "changed_name", "current_project"),
       // add new assets while preserving old ones
@@ -1128,13 +1134,13 @@ describe("insert instances slice copy", () => {
   });
 
   test("merge breakpoints with existing ones", () => {
-    $breakpoints.set(
-      toMap([
-        { id: "existing_base", label: "base" },
-        { id: "existing_small", label: "small", minWidth: 768 },
-      ])
-    );
+    const breakpoints = toMap<Breakpoint>([
+      { id: "existing_base", label: "base" },
+      { id: "existing_small", label: "small", minWidth: 768 },
+    ]);
+    const data = getWebstudioData({ breakpoints });
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         breakpoints: [
@@ -1153,7 +1159,7 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(),
     });
-    expect(Array.from($breakpoints.get().values())).toEqual([
+    expect(Array.from(data.breakpoints.values())).toEqual([
       { id: "existing_base", label: "base" },
       { id: "existing_small", label: "small", minWidth: 768 },
       { id: "new_large", label: "Large", minWidth: 1200 },
@@ -1161,11 +1167,13 @@ describe("insert instances slice copy", () => {
   });
 
   test("insert missing tokens and use merged breakpoint ids", () => {
-    $breakpoints.set(toMap([{ id: "base", label: "base" }]));
-    $styleSources.set(
-      toMap([{ id: "token1", type: "token", name: "oldLabel" }])
-    );
+    const breakpoints = toMap<Breakpoint>([{ id: "base", label: "base" }]);
+    const styleSources = toMap<StyleSource>([
+      { id: "token1", type: "token", name: "oldLabel" },
+    ]);
+    const data = getWebstudioData({ breakpoints, styleSources });
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         breakpoints: [{ id: "new_base", label: "Base" }],
@@ -1190,11 +1198,11 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(),
     });
-    expect(Array.from($styleSources.get().values())).toEqual([
+    expect(Array.from(data.styleSources.values())).toEqual([
       { id: "token1", type: "token", name: "oldLabel" },
       { id: "token2", type: "token", name: "myToken" },
     ]);
-    expect(Array.from($styles.get().values())).toEqual([
+    expect(Array.from(data.styles.values())).toEqual([
       {
         styleSourceId: "token2",
         breakpointId: "base",
@@ -1205,7 +1213,9 @@ describe("insert instances slice copy", () => {
   });
 
   test("insert instances", () => {
+    const data = getWebstudioData();
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         instances: [
@@ -1219,7 +1229,7 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(),
     });
-    expect(Array.from($instances.get().keys())).toEqual([
+    expect(Array.from(data.instances.keys())).toEqual([
       expect.not.stringMatching("box"),
     ]);
   });
@@ -1248,8 +1258,10 @@ describe("insert instances slice copy", () => {
         children: [{ type: "text", value: "First" }],
       },
     ];
+    const data = getWebstudioData();
 
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         instances: instancesWithPortals,
@@ -1257,7 +1269,7 @@ describe("insert instances slice copy", () => {
       availableDataSources: new Set(),
     });
 
-    expect(Array.from($instances.get().values())).toEqual([
+    expect(Array.from(data.instances.values())).toEqual([
       {
         type: "instance",
         id: "fragment",
@@ -1280,16 +1292,15 @@ describe("insert instances slice copy", () => {
 
     // change portal content and make sure it does not break
     // when stale portal with same id is inserted
-    const instancesWithDeletedBoxes = new Map($instances.get());
-    instancesWithDeletedBoxes.delete("box");
-    instancesWithDeletedBoxes.set("fragment", {
+    data.instances.delete("box");
+    data.instances.set("fragment", {
       type: "instance",
       id: "fragment",
       component: "Fragment",
       children: [],
     });
-    $instances.set(instancesWithDeletedBoxes);
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         instances: instancesWithPortals,
@@ -1297,7 +1308,7 @@ describe("insert instances slice copy", () => {
       availableDataSources: new Set(),
     });
 
-    expect(Array.from($instances.get().values())).toEqual([
+    expect(Array.from(data.instances.values())).toEqual([
       {
         type: "instance",
         id: "fragment",
@@ -1320,7 +1331,9 @@ describe("insert instances slice copy", () => {
   });
 
   test("insert props with new ids", () => {
+    const data = getWebstudioData();
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         props: [
@@ -1335,7 +1348,7 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(),
     });
-    expect(Array.from($props.get().values())).toEqual([
+    expect(Array.from(data.props.values())).toEqual([
       {
         id: expect.not.stringMatching("prop1"),
         instanceId: expect.not.stringMatching("body"),
@@ -1347,7 +1360,9 @@ describe("insert instances slice copy", () => {
   });
 
   test("insert props from portals with old ids", () => {
+    const data = getWebstudioData();
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         // portal
@@ -1378,7 +1393,7 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(),
     });
-    expect(Array.from($props.get().values())).toEqual([
+    expect(Array.from(data.props.values())).toEqual([
       {
         id: "prop1",
         instanceId: "fragment",
@@ -1390,7 +1405,9 @@ describe("insert instances slice copy", () => {
   });
 
   test("insert data sources with new ids", () => {
+    const data = getWebstudioData();
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         dataSources: [
@@ -1434,9 +1451,9 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(),
     });
-    const [newVariableId] = $dataSources.get().keys();
+    const [newVariableId] = data.dataSources.keys();
     expect(newVariableId).not.toEqual("variableId");
-    expect(Array.from($dataSources.get().values())).toEqual([
+    expect(Array.from(data.dataSources.values())).toEqual([
       {
         id: newVariableId,
         scopeInstanceId: expect.not.stringMatching("body"),
@@ -1445,7 +1462,7 @@ describe("insert instances slice copy", () => {
         value: { type: "string", value: "" },
       },
     ]);
-    expect(Array.from($props.get().values())).toEqual([
+    expect(Array.from(data.props.values())).toEqual([
       {
         id: expect.not.stringMatching("expressionId"),
         instanceId: expect.not.stringMatching("body"),
@@ -1477,7 +1494,9 @@ describe("insert instances slice copy", () => {
   });
 
   test("inline data sources when not available in scope", () => {
+    const data = getWebstudioData();
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         dataSources: [
@@ -1527,8 +1546,8 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(["insideVariableId"]),
     });
-    expect($dataSources.get()).toEqual(new Map());
-    expect(Array.from($props.get().values())).toEqual([
+    expect(data.dataSources).toEqual(new Map());
+    expect(Array.from(data.props.values())).toEqual([
       {
         id: expect.not.stringMatching("expressionId"),
         instanceId: expect.not.stringMatching("body"),
@@ -1553,7 +1572,9 @@ describe("insert instances slice copy", () => {
   });
 
   test("insert data sources from portals with old ids", () => {
+    const data = getWebstudioData();
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         // portal
@@ -1613,7 +1634,7 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(),
     });
-    expect(Array.from($dataSources.get().values())).toEqual([
+    expect(Array.from(data.dataSources.values())).toEqual([
       {
         id: "variableId",
         scopeInstanceId: "fragment",
@@ -1622,7 +1643,7 @@ describe("insert instances slice copy", () => {
         value: { type: "string", value: "" },
       },
     ]);
-    expect(Array.from($props.get().values())).toEqual([
+    expect(Array.from(data.props.values())).toEqual([
       {
         id: "expressionId",
         instanceId: "fragment",
@@ -1654,7 +1675,9 @@ describe("insert instances slice copy", () => {
   });
 
   test("inline data sources from portals when not available in scope", () => {
+    const data = getWebstudioData();
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         // portal
@@ -1720,8 +1743,8 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(["insideVariableId"]),
     });
-    expect($dataSources.get()).toEqual(new Map());
-    expect(Array.from($props.get().values())).toEqual([
+    expect(data.dataSources).toEqual(new Map());
+    expect(Array.from(data.props.values())).toEqual([
       {
         id: "expressionId",
         instanceId: "fragment",
@@ -1746,8 +1769,10 @@ describe("insert instances slice copy", () => {
   });
 
   test("insert local styles with new ids and use merged breakpoint ids", () => {
-    $breakpoints.set(toMap([{ id: "base", label: "base" }]));
+    const breakpoints = toMap<Breakpoint>([{ id: "base", label: "base" }]);
+    const data = getWebstudioData({ breakpoints });
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         instances: [
@@ -1781,16 +1806,16 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(),
     });
-    expect(Array.from($styleSourceSelections.get().values())).toEqual([
+    expect(Array.from(data.styleSourceSelections.values())).toEqual([
       {
         instanceId: expect.not.stringMatching("box"),
         values: [expect.not.stringMatching("localId"), "tokenId"],
       },
     ]);
-    expect(Array.from($styleSources.get().values())).toEqual([
+    expect(Array.from(data.styleSources.values())).toEqual([
       { id: expect.not.stringMatching("localId"), type: "local" },
     ]);
-    expect(Array.from($styles.get().values())).toEqual([
+    expect(Array.from(data.styles.values())).toEqual([
       {
         styleSourceId: expect.not.stringMatching("localId"),
         breakpointId: "base",
@@ -1801,8 +1826,10 @@ describe("insert instances slice copy", () => {
   });
 
   test("insert local styles from portal and use merged breakpoint ids", () => {
-    $breakpoints.set(toMap([{ id: "base", label: "base" }]));
+    const breakpoints = toMap<Breakpoint>([{ id: "base", label: "base" }]);
+    const data = getWebstudioData({ breakpoints });
     insertInstancesSliceCopy({
+      data,
       slice: {
         ...emptySlice,
         // portal
@@ -1844,13 +1871,13 @@ describe("insert instances slice copy", () => {
       },
       availableDataSources: new Set(),
     });
-    expect(Array.from($styleSourceSelections.get().values())).toEqual([
+    expect(Array.from(data.styleSourceSelections.values())).toEqual([
       { instanceId: "fragment", values: ["localId", "tokenId"] },
     ]);
-    expect(Array.from($styleSources.get().values())).toEqual([
+    expect(Array.from(data.styleSources.values())).toEqual([
       { id: "localId", type: "local" },
     ]);
-    expect(Array.from($styles.get().values())).toEqual([
+    expect(Array.from(data.styles.values())).toEqual([
       {
         styleSourceId: "localId",
         breakpointId: "base",


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2532

Here refactored insertInstancesSliceCopy to accept webstudio data instead of creating transaction.

This let us avoid hacky callbacks in duplicate instance and duplicate page functionalities.

Note: review with hidden whitespaces

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
