### PR TITLE
feat: Use home icon on the home page

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -204,7 +204,7 @@ const PagesPanel = ({
         </TreeItemBody>
       );
     },
-    [editingItemId, onEdit]
+    [editingItemId, onEdit, pages]
   );
 
   const selectTreeNode = useCallback(

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -17,6 +17,7 @@ import {
 import {
   ChevronRightIcon,
   FolderIcon,
+  HomeIcon,
   MenuIcon,
   NewFolderIcon,
   NewPageIcon,
@@ -188,7 +189,15 @@ const PagesPanel = ({
             </TreeItemLabel>
           )}
           {props.itemData.type === "page" && (
-            <TreeItemLabel prefix={<PageIcon />}>
+            <TreeItemLabel
+              prefix={
+                props.itemData.id === pages?.homePage.id ? (
+                  <HomeIcon />
+                ) : (
+                  <PageIcon />
+                )
+              }
+            >
               {props.itemData.data.name}
             </TreeItemLabel>
           )}


### PR DESCRIPTION
## Description

Just a different icon instead of standard page icon when its a home page

## Steps for reproduction

1. open pages
2. see home with home icon, the rest of pages regular icon

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
