### PR TITLE
fix: hide page path tooltip

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -417,17 +417,19 @@ const FormFields = ({
               <Label htmlFor={fieldIds.path}>
                 <Flex align="center" css={{ gap: theme.spacing[3] }}>
                   Path
-                  <Tooltip
-                    content={
-                      "The path can include dynamic parameters like :name, which could be made optional using :name?, or have a wildcard such as /* or /:name* to store whole remaining part at the end of the URL."
-                    }
-                    variant="wrapped"
-                  >
-                    <HelpIcon
-                      color={rawTheme.colors.foregroundSubtle}
-                      tabIndex={0}
-                    />
-                  </Tooltip>
+                  {isFeatureEnabled("cms") && (
+                    <Tooltip
+                      content={
+                        "The path can include dynamic parameters like :name, which could be made optional using :name?, or have a wildcard such as /* or /:name* to store whole remaining part at the end of the URL."
+                      }
+                      variant="wrapped"
+                    >
+                      <HelpIcon
+                        color={rawTheme.colors.foregroundSubtle}
+                        tabIndex={0}
+                      />
+                    </Tooltip>
+                  )}
                 </Flex>
               </Label>
               <InputErrorsTooltip errors={errors.path}>


### PR DESCRIPTION
Fixes https://discord.com/channels/955905230107738152/1198946829778305044/1198946829778305044

Should be behind cms flag

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
