### PR TITLE
fix: handle invalid request errors in resource loader

### DIFF
--- a/packages/sdk/src/resource-loader.ts
+++ b/packages/sdk/src/resource-loader.ts
@@ -12,21 +12,30 @@ export const loadResource = async (resourceData: Resource) => {
   if (method !== "get" && body !== undefined) {
     requestInit.body = body;
   }
-  const response = await fetch(url, requestInit);
-  let data;
-  if (
-    response.ok &&
-    // accept json by default and when specified explicitly
-    (requestHeaders.has("accept") === false ||
-      requestHeaders.get("accept") === "application/json")
-  ) {
-    data = await response.json();
-  } else {
-    data = await response.text();
+  try {
+    const response = await fetch(url, requestInit);
+    let data;
+    if (
+      response.ok &&
+      // accept json by default and when specified explicitly
+      (requestHeaders.has("accept") === false ||
+        requestHeaders.get("accept") === "application/json")
+    ) {
+      data = await response.json();
+    } else {
+      data = await response.text();
+    }
+    return {
+      data,
+      status: response.status,
+      statusText: response.statusText,
+    };
+  } catch (error) {
+    const message = (error as unknown as Error).message;
+    return {
+      data: undefined,
+      status: 500,
+      statusText: message,
+    };
   }
-  return {
-    data,
-    status: response.status,
-    statusText: response.statusText,
-  };
 };


### PR DESCRIPTION
Here fixed the case with broken published site when invalid url is passed to fetch. The error is passed to user as statusText with 500 status code.

As a result correct everything will continue to render just with empty data.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
