### PR TITLE
chore: Improve wording for empty state in variables and binding panels

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -149,7 +149,10 @@ const EmptyVariables = () => {
   return (
     <Flex direction="column" css={{ gap: theme.spacing[5] }}>
       <Flex justify="center" align="center" css={{ height: theme.spacing[13] }}>
-        <Text variant="labelsSentenceCase">No variables yet</Text>
+        <Text variant="labelsSentenceCase" align="center">
+          No variables created
+          <br /> on this instance
+        </Text>
       </Flex>
       <Flex justify="center" align="center" css={{ height: theme.spacing[13] }}>
         <VariablePopoverTrigger>

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -114,6 +114,7 @@ const BindingPanel = ({
   const usedIdentifiers = useMemo(() => getUsedIdentifiers(value), [value]);
   const [error, setError] = useState<undefined | string>();
   const [touched, setTouched] = useState(false);
+  const scopeEntries = Object.entries(scope);
 
   const updateExpression = (newExpression: string) => {
     setExpression(newExpression);
@@ -157,9 +158,15 @@ const BindingPanel = ({
             <InfoCircleIcon tabIndex={0} />
           </Tooltip>
         </Flex>
-
+        {scopeEntries.length === 0 && (
+          <Flex justify="center" align="center" css={{ py: theme.spacing[5] }}>
+            <Text variant="labelsSentenceCase">
+              No variables available in this scope
+            </Text>
+          </Flex>
+        )}
         <CssValueListArrowFocus>
-          {Object.entries(scope).map(([identifier, value], index) => {
+          {scopeEntries.map(([identifier, value], index) => {
             const name = aliases.get(identifier);
             const label =
               value === undefined


### PR DESCRIPTION
## Description

![image](https://github.com/webstudio-is/webstudio/assets/52824/2d941caa-7b3d-43fc-9577-59f81dd38409)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
