### PR TITLE
fix: compute styles for collection children correctly

### DIFF
--- a/apps/builder/app/builder/features/style-panel/parent-style.ts
+++ b/apps/builder/app/builder/features/style-panel/parent-style.ts
@@ -21,7 +21,8 @@ export const useParentStyle = () => {
     const meta = component
       ? registeredComponentMetas.get(component)
       : undefined;
-    if (meta?.stylable !== false) {
+    // ignore instances without meta and unstylable components
+    if (meta !== undefined && meta.stylable !== false) {
       break;
     }
   }


### PR DESCRIPTION
Here fixed detecting flex child on collection children where collection parent is flexbox.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
