### PR TITLE
fix: Use custom logic for showing style source label for property names. 

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
@@ -121,15 +121,17 @@ const FlexChildSectionSizing = (props: RenderCategoryProps) => {
   const onReset = () => {
     setSizing.deleteProperty("flexGrow");
     setSizing.deleteProperty("flexShrink");
+    setSizing.deleteProperty("flexBasis");
     setSizing.publish();
   };
+
   return (
     <Grid css={{ gridTemplateColumns: "4fr auto" }}>
       <PropertyName
         style={currentStyle}
-        properties={["flexGrow", "flexShrink"]}
+        properties={["flexGrow", "flexShrink", "flexBasis"]}
         label="Sizing"
-        description="Specifies the ability of a flex item to grow or shrink"
+        description="Specifies the ability of a flex item to grow, shrink, or set its initial size within a flex container."
         onReset={onReset}
       />
       <ToggleGroupControl

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -33,6 +33,7 @@ import {
   type StyleInfo,
   getStyleSource,
   type StyleValueInfo,
+  getPriorityStyleSource,
 } from "./style-info";
 import { humanizeString } from "~/shared/string-utils";
 import { getInstanceLabel } from "~/shared/instance-utils";
@@ -371,8 +372,17 @@ const PropertyNameInternal = ({
   onReset,
   disabled,
 }: PropertyNameInternalProps) => {
-  // When we have multiple properties, they must be originating from the same source, so we can just use one.
   const property = properties[0];
+  /*
+    When there are multiple properties. We need to make a consolidated choice.
+    As we can't show multiple badges in the property name.
+    Eg: flex-grow, flex-shrink, flex-basis
+    All three managed by single section. If flex-basis is set, but if we pick only flex-grow from the three.
+    The section does't show the badge. So, we need to pick the one which is being used.
+  */
+  const styleSourcesList = properties.map((property) =>
+    getStyleSource(style[property])
+  );
 
   return (
     <Flex align="center">
@@ -390,7 +400,9 @@ const PropertyNameInternal = ({
               color={
                 onReset === undefined
                   ? "default"
-                  : getStyleSource(style[property])
+                  : styleSourcesList.length === 0
+                  ? "default"
+                  : getPriorityStyleSource(styleSourcesList)
               }
               truncate
               disabled={disabled}

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -373,13 +373,13 @@ const PropertyNameInternal = ({
   disabled,
 }: PropertyNameInternalProps) => {
   const property = properties[0];
-  /*
-    When there are multiple properties. We need to make a consolidated choice.
-    As we can't show multiple badges in the property name.
-    Eg: flex-grow, flex-shrink, flex-basis
-    All three managed by single section. If flex-basis is set, but if we pick only flex-grow from the three.
-    The section does't show the badge. So, we need to pick the one which is being used.
-  */
+
+  // When there are multiple properties. We need to make a consolidated choice.
+  // As we can't show multiple badges in the property name.
+  // Eg: flex-grow, flex-shrink, flex-basis
+  // All three managed by single section. If flex-basis is set, but if we pick only flex-grow from the three.
+  // The section does't show the badge. So, we need to pick the one which is being used.
+
   const styleSourcesList = properties.map((property) =>
     getStyleSource(style[property])
   );

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -28,6 +28,7 @@ import {
   getInheritedInfo,
   getNextSourceInfo,
   getPreviousSourceInfo,
+  getPriorityStyleSource,
   getStyleSource,
   useStyleInfo,
 } from "./style-info";
@@ -946,5 +947,20 @@ describe("active states", () => {
       type: "keyword",
       value: "green",
     });
+  });
+
+  test("get the style source from ['local', 'default', 'preset']", () => {
+    const result = getPriorityStyleSource(["local", "default", "preset"]);
+    expect(result).toBe("local");
+  });
+
+  test("get the style source from ['local', 'overwritten', 'preset']", () => {
+    const result = getPriorityStyleSource(["local", "overwritten", "preset"]);
+    expect(result).toBe("overwritten");
+  });
+
+  test("get the style source from ['default', 'default', 'preset']", () => {
+    const result = getPriorityStyleSource(["default", "default", "preset"]);
+    expect(result).toBe("preset");
   });
 });

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -842,3 +842,23 @@ export const useStyleInfoByInstanceId = (
     lastStyleSource
   );
 };
+
+export const getPriorityStyleSource = (
+  styleSources: StyleSource[]
+): StyleSource => {
+  const customOrder: StyleSource[] = [
+    "overwritten",
+    "local",
+    "remote",
+    "preset",
+    "default",
+  ];
+
+  for (const style of customOrder) {
+    if (styleSources.includes(style)) {
+      return style;
+    }
+  }
+
+  return "default";
+};


### PR DESCRIPTION
## Description

fixes #2799 

The issue is related to picking only one property from the list of `properties` that being sent to `PropertyName` component. The `Sizing` section is sending `flexGrow`, `flexShrink' and `flexBasis`. But the property tooltip is taking only `flexGrow` to show the label.
And in this case, `flexGrow` and `flexShrink` are missing. So, the label doesn't show up. Added a custom logic to show the label by following the order instead. Let me know, your opinions. 

Bug location
https://github.com/webstudio-is/webstudio/blob/main/apps/builder/app/builder/features/style-panel/shared/property-name.tsx#L375

```jsx
}: PropertyNameInternalProps) => {
  // When we have multiple properties, they must be originating from the same source, so we can just use one.
  const property = properties[0];
```

## Steps for reproduction
Steps to reproduce are from the main issue link, with a gif.


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] added tests
