### PR TITLE
fix: Label shouldn't be used for section titles

### DIFF
--- a/apps/builder/app/builder/features/seo/project-settings.tsx
+++ b/apps/builder/app/builder/features/seo/project-settings.tsx
@@ -85,7 +85,7 @@ const ProjectSettingsContentMeta = (props: {
       <Separator />
 
       <Grid gap={2} css={{ mx: theme.spacing[5], px: theme.spacing[5] }}>
-        <Label sectionTitle>Favicon</Label>
+        <Text variant="titles">Favicon</Text>
         <Grid flow="column" gap={3}>
           <Image
             width={72}
@@ -114,9 +114,7 @@ const ProjectSettingsContentMeta = (props: {
       <Separator />
 
       <Grid gap={2} css={{ mx: theme.spacing[5], px: theme.spacing[5] }}>
-        <Label htmlFor={ids.code} sectionTitle>
-          Custom Code
-        </Label>
+        <Text variant="titles">Custom Code</Text>
         <Text color="subtle">
           Custom code and scripts will be added at the end of the &lt;head&gt;
           tag to every page across the published project.
@@ -153,7 +151,7 @@ const ProjectAdvancedSettings = (props: {
     <>
       <Separator />
       <Grid gap={2} css={{ mx: theme.spacing[5], px: theme.spacing[5] }}>
-        <Label sectionTitle>Publish Settings</Label>
+        <Text variant="titles">Publish Settings</Text>
         <CheckboxAndLabel>
           <Checkbox
             checked={props.settings.atomicStyles ?? true}

--- a/apps/builder/app/builder/features/seo/project-settings.tsx
+++ b/apps/builder/app/builder/features/seo/project-settings.tsx
@@ -85,9 +85,7 @@ const ProjectSettingsContentMeta = (props: {
       <Separator />
 
       <Grid gap={2} css={{ mx: theme.spacing[5], px: theme.spacing[5] }}>
-        <Label htmlFor={ids.favicon} sectionTitle>
-          Favicon
-        </Label>
+        <Label sectionTitle>Favicon</Label>
         <Grid flow="column" gap={3}>
           <Image
             width={72}


### PR DESCRIPTION
## Description

When clicking on favicon upload label, it shouldn't trigger the upload button click

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
