### PR TITLE
feat: support avif upload

### DIFF
--- a/apps/builder/app/builder/shared/assets/asset-upload.tsx
+++ b/apps/builder/app/builder/shared/assets/asset-upload.tsx
@@ -5,6 +5,7 @@ import { UploadIcon } from "@webstudio-is/icons";
 import {
   type AssetType,
   MAX_UPLOAD_SIZE,
+  IMAGE_MIME_TYPES,
   toBytes,
 } from "@webstudio-is/asset-uploader";
 import { FONT_MIME_TYPES } from "@webstudio-is/fonts";
@@ -45,19 +46,8 @@ const useUpload = (type: AssetType) => {
   return { inputRef, onChange };
 };
 
-// https://developers.cloudflare.com/images/image-resizing/format-limitations/
-const imageMimeTypes = [
-  "image/jpeg",
-  "image/png",
-  "image/gif",
-  "image/webp",
-  "image/svg+xml",
-  "image/x-icon",
-  "image/ico",
-];
-
 const acceptMap = {
-  image: imageMimeTypes.join(", "),
+  image: IMAGE_MIME_TYPES.join(", "),
   font: FONT_MIME_TYPES,
 };
 

--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -21,7 +21,7 @@
     "@webstudio-is/sdk": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
     "fontkit": "^2.0.2",
-    "image-size": "^1.0.2",
+    "image-size": "^1.1.1",
     "immer": "^10.0.3",
     "nanoid": "^5.0.1",
     "warn-once": "^0.1.1"

--- a/packages/asset-uploader/src/utils/mime.ts
+++ b/packages/asset-uploader/src/utils/mime.ts
@@ -17,11 +17,11 @@ const mimeCategories = [
 
 type MimeCategory = (typeof mimeCategories)[number];
 
-const extensionToMime = new Map([
-  [".avif" as string, "image/avif"],
-  [".bmp", "image/bmp"],
+// https://developers.cloudflare.com/images/image-resizing/format-limitations/
+const imageExtensionsToMime = new Map([
+  [".avif", "image/avif"],
   [".gif", "image/gif"],
-  [".ico", "image/vnd.microsoft.icon"],
+  [".ico", "image/x-icon"],
   [".jpeg", "image/jpeg"],
   [".jpg", "image/jpeg"],
   [".png", "image/png"],
@@ -29,11 +29,25 @@ const extensionToMime = new Map([
   [".tif", "image/tiff"],
   [".tiff", "image/tiff"],
   [".webp", "image/webp"],
+] as const);
+
+const fontsExtensionsToMime = new Map([
   [".woff", "font/woff"],
   [".woff2", "font/woff2"],
   [".ttf", "font/ttf"],
   [".otf", "font/otf"],
 ] as const);
+
+const extensionToMime = new Map([
+  ...imageExtensionsToMime,
+  ...fontsExtensionsToMime,
+]);
+
+export const IMAGE_MIME_TYPES = Array.from(
+  new Set(imageExtensionsToMime.values()).values()
+);
+
+const extensions = Array.from(extensionToMime.keys());
 
 const mimeTypes = new Set(extensionToMime.values());
 type Mime = SetType<typeof mimeTypes>;
@@ -43,7 +57,7 @@ const mimePatterns = new Set([
   ...mimeTypes.values(),
   ...mimeCategories.map((category): `${MimeCategory}/*` => `${category}/*`),
 ]);
-type MimePattern = SetType<typeof mimePatterns>;
+export type MimePattern = SetType<typeof mimePatterns>;
 const isMimePattern = (value: string): value is MimePattern =>
   mimePatterns.has(value as MimePattern);
 
@@ -77,7 +91,7 @@ export const acceptToMimePatterns = (
       result.add(trimmed);
       continue;
     }
-    const mime = extensionToMime.get(trimmed);
+    const mime = extensionToMime.get(trimmed as (typeof extensions)[number]);
 
     if (mime === undefined) {
       warnOnce(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -779,8 +779,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       image-size:
-        specifier: ^1.0.2
-        version: 1.0.2
+        specifier: ^1.1.1
+        version: 1.1.1
       immer:
         specifier: ^10.0.3
         version: 10.0.3
@@ -11787,9 +11787,9 @@ packages:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
 
-  /image-size@1.0.2:
-    resolution: {integrity: sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==}
-    engines: {node: '>=14.0.0'}
+  /image-size@1.1.1:
+    resolution: {integrity: sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==}
+    engines: {node: '>=16.x'}
     hasBin: true
     dependencies:
       queue: 6.0.2


### PR DESCRIPTION
## Description

We simply didn't have avif in the list for available formats for upload and I used the opportunity to reuse the mime list

@istarkov  CFs resizer input formats don't have avif, https://developers.cloudflare.com/images/image-resizing/format-limitations/ 
will it automatically ignore it? or do we need to do something to support avif upload?

## Steps for reproduction

1. upload avif image

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
