### PR TITLE
feat: Show plan name instead of Pro badge

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -395,7 +395,7 @@ const VariablePanel = forwardRef<
             {getTypeLabel(option)}
             {option === "resource" && allowResourceVariables === false && (
               <Box css={{ display: "inline-block", ml: theme.spacing[3] }}>
-                <ProBadge />
+                <ProBadge>Pro</ProBadge>
               </Box>
             )}
           </SelectItem>

--- a/apps/builder/app/dashboard/header.tsx
+++ b/apps/builder/app/dashboard/header.tsx
@@ -50,7 +50,7 @@ const Menu = ({
           <Flex gap="1" align="center">
             {userPlanFeatures.hasProPlan && (
               <>
-                <ProBadge />
+                <ProBadge>{userPlanFeatures.planName}</ProBadge>
                 <div />
               </>
             )}

--- a/apps/builder/app/shared/db/user-plan-features.server.ts
+++ b/apps/builder/app/shared/db/user-plan-features.server.ts
@@ -1,18 +1,7 @@
 import { prisma } from "@webstudio-is/prisma-client";
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
 
-/**
- * Plan features are available on the client, do not use any secrets, 3rd party ids etc
- **/
-export type UserPlanFeatures = {
-  allowShareAdminLinks: boolean;
-  allowResourceVariables: boolean;
-  maxDomainsAllowedPerUser: number;
-  hasSubscription: boolean;
-  hasProPlan: boolean;
-};
-
-// No strings - no secrets
-({}) as UserPlanFeatures satisfies Record<string, boolean | number>;
+export type UserPlanFeatures = NonNullable<AppContext["userPlanFeatures"]>;
 
 export const getTokenPlanFeatures = async (token: string) => {
   const projectOwnerIdByToken = await prisma.authorizationToken.findUnique({
@@ -77,6 +66,7 @@ export const getUserPlanFeatures = async (
       maxDomainsAllowedPerUser: Number.MAX_SAFE_INTEGER,
       hasSubscription,
       hasProPlan: true,
+      planName: userProducts[0].product.name,
     };
   }
 

--- a/packages/design-system/src/components/pro-badge.tsx
+++ b/packages/design-system/src/components/pro-badge.tsx
@@ -1,7 +1,8 @@
+import type { ReactNode } from "react";
 import { theme } from "../stitches.config";
 import { Text } from "./text";
 
-export const ProBadge = () => {
+export const ProBadge = (props: { children: ReactNode }) => {
   return (
     <Text
       css={{
@@ -20,7 +21,7 @@ export const ProBadge = () => {
         background: theme.colors.backgroundStyleSourceNeutral,
       }}
     >
-      Pro
+      {props.children}
     </Text>
   );
 };

--- a/packages/prisma-client/src/types.ts
+++ b/packages/prisma-client/src/types.ts
@@ -13,4 +13,5 @@ export type {
   LatestBuildPerProjectDomain,
   LatestBuildPerProject,
   PublishStatus,
+  Product,
 } from "./__generated__";

--- a/packages/trpc-interface/src/context/context.server.ts
+++ b/packages/trpc-interface/src/context/context.server.ts
@@ -55,8 +55,19 @@ type UserPlanFeatures = {
   allowResourceVariables: boolean;
   maxDomainsAllowedPerUser: number;
   hasSubscription: boolean;
-  hasProPlan: boolean;
-};
+} & (
+  | {
+      hasProPlan: true;
+      planName: string;
+    }
+  | { hasProPlan: false }
+);
+
+// No strings except planName - no secrets
+({}) as Omit<UserPlanFeatures, "planName"> satisfies Record<
+  string,
+  boolean | number
+>;
 
 /**
  * AppContext is a global context that is passed to all trpc/api queries/mutations


### PR DESCRIPTION
## Description

By request of AppSumo.

Additionally we need to rename existing products on stripe

```
RocketHub T1
RocketHub T2
RocketHub T3

LTD T1
LTD T2
LTD T3
```

And fix n8n schemas to update product names

to 

```
AppSumo T1
AppSumo T2
AppSumo T3
AppSumo T4
```

during product upsert.



## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
