### PR TITLE
refactor: generalize generating components

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -44,8 +44,7 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Page = ({ params: PageParams }: { params: any }) => {
   return (
     <Body data-ws-id="ibXgMoi9_ipHx1gVrvii0" data-ws-component="Body">
       <Heading
@@ -61,6 +60,7 @@ const Page = (_props: { params: Params }) => {
 
 export { Page };
 
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -29,8 +29,7 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Page = ({ params: PageParams }: { params: any }) => {
   return (
     <Body data-ws-id="MMimeobf_zi4ZkRGXapju" data-ws-component="Body">
       <Heading data-ws-id="MYDt0guk1-vzc7yzqyN6A" data-ws-component="Heading">
@@ -45,6 +44,7 @@ const Page = (_props: { params: Params }) => {
 
 export { Page };
 
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -29,8 +29,7 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Page = ({ params: PageParams }: { params: any }) => {
   return (
     <Body data-ws-id="MMimeobf_zi4ZkRGXapju" data-ws-component="Body">
       <Heading data-ws-id="MYDt0guk1-vzc7yzqyN6A" data-ws-component="Heading">
@@ -45,6 +44,7 @@ const Page = (_props: { params: Params }) => {
 
 export { Page };
 
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -64,8 +64,7 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Page = ({ params: PageParams }: { params: any }) => {
   return (
     <Body data-ws-id="EDEfpMPRqDejthtwkH7ws" data-ws-component="Body">
       <Image
@@ -80,6 +79,7 @@ const Page = (_props: { params: Params }) => {
 
 export { Page };
 
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -73,8 +73,7 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Page = ({ params: PageParams }: { params: any }) => {
   let [formState, set$formState] = useState<any>("initial");
   let [formState_1, set$formState_1] = useState<any>("initial");
   return (
@@ -193,6 +192,7 @@ const Page = (_props: { params: Params }) => {
 
 export { Page };
 
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -64,8 +64,7 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Page = ({ params: PageParams }: { params: any }) => {
   return (
     <Body data-ws-id="O-ljaGZQ0iRNTlEshMkgE" data-ws-component="Body">
       <Heading
@@ -81,6 +80,7 @@ const Page = (_props: { params: Params }) => {
 
 export { Page };
 
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -69,8 +69,7 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Page = ({ params: PageParams }: { params: any }) => {
   return (
     <Body data-ws-id="L0ZXd5F9xk9Rsl9ORzIkJ" data-ws-component="Body">
       <Heading data-ws-id="VFPjLwt6Caq4l9PPJSiyI" data-ws-component="Heading">
@@ -82,6 +81,7 @@ const Page = (_props: { params: Params }) => {
 
 export { Page };
 
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -80,8 +80,7 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Page = ({ params: PageParams }: { params: any }) => {
   let [accordionValue, set$accordionValue] = useState<any>("0");
   return (
     <Body data-ws-id="uKWGyE9JY3cPwY-xI9vk6" data-ws-component="Body">
@@ -232,6 +231,7 @@ const Page = (_props: { params: Params }) => {
 
 export { Page };
 
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -72,8 +72,7 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Page = ({ params: PageParams }: { params: any }) => {
   let list = useResource("list_1");
   return (
     <Body data-ws-id="AWY2qZfpbykoiWELeJhse" data-ws-component="Body">
@@ -94,6 +93,7 @@ const Page = (_props: { params: Params }) => {
 
 export { Page };
 
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -78,8 +78,7 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Page = ({ params: PageParams }: { params: any }) => {
   return (
     <Body
       data-ws-id="On9cvWCxr5rdZtY9O1Bv0"
@@ -177,6 +176,7 @@ const Page = (_props: { params: Params }) => {
 
 export { Page };
 
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -18,7 +18,7 @@ import merge from "deepmerge";
 import {
   generateCss,
   generateUtilsExport,
-  generatePageComponent,
+  generateWebstudioComponent,
   getIndexesWithinAncestors,
   namespaceMeta,
   type Params,
@@ -503,9 +503,29 @@ export const prebuild = async (options: {
       pages: siteData.build.pages,
       props,
     });
-    const pageComponent = generatePageComponent({
+    // generate new Page Params variable if does not exist
+    // to allow always passing it from route template
+    const pathVariableId = pageData.page.pathVariableId ?? "pathVariableId";
+    if (pageData.page.pathVariableId == undefined) {
+      dataSources.set(pathVariableId, {
+        id: pathVariableId,
+        name: "Page Params",
+        type: "parameter",
+      });
+    }
+    const pageComponent = generateWebstudioComponent({
       scope,
-      page: pageData.page,
+      name: "Page",
+      rootInstanceId: pageData.page.rootInstanceId,
+      parameters: [
+        {
+          id: `params`,
+          instanceId: "",
+          name: "params",
+          type: "parameter",
+          value: pathVariableId,
+        },
+      ],
       instances,
       props,
       dataSources,

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -506,7 +506,7 @@ export const prebuild = async (options: {
     // generate new Page Params variable if does not exist
     // to allow always passing it from route template
     const pathVariableId = pageData.page.pathVariableId ?? "pathVariableId";
-    if (pageData.page.pathVariableId == undefined) {
+    if (pageData.page.pathVariableId === undefined) {
       dataSources.set(pathVariableId, {
         id: pathVariableId,
         name: "Page Params",

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -4,7 +4,6 @@ import {
   createScope,
   type DataSource,
   type Instance,
-  type Page,
   type Prop,
 } from "@webstudio-is/sdk";
 import { showAttribute } from "./props";
@@ -12,7 +11,7 @@ import { collectionComponent } from "./core-components";
 import {
   generateJsxChildren,
   generateJsxElement,
-  generatePageComponent,
+  generateWebstudioComponent,
 } from "./component-generator";
 
 const clear = (input: string) =>
@@ -588,12 +587,14 @@ test("generate collection component as map", () => {
   );
 });
 
-test("generate page component with variables and actions", () => {
+test("generate component with variables and actions", () => {
   expect(
-    generatePageComponent({
+    generateWebstudioComponent({
       classesMap: new Map(),
       scope: createScope(),
-      page: { rootInstanceId: "body" } as Page,
+      name: "Page",
+      rootInstanceId: "body",
+      parameters: [],
       instances: new Map([
         createInstancePair("body", "Body", [{ type: "id", value: "input" }]),
         createInstancePair("input", "Input", []),
@@ -632,8 +633,7 @@ test("generate page component with variables and actions", () => {
     })
   ).toEqual(
     clear(`
-      type Params = Record<string, string | undefined>
-      const Page = (_props: { params: Params }) => {
+      const Page = () => {
       let [variableName, set$variableName] = useState<any>("initial")
       return <Body
       data-ws-id="body"
@@ -655,10 +655,12 @@ test("generate page component with variables and actions", () => {
 
 test("add classes and merge classes", () => {
   expect(
-    generatePageComponent({
+    generateWebstudioComponent({
       classesMap: new Map([["body", ["cls1"]]]),
       scope: createScope(),
-      page: { rootInstanceId: "body" } as Page,
+      name: "Page",
+      rootInstanceId: "body",
+      parameters: [],
       instances: new Map([createInstancePair("body", "Body", [])]),
       dataSources: new Map(),
       props: new Map([
@@ -674,8 +676,7 @@ test("add classes and merge classes", () => {
     })
   ).toEqual(
     clear(`
-    type Params = Record<string, string | undefined>
-    const Page = (_props: { params: Params }) => {
+    const Page = () => {
     return <Body
     data-ws-id="body"
     data-ws-component="Body"
@@ -687,10 +688,12 @@ test("add classes and merge classes", () => {
 
 test("avoid generating collection parameter variable as state", () => {
   expect(
-    generatePageComponent({
+    generateWebstudioComponent({
       classesMap: new Map(),
       scope: createScope(),
-      page: { rootInstanceId: "body" } as Page,
+      name: "Page",
+      rootInstanceId: "body",
+      parameters: [],
       instances: new Map([
         createInstancePair("body", "Body", [{ type: "id", value: "list" }]),
         createInstancePair("list", collectionComponent, []),
@@ -730,8 +733,7 @@ test("avoid generating collection parameter variable as state", () => {
     })
   ).toEqual(
     clear(`
-    type Params = Record<string, string | undefined>
-    const Page = (_props: { params: Params }) => {
+    const Page = () => {
     let [data, set$data] = useState<any>(["apple","orange","mango"])
     return <Body
     data-ws-id="body"
@@ -748,10 +750,20 @@ test("avoid generating collection parameter variable as state", () => {
 
 test("generate params variable when present", () => {
   expect(
-    generatePageComponent({
+    generateWebstudioComponent({
       classesMap: new Map(),
       scope: createScope(["params"]),
-      page: { rootInstanceId: "body", pathVariableId: "pathParamsId" } as Page,
+      name: "Page",
+      rootInstanceId: "body",
+      parameters: [
+        {
+          id: "pathParamsPropId",
+          type: "parameter",
+          instanceId: "",
+          name: "params",
+          value: "pathParamsId",
+        },
+      ],
       instances: new Map([createInstancePair("body", "Body", [])]),
       dataSources: new Map([
         createDataSourcePair({
@@ -774,9 +786,7 @@ test("generate params variable when present", () => {
     })
   ).toEqual(
     clear(`
-    type Params = Record<string, string | undefined>
-    const Page = (_props: { params: Params }) => {
-    let params_1 = _props.params
+    const Page = ({ params: params_1, }: { params: any; }) => {
     return <Body
     data-ws-id="body"
     data-ws-component="Body"
@@ -788,10 +798,12 @@ test("generate params variable when present", () => {
 
 test("generate resources loading", () => {
   expect(
-    generatePageComponent({
+    generateWebstudioComponent({
       classesMap: new Map(),
       scope: createScope(),
-      page: { rootInstanceId: "body" } as Page,
+      name: "Page",
+      rootInstanceId: "body",
+      parameters: [],
       instances: new Map([createInstancePair("body", "Body", [])]),
       dataSources: new Map([
         createDataSourcePair({
@@ -829,8 +841,7 @@ test("generate resources loading", () => {
     })
   ).toEqual(
     clear(`
-    type Params = Record<string, string | undefined>
-    const Page = (_props: { params: Params }) => {
+    const Page = () => {
     let [data, set$data] = useState<any>("data")
     let data_1 = useResource("data_2")
     return <Body

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -26,7 +26,7 @@ export { getIndexesWithinAncestors } from "./instance-utils";
 export * from "./hook";
 export { generateUtilsExport } from "./generator";
 export {
-  generatePageComponent,
+  generateWebstudioComponent,
   generateJsxElement,
   generateJsxChildren,
 } from "./component-generator";

--- a/packages/react-sdk/src/remix.test.ts
+++ b/packages/react-sdk/src/remix.test.ts
@@ -33,6 +33,7 @@ test("convert named groups to remix route", () => {
 
 test("generate remix params for static pathname", () => {
   expect("\n" + generateRemixParams("/blog/my-post")).toEqual(`
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params
 }
@@ -41,6 +42,7 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 test("generate remix params converter with wildcard", () => {
   expect("\n" + generateRemixParams("/blog/*")).toEqual(`
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   params[0] = params["*"]
   delete params["*"]
@@ -51,6 +53,7 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 test("generate remix params converter with named group and * modifier", () => {
   expect("\n" + generateRemixParams("/blog/:name*")).toEqual(`
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   params["name"] = params["*"]
   delete params["*"]

--- a/packages/react-sdk/src/remix.ts
+++ b/packages/react-sdk/src/remix.ts
@@ -54,6 +54,7 @@ export const generateRemixRoute = (pathname: string) => {
 export const generateRemixParams = (pathname: string) => {
   const name = pathname.match(/:(?<name>\w+)\*$/)?.groups?.name;
   let generated = "";
+  generated += `type Params = Record<string, string | undefined>;\n`;
   generated += `export const getRemixParams = ({ ...params }: Params): Params => {\n`;
   if (name) {
     generated += `  params["${name}"] = params["*"]\n`;

--- a/packages/sdk-cli/src/generate-stories.ts
+++ b/packages/sdk-cli/src/generate-stories.ts
@@ -8,13 +8,12 @@ import {
   createScope,
   parseComponentName,
   getStyleDeclKey,
-  type Page,
 } from "@webstudio-is/sdk";
 import {
   type WsComponentMeta,
   generateCss,
   generateDataFromEmbedTemplate,
-  generatePageComponent,
+  generateWebstudioComponent,
   getIndexesWithinAncestors,
 } from "@webstudio-is/react-sdk";
 import * as baseMetasExports from "@webstudio-is/sdk-components-react/metas";
@@ -86,7 +85,7 @@ const Story = {
 ${css}
       \`}
       </style>
-      <Page params={{}} />
+      <Component />
     </>
   }
 }
@@ -161,7 +160,7 @@ export const generateStories = async () => {
       },
       { assetBaseUrl: "/", atomic: true }
     );
-    const scope = createScope(["Page", "Story", "props", "useState"]);
+    const scope = createScope(["Component", "Story", "props", "useState"]);
     let content = "";
     content += getStoriesImports({
       hasState: data.dataSources.some(
@@ -174,10 +173,12 @@ export const generateStories = async () => {
       components,
     });
     content += `\n`;
-    content += generatePageComponent({
+    content += generateWebstudioComponent({
       classesMap,
       scope,
-      page: { rootInstanceId } as Page,
+      name: `Component`,
+      rootInstanceId,
+      parameters: [],
       instances,
       props: new Map(data.props.map((prop) => [prop.id, prop])),
       dataSources: new Map(data.dataSources.map((prop) => [prop.id, prop])),

--- a/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
@@ -12,8 +12,7 @@ import {
   AccordionContent as AccordionContent,
 } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [accordionValue, set$accordionValue] = useState<any>("0");
   return (
     <Box data-ws-id="root" data-ws-component="Box">
@@ -421,7 +420,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
@@ -10,8 +10,7 @@ import {
   CheckboxIndicator as CheckboxIndicator,
 } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [checkboxChecked, set$checkboxChecked] = useState<any>(false);
   return (
     <Box data-ws-id="root" data-ws-component="Box">
@@ -320,7 +319,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
@@ -10,8 +10,7 @@ import {
   CollapsibleContent as CollapsibleContent,
 } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [collapsibleOpen, set$collapsibleOpen] = useState<any>(false);
   return (
     <Box data-ws-id="root" data-ws-component="Box">
@@ -312,7 +311,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
@@ -15,8 +15,7 @@ import {
   DialogClose as DialogClose,
 } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [dialogOpen, set$dialogOpen] = useState<any>(false);
   return (
     <Box data-ws-id="root" data-ws-component="Box">
@@ -558,7 +557,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
@@ -1,8 +1,7 @@
 import { Box as Box } from "@webstudio-is/sdk-components-react";
 import { Label as Label } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   return (
     <Box data-ws-id="root" data-ws-component="Box">
       <Label
@@ -145,7 +144,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
@@ -17,8 +17,7 @@ import {
   NavigationMenuViewport as NavigationMenuViewport,
 } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [menuValue, set$menuValue] = useState<any>("");
   return (
     <Box data-ws-id="root" data-ws-component="Box">
@@ -981,7 +980,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
@@ -10,8 +10,7 @@ import {
   PopoverContent as PopoverContent,
 } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [popoverOpen, set$popoverOpen] = useState<any>(false);
   return (
     <Box data-ws-id="root" data-ws-component="Box">
@@ -335,7 +334,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
@@ -11,8 +11,7 @@ import {
   RadioGroupIndicator as RadioGroupIndicator,
 } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [radioGroupValue, set$radioGroupValue] = useState<any>("");
   return (
     <Box data-ws-id="root" data-ws-component="Box">
@@ -385,7 +384,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
@@ -14,8 +14,7 @@ import {
   SelectItemText as SelectItemText,
 } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [selectValue, set$selectValue] = useState<any>("");
   let [selectOpen, set$selectOpen] = useState<any>(false);
   return (
@@ -519,7 +518,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
@@ -15,8 +15,7 @@ import {
   DialogClose as DialogClose,
 } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [sheetOpen, set$sheetOpen] = useState<any>(false);
   return (
     <Box data-ws-id="root" data-ws-component="Box">
@@ -556,7 +555,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
@@ -2,8 +2,7 @@ import { useState } from "react";
 import { Box as Box } from "@webstudio-is/sdk-components-react";
 import { Switch as Switch, SwitchThumb as SwitchThumb } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [switchChecked, set$switchChecked] = useState<any>(false);
   return (
     <Box data-ws-id="root" data-ws-component="Box">
@@ -305,7 +304,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
@@ -7,8 +7,7 @@ import {
   TabsContent as TabsContent,
 } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [tabsValue, set$tabsValue] = useState<any>("0");
   return (
     <Box data-ws-id="root" data-ws-component="Box">
@@ -337,7 +336,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
@@ -10,8 +10,7 @@ import {
   TooltipContent as TooltipContent,
 } from "../components";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+const Component = () => {
   let [tooltipOpen, set$tooltipOpen] = useState<any>(false);
   return (
     <Box data-ws-id="root" data-ws-component="Box">
@@ -329,7 +328,7 @@ html {margin: 0; display: grid; min-height: 100%}
 }
       `}
         </style>
-        <Page params={{}} />
+        <Component />
       </>
     );
   },


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2791

Here renamed generatePageComponent to generateWebstudioComponent and refactored to use it later for slots.

"Page Params" variable is now passed as parameter. Similar way we will support parameters in design components.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
