### PR TITLE
fix: Settings panel spacing

### DIFF
--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -14,6 +14,7 @@ import {
   EnhancedTooltipProvider,
   Flex,
   ScrollArea,
+  Separator,
 } from "@webstudio-is/design-system";
 import { StylePanel } from "~/builder/features/style-panel";
 import { SettingsPanelContainer } from "~/builder/features/settings-panel";
@@ -43,6 +44,7 @@ const InstanceInfo = ({ instance }: { instance: Instance }) => {
       align="center"
       css={{
         px: theme.spacing[9],
+        my: theme.spacing[3],
         height: theme.spacing[13],
         color: theme.colors.foregroundSubtle,
       }}
@@ -120,6 +122,7 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
                 )}
                 <PanelTabsTrigger value="settings">Settings</PanelTabsTrigger>
               </PanelTabsList>
+              <Separator />
               <PanelTabsContent value="style" css={contentStyle} tabIndex={-1}>
                 <InstanceInfo instance={selectedInstance} />
                 <StylePanel selectedInstance={selectedInstance} />

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -174,7 +174,7 @@ export const PropsSection = (props: PropsSectionProps) => {
 
   return (
     <>
-      <Row css={{ py: theme.spacing[5] }}>
+      <Row css={{ py: theme.spacing[3] }}>
         {logic.systemProps.map((item) => renderProperty(props, item))}
       </Row>
 
@@ -185,7 +185,7 @@ export const PropsSection = (props: PropsSectionProps) => {
         onAdd={() => setAddingProp(true)}
         hasItems={hasItems}
       >
-        <Flex gap="2" direction="column">
+        <Flex gap="1" direction="column">
           {addingProp && (
             <AddPropertyForm
               availableProps={logic.availableProps}

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -27,7 +27,6 @@ import {
   Grid,
   Text,
   theme,
-  type CSS,
   rawTheme,
 } from "@webstudio-is/design-system";
 import { humanizeString } from "~/shared/string-utils";

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   useEffect,
   useMemo,
+  type ComponentProps,
 } from "react";
 import equal from "fast-deep-equal";
 import {
@@ -294,8 +295,11 @@ export const ResponsiveLayout = ({
   );
 };
 
-export const Row = ({ children, css }: { children: ReactNode; css?: CSS }) => (
-  <Flex css={{ px: theme.spacing[9], ...css }} gap="2" direction="column">
+export const Row = ({
+  children,
+  css,
+}: Pick<ComponentProps<typeof Flex>, "css" | "children">) => (
+  <Flex css={{ px: theme.spacing[9], ...css }} direction="column">
     {children}
   </Flex>
 );

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -244,14 +244,14 @@ const bindingOpacityProperty = "--ws-binding-opacity";
 
 export const BindingControl = ({ children }: { children: ReactNode }) => {
   return (
-    <Box
+    <Flex
       css={{
         position: "relative",
         "&:hover": { [bindingOpacityProperty]: 1 },
       }}
     >
       {children}
-    </Box>
+    </Flex>
   );
 };
 

--- a/packages/design-system/src/components/panel-tabs.tsx
+++ b/packages/design-system/src/components/panel-tabs.tsx
@@ -14,10 +14,8 @@ export const PanelTabs = styled(Primitive.Root, {
 
 export const PanelTabsList = styled(Primitive.List, {
   display: "flex",
-  paddingRight: theme.spacing[5],
-  paddingLeft: theme.spacing[5],
-  paddingTop: theme.spacing[3],
-  paddingBottom: theme.spacing[3],
+  px: theme.spacing[5],
+  py: theme.spacing[3],
 });
 
 export const PanelTabsTrigger = styled(Primitive.Trigger, {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1947

## Description

It's getting it closer, but not quite all the things, so not closing the issue yet

Before:

<img width="253" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/0d31a706-a6c7-4dea-b5e8-976c0657f4b4">


After:
<img width="259" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/d64ff71c-af11-48fb-92ca-92ccd0bfa949">

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
