### PR TITLE
fix: Font smoothing antialised makes all fonts look like in figma

### DIFF
--- a/apps/builder/app/builder/builder.css
+++ b/apps/builder/app/builder/builder.css
@@ -5,4 +5,5 @@ html {
 body {
   overflow: hidden;
   overscroll-behavior: contain;
+  -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/1848

## Description

Under closer look all fonts were a bit bolder than in figma and this seems to be fixing it

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @istarkov , I need you to do
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
