### PR TITLE
fix: Align spacing for size section with figma

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/size/size.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/size/size.tsx
@@ -1,6 +1,6 @@
 import type { StyleProperty } from "@webstudio-is/css-engine";
 import { toValue } from "@webstudio-is/css-engine";
-import { Flex, Grid } from "@webstudio-is/design-system";
+import { Grid, Separator, styled } from "@webstudio-is/design-system";
 import { styleConfigByName } from "../../shared/configs";
 import type { RenderCategoryProps } from "../../style-sections";
 import { PropertyName } from "../../shared/property-name";
@@ -62,6 +62,12 @@ const properties: StyleProperty[] = [
   "aspectRatio",
 ];
 
+const Section = styled(Grid, {
+  columnGap: theme.spacing[5],
+  rowGap: theme.spacing[5],
+  px: theme.spacing[9],
+});
+
 export const SizeSection = ({
   currentStyle: style,
   setProperty,
@@ -72,11 +78,9 @@ export const SizeSection = ({
       label="Size"
       currentStyle={style}
       properties={properties}
+      fullWidth
     >
-      <Grid
-        columns={2}
-        css={{ columnGap: theme.spacing[5], rowGap: theme.spacing[7] }}
-      >
+      <Section columns={2}>
         <SizeField
           property="width"
           style={style}
@@ -125,6 +129,9 @@ export const SizeSection = ({
           setProperty={setProperty}
           deleteProperty={deleteProperty}
         />
+      </Section>
+      <Separator />
+      <Section columns={2}>
         <PropertyName
           label={styleConfigByName("overflow").label}
           properties={["overflow"]}
@@ -184,8 +191,6 @@ export const SizeSection = ({
           setProperty={setProperty}
           deleteProperty={deleteProperty}
         />
-      </Grid>
-      <Flex justify="between">
         <PropertyName
           label={styleConfigByName("objectPosition").label}
           properties={["objectPosition"]}
@@ -198,7 +203,7 @@ export const SizeSection = ({
           setProperty={setProperty}
           deleteProperty={deleteProperty}
         />
-      </Flex>
+      </Section>
     </CollapsibleSection>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/shared/collapsible-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/collapsible-section.tsx
@@ -28,8 +28,9 @@ export const CollapsibleSection = (props: {
   children: ReactNode;
   currentStyle: StyleInfo;
   properties: ReadonlyArray<StyleProperty>;
+  fullWidth?: boolean;
 }) => {
-  const { label, children, currentStyle, properties } = props;
+  const { label, children, currentStyle, properties, fullWidth } = props;
   const [isOpen, setIsOpen] = useOpenState(props);
 
   return (
@@ -42,6 +43,7 @@ export const CollapsibleSection = (props: {
           <SectionTitleLabel>{label}</SectionTitleLabel>
         </SectionTitle>
       }
+      fullWidth={fullWidth}
     >
       {children}
     </CollapsibleSectionBase>


### PR DESCRIPTION
closes https://github.com/webstudio-is/webstudio/issues/1847

## Description

Just spacing for sizes section

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
