### PR TITLE
fix: trim url for cloudflare worker

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -309,6 +309,11 @@ export const ResourceForm = forwardRef<
       if (evaluatedValue.length === 0) {
         return "URL is required";
       }
+      try {
+        new URL(evaluatedValue);
+      } catch {
+        return "URL is invalid";
+      }
     },
   });
   const [method, setMethod] = useState<Resource["method"]>(

--- a/packages/sdk/src/resource-loader.ts
+++ b/packages/sdk/src/resource-loader.ts
@@ -13,7 +13,9 @@ export const loadResource = async (resourceData: Resource) => {
     requestInit.body = body;
   }
   try {
-    const response = await fetch(url, requestInit);
+    // cloudflare workers fail when fetching url contains spaces
+    // even though new URL suppose to trim them on parsing by spec
+    const response = await fetch(url.trim(), requestInit);
     let data;
     if (
       response.ok &&


### PR DESCRIPTION
Fixes https://discord.com/channels/955905230107738152/1199803387005390858/1199803387005390858

Here fixed the issue with leading spaces in resource urls fail when fetch in workers. Trimmed urls and added validation for urls.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
