### PR TITLE
fix: compile expressions when compute properties

### DIFF
--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -120,6 +120,14 @@ test("compute expression prop values", () => {
         type: "expression",
         value: `$ws$dataSource$var2 + ' World!'`,
       },
+      {
+        id: "prop3",
+        name: "third",
+        instanceId: "box",
+        type: "expression",
+        // do not fail when access fields of undefined
+        value: `$ws$dataSource$var1.second.third || "something"`,
+      },
     ])
   );
   expect(
@@ -128,6 +136,7 @@ test("compute expression prop values", () => {
     new Map<string, unknown>([
       ["first", 3],
       ["second", "Hello World!"],
+      ["third", "something"],
     ])
   );
 
@@ -138,6 +147,7 @@ test("compute expression prop values", () => {
     new Map<string, unknown>([
       ["first", 6],
       ["second", "Hello World!"],
+      ["third", "something"],
     ])
   );
 

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -141,7 +141,11 @@ const computeExpression = (
     const identifier = encodeDataSourceVariable(id);
     code += `const ${identifier} = ${JSON.stringify(value)};\n`;
   }
-  code += `return (${expression})`;
+  const transpiled = validateExpression(expression, {
+    effectful: true,
+    optional: true,
+  });
+  code += `return (${transpiled})`;
   try {
     const result = new Function(code)();
     return result;


### PR DESCRIPTION
Here missed the case we have to compile our expressions before executing them with optional flag to prevent failing when properties are accessed from undefined.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
