### PR TITLE
feat: Disable domain link button when published site is not ready

### DIFF
--- a/apps/builder/app/builder/features/topbar/domains.tsx
+++ b/apps/builder/app/builder/features/topbar/domains.tsx
@@ -387,6 +387,7 @@ const DomainItem = (props: {
           <Tooltip content={`Proceed to ${props.projectDomain.domain.domain}`}>
             <IconButton
               tabIndex={-1}
+              disabled={status !== "VERIFIED_ACTIVE"}
               onClick={(event) => {
                 const url = new URL(
                   `https://${props.projectDomain.domain.domain}`

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -139,7 +139,7 @@ const ChangeProjectDomain = ({
       ? getPublishStatusAndText(project.latestBuild)
       : {
           statusText: "Not published",
-          status: "PENDING",
+          status: "PENDING" as const,
         };
 
   return (
@@ -168,10 +168,10 @@ const ChangeProjectDomain = ({
               )}
             </Flex>
           </Tooltip>
-
           <Tooltip content={`Proceed to ${publishedUrl.href}`}>
             <IconButton
               tabIndex={-1}
+              disabled={error !== undefined || status !== "PUBLISHED"}
               onClick={(event) => {
                 window.open(publishedUrl.href, "_blank");
                 event.preventDefault();


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2826

## Description

An active domain link icon button causes peopple to click on it when domain/publish is not done and they end up seeing the worker error

## Steps for reproduction

1. when domain is not fully connected or at least one publish is not done
2. expect external link button to be deactivated

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
