### PR TITLE
feat: Topbar pages button

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/breakpoints-popover-toolbar-button.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-popover-toolbar-button.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, type ComponentProps } from "react";
 import { useStore } from "@nanostores/react";
-import { Flex, theme } from "@webstudio-is/design-system";
+import { Flex, theme, ToolbarButton } from "@webstudio-is/design-system";
 import { $scale, useCanvasWidth } from "~/builder/shared/nano-states";
 import { $selectedBreakpoint } from "~/shared/nano-states";
 
@@ -25,7 +25,7 @@ const Value = ({
 
 export const BreakpointsPopoverToolbarButton = forwardRef<
   HTMLButtonElement,
-  ComponentProps<"button">
+  ComponentProps<typeof ToolbarButton>
 >((props, ref) => {
   const scale = useStore($scale);
   const breakpoint = useStore($selectedBreakpoint);
@@ -35,7 +35,7 @@ export const BreakpointsPopoverToolbarButton = forwardRef<
   }
   const roundedScale = Math.round(scale);
   return (
-    <button ref={ref} {...props}>
+    <ToolbarButton ref={ref} {...props}>
       <Value unit="PX" minWidth={55}>
         {Math.round(canvasWidth)}
       </Value>
@@ -44,7 +44,7 @@ export const BreakpointsPopoverToolbarButton = forwardRef<
           {roundedScale}
         </Value>
       )}
-    </button>
+    </ToolbarButton>
   );
 });
 

--- a/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
@@ -11,7 +11,6 @@ import {
   PopoverPortal,
   PopoverContent,
   PopoverTrigger,
-  toggleItemStyle,
   MenuCheckedIcon,
   MenuItemIndicator,
   List,
@@ -90,11 +89,7 @@ export const BreakpointsPopover = () => {
       }}
     >
       <PopoverTrigger aria-label="Show breakpoints" asChild>
-        <BreakpointsPopoverToolbarButton
-          className={toggleItemStyle({
-            css: { gap: theme.spacing[5] },
-          })}
-        />
+        <BreakpointsPopoverToolbarButton css={{ gap: theme.spacing[5] }} />
       </PopoverTrigger>
       <PopoverPortal>
         <PopoverContent

--- a/apps/builder/app/builder/features/topbar/menu/menu-button.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu-button.tsx
@@ -2,7 +2,7 @@ import {
   css,
   DropdownMenuTrigger,
   rawTheme,
-  toggleItemStyle,
+  ToolbarButton,
 } from "@webstudio-is/design-system";
 import { HamburgerMenuIcon, WebstudioIcon } from "@webstudio-is/icons";
 
@@ -49,18 +49,17 @@ const faceStyle = css({
 
 export const MenuButton = () => {
   return (
-    <DropdownMenuTrigger
-      className={toggleItemStyle({ className: triggerStyle() })}
-      aria-label="Menu Button"
-    >
-      <span className={innerContainerStyle()}>
-        <span className={faceStyle({ front: true })}>
-          <WebstudioIcon width="22" height="22" />
+    <ToolbarButton asChild className={triggerStyle()} aria-label="Menu Button">
+      <DropdownMenuTrigger>
+        <span className={innerContainerStyle()}>
+          <span className={faceStyle({ front: true })}>
+            <WebstudioIcon width="22" height="22" />
+          </span>
+          <span className={faceStyle({ back: true })}>
+            <HamburgerMenuIcon size={22} />
+          </span>
         </span>
-        <span className={faceStyle({ back: true })}>
-          <HamburgerMenuIcon size={22} />
-        </span>
-      </span>
-    </DropdownMenuTrigger>
+      </DropdownMenuTrigger>
+    </ToolbarButton>
   );
 };

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -3,9 +3,9 @@ import {
   theme,
   css,
   Flex,
-  Text,
   Toolbar,
   ToolbarToggleGroup,
+  ToolbarButton,
 } from "@webstudio-is/design-system";
 import type { Project } from "@webstudio-is/project";
 import { $selectedPage } from "~/shared/nano-states";
@@ -37,19 +37,27 @@ type TopbarProps = {
 
 export const Topbar = ({ gridArea, project, hasProPlan }: TopbarProps) => {
   const page = useStore($selectedPage);
+  if (page === undefined) {
+    return;
+  }
 
   return (
     <nav className={topbarContainerStyle({ css: { gridArea } })}>
       <Flex grow={false} shrink={false}>
         <Menu />
       </Flex>
-      <Flex
-        css={{ px: theme.spacing[9], maxWidth: theme.spacing[24] }}
-        align="center"
-      >
-        <Text variant="labelsTitleCase" color="contrast" truncate>
-          {page?.name ?? ""}
-        </Text>
+      <Flex align="center">
+        <ToolbarButton
+          css={{
+            px: theme.spacing[9],
+            maxWidth: theme.spacing[24],
+          }}
+          aria-label="Toggle Pages"
+          onClick={() => {}}
+          tabIndex={0}
+        >
+          {page.name}
+        </ToolbarButton>
       </Flex>
       <Flex css={{ minWidth: theme.spacing[23] }}>
         <BreakpointsPopover />

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -38,9 +38,6 @@ type TopbarProps = {
 
 export const Topbar = ({ gridArea, project, hasProPlan }: TopbarProps) => {
   const page = useStore($selectedPage);
-  if (page === undefined) {
-    return;
-  }
 
   return (
     <nav className={topbarContainerStyle({ css: { gridArea } })}>
@@ -61,7 +58,7 @@ export const Topbar = ({ gridArea, project, hasProPlan }: TopbarProps) => {
           }}
           tabIndex={0}
         >
-          {page.name}
+          {page?.name}
         </ToolbarButton>
       </Flex>
       <Flex css={{ minWidth: theme.spacing[23] }}>

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -19,6 +19,7 @@ import {
   BreakpointsPopover,
 } from "../breakpoints";
 import { ViewMode } from "./view-mode";
+import { $activeSidebarPanel } from "~/builder/shared/nano-states";
 
 const topbarContainerStyle = css({
   display: "flex",
@@ -53,7 +54,11 @@ export const Topbar = ({ gridArea, project, hasProPlan }: TopbarProps) => {
             maxWidth: theme.spacing[24],
           }}
           aria-label="Toggle Pages"
-          onClick={() => {}}
+          onClick={() => {
+            $activeSidebarPanel.set(
+              $activeSidebarPanel.get() === "pages" ? "none" : "pages"
+            );
+          }}
           tabIndex={0}
         >
           {page.name}

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -52,6 +52,7 @@
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-separator": "^1.0.3",
+    "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",

--- a/packages/design-system/src/components/toolbar.tsx
+++ b/packages/design-system/src/components/toolbar.tsx
@@ -3,9 +3,11 @@
  * https://www.figma.com/file/sfCE7iLS0k25qCxiifQNLE/%F0%9F%93%9A-Webstudio-Library?node-id=1512%3A7422&t=BOWCrlme5NepfLUm-4
  */
 import * as ToolbarPrimitive from "@radix-ui/react-toolbar";
+import { Slot, type SlotProps } from "@radix-ui/react-slot";
 import { css, styled, theme } from "../stitches.config";
 import { separatorStyle } from "./separator";
 import { textVariants } from "./text";
+import { forwardRef, type Ref } from "react";
 
 export const Toolbar = styled(ToolbarPrimitive.Root, {
   display: "flex",
@@ -34,7 +36,7 @@ const toolbarItemFocusRing = {
   },
 };
 
-export const toggleItemStyle = css(textVariants.labelsTitleCase, {
+const toggleItemStyle = css(textVariants.labelsTitleCase, {
   // reset styles
   boxSizing: "border-box",
   position: "relative",
@@ -86,6 +88,20 @@ export const ToolbarToggleItem = styled(
   ToolbarPrimitive.ToggleItem,
   toggleItemStyle
 );
+
+type ToolbarButtonProps = SlotProps & {
+  asChild?: boolean;
+};
+
+const ToolbarButtonBase = forwardRef(
+  ({ asChild, ...props }: ToolbarButtonProps, ref: Ref<HTMLButtonElement>) => {
+    const Component = asChild ? Slot : "button";
+    return <Component {...props} ref={ref} />;
+  }
+);
+ToolbarButtonBase.displayName = "ToolbarButton";
+
+export const ToolbarButton = styled(ToolbarButtonBase, toggleItemStyle);
 
 export const ToolbarSeparator = styled(
   ToolbarPrimitive.Separator,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,6 +1090,9 @@ importers:
       '@radix-ui/react-separator':
         specifier: ^1.0.3
         version: 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot':
+        specifier: ^1.0.2
+        version: 1.0.2(@types/react@18.2.21)(react@18.2.0)
       '@radix-ui/react-switch':
         specifier: ^1.0.3
         version: 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2826

## Description

Previously active page in the topbar was only text, now its a button that can toggle pages panel

## Steps for reproduction

1. click on page name in topbar
2. expect it to toggle pages panel

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
