### PR TITLE
chore: Drop view if exists always

### DIFF
--- a/packages/prisma-client/prisma/migrations/20240127230238_project-preview/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20240127230238_project-preview/migration.sql
@@ -11,9 +11,11 @@ ADD
 SET
   NULL;
 
+-- Drop DashboardProject View
+DROP VIEW IF EXISTS "DashboardProject";
+
 -- Update DashboardProject View
-CREATE
-OR REPLACE VIEW "DashboardProject" AS
+CREATE VIEW "DashboardProject" AS
 SELECT
   *,
   EXISTS (


### PR DESCRIPTION
## Description

Fixes migration in https://github.com/webstudio-is/webstudio/pull/2836

It turned out updating a view reuires the order of the added fields to be the same, otherwise it may cause weird effects .


![image](https://github.com/webstudio-is/webstudio/assets/52824/490fb38c-e2c1-46b0-9d82-4eece71f1148)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
