### PR TITLE
refactor: generate page meta in loader

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -39,7 +39,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
 export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -4,6 +4,7 @@
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
   Link as Link,
@@ -31,24 +32,24 @@ export const pageData: PageData = {
     faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
     code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
   },
-  page: {
-    id: "xT46WZKzCBTvUCIObMELW",
-    name: "Script Test",
-    title: "Script Test",
-    meta: {
-      description: "",
-      excludePageFromSearch: false,
-      socialImageAssetId: "",
-      custom: [{ property: "", content: "" }],
-    },
-    rootInstanceId: "LW98_-srDnnagkR10lsk4",
-    path: "/script-test",
-  },
 };
 export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
+
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Script Test",
+    description: "",
+    excludePageFromSearch: false,
+    socialImageAssetId: "",
+    custom: [],
+  };
+};
 
 const Page = ({ params: PageParams }: { params: any }) => {
   return (

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -39,7 +39,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
 export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -4,6 +4,7 @@
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
   Link as Link,
@@ -31,21 +32,24 @@ export const pageData: PageData = {
     faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
     code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
   },
-  page: {
-    id: "nfzls_SkTc9jKYyxcZ8Lw",
-    name: "Home",
-    title: "Site Title",
-    meta: {
-      description: "Page description f511c297-b44f-4e4b-96bd-d013da06bada",
-    },
-    rootInstanceId: "ibXgMoi9_ipHx1gVrvii0",
-    path: "",
-  },
 };
 export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
+
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Site Title",
+    description: "Page description f511c297-b44f-4e4b-96bd-d013da06bada",
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    custom: [],
+  };
+};
 
 const Page = ({ params: PageParams }: { params: any }) => {
   return (

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -28,7 +28,6 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -28,7 +28,6 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {

--- a/fixtures/webstudio-custom-template/custom-template/__templates__/route-template.tsx
+++ b/fixtures/webstudio-custom-template/custom-template/__templates__/route-template.tsx
@@ -28,7 +28,6 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -23,7 +23,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
 export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -4,6 +4,7 @@
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Heading as Heading,
@@ -15,19 +16,24 @@ export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [];
 export const pageData: PageData = {
   project: { siteName: "", faviconAssetId: "", code: "" },
-  page: {
-    id: "9di_L14CzctvSruIoKVvE",
-    name: "Home",
-    title: "Home",
-    meta: {},
-    rootInstanceId: "MMimeobf_zi4ZkRGXapju",
-    path: "",
-  },
 };
 export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
+
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Home",
+    description: undefined,
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    custom: [],
+  };
+};
 
 const Page = ({ params: PageParams }: { params: any }) => {
   return (

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -8,7 +8,7 @@ import {
   json,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { Page as PageType, ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -21,6 +21,7 @@ import {
   Page,
   imageAssets,
   getRemixParams,
+  getPageMeta,
 } from "../__generated__/_index";
 import { loadResources } from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
@@ -28,12 +29,12 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
+  const pageMeta = getPageMeta({ params, resources });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -54,6 +55,7 @@ export const loader = async (arg: LoaderArgs) => {
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
       resources,
+      pageMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -68,29 +70,32 @@ export const headers = () => {
 };
 
 export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const { page, project } = pageData;
-
   const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+  if (data === undefined) {
+    return metas;
+  }
+  const { pageMeta } = data;
+  const { project } = pageData;
 
-  if (data?.url) {
+  if (data.url) {
     metas.push({
       property: "og:url",
       content: data.url,
     });
   }
 
-  if (page.title) {
-    metas.push({ title: page.title });
+  if (pageMeta.title) {
+    metas.push({ title: pageMeta.title });
 
     metas.push({
       property: "og:title",
-      content: page.title,
+      content: pageMeta.title,
     });
   }
 
   metas.push({ property: "og:type", content: "website" });
 
-  const origin = `https://${data?.host}`;
+  const origin = `https://${data.host}`;
 
   if (project?.siteName) {
     metas.push({
@@ -107,33 +112,33 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+  if (pageMeta.excludePageFromSearch || data.excludeFromSearch) {
     metas.push({
       name: "robots",
       content: "noindex, nofollow",
     });
   }
 
-  if (page.meta.description) {
+  if (pageMeta.description) {
     metas.push({
       name: "description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
     metas.push({
       property: "og:description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
   }
 
-  if (page.meta.socialImageAssetId) {
+  if (pageMeta.socialImageAssetId) {
     const imageAsset = imageAssets.find(
-      (asset) => asset.id === page.meta.socialImageAssetId
+      (asset) => asset.id === pageMeta.socialImageAssetId
     );
 
     if (imageAsset) {
       metas.push({
         property: "og:image",
-        content: `https://${data?.host}${imageLoader({
+        content: `https://${data.host}${imageLoader({
           src: imageAsset.name,
           // Do not transform social image (not enough information do we need to do this)
           format: "raw",
@@ -142,12 +147,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     }
   }
 
-  for (const customMeta of page.meta.custom ?? []) {
-    if (customMeta.property.trim().length === 0) {
-      continue;
-    }
-    metas.push(customMeta);
-  }
+  metas.push(...pageMeta.custom);
 
   return metas;
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -23,7 +23,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
 export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -4,6 +4,7 @@
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Heading as Heading,
@@ -15,19 +16,24 @@ export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [];
 export const pageData: PageData = {
   project: { siteName: "", faviconAssetId: "", code: "" },
-  page: {
-    id: "9di_L14CzctvSruIoKVvE",
-    name: "Home",
-    title: "Home",
-    meta: {},
-    rootInstanceId: "MMimeobf_zi4ZkRGXapju",
-    path: "",
-  },
 };
 export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
+
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Home",
+    description: undefined,
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    custom: [],
+  };
+};
 
 const Page = ({ params: PageParams }: { params: any }) => {
   return (

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -8,7 +8,7 @@ import {
   json,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { Page as PageType, ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -21,6 +21,7 @@ import {
   Page,
   imageAssets,
   getRemixParams,
+  getPageMeta,
 } from "../__generated__/_index";
 import { loadResources } from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
@@ -28,12 +29,12 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
+  const pageMeta = getPageMeta({ params, resources });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -54,6 +55,7 @@ export const loader = async (arg: LoaderArgs) => {
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
       resources,
+      pageMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -68,29 +70,32 @@ export const headers = () => {
 };
 
 export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const { page, project } = pageData;
-
   const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+  if (data === undefined) {
+    return metas;
+  }
+  const { pageMeta } = data;
+  const { project } = pageData;
 
-  if (data?.url) {
+  if (data.url) {
     metas.push({
       property: "og:url",
       content: data.url,
     });
   }
 
-  if (page.title) {
-    metas.push({ title: page.title });
+  if (pageMeta.title) {
+    metas.push({ title: pageMeta.title });
 
     metas.push({
       property: "og:title",
-      content: page.title,
+      content: pageMeta.title,
     });
   }
 
   metas.push({ property: "og:type", content: "website" });
 
-  const origin = `https://${data?.host}`;
+  const origin = `https://${data.host}`;
 
   if (project?.siteName) {
     metas.push({
@@ -107,33 +112,33 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+  if (pageMeta.excludePageFromSearch || data.excludeFromSearch) {
     metas.push({
       name: "robots",
       content: "noindex, nofollow",
     });
   }
 
-  if (page.meta.description) {
+  if (pageMeta.description) {
     metas.push({
       name: "description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
     metas.push({
       property: "og:description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
   }
 
-  if (page.meta.socialImageAssetId) {
+  if (pageMeta.socialImageAssetId) {
     const imageAsset = imageAssets.find(
-      (asset) => asset.id === page.meta.socialImageAssetId
+      (asset) => asset.id === pageMeta.socialImageAssetId
     );
 
     if (imageAsset) {
       metas.push({
         property: "og:image",
-        content: `https://${data?.host}${imageLoader({
+        content: `https://${data.host}${imageLoader({
           src: imageAsset.name,
           // Do not transform social image (not enough information do we need to do this)
           format: "raw",
@@ -142,12 +147,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     }
   }
 
-  for (const customMeta of page.meta.custom ?? []) {
-    if (customMeta.property.trim().length === 0) {
-      continue;
-    }
-    metas.push(customMeta);
-  }
+  metas.push(...pageMeta.custom);
 
   return metas;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -58,7 +58,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -4,6 +4,7 @@
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Image as Image } from "@webstudio-is/sdk-components-react";
 
@@ -50,19 +51,24 @@ export const pageData: PageData = {
     faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
     code: "<script>console.log('KittyGuardedZone')</script>\n",
   },
-  page: {
-    id: "szYLvBduHPmbtqQKCDY0b",
-    name: "RouteWithSymbols",
-    title: "RouteWithSymbols",
-    meta: { description: "" },
-    rootInstanceId: "EDEfpMPRqDejthtwkH7ws",
-    path: "/_route_with_symbols_",
-  },
 };
 export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "RouteWithSymbols",
+    description: "",
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    custom: [],
+  };
+};
 
 const Page = ({ params: PageParams }: { params: any }) => {
   return (

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -4,6 +4,7 @@
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
   Form as Form,
@@ -59,19 +60,24 @@ export const pageData: PageData = {
     faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
     code: "<script>console.log('KittyGuardedZone')</script>\n",
   },
-  page: {
-    id: "U1tRJl2ERr8_OFe0g9cN_",
-    name: "form",
-    title: "form",
-    meta: { description: "" },
-    rootInstanceId: "a-4nDFkaWy4px1fn38XWJ",
-    path: "/form",
-  },
 };
 export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "form",
+    description: "",
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    custom: [],
+  };
+};
 
 const Page = ({ params: PageParams }: { params: any }) => {
   let [formState, set$formState] = useState<any>("initial");

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -67,7 +67,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -4,6 +4,7 @@
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
@@ -50,19 +51,24 @@ export const pageData: PageData = {
     faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
     code: "<script>console.log('KittyGuardedZone')</script>\n",
   },
-  page: {
-    id: "-J9I4Oo6mONfQlf_3-OqG",
-    name: "heading-with-id",
-    title: "heading-with-id",
-    meta: { description: "" },
-    rootInstanceId: "O-ljaGZQ0iRNTlEshMkgE",
-    path: "/heading-with-id",
-  },
 };
 export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "heading-with-id",
+    description: "",
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    custom: [],
+  };
+};
 
 const Page = ({ params: PageParams }: { params: any }) => {
   return (

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -58,7 +58,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -4,6 +4,7 @@
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
@@ -50,24 +51,24 @@ export const pageData: PageData = {
     faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
     code: "<script>console.log('KittyGuardedZone')</script>\n",
   },
-  page: {
-    id: "Pnz-BxUm6XmvFygk_XdEy",
-    name: "Nested Page",
-    title: "Nested Page",
-    meta: {
-      description: "",
-      excludePageFromSearch: false,
-      socialImageAssetId: "",
-      custom: [{ property: "", content: "" }],
-    },
-    rootInstanceId: "L0ZXd5F9xk9Rsl9ORzIkJ",
-    path: "/nested-page",
-  },
 };
 export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Nested Page",
+    description: "",
+    excludePageFromSearch: false,
+    socialImageAssetId: "",
+    custom: [],
+  };
+};
 
 const Page = ({ params: PageParams }: { params: any }) => {
   return (

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -58,7 +58,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -4,6 +4,7 @@
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Accordion as Accordion,
@@ -61,24 +62,25 @@ export const pageData: PageData = {
     faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
     code: "<script>console.log('KittyGuardedZone')</script>\n",
   },
-  page: {
-    id: "xfvB4UThQXmQ_OubPYrkg",
-    name: "radix excluded from the search",
-    title: "Radix Revelations: Unraveling the Feline Mystique",
-    meta: {
-      description:
-        "Delve deep into the radix roots of feline behaviors. At KittyNoTouchy, we dissect the core essence, or 'radix', of what makes cats the enigmatic creatures they are. Join us as we explore the radix of their instincts, habits, and quirks.",
-      excludePageFromSearch: true,
-      socialImageAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    },
-    rootInstanceId: "uKWGyE9JY3cPwY-xI9vk6",
-    path: "/radix",
-  },
 };
 export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Radix Revelations: Unraveling the Feline Mystique",
+    description:
+      "Delve deep into the radix roots of feline behaviors. At KittyNoTouchy, we dissect the core essence, or 'radix', of what makes cats the enigmatic creatures they are. Join us as we explore the radix of their instincts, habits, and quirks.",
+    excludePageFromSearch: true,
+    socialImageAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+    custom: [],
+  };
+};
 
 const Page = ({ params: PageParams }: { params: any }) => {
   let [accordionValue, set$accordionValue] = useState<any>("0");

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -69,7 +69,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -4,6 +4,7 @@
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Box as Box,
@@ -53,24 +54,24 @@ export const pageData: PageData = {
     faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
     code: "<script>console.log('KittyGuardedZone')</script>\n",
   },
-  page: {
-    id: "TS39WeBd0Qr3QgbSlzdf2",
-    name: "resources",
-    title: "resources",
-    meta: {
-      description: "",
-      excludePageFromSearch: false,
-      socialImageAssetId: "",
-      custom: [{ property: "", content: "" }],
-    },
-    rootInstanceId: "AWY2qZfpbykoiWELeJhse",
-    path: "/resources",
-  },
 };
 export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "resources",
+    description: "",
+    excludePageFromSearch: false,
+    socialImageAssetId: "",
+    custom: [],
+  };
+};
 
 const Page = ({ params: PageParams }: { params: any }) => {
   let list = useResource("list_1");

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -61,7 +61,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -67,7 +67,7 @@ export const user: { email: string | null } | undefined = {
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -4,6 +4,7 @@
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
   Link as Link,
@@ -59,24 +60,30 @@ export const pageData: PageData = {
     faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
     code: "<script>console.log('KittyGuardedZone')</script>\n",
   },
-  page: {
-    id: "7Db64ZXgYiRqKSQNR-qTQ",
-    name: "Home",
-    title: "The Ultimate Cat Protection Zone",
-    meta: {
-      description:
-        "Dive into the world of felines and discover why some whiskers are best left untouched. From intriguing cat behaviors to protective measures, \nKittyGuardedZone is your go-to hub for all things 'hands-off' in the cat realm.",
-      socialImageAssetId: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-      custom: [{ property: "fb:app_id", content: "app_id_app_id_app_id" }],
-    },
-    rootInstanceId: "On9cvWCxr5rdZtY9O1Bv0",
-    path: "",
-  },
 };
 export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "The Ultimate Cat Protection Zone",
+    description:
+      "Dive into the world of felines and discover why some whiskers are best left untouched. From intriguing cat behaviors to protective measures, \nKittyGuardedZone is your go-to hub for all things 'hands-off' in the cat realm.",
+    excludePageFromSearch: undefined,
+    socialImageAssetId: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+    custom: [
+      {
+        property: "fb:app_id",
+        content: "app_id_app_id_app_id",
+      },
+    ],
+  };
+};
 
 const Page = ({ params: PageParams }: { params: any }) => {
   return (

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -8,7 +8,7 @@ import {
   json,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { Page as PageType, ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -21,6 +21,7 @@ import {
   Page,
   imageAssets,
   getRemixParams,
+  getPageMeta,
 } from "../__generated__/[_route_with_symbols_]._index";
 import { loadResources } from "../__generated__/[_route_with_symbols_]._index.server";
 import css from "../__generated__/index.css";
@@ -28,12 +29,12 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
+  const pageMeta = getPageMeta({ params, resources });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -54,6 +55,7 @@ export const loader = async (arg: LoaderArgs) => {
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
       resources,
+      pageMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -68,29 +70,32 @@ export const headers = () => {
 };
 
 export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const { page, project } = pageData;
-
   const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+  if (data === undefined) {
+    return metas;
+  }
+  const { pageMeta } = data;
+  const { project } = pageData;
 
-  if (data?.url) {
+  if (data.url) {
     metas.push({
       property: "og:url",
       content: data.url,
     });
   }
 
-  if (page.title) {
-    metas.push({ title: page.title });
+  if (pageMeta.title) {
+    metas.push({ title: pageMeta.title });
 
     metas.push({
       property: "og:title",
-      content: page.title,
+      content: pageMeta.title,
     });
   }
 
   metas.push({ property: "og:type", content: "website" });
 
-  const origin = `https://${data?.host}`;
+  const origin = `https://${data.host}`;
 
   if (project?.siteName) {
     metas.push({
@@ -107,33 +112,33 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+  if (pageMeta.excludePageFromSearch || data.excludeFromSearch) {
     metas.push({
       name: "robots",
       content: "noindex, nofollow",
     });
   }
 
-  if (page.meta.description) {
+  if (pageMeta.description) {
     metas.push({
       name: "description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
     metas.push({
       property: "og:description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
   }
 
-  if (page.meta.socialImageAssetId) {
+  if (pageMeta.socialImageAssetId) {
     const imageAsset = imageAssets.find(
-      (asset) => asset.id === page.meta.socialImageAssetId
+      (asset) => asset.id === pageMeta.socialImageAssetId
     );
 
     if (imageAsset) {
       metas.push({
         property: "og:image",
-        content: `https://${data?.host}${imageLoader({
+        content: `https://${data.host}${imageLoader({
           src: imageAsset.name,
           // Do not transform social image (not enough information do we need to do this)
           format: "raw",
@@ -142,12 +147,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     }
   }
 
-  for (const customMeta of page.meta.custom ?? []) {
-    if (customMeta.property.trim().length === 0) {
-      continue;
-    }
-    metas.push(customMeta);
-  }
+  metas.push(...pageMeta.custom);
 
   return metas;
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -8,7 +8,7 @@ import {
   json,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { Page as PageType, ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -21,6 +21,7 @@ import {
   Page,
   imageAssets,
   getRemixParams,
+  getPageMeta,
 } from "../__generated__/[form]._index";
 import { loadResources } from "../__generated__/[form]._index.server";
 import css from "../__generated__/index.css";
@@ -28,12 +29,12 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
+  const pageMeta = getPageMeta({ params, resources });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -54,6 +55,7 @@ export const loader = async (arg: LoaderArgs) => {
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
       resources,
+      pageMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -68,29 +70,32 @@ export const headers = () => {
 };
 
 export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const { page, project } = pageData;
-
   const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+  if (data === undefined) {
+    return metas;
+  }
+  const { pageMeta } = data;
+  const { project } = pageData;
 
-  if (data?.url) {
+  if (data.url) {
     metas.push({
       property: "og:url",
       content: data.url,
     });
   }
 
-  if (page.title) {
-    metas.push({ title: page.title });
+  if (pageMeta.title) {
+    metas.push({ title: pageMeta.title });
 
     metas.push({
       property: "og:title",
-      content: page.title,
+      content: pageMeta.title,
     });
   }
 
   metas.push({ property: "og:type", content: "website" });
 
-  const origin = `https://${data?.host}`;
+  const origin = `https://${data.host}`;
 
   if (project?.siteName) {
     metas.push({
@@ -107,33 +112,33 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+  if (pageMeta.excludePageFromSearch || data.excludeFromSearch) {
     metas.push({
       name: "robots",
       content: "noindex, nofollow",
     });
   }
 
-  if (page.meta.description) {
+  if (pageMeta.description) {
     metas.push({
       name: "description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
     metas.push({
       property: "og:description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
   }
 
-  if (page.meta.socialImageAssetId) {
+  if (pageMeta.socialImageAssetId) {
     const imageAsset = imageAssets.find(
-      (asset) => asset.id === page.meta.socialImageAssetId
+      (asset) => asset.id === pageMeta.socialImageAssetId
     );
 
     if (imageAsset) {
       metas.push({
         property: "og:image",
-        content: `https://${data?.host}${imageLoader({
+        content: `https://${data.host}${imageLoader({
           src: imageAsset.name,
           // Do not transform social image (not enough information do we need to do this)
           format: "raw",
@@ -142,12 +147,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     }
   }
 
-  for (const customMeta of page.meta.custom ?? []) {
-    if (customMeta.property.trim().length === 0) {
-      continue;
-    }
-    metas.push(customMeta);
-  }
+  metas.push(...pageMeta.custom);
 
   return metas;
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -8,7 +8,7 @@ import {
   json,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { Page as PageType, ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -21,6 +21,7 @@ import {
   Page,
   imageAssets,
   getRemixParams,
+  getPageMeta,
 } from "../__generated__/[heading-with-id]._index";
 import { loadResources } from "../__generated__/[heading-with-id]._index.server";
 import css from "../__generated__/index.css";
@@ -28,12 +29,12 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
+  const pageMeta = getPageMeta({ params, resources });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -54,6 +55,7 @@ export const loader = async (arg: LoaderArgs) => {
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
       resources,
+      pageMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -68,29 +70,32 @@ export const headers = () => {
 };
 
 export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const { page, project } = pageData;
-
   const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+  if (data === undefined) {
+    return metas;
+  }
+  const { pageMeta } = data;
+  const { project } = pageData;
 
-  if (data?.url) {
+  if (data.url) {
     metas.push({
       property: "og:url",
       content: data.url,
     });
   }
 
-  if (page.title) {
-    metas.push({ title: page.title });
+  if (pageMeta.title) {
+    metas.push({ title: pageMeta.title });
 
     metas.push({
       property: "og:title",
-      content: page.title,
+      content: pageMeta.title,
     });
   }
 
   metas.push({ property: "og:type", content: "website" });
 
-  const origin = `https://${data?.host}`;
+  const origin = `https://${data.host}`;
 
   if (project?.siteName) {
     metas.push({
@@ -107,33 +112,33 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+  if (pageMeta.excludePageFromSearch || data.excludeFromSearch) {
     metas.push({
       name: "robots",
       content: "noindex, nofollow",
     });
   }
 
-  if (page.meta.description) {
+  if (pageMeta.description) {
     metas.push({
       name: "description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
     metas.push({
       property: "og:description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
   }
 
-  if (page.meta.socialImageAssetId) {
+  if (pageMeta.socialImageAssetId) {
     const imageAsset = imageAssets.find(
-      (asset) => asset.id === page.meta.socialImageAssetId
+      (asset) => asset.id === pageMeta.socialImageAssetId
     );
 
     if (imageAsset) {
       metas.push({
         property: "og:image",
-        content: `https://${data?.host}${imageLoader({
+        content: `https://${data.host}${imageLoader({
           src: imageAsset.name,
           // Do not transform social image (not enough information do we need to do this)
           format: "raw",
@@ -142,12 +147,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     }
   }
 
-  for (const customMeta of page.meta.custom ?? []) {
-    if (customMeta.property.trim().length === 0) {
-      continue;
-    }
-    metas.push(customMeta);
-  }
+  metas.push(...pageMeta.custom);
 
   return metas;
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -8,7 +8,7 @@ import {
   json,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { Page as PageType, ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -21,6 +21,7 @@ import {
   Page,
   imageAssets,
   getRemixParams,
+  getPageMeta,
 } from "../__generated__/[nested].[nested-page]._index";
 import { loadResources } from "../__generated__/[nested].[nested-page]._index.server";
 import css from "../__generated__/index.css";
@@ -28,12 +29,12 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
+  const pageMeta = getPageMeta({ params, resources });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -54,6 +55,7 @@ export const loader = async (arg: LoaderArgs) => {
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
       resources,
+      pageMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -68,29 +70,32 @@ export const headers = () => {
 };
 
 export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const { page, project } = pageData;
-
   const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+  if (data === undefined) {
+    return metas;
+  }
+  const { pageMeta } = data;
+  const { project } = pageData;
 
-  if (data?.url) {
+  if (data.url) {
     metas.push({
       property: "og:url",
       content: data.url,
     });
   }
 
-  if (page.title) {
-    metas.push({ title: page.title });
+  if (pageMeta.title) {
+    metas.push({ title: pageMeta.title });
 
     metas.push({
       property: "og:title",
-      content: page.title,
+      content: pageMeta.title,
     });
   }
 
   metas.push({ property: "og:type", content: "website" });
 
-  const origin = `https://${data?.host}`;
+  const origin = `https://${data.host}`;
 
   if (project?.siteName) {
     metas.push({
@@ -107,33 +112,33 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+  if (pageMeta.excludePageFromSearch || data.excludeFromSearch) {
     metas.push({
       name: "robots",
       content: "noindex, nofollow",
     });
   }
 
-  if (page.meta.description) {
+  if (pageMeta.description) {
     metas.push({
       name: "description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
     metas.push({
       property: "og:description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
   }
 
-  if (page.meta.socialImageAssetId) {
+  if (pageMeta.socialImageAssetId) {
     const imageAsset = imageAssets.find(
-      (asset) => asset.id === page.meta.socialImageAssetId
+      (asset) => asset.id === pageMeta.socialImageAssetId
     );
 
     if (imageAsset) {
       metas.push({
         property: "og:image",
-        content: `https://${data?.host}${imageLoader({
+        content: `https://${data.host}${imageLoader({
           src: imageAsset.name,
           // Do not transform social image (not enough information do we need to do this)
           format: "raw",
@@ -142,12 +147,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     }
   }
 
-  for (const customMeta of page.meta.custom ?? []) {
-    if (customMeta.property.trim().length === 0) {
-      continue;
-    }
-    metas.push(customMeta);
-  }
+  metas.push(...pageMeta.custom);
 
   return metas;
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -8,7 +8,7 @@ import {
   json,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { Page as PageType, ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -21,6 +21,7 @@ import {
   Page,
   imageAssets,
   getRemixParams,
+  getPageMeta,
 } from "../__generated__/[radix]._index";
 import { loadResources } from "../__generated__/[radix]._index.server";
 import css from "../__generated__/index.css";
@@ -28,12 +29,12 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
+  const pageMeta = getPageMeta({ params, resources });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -54,6 +55,7 @@ export const loader = async (arg: LoaderArgs) => {
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
       resources,
+      pageMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -68,29 +70,32 @@ export const headers = () => {
 };
 
 export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const { page, project } = pageData;
-
   const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+  if (data === undefined) {
+    return metas;
+  }
+  const { pageMeta } = data;
+  const { project } = pageData;
 
-  if (data?.url) {
+  if (data.url) {
     metas.push({
       property: "og:url",
       content: data.url,
     });
   }
 
-  if (page.title) {
-    metas.push({ title: page.title });
+  if (pageMeta.title) {
+    metas.push({ title: pageMeta.title });
 
     metas.push({
       property: "og:title",
-      content: page.title,
+      content: pageMeta.title,
     });
   }
 
   metas.push({ property: "og:type", content: "website" });
 
-  const origin = `https://${data?.host}`;
+  const origin = `https://${data.host}`;
 
   if (project?.siteName) {
     metas.push({
@@ -107,33 +112,33 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+  if (pageMeta.excludePageFromSearch || data.excludeFromSearch) {
     metas.push({
       name: "robots",
       content: "noindex, nofollow",
     });
   }
 
-  if (page.meta.description) {
+  if (pageMeta.description) {
     metas.push({
       name: "description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
     metas.push({
       property: "og:description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
   }
 
-  if (page.meta.socialImageAssetId) {
+  if (pageMeta.socialImageAssetId) {
     const imageAsset = imageAssets.find(
-      (asset) => asset.id === page.meta.socialImageAssetId
+      (asset) => asset.id === pageMeta.socialImageAssetId
     );
 
     if (imageAsset) {
       metas.push({
         property: "og:image",
-        content: `https://${data?.host}${imageLoader({
+        content: `https://${data.host}${imageLoader({
           src: imageAsset.name,
           // Do not transform social image (not enough information do we need to do this)
           format: "raw",
@@ -142,12 +147,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     }
   }
 
-  for (const customMeta of page.meta.custom ?? []) {
-    if (customMeta.property.trim().length === 0) {
-      continue;
-    }
-    metas.push(customMeta);
-  }
+  metas.push(...pageMeta.custom);
 
   return metas;
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -8,7 +8,7 @@ import {
   json,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { Page as PageType, ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -21,6 +21,7 @@ import {
   Page,
   imageAssets,
   getRemixParams,
+  getPageMeta,
 } from "../__generated__/[resources]._index";
 import { loadResources } from "../__generated__/[resources]._index.server";
 import css from "../__generated__/index.css";
@@ -28,12 +29,12 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
+  const pageMeta = getPageMeta({ params, resources });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -54,6 +55,7 @@ export const loader = async (arg: LoaderArgs) => {
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
       resources,
+      pageMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -68,29 +70,32 @@ export const headers = () => {
 };
 
 export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const { page, project } = pageData;
-
   const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+  if (data === undefined) {
+    return metas;
+  }
+  const { pageMeta } = data;
+  const { project } = pageData;
 
-  if (data?.url) {
+  if (data.url) {
     metas.push({
       property: "og:url",
       content: data.url,
     });
   }
 
-  if (page.title) {
-    metas.push({ title: page.title });
+  if (pageMeta.title) {
+    metas.push({ title: pageMeta.title });
 
     metas.push({
       property: "og:title",
-      content: page.title,
+      content: pageMeta.title,
     });
   }
 
   metas.push({ property: "og:type", content: "website" });
 
-  const origin = `https://${data?.host}`;
+  const origin = `https://${data.host}`;
 
   if (project?.siteName) {
     metas.push({
@@ -107,33 +112,33 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+  if (pageMeta.excludePageFromSearch || data.excludeFromSearch) {
     metas.push({
       name: "robots",
       content: "noindex, nofollow",
     });
   }
 
-  if (page.meta.description) {
+  if (pageMeta.description) {
     metas.push({
       name: "description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
     metas.push({
       property: "og:description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
   }
 
-  if (page.meta.socialImageAssetId) {
+  if (pageMeta.socialImageAssetId) {
     const imageAsset = imageAssets.find(
-      (asset) => asset.id === page.meta.socialImageAssetId
+      (asset) => asset.id === pageMeta.socialImageAssetId
     );
 
     if (imageAsset) {
       metas.push({
         property: "og:image",
-        content: `https://${data?.host}${imageLoader({
+        content: `https://${data.host}${imageLoader({
           src: imageAsset.name,
           // Do not transform social image (not enough information do we need to do this)
           format: "raw",
@@ -142,12 +147,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     }
   }
 
-  for (const customMeta of page.meta.custom ?? []) {
-    if (customMeta.property.trim().length === 0) {
-      continue;
-    }
-    metas.push(customMeta);
-  }
+  metas.push(...pageMeta.custom);
 
   return metas;
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -8,7 +8,7 @@ import {
   json,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { Page as PageType, ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -21,6 +21,7 @@ import {
   Page,
   imageAssets,
   getRemixParams,
+  getPageMeta,
 } from "../__generated__/_index";
 import { loadResources } from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
@@ -28,12 +29,12 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
+  const pageMeta = getPageMeta({ params, resources });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -54,6 +55,7 @@ export const loader = async (arg: LoaderArgs) => {
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
       resources,
+      pageMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -68,29 +70,32 @@ export const headers = () => {
 };
 
 export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const { page, project } = pageData;
-
   const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+  if (data === undefined) {
+    return metas;
+  }
+  const { pageMeta } = data;
+  const { project } = pageData;
 
-  if (data?.url) {
+  if (data.url) {
     metas.push({
       property: "og:url",
       content: data.url,
     });
   }
 
-  if (page.title) {
-    metas.push({ title: page.title });
+  if (pageMeta.title) {
+    metas.push({ title: pageMeta.title });
 
     metas.push({
       property: "og:title",
-      content: page.title,
+      content: pageMeta.title,
     });
   }
 
   metas.push({ property: "og:type", content: "website" });
 
-  const origin = `https://${data?.host}`;
+  const origin = `https://${data.host}`;
 
   if (project?.siteName) {
     metas.push({
@@ -107,33 +112,33 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+  if (pageMeta.excludePageFromSearch || data.excludeFromSearch) {
     metas.push({
       name: "robots",
       content: "noindex, nofollow",
     });
   }
 
-  if (page.meta.description) {
+  if (pageMeta.description) {
     metas.push({
       name: "description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
     metas.push({
       property: "og:description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
   }
 
-  if (page.meta.socialImageAssetId) {
+  if (pageMeta.socialImageAssetId) {
     const imageAsset = imageAssets.find(
-      (asset) => asset.id === page.meta.socialImageAssetId
+      (asset) => asset.id === pageMeta.socialImageAssetId
     );
 
     if (imageAsset) {
       metas.push({
         property: "og:image",
-        content: `https://${data?.host}${imageLoader({
+        content: `https://${data.host}${imageLoader({
           src: imageAsset.name,
           // Do not transform social image (not enough information do we need to do this)
           format: "raw",
@@ -142,12 +147,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     }
   }
 
-  for (const customMeta of page.meta.custom ?? []) {
-    if (customMeta.property.trim().length === 0) {
-      continue;
-    }
-    metas.push(customMeta);
-  }
+  metas.push(...pageMeta.custom);
 
   return metas;
 };

--- a/packages/cli/__generated__/_index.tsx
+++ b/packages/cli/__generated__/_index.tsx
@@ -3,6 +3,7 @@
  **/
 import type { Asset, ImageAsset } from "@webstudio-is/sdk";
 import type { PageData } from "../templates/defaults/__templates__/route-template";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 
 export const fontAssets: Asset[] = [];
 export const imageAssets: ImageAsset[] = [];
@@ -13,14 +14,6 @@ export const pageData: PageData = {
     faviconAssetId: "",
     code: "",
   },
-  page: {
-    id: "",
-    name: "",
-    title: "",
-    meta: {},
-    rootInstanceId: "",
-    path: "",
-  },
 };
 
 export const user: { email: string | null } | undefined = {
@@ -28,13 +21,23 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "project-id";
 
-type Params = Record<string, string | undefined>;
-const Page = (_props: { params: Params }) => {
+export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Page title",
+    custom: [],
+  };
+};
+
+const Page = (_props: { params: any }) => {
   return <></>;
 };
 
 export { Page };
 
+type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -28,6 +28,7 @@ import {
   generateRemixParams,
   generateResourcesLoader,
   collectionComponent,
+  generatePageMeta,
 } from "@webstudio-is/react-sdk";
 import type {
   Instance,
@@ -444,6 +445,8 @@ export const prebuild = async (options: {
       "useState",
       "Fragment",
       "useResource",
+      "PageMeta",
+      "createPageMeta",
       "PageData",
       "Asset",
       "fontAssets",
@@ -499,7 +502,6 @@ export const prebuild = async (options: {
     // serialize data only used in runtime
     const renderedPageData: PageData = {
       project: siteData.build.pages.meta,
-      page: pageData.page,
     };
 
     const rootInstanceId = pageData.page.rootInstanceId;
@@ -550,6 +552,7 @@ export const prebuild = async (options: {
 import { Fragment, useState } from "react";
 import type { Asset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
+import type { PageMeta } from "@webstudio-is/react-sdk";
 ${componentImports}
 import type { PageData } from "~/routes/_index";
 export const fontAssets: Asset[] = ${JSON.stringify(fontAssets)}
@@ -559,6 +562,8 @@ export const user: { email: string | null } | undefined = ${JSON.stringify(
       siteData.user
     )};
 export const projectId = "${siteData.build.projectId}";
+
+${generatePageMeta({ page: pageData.page, dataSources })}
 
 ${pageComponent}
 

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -8,7 +8,7 @@ import {
   json,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { Page as PageType, ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -21,6 +21,7 @@ import {
   Page,
   imageAssets,
   getRemixParams,
+  getPageMeta,
 } from "../../../__generated__/_index";
 import { loadResources } from "../../../__generated__/_index.server";
 import css from "../__generated__/index.css";
@@ -28,12 +29,12 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
 export type PageData = {
   project?: ProjectMeta;
-  page: PageType;
 };
 
 export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
+  const pageMeta = getPageMeta({ params, resources });
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||
@@ -54,6 +55,7 @@ export const loader = async (arg: LoaderArgs) => {
       excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
       params,
       resources,
+      pageMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -68,29 +70,32 @@ export const headers = () => {
 };
 
 export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const { page, project } = pageData;
-
   const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+  if (data === undefined) {
+    return metas;
+  }
+  const { pageMeta } = data;
+  const { project } = pageData;
 
-  if (data?.url) {
+  if (data.url) {
     metas.push({
       property: "og:url",
       content: data.url,
     });
   }
 
-  if (page.title) {
-    metas.push({ title: page.title });
+  if (pageMeta.title) {
+    metas.push({ title: pageMeta.title });
 
     metas.push({
       property: "og:title",
-      content: page.title,
+      content: pageMeta.title,
     });
   }
 
   metas.push({ property: "og:type", content: "website" });
 
-  const origin = `https://${data?.host}`;
+  const origin = `https://${data.host}`;
 
   if (project?.siteName) {
     metas.push({
@@ -107,33 +112,33 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (page.meta.excludePageFromSearch || data?.excludeFromSearch) {
+  if (pageMeta.excludePageFromSearch || data.excludeFromSearch) {
     metas.push({
       name: "robots",
       content: "noindex, nofollow",
     });
   }
 
-  if (page.meta.description) {
+  if (pageMeta.description) {
     metas.push({
       name: "description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
     metas.push({
       property: "og:description",
-      content: page.meta.description,
+      content: pageMeta.description,
     });
   }
 
-  if (page.meta.socialImageAssetId) {
+  if (pageMeta.socialImageAssetId) {
     const imageAsset = imageAssets.find(
-      (asset) => asset.id === page.meta.socialImageAssetId
+      (asset) => asset.id === pageMeta.socialImageAssetId
     );
 
     if (imageAsset) {
       metas.push({
         property: "og:image",
-        content: `https://${data?.host}${imageLoader({
+        content: `https://${data.host}${imageLoader({
           src: imageAsset.name,
           // Do not transform social image (not enough information do we need to do this)
           format: "raw",
@@ -142,12 +147,7 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     }
   }
 
-  for (const customMeta of page.meta.custom ?? []) {
-    if (customMeta.property.trim().length === 0) {
-      continue;
-    }
-    metas.push(customMeta);
-  }
+  metas.push(...pageMeta.custom);
 
   return metas;
 };

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -31,3 +31,4 @@ export {
   generateJsxChildren,
 } from "./component-generator";
 export { generateResourcesLoader } from "./resources-generator";
+export * from "./page-meta-generator";

--- a/packages/react-sdk/src/page-meta-generator.test.ts
+++ b/packages/react-sdk/src/page-meta-generator.test.ts
@@ -16,7 +16,7 @@ test("generate minimal static page meta factory", () => {
     })
   ).toMatchInlineSnapshot(`
 "export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {
@@ -55,7 +55,7 @@ test("generate complete static page meta factory", () => {
     })
   ).toMatchInlineSnapshot(`
 "export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {
@@ -99,7 +99,7 @@ test("generate custom meta ignoring empty property name", () => {
     })
   ).toMatchInlineSnapshot(`
 "export const getPageMeta = ({}: {
-  params: Record<string, any>;
+  params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
   return {

--- a/packages/react-sdk/src/page-meta-generator.test.ts
+++ b/packages/react-sdk/src/page-meta-generator.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "@jest/globals";
+import { generatePageMeta } from "./page-meta-generator";
+
+test("generate minimal static page meta factory", () => {
+  expect(
+    generatePageMeta({
+      page: {
+        id: "",
+        name: "",
+        path: "",
+        rootInstanceId: "",
+        title: "Page title",
+        meta: {},
+      },
+      dataSources: new Map(),
+    })
+  ).toMatchInlineSnapshot(`
+"export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Page title",
+    description: undefined,
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    custom: [
+    ],
+  };
+};
+"
+`);
+});
+
+test("generate complete static page meta factory", () => {
+  expect(
+    generatePageMeta({
+      page: {
+        id: "",
+        name: "",
+        path: "",
+        rootInstanceId: "",
+        title: "Page title",
+        meta: {
+          description: "Page description",
+          excludePageFromSearch: true,
+          socialImageAssetId: "social-image-name",
+          custom: [
+            { property: "custom-property-1", content: "custom content 1" },
+            { property: "custom-property-2", content: "custom content 2" },
+          ],
+        },
+      },
+      dataSources: new Map(),
+    })
+  ).toMatchInlineSnapshot(`
+"export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Page title",
+    description: "Page description",
+    excludePageFromSearch: true,
+    socialImageAssetId: "social-image-name",
+    custom: [
+      {
+        property: "custom-property-1",
+        content: "custom content 1",
+      },
+      {
+        property: "custom-property-2",
+        content: "custom content 2",
+      },
+    ],
+  };
+};
+"
+`);
+});
+
+test("generate custom meta ignoring empty property name", () => {
+  expect(
+    generatePageMeta({
+      page: {
+        id: "",
+        name: "",
+        path: "",
+        rootInstanceId: "",
+        title: "Page title",
+        meta: {
+          custom: [
+            { property: "custom-property", content: "custom content 1" },
+            { property: "", content: "custom content 2" },
+          ],
+        },
+      },
+      dataSources: new Map(),
+    })
+  ).toMatchInlineSnapshot(`
+"export const getPageMeta = ({}: {
+  params: Record<string, any>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Page title",
+    description: undefined,
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    custom: [
+      {
+        property: "custom-property",
+        content: "custom content 1",
+      },
+    ],
+  };
+};
+"
+`);
+});

--- a/packages/react-sdk/src/page-meta-generator.ts
+++ b/packages/react-sdk/src/page-meta-generator.ts
@@ -24,7 +24,7 @@ export const generatePageMeta = ({
   );
   let generated = "";
   generated += `export const getPageMeta = ({}: {\n`;
-  generated += `  params: Record<string, any>;\n`;
+  generated += `  params: Record<string, undefined | string>;\n`;
   generated += `  resources: Record<string, any>;\n`;
   generated += `}): PageMeta => {\n`;
   generated += `  return {\n`;

--- a/packages/react-sdk/src/page-meta-generator.ts
+++ b/packages/react-sdk/src/page-meta-generator.ts
@@ -1,0 +1,53 @@
+import type { Asset, DataSources, Page } from "@webstudio-is/sdk";
+
+export type PageMeta = {
+  title: string;
+  description?: string;
+  excludePageFromSearch?: boolean;
+  socialImageAssetId?: Asset["id"];
+  custom: Array<{ property: string; content: string }>;
+};
+
+export const generatePageMeta = ({
+  page,
+}: {
+  page: Page;
+  dataSources: DataSources;
+}) => {
+  const titleExpression = JSON.stringify(page.title);
+  const descriptionExpression = JSON.stringify(page.meta.description);
+  const excludePageFromSearchExpression = JSON.stringify(
+    page.meta.excludePageFromSearch
+  );
+  const socialImageAssetIdExpression = JSON.stringify(
+    page.meta.socialImageAssetId
+  );
+  let generated = "";
+  generated += `export const getPageMeta = ({}: {\n`;
+  generated += `  params: Record<string, any>;\n`;
+  generated += `  resources: Record<string, any>;\n`;
+  generated += `}): PageMeta => {\n`;
+  generated += `  return {\n`;
+  generated += `    title: ${titleExpression},\n`;
+  generated += `    description: ${descriptionExpression},\n`;
+  generated += `    excludePageFromSearch: ${excludePageFromSearchExpression},\n`;
+  generated += `    socialImageAssetId: ${socialImageAssetIdExpression},\n`;
+  generated += `    custom: [\n`;
+  if (page.meta.custom) {
+    for (const customMeta of page.meta.custom) {
+      if (customMeta.property.trim().length === 0) {
+        continue;
+      }
+      const propertyExpression = JSON.stringify(customMeta.property);
+      const contentExpression = JSON.stringify(customMeta.content);
+      generated += `      {\n`;
+      generated += `        property: ${propertyExpression},\n`;
+      generated += `        content: ${contentExpression},\n`;
+      generated += `      },\n`;
+    }
+  }
+  generated += `    ],\n`;
+  generated += `  };\n`;
+  generated += `};\n`;
+  return generated;
+};


### PR DESCRIPTION
Here refactored page meta with simpler type than full page data and moved it into factory which is invoked lazily in loader.

This will let us support variables and resources in page settings later.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
