### PR TITLE
feat: support social image url

### DIFF
--- a/apps/builder/app/builder/features/seo/image-control.tsx
+++ b/apps/builder/app/builder/features/seo/image-control.tsx
@@ -3,7 +3,6 @@ import { ImageManager } from "~/builder/shared/image-manager";
 import type { ReactElement } from "react";
 
 export const ImageControl = (props: {
-  assetId: string;
   onAssetIdChange: (assetId: string) => void;
   children: ReactElement;
 }) => {

--- a/apps/builder/app/builder/features/seo/project-settings.tsx
+++ b/apps/builder/app/builder/features/seo/project-settings.tsx
@@ -101,10 +101,7 @@ const ProjectSettingsContentMeta = (props: {
             <Text color="subtle">
               Upload a 32 x 32 px image to display in browser tabs.
             </Text>
-            <ImageControl
-              assetId={props.meta.faviconAssetId ?? ""}
-              onAssetIdChange={handleChange("faviconAssetId")}
-            >
+            <ImageControl onAssetIdChange={handleChange("faviconAssetId")}>
               <Button id={ids.favicon} css={{ justifySelf: "start" }}>
                 Upload
               </Button>

--- a/apps/builder/app/builder/features/settings-panel/controls/file.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/file.tsx
@@ -30,7 +30,7 @@ const UrlInput = ({
     id={id}
     disabled={readOnly}
     value={localValue.value ?? ""}
-    placeholder="http://www.url.com"
+    placeholder="https://www.url.com"
     onChange={(event) => localValue.set(event.target.value)}
     onBlur={localValue.save}
     onKeyDown={(event) => {

--- a/apps/builder/app/builder/features/settings-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/url.tsx
@@ -113,7 +113,7 @@ const BaseUrl = ({ readOnly, prop, value, onChange, id }: BaseControlProps) => {
         disabled={readOnly}
         id={id}
         value={localValue.value}
-        placeholder="http://www.url.com"
+        placeholder="https://www.url.com"
         onChange={(event) => localValue.set(event.target.value)}
         onBlur={() => {
           localValue.set(addHttpsIfMissing(localValue.value));

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -88,6 +88,7 @@ const fieldDefaultValues = {
   description: "",
   isHomePage: false,
   excludePageFromSearch: false,
+  socialImageUrl: "",
   socialImageAssetId: "",
   customMetas: [
     {
@@ -205,6 +206,8 @@ const toFormValues = (
     path: page.path,
     title: page.title,
     description: page.meta.description ?? fieldDefaultValues.description,
+    socialImageUrl:
+      page.meta.socialImageUrl ?? fieldDefaultValues.socialImageUrl,
     socialImageAssetId:
       page.meta.socialImageAssetId ?? fieldDefaultValues.socialImageAssetId,
     excludePageFromSearch:
@@ -593,15 +596,28 @@ const FormFields = ({
             Project Settings will be used. The optimal dimensions for the image
             are 1200x630 px or larger with a 1.91:1 aspect ratio.
           </Text>
+          {isFeatureEnabled("cms") && (
+            <InputField
+              placeholder="http://www.url.com"
+              value={values.socialImageUrl}
+              onChange={(event) => {
+                onChange({
+                  field: "socialImageUrl",
+                  value: event.target.value,
+                });
+                onChange({ field: "socialImageAssetId", value: "" });
+              }}
+            />
+          )}
           <Grid gap={1} flow={"column"}>
             <ImageControl
-              assetId={values.socialImageAssetId}
-              onAssetIdChange={(socialImageAssetId) =>
+              onAssetIdChange={(socialImageAssetId) => {
                 onChange({
                   field: "socialImageAssetId",
                   value: socialImageAssetId,
-                })
-              }
+                });
+                onChange({ field: "socialImageUrl", value: "" });
+              }}
             >
               <Button
                 id={fieldIds.socialImageAssetId}
@@ -626,8 +642,10 @@ const FormFields = ({
           )}
           <div />
           <SocialPreview
-            asset={
-              socialImageAsset?.type === "image" ? socialImageAsset : undefined
+            ogImageUrl={
+              socialImageAsset?.type === "image"
+                ? socialImageAsset.name
+                : values.socialImageUrl
             }
             ogUrl={pageUrl}
             ogTitle={values.title}
@@ -832,7 +850,14 @@ const updatePage = (pageId: Page["id"], values: Partial<Values>) => {
     }
 
     if (values.socialImageAssetId !== undefined) {
-      page.meta.socialImageAssetId = values.socialImageAssetId;
+      page.meta.socialImageAssetId =
+        values.socialImageAssetId.length > 0
+          ? values.socialImageAssetId
+          : undefined;
+    }
+    if (values.socialImageUrl !== undefined) {
+      page.meta.socialImageUrl =
+        values.socialImageUrl.length > 0 ? values.socialImageUrl : undefined;
     }
 
     if (values.customMetas !== undefined) {

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -598,7 +598,7 @@ const FormFields = ({
           </Text>
           {isFeatureEnabled("cms") && (
             <InputField
-              placeholder="http://www.url.com"
+              placeholder="https://www.url.com"
               value={values.socialImageUrl}
               onChange={(event) => {
                 onChange({

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/social-preview.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/social-preview.tsx
@@ -1,11 +1,10 @@
 import { Box, Grid, Label, css, theme } from "@webstudio-is/design-system";
 import { Image, createImageLoader } from "@webstudio-is/image";
-import type { ImageAsset } from "@webstudio-is/sdk";
 import env from "~/shared/env";
 import { truncateByWords, truncate } from "./social-utils";
 
 type SocialPreviewProps = {
-  asset?: ImageAsset;
+  ogImageUrl?: string;
   ogUrl: string;
   ogTitle: string;
   ogDescription: string;
@@ -28,7 +27,7 @@ const imgStyle = css({
 });
 
 export const SocialPreview = ({
-  asset,
+  ogImageUrl,
   ogDescription,
   ogTitle,
   ogUrl,
@@ -50,10 +49,10 @@ export const SocialPreview = ({
         }}
       >
         <Image
-          src={asset?.type === "image" ? asset.name : undefined}
+          src={ogImageUrl}
           loader={imageLoader}
           className={imgStyle({
-            hasImage: asset?.type === "image" ? true : undefined,
+            hasImage: ogImageUrl !== undefined ? true : undefined,
           })}
         />
 

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -47,6 +47,7 @@ export const getPageMeta = ({}: {
     description: "",
     excludePageFromSearch: false,
     socialImageAssetId: "",
+    socialImageUrl: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -47,6 +47,7 @@ export const getPageMeta = ({}: {
     description: "Page description f511c297-b44f-4e4b-96bd-d013da06bada",
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
+    socialImageUrl: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -31,6 +31,7 @@ export const getPageMeta = ({}: {
     description: undefined,
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
+    socialImageUrl: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -145,6 +145,11 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         })}`,
       });
     }
+  } else if (pageMeta.socialImageUrl) {
+    metas.push({
+      property: "og:image",
+      content: pageMeta.socialImageUrl,
+    });
   }
 
   metas.push(...pageMeta.custom);

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -31,6 +31,7 @@ export const getPageMeta = ({}: {
     description: undefined,
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
+    socialImageUrl: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -145,6 +145,11 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         })}`,
       });
     }
+  } else if (pageMeta.socialImageUrl) {
+    metas.push({
+      property: "og:image",
+      content: pageMeta.socialImageUrl,
+    });
   }
 
   metas.push(...pageMeta.custom);

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -66,6 +66,7 @@ export const getPageMeta = ({}: {
     description: "",
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
+    socialImageUrl: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -75,6 +75,7 @@ export const getPageMeta = ({}: {
     description: "",
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
+    socialImageUrl: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -66,6 +66,7 @@ export const getPageMeta = ({}: {
     description: "",
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
+    socialImageUrl: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -66,6 +66,7 @@ export const getPageMeta = ({}: {
     description: "",
     excludePageFromSearch: false,
     socialImageAssetId: "",
+    socialImageUrl: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -78,6 +78,7 @@ export const getPageMeta = ({}: {
       "Delve deep into the radix roots of feline behaviors. At KittyNoTouchy, we dissect the core essence, or 'radix', of what makes cats the enigmatic creatures they are. Join us as we explore the radix of their instincts, habits, and quirks.",
     excludePageFromSearch: true,
     socialImageAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+    socialImageUrl: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -69,6 +69,7 @@ export const getPageMeta = ({}: {
     description: "",
     excludePageFromSearch: false,
     socialImageAssetId: "",
+    socialImageUrl: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -76,6 +76,7 @@ export const getPageMeta = ({}: {
       "Dive into the world of felines and discover why some whiskers are best left untouched. From intriguing cat behaviors to protective measures, \nKittyGuardedZone is your go-to hub for all things 'hands-off' in the cat realm.",
     excludePageFromSearch: undefined,
     socialImageAssetId: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+    socialImageUrl: undefined,
     custom: [
       {
         property: "fb:app_id",

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -145,6 +145,11 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         })}`,
       });
     }
+  } else if (pageMeta.socialImageUrl) {
+    metas.push({
+      property: "og:image",
+      content: pageMeta.socialImageUrl,
+    });
   }
 
   metas.push(...pageMeta.custom);

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -145,6 +145,11 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         })}`,
       });
     }
+  } else if (pageMeta.socialImageUrl) {
+    metas.push({
+      property: "og:image",
+      content: pageMeta.socialImageUrl,
+    });
   }
 
   metas.push(...pageMeta.custom);

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -145,6 +145,11 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         })}`,
       });
     }
+  } else if (pageMeta.socialImageUrl) {
+    metas.push({
+      property: "og:image",
+      content: pageMeta.socialImageUrl,
+    });
   }
 
   metas.push(...pageMeta.custom);

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -145,6 +145,11 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         })}`,
       });
     }
+  } else if (pageMeta.socialImageUrl) {
+    metas.push({
+      property: "og:image",
+      content: pageMeta.socialImageUrl,
+    });
   }
 
   metas.push(...pageMeta.custom);

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -145,6 +145,11 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         })}`,
       });
     }
+  } else if (pageMeta.socialImageUrl) {
+    metas.push({
+      property: "og:image",
+      content: pageMeta.socialImageUrl,
+    });
   }
 
   metas.push(...pageMeta.custom);

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -145,6 +145,11 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         })}`,
       });
     }
+  } else if (pageMeta.socialImageUrl) {
+    metas.push({
+      property: "og:image",
+      content: pageMeta.socialImageUrl,
+    });
   }
 
   metas.push(...pageMeta.custom);

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -145,6 +145,11 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         })}`,
       });
     }
+  } else if (pageMeta.socialImageUrl) {
+    metas.push({
+      property: "og:image",
+      content: pageMeta.socialImageUrl,
+    });
   }
 
   metas.push(...pageMeta.custom);

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -145,6 +145,11 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
         })}`,
       });
     }
+  } else if (pageMeta.socialImageUrl) {
+    metas.push({
+      property: "og:image",
+      content: pageMeta.socialImageUrl,
+    });
   }
 
   metas.push(...pageMeta.custom);

--- a/packages/image/src/image-loaders.ts
+++ b/packages/image/src/image-loaders.ts
@@ -16,6 +16,14 @@ export const createImageLoader =
     const quality = props.format === "raw" ? 100 : props.quality;
     const { format, src } = props;
 
+    // load absolute images without changes
+    try {
+      new URL(src);
+      return src;
+    } catch {
+      // empty block
+    }
+
     if (process.env.NODE_ENV !== "production") {
       warnOnce(
         allSizes.includes(width) === false,

--- a/packages/react-sdk/src/page-meta-generator.test.ts
+++ b/packages/react-sdk/src/page-meta-generator.test.ts
@@ -24,6 +24,7 @@ test("generate minimal static page meta factory", () => {
     description: undefined,
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
+    socialImageUrl: undefined,
     custom: [
     ],
   };
@@ -63,6 +64,7 @@ test("generate complete static page meta factory", () => {
     description: "Page description",
     excludePageFromSearch: true,
     socialImageAssetId: "social-image-name",
+    socialImageUrl: undefined,
     custom: [
       {
         property: "custom-property-1",
@@ -72,6 +74,40 @@ test("generate complete static page meta factory", () => {
         property: "custom-property-2",
         content: "custom content 2",
       },
+    ],
+  };
+};
+"
+`);
+});
+
+test("generate asset url instead of id", () => {
+  expect(
+    generatePageMeta({
+      page: {
+        id: "",
+        name: "",
+        path: "",
+        rootInstanceId: "",
+        title: "Page title",
+        meta: {
+          socialImageUrl: "https://my-image",
+        },
+      },
+      dataSources: new Map(),
+    })
+  ).toMatchInlineSnapshot(`
+"export const getPageMeta = ({}: {
+  params: Record<string, undefined | string>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Page title",
+    description: undefined,
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    socialImageUrl: "https://my-image",
+    custom: [
     ],
   };
 };
@@ -107,6 +143,7 @@ test("generate custom meta ignoring empty property name", () => {
     description: undefined,
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
+    socialImageUrl: undefined,
     custom: [
       {
         property: "custom-property",

--- a/packages/react-sdk/src/page-meta-generator.ts
+++ b/packages/react-sdk/src/page-meta-generator.ts
@@ -5,6 +5,7 @@ export type PageMeta = {
   description?: string;
   excludePageFromSearch?: boolean;
   socialImageAssetId?: Asset["id"];
+  socialImageUrl?: string;
   custom: Array<{ property: string; content: string }>;
 };
 
@@ -22,6 +23,7 @@ export const generatePageMeta = ({
   const socialImageAssetIdExpression = JSON.stringify(
     page.meta.socialImageAssetId
   );
+  const socialImageUrlExpression = JSON.stringify(page.meta.socialImageUrl);
   let generated = "";
   generated += `export const getPageMeta = ({}: {\n`;
   generated += `  params: Record<string, undefined | string>;\n`;
@@ -32,6 +34,7 @@ export const generatePageMeta = ({
   generated += `    description: ${descriptionExpression},\n`;
   generated += `    excludePageFromSearch: ${excludePageFromSearchExpression},\n`;
   generated += `    socialImageAssetId: ${socialImageAssetIdExpression},\n`;
+  generated += `    socialImageUrl: ${socialImageUrlExpression},\n`;
   generated += `    custom: [\n`;
   if (page.meta.custom) {
     for (const customMeta of page.meta.custom) {

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -45,6 +45,7 @@ const commonPageFields = {
     title: z.string().optional(),
     excludePageFromSearch: z.boolean().optional(),
     socialImageAssetId: z.string().optional(),
+    socialImageUrl: z.string().optional(),
     custom: z
       .array(
         z.object({


### PR DESCRIPTION
To integrate cms we need to be able to specify arbitary url as social image instead of just asset.

Here added input which overrides selected asset. Hidden behind the flag.

<img width="538" alt="Screenshot 2024-01-30 at 21 27 40" src="https://github.com/webstudio-is/webstudio/assets/5635476/e472028c-1cea-4e7d-9320-75d0cb9d2eff">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
