### PR TITLE
feat: Make publish permission visible for everyone but enabled for pro

### DIFF
--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -18,9 +18,11 @@ import {
   Text,
   InputField,
   PopoverPortal,
+  Link,
+  buttonStyle,
 } from "@webstudio-is/design-system";
 import { CopyIcon, MenuIcon, PlusIcon, HelpIcon } from "@webstudio-is/icons";
-import { Fragment, useState, type ComponentProps } from "react";
+import { Fragment, useState, type ComponentProps, type ReactNode } from "react";
 
 const Item = (props: ComponentProps<typeof Flex>) => (
   <Flex
@@ -33,14 +35,16 @@ const Item = (props: ComponentProps<typeof Flex>) => (
 
 type PermissionProps = {
   title: string;
-  info: string;
+  info: ReactNode;
   checked: boolean;
+  disabled?: boolean;
   onCheckedChange: (checked: boolean) => void;
 };
 const Permission = ({
   title,
   info,
   checked,
+  disabled = false,
   onCheckedChange,
 }: PermissionProps) => {
   const id = useId();
@@ -54,8 +58,15 @@ const Permission = ({
 
   return (
     <Flex align="center" gap="1">
-      <Switch checked={checked} id={id} onCheckedChange={onCheckedChange} />
-      <Label htmlFor={id}>{title}</Label>
+      <Switch
+        disabled={disabled}
+        checked={checked}
+        id={id}
+        onCheckedChange={onCheckedChange}
+      />
+      <Label disabled={disabled} htmlFor={id}>
+        {title}
+      </Label>
       <Tooltip content={tooltipContent} variant="wrapped">
         <HelpIcon color={rawTheme.colors.foregroundSubtle} tabIndex={0} />
       </Tooltip>
@@ -157,14 +168,35 @@ const Menu = ({
               info="Recipients can make any changes but can not publish the project."
             />
 
-            {hasProPlan && (
-              <Permission
-                onCheckedChange={handleCheckedChange("administrators")}
-                checked={relation === "administrators"}
-                title="Admin"
-                info="Recipients can make any changes and can also publish the project."
-              />
-            )}
+            <Permission
+              disabled={hasProPlan !== true}
+              onCheckedChange={handleCheckedChange("administrators")}
+              checked={relation === "administrators"}
+              title="Admin"
+              info={
+                <Flex direction="column">
+                  Recipients can make any changes and can also publish the
+                  project.
+                  {hasProPlan !== true && (
+                    <>
+                      <br />
+                      <br />
+                      Admin permission is available on the Pro plan.
+                      <br /> <br />
+                      <Link
+                        className={buttonStyle({ color: "gradient" })}
+                        color="contrast"
+                        underline="none"
+                        href="https://webstudio.is/pricing"
+                        target="_blank"
+                      >
+                        Upgrade
+                      </Link>
+                    </>
+                  )}
+                </Flex>
+              }
+            />
           </Item>
           <Separator />
           <Item>

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -181,7 +181,7 @@ const Menu = ({
                     <>
                       <br />
                       <br />
-                      Admin permission is available on the Pro plan.
+                      Upgrade to a Pro account to share with Admin permissions.
                       <br /> <br />
                       <Link
                         className={buttonStyle({ color: "gradient" })}

--- a/packages/design-system/src/components/button.tsx
+++ b/packages/design-system/src/components/button.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from "react";
 import { textVariants } from "./text";
-import { styled, theme } from "../stitches.config";
+import { css, styled, theme, type CSS } from "../stitches.config";
 import { LoadingDotsIcon } from "@webstudio-is/icons";
 import { Flex } from "./flex";
 
@@ -106,7 +106,7 @@ const perColorStyle = (variant: ButtonColor) => ({
   },
 });
 
-const StyledButton = styled("button", {
+export const buttonStyle = css({
   all: "unset",
   boxSizing: "border-box",
   minWidth: 0,
@@ -160,7 +160,7 @@ type ButtonProps = {
 
   // We don't want all the noise from StyledButton,
   // so we're cherry-picking just the props we need
-  css?: ComponentProps<typeof StyledButton>["css"];
+  css?: CSS;
 
   // prefix/suffix are primarily for Icons
   // this is a replacement for icon/icon-left/icon-right in Figma
@@ -180,6 +180,9 @@ export const Button = forwardRef(
       suffix,
       children,
       "data-state": dataState,
+      className,
+      css,
+      color,
       ...restProps
     }: ButtonProps,
     ref: Ref<HTMLButtonElement>
@@ -199,11 +202,12 @@ export const Button = forwardRef(
     }
 
     return (
-      <StyledButton
+      <button
         {...restProps}
         disabled={disabled || state === "pending"}
         data-state={finalState ?? "auto"}
         ref={ref}
+        className={buttonStyle({ color, className, css })}
       >
         {prefix}
         {children && (
@@ -227,7 +231,7 @@ export const Button = forwardRef(
         )}
 
         {suffix}
-      </StyledButton>
+      </button>
     );
   }
 );


### PR DESCRIPTION
## Description

Publish permission was hidden for non-pro accounts but this makes it  hard to discover.

<img width="151" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/e880d535-bbf6-431b-834f-f0fa1f1324c6">

## Steps for reproduction

1. open share dialog
2. see publish permission is disabled for non-pro
3. enabled for pro
4. has a tooltip that explains it
5. has link button that leads to the pricing page

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
