### PR TITLE
build: drop macos cli test

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Macos tests are very flacky and often fail after 20min timeout. In most cases linux tests are enough.