### PR TITLE
fix: prevent quoting page description

### DIFF
--- a/packages/prisma-client/prisma/migrations/20240131200102_page_meta_expressions/migration.ts
+++ b/packages/prisma-client/prisma/migrations/20240131200102_page_meta_expressions/migration.ts
@@ -65,7 +65,6 @@ const mutatePageMeta = (page: Page) => {
     page.meta.excludePageFromSearch
   );
   page.meta.socialImageUrl = JSON.stringify(page.meta.socialImageUrl);
-  page.meta.description = JSON.stringify(page.meta.description);
   if (page.meta.custom) {
     for (const item of page.meta.custom) {
       item.content = JSON.stringify(item.content);


### PR DESCRIPTION
Accidentally duplicated description conversion to expression which made all descriptions qouted.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
