### PR TITLE
fix: Font familes with a space were not rendering correctly

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
@@ -29,7 +29,8 @@ export const FontFamilyControl = ({
       onOpenChange={setIsOpen}
     >
       <DeprecatedTextField
-        defaultValue={toValue(value)}
+        // Replacing the quotes just to make it look cleaner in the UI
+        defaultValue={toValue(value).replace(/"/, "")}
         state={isOpen ? "active" : undefined}
       />
     </FloatingPanel>

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -180,9 +180,12 @@ export class FontFaceRule {
     const decls = [];
     const { fontFamily, fontStyle, fontWeight, fontDisplay, src } =
       this.options;
-    decls.push(
-      `font-family: ${/\s/.test(fontFamily) ? `"${fontFamily}"` : fontFamily}`
+    const value = toValue(
+      { type: "fontFamily", value: [fontFamily] },
+      // Avoids adding a fallback automatically which needs to happen for font family in general but not for font face.
+      (value) => value
     );
+    decls.push(`font-family: ${value}`);
     decls.push(`font-style: ${fontStyle}`);
     decls.push(`font-weight: ${fontWeight}`);
     decls.push(`font-display: ${fontDisplay}`);

--- a/packages/css-engine/src/core/style-sheet-regular.test.ts
+++ b/packages/css-engine/src/core/style-sheet-regular.test.ts
@@ -451,19 +451,19 @@ describe("Style Sheet Regular", () => {
     `);
   });
 
-  test("font family rule", () => {
+  test("font family rule with space in the name", () => {
     sheet.addFontFaceRule({
-      fontFamily: "Roboto",
+      fontFamily: "Some Font",
       fontStyle: "normal",
       fontWeight: 400,
       fontDisplay: "swap",
       src: "url(/src)",
     });
     expect(sheet.cssText).toMatchInlineSnapshot(`
-      "@font-face {
-        font-family: Roboto; font-style: normal; font-weight: 400; font-display: swap; src: url(/src);
-      }"
-    `);
+"@font-face {
+  font-family: "Some Font"; font-style: normal; font-weight: 400; font-display: swap; src: url(/src);
+}"
+`);
   });
 
   test("clear", () => {

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -51,7 +51,7 @@ describe("Convert WS CSS Values to native CSS strings", () => {
       type: "fontFamily",
       value: ["Courier New"],
     });
-    expect(value).toBe("Courier New, monospace");
+    expect(value).toBe('"Courier New", monospace');
   });
 
   test("Transform font family value to override default fallback", () => {
@@ -69,7 +69,7 @@ describe("Convert WS CSS Values to native CSS strings", () => {
         }
       }
     );
-    expect(value).toBe("Courier New");
+    expect(value).toBe('"Courier New"');
   });
 
   test("array", () => {

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -39,7 +39,11 @@ export const toValue = (
     return value.value + (value.unit === "number" ? "" : value.unit);
   }
   if (value.type === "fontFamily") {
-    return value.value.join(", ");
+    const families = [];
+    for (const family of value.value) {
+      families.push(family.includes(" ") ? `"${family}"` : family);
+    }
+    return families.join(", ");
   }
   if (value.type === "var") {
     const fallbacks = [];

--- a/packages/react-sdk/src/css/global-rules.ts
+++ b/packages/react-sdk/src/css/global-rules.ts
@@ -26,5 +26,4 @@ export const addGlobalRules = (
   for (const fontFace of fontFaces) {
     sheet.addFontFaceRule(fontFace);
   }
-  console.log(sheet.cssText);
 };

--- a/packages/react-sdk/src/css/global-rules.ts
+++ b/packages/react-sdk/src/css/global-rules.ts
@@ -26,4 +26,5 @@ export const addGlobalRules = (
   for (const fontFace of fontFaces) {
     sheet.addFontFaceRule(fontFace);
   }
+  console.log(sheet.cssText);
 };


### PR DESCRIPTION
## Description

Now any font that contains a space should render

## Steps for reproduction

1. select any font that has a space in the name
2. check it actually renders on canvas

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
