### PR TITLE
chore: Add DIRECT_URL to the .env.example file

### DIFF
--- a/apps/builder/.env.example
+++ b/apps/builder/.env.example
@@ -1,5 +1,6 @@
 BUILDER_HOST=webstudio.is
 DATABASE_URL=postgresql://user:pass@localhost/webstudio
+DIRECT_URL=postgresql://user:pass@localhost/webstudio
 AUTH_SECRET="# Linux: $(openssl rand -hex 32) or go to https://generate-secret.now.sh/64"
 GH_CLIENT_SECRET=
 GH_CLIENT_ID=

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "storybook": "pnpm run --parallel --recursive storybook:dev",
     "storybook:build": "storybook build",
-    "migrations": "cd apps/builder && pnpm migrations --dev",
+    "migrations": "cd apps/builder && pnpm migrations migrate --dev",
     "build-figma-tokens": "cd packages/design-system && pnpm build-figma-tokens",
     "prepare": "git config core.hooksPath .git/hooks/ && simple-git-hooks",
     "local:version-snapshot": "pnpm -r exec pnpm version prepatch --preid $(cat /dev/urandom | LC_ALL=C tr -dc 'a-z' | fold -w 8 | head -n 1)",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "storybook": "pnpm run --parallel --recursive storybook:dev",
     "storybook:build": "storybook build",
-    "migrations": "cd apps/builder && pnpm migrations migrate --dev",
+    "migrations": "cd apps/builder && pnpm migrations --dev",
     "build-figma-tokens": "cd packages/design-system && pnpm build-figma-tokens",
     "prepare": "git config core.hooksPath .git/hooks/ && simple-git-hooks",
     "local:version-snapshot": "pnpm -r exec pnpm version prepatch --preid $(cat /dev/urandom | LC_ALL=C tr -dc 'a-z' | fold -w 8 | head -n 1)",


### PR DESCRIPTION
## Description

Connecting to database now needs `DIRECT_URL` too, referene
https://github.com/webstudio-is/webstudio/blob/main/packages/prisma-client/prisma/schema.prisma#L13-L17

```sh
datasource db {
  provider  = "postgres"
  url       = env("DATABASE_URL")
  directUrl = env("DIRECT_URL")
}
```



## Code Review

- [ ] hi @istarkov , I need you to do
  - detailed review (read every line)
  
## Before requesting a review

- [x] made a self-review