### PR TITLE
feat: Use a number as a shortcut for breakpoints without modifiers

### DIFF
--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -30,7 +30,7 @@ const makeBreakpointCommand = <CommandName extends string>(
   number: number
 ): Command<CommandName> => ({
   name,
-  defaultHotkeys: [`meta+${number}`, `ctrl+${number}`],
+  defaultHotkeys: [`${number}`],
   handler: () => {
     selectBreakpointByOrder(number);
   },

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -31,6 +31,7 @@ const makeBreakpointCommand = <CommandName extends string>(
 ): Command<CommandName> => ({
   name,
   defaultHotkeys: [`${number}`],
+  disableHotkeyOnFormTags: true,
   handler: () => {
     selectBreakpointByOrder(number);
   },

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -32,6 +32,7 @@ const makeBreakpointCommand = <CommandName extends string>(
   name,
   defaultHotkeys: [`${number}`],
   disableHotkeyOnFormTags: true,
+  disableHotkeyOnContentEditable: true,
   handler: () => {
     selectBreakpointByOrder(number);
   },

--- a/apps/builder/app/shared/commands-emitter.ts
+++ b/apps/builder/app/shared/commands-emitter.ts
@@ -57,7 +57,7 @@ const findCommandsMatchingHotkeys = (event: KeyboardEvent) => {
     pressedKeys.add("shift");
   }
   if (altKey) {
-    pressedKeys.add("altKey");
+    pressedKeys.add("alt");
   }
 
   const commandMetas = $commandMetas.get();


### PR DESCRIPTION
## Description

Both ctrl/cmd + number are used to in browsers to switch between tabs. Webflow is just using a number shortcut without modifier, lets do the same

## Steps for reproduction

1. hit numbers to switch breakpoints
2. can still type numbers in inputs

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
