### PR TITLE
fix: Show active state of the menu button for advanced typography options

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
@@ -1,9 +1,9 @@
 import {
   Flex,
   Grid,
-  DeprecatedIconButton,
-  Tooltip,
+  EnhancedTooltip,
   theme,
+  IconButton,
 } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
 import type { StyleProperty } from "@webstudio-is/css-engine";
@@ -38,6 +38,7 @@ import { ToggleGroupControl } from "../../controls/toggle/toggle-control";
 import { FloatingPanel } from "~/builder/shared/floating-panel";
 import { getStyleSource } from "../../shared/style-info";
 import { CollapsibleSection } from "../../shared/collapsible-section";
+import { forwardRef, type ComponentProps } from "react";
 
 const properties: StyleProperty[] = [
   "fontFamily",
@@ -360,6 +361,22 @@ export const TypographySectionAdvanced = (props: RenderCategoryProps) => {
   );
 };
 
+const AdvancedOptionsButton = forwardRef<
+  HTMLButtonElement,
+  ComponentProps<typeof IconButton>
+>((props, ref) => {
+  return (
+    <Flex>
+      <EnhancedTooltip content="More typography options">
+        <IconButton {...props} ref={ref}>
+          <EllipsesIcon />
+        </IconButton>
+      </EnhancedTooltip>
+    </Flex>
+  );
+});
+AdvancedOptionsButton.displayName = "AdvancedOptionsButton";
+
 export const TypographySectionAdvancedPopover = (
   props: RenderCategoryProps
 ) => {
@@ -492,13 +509,7 @@ export const TypographySectionAdvancedPopover = (
         </Grid>
       }
     >
-      <Flex>
-        <Tooltip content="More typography options" delayDuration={0}>
-          <DeprecatedIconButton>
-            <EllipsesIcon />
-          </DeprecatedIconButton>
-        </Tooltip>
-      </Flex>
+      <AdvancedOptionsButton />
     </FloatingPanel>
   );
 };


### PR DESCRIPTION
## Description

Show active state of the menu button for advanced typography options
## Steps for reproduction

1. typography section > advanced settings menu > click
2. panel opens, button has active state

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
