### PR TITLE
fix: Normalize border style

### DIFF
--- a/fixtures/webstudio-remix-vercel/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/index.css
@@ -232,13 +232,13 @@ html {
     border-right-width: 0px;
     border-bottom-width: 0px;
     border-left-width: 0px;
-    text-transform: none;
-    background-color: transparent;
-    background-image: none;
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
     border-left-style: solid;
+    text-transform: none;
+    background-color: transparent;
+    background-image: none;
     border-top-color: rgba(226, 232, 240, 1);
     border-right-color: rgba(226, 232, 240, 1);
     border-bottom-color: rgba(226, 232, 240, 1);
@@ -289,6 +289,10 @@ html {
     border-right-width: 1px;
     border-bottom-width: 1px;
     border-left-width: 1px;
+    border-top-style: solid;
+    border-right-style: solid;
+    border-bottom-style: solid;
+    border-left-style: solid;
     display: block;
   }
   button:where([data-ws-component="Button"]) {
@@ -304,6 +308,10 @@ html {
     border-right-width: 1px;
     border-bottom-width: 1px;
     border-left-width: 1px;
+    border-top-style: solid;
+    border-right-style: solid;
+    border-bottom-style: solid;
+    border-left-style: solid;
     text-transform: none;
   }
 }

--- a/packages/react-sdk/src/css/normalize-type-check.ts
+++ b/packages/react-sdk/src/css/normalize-type-check.ts
@@ -7,7 +7,8 @@ import type { Style } from "@webstudio-is/css-engine";
 const normalizeWithKeyof = { ...normalize };
 
 type ExportedTags = keyof typeof normalizeWithKeyof;
+type ExpectedTags = HtmlTags | "checkbox" | "radio";
 
-type ValidTags = ExportedTags extends HtmlTags ? ExportedTags : false;
+type ValidTags = ExportedTags extends ExpectedTags ? ExportedTags : false;
 
 normalizeWithKeyof satisfies Record<ValidTags, Style>;

--- a/packages/react-sdk/src/css/normalize-type-check.ts
+++ b/packages/react-sdk/src/css/normalize-type-check.ts
@@ -7,7 +7,10 @@ import type { Style } from "@webstudio-is/css-engine";
 const normalizeWithKeyof = { ...normalize };
 
 type ExportedTags = keyof typeof normalizeWithKeyof;
-type ExpectedTags = HtmlTags | "checkbox" | "radio";
+// Custom tags are needed because we need to be able to address
+// elements like input `type="checkbox"` and HTML has historically terrible naming.
+type CustomTags = "checkbox" | "radio";
+type ExpectedTags = HtmlTags | CustomTags;
 
 type ValidTags = ExportedTags extends ExpectedTags ? ExportedTags : false;
 

--- a/packages/react-sdk/src/css/normalize.ts
+++ b/packages/react-sdk/src/css/normalize.ts
@@ -16,7 +16,12 @@
  */
 
 // webstudio custom opinionated presets
-import { borders, outline } from "./presets";
+import {
+  borderStyleNone,
+  borderStyleSolid,
+  borderWidth,
+  outline,
+} from "./presets";
 import type { EmbedTemplateStyleDecl } from "../embed-template";
 
 export type Styles = EmbedTemplateStyleDecl[];
@@ -37,7 +42,7 @@ const boxSizing = {
  *   box-sizing: border-box;
   }
 */
-const baseStyle = [boxSizing, ...borders, ...outline] satisfies Styles;
+const baseStyle = [boxSizing, ...borderWidth, ...outline] satisfies Styles;
 
 export const div = baseStyle;
 export const address = baseStyle;
@@ -94,7 +99,7 @@ export const html = [
     value: { type: "unit", value: 4, unit: "number" },
   },
   boxSizing,
-  ...borders,
+  ...borderWidth,
 ] satisfies Styles;
 
 /**
@@ -136,7 +141,7 @@ export const body = [
     value: { type: "unit", unit: "number", value: 1.2 },
   },
   boxSizing,
-  ...borders,
+  ...borderWidth,
 ] satisfies Styles;
 
 /**
@@ -155,7 +160,7 @@ export const hr = [
     value: { type: "keyword", value: "inherit" },
   },
   boxSizing,
-  ...borders,
+  ...borderWidth,
 ] satisfies Styles;
 
 /**
@@ -177,7 +182,7 @@ export const b = [
     value: { type: "keyword", value: "700" },
   },
   boxSizing,
-  ...borders,
+  ...borderWidth,
 ] satisfies Styles;
 export const strong = b;
 
@@ -200,7 +205,7 @@ export const code = [
     value: { type: "unit", value: 1, unit: "em" },
   },
   boxSizing,
-  ...borders,
+  ...borderWidth,
 ] satisfies Styles;
 
 export const kbd = code;
@@ -217,7 +222,7 @@ export const small = [
     value: { type: "unit", value: 80, unit: "%" },
   },
   boxSizing,
-  ...borders,
+  ...borderWidth,
 ] satisfies Styles;
 
 /**
@@ -242,7 +247,7 @@ const subSupBase = [
     value: { type: "keyword", value: "baseline" },
   },
   boxSizing,
-  ...borders,
+  ...borderWidth,
 ] satisfies Styles;
 
 export const sub = [
@@ -277,7 +282,7 @@ export const table = [
     property: "textIndent",
     value: { type: "unit", value: 0, unit: "number" },
   },
-  ...borders,
+  ...borderWidth,
   /* 2 */
   {
     property: "borderTopColor",
@@ -340,12 +345,15 @@ const buttonBase = [
     value: { type: "unit", value: 0, unit: "number" },
   },
   boxSizing,
-  ...borders,
+  ...borderStyleSolid,
+  ...borderWidth,
 ] satisfies Styles;
 
 export const input = buttonBase;
 export const optgroup = buttonBase;
 export const textarea = buttonBase;
+export const checkbox = [...input, ...borderStyleNone] satisfies Styles;
+export const radio = [...input, ...borderStyleNone] satisfies Styles;
 
 /**
 Remove the inheritance of text transform in Edge and Firefox.
@@ -427,7 +435,7 @@ export const legend = [
     value: { type: "unit", value: 0, unit: "number" },
   },
   boxSizing,
-  ...borders,
+  ...borderWidth,
 ] satisfies Styles;
 
 /**
@@ -440,7 +448,7 @@ export const progress = [
     value: { type: "keyword", value: "baseline" },
   },
   boxSizing,
-  ...borders,
+  ...borderWidth,
 ] satisfies Styles;
 
 /**
@@ -503,5 +511,5 @@ export const summary = [
     value: { type: "keyword", value: "list-item" },
   },
   boxSizing,
-  ...borders,
+  ...borderWidth,
 ] satisfies Styles;

--- a/packages/react-sdk/src/css/normalize.ts
+++ b/packages/react-sdk/src/css/normalize.ts
@@ -16,32 +16,27 @@
  */
 
 // webstudio custom opinionated presets
-import {
-  borderStyleNone,
-  borderStyleSolid,
-  borderWidth,
-  outline,
-} from "./presets";
+import { borderStyle, borderWidth, outline } from "./presets";
 import type { EmbedTemplateStyleDecl } from "../embed-template";
 
 export type Styles = EmbedTemplateStyleDecl[];
 
 /**
-Use a better box model (opinionated).
-*/
+ * Use a better box model (opinionated).
+ */
 const boxSizing = {
   property: "boxSizing",
   value: { type: "keyword", value: "border-box" },
 } satisfies EmbedTemplateStyleDecl;
 
 /**
- *  We dont support rules like this now, implement boxSizing for each used element
- *  *,
+ * We dont support rules like this now, implement boxSizing for each used element
+ * *,
  * ::before,
  * ::after {
  *   box-sizing: border-box;
-  }
-*/
+ * }
+ */
 const baseStyle = [boxSizing, ...borderWidth, ...outline] satisfies Styles;
 
 export const div = baseStyle;
@@ -78,10 +73,10 @@ export const span = baseStyle;
 
 // @todo for now not applied to html, as we don't have html element
 /**
-1. Correct the line height in all browsers.
-2. Prevent adjustments of font size after orientation changes in iOS.
-3. Use a more readable tab size (opinionated).
-*/
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ * 3. Use a more readable tab size (opinionated).
+ */
 export const html = [
   /* 1 */
   {
@@ -103,9 +98,9 @@ export const html = [
 ] satisfies Styles;
 
 /**
-1. Remove the margin in all browsers.
-2. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
-*/
+ * 1. Remove the margin in all browsers.
+ * 2. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+ */
 export const body = [
   /* 1 */
   {
@@ -145,9 +140,9 @@ export const body = [
 ] satisfies Styles;
 
 /**
-1. Add the correct height in Firefox.
-2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
-*/
+ * 1. Add the correct height in Firefox.
+ * 2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+ */
 export const hr = [
   /* 1 */
   {
@@ -174,8 +169,8 @@ abbr[title] {
 */
 
 /**
-Add the correct font weight in Edge and Safari.
-*/
+ * Add the correct font weight in Edge and Safari.
+ */
 export const b = [
   {
     property: "fontWeight",
@@ -184,12 +179,13 @@ export const b = [
   boxSizing,
   ...borderWidth,
 ] satisfies Styles;
+
 export const strong = b;
 
 /**
-1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
-2. Correct the odd 'em' font sizing in all browsers.
-*/
+ * 1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+ * 2. Correct the odd 'em' font sizing in all browsers.
+ */
 export const code = [
   /* 1 */
   {
@@ -213,9 +209,8 @@ export const samp = code;
 export const pre = code;
 
 /**
-Add the correct font size in all browsers.
-*/
-
+ * Add the correct font size in all browsers.
+ */
 export const small = [
   {
     property: "fontSize",
@@ -226,9 +221,8 @@ export const small = [
 ] satisfies Styles;
 
 /**
-Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
-*/
-
+ * Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
+ */
 const subSupBase = [
   {
     property: "fontSize",
@@ -272,10 +266,9 @@ Tabular data
 */
 
 /**
-1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
-2. Correct table border color inheritance in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
-*/
-
+ * 1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+ * 2. Correct table border color inheritance in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+ */
 export const table = [
   /* 1 */
   {
@@ -309,10 +302,9 @@ Forms
 */
 
 /**
-1. Change the font styles in all browsers.
-2. Remove the margin in Firefox and Safari.
-*/
-
+ * 1. Change the font styles in all browsers.
+ * 2. Remove the margin in Firefox and Safari.
+ */
 const buttonBase = [
   /* 1 */
   {
@@ -345,21 +337,25 @@ const buttonBase = [
     value: { type: "unit", value: 0, unit: "number" },
   },
   boxSizing,
-  ...borderStyleSolid,
   ...borderWidth,
 ] satisfies Styles;
 
-export const input = buttonBase;
+// Input and Textarea uses border style inset by default, wich we don't support in style panel.
+export const input = [...buttonBase, ...borderStyle("solid")];
+export const textarea = input;
 export const optgroup = buttonBase;
-export const textarea = buttonBase;
-export const checkbox = [...input, ...borderStyleNone] satisfies Styles;
-export const radio = [...input, ...borderStyleNone] satisfies Styles;
+
+// Radio and checkbox have by default border style "none", we are setting it here to reflect in the style panel.
+export const radio = [...buttonBase, ...borderStyle("none")];
+export const checkbox = [...buttonBase, ...borderStyle("none")];
 
 /**
-Remove the inheritance of text transform in Edge and Firefox.
-*/
+ * Remove the inheritance of text transform in Edge and Firefox.
+ */
 export const button = [
   ...buttonBase,
+  // Button uses border style outset by default, wich we don't support in style panel.
+  ...borderStyle("solid"),
   {
     property: "textTransform",
     value: { type: "keyword", value: "none" },
@@ -414,9 +410,8 @@ See: https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d4
 */
 
 /**
-Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
-*/
-
+ * Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
+ */
 export const legend = [
   {
     property: "paddingTop",
@@ -439,9 +434,8 @@ export const legend = [
 ] satisfies Styles;
 
 /**
-Add the correct vertical alignment in Chrome and Firefox.
-*/
-
+ * Add the correct vertical alignment in Chrome and Firefox.
+ */
 export const progress = [
   {
     property: "verticalAlign",
@@ -501,10 +495,9 @@ Interactive
 ===========
 */
 
-/*
-Add the correct display in Chrome and Safari.
-*/
-
+/**
+ * Add the correct display in Chrome and Safari.
+ */
 export const summary = [
   {
     property: "display",

--- a/packages/react-sdk/src/css/presets.ts
+++ b/packages/react-sdk/src/css/presets.ts
@@ -1,6 +1,6 @@
 import type { Styles } from "./normalize";
 
-export const borders: Styles = [
+export const borderWidth: Styles = [
   {
     property: "borderTopWidth",
     value: { type: "unit", value: 1, unit: "px" },
@@ -23,5 +23,43 @@ export const outline: Styles = [
   {
     property: "outlineWidth",
     value: { type: "unit", value: 1, unit: "px" },
+  },
+];
+
+export const borderStyleSolid: Styles = [
+  {
+    property: "borderTopStyle",
+    value: { type: "keyword", value: "solid" },
+  },
+  {
+    property: "borderRightStyle",
+    value: { type: "keyword", value: "solid" },
+  },
+  {
+    property: "borderBottomStyle",
+    value: { type: "keyword", value: "solid" },
+  },
+  {
+    property: "borderLeftStyle",
+    value: { type: "keyword", value: "solid" },
+  },
+];
+
+export const borderStyleNone: Styles = [
+  {
+    property: "borderTopStyle",
+    value: { type: "keyword", value: "none" },
+  },
+  {
+    property: "borderRightStyle",
+    value: { type: "keyword", value: "none" },
+  },
+  {
+    property: "borderBottomStyle",
+    value: { type: "keyword", value: "none" },
+  },
+  {
+    property: "borderLeftStyle",
+    value: { type: "keyword", value: "none" },
   },
 ];

--- a/packages/react-sdk/src/css/presets.ts
+++ b/packages/react-sdk/src/css/presets.ts
@@ -26,40 +26,21 @@ export const outline: Styles = [
   },
 ];
 
-export const borderStyleSolid: Styles = [
+export const borderStyle = (value: string): Styles => [
   {
     property: "borderTopStyle",
-    value: { type: "keyword", value: "solid" },
+    value: { type: "keyword", value },
   },
   {
     property: "borderRightStyle",
-    value: { type: "keyword", value: "solid" },
+    value: { type: "keyword", value },
   },
   {
     property: "borderBottomStyle",
-    value: { type: "keyword", value: "solid" },
+    value: { type: "keyword", value },
   },
   {
     property: "borderLeftStyle",
-    value: { type: "keyword", value: "solid" },
-  },
-];
-
-export const borderStyleNone: Styles = [
-  {
-    property: "borderTopStyle",
-    value: { type: "keyword", value: "none" },
-  },
-  {
-    property: "borderRightStyle",
-    value: { type: "keyword", value: "none" },
-  },
-  {
-    property: "borderBottomStyle",
-    value: { type: "keyword", value: "none" },
-  },
-  {
-    property: "borderLeftStyle",
-    value: { type: "keyword", value: "none" },
+    value: { type: "keyword", value },
   },
 ];

--- a/packages/sdk-components-react/src/checkbox.ws.ts
+++ b/packages/sdk-components-react/src/checkbox.ws.ts
@@ -5,13 +5,13 @@ import {
   type PresetStyle,
   defaultStates,
 } from "@webstudio-is/react-sdk";
-import { input } from "@webstudio-is/react-sdk/css-normalize";
+import { checkbox } from "@webstudio-is/react-sdk/css-normalize";
 import type { defaultTag } from "./checkbox";
 import { props } from "./__generated__/checkbox.props";
 
 const presetStyle = {
   input: [
-    ...input,
+    ...checkbox,
     {
       property: "marginRight",
       value: { type: "unit", unit: "em", value: 0.5 },

--- a/packages/sdk-components-react/src/radio-button.ws.ts
+++ b/packages/sdk-components-react/src/radio-button.ws.ts
@@ -6,12 +6,12 @@ import {
   defaultStates,
 } from "@webstudio-is/react-sdk";
 import type { defaultTag } from "./radio-button";
-import { input } from "@webstudio-is/react-sdk/css-normalize";
+import { radio } from "@webstudio-is/react-sdk/css-normalize";
 import { props } from "./__generated__/radio-button.props";
 
 const presetStyle = {
   input: [
-    ...input,
+    ...radio,
     {
       property: "marginRight",
       value: { type: "unit", unit: "em", value: 0.5 },


### PR DESCRIPTION
## Description

We don't support inset/outset in the style panel which is the initial for inputs/buttons

New defaults are:

- input, textarea, button - solid
- radio, checkbox - none (already was none, no change,but we didn't reflect that in sp)

## Steps for reproduction

1. add those components to canvas
2. see that  input, textarea, button - have solid border style in style panel
3. see that radio, checkbox - show none

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
