### PR TITLE
fix: selecting transition property when filtering

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -88,7 +88,7 @@ export const TransitionProperty = ({
       We are splitting the items into two lists.
       But when users pass a input, the list is filtered and mixed together.
       The UI is still showing the lists as separated. But the items are mixed together in background.
-      Since, first we show the common-proeprties followed by filtered-properties. We can use matchSorter to sort the items.
+      Since, first we show the common-properties followed by filtered-properties. We can use matchSorter to sort the items.
     */
     match: (search, itemsToFilter, itemToString) => {
       if (search === "") {

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -23,6 +23,7 @@ import {
 } from "@webstudio-is/design-system";
 import type { KeywordValue } from "@webstudio-is/css-engine";
 import { humanizeString } from "~/shared/string-utils";
+import { matchSorter } from "match-sorter";
 
 type AnimatableProperties = (typeof animatableProperties)[number];
 type NameAndLabel = { name: AnimatableProperties; label?: string };
@@ -83,6 +84,27 @@ export const TransitionProperty = ({
       onPropertySelection({ property: { type: "keyword", value: prop.name } });
     },
     onInputChange: (value) => setInputValue(value ?? ""),
+    /*
+      We are splitting the items into two lists.
+      But when users pass a input, the list is filtered and mixed together.
+      The UI is still showing the lists as separated. But the items are mixed together in background.
+      Since, first we show the common-proeprties followed by filtered-properties. We can use matchSorter to sort the items.
+    */
+    match: (search, itemsToFilter, itemToString) => {
+      if (search === "") {
+        return itemsToFilter;
+      }
+
+      const sortedItems = matchSorter(itemsToFilter, search, {
+        keys: [itemToString],
+        sorter: (rankedItems) =>
+          rankedItems.sort((a) =>
+            commonPropertiesSet.has(a.item.name) ? -1 : 1
+          ),
+      });
+
+      return sortedItems;
+    },
   });
 
   const commonProperties = items.filter(


### PR DESCRIPTION
## Description
https://discord.com/channels/955905230107738152/1203772575298232412
Fixes, wrong selection of property when a list is being filtered for transition proeprties.

## Steps for reproduction

- Add a transition property.
- Then select the `property` and enter some characters for filtering.
- Now, select a value from the newly filtered list.


## Code Review

- [ ] hi, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [] tested locally and on preview environment (preview dev login: 5de6)