### PR TITLE
chore: Allow logging console.info and console.error

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -26,7 +26,7 @@ module.exports = {
     },
   },
   rules: {
-    "no-console": 2,
+    "no-console": ["error", { allow: ["info", "error"] }],
     // It's too dumb to understand properly what's defined in ts
     "react/prop-types": 0,
     "no-unused-vars": "off",


### PR DESCRIPTION
## Description

In cases where we need permanent logs, we need to be able to log and commit and there is no point of having that rule. That rule protects against accidentally forgetting console.log

## Steps for reproduction

1. write console.warn or console.error and pass the linter

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
