### PR TITLE
fix: prevent form validation in canvas mode

### DIFF
--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -44,6 +44,11 @@ export const subscribeInterceptedEvents = () => {
           handleLinkClick(a);
         }
       }
+      // prevent invoking submit with buttons in canvas mode
+      // because form with prevented submit still invokes validation
+      if (event.target.closest("button") && $isPreviewMode.get() === false) {
+        event.preventDefault();
+      }
     }
   };
   const handleSubmit = (event: SubmitEvent) => {


### PR DESCRIPTION
Fixes https://discord.com/channels/955905230107738152/1203979363738193960

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
