### PR TITLE
fix: fix db consistency issues with assets

### DIFF
--- a/packages/asset-uploader/src/delete.ts
+++ b/packages/asset-uploader/src/delete.ts
@@ -38,6 +38,13 @@ export const deleteAssets = async (
     throw new Error("Assets not found");
   }
 
+  await prisma.project.update({
+    where: { id: props.projectId },
+    data: {
+      previewImageAssetId: null,
+    },
+  });
+
   await prisma.asset.deleteMany({
     where: { id: { in: props.ids }, projectId: props.projectId },
   });

--- a/packages/project/src/db/project.ts
+++ b/packages/project/src/db/project.ts
@@ -172,6 +172,18 @@ export const clone = async (
   );
 
   const clonedProject = await prisma.$transaction(async (client) => {
+    await cloneAssets(
+      {
+        fromProjectId: project.id,
+        toProjectId: newProjectId,
+
+        // Permission check on newProjectId will fail until this transaction is committed.
+        // We have to skip it, but it's ok because registerProjectOwner is right above
+        dontCheckEditPermission: true,
+      },
+      context
+    );
+
     const clonedProject = await client.project.create({
       data: {
         id: newProjectId,
@@ -193,18 +205,6 @@ export const clone = async (
       },
       context,
       client
-    );
-
-    await cloneAssets(
-      {
-        fromProjectId: project.id,
-        toProjectId: newProjectId,
-
-        // Permission check on newProjectId will fail until this transaction is committed.
-        // We have to skip it, but it's ok because registerProjectOwner is right above
-        dontCheckEditPermission: true,
-      },
-      context
     );
 
     return clonedProject;


### PR DESCRIPTION
## Description

The issue that postgres doesn't allow automatically set null on specific field in multi-column FK contraints

i.e.following  is not possible
```
FOREIGN KEY ("previewImageAssetId", "id") REFERENCES "Asset"("id", "projectId") ON DELETE SET previewImageAssetId=NULL
```

1. Create assets before project created on clone (otherwise we need magic like DEFERRABLE INITIALLY IMMEDIATE on constraints)

2. Drop project asset reference before asset delete.


## Steps for reproduction

Add asset to home page, delete it, no issues.
Duplicate project - no issues.


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
