### PR TITLE
fix: Return the check for templates permission

### DIFF
--- a/fixtures/webstudio-custom-template/.webstudio/data.json
+++ b/fixtures/webstudio-custom-template/.webstudio/data.json
@@ -1,10 +1,10 @@
 {
   "build": {
-    "id": "004b90b4-7038-4c4e-bd6c-d29f6f68fe94",
+    "id": "5eb1ac93-67ea-45e9-86a7-152a34d5dab6",
     "projectId": "0d856812-61d8-4014-a20a-82e01c0eb8ee",
     "version": 113,
-    "createdAt": "2024-02-01T08:22:38.726Z",
-    "updatedAt": "2024-02-01T08:22:38.726Z",
+    "createdAt": "2024-02-07T18:05:33.222Z",
+    "updatedAt": "2024-02-07T18:05:33.222Z",
     "pages": {
       "meta": {
         "siteName": "Fixture Site",

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml].ts
@@ -2,11 +2,11 @@ export const sitemap = {
   pages: [
     {
       path: "",
-      lastModified: "2024-02-01T08:22:38.726Z",
+      lastModified: "2024-02-07T18:05:33.222Z",
     },
     {
       path: "/script-test",
-      lastModified: "2024-02-01T08:22:38.726Z",
+      lastModified: "2024-02-07T18:05:33.222Z",
     },
   ],
 };

--- a/packages/trpc-interface/src/authorize/project.server.ts
+++ b/packages/trpc-interface/src/authorize/project.server.ts
@@ -51,6 +51,13 @@ export const hasProjectPermit = async (
       return true;
     }
 
+    const isTemplate = context.authorization.projectTemplates.includes(
+      props.projectId
+    );
+    if (props.permit === "view" && isTemplate) {
+      return true;
+    }
+
     // Check if the user is allowed to access the project
     if (authorization.userId !== undefined) {
       checks.push(


### PR DESCRIPTION
## Description

We just removed that check for the wrong reasons, readding it back before we ca find a better solution and avoid having a shortlist check in the permissions check

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
