### PR TITLE
fix: Loading indicator was deactivated

### DIFF
--- a/apps/builder/app/dashboard/shared/spinner/spinner.tsx
+++ b/apps/builder/app/dashboard/shared/spinner/spinner.tsx
@@ -1,6 +1,7 @@
 import { css } from "@webstudio-is/design-system";
 import { useDebounce } from "use-debounce";
 import { SpinnerIcon } from "@webstudio-is/icons";
+import { useEffect } from "react";
 
 const containerStyle = css({
   position: "absolute",
@@ -22,12 +23,12 @@ export const Spinner = ({
 }) => {
   const [isVisible, setIsVisible] = useDebounce(false, delay);
 
-  if (delay !== 0) {
+  useEffect(() => {
     setIsVisible(true);
-  }
+  }, [setIsVisible]);
 
   if (isVisible === false) {
-    return null;
+    return;
   }
 
   return (


### PR DESCRIPTION
## Description

In the previous attempt to fix React warnings I accidentally deactivated the loading indicator completely, now this fix works.

## Steps for reproduction

1. click on any project
2. see loading indicator right away

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
