### PR TITLE
refactor: improve path params

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/address-bar.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/address-bar.tsx
@@ -1,0 +1,98 @@
+import { Fragment, useId, useState } from "react";
+import { compilePathnamePattern, parsePathnamePattern } from "./url-pattern";
+import { Grid, InputField, Label } from "@webstudio-is/design-system";
+import { useStore } from "@nanostores/react";
+import { $dataSourceVariables } from "~/shared/nano-states";
+import type { DataSource } from "@webstudio-is/sdk";
+
+type PathParams = Record<string, string>;
+
+export type AddressBarApi = {
+  pathParamNames: string[];
+  pathParams: PathParams;
+  compiledPath: string;
+  updatePathParam: (name: string, value: string) => void;
+  savePathParams: () => void;
+};
+
+const setPathParams = (
+  dataSourceId: DataSource["id"],
+  newParams: PathParams
+) => {
+  const dataSourceVariables = new Map($dataSourceVariables.get());
+  dataSourceVariables.set(dataSourceId, newParams);
+  $dataSourceVariables.set(dataSourceVariables);
+};
+
+export const useAddressBar = ({
+  path,
+  dataSourceId,
+}: {
+  path: string;
+  dataSourceId?: string;
+}): AddressBarApi => {
+  const pathParamNames = parsePathnamePattern(path);
+  const [localParams, setLocalParams] = useState<PathParams>({});
+  const dataSourceVariables = useStore($dataSourceVariables);
+  const storedParams =
+    dataSourceId === undefined
+      ? undefined
+      : (dataSourceVariables.get(dataSourceId) as Record<string, string>);
+  const pathParams = storedParams ?? localParams;
+
+  const compiledPath = compilePathnamePattern(path, pathParams);
+
+  const updatePathParam: AddressBarApi["updatePathParam"] = (name, value) => {
+    // delete stale fields
+    const newParams: Record<string, string> = {};
+    for (const name of pathParamNames) {
+      newParams[name] = pathParams[name] ?? "";
+    }
+    newParams[name] = value;
+    setLocalParams(newParams);
+    if (dataSourceId) {
+      setPathParams(dataSourceId, newParams);
+    }
+  };
+
+  const savePathParams: AddressBarApi["savePathParams"] = () => {
+    const newParams: Record<string, string> = {};
+    for (const name of pathParamNames) {
+      newParams[name] = pathParams[name] ?? "";
+    }
+    if (dataSourceId === undefined) {
+      console.error("Cannot save path params because variable is not created");
+      return;
+    }
+    setPathParams(dataSourceId, newParams);
+  };
+
+  return {
+    pathParamNames,
+    pathParams,
+    compiledPath,
+    updatePathParam,
+    savePathParams,
+  };
+};
+
+export const AddressBar = ({ addressBar }: { addressBar: AddressBarApi }) => {
+  const { pathParamNames, pathParams, updatePathParam } = addressBar;
+  const id = useId();
+
+  return (
+    <Grid gap={1}>
+      {pathParamNames.map((name) => (
+        <Fragment key={name}>
+          <Label htmlFor={`${id}-${name}`}>{name}</Label>
+          <InputField
+            tabIndex={1}
+            id={`${id}-${name}`}
+            value={pathParams[name] ?? ""}
+            onChange={(event) => updatePathParam(name, event.target.value)}
+          />
+        </Fragment>
+      ))}
+    </Grid>
+  );
+};

--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -50,6 +50,8 @@ beforeEach(() => {
   $props.set(new Map());
   $resources.set(new Map());
   $dataSources.set(new Map());
+  $dataSourceVariables.set(new Map());
+  $resourceValues.set(new Map());
 });
 
 test("collect prop values", () => {
@@ -825,6 +827,52 @@ test("stop variables lookup outside of slots", () => {
       [
         JSON.stringify(["box", "slot", "body"]),
         new Map<string, unknown>([["boxVariable", "box"]]),
+      ],
+    ])
+  );
+
+  cleanStores($variableValuesByInstanceSelector);
+});
+
+test("compute parameter and resource variables without values to make it available in scope", () => {
+  $instances.set(
+    toMap([
+      {
+        id: "body",
+        type: "instance",
+        component: "Body",
+        children: [],
+      },
+    ])
+  );
+  selectPageRoot("body");
+  $dataSources.set(
+    toMap([
+      {
+        id: "parameterVariableId",
+        scopeInstanceId: "body",
+        name: "parameterName",
+        type: "parameter",
+      },
+      {
+        id: "resourceVariableId",
+        scopeInstanceId: "body",
+        name: "resourceName",
+        type: "resource",
+        resourceId: "resourceId",
+      },
+    ])
+  );
+  $props.set(new Map());
+
+  expect($variableValuesByInstanceSelector.get()).toEqual(
+    new Map([
+      [
+        JSON.stringify(["body"]),
+        new Map<string, unknown>([
+          ["parameterVariableId", undefined],
+          ["resourceVariableId", undefined],
+        ]),
       ],
     ])
   );

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -335,15 +335,11 @@ export const $variableValuesByInstanceSelector = computed(
           }
           if (variable.type === "parameter") {
             const value = dataSourceVariables.get(variable.id);
-            if (value !== undefined) {
-              variableValues.set(variable.id, value);
-            }
+            variableValues.set(variable.id, value);
           }
           if (variable.type === "resource") {
             const value = resourceValues.get(variable.resourceId);
-            if (value !== undefined) {
-              variableValues.set(variable.id, value);
-            }
+            variableValues.set(variable.id, value);
           }
         }
       }
@@ -378,7 +374,12 @@ export const $variableValuesByInstanceSelector = computed(
       if (instance.component === collectionComponent) {
         const data = propValues.get("data");
         const itemVariableId = parameters.get("item");
-        if (Array.isArray(data) && itemVariableId !== undefined) {
+        if (itemVariableId === undefined) {
+          return;
+        }
+        // prevent accessing item from collection
+        variableValues.delete(itemVariableId);
+        if (Array.isArray(data)) {
           data.forEach((item, index) => {
             const itemVariableValues = new Map(variableValues);
             itemVariableValues.set(itemVariableId, item);


### PR DESCRIPTION
- generate path params fields on the fly, even for new page
- fill entered values when path params variable is created
- fixed showing $ws$dataSource$id instead of variable name when no values path params entered
- renamed variable to "Path Params"

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
