### PR TITLE
fix: Fix clone from builder when shared link is used

### DIFF
--- a/apps/builder/app/shared/clone-project.tsx
+++ b/apps/builder/app/shared/clone-project.tsx
@@ -17,8 +17,11 @@ import {
 import { Title, type ProjectRouter, Project } from "@webstudio-is/project";
 import { projectsPath, builderPath } from "~/shared/router-utils";
 import { createTrpcRemixProxy } from "~/shared/remix/trpc-remix-proxy";
+import { $authToken } from "./nano-states";
 
-const trpc = createTrpcRemixProxy<ProjectRouter>(projectsPath);
+const trpc = createTrpcRemixProxy<ProjectRouter>((method) =>
+  projectsPath(method, { authToken: $authToken.get() })
+);
 
 const useCloneProject = ({
   projectId,

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -73,7 +73,18 @@ export const builderDomainsPath = (method: string) => {
   }`;
 };
 
-export const projectsPath = (method: string) => `/rest/projects/${method}`;
+export const projectsPath = (
+  method: string,
+  { authToken }: { authToken?: string } = {}
+) => {
+  const path = `/rest/projects/${method}`;
+  if (authToken === undefined) {
+    return path;
+  }
+  const urlSearchParams = new URLSearchParams();
+  urlSearchParams.set("authToken", authToken);
+  return path + `?${urlSearchParams.toString()}`;
+};
 
 export const dashboardProjectsPath = (method: string) =>
   `${dashboardPath()}/projects/${method}`;


### PR DESCRIPTION
## Description

Clone had no authToken provided via shared url

## Steps for reproduction

1. create a shared url with view permission
2. open it from a different account
3. clone from menu should work

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
