### PR TITLE
fix: Allow opening pages from topbar when in preview mode

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -73,14 +73,14 @@ const useSetWindowTitle = () => {
 
 type SidePanelProps = {
   children: JSX.Element | Array<JSX.Element>;
-  isPreviewMode: boolean;
+  isPreviewMode?: boolean;
   css?: CSS;
   gridArea: "inspector" | "sidebar" | "navigator";
 };
 
 const SidePanel = ({
   children,
-  isPreviewMode,
+  isPreviewMode = false,
   gridArea,
   css,
 }: SidePanelProps) => {
@@ -328,7 +328,7 @@ export const Builder = ({
           </Workspace>
           <AiCommandBar isPreviewMode={isPreviewMode} />
         </Main>
-        <SidePanel gridArea="sidebar" isPreviewMode={isPreviewMode}>
+        <SidePanel gridArea="sidebar">
           <SidebarLeft publish={publish} />
         </SidePanel>
         <NavigatorPanel

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { Box, Tooltip } from "@webstudio-is/design-system";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
-import { $dragAndDropState } from "~/shared/nano-states";
+import { $dragAndDropState, $isPreviewMode } from "~/shared/nano-states";
 import { panels } from "./panels";
 import type { TabName } from "./types";
 import { useClientSettings } from "~/builder/shared/client-settings";
@@ -33,6 +33,67 @@ const useActiveTab = () => {
   return [nextTab, $activeSidebarPanel.set] as const;
 };
 
+const AiTabTrigger = () => {
+  const [clientSettings, setClientSetting] = useClientSettings();
+  return (
+    <SidebarTabsTrigger
+      aria-label="ai"
+      value={
+        "anyValueNotInTabName" /* !!! This button does not have active state, use impossible tab value  !!! */
+      }
+      onClick={() => {
+        setClientSetting(
+          "isAiCommandBarVisible",
+          clientSettings.isAiCommandBarVisible === true ? false : true
+        );
+      }}
+    >
+      <AiIcon />
+    </SidebarTabsTrigger>
+  );
+};
+
+const HelpTabTrigger = () => {
+  const [helpIsOpen, setHelpIsOpen] = useState(false);
+  return (
+    <HelpPopover onOpenChange={setHelpIsOpen}>
+      <Tooltip
+        side="right"
+        content="Learn Webstudio or ask for help"
+        delayDuration={0}
+      >
+        <HelpPopover.Trigger asChild>
+          <SidebarTabsTrigger
+            as="button"
+            aria-label="Ask for help"
+            data-state={helpIsOpen ? "active" : undefined}
+          >
+            <HelpIcon size={22} />
+          </SidebarTabsTrigger>
+        </HelpPopover.Trigger>
+      </Tooltip>
+    </HelpPopover>
+  );
+};
+
+const GithubTabTrigger = () => {
+  return (
+    <Tooltip side="right" content="Report a bug on Github" delayDuration={0}>
+      <SidebarTabsTrigger
+        as="button"
+        aria-label="Report bug"
+        onClick={() => {
+          window.open(
+            "https://github.com/webstudio-is/webstudio-community/discussions/new?category=q-a&labels=bug&title=[Bug]"
+          );
+        }}
+      >
+        <BugIcon size={22} />
+      </SidebarTabsTrigger>
+    </Tooltip>
+  );
+};
+
 type SidebarLeftProps = {
   publish: Publish;
 };
@@ -40,9 +101,8 @@ type SidebarLeftProps = {
 export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
   const [activeTab, setActiveTab] = useActiveTab();
   const dragAndDropState = useStore($dragAndDropState);
-  const [helpIsOpen, setHelpIsOpen] = useState(false);
-  const [clientSettings, setClientSetting] = useClientSettings();
   const { TabContent } = activeTab === "none" ? none : panels[activeTab];
+  const isPreviewMode = useStore($isPreviewMode);
 
   useSubscribe("dragEnd", () => {
     setActiveTab("none");
@@ -55,71 +115,35 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
         value={activeTab}
         orientation="vertical"
       >
-        <SidebarTabsList>
-          {(Object.keys(panels) as Array<TabName>).map((tabName: TabName) => (
-            <SidebarTabsTrigger
-              aria-label={tabName}
-              key={tabName}
-              value={tabName}
-              onClick={() => {
-                setActiveTab(activeTab !== tabName ? tabName : "none");
-              }}
-            >
-              {tabName === "none" ? null : panels[tabName].icon}
-            </SidebarTabsTrigger>
-          ))}
-          <SidebarTabsTrigger
-            aria-label="ai"
-            value={
-              "anyValueNotInTabName" /* !!! This button does not have active state, use impossible tab value  !!! */
-            }
-            onClick={() => {
-              setClientSetting(
-                "isAiCommandBarVisible",
-                clientSettings.isAiCommandBarVisible === true ? false : true
-              );
-            }}
-          >
-            <AiIcon />
-          </SidebarTabsTrigger>
-        </SidebarTabsList>
-        <Box css={{ borderRight: `1px solid  ${theme.colors.borderMain}` }}>
-          <HelpPopover onOpenChange={setHelpIsOpen}>
-            <Tooltip
-              side="right"
-              content="Learn Webstudio or ask for help"
-              delayDuration={0}
-            >
-              <HelpPopover.Trigger asChild>
-                <SidebarTabsTrigger
-                  as="button"
-                  aria-label="Ask for help"
-                  data-state={helpIsOpen ? "active" : undefined}
-                >
-                  <HelpIcon size={22} />
-                </SidebarTabsTrigger>
-              </HelpPopover.Trigger>
-            </Tooltip>
-          </HelpPopover>
-
-          <Tooltip
-            side="right"
-            content="Report a bug on Github"
-            delayDuration={0}
-          >
-            <SidebarTabsTrigger
-              as="button"
-              aria-label="Report bug"
-              onClick={() => {
-                window.open(
-                  "https://github.com/webstudio-is/webstudio-community/discussions/new?category=q-a&labels=bug&title=[Bug]"
-                );
-              }}
-            >
-              <BugIcon size={22} />
-            </SidebarTabsTrigger>
-          </Tooltip>
-        </Box>
+        {
+          // In preview mode, we don't show left sidebar, but we want to allow pages panel to be open in the preview mode.
+          // This way user can switch pages without exiting preview mode.
+        }
+        {isPreviewMode === false && (
+          <>
+            <SidebarTabsList>
+              {(Object.keys(panels) as Array<TabName>).map(
+                (tabName: TabName) => (
+                  <SidebarTabsTrigger
+                    key={tabName}
+                    aria-label={tabName}
+                    value={tabName}
+                    onClick={() => {
+                      setActiveTab(activeTab === tabName ? "none" : tabName);
+                    }}
+                  >
+                    {tabName !== "none" && panels[tabName].icon}
+                  </SidebarTabsTrigger>
+                )
+              )}
+              <AiTabTrigger />
+            </SidebarTabsList>
+            <Box css={{ borderRight: `1px solid  ${theme.colors.borderMain}` }}>
+              <HelpTabTrigger />
+              <GithubTabTrigger />
+            </Box>
+          </>
+        )}
 
         <SidebarTabsContent
           value={activeTab === "none" ? "" : activeTab}

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useState } from "react";
 import { Box, Tooltip } from "@webstudio-is/design-system";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
 import { $dragAndDropState, $isPreviewMode } from "~/shared/nano-states";

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -21,6 +21,31 @@ import {
 import { ViewMode } from "./view-mode";
 import { $activeSidebarPanel } from "~/builder/shared/nano-states";
 
+const PagesButton = () => {
+  const page = useStore($selectedPage);
+  if (page === undefined) {
+    return;
+  }
+
+  return (
+    <ToolbarButton
+      css={{
+        px: theme.spacing[9],
+        maxWidth: theme.spacing[24],
+      }}
+      aria-label="Toggle Pages"
+      onClick={() => {
+        $activeSidebarPanel.set(
+          $activeSidebarPanel.get() === "pages" ? "none" : "pages"
+        );
+      }}
+      tabIndex={0}
+    >
+      {page.name}
+    </ToolbarButton>
+  );
+};
+
 const topbarContainerStyle = css({
   display: "flex",
   background: theme.colors.backgroundTopbar,
@@ -37,29 +62,13 @@ type TopbarProps = {
 };
 
 export const Topbar = ({ gridArea, project, hasProPlan }: TopbarProps) => {
-  const page = useStore($selectedPage);
-
   return (
     <nav className={topbarContainerStyle({ css: { gridArea } })}>
       <Flex grow={false} shrink={false}>
         <Menu />
       </Flex>
       <Flex align="center">
-        <ToolbarButton
-          css={{
-            px: theme.spacing[9],
-            maxWidth: theme.spacing[24],
-          }}
-          aria-label="Toggle Pages"
-          onClick={() => {
-            $activeSidebarPanel.set(
-              $activeSidebarPanel.get() === "pages" ? "none" : "pages"
-            );
-          }}
-          tabIndex={0}
-        >
-          {page?.name}
-        </ToolbarButton>
+        <PagesButton />
       </Flex>
       <Flex css={{ minWidth: theme.spacing[23] }}>
         <BreakpointsPopover />


### PR DESCRIPTION
## Description

Topbar pages button works when in build mode, but in preview it doesn't, this changes it. So one can switch pages when in preview mode

## Steps for reproduction

1. switch to preview mode
2. toggle pages button in top bar

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
