### PR TITLE
experimental: update variables when duplicate page

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -48,11 +48,7 @@ import {
 } from "@webstudio-is/icons";
 import { useIds } from "~/shared/form-utils";
 import { Header, HeaderSuffixSpacer } from "../../header";
-import {
-  getInstancesSlice,
-  insertInstancesSliceCopy,
-  updateWebstudioData,
-} from "~/shared/instance-utils";
+import { updateWebstudioData } from "~/shared/instance-utils";
 import {
   $assets,
   $domains,
@@ -83,6 +79,7 @@ import {
   registerFolderChildMutable,
   deletePageMutable,
   $pageRootScope,
+  duplicatePage,
 } from "./page-utils";
 import { Form } from "./form";
 import { AddressBar, useAddressBar, type AddressBarApi } from "./address-bar";
@@ -1073,51 +1070,6 @@ const updatePage = (
     }
   );
   addressBar.savePathParams();
-};
-
-const duplicatePage = (pageId: Page["id"]) => {
-  const pages = $pages.get();
-  if (pages === undefined) {
-    return;
-  }
-  const page = findPageByIdOrPath(pageId, pages);
-
-  if (page === undefined) {
-    return;
-  }
-
-  const newPageId = nanoid();
-  const { name = page.name, copyNumber } =
-    // extract a number from "name (copyNumber)"
-    page.name.match(/^(?<name>.+) \((?<copyNumber>\d+)\)$/)?.groups ?? {};
-  const newName = `${name} (${Number(copyNumber ?? "0") + 1})`;
-
-  const slice = getInstancesSlice(page.rootInstanceId);
-  updateWebstudioData((data) => {
-    const rootInstanceId = insertInstancesSliceCopy({
-      data,
-      slice,
-      availableDataSources: new Set(),
-    });
-    if (rootInstanceId === undefined) {
-      return;
-    }
-    const newPage = {
-      ...page,
-      id: newPageId,
-      rootInstanceId,
-      name: newName,
-      path: nameToPath(pages, newName),
-    } satisfies Page;
-    data.pages.pages.push(newPage);
-    const currentFolder = findParentFolderByChildId(pageId, data.pages.folders);
-    registerFolderChildMutable(
-      data.pages.folders,
-      newPageId,
-      currentFolder?.id
-    );
-  });
-  return newPageId;
 };
 
 export const PageSettings = ({

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -187,7 +187,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
         const parentInstanceSelector = instanceSelector.slice(1);
         const slice = getInstancesSlice(targetInstanceId);
         updateWebstudioData((data) => {
-          const rootInstanceId = insertInstancesSliceCopy({
+          const { newInstanceIds } = insertInstancesSliceCopy({
             data,
             slice,
             availableDataSources: findAvailableDataSources(
@@ -196,7 +196,8 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
               parentInstanceSelector
             ),
           });
-          if (rootInstanceId === undefined) {
+          const newRootInstanceId = newInstanceIds.get(targetInstanceId);
+          if (newRootInstanceId === undefined) {
             return;
           }
           const parentInstance = data.instances.get(parentInstanceId);
@@ -210,11 +211,11 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
           const position = indexWithinChildren + 1;
           parentInstance.children.splice(position, 0, {
             type: "id",
-            value: rootInstanceId,
+            value: newRootInstanceId,
           });
           // select new instance
           $selectedInstanceSelector.set([
-            rootInstanceId,
+            newRootInstanceId,
             ...parentInstanceSelector,
           ]);
         });

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -190,7 +190,7 @@ export const onPaste = (clipboardData: string): boolean => {
   }
 
   updateWebstudioData((data) => {
-    const rootInstanceId = insertInstancesSliceCopy({
+    const { newInstanceIds } = insertInstancesSliceCopy({
       data,
       slice: fragment,
       availableDataSources: findAvailableDataSources(
@@ -199,7 +199,8 @@ export const onPaste = (clipboardData: string): boolean => {
         instanceSelector
       ),
     });
-    if (rootInstanceId === undefined) {
+    const newRootInstanceId = newInstanceIds.get(fragment.instances[0].id);
+    if (newRootInstanceId === undefined) {
       return;
     }
     let dropTarget = pasteTarget;
@@ -220,7 +221,7 @@ export const onPaste = (clipboardData: string): boolean => {
     }
     const child: Instance["children"][number] = {
       type: "id",
-      value: rootInstanceId,
+      value: newRootInstanceId,
     };
     const { position } = dropTarget;
     if (position === "end") {


### PR DESCRIPTION
Here improved page duplicate logic to support replacing old variables in page meta and path params variable with new references.

Also improved path duplicating to preserve path params by prefixing with `/copy-n` subpath.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview (check page params is updated in both title and body id)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
