### PR TITLE
fix: fix color picker updating value and not selecting text when outside

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -172,9 +172,12 @@ export const ColorPicker = ({
     if (open) {
       // Dragging over canvas iframe with CORS policies will lead to loosing events and getting stuck in mousedown state.
       disableCanvasPointerEvents();
+      // User may drag outside of the color picker and that will select everything.
+      document.body.style.userSelect = "none";
       return;
     }
 
+    document.body.style.removeProperty("user-select");
     enableCanvasPointerEvents();
   };
 
@@ -192,10 +195,6 @@ export const ColorPicker = ({
         <SketchPicker
           color={rgbValue}
           onChange={(color: ColorResult, event) => {
-            // Prevents selection of text during drag.
-            if (event.type === "mousedown") {
-              event.preventDefault();
-            }
             const newColor = fixColor(color);
             onChange(newColor);
           }}


### PR DESCRIPTION
https://github.com/webstudio-is/webstudio/issues/2890

Previous attempt to prevent selection resulted in not updating the value in the picker

## Description

When dragging color handle it should be updating the hex value and when dragging outside of the picker it should  not select the entire text


## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
