### PR TITLE
fix:  Fix tokens outside click accidentally creating tokens

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -59,7 +59,7 @@ const PropsCombobox = ({
   });
 
   return (
-    <Combobox>
+    <Combobox open={combobox.isOpen}>
       <div {...combobox.getComboboxProps()}>
         <ComboboxAnchor>
           <InputField

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -149,7 +149,7 @@ export const TransitionProperty = ({
           <Label css={{ display: "inline" }}> Property </Label>
         </Tooltip>
       </Flex>
-      <Combobox>
+      <Combobox open={isOpen}>
         <div {...getComboboxProps()}>
           <ComboboxAnchor>
             <InputField

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -609,7 +609,7 @@ export const CssValueInput = ({
     );
 
   return (
-    <Combobox>
+    <Combobox open={isOpen}>
       <Box {...getComboboxProps()}>
         <ComboboxAnchor>
           <InputField

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -9,7 +9,6 @@
  * - Click to toggle select/unselect
  * - Double click to edit name
  * - Local source can only be disabled, nothing else should be possible
- * - Hit Backspace to delete the last Source item when you are in the input
  */
 
 import { nanoid } from "nanoid";
@@ -438,7 +437,7 @@ export const StyleSourceInput = (
   const states = props.componentStates ?? [];
 
   return (
-    <Combobox>
+    <Combobox open={isOpen}>
       <Box {...getComboboxProps()}>
         <ComboboxAnchor>
           <TextField

--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -10,11 +10,12 @@ import {
   useEffect,
   useRef,
 } from "react";
-// @todo:
-//   react-popper "is an internal utility, not intended for public usage"
-//   probably need to switch to @radix-ui/react-popover
-import { Popper, PopperContent, PopperAnchor } from "@radix-ui/react-popper";
-import { Portal } from "@radix-ui/react-portal";
+import {
+  Portal,
+  Popover,
+  PopoverContent,
+  PopoverAnchor,
+} from "@radix-ui/react-popover";
 import {
   type UseComboboxState,
   type UseComboboxStateChangeOptions,
@@ -93,20 +94,26 @@ export const ComboboxListbox = Listbox;
 
 export const ComboboxListboxItem = forwardRef(ListboxItemBase);
 
-export const Combobox = Popper;
+export const Combobox = (props: ComponentProps<typeof Popover>) => {
+  return <Popover {...props} modal />;
+};
 
 export const ComboboxContent = forwardRef(
-  (props: ComponentProps<typeof PopperContent>, ref: Ref<HTMLDivElement>) => (
-    // @radix-ui/react-popover adds pointer-events: none to body
-    // so need to reset for combobox rendered inside of popover
-    <Portal style={{ pointerEvents: "auto" }}>
-      <PopperContent ref={ref} {...props} />
+  (props: ComponentProps<typeof PopoverContent>, ref: Ref<HTMLDivElement>) => (
+    <Portal>
+      <PopoverContent
+        ref={ref}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+        }}
+        {...props}
+      />
     </Portal>
   )
 );
 ComboboxContent.displayName = "ComboboxContent";
 
-export const ComboboxAnchor = PopperAnchor;
+export const ComboboxAnchor = PopoverAnchor;
 
 type Match<Item> = (
   search: string,

--- a/packages/design-system/src/components/menu.stories.tsx
+++ b/packages/design-system/src/components/menu.stories.tsx
@@ -145,6 +145,7 @@ const ComboboxDemo = () => {
   const [selectedItem, onItemSelect] = useState<Fruit>();
 
   const {
+    isOpen,
     items,
     getInputProps,
     getComboboxProps,
@@ -175,7 +176,7 @@ const ComboboxDemo = () => {
   const longItems = items.filter((item) => item === "Banana");
 
   return (
-    <Combobox>
+    <Combobox open={isOpen}>
       <div {...getComboboxProps()}>
         <ComboboxAnchor>
           <DeprecatedTextField


### PR DESCRIPTION
## Description

We were using popper in combobox and that is not handling click outside, so a click outside has resulted in selected item change.

In case of  style source we were creating a new token instead of just closing

## Steps for reproduction


https://github.com/webstudio-is/webstudio/assets/52824/4019e57f-3072-476f-a525-0d49b742df79


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
