### PR TITLE
experimental: generate variables for page meta website

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -38,7 +38,10 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
-export const getPageMeta = ({}: {
+export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -38,7 +38,10 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
-export const getPageMeta = ({}: {
+export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -22,7 +22,10 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
-export const getPageMeta = ({}: {
+export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -22,7 +22,10 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
-export const getPageMeta = ({}: {
+export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -57,7 +57,10 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const getPageMeta = ({}: {
+export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -66,7 +66,10 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const getPageMeta = ({}: {
+export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -57,7 +57,10 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const getPageMeta = ({}: {
+export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -57,7 +57,10 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const getPageMeta = ({}: {
+export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -68,7 +68,10 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const getPageMeta = ({}: {
+export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -60,7 +60,10 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const getPageMeta = ({}: {
+export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -66,7 +66,10 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const getPageMeta = ({}: {
+export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -564,7 +564,7 @@ export const user: { email: string | null } | undefined = ${JSON.stringify(
     )};
 export const projectId = "${siteData.build.projectId}";
 
-${generatePageMeta({ scope, page: pageData.page, dataSources })}
+${generatePageMeta({ globalScope: scope, page: pageData.page, dataSources })}
 
 ${pageComponent}
 

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -188,10 +188,12 @@ export const decodeDataSourceVariable = (name: string) => {
 export const generateExpression = ({
   expression,
   dataSources,
+  usedDataSources,
   scope,
 }: {
   expression: string;
   dataSources: DataSources;
+  usedDataSources?: DataSources;
   scope: Scope;
 }) => {
   return validateExpression(expression, {
@@ -203,6 +205,7 @@ export const generateExpression = ({
       const depId = decodeDataSourceVariable(identifier);
       const dep = depId ? dataSources.get(depId) : undefined;
       if (dep) {
+        usedDataSources?.set(dep.id, dep);
         return scope.getName(dep.id, dep.name);
       }
       return identifier;

--- a/packages/react-sdk/src/page-meta-generator.test.ts
+++ b/packages/react-sdk/src/page-meta-generator.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@jest/globals";
-import { generatePageMeta } from "./page-meta-generator";
 import { createScope } from "@webstudio-is/sdk";
+import { generatePageMeta } from "./page-meta-generator";
+
+const toMap = <T extends { id: string }>(list: T[]) =>
+  new Map(list.map((item) => [item.id, item] as const));
 
 test("generate minimal static page meta factory", () => {
   expect(
@@ -17,7 +20,10 @@ test("generate minimal static page meta factory", () => {
       dataSources: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({}: {
+"export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
@@ -58,7 +64,10 @@ test("generate complete static page meta factory", () => {
       dataSources: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({}: {
+"export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
@@ -101,7 +110,10 @@ test("generate asset url instead of id", () => {
       dataSources: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({}: {
+"export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
@@ -139,7 +151,10 @@ test("generate custom meta ignoring empty property name", () => {
       dataSources: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({}: {
+"export const getPageMeta = ({
+  params,
+  resources,
+}: {
   params: Record<string, undefined | string>;
   resources: Record<string, any>;
 }): PageMeta => {
@@ -154,6 +169,207 @@ test("generate custom meta ignoring empty property name", () => {
         property: "custom-property",
         content: "custom content 1",
       },
+    ],
+  };
+};
+"
+`);
+});
+
+test("generate page meta factory with variables", () => {
+  expect(
+    generatePageMeta({
+      scope: createScope(),
+      page: {
+        id: "",
+        name: "",
+        path: "",
+        rootInstanceId: "",
+        title: `$ws$dataSource$variableId`,
+        meta: {},
+      },
+      dataSources: toMap([
+        {
+          id: "variableId",
+          scopeInstanceId: "body",
+          name: "Variable Name",
+          type: "variable",
+          value: { type: "string", value: "" },
+        },
+      ]),
+    })
+  ).toMatchInlineSnapshot(`
+"export const getPageMeta = ({
+  params,
+  resources,
+}: {
+  params: Record<string, undefined | string>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  let VariableName = ""
+  return {
+    title: VariableName,
+    description: undefined,
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    socialImageUrl: undefined,
+    custom: [
+    ],
+  };
+};
+"
+`);
+});
+
+test("generate page meta factory with path params", () => {
+  expect(
+    generatePageMeta({
+      scope: createScope(),
+      page: {
+        id: "",
+        name: "",
+        path: "",
+        rootInstanceId: "",
+        title: `$ws$dataSource$pathParamsId.slug`,
+        meta: {},
+        pathVariableId: "pathParamsId",
+      },
+      dataSources: toMap([
+        {
+          id: "pathParamsId",
+          scopeInstanceId: "body",
+          name: "Path Params",
+          type: "parameter",
+        },
+      ]),
+    })
+  ).toMatchInlineSnapshot(`
+"export const getPageMeta = ({
+  params,
+  resources,
+}: {
+  params: Record<string, undefined | string>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  let PathParams = params
+  return {
+    title: PathParams?.slug,
+    description: undefined,
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    socialImageUrl: undefined,
+    custom: [
+    ],
+  };
+};
+"
+`);
+});
+
+test("generate page meta factory with resources", () => {
+  expect(
+    generatePageMeta({
+      scope: createScope(),
+      page: {
+        id: "",
+        name: "",
+        path: "",
+        rootInstanceId: "",
+        title: `$ws$dataSource$resourceVariableId.data.title`,
+        meta: {},
+      },
+      dataSources: toMap([
+        {
+          id: "resourceVariableId",
+          scopeInstanceId: "body",
+          name: "Cms Page",
+          type: "resource",
+          resourceId: "resourceId",
+        },
+      ]),
+    })
+  ).toMatchInlineSnapshot(`
+"export const getPageMeta = ({
+  params,
+  resources,
+}: {
+  params: Record<string, undefined | string>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  let CmsPage = resources.CmsPage
+  return {
+    title: CmsPage?.data?.title,
+    description: undefined,
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    socialImageUrl: undefined,
+    custom: [
+    ],
+  };
+};
+"
+`);
+});
+
+test("generate page meta factory without unused variables", () => {
+  expect(
+    generatePageMeta({
+      scope: createScope(),
+      page: {
+        id: "",
+        name: "",
+        path: "",
+        rootInstanceId: "",
+        pathVariableId: "unusedPathParamsId",
+        title: `$ws$dataSource$usedVariableId`,
+        meta: {},
+      },
+      dataSources: toMap([
+        {
+          id: "usedVariableId",
+          scopeInstanceId: "body",
+          name: "Used Name",
+          type: "variable",
+          value: { type: "string", value: "" },
+        },
+        {
+          id: "unusedVariableId",
+          scopeInstanceId: "body",
+          name: "Unused Name",
+          type: "variable",
+          value: { type: "string", value: "" },
+        },
+        {
+          id: "unusedPathParamsId",
+          scopeInstanceId: "body",
+          name: "Unused Path Params",
+          type: "parameter",
+        },
+        {
+          id: "unusedResourceVariableId",
+          scopeInstanceId: "body",
+          name: "Unused Cms Page",
+          type: "resource",
+          resourceId: "resourceId",
+        },
+      ]),
+    })
+  ).toMatchInlineSnapshot(`
+"export const getPageMeta = ({
+  params,
+  resources,
+}: {
+  params: Record<string, undefined | string>;
+  resources: Record<string, any>;
+}): PageMeta => {
+  let UsedName = ""
+  return {
+    title: UsedName,
+    description: undefined,
+    excludePageFromSearch: undefined,
+    socialImageAssetId: undefined,
+    socialImageUrl: undefined,
+    custom: [
     ],
   };
 };

--- a/packages/react-sdk/src/page-meta-generator.test.ts
+++ b/packages/react-sdk/src/page-meta-generator.test.ts
@@ -8,7 +8,7 @@ const toMap = <T extends { id: string }>(list: T[]) =>
 test("generate minimal static page meta factory", () => {
   expect(
     generatePageMeta({
-      scope: createScope(),
+      globalScope: createScope(),
       page: {
         id: "",
         name: "",
@@ -44,7 +44,7 @@ test("generate minimal static page meta factory", () => {
 test("generate complete static page meta factory", () => {
   expect(
     generatePageMeta({
-      scope: createScope(),
+      globalScope: createScope(),
       page: {
         id: "",
         name: "",
@@ -96,7 +96,7 @@ test("generate complete static page meta factory", () => {
 test("generate asset url instead of id", () => {
   expect(
     generatePageMeta({
-      scope: createScope(),
+      globalScope: createScope(),
       page: {
         id: "",
         name: "",
@@ -134,7 +134,7 @@ test("generate asset url instead of id", () => {
 test("generate custom meta ignoring empty property name", () => {
   expect(
     generatePageMeta({
-      scope: createScope(),
+      globalScope: createScope(),
       page: {
         id: "",
         name: "",
@@ -179,7 +179,7 @@ test("generate custom meta ignoring empty property name", () => {
 test("generate page meta factory with variables", () => {
   expect(
     generatePageMeta({
-      scope: createScope(),
+      globalScope: createScope(),
       page: {
         id: "",
         name: "",
@@ -224,7 +224,7 @@ test("generate page meta factory with variables", () => {
 test("generate page meta factory with path params", () => {
   expect(
     generatePageMeta({
-      scope: createScope(),
+      globalScope: createScope(),
       page: {
         id: "",
         name: "",
@@ -269,7 +269,7 @@ test("generate page meta factory with path params", () => {
 test("generate page meta factory with resources", () => {
   expect(
     generatePageMeta({
-      scope: createScope(),
+      globalScope: createScope(),
       page: {
         id: "",
         name: "",
@@ -314,7 +314,7 @@ test("generate page meta factory with resources", () => {
 test("generate page meta factory without unused variables", () => {
   expect(
     generatePageMeta({
-      scope: createScope(),
+      globalScope: createScope(),
       page: {
         id: "",
         name: "",

--- a/packages/react-sdk/src/page-meta-generator.ts
+++ b/packages/react-sdk/src/page-meta-generator.ts
@@ -25,7 +25,9 @@ export const generatePageMeta = ({
   page: Page;
   dataSources: DataSources;
 }) => {
-  // reserve initial parameters
+  // use global scope only to retrieve resource names
+  // create new scope for local variables to avoid bloating names
+  // reserve passed parameter names
   const scope = createScope(["params", "resources"]);
   const usedDataSources: DataSources = new Map();
   const titleExpression = generateExpression({

--- a/packages/react-sdk/src/page-meta-generator.ts
+++ b/packages/react-sdk/src/page-meta-generator.ts
@@ -1,4 +1,10 @@
-import type { Asset, DataSources, Page, Scope } from "@webstudio-is/sdk";
+import {
+  createScope,
+  type Asset,
+  type DataSources,
+  type Page,
+  type Scope,
+} from "@webstudio-is/sdk";
 import { generateExpression } from "./expression";
 
 export type PageMeta = {
@@ -11,7 +17,7 @@ export type PageMeta = {
 };
 
 export const generatePageMeta = ({
-  scope,
+  scope: resourcesScope,
   page,
   dataSources,
 }: {
@@ -19,19 +25,25 @@ export const generatePageMeta = ({
   page: Page;
   dataSources: DataSources;
 }) => {
+  // reserve initial parameters
+  const scope = createScope(["params", "resources"]);
+  const usedDataSources: DataSources = new Map();
   const titleExpression = generateExpression({
     expression: page.title,
     dataSources,
+    usedDataSources,
     scope,
   });
   const descriptionExpression = generateExpression({
     expression: page.meta.description ?? "undefined",
     dataSources,
+    usedDataSources,
     scope,
   });
   const excludePageFromSearchExpression = generateExpression({
     expression: page.meta.excludePageFromSearch ?? "undefined",
     dataSources,
+    usedDataSources,
     scope,
   });
   const socialImageAssetIdExpression = JSON.stringify(
@@ -40,38 +52,67 @@ export const generatePageMeta = ({
   const socialImageUrlExpression = generateExpression({
     expression: page.meta.socialImageUrl ?? "undefined",
     dataSources,
+    usedDataSources,
     scope,
   });
+  let customExpression = "";
+  customExpression += `[\n`;
+  for (const customMeta of page.meta.custom ?? []) {
+    if (customMeta.property.trim().length === 0) {
+      continue;
+    }
+    const propertyExpression = JSON.stringify(customMeta.property);
+    const contentExpression = generateExpression({
+      scope,
+      dataSources,
+      usedDataSources,
+      expression: customMeta.content,
+    });
+    customExpression += `      {\n`;
+    customExpression += `        property: ${propertyExpression},\n`;
+    customExpression += `        content: ${contentExpression},\n`;
+    customExpression += `      },\n`;
+  }
+  customExpression += `    ]`;
   let generated = "";
-  generated += `export const getPageMeta = ({}: {\n`;
+  generated += `export const getPageMeta = ({\n`;
+  generated += `  params,\n`;
+  generated += `  resources,\n`;
+  generated += `}: {\n`;
   generated += `  params: Record<string, undefined | string>;\n`;
   generated += `  resources: Record<string, any>;\n`;
   generated += `}): PageMeta => {\n`;
+  for (const dataSource of usedDataSources.values()) {
+    if (dataSource.type === "variable") {
+      const valueName = scope.getName(dataSource.id, dataSource.name);
+      const initialValueString = JSON.stringify(dataSource.value.value);
+      generated += `  let ${valueName} = ${initialValueString}\n`;
+      continue;
+    }
+    if (dataSource.type === "parameter") {
+      if (dataSource.id === page.pathVariableId) {
+        const valueName = scope.getName(dataSource.id, dataSource.name);
+        generated += `  let ${valueName} = params\n`;
+      }
+      continue;
+    }
+    if (dataSource.type === "resource") {
+      const valueName = scope.getName(dataSource.id, dataSource.name);
+      const resourceName = resourcesScope.getName(
+        dataSource.resourceId,
+        dataSource.name
+      );
+      generated += `  let ${valueName} = resources.${resourceName}\n`;
+      continue;
+    }
+  }
   generated += `  return {\n`;
   generated += `    title: ${titleExpression},\n`;
   generated += `    description: ${descriptionExpression},\n`;
   generated += `    excludePageFromSearch: ${excludePageFromSearchExpression},\n`;
   generated += `    socialImageAssetId: ${socialImageAssetIdExpression},\n`;
   generated += `    socialImageUrl: ${socialImageUrlExpression},\n`;
-  generated += `    custom: [\n`;
-  if (page.meta.custom) {
-    for (const customMeta of page.meta.custom) {
-      if (customMeta.property.trim().length === 0) {
-        continue;
-      }
-      const propertyExpression = JSON.stringify(customMeta.property);
-      const contentExpression = generateExpression({
-        scope,
-        dataSources,
-        expression: customMeta.content,
-      });
-      generated += `      {\n`;
-      generated += `        property: ${propertyExpression},\n`;
-      generated += `        content: ${contentExpression},\n`;
-      generated += `      },\n`;
-    }
-  }
-  generated += `    ],\n`;
+  generated += `    custom: ${customExpression},\n`;
   generated += `  };\n`;
   generated += `};\n`;
   return generated;


### PR DESCRIPTION
Here added support for variables in page meta in generated websites. Prevented creating unused variables. We can reuse the same way for other generated parts later.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
