### PR TITLE
experimental: add redirect field to page settings

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/address-bar.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/address-bar.tsx
@@ -81,11 +81,9 @@ export const useAddressBar = ({
     for (const name of pathParamNames) {
       newParams[name] = pathParams[name] ?? "";
     }
-    if (dataSourceId === undefined) {
-      console.error("Cannot save path params because variable is not created");
-      return;
+    if (dataSourceId) {
+      setPathParams(dataSourceId, newParams);
     }
-    setPathParams(dataSourceId, newParams);
   };
 
   return {

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -191,7 +191,8 @@ const scopeCompletionSource: CompletionSource = (context) => {
       displayLabel: aliases.get(name),
       detail: formatValuePreview(value),
       apply: (view, completion, from, to) => {
-        if (Identifier.test(name)) {
+        // complete valid js identifier or top level variable without quotes
+        if (Identifier.test(name) || path.path.length === 0) {
           // complete with dot
           view.dispatch({
             ...insertCompletionText(view.state, name, from, to),

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -51,6 +51,7 @@ export const getPageMeta = ({
     excludePageFromSearch: false,
     socialImageAssetId: "",
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -51,6 +51,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -35,6 +35,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -35,6 +36,10 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
   const pageMeta = getPageMeta({ params, resources });
+
+  if (pageMeta.redirect) {
+    return redirect(pageMeta.redirect, 302);
+  }
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -35,6 +35,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -35,6 +36,10 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
   const pageMeta = getPageMeta({ params, resources });
+
+  if (pageMeta.redirect) {
+    return redirect(pageMeta.redirect, 302);
+  }
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -70,6 +70,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -79,6 +79,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -70,6 +70,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -70,6 +70,7 @@ export const getPageMeta = ({
     excludePageFromSearch: false,
     socialImageAssetId: "",
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -82,6 +82,7 @@ export const getPageMeta = ({
     excludePageFromSearch: true,
     socialImageAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -73,6 +73,7 @@ export const getPageMeta = ({
     excludePageFromSearch: false,
     socialImageAssetId: "",
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [],
   };
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -80,6 +80,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [
       {
         property: "fb:app_id",

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -35,6 +36,10 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
   const pageMeta = getPageMeta({ params, resources });
+
+  if (pageMeta.redirect) {
+    return redirect(pageMeta.redirect, 302);
+  }
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -35,6 +36,10 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
   const pageMeta = getPageMeta({ params, resources });
+
+  if (pageMeta.redirect) {
+    return redirect(pageMeta.redirect, 302);
+  }
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -35,6 +36,10 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
   const pageMeta = getPageMeta({ params, resources });
+
+  if (pageMeta.redirect) {
+    return redirect(pageMeta.redirect, 302);
+  }
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -35,6 +36,10 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
   const pageMeta = getPageMeta({ params, resources });
+
+  if (pageMeta.redirect) {
+    return redirect(pageMeta.redirect, 302);
+  }
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -35,6 +36,10 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
   const pageMeta = getPageMeta({ params, resources });
+
+  if (pageMeta.redirect) {
+    return redirect(pageMeta.redirect, 302);
+  }
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -35,6 +36,10 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
   const pageMeta = getPageMeta({ params, resources });
+
+  if (pageMeta.redirect) {
+    return redirect(pageMeta.redirect, 302);
+  }
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -35,6 +36,10 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
   const pageMeta = getPageMeta({ params, resources });
+
+  if (pageMeta.redirect) {
+    return redirect(pageMeta.redirect, 302);
+  }
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -35,6 +36,10 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const resources = await loadResources({ params });
   const pageMeta = getPageMeta({ params, resources });
+
+  if (pageMeta.redirect) {
+    return redirect(pageMeta.redirect, 302);
+  }
 
   const host =
     arg.request.headers.get("x-forwarded-host") ||

--- a/packages/react-sdk/src/page-meta-generator.test.ts
+++ b/packages/react-sdk/src/page-meta-generator.test.ts
@@ -33,6 +33,7 @@ test("generate minimal static page meta factory", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [
     ],
   };
@@ -55,6 +56,7 @@ test("generate complete static page meta factory", () => {
           description: `"Page description"`,
           excludePageFromSearch: "true",
           socialImageAssetId: "social-image-name",
+          redirect: `"/new-path"`,
           custom: [
             { property: "custom-property-1", content: `"custom content 1"` },
             { property: "custom-property-2", content: `"custom content 2"` },
@@ -77,6 +79,7 @@ test("generate complete static page meta factory", () => {
     excludePageFromSearch: true,
     socialImageAssetId: "social-image-name",
     socialImageUrl: undefined,
+    redirect: "/new-path",
     custom: [
       {
         property: "custom-property-1",
@@ -123,6 +126,7 @@ test("generate asset url instead of id", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: "https://my-image",
+    redirect: undefined,
     custom: [
     ],
   };
@@ -164,6 +168,7 @@ test("generate custom meta ignoring empty property name", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [
       {
         property: "custom-property",
@@ -213,6 +218,7 @@ test("generate page meta factory with variables", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [
     ],
   };
@@ -258,6 +264,7 @@ test("generate page meta factory with path params", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [
     ],
   };
@@ -303,6 +310,7 @@ test("generate page meta factory with resources", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [
     ],
   };
@@ -369,6 +377,7 @@ test("generate page meta factory without unused variables", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    redirect: undefined,
     custom: [
     ],
   };

--- a/packages/react-sdk/src/page-meta-generator.ts
+++ b/packages/react-sdk/src/page-meta-generator.ts
@@ -13,6 +13,7 @@ export type PageMeta = {
   excludePageFromSearch?: boolean;
   socialImageAssetId?: Asset["id"];
   socialImageUrl?: string;
+  redirect?: string;
   custom: Array<{ property: string; content: string }>;
 };
 
@@ -51,6 +52,12 @@ export const generatePageMeta = ({
   );
   const socialImageUrlExpression = generateExpression({
     expression: page.meta.socialImageUrl ?? "undefined",
+    dataSources,
+    usedDataSources,
+    scope: localScope,
+  });
+  const redirectExpression = generateExpression({
+    expression: page.meta.redirect ?? "undefined",
     dataSources,
     usedDataSources,
     scope: localScope,
@@ -113,6 +120,7 @@ export const generatePageMeta = ({
   generated += `    excludePageFromSearch: ${excludePageFromSearchExpression},\n`;
   generated += `    socialImageAssetId: ${socialImageAssetIdExpression},\n`;
   generated += `    socialImageUrl: ${socialImageUrlExpression},\n`;
+  generated += `    redirect: ${redirectExpression},\n`;
   generated += `    custom: ${customExpression},\n`;
   generated += `  };\n`;
   generated += `};\n`;

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -46,6 +46,7 @@ const commonPageFields = {
     excludePageFromSearch: z.string().optional(),
     socialImageAssetId: z.string().optional(),
     socialImageUrl: z.string().optional(),
+    redirect: z.string().optional(),
     custom: z
       .array(
         z.object({


### PR DESCRIPTION
Here added new field to page settings ui and page meta schema to redirect page when specified. Having bindings support redirect can be specified conditionally based on cms cata.

Tested locally, works with both urls and paths.

<img width="702" alt="Screenshot 2024-02-12 at 15 58 11" src="https://github.com/webstudio-is/webstudio/assets/5635476/a4c171b4-8091-4241-b36f-401fc543427c">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview
- [ ] hi @JayaKrishnaNamburu, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
