### PR TITLE
fix: Image on canvas in latest chrome may not render when loading is lazy

### DIFF
--- a/packages/sdk-components-react/src/image.tsx
+++ b/packages/sdk-components-react/src/image.tsx
@@ -37,7 +37,12 @@ type Props = Omit<ComponentPropsWithoutRef<typeof WebstudioImage>, "loader">;
 
 export const Image = forwardRef<ElementRef<typeof defaultTag>, Props>(
   ({ loading = "lazy", ...props }, ref) => {
-    const { imageLoader, assetBaseUrl } = useContext(ReactSdkContext);
+    const { imageLoader, renderer, assetBaseUrl } = useContext(ReactSdkContext);
+
+    if (renderer === "canvas") {
+      // With disabled cache and loading lazy, chrome may not render the image at all
+      loading = "eager";
+    }
 
     if (
       props.src === undefined ||


### PR DESCRIPTION
## Description

When on canvas inside builder we need to always eager load images to avoid this bug in latest chrome with cache turned off

## Steps for reproduction

1. turn off cache
2. add image component on canvas
3. see it renders as expected (loading lazy in settings is default, but on canvas it renders as loading eager)

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
