### PR TITLE
experimental: allow changing page status

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -51,6 +51,7 @@ export const getPageMeta = ({
     excludePageFromSearch: false,
     socialImageAssetId: "",
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [],
   };

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -51,6 +51,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [],
   };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -35,6 +35,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [],
   };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -38,7 +38,11 @@ export const loader = async (arg: LoaderArgs) => {
   const pageMeta = getPageMeta({ params, resources });
 
   if (pageMeta.redirect) {
-    return redirect(pageMeta.redirect, 302);
+    const status =
+      pageMeta.status === 301 || pageMeta.status === 302
+        ? pageMeta.status
+        : 302;
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =
@@ -64,7 +68,10 @@ export const loader = async (arg: LoaderArgs) => {
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
-    { headers: { "Cache-Control": "public, max-age=600" } }
+    {
+      status: pageMeta.status,
+      headers: { "Cache-Control": "public, max-age=600" },
+    }
   );
 };
 

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -35,6 +35,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [],
   };

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -38,7 +38,11 @@ export const loader = async (arg: LoaderArgs) => {
   const pageMeta = getPageMeta({ params, resources });
 
   if (pageMeta.redirect) {
-    return redirect(pageMeta.redirect, 302);
+    const status =
+      pageMeta.status === 301 || pageMeta.status === 302
+        ? pageMeta.status
+        : 302;
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =
@@ -64,7 +68,10 @@ export const loader = async (arg: LoaderArgs) => {
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
-    { headers: { "Cache-Control": "public, max-age=600" } }
+    {
+      status: pageMeta.status,
+      headers: { "Cache-Control": "public, max-age=600" },
+    }
   );
 };
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -70,6 +70,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [],
   };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -79,6 +79,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [],
   };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -70,6 +70,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [],
   };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -70,6 +70,7 @@ export const getPageMeta = ({
     excludePageFromSearch: false,
     socialImageAssetId: "",
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [],
   };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -82,6 +82,7 @@ export const getPageMeta = ({
     excludePageFromSearch: true,
     socialImageAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [],
   };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -73,6 +73,7 @@ export const getPageMeta = ({
     excludePageFromSearch: false,
     socialImageAssetId: "",
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [],
   };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -80,6 +80,7 @@ export const getPageMeta = ({
     excludePageFromSearch: undefined,
     socialImageAssetId: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [
       {

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -38,7 +38,11 @@ export const loader = async (arg: LoaderArgs) => {
   const pageMeta = getPageMeta({ params, resources });
 
   if (pageMeta.redirect) {
-    return redirect(pageMeta.redirect, 302);
+    const status =
+      pageMeta.status === 301 || pageMeta.status === 302
+        ? pageMeta.status
+        : 302;
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =
@@ -64,7 +68,10 @@ export const loader = async (arg: LoaderArgs) => {
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
-    { headers: { "Cache-Control": "public, max-age=600" } }
+    {
+      status: pageMeta.status,
+      headers: { "Cache-Control": "public, max-age=600" },
+    }
   );
 };
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -38,7 +38,11 @@ export const loader = async (arg: LoaderArgs) => {
   const pageMeta = getPageMeta({ params, resources });
 
   if (pageMeta.redirect) {
-    return redirect(pageMeta.redirect, 302);
+    const status =
+      pageMeta.status === 301 || pageMeta.status === 302
+        ? pageMeta.status
+        : 302;
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =
@@ -64,7 +68,10 @@ export const loader = async (arg: LoaderArgs) => {
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
-    { headers: { "Cache-Control": "public, max-age=600" } }
+    {
+      status: pageMeta.status,
+      headers: { "Cache-Control": "public, max-age=600" },
+    }
   );
 };
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -38,7 +38,11 @@ export const loader = async (arg: LoaderArgs) => {
   const pageMeta = getPageMeta({ params, resources });
 
   if (pageMeta.redirect) {
-    return redirect(pageMeta.redirect, 302);
+    const status =
+      pageMeta.status === 301 || pageMeta.status === 302
+        ? pageMeta.status
+        : 302;
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =
@@ -64,7 +68,10 @@ export const loader = async (arg: LoaderArgs) => {
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
-    { headers: { "Cache-Control": "public, max-age=600" } }
+    {
+      status: pageMeta.status,
+      headers: { "Cache-Control": "public, max-age=600" },
+    }
   );
 };
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -38,7 +38,11 @@ export const loader = async (arg: LoaderArgs) => {
   const pageMeta = getPageMeta({ params, resources });
 
   if (pageMeta.redirect) {
-    return redirect(pageMeta.redirect, 302);
+    const status =
+      pageMeta.status === 301 || pageMeta.status === 302
+        ? pageMeta.status
+        : 302;
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =
@@ -64,7 +68,10 @@ export const loader = async (arg: LoaderArgs) => {
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
-    { headers: { "Cache-Control": "public, max-age=600" } }
+    {
+      status: pageMeta.status,
+      headers: { "Cache-Control": "public, max-age=600" },
+    }
   );
 };
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -38,7 +38,11 @@ export const loader = async (arg: LoaderArgs) => {
   const pageMeta = getPageMeta({ params, resources });
 
   if (pageMeta.redirect) {
-    return redirect(pageMeta.redirect, 302);
+    const status =
+      pageMeta.status === 301 || pageMeta.status === 302
+        ? pageMeta.status
+        : 302;
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =
@@ -64,7 +68,10 @@ export const loader = async (arg: LoaderArgs) => {
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
-    { headers: { "Cache-Control": "public, max-age=600" } }
+    {
+      status: pageMeta.status,
+      headers: { "Cache-Control": "public, max-age=600" },
+    }
   );
 };
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -38,7 +38,11 @@ export const loader = async (arg: LoaderArgs) => {
   const pageMeta = getPageMeta({ params, resources });
 
   if (pageMeta.redirect) {
-    return redirect(pageMeta.redirect, 302);
+    const status =
+      pageMeta.status === 301 || pageMeta.status === 302
+        ? pageMeta.status
+        : 302;
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =
@@ -64,7 +68,10 @@ export const loader = async (arg: LoaderArgs) => {
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
-    { headers: { "Cache-Control": "public, max-age=600" } }
+    {
+      status: pageMeta.status,
+      headers: { "Cache-Control": "public, max-age=600" },
+    }
   );
 };
 

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -38,7 +38,11 @@ export const loader = async (arg: LoaderArgs) => {
   const pageMeta = getPageMeta({ params, resources });
 
   if (pageMeta.redirect) {
-    return redirect(pageMeta.redirect, 302);
+    const status =
+      pageMeta.status === 301 || pageMeta.status === 302
+        ? pageMeta.status
+        : 302;
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =
@@ -64,7 +68,10 @@ export const loader = async (arg: LoaderArgs) => {
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
-    { headers: { "Cache-Control": "public, max-age=600" } }
+    {
+      status: pageMeta.status,
+      headers: { "Cache-Control": "public, max-age=600" },
+    }
   );
 };
 

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -38,7 +38,11 @@ export const loader = async (arg: LoaderArgs) => {
   const pageMeta = getPageMeta({ params, resources });
 
   if (pageMeta.redirect) {
-    return redirect(pageMeta.redirect, 302);
+    const status =
+      pageMeta.status === 301 || pageMeta.status === 302
+        ? pageMeta.status
+        : 302;
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =
@@ -64,7 +68,10 @@ export const loader = async (arg: LoaderArgs) => {
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
-    { headers: { "Cache-Control": "public, max-age=600" } }
+    {
+      status: pageMeta.status,
+      headers: { "Cache-Control": "public, max-age=600" },
+    }
   );
 };
 

--- a/packages/react-sdk/src/page-meta-generator.test.ts
+++ b/packages/react-sdk/src/page-meta-generator.test.ts
@@ -33,6 +33,7 @@ test("generate minimal static page meta factory", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [
     ],
@@ -56,6 +57,7 @@ test("generate complete static page meta factory", () => {
           description: `"Page description"`,
           excludePageFromSearch: "true",
           socialImageAssetId: "social-image-name",
+          status: `302`,
           redirect: `"/new-path"`,
           custom: [
             { property: "custom-property-1", content: `"custom content 1"` },
@@ -79,6 +81,7 @@ test("generate complete static page meta factory", () => {
     excludePageFromSearch: true,
     socialImageAssetId: "social-image-name",
     socialImageUrl: undefined,
+    status: 302,
     redirect: "/new-path",
     custom: [
       {
@@ -126,6 +129,7 @@ test("generate asset url instead of id", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: "https://my-image",
+    status: undefined,
     redirect: undefined,
     custom: [
     ],
@@ -168,6 +172,7 @@ test("generate custom meta ignoring empty property name", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [
       {
@@ -218,6 +223,7 @@ test("generate page meta factory with variables", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [
     ],
@@ -264,6 +270,7 @@ test("generate page meta factory with path params", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [
     ],
@@ -310,6 +317,7 @@ test("generate page meta factory with resources", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [
     ],
@@ -377,6 +385,7 @@ test("generate page meta factory without unused variables", () => {
     excludePageFromSearch: undefined,
     socialImageAssetId: undefined,
     socialImageUrl: undefined,
+    status: undefined,
     redirect: undefined,
     custom: [
     ],

--- a/packages/react-sdk/src/page-meta-generator.ts
+++ b/packages/react-sdk/src/page-meta-generator.ts
@@ -13,6 +13,7 @@ export type PageMeta = {
   excludePageFromSearch?: boolean;
   socialImageAssetId?: Asset["id"];
   socialImageUrl?: string;
+  status?: number;
   redirect?: string;
   custom: Array<{ property: string; content: string }>;
 };
@@ -52,6 +53,12 @@ export const generatePageMeta = ({
   );
   const socialImageUrlExpression = generateExpression({
     expression: page.meta.socialImageUrl ?? "undefined",
+    dataSources,
+    usedDataSources,
+    scope: localScope,
+  });
+  const statusExpression = generateExpression({
+    expression: page.meta.status ?? "undefined",
     dataSources,
     usedDataSources,
     scope: localScope,
@@ -120,6 +127,7 @@ export const generatePageMeta = ({
   generated += `    excludePageFromSearch: ${excludePageFromSearchExpression},\n`;
   generated += `    socialImageAssetId: ${socialImageAssetIdExpression},\n`;
   generated += `    socialImageUrl: ${socialImageUrlExpression},\n`;
+  generated += `    status: ${statusExpression},\n`;
   generated += `    redirect: ${redirectExpression},\n`;
   generated += `    custom: ${customExpression},\n`;
   generated += `  };\n`;

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -46,6 +46,7 @@ const commonPageFields = {
     excludePageFromSearch: z.string().optional(),
     socialImageAssetId: z.string().optional(),
     socialImageUrl: z.string().optional(),
+    status: z.string().optional(),
     redirect: z.string().optional(),
     custom: z
       .array(


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Here added support for changing page status in page settings. This works for both redirect and content rendering.

User can render error message based on received cms data and give 404 status code.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
