### PR TITLE
fix: Popover content position change to absolute throw error on canvas

### DIFF
--- a/apps/builder/app/canvas/collapsed.ts
+++ b/apps/builder/app/canvas/collapsed.ts
@@ -184,6 +184,7 @@ const recalculate = () => {
     if (element.tagName === "HTML") {
       continue;
     }
+
     // All children are absolute or fixed
     if (value === 0) {
       elementsToRecalculate.push(element);
@@ -208,7 +209,8 @@ const recalculate = () => {
     const elementInstanceId = element.getAttribute(idAttribute);
 
     if (elementInstanceId === null) {
-      throw new Error(`Element ${idAttribute} has no instance id`);
+      // Not a webstudio controlled element, like popover portal
+      continue;
     }
 
     const tagName = element.tagName.toLowerCase();


### PR DESCRIPTION
## Description

closes #2735

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
