### PR TITLE
experimental: put dynamic path behind feature flag

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -334,7 +334,7 @@ const VariablePanel = forwardRef<
     variable?: DataSource;
   }
 >(({ variable }, ref) => {
-  const { allowResourceVariables } = useStore($userPlanFeatures);
+  const { allowDynamicData } = useStore($userPlanFeatures);
 
   const nameField = useField({
     initialValue: variable?.name ?? "",
@@ -395,10 +395,10 @@ const VariablePanel = forwardRef<
             key={option}
             value={option}
             textValue={getTypeLabel(option)}
-            disabled={option === "resource" && allowResourceVariables === false}
+            disabled={option === "resource" && allowDynamicData === false}
           >
             {getTypeLabel(option)}
-            {option === "resource" && allowResourceVariables === false && (
+            {option === "resource" && allowDynamicData === false && (
               <Box css={{ display: "inline-block", ml: theme.spacing[3] }}>
                 <ProBadge>Pro</ProBadge>
               </Box>

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/address-bar.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/address-bar.tsx
@@ -166,11 +166,11 @@ const CopyPageUrl = ({
 export const AddressBar = ({ addressBar }: { addressBar: AddressBarApi }) => {
   const { pathParamNames, pathParams, pageUrl, updatePathParam } = addressBar;
   const id = useId();
-  const { allowCmsFeatures } = useStore($userPlanFeatures);
+  const { allowDynamicData } = useStore($userPlanFeatures);
 
   return (
     <Grid gap={1}>
-      {allowCmsFeatures &&
+      {allowDynamicData &&
         pathParamNames.map((name) => (
           <Fragment key={name}>
             <Label htmlFor={`${id}-${name}`}>{name}</Label>
@@ -184,7 +184,7 @@ export const AddressBar = ({ addressBar }: { addressBar: AddressBarApi }) => {
         ))}
       <CopyPageUrl
         pageUrl={pageUrl}
-        disabled={allowCmsFeatures === false && pathParamNames.length > 0}
+        disabled={allowDynamicData === false && pathParamNames.length > 0}
       />
     </Grid>
   );

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/address-bar.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/address-bar.tsx
@@ -13,6 +13,7 @@ import type { DataSource } from "@webstudio-is/sdk";
 import { $dataSourceVariables, $domains, $project } from "~/shared/nano-states";
 import env from "~/shared/env";
 import { compilePathnamePattern, parsePathnamePattern } from "./url-pattern";
+import { $userPlanFeatures } from "~/builder/shared/nano-states";
 
 const $publishedOrigin = computed([$project, $domains], (project, domains) => {
   const customDomain: string | undefined = domains[0];
@@ -95,7 +96,13 @@ export const useAddressBar = ({
   };
 };
 
-const CopyPageUrl = ({ pageUrl }: { pageUrl: string }) => {
+const CopyPageUrl = ({
+  pageUrl,
+  disabled,
+}: {
+  pageUrl: string;
+  disabled: boolean;
+}) => {
   const [copyState, setCopyState] = useState<"copy" | "copied">("copy");
 
   // reset copied state after 2 seconds
@@ -136,6 +143,7 @@ const CopyPageUrl = ({ pageUrl }: { pageUrl: string }) => {
       <Button
         color="ghost"
         type="button"
+        disabled={disabled}
         onClick={() => {
           navigator.clipboard.writeText(pageUrl);
           setCopyState("copied");
@@ -158,21 +166,26 @@ const CopyPageUrl = ({ pageUrl }: { pageUrl: string }) => {
 export const AddressBar = ({ addressBar }: { addressBar: AddressBarApi }) => {
   const { pathParamNames, pathParams, pageUrl, updatePathParam } = addressBar;
   const id = useId();
+  const { allowDynamicPath } = useStore($userPlanFeatures);
 
   return (
     <Grid gap={1}>
-      {pathParamNames.map((name) => (
-        <Fragment key={name}>
-          <Label htmlFor={`${id}-${name}`}>{name}</Label>
-          <InputField
-            tabIndex={1}
-            id={`${id}-${name}`}
-            value={pathParams[name] ?? ""}
-            onChange={(event) => updatePathParam(name, event.target.value)}
-          />
-        </Fragment>
-      ))}
-      <CopyPageUrl pageUrl={pageUrl} />
+      {allowDynamicPath &&
+        pathParamNames.map((name) => (
+          <Fragment key={name}>
+            <Label htmlFor={`${id}-${name}`}>{name}</Label>
+            <InputField
+              tabIndex={1}
+              id={`${id}-${name}`}
+              value={pathParams[name] ?? ""}
+              onChange={(event) => updatePathParam(name, event.target.value)}
+            />
+          </Fragment>
+        ))}
+      <CopyPageUrl
+        pageUrl={pageUrl}
+        disabled={allowDynamicPath === false && pathParamNames.length > 0}
+      />
     </Grid>
   );
 };

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/address-bar.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/address-bar.tsx
@@ -166,11 +166,11 @@ const CopyPageUrl = ({
 export const AddressBar = ({ addressBar }: { addressBar: AddressBarApi }) => {
   const { pathParamNames, pathParams, pageUrl, updatePathParam } = addressBar;
   const id = useId();
-  const { allowDynamicPath } = useStore($userPlanFeatures);
+  const { allowCmsFeatures } = useStore($userPlanFeatures);
 
   return (
     <Grid gap={1}>
-      {allowDynamicPath &&
+      {allowCmsFeatures &&
         pathParamNames.map((name) => (
           <Fragment key={name}>
             <Label htmlFor={`${id}-${name}`}>{name}</Label>
@@ -184,7 +184,7 @@ export const AddressBar = ({ addressBar }: { addressBar: AddressBarApi }) => {
         ))}
       <CopyPageUrl
         pageUrl={pageUrl}
-        disabled={allowDynamicPath === false && pathParamNames.length > 0}
+        disabled={allowCmsFeatures === false && pathParamNames.length > 0}
       />
     </Grid>
   );

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -238,7 +238,7 @@ const validateValues = (
     }
     const pathParamNames = parsePathnamePattern(values.path);
     if (
-      userPlanFeatures.allowCmsFeatures === false &&
+      userPlanFeatures.allowDynamicData === false &&
       pathParamNames.length > 0
     ) {
       errors.path = errors.path ?? [];
@@ -286,12 +286,12 @@ const PathField = ({
   value: string;
   onChange: (value: string) => void;
 }) => {
-  const { allowCmsFeatures } = useStore($userPlanFeatures);
+  const { allowDynamicData } = useStore($userPlanFeatures);
   const id = useId();
   return (
     <Grid gap={1}>
       <Label htmlFor={id}>
-        {allowCmsFeatures && isFeatureEnabled("cms") ? (
+        {allowDynamicData && isFeatureEnabled("cms") ? (
           <Flex align="center" css={{ gap: theme.spacing[3] }}>
             Dynamic Path
             <Tooltip

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -238,7 +238,7 @@ const validateValues = (
     }
     const pathParamNames = parsePathnamePattern(values.path);
     if (
-      userPlanFeatures.allowDynamicPath === false &&
+      userPlanFeatures.allowCmsFeatures === false &&
       pathParamNames.length > 0
     ) {
       errors.path = errors.path ?? [];
@@ -286,12 +286,12 @@ const PathField = ({
   value: string;
   onChange: (value: string) => void;
 }) => {
-  const { allowDynamicPath } = useStore($userPlanFeatures);
+  const { allowCmsFeatures } = useStore($userPlanFeatures);
   const id = useId();
   return (
     <Grid gap={1}>
       <Label htmlFor={id}>
-        {allowDynamicPath && isFeatureEnabled("cms") ? (
+        {allowCmsFeatures && isFeatureEnabled("cms") ? (
           <Flex align="center" css={{ gap: theme.spacing[3] }}>
             Dynamic Path
             <Tooltip

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -283,7 +283,7 @@ const PathField = ({
   onChange,
 }: {
   errors?: string[];
-  value?: string;
+  value: string;
   onChange: (value: string) => void;
 }) => {
   const { allowDynamicPath } = useStore($userPlanFeatures);

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -1,6 +1,6 @@
 import { nanoid } from "nanoid";
 import { z } from "zod";
-import { type FocusEventHandler, useState, useCallback } from "react";
+import { type FocusEventHandler, useState, useCallback, useId } from "react";
 import { useStore } from "@nanostores/react";
 import { useDebouncedCallback } from "use-debounce";
 import { useUnmount } from "react-use";
@@ -79,6 +79,8 @@ import {
 } from "./page-utils";
 import { Form } from "./form";
 import { AddressBar, useAddressBar, type AddressBarApi } from "./address-bar";
+import { $userPlanFeatures } from "~/builder/shared/nano-states";
+import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 
 const fieldDefaultValues = {
   name: "Untitled",
@@ -198,7 +200,8 @@ const validateValues = (
   pageId: undefined | Page["id"],
   values: Values,
   isHomePage: boolean,
-  variableValues: Map<string, unknown>
+  variableValues: Map<string, unknown>,
+  userPlanFeatures: UserPlanFeatures
 ): Errors => {
   const computedValues = {
     name: values.name,
@@ -233,6 +236,14 @@ const validateValues = (
       errors.path = errors.path ?? [];
       errors.path.push(...messages);
     }
+    const pathParamNames = parsePathnamePattern(values.path);
+    if (
+      userPlanFeatures.allowDynamicPath === false &&
+      pathParamNames.length > 0
+    ) {
+      errors.path = errors.path ?? [];
+      errors.path.push("Dynamic path is supported only for paid users");
+    }
   }
   return errors;
 };
@@ -266,16 +277,60 @@ const toFormValues = (
 const autoSelectHandler: FocusEventHandler<HTMLInputElement> = (event) =>
   event.target.select();
 
+const PathField = ({
+  errors,
+  value,
+  onChange,
+}: {
+  errors?: string[];
+  value?: string;
+  onChange: (value: string) => void;
+}) => {
+  const { allowDynamicPath } = useStore($userPlanFeatures);
+  const id = useId();
+  return (
+    <Grid gap={1}>
+      <Label htmlFor={id}>
+        {allowDynamicPath && isFeatureEnabled("cms") ? (
+          <Flex align="center" css={{ gap: theme.spacing[3] }}>
+            Dynamic Path
+            <Tooltip
+              content={
+                "The path can include dynamic parameters like :name, which could be made optional using :name?, or have a wildcard such as /* or /:name* to store whole remaining part at the end of the URL."
+              }
+              variant="wrapped"
+            >
+              <HelpIcon
+                color={rawTheme.colors.foregroundSubtle}
+                tabIndex={-1}
+              />
+            </Tooltip>
+          </Flex>
+        ) : (
+          "Path"
+        )}
+      </Label>
+      <InputErrorsTooltip errors={errors}>
+        <InputField
+          color={errors && "error"}
+          id={id}
+          placeholder="/about"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </InputErrorsTooltip>
+    </Grid>
+  );
+};
+
 const FormFields = ({
   addressBar,
-  disabled,
   autoSelect,
   errors,
   values,
   onChange,
 }: {
   addressBar: AddressBarApi;
-  disabled?: boolean;
   autoSelect?: boolean;
   errors: Errors;
   values: Values;
@@ -330,7 +385,6 @@ const FormFields = ({
                 onFocus={autoSelect ? autoSelectHandler : undefined}
                 name="name"
                 placeholder="About"
-                disabled={disabled}
                 value={values.name}
                 onChange={(event) => {
                   onChange({ field: "name", value: event.target.value });
@@ -390,39 +444,11 @@ const FormFields = ({
           )}
 
           {values.isHomePage === false && (
-            <Grid gap={1}>
-              <Label htmlFor={fieldIds.path}>
-                <Flex align="center" css={{ gap: theme.spacing[3] }}>
-                  Path
-                  {isFeatureEnabled("cms") && (
-                    <Tooltip
-                      content={
-                        "The path can include dynamic parameters like :name, which could be made optional using :name?, or have a wildcard such as /* or /:name* to store whole remaining part at the end of the URL."
-                      }
-                      variant="wrapped"
-                    >
-                      <HelpIcon
-                        color={rawTheme.colors.foregroundSubtle}
-                        tabIndex={-1}
-                      />
-                    </Tooltip>
-                  )}
-                </Flex>
-              </Label>
-              <InputErrorsTooltip errors={errors.path}>
-                <InputField
-                  color={errors.path && "error"}
-                  id={fieldIds.path}
-                  name="path"
-                  placeholder="/about"
-                  disabled={disabled}
-                  value={values?.path}
-                  onChange={(event) => {
-                    onChange({ field: "path", value: event.target.value });
-                  }}
-                />
-              </InputErrorsTooltip>
-            </Grid>
+            <PathField
+              errors={errors.path}
+              value={values.path}
+              onChange={(value) => onChange({ field: "path", value })}
+            />
           )}
           <AddressBar addressBar={addressBar} />
         </Grid>
@@ -499,9 +525,7 @@ const FormFields = ({
                   id={fieldIds.title}
                   name="title"
                   placeholder="My awesome project - About"
-                  disabled={
-                    disabled || isLiteralExpression(values.title) === false
-                  }
+                  disabled={isLiteralExpression(values.title) === false}
                   value={title}
                   onChange={(event) => {
                     onChange({
@@ -546,10 +570,7 @@ const FormFields = ({
                   state={errors.description && "invalid"}
                   id={fieldIds.description}
                   name="description"
-                  disabled={
-                    disabled ||
-                    isLiteralExpression(values.description) === false
-                  }
+                  disabled={isLiteralExpression(values.description) === false}
                   value={description}
                   onChange={(value) => {
                     onChange({
@@ -597,7 +618,6 @@ const FormFields = ({
                 <Checkbox
                   id={fieldIds.excludePageFromSearch}
                   disabled={
-                    disabled ||
                     isLiteralExpression(values.excludePageFromSearch) === false
                   }
                   checked={excludePageFromSearch}
@@ -650,9 +670,7 @@ const FormFields = ({
                     id={fieldIds.status}
                     name="status"
                     placeholder="/another-path"
-                    disabled={
-                      disabled || isLiteralExpression(values.status) === false
-                    }
+                    disabled={isLiteralExpression(values.status) === false}
                     value={String(
                       computeExpression(values.status, variableValues)
                     )}
@@ -702,9 +720,7 @@ const FormFields = ({
                     id={fieldIds.redirect}
                     name="redirect"
                     placeholder="/another-path"
-                    disabled={
-                      disabled || isLiteralExpression(values.redirect) === false
-                    }
+                    disabled={isLiteralExpression(values.redirect) === false}
                     value={String(
                       computeExpression(values.redirect, variableValues)
                     )}
@@ -764,7 +780,6 @@ const FormFields = ({
                 <InputField
                   placeholder="https://www.url.com"
                   disabled={
-                    disabled ||
                     isLiteralExpression(values.socialImageUrl) === false
                   }
                   color={errors.socialImageUrl && "error"}
@@ -884,13 +899,15 @@ export const NewPageSettings = ({
     ...fieldDefaultValues,
     path: nameToPath(pages, fieldDefaultValues.name),
   });
+  const userPlanFeatures = useStore($userPlanFeatures);
   const { variableValues } = useStore($pageRootScope);
   const errors = validateValues(
     pages,
     undefined,
     values,
     false,
-    variableValues
+    variableValues,
+    userPlanFeatures
   );
   const foldersPath =
     pages === undefined ? "" : getPagePath(values.parentFolderId, pages);
@@ -920,7 +937,6 @@ export const NewPageSettings = ({
         autoSelect
         addressBar={addressBar}
         errors={errors}
-        disabled={false}
         values={values}
         onChange={(val) => {
           setValues((values) => {
@@ -1150,12 +1166,14 @@ export const PageSettings = ({
   };
 
   const { variableValues } = useStore($pageRootScope);
+  const userPlanFeatures = useStore($userPlanFeatures);
   const errors = validateValues(
     pages,
     pageId,
     values,
     values.isHomePage,
-    variableValues
+    variableValues,
+    userPlanFeatures
   );
   const foldersPath =
     pages === undefined ? "" : getPagePath(values.parentFolderId, pages);

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -45,7 +45,7 @@ export const $activeSidebarPanel = atom<TabName>("none");
 export const $userPlanFeatures = atom<UserPlanFeatures>({
   allowShareAdminLinks: false,
   allowResourceVariables: false,
-  allowDynamicPath: false,
+  allowCmsFeatures: false,
   maxDomainsAllowedPerUser: 5,
   hasSubscription: false,
   hasProPlan: false,

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -45,6 +45,7 @@ export const $activeSidebarPanel = atom<TabName>("none");
 export const $userPlanFeatures = atom<UserPlanFeatures>({
   allowShareAdminLinks: false,
   allowResourceVariables: false,
+  allowDynamicPath: false,
   maxDomainsAllowedPerUser: 5,
   hasSubscription: false,
   hasProPlan: false,

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -44,8 +44,7 @@ export const $activeSidebarPanel = atom<TabName>("none");
 // keep in sync with user-plan-features.server
 export const $userPlanFeatures = atom<UserPlanFeatures>({
   allowShareAdminLinks: false,
-  allowResourceVariables: false,
-  allowCmsFeatures: false,
+  allowDynamicData: false,
   maxDomainsAllowedPerUser: 5,
   hasSubscription: false,
   hasProPlan: false,

--- a/apps/builder/app/dashboard/dashboard.stories.tsx
+++ b/apps/builder/app/dashboard/dashboard.stories.tsx
@@ -31,6 +31,7 @@ const userPlanFeatures: UserPlanFeatures = {
   hasSubscription: false,
   allowShareAdminLinks: false,
   allowResourceVariables: false,
+  allowDynamicPath: false,
   maxDomainsAllowedPerUser: 5,
 };
 

--- a/apps/builder/app/dashboard/dashboard.stories.tsx
+++ b/apps/builder/app/dashboard/dashboard.stories.tsx
@@ -30,8 +30,7 @@ const userPlanFeatures: UserPlanFeatures = {
   hasProPlan: false,
   hasSubscription: false,
   allowShareAdminLinks: false,
-  allowResourceVariables: false,
-  allowCmsFeatures: false,
+  allowDynamicData: false,
   maxDomainsAllowedPerUser: 5,
 };
 

--- a/apps/builder/app/dashboard/dashboard.stories.tsx
+++ b/apps/builder/app/dashboard/dashboard.stories.tsx
@@ -31,7 +31,7 @@ const userPlanFeatures: UserPlanFeatures = {
   hasSubscription: false,
   allowShareAdminLinks: false,
   allowResourceVariables: false,
-  allowDynamicPath: false,
+  allowCmsFeatures: false,
   maxDomainsAllowedPerUser: 5,
 };
 

--- a/apps/builder/app/shared/db/user-plan-features.server.ts
+++ b/apps/builder/app/shared/db/user-plan-features.server.ts
@@ -62,8 +62,7 @@ export const getUserPlanFeatures = async (
 
     return {
       allowShareAdminLinks: true,
-      allowResourceVariables: true,
-      allowCmsFeatures: true,
+      allowDynamicData: true,
       maxDomainsAllowedPerUser: Number.MAX_SAFE_INTEGER,
       hasSubscription,
       hasProPlan: true,
@@ -73,8 +72,7 @@ export const getUserPlanFeatures = async (
 
   return {
     allowShareAdminLinks: false,
-    allowResourceVariables: false,
-    allowCmsFeatures: false,
+    allowDynamicData: false,
     maxDomainsAllowedPerUser: 5,
     hasSubscription: false,
     hasProPlan: false,

--- a/apps/builder/app/shared/db/user-plan-features.server.ts
+++ b/apps/builder/app/shared/db/user-plan-features.server.ts
@@ -63,6 +63,7 @@ export const getUserPlanFeatures = async (
     return {
       allowShareAdminLinks: true,
       allowResourceVariables: true,
+      allowDynamicPath: true,
       maxDomainsAllowedPerUser: Number.MAX_SAFE_INTEGER,
       hasSubscription,
       hasProPlan: true,
@@ -73,6 +74,7 @@ export const getUserPlanFeatures = async (
   return {
     allowShareAdminLinks: false,
     allowResourceVariables: false,
+    allowDynamicPath: false,
     maxDomainsAllowedPerUser: 5,
     hasSubscription: false,
     hasProPlan: false,

--- a/apps/builder/app/shared/db/user-plan-features.server.ts
+++ b/apps/builder/app/shared/db/user-plan-features.server.ts
@@ -63,7 +63,7 @@ export const getUserPlanFeatures = async (
     return {
       allowShareAdminLinks: true,
       allowResourceVariables: true,
-      allowDynamicPath: true,
+      allowCmsFeatures: true,
       maxDomainsAllowedPerUser: Number.MAX_SAFE_INTEGER,
       hasSubscription,
       hasProPlan: true,
@@ -74,7 +74,7 @@ export const getUserPlanFeatures = async (
   return {
     allowShareAdminLinks: false,
     allowResourceVariables: false,
-    allowDynamicPath: false,
+    allowCmsFeatures: false,
     maxDomainsAllowedPerUser: 5,
     hasSubscription: false,
     hasProPlan: false,

--- a/packages/trpc-interface/src/context/context.server.ts
+++ b/packages/trpc-interface/src/context/context.server.ts
@@ -53,7 +53,7 @@ type DeploymentContext = {
 type UserPlanFeatures = {
   allowShareAdminLinks: boolean;
   allowResourceVariables: boolean;
-  allowDynamicPath: boolean;
+  allowCmsFeatures: boolean;
   maxDomainsAllowedPerUser: number;
   hasSubscription: boolean;
 } & (

--- a/packages/trpc-interface/src/context/context.server.ts
+++ b/packages/trpc-interface/src/context/context.server.ts
@@ -53,6 +53,7 @@ type DeploymentContext = {
 type UserPlanFeatures = {
   allowShareAdminLinks: boolean;
   allowResourceVariables: boolean;
+  allowDynamicPath: boolean;
   maxDomainsAllowedPerUser: number;
   hasSubscription: boolean;
 } & (

--- a/packages/trpc-interface/src/context/context.server.ts
+++ b/packages/trpc-interface/src/context/context.server.ts
@@ -52,8 +52,7 @@ type DeploymentContext = {
 
 type UserPlanFeatures = {
   allowShareAdminLinks: boolean;
-  allowResourceVariables: boolean;
-  allowCmsFeatures: boolean;
+  allowDynamicData: boolean;
   maxDomainsAllowedPerUser: number;
   hasSubscription: boolean;
 } & (


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Added additional validation for hobby users to forbid dynamic path parameters and disable copy address button.


<img width="453" alt="Screenshot 2024-02-14 at 16 00 31" src="https://github.com/webstudio-is/webstudio/assets/5635476/a58aecf5-2b06-4f3d-9e8d-06eb2fe3bf5f">
<img width="737" alt="Screenshot 2024-02-14 at 15 53 52" src="https://github.com/webstudio-is/webstudio/assets/5635476/e3e9b5cf-a571-4897-b415-1240d97e71cc">

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
