### PR TITLE
refactor: rename page.pathVariableId to pathParamsDataSourceId

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -1174,10 +1174,13 @@ const updatePage = (
           // create "Path Params" variable when pattern is specified in path
           const paramNames = parsePathnamePattern(page.path);
 
-          if (paramNames.length > 0 && page.pathVariableId === undefined) {
-            page.pathVariableId = nanoid();
-            dataSources.set(page.pathVariableId, {
-              id: page.pathVariableId,
+          if (
+            paramNames.length > 0 &&
+            page.pathParamsDataSourceId === undefined
+          ) {
+            page.pathParamsDataSourceId = nanoid();
+            dataSources.set(page.pathParamsDataSourceId, {
+              id: page.pathParamsDataSourceId,
               // scope new variable to page root
               scopeInstanceId: page.rootInstanceId,
               type: "parameter",
@@ -1231,7 +1234,7 @@ export const PageSettings = ({
       .filter(Boolean)
       .join("/")
       .replace(/\/+/g, "/"),
-    dataSourceId: page?.pathVariableId,
+    dataSourceId: page?.pathParamsDataSourceId,
   });
 
   const debouncedFn = useEffectEvent(() => {

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
@@ -673,7 +673,7 @@ describe("duplicate page", () => {
         title: `"My Title"`,
         meta: {},
         rootInstanceId: "body",
-        pathVariableId: "pathParamsId",
+        pathParamsDataSourceId: "pathParamsId",
       },
       pages: [],
       folders: [],
@@ -688,7 +688,7 @@ describe("duplicate page", () => {
       title: `"My Title"`,
       meta: {},
       rootInstanceId: expect.not.stringMatching("body"),
-      pathVariableId: newDataSource.id,
+      pathParamsDataSourceId: newDataSource.id,
     });
   });
 });

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
@@ -385,10 +385,10 @@ export const duplicatePage = (pageId: Page["id"]) => {
       availableDataSources: new Set(),
     });
     const newRootInstanceId = newInstanceIds.get(page.rootInstanceId);
-    const newPathVariableId =
-      page.pathVariableId === undefined
+    const newPathParamsDataSourceId =
+      page.pathParamsDataSourceId === undefined
         ? undefined
-        : newDataSourceIds.get(page.pathVariableId);
+        : newDataSourceIds.get(page.pathParamsDataSourceId);
     if (newRootInstanceId === undefined) {
       return;
     }
@@ -396,7 +396,7 @@ export const duplicatePage = (pageId: Page["id"]) => {
       ...page,
       id: newPageId,
       rootInstanceId: newRootInstanceId,
-      pathVariableId: newPathVariableId,
+      pathParamsDataSourceId: newPathParamsDataSourceId,
       name: newName,
       path: deduplicatePath(pages, page.path),
       title: replaceDataSources(page.title, newDataSourceIds),

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -516,11 +516,12 @@ export const prebuild = async (options: {
     });
     // generate new Page Params variable if does not exist
     // to allow always passing it from route template
-    const pathVariableId = pageData.page.pathVariableId ?? "pathVariableId";
-    if (pageData.page.pathVariableId === undefined) {
-      dataSources.set(pathVariableId, {
-        id: pathVariableId,
-        name: "Page Params",
+    const pathParamsDataSourceId =
+      pageData.page.pathParamsDataSourceId ?? "pathParamsDataSourceId";
+    if (pageData.page.pathParamsDataSourceId === undefined) {
+      dataSources.set(pathParamsDataSourceId, {
+        id: pathParamsDataSourceId,
+        name: "Path Params",
         type: "parameter",
       });
     }
@@ -534,7 +535,7 @@ export const prebuild = async (options: {
           instanceId: "",
           name: "params",
           type: "parameter",
-          value: pathVariableId,
+          value: pathParamsDataSourceId,
         },
       ],
       instances,

--- a/packages/react-sdk/src/page-meta-generator.test.ts
+++ b/packages/react-sdk/src/page-meta-generator.test.ts
@@ -244,7 +244,7 @@ test("generate page meta factory with path params", () => {
         rootInstanceId: "",
         title: `$ws$dataSource$pathParamsId.slug`,
         meta: {},
-        pathVariableId: "pathParamsId",
+        pathParamsDataSourceId: "pathParamsId",
       },
       dataSources: toMap([
         {
@@ -336,7 +336,7 @@ test("generate page meta factory without unused variables", () => {
         name: "",
         path: "",
         rootInstanceId: "",
-        pathVariableId: "unusedPathParamsId",
+        pathParamsDataSourceId: "unusedPathParamsId",
         title: `$ws$dataSource$usedVariableId`,
         meta: {},
       },

--- a/packages/react-sdk/src/page-meta-generator.ts
+++ b/packages/react-sdk/src/page-meta-generator.ts
@@ -104,7 +104,7 @@ export const generatePageMeta = ({
       continue;
     }
     if (dataSource.type === "parameter") {
-      if (dataSource.id === page.pathVariableId) {
+      if (dataSource.id === page.pathParamsDataSourceId) {
         const valueName = localScope.getName(dataSource.id, dataSource.name);
         generated += `  let ${valueName} = params\n`;
       }

--- a/packages/react-sdk/src/resources-generator.test.ts
+++ b/packages/react-sdk/src/resources-generator.test.ts
@@ -67,7 +67,7 @@ test("generate variable and use in resources loader", () => {
       scope: createScope(),
       page: {
         rootInstanceId: "body",
-        pathVariableId: "variableParamsId",
+        pathParamsDataSourceId: "variableParamsId",
       } as Page,
       dataSources: toMap([
         {
@@ -135,7 +135,7 @@ test("generate page params variable and use in resources loader", () => {
       scope: createScope(),
       page: {
         rootInstanceId: "body",
-        pathVariableId: "variableParamsId",
+        pathParamsDataSourceId: "variableParamsId",
       } as Page,
       dataSources: toMap([
         {

--- a/packages/react-sdk/src/resources-generator.ts
+++ b/packages/react-sdk/src/resources-generator.ts
@@ -26,7 +26,7 @@ export const generateResourcesLoader = ({
 
     if (dataSource.type === "parameter") {
       // support only page path params parameter
-      if (dataSource.id !== page.pathVariableId) {
+      if (dataSource.id !== page.pathParamsDataSourceId) {
         continue;
       }
       const name = scope.getName(dataSource.id, dataSource.name);

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -58,7 +58,7 @@ const commonPageFields = {
       .optional(),
   }),
   rootInstanceId: z.string(),
-  pathVariableId: z.optional(z.string()),
+  pathParamsDataSourceId: z.optional(z.string()),
 } as const;
 
 export const HomePagePath = z


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Small renaming for clarity

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
