### PR TITLE
fix: Fix truncation of a long page name in the top bar button

### DIFF
--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -6,6 +6,7 @@ import {
   Toolbar,
   ToolbarToggleGroup,
   ToolbarButton,
+  Text,
 } from "@webstudio-is/design-system";
 import type { Project } from "@webstudio-is/project";
 import { $selectedPage } from "~/shared/nano-states";
@@ -41,7 +42,7 @@ const PagesButton = () => {
       }}
       tabIndex={0}
     >
-      {page.name}
+      <Text truncate>{page.name}</Text>
     </ToolbarButton>
   );
 };


### PR DESCRIPTION
## Description

With the introduction of a button in the top bar we  forgot to truncate when page name is too long

## Steps for reproduction

1. create a page with a very long name
2. see it's name being truncated in the top bar

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
