### PR TITLE
experimental: add pro banner to page settings

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -315,10 +315,10 @@ const PathField = ({
               content={
                 <>
                   <Text>
-                    Path is a subset of the URL that looks like this: "/blog".
-                    To make the path dynamic and use it with CMS, you can use
-                    parameters and other features. CMS features are part of the
-                    Pro plan.
+                    Path is a subset of the URL that looks like this:
+                    &quot;/blog&quot;. To make the path dynamic and use it with
+                    CMS, you can use parameters and other features. CMS features
+                    are part of the Pro plan.
                   </Text>
                   <Link
                     className={buttonStyle({ color: "gradient" })}

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -315,7 +315,10 @@ const PathField = ({
               content={
                 <>
                   <Text>
-                    The path can include dynamic parameters like :name in Pro.
+                    Path is a subset of the URL that looks like this: "/blog".
+                    To make the path dynamic and use it with CMS, you can use
+                    parameters and other features. CMS features are part of the
+                    Pro plan.
                   </Text>
                   <Link
                     className={buttonStyle({ color: "gradient" })}

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -38,6 +38,8 @@ import {
   Flex,
   Select,
   Link,
+  buttonStyle,
+  PanelBanner,
 } from "@webstudio-is/design-system";
 import {
   ChevronDoubleLeftIcon,
@@ -45,6 +47,7 @@ import {
   TrashIcon,
   HomeIcon,
   HelpIcon,
+  UploadIcon,
 } from "@webstudio-is/icons";
 import { useIds } from "~/shared/form-utils";
 import { Header, HeaderSuffixSpacer } from "../../header";
@@ -243,7 +246,7 @@ const validateValues = (
       pathParamNames.length > 0
     ) {
       errors.path = errors.path ?? [];
-      errors.path.push("Dynamic path is supported only for paid users");
+      errors.path.push("Dynamic path is supported only in Pro");
     }
   }
   return errors;
@@ -306,7 +309,34 @@ const PathField = ({
             </Tooltip>
           </Flex>
         ) : (
-          "Path"
+          <Flex align="center" gap={1}>
+            Path
+            <Tooltip
+              content={
+                <>
+                  <Text>
+                    The path can include dynamic parameters like :name in Pro.
+                  </Text>
+                  <Link
+                    className={buttonStyle({ color: "gradient" })}
+                    css={{ marginTop: theme.spacing[5], width: "100%" }}
+                    color="contrast"
+                    underline="none"
+                    target="_blank"
+                    href="https://webstudio.is/pricing"
+                  >
+                    Upgrade
+                  </Link>
+                </>
+              }
+              variant="wrapped"
+            >
+              <HelpIcon
+                color={rawTheme.colors.foregroundSubtle}
+                tabIndex={-1}
+              />
+            </Tooltip>
+          </Flex>
         )}
       </Label>
       <InputErrorsTooltip errors={errors}>
@@ -342,16 +372,16 @@ const StatusField = ({
           <Tooltip
             content={
               <Text>
-                {"Status code value can be a "}
+                Status code value can be a{" "}
                 <Link
                   color="inherit"
+                  target="_blank"
                   href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status"
                 >
                   HTTP Status
-                </Link>
-                {
-                  " number or an expression that returns the status code dynamic response handling."
-                }
+                </Link>{" "}
+                number or an expression that returns the status code dynamic
+                response handling.
               </Text>
             }
             variant="wrapped"
@@ -597,6 +627,23 @@ const FormFields = ({
               onChange={(value) => onChange({ field: "redirect", value })}
             />
           )}
+
+          <PanelBanner>
+            <Text>
+              Dynamic routing, redirect and status code are a part of the CMS
+              functionality.
+            </Text>
+            <Flex align="center" gap={1}>
+              <UploadIcon />
+              <Link
+                color="inherit"
+                target="_blank"
+                href="https://webstudio.is/pricing"
+              >
+                Upgrade to Pro
+              </Link>
+            </Flex>
+          </PanelBanner>
         </Grid>
 
         <Separator />


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

<img width="575" alt="Screenshot 2024-02-15 at 17 52 00" src="https://github.com/webstudio-is/webstudio/assets/5635476/54124996-e857-45bf-adfa-ec14b5a4aadd">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
