### PR TITLE
fix: Fix unnecessary separator

### DIFF
--- a/apps/builder/app/builder/features/project-settings/project-settings.tsx
+++ b/apps/builder/app/builder/features/project-settings/project-settings.tsx
@@ -37,8 +37,12 @@ const ProjectSettingsView = ({
             <MetaSection />
             <Separator />
             <CompilerSection />
-            <Separator />
-            {isFeatureEnabled("redirects") && <RedirectSection />}
+            {isFeatureEnabled("redirects") && (
+              <>
+                <Separator />
+                <RedirectSection />
+              </>
+            )}
             <div />
           </Grid>
         </ScrollArea>

--- a/apps/builder/app/builder/features/project-settings/redirect-section.tsx
+++ b/apps/builder/app/builder/features/project-settings/redirect-section.tsx
@@ -1,6 +1,5 @@
 import {
   Grid,
-  Separator,
   Flex,
   InputField,
   Button,

--- a/apps/builder/app/builder/features/project-settings/redirect-section.tsx
+++ b/apps/builder/app/builder/features/project-settings/redirect-section.tsx
@@ -129,7 +129,6 @@ export const RedirectSection = () => {
 
   return (
     <>
-      <Separator />
       <Grid gap={2} css={{ mx: theme.spacing[5], px: theme.spacing[5] }}>
         <Text variant="titles">301 Redirects</Text>
         <Text color="subtle">


### PR DESCRIPTION
## Description

We have 2 separators between redirects section in project settings, when Redirects are enabled


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
