### PR TITLE
fix: use editing page scope instead of selected page

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useStore } from "@nanostores/react";
 import {
   DeprecatedIconButton,
@@ -30,6 +30,7 @@ import { NewPageSettings, PageSettings } from "./page-settings";
 import { $pages, $selectedPageId } from "~/shared/nano-states";
 import { switchPage } from "~/shared/pages";
 import {
+  $editingPagesItemId,
   getAllChildrenAndSelf,
   reparentOrphansMutable,
   toTreeData,
@@ -385,7 +386,7 @@ const FolderEditor = ({
 
 export const TabContent = ({ onSetActiveTab }: TabContentProps) => {
   const currentPageId = useStore($selectedPageId);
-  const [editingItemId, setEditingItemId] = useState<string>();
+  const editingItemId = useStore($editingPagesItemId);
   const pages = useStore($pages);
 
   if (currentPageId === undefined || pages === undefined) {
@@ -397,12 +398,14 @@ export const TabContent = ({ onSetActiveTab }: TabContentProps) => {
       <PagesPanel
         onClose={() => onSetActiveTab("none")}
         onCreateNewFolder={() => {
-          setEditingItemId(
+          $editingPagesItemId.set(
             editingItemId === newFolderId ? undefined : newFolderId
           );
         }}
         onCreateNewPage={() =>
-          setEditingItemId(editingItemId === newPageId ? undefined : newPageId)
+          $editingPagesItemId.set(
+            editingItemId === newPageId ? undefined : newPageId
+          )
         }
         onSelect={(itemId) => {
           if (isFolder(itemId, pages.folders)) {
@@ -412,7 +415,7 @@ export const TabContent = ({ onSetActiveTab }: TabContentProps) => {
           onSetActiveTab("none");
         }}
         selectedPageId={currentPageId}
-        onEdit={setEditingItemId}
+        onEdit={$editingPagesItemId.set}
         editingItemId={editingItemId}
       />
 
@@ -421,12 +424,12 @@ export const TabContent = ({ onSetActiveTab }: TabContentProps) => {
           {isFolder(editingItemId, pages.folders) ? (
             <FolderEditor
               editingFolderId={editingItemId}
-              setEditingFolderId={setEditingItemId}
+              setEditingFolderId={$editingPagesItemId.set}
             />
           ) : (
             <PageEditor
               editingPageId={editingItemId}
-              setEditingPageId={setEditingItemId}
+              setEditingPageId={$editingPagesItemId.set}
             />
           )}
         </SettingsPanel>


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Here fixing an issue with showing scope of selected page instead of currently opened in editor.

## Steps for reproduction

- select page
- add variable to body
- start editing another page settings without selecting
- make sure that variable is not visible on editing page

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
