### PR TITLE
experimental: use dynamic page icon in pages navigator

### DIFF
--- a/apps/builder/app/builder/features/address-bar.tsx
+++ b/apps/builder/app/builder/features/address-bar.tsx
@@ -31,6 +31,7 @@ import {
 import env from "~/shared/env";
 import {
   compilePathnamePattern,
+  isPathnamePattern,
   tokenizePathnamePattern,
 } from "~/builder/shared/url-pattern";
 
@@ -195,10 +196,11 @@ const AddressBar = () => {
 export const AddressBarPopover = () => {
   const [isOpen, setIsOpen] = useState(false);
   const path = useStore($selectedPagePath);
-  const tokens = tokenizePathnamePattern(path);
   const publishedOrigin = useStore($publishedOrigin);
   const { tooltipProps, buttonProps } = useCopyUrl(`${publishedOrigin}${path}`);
-  if (tokens.length === 1) {
+
+  // show only copy button when path is static
+  if (isPathnamePattern(path) === false) {
     return (
       <Tooltip {...tooltipProps}>
         <ToolbarButton
@@ -209,6 +211,7 @@ export const AddressBarPopover = () => {
       </Tooltip>
     );
   }
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -78,7 +78,7 @@ import { useEffectEvent } from "~/builder/features/ai/hooks/effect-event";
 import { CustomMetadata } from "./custom-metadata";
 import {
   compilePathnamePattern,
-  parsePathnamePattern,
+  isPathnamePattern,
   tokenizePathnamePattern,
   validatePathnamePattern,
 } from "~/builder/shared/url-pattern";
@@ -247,10 +247,10 @@ const validateValues = (
       errors.path = errors.path ?? [];
       errors.path.push(...messages);
     }
-    const pathParamNames = parsePathnamePattern(values.path);
+
     if (
       userPlanFeatures.allowDynamicData === false &&
-      pathParamNames.length > 0
+      isPathnamePattern(values.path)
     ) {
       errors.path = errors.path ?? [];
       errors.path.push("Dynamic path is supported only in Pro");
@@ -1245,10 +1245,9 @@ const updatePage = (pageId: Page["id"], values: Partial<Values>) => {
           // mutate page before working with path params
           updatePageMutable(page, values, pages.folders);
           // create "Path Params" variable when pattern is specified in path
-          const paramNames = parsePathnamePattern(page.path);
 
           if (
-            paramNames.length > 0 &&
+            isPathnamePattern(page.path) &&
             page.pathParamsDataSourceId === undefined
           ) {
             page.pathParamsDataSourceId = nanoid();

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -22,6 +22,7 @@ import {
   NewFolderIcon,
   NewPageIcon,
   PageIcon,
+  DynamicPageIcon,
 } from "@webstudio-is/icons";
 import type { TabContentProps } from "../../types";
 import { CloseButton, Header } from "../../header";
@@ -46,6 +47,7 @@ import { serverSyncStore } from "~/shared/sync";
 import { useMount } from "~/shared/hook-utils/use-mount";
 import { ROOT_FOLDER_ID, type Folder } from "@webstudio-is/sdk";
 import { atom } from "nanostores";
+import { isPathnamePattern } from "~/builder/shared/url-pattern";
 
 const MenuButton = styled(DeprecatedIconButton, {
   color: theme.colors.hint,
@@ -190,6 +192,8 @@ const PagesPanel = ({
               prefix={
                 props.itemData.id === pages?.homePage.id ? (
                   <HomeIcon />
+                ) : isPathnamePattern(props.itemData.data.path) ? (
+                  <DynamicPageIcon />
                 ) : (
                   <PageIcon />
                 )

--- a/apps/builder/app/builder/shared/url-pattern.test.ts
+++ b/apps/builder/app/builder/shared/url-pattern.test.ts
@@ -1,17 +1,21 @@
 import { expect, test } from "@jest/globals";
 import {
   compilePathnamePattern,
-  parsePathnamePattern,
+  isPathnamePattern,
   tokenizePathnamePattern,
   validatePathnamePattern,
 } from "./url-pattern";
 
-test("parse keys from pathname pattern", () => {
-  expect(parsePathnamePattern("/blog/:id/:date")).toEqual(["id", "date"]);
-});
+test("check pathname is pattern", () => {
+  expect(isPathnamePattern("/:name")).toEqual(true);
+  expect(isPathnamePattern("/:slug*")).toEqual(true);
+  expect(isPathnamePattern("/:id?")).toEqual(true);
+  expect(isPathnamePattern("/*")).toEqual(true);
 
-test("parse wildcard and named wildcard from pathname pattern", () => {
-  expect(parsePathnamePattern("/blog/*/:slug*/*")).toEqual(["0", "1", "slug"]);
+  expect(isPathnamePattern("")).toEqual(false);
+  expect(isPathnamePattern("/")).toEqual(false);
+  expect(isPathnamePattern("/blog")).toEqual(false);
+  expect(isPathnamePattern("/blog/post-name")).toEqual(false);
 });
 
 test("tokenize named params in pathname pattern", () => {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Here added new isPathnamePattern utility to check the path is dynamic. We can use to change the icon in pages list.

<img width="435" alt="Screenshot 2024-02-18 at 21 01 02" src="https://github.com/webstudio-is/webstudio/assets/5635476/cca0fdeb-5576-4c7d-a905-92e9061d9add">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
