### PR TITLE
feat: allow users to set custom redirect status code

### DIFF
--- a/apps/builder/app/builder/features/project-settings/redirect-section.tsx
+++ b/apps/builder/app/builder/features/project-settings/redirect-section.tsx
@@ -167,13 +167,13 @@ export const RedirectSection = () => {
             placeholder="301"
             options={["301", "302"]}
             value={httpStatus ?? "301"}
-            css={{ zIndex: theme.zIndices["2"], width: theme.spacing[19] }}
+            css={{ zIndex: theme.zIndices["1"], width: theme.spacing[18] }}
             onChange={(value) => {
               setHttpStatus(value as PageRedirect["status"]);
             }}
           />
 
-          <ArrowRightIcon />
+          <ArrowRightIcon size={16} style={{ flexShrink: 0 }} />
 
           <InputErrorsTooltip
             errors={newPathErrors.length > 0 ? newPathErrors : undefined}
@@ -225,7 +225,7 @@ export const RedirectSection = () => {
                         <Text>
                           {redirect.old}, {redirect.status ?? "301"}
                         </Text>
-                        <ArrowRightIcon />
+                        <ArrowRightIcon size={16} />
                         <Text truncate>{redirect.new}</Text>
                       </Flex>
                       <SmallIconButton

--- a/apps/builder/app/builder/features/project-settings/redirect-section.tsx
+++ b/apps/builder/app/builder/features/project-settings/redirect-section.tsx
@@ -122,7 +122,7 @@ export const RedirectSection = () => {
       {
         old: oldPath,
         new: newPath,
-        status: httpStatus === undefined ? "301" : httpStatus,
+        status: httpStatus ?? "301",
       },
       ...redirects,
     ]);
@@ -139,7 +139,7 @@ export const RedirectSection = () => {
   return (
     <>
       <Grid gap={2} css={{ mx: theme.spacing[5], px: theme.spacing[5] }}>
-        <Text variant="titles">301 Redirects</Text>
+        <Text variant="titles">Redirects</Text>
         <Text color="subtle">
           Redirects old URLs to new ones so that you don’t lose any traffic or
           search engine rankings.
@@ -182,7 +182,7 @@ export const RedirectSection = () => {
             id="redirect-type"
             placeholder="301"
             options={["301", "302"]}
-            value={httpStatus === undefined ? "301" : httpStatus}
+            value={httpStatus ?? "301"}
             css={{ zIndex: theme.zIndices["2"], width: theme.spacing[19] }}
             onChange={(value) => {
               setHttpStatus(value as PageRedirect["status"]);
@@ -221,12 +221,8 @@ export const RedirectSection = () => {
                       }}
                     >
                       <Flex gap="2">
-                        <Text>{redirect.old}</Text>
-                        <ArrowRightIcon />
                         <Text>
-                          {redirect.status === undefined
-                            ? "301"
-                            : redirect.status}
+                          {redirect.old}, {redirect.status ?? "301"}
                         </Text>
                         <ArrowRightIcon />
                         <Text truncate>{redirect.new}</Text>

--- a/apps/builder/app/builder/features/project-settings/redirect-section.tsx
+++ b/apps/builder/app/builder/features/project-settings/redirect-section.tsx
@@ -161,6 +161,18 @@ export const RedirectSection = () => {
               color={oldPathErrors.length === 0 ? undefined : "error"}
             />
           </InputErrorsTooltip>
+
+          <Select
+            id="redirect-type"
+            placeholder="301"
+            options={["301", "302"]}
+            value={httpStatus ?? "301"}
+            css={{ zIndex: theme.zIndices["2"], width: theme.spacing[19] }}
+            onChange={(value) => {
+              setHttpStatus(value as PageRedirect["status"]);
+            }}
+          />
+
           <ArrowRightIcon />
 
           <InputErrorsTooltip
@@ -177,17 +189,6 @@ export const RedirectSection = () => {
               color={newPathErrors.length === 0 ? undefined : "error"}
             />
           </InputErrorsTooltip>
-
-          <Select
-            id="redirect-type"
-            placeholder="301"
-            options={["301", "302"]}
-            value={httpStatus ?? "301"}
-            css={{ zIndex: theme.zIndices["2"], width: theme.spacing[19] }}
-            onChange={(value) => {
-              setHttpStatus(value as PageRedirect["status"]);
-            }}
-          />
 
           <Button
             disabled={isValidRedirects === false || oldPath === newPath}

--- a/apps/builder/app/builder/features/project-settings/redirect-section.tsx
+++ b/apps/builder/app/builder/features/project-settings/redirect-section.tsx
@@ -9,6 +9,7 @@ import {
   ListItem,
   SmallIconButton,
   InputErrorsTooltip,
+  Select,
 } from "@webstudio-is/design-system";
 import { ArrowRightIcon, TrashIcon } from "@webstudio-is/icons";
 import { useState, type ChangeEvent } from "react";
@@ -28,6 +29,8 @@ export const RedirectSection = () => {
   );
   const [oldPath, setOldPath] = useState<string>("");
   const [newPath, setNewPath] = useState<string>("");
+  const [httpStatus, setHttpStatus] =
+    useState<PageRedirect["status"]>(undefined);
   const [oldPathErrors, setOldPathErrors] = useState<string[]>([]);
   const [newPathErrors, setNewPathErrors] = useState<string[]>([]);
   const pages = useStore($pages);
@@ -115,7 +118,14 @@ export const RedirectSection = () => {
       return;
     }
 
-    handleSave([{ old: oldPath, new: newPath }, ...redirects]);
+    handleSave([
+      {
+        old: oldPath,
+        new: newPath,
+        status: httpStatus === undefined ? "301" : httpStatus,
+      },
+      ...redirects,
+    ]);
     setOldPath("");
     setNewPath("");
   };
@@ -168,6 +178,17 @@ export const RedirectSection = () => {
             />
           </InputErrorsTooltip>
 
+          <Select
+            id="redirect-type"
+            placeholder="301"
+            options={["301", "302"]}
+            value={httpStatus === undefined ? "301" : httpStatus}
+            css={{ zIndex: theme.zIndices["2"], width: theme.spacing[19] }}
+            onChange={(value) => {
+              setHttpStatus(value as PageRedirect["status"]);
+            }}
+          />
+
           <Button
             disabled={isValidRedirects === false || oldPath === newPath}
             onClick={handleAddRedirect}
@@ -201,6 +222,12 @@ export const RedirectSection = () => {
                     >
                       <Flex gap="2">
                         <Text>{redirect.old}</Text>
+                        <ArrowRightIcon />
+                        <Text>
+                          {redirect.status === undefined
+                            ? "301"
+                            : redirect.status}
+                        </Text>
                         <ArrowRightIcon />
                         <Text truncate>{redirect.new}</Text>
                       </Flex>

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -650,7 +650,9 @@ ${utilsExport}
       const content = `import { type LoaderArgs, redirect } from "@remix-run/server-runtime";
 
 export const loader = (arg: LoaderArgs) => {
-  return redirect("${redirect.new}", 301);
+  return redirect("${redirect.new}", ${
+    redirect.status === undefined ? 301 : redirect.status
+  });
 };
 `;
 

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -650,9 +650,7 @@ ${utilsExport}
       const content = `import { type LoaderArgs, redirect } from "@remix-run/server-runtime";
 
 export const loader = (arg: LoaderArgs) => {
-  return redirect("${redirect.new}", ${
-    redirect.status === undefined ? 301 : redirect.status
-  });
+  return redirect("${redirect.new}", ${redirect.status ?? 301});
 };
 `;
 

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -120,6 +120,7 @@ export const ProjectNewRedirectPath = PagePath.or(
 export const PageRedirect = z.object({
   old: PagePath,
   new: ProjectNewRedirectPath,
+  status: z.enum(["301", "302"]).optional(),
 });
 export type PageRedirect = z.infer<typeof PageRedirect>;
 


### PR DESCRIPTION
## Description

Allow users to configure `301` or `302` status code for redirects.

## Steps for reproduction

- Go to project settings
- Add a redirect
- Select a status code from the dropdown at the time of adding a redirect.
- When the project is deployed, and redirects should reflect the status code that is added in project settings.

![Screenshot 2024-02-21 at 13 48 18](https://github.com/webstudio-is/webstudio/assets/11075561/69999f06-8140-4b98-b095-eda32530047b)


## Code Review

- [ ] hi @kof   I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
