### PR TITLE
experimental: hide the CMS banner until released

### DIFF
--- a/apps/builder/app/builder/features/project-settings/project-settings.tsx
+++ b/apps/builder/app/builder/features/project-settings/project-settings.tsx
@@ -8,7 +8,6 @@ import {
   Separator,
   ScrollArea,
 } from "@webstudio-is/design-system";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { $isProjectSettingsOpen } from "~/shared/nano-states/seo";
 import { MetaSection } from "./meta-section";
 import { CompilerSection } from "./compiler-section";
@@ -37,12 +36,8 @@ const ProjectSettingsView = ({
             <MetaSection />
             <Separator />
             <CompilerSection />
-            {isFeatureEnabled("redirects") && (
-              <>
-                <Separator />
-                <RedirectSection />
-              </>
-            )}
+            <Separator />
+            <RedirectSection />
             <div />
           </Grid>
         </ScrollArea>

--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -2,7 +2,6 @@ import type { Instance } from "@webstudio-is/sdk";
 import { SettingsSection } from "./settings-section";
 import { PropsSectionContainer } from "./props-section/props-section";
 import { VariablesSection } from "./variables-section";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 export const SettingsPanelContainer = ({
   selectedInstance,
@@ -13,7 +12,7 @@ export const SettingsPanelContainer = ({
     <>
       <SettingsSection />
       <PropsSectionContainer selectedInstance={selectedInstance} />
-      {isFeatureEnabled("bindings") && <VariablesSection />}
+      <VariablesSection />
     </>
   );
 };

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -27,7 +27,6 @@ import { MetaIcon } from "~/builder/shared/meta-icon";
 import { $registeredComponentMetas } from "~/shared/nano-states";
 import { getMetaMaps } from "./get-meta-maps";
 import { getInstanceLabel } from "~/shared/instance-utils";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
   const metaByComponentName = useStore($registeredComponentMetas);
@@ -80,10 +79,7 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
                         if (component === undefined) {
                           return;
                         }
-                        if (
-                          component === collectionComponent &&
-                          isFeatureEnabled("bindings") === false
-                        ) {
+                        if (component === collectionComponent) {
                           return;
                         }
                         return (

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -622,7 +622,7 @@ const FormFields = ({
             </Grid>
           </Grid>
 
-          {isFeatureEnabled("folders") && values.isHomePage === false && (
+          {values.isHomePage === false && (
             <Grid gap={1}>
               <Label htmlFor={fieldIds.parentFolderId}>Parent Folder</Label>
               <Select
@@ -652,37 +652,35 @@ const FormFields = ({
           )}
 
           {isFeatureEnabled("cms") && (
-            <StatusField
-              errors={errors.status}
-              value={values.status}
-              onChange={(value) => onChange({ field: "status", value })}
-            />
+            <>
+              <StatusField
+                errors={errors.status}
+                value={values.status}
+                onChange={(value) => onChange({ field: "status", value })}
+              />
+              <RedirectField
+                errors={errors.redirect}
+                value={values.redirect}
+                onChange={(value) => onChange({ field: "redirect", value })}
+              />
+              <PanelBanner>
+                <Text>
+                  Dynamic routing, redirect and status code are a part of the
+                  CMS functionality.
+                </Text>
+                <Flex align="center" gap={1}>
+                  <UploadIcon />
+                  <Link
+                    color="inherit"
+                    target="_blank"
+                    href="https://webstudio.is/pricing"
+                  >
+                    Upgrade to Pro
+                  </Link>
+                </Flex>
+              </PanelBanner>
+            </>
           )}
-
-          {isFeatureEnabled("cms") && (
-            <RedirectField
-              errors={errors.redirect}
-              value={values.redirect}
-              onChange={(value) => onChange({ field: "redirect", value })}
-            />
-          )}
-
-          <PanelBanner>
-            <Text>
-              Dynamic routing, redirect and status code are a part of the CMS
-              functionality.
-            </Text>
-            <Flex align="center" gap={1}>
-              <UploadIcon />
-              <Link
-                color="inherit"
-                target="_blank"
-                href="https://webstudio.is/pricing"
-              >
-                Upgrade to Pro
-              </Link>
-            </Flex>
-          </PanelBanner>
         </Grid>
 
         <Separator />

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -42,7 +42,6 @@ import {
   NewFolderSettings,
   newFolderId,
 } from "./folder-settings";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { serverSyncStore } from "~/shared/sync";
 import { useMount } from "~/shared/hook-utils/use-mount";
 import { ROOT_FOLDER_ID, type Folder } from "@webstudio-is/sdk";
@@ -249,16 +248,14 @@ const PagesPanel = ({
         title="Pages"
         suffix={
           <>
-            {isFeatureEnabled("folders") && (
-              <Tooltip content="New folder" side="bottom">
-                <Button
-                  onClick={() => onCreateNewFolder()}
-                  aria-label="New folder"
-                  prefix={<NewFolderIcon />}
-                  color="ghost"
-                />
-              </Tooltip>
-            )}
+            <Tooltip content="New folder" side="bottom">
+              <Button
+                onClick={() => onCreateNewFolder()}
+                aria-label="New folder"
+                prefix={<NewFolderIcon />}
+                color="ghost"
+              />
+            </Tooltip>
             <Tooltip content="New page" side="bottom">
               <Button
                 onClick={() => onCreateNewPage()}

--- a/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
@@ -34,7 +34,6 @@ import {
   CssValueInput,
 } from "../../shared/css-value-input";
 import { theme } from "@webstudio-is/design-system";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { TooltipContent } from "../../../style-panel/shared/property-name";
 
 const GapLinked = ({
@@ -453,10 +452,8 @@ const orderedDisplayValues = [
   "inline-flex",
   "inline",
   "none",
+  "contents",
 ];
-if (isFeatureEnabled("displayContents")) {
-  orderedDisplayValues.push("contents");
-}
 
 const compareDisplayValues = (a: { name: string }, b: { name: string }) => {
   const aIndex = orderedDisplayValues.indexOf(a.name);

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -9,7 +9,6 @@ import {
   useContext,
   type ReactNode,
 } from "react";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import {
   DotIcon,
   InfoCircleIcon,
@@ -396,9 +395,6 @@ export const BindingPopover = ({
   const hasUnsavedChange = useRef<boolean>(false);
   const preventedClosing = useRef<boolean>(false);
 
-  if (isFeatureEnabled("bindings") === false) {
-    return;
-  }
   const valueError = validate?.(evaluateExpressionWithinScope(value, scope));
   return (
     <FloatingPanelPopover

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -1,9 +1,4 @@
 export const dark = false;
 export const unsupportedBrowsers = false;
-export const displayContents = false;
-export const ai = true;
 export const aiRadixComponents = false;
-export const bindings = false;
 export const cms = false;
-export const folders = false;
-export const redirects = false;


### PR DESCRIPTION
## Description

1. We accidentally released the CMS banner to everyone, which will be misleading
2. Removed old feature flags

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
