### PR TITLE
fix: hide cms banner before launch

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -544,6 +544,7 @@ const FormFields = ({
   const fieldIds = useIds(fieldNames);
   const assets = useStore($assets);
   const pages = useStore($pages);
+  const { allowDynamicData } = useStore($userPlanFeatures);
   const { variableValues, scope, aliases } = useStore($pageRootScope);
 
   const pageUrl = usePageUrl(values, pathParamsDataSourceId);
@@ -667,22 +668,24 @@ const FormFields = ({
             />
           )}
 
-          <PanelBanner>
-            <Text>
-              Dynamic routing, redirect and status code are a part of the CMS
-              functionality.
-            </Text>
-            <Flex align="center" gap={1}>
-              <UploadIcon />
-              <Link
-                color="inherit"
-                target="_blank"
-                href="https://webstudio.is/pricing"
-              >
-                Upgrade to Pro
-              </Link>
-            </Flex>
-          </PanelBanner>
+          {isFeatureEnabled("cms") && allowDynamicData === false && (
+            <PanelBanner>
+              <Text>
+                Dynamic routing, redirect and status code are a part of the CMS
+                functionality.
+              </Text>
+              <Flex align="center" gap={1}>
+                <UploadIcon />
+                <Link
+                  color="inherit"
+                  target="_blank"
+                  href="https://webstudio.is/pricing"
+                >
+                  Upgrade to Pro
+                </Link>
+              </Flex>
+            </PanelBanner>
+          )}
         </Grid>
 
         <Separator />


### PR DESCRIPTION
Here fixed showing cms banner in page settings before we actually launched cms support.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
