### PR TITLE
feat: Make fullscreen option available to all code editors

### DIFF
--- a/apps/builder/app/builder/shared/html-editor.tsx
+++ b/apps/builder/app/builder/shared/html-editor.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo, type ReactNode, useState } from "react";
+import { forwardRef, useMemo, type ReactNode } from "react";
 import {
   keymap,
   drawSelection,
@@ -21,22 +21,8 @@ import {
   completionKeymap,
 } from "@codemirror/autocomplete";
 import { html } from "@codemirror/lang-html";
-import {
-  theme,
-  textVariants,
-  css,
-  Dialog,
-  DialogContent,
-  SmallIconButton,
-  DialogTrigger,
-  DialogTitle,
-  Button,
-  DialogClose,
-  Grid,
-  rawTheme,
-} from "@webstudio-is/design-system";
+import { theme, textVariants, css } from "@webstudio-is/design-system";
 import { CodeEditor } from "./code-editor";
-import { CrossIcon, MaximizeIcon, MinimizeIcon } from "@webstudio-is/icons";
 
 const autocompletionStyle = css({
   "&.cm-tooltip.cm-tooltip-autocomplete": {
@@ -137,106 +123,19 @@ export const HtmlEditor = forwardRef<
       []
     );
 
-    const editor = (
-      <CodeEditor
-        extensions={extensions}
-        readOnly={readOnly}
-        invalid={invalid}
-        value={value}
-        onChange={onChange}
-        onBlur={onBlur}
-      />
-    );
-
     return (
-      <div className={wrapperStyle.toString()} ref={ref}>
-        {editor}
-        <CodeEditorDialog title={title} content={editor}>
-          <SmallIconButton
-            icon={<MaximizeIcon />}
-            css={{
-              position: "absolute",
-              top: 2,
-              right: 2,
-              display: `var(--ws-code-editor-dialog-maximize-icon-display, none)`,
-            }}
-          />
-        </CodeEditorDialog>
+      <div className={wrapperStyle()} ref={ref}>
+        <CodeEditor
+          extensions={extensions}
+          readOnly={readOnly}
+          invalid={invalid}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
       </div>
     );
   }
 );
 
 HtmlEditor.displayName = "HtmlEditor";
-
-const CodeEditorDialog = ({
-  title,
-  content,
-  children,
-}: {
-  title: ReactNode;
-  content: ReactNode;
-  children: ReactNode;
-}) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const width = isExpanded ? "80vw" : "640px";
-  const height = isExpanded ? "80vh" : "480px";
-  const padding = rawTheme.spacing[7];
-
-  return (
-    <Dialog>
-      <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent
-        // Left Aside panels (e.g., Pages, Components) use zIndex: theme.zIndices[1].
-        // For a dialog to appear above these panels, both overlay and content should also have zIndex: theme.zIndices[1].
-        css={{
-          maxWidth: "none",
-          maxHeight: "none",
-          zIndex: theme.zIndices[1],
-        }}
-        overlayCss={{ zIndex: theme.zIndices[1] }}
-      >
-        <Grid
-          css={{
-            padding,
-            width,
-            height,
-            overflow: "hidden",
-            boxSizing: "content-box",
-            "& .cm-content": {
-              maxHeight: `calc(${height} - ${padding})`,
-            },
-          }}
-        >
-          {content}
-        </Grid>
-        {/* Title is at the end intentionally,
-         * to make the close button last in the tab order
-         */}
-        <DialogTitle
-          suffix={
-            <>
-              <Button
-                color="ghost"
-                prefix={isExpanded ? <MinimizeIcon /> : <MaximizeIcon />}
-                aria-label="Expand"
-                onClick={() => {
-                  setIsExpanded(isExpanded ? false : true);
-                }}
-              />
-              <DialogClose asChild>
-                <Button
-                  color="ghost"
-                  prefix={<CrossIcon />}
-                  aria-label="Close"
-                />
-              </DialogClose>
-            </>
-          }
-        >
-          {title}
-        </DialogTitle>
-      </DialogContent>
-    </Dialog>
-  );
-};


### PR DESCRIPTION
## Description

When collection Data renders a large json, its hard to read or edit without a bigger editor. With this full-screen is available on all Code Editors

## Steps for reproduction

1. See expanding works in all properties
- Collection: Data
- HTML Embed: Code
- Edit variable type JSON

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
