### PR TITLE
refactor: use native Response.redirect method

### DIFF
--- a/fixtures/webstudio-custom-template/app/routes/[hello]._index.ts
+++ b/fixtures/webstudio-custom-template/app/routes/[hello]._index.ts
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 import { type LoaderArgs, redirect } from "@remix-run/server-runtime";
 
 export const loader = (arg: LoaderArgs) => {
   return redirect("/world", 301);
+=======
+export const loader = () => {
+  return Response.redirect("/world", 301);
+>>>>>>> 2d1936ae4 (Resync and rebuild)
 };

--- a/fixtures/webstudio-custom-template/app/routes/[hello]._index.ts
+++ b/fixtures/webstudio-custom-template/app/routes/[hello]._index.ts
@@ -1,10 +1,3 @@
-<<<<<<< HEAD
-import { type LoaderArgs, redirect } from "@remix-run/server-runtime";
-
-export const loader = (arg: LoaderArgs) => {
-  return redirect("/world", 301);
-=======
 export const loader = () => {
   return Response.redirect("/world", 301);
->>>>>>> 2d1936ae4 (Resync and rebuild)
 };

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -6,10 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-<<<<<<< HEAD
-  redirect,
-=======
->>>>>>> 2d1936ae4 (Resync and rebuild)
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -46,11 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-<<<<<<< HEAD
-    return redirect(pageMeta.redirect, status);
-=======
     return Response.redirect(pageMeta.redirect, status);
->>>>>>> 2d1936ae4 (Resync and rebuild)
   }
 
   const host =
@@ -221,28 +213,16 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-<<<<<<< HEAD
       href: `${assetBaseUrl}${asset.name}`,
       as: "font",
       crossOrigin: "anonymous",
-=======
-      href: assetBaseUrl + asset.name,
-      as: "font",
->>>>>>> 2d1936ae4 (Resync and rebuild)
     });
   }
 
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-<<<<<<< HEAD
       href: `${assetBaseUrl}${backgroundImageAsset.name}`,
-=======
-      href: imageLoader({
-        src: backgroundImageAsset.name,
-        format: "raw",
-      }),
->>>>>>> 2d1936ae4 (Resync and rebuild)
       as: "image",
     });
   }

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -6,7 +6,10 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+<<<<<<< HEAD
   redirect,
+=======
+>>>>>>> 2d1936ae4 (Resync and rebuild)
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +46,11 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
+<<<<<<< HEAD
     return redirect(pageMeta.redirect, status);
+=======
+    return Response.redirect(pageMeta.redirect, status);
+>>>>>>> 2d1936ae4 (Resync and rebuild)
   }
 
   const host =
@@ -214,16 +221,28 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
+<<<<<<< HEAD
       href: `${assetBaseUrl}${asset.name}`,
       as: "font",
       crossOrigin: "anonymous",
+=======
+      href: assetBaseUrl + asset.name,
+      as: "font",
+>>>>>>> 2d1936ae4 (Resync and rebuild)
     });
   }
 
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
+<<<<<<< HEAD
       href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+=======
+      href: imageLoader({
+        src: backgroundImageAsset.name,
+        format: "raw",
+      }),
+>>>>>>> 2d1936ae4 (Resync and rebuild)
       as: "image",
     });
   }

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -711,14 +711,10 @@ ${utilsExport}
     for (const redirect of redirects) {
       const redirectPagePath = generateRemixRoute(redirect.old);
       const redirectFileName = `${redirectPagePath}.ts`;
-
-      const content = `import { type LoaderArgs, redirect } from "@remix-run/server-runtime";
-
-export const loader = (arg: LoaderArgs) => {
-  return redirect("${redirect.new}", ${redirect.status ?? 301});
+      const content = `export const loader = () => {
+  return Response.redirect("${redirect.new}", ${redirect.status ?? 301});
 };
 `;
-
       await ensureFileInPath(join(routesDir, redirectFileName), content);
     }
   }

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -6,7 +6,6 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
-  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -43,7 +42,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return redirect(pageMeta.redirect, status);
+    return Response.redirect(pageMeta.redirect, status);
   }
 
   const host =


### PR DESCRIPTION
Here switched from remix redirect method to native Response.redirect available in all platforms.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
