### PR TITLE
fix: replace unknown variables on paste

### DIFF
--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -424,7 +424,8 @@ export const ExpressionEditor = ({
         onChange={(value) => {
           try {
             let hasReplacements = false;
-            // replace unknown webstudio variables with null to prevent invalid compilation
+            // replace unknown webstudio variables with undefined
+            // to prevent invalid compilation
             const newExpression = validateExpression(value, {
               effectful: true,
               transformIdentifier: (identifier) => {
@@ -433,7 +434,7 @@ export const ExpressionEditor = ({
                   aliases.has(identifier) === false
                 ) {
                   hasReplacements = true;
-                  return `null`;
+                  return `undefined`;
                 }
                 return identifier;
               },

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -36,7 +36,10 @@ import {
 } from "@codemirror/autocomplete";
 import { javascript } from "@codemirror/lang-javascript";
 import { theme, textVariants, css } from "@webstudio-is/design-system";
-import { validateExpression } from "@webstudio-is/react-sdk";
+import {
+  decodeDataSourceVariable,
+  validateExpression,
+} from "@webstudio-is/react-sdk";
 import { CodeEditor } from "./code-editor";
 
 export const formatValue = (value: unknown) => {
@@ -421,11 +424,14 @@ export const ExpressionEditor = ({
         onChange={(value) => {
           try {
             let hasReplacements = false;
-            // replace unknown variables with null to prevent invalid compilation
+            // replace unknown webstudio variables with null to prevent invalid compilation
             const newExpression = validateExpression(value, {
               effectful: true,
               transformIdentifier: (identifier) => {
-                if (aliases.has(identifier) === false) {
+                if (
+                  decodeDataSourceVariable(identifier) &&
+                  aliases.has(identifier) === false
+                ) {
                   hasReplacements = true;
                   return `null`;
                 }

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -36,6 +36,7 @@ import {
 } from "@codemirror/autocomplete";
 import { javascript } from "@codemirror/lang-javascript";
 import { theme, textVariants, css } from "@webstudio-is/design-system";
+import { validateExpression } from "@webstudio-is/react-sdk";
 import { CodeEditor } from "./code-editor";
 
 export const formatValue = (value: unknown) => {
@@ -417,7 +418,30 @@ export const ExpressionEditor = ({
         readOnly={readOnly}
         autoFocus={autoFocus}
         value={value}
-        onChange={onChange}
+        onChange={(value) => {
+          try {
+            let hasReplacements = false;
+            // replace unknown variables with null to prevent invalid compilation
+            const newExpression = validateExpression(value, {
+              effectful: true,
+              transformIdentifier: (identifier) => {
+                if (aliases.has(identifier) === false) {
+                  hasReplacements = true;
+                  return `null`;
+                }
+                return identifier;
+              },
+            });
+            // reformat only when something is replaced
+            // to break user interaction
+            if (hasReplacements) {
+              value = newExpression;
+            }
+          } catch {
+            // empty block
+          }
+          onChange(value);
+        }}
         onBlur={onBlur}
       />
     </div>

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -8,6 +8,8 @@ import type {
 import type { ObjectExpression, Property } from "@jsep-plugin/object";
 import type { DataSources, Scope } from "@webstudio-is/sdk";
 
+jsep.literals["undefined"] = "undefined";
+
 jsep.plugins.register(jsepAssignment);
 jsep.plugins.register(jsepObject);
 


### PR DESCRIPTION
Here fixing the issue with saving expressions with variables not available in the scope which leads to user confusion and compilation errors.

<img width="481" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5635476/176a0e1e-a74c-433f-8e7f-fdba9d4b8c71">



## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
