### PR TITLE
refactor: check literals with parser

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/json.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/json.tsx
@@ -29,15 +29,15 @@ export const JsonControl = ({
   onChange,
   onDelete,
 }: ControlProps<"json">) => {
-  const [error, setError] = useState<undefined | string>(undefined);
+  const [error, setError] = useState<boolean>(false);
   const valueString = formatValue(computedValue ?? "");
   const localValue = useLocalValue(valueString, (value) => {
+    const isLiteral = isLiteralExpression(value);
+    setError(isLiteral ? false : true);
     // prevent executing expressions which depends on global variables
-    if (isLiteralExpression(value) === false) {
-      setError("color");
+    if (isLiteral === false) {
       return;
     }
-    setError(undefined);
     try {
       // wrap into parens to treat object expression as value instead of block
       const parsedValue = eval(`(${value})`);

--- a/apps/builder/app/builder/features/settings-panel/controls/json.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/json.tsx
@@ -1,4 +1,5 @@
 import { useStore } from "@nanostores/react";
+import { isLiteralExpression } from "@webstudio-is/react-sdk";
 import {
   type ControlProps,
   getLabel,
@@ -17,6 +18,7 @@ import {
   BindingControl,
   BindingPopover,
 } from "~/builder/shared/binding-popover";
+import { useState } from "react";
 
 export const JsonControl = ({
   meta,
@@ -27,8 +29,16 @@ export const JsonControl = ({
   onChange,
   onDelete,
 }: ControlProps<"json">) => {
+  const [error, setError] = useState<undefined | string>(undefined);
   const valueString = formatValue(computedValue ?? "");
   const localValue = useLocalValue(valueString, (value) => {
+    // console.log(value, isLiteralExpression(value))
+    // prevent executing expressions which depends on global variables
+    if (isLiteralExpression(value) === false) {
+      setError("color");
+      return;
+    }
+    setError(undefined);
     try {
       // wrap into parens to treat object expression as value instead of block
       const parsedValue = eval(`(${value})`);
@@ -61,6 +71,7 @@ export const JsonControl = ({
     >
       <BindingControl>
         <ExpressionEditor
+          color={error ? "error" : undefined}
           readOnly={overwritable === false}
           value={localValue.value}
           onChange={localValue.set}

--- a/apps/builder/app/builder/features/settings-panel/controls/json.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/json.tsx
@@ -32,7 +32,6 @@ export const JsonControl = ({
   const [error, setError] = useState<undefined | string>(undefined);
   const valueString = formatValue(computedValue ?? "");
   const localValue = useLocalValue(valueString, (value) => {
-    // console.log(value, isLiteralExpression(value))
     // prevent executing expressions which depends on global variables
     if (isLiteralExpression(value) === false) {
       setError("color");

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -9,7 +9,10 @@ import {
 } from "react";
 import { useStore } from "@nanostores/react";
 import type { DataSource, Resource } from "@webstudio-is/sdk";
-import { encodeDataSourceVariable } from "@webstudio-is/react-sdk";
+import {
+  encodeDataSourceVariable,
+  isLiteralExpression,
+} from "@webstudio-is/react-sdk";
 import {
   Box,
   Button,
@@ -37,7 +40,6 @@ import {
   BindingControl,
   BindingPopover,
   evaluateExpressionWithinScope,
-  isLiteralExpression,
 } from "~/builder/shared/binding-popover";
 import {
   type Field,

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/custom-metadata.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/custom-metadata.tsx
@@ -12,10 +12,10 @@ import {
 } from "@webstudio-is/design-system";
 import { DeleteIcon, PlusIcon } from "@webstudio-is/icons";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
+import { isLiteralExpression } from "@webstudio-is/react-sdk";
 import {
   BindingControl,
   BindingPopover,
-  isLiteralExpression,
 } from "~/builder/shared/binding-popover";
 import { computeExpression } from "~/shared/nano-states";
 import { $pageRootScope } from "./page-utils";

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -50,6 +50,7 @@ import {
   HelpIcon,
   UploadIcon,
 } from "@webstudio-is/icons";
+import { isLiteralExpression } from "@webstudio-is/react-sdk";
 import { useIds } from "~/shared/form-utils";
 import { Header, HeaderSuffixSpacer } from "../../header";
 import { updateWebstudioData } from "~/shared/instance-utils";
@@ -65,7 +66,6 @@ import {
 import {
   BindingControl,
   BindingPopover,
-  isLiteralExpression,
 } from "~/builder/shared/binding-popover";
 import { serverSyncStore } from "~/shared/sync";
 import { SearchPreview } from "./search-preview";

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -60,20 +60,6 @@ export const evaluateExpressionWithinScope = (
   }
 };
 
-/**
- * execute valid expression without scope
- * to check any variable usage
- */
-export const isLiteralExpression = (expression: string) => {
-  try {
-    const fn = new Function(`return (${expression})`);
-    fn();
-    return true;
-  } catch {
-    return false;
-  }
-};
-
 const getUsedIdentifiers = (expression: string) => {
   const identifiers = new Set<string>();
   // prevent parsing empty expression

--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -251,16 +251,14 @@ const codeEditorStyle = css({
 });
 
 export const CodeEditor = ({
-  className,
   title,
   ...editorContentProps
 }: EditorContentProps & {
-  className?: string;
   title?: ReactNode;
 }) => {
   const content = <EditorContent {...editorContentProps} />;
   return (
-    <div className={codeEditorStyle({ className })}>
+    <div className={codeEditorStyle()}>
       {content}
       <CodeEditorDialog title={title} content={content}>
         <SmallIconButton

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -348,10 +348,6 @@ const wrapperStyle = css({
   },
 });
 
-const errorStyle = css({
-  borderColor: theme.colors.borderDestructiveMain,
-});
-
 export const ExpressionEditor = ({
   scope = emptyScope,
   aliases = emptyAliases,
@@ -417,7 +413,7 @@ export const ExpressionEditor = ({
     <div className={wrapperStyle.toString()}>
       <CodeEditor
         extensions={extensions}
-        className={color === "error" ? errorStyle.toString() : undefined}
+        invalid={color === "error"}
         readOnly={readOnly}
         autoFocus={autoFocus}
         value={value}

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -3,6 +3,7 @@ import {
   decodeDataSourceVariable,
   encodeDataSourceVariable,
   executeExpression,
+  isLiteralExpression,
   validateExpression,
 } from "./expression";
 
@@ -86,6 +87,28 @@ test("allow indexed member expressions with identifiers", () => {
     })
   ).toEqual(`a[b]`);
   expect(ids).toEqual(["a", "b"]);
+});
+
+test("check simple literals", () => {
+  expect(isLiteralExpression(`""`)).toEqual(true);
+  expect(isLiteralExpression(`''`)).toEqual(true);
+  expect(isLiteralExpression(`0`)).toEqual(true);
+  expect(isLiteralExpression(`true`)).toEqual(true);
+  expect(isLiteralExpression(`[]`)).toEqual(true);
+  expect(isLiteralExpression(`{}`)).toEqual(true);
+  expect(isLiteralExpression(`"" + ""`)).toEqual(false);
+  expect(isLiteralExpression(`{}.field`)).toEqual(false);
+  expect(isLiteralExpression(`variable`)).toEqual(false);
+});
+
+test("check complex objects and arrays", () => {
+  expect(isLiteralExpression(`[1, 2, 3]`)).toEqual(true);
+  expect(isLiteralExpression(`[1, 2, variable]`)).toEqual(false);
+  expect(isLiteralExpression(`{ param: 0 }`)).toEqual(true);
+  expect(isLiteralExpression(`{ "param": 0 }`)).toEqual(true);
+  expect(isLiteralExpression(`{ param: variable }`)).toEqual(false);
+  expect(isLiteralExpression(`{ ["param"]: 0 }`)).toEqual(true);
+  expect(isLiteralExpression(`{ [variable]: 0 }`)).toEqual(false);
 });
 
 test("optionally transpile all member expressions into optional chaining", () => {

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -168,6 +168,43 @@ export const validateExpression = (
   });
 };
 
+const isLiteralNode = (node: Node): boolean => {
+  if (node.type === "Literal") {
+    return true;
+  }
+  if (node.type === "ArrayExpression") {
+    return (node.elements as Node[]).every(isLiteralNode);
+  }
+  if (node.type === "ObjectExpression") {
+    return node.properties.every((property) => {
+      const key = property.key as Node;
+      const isIdentifierKey =
+        key.type === "Identifier" && property.computed === false;
+      const isLiteralKey = key.type === "Literal";
+      return (
+        (isLiteralKey || isIdentifierKey) &&
+        isLiteralNode(property.value as Node)
+      );
+    });
+  }
+  return false;
+};
+
+/**
+ * check whether provided expression is a literal value
+ * like "", 0 or { param: "value" }
+ * which does not depends on any variable
+ */
+export const isLiteralExpression = (expression: string) => {
+  try {
+    const node = jsep(expression) as Node;
+    return isLiteralNode(node);
+  } catch {
+    // treat invalid expression as non-literal
+    return false;
+  }
+};
+
 const dataSourceVariablePrefix = "$ws$dataSource$";
 
 // data source id is generated with nanoid which has "-" in alphabeta

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -17,12 +17,7 @@ export {
 export * from "./embed-template";
 export * from "./props";
 export * from "./context";
-export {
-  validateExpression,
-  encodeDataSourceVariable,
-  decodeDataSourceVariable,
-  executeExpression,
-} from "./expression";
+export * from "./expression";
 export { getIndexesWithinAncestors } from "./instance-utils";
 export * from "./hook";
 export { generateUtilsExport } from "./generator";


### PR DESCRIPTION
Here improved detecting literal values in expressions without executing with potentially global variables.

Also fixed expression errors

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
