### PR TITLE
refactor: revert remix redirect method

### DIFF
--- a/fixtures/webstudio-custom-template/app/routes/[hello]._index.ts
+++ b/fixtures/webstudio-custom-template/app/routes/[hello]._index.ts
@@ -1,3 +1,5 @@
-export const loader = () => {
-  return Response.redirect("/world", 301);
+import { type LoaderArgs, redirect } from "@remix-run/server-runtime";
+
+export const loader = (arg: LoaderArgs) => {
+  return redirect("/world", 301);
 };

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -711,10 +711,14 @@ ${utilsExport}
     for (const redirect of redirects) {
       const redirectPagePath = generateRemixRoute(redirect.old);
       const redirectFileName = `${redirectPagePath}.ts`;
-      const content = `export const loader = () => {
-  return Response.redirect("${redirect.new}", ${redirect.status ?? 301});
+
+      const content = `import { type LoaderArgs, redirect } from "@remix-run/server-runtime";
+
+export const loader = (arg: LoaderArgs) => {
+  return redirect("${redirect.new}", ${redirect.status ?? 301});
 };
 `;
+
       await ensureFileInPath(join(routesDir, redirectFileName), content);
     }
   }

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -6,6 +6,7 @@ import {
   type ActionArgs,
   type LoaderArgs,
   json,
+  redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { ProjectMeta } from "@webstudio-is/sdk";
@@ -42,7 +43,7 @@ export const loader = async (arg: LoaderArgs) => {
       pageMeta.status === 301 || pageMeta.status === 302
         ? pageMeta.status
         : 302;
-    return Response.redirect(pageMeta.redirect, status);
+    return redirect(pageMeta.redirect, status);
   }
 
   const host =


### PR DESCRIPTION
This reverts commit fa376d4204bc182ef51be9eb0de31cc344bf6686.

Seems like native redirect does not suppot relative paths which are essential for redirect ui.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
