### PR TITLE
fix: upload images serially to avoid being rate limited

### DIFF
--- a/apps/builder/app/builder/shared/assets/use-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/use-assets.tsx
@@ -168,7 +168,7 @@ export const useUploadAsset = () => {
     setAsset({ ...uploadedAsset, id: assetId });
   };
 
-  const uploadAssets = (type: AssetType, files: File[]) => {
+  const uploadAssets = async (type: AssetType, files: File[]) => {
     const projectId = $project.get()?.id;
     const authToken = $authToken.get();
     if (projectId === undefined) {
@@ -181,7 +181,7 @@ export const useUploadAsset = () => {
 
     for (const fileData of filesData) {
       const assetId = fileData.assetId;
-      uploadAsset({
+      await uploadAsset({
         authToken,
         projectId,
         file: fileData.file,


### PR DESCRIPTION
## Description

When uploading 15+ images at once it will be rate limited as they upload in parallel and that looks like DDOS to the rate limiter

## Steps for reproduction

1. select many files
2. upload and see no error

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
