### PR TITLE
feat: support json in resource body

### DIFF
--- a/apps/builder/app/routes/rest.resources-loader.ts
+++ b/apps/builder/app/routes/rest.resources-loader.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 import type { ActionArgs } from "@remix-run/node";
-import { loadResource, Resource } from "@webstudio-is/sdk";
+import { loadResource, ResourceRequest } from "@webstudio-is/sdk";
 
 export const action = async ({ request }: ActionArgs) => {
-  const computedResources = z.array(Resource).parse(await request.json());
+  const computedResources = z
+    .array(ResourceRequest)
+    .parse(await request.json());
   const responses = await Promise.all(computedResources.map(loadResource));
-  const output: [Resource["id"], unknown][] = [];
+  const output: [ResourceRequest["id"], unknown][] = [];
   responses.forEach((response, index) => {
     const request = computedResources[index];
     output.push([request.id, response]);

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -1,5 +1,11 @@
 import { atom, computed } from "nanostores";
-import type { Resource, DataSource, Instance, Prop } from "@webstudio-is/sdk";
+import type {
+  Resource,
+  DataSource,
+  Instance,
+  Prop,
+  ResourceRequest,
+} from "@webstudio-is/sdk";
 import {
   collectionComponent,
   decodeDataSourceVariable,
@@ -433,8 +439,8 @@ const $loaderVariableValues = computed(
 const computeResource = (
   resource: Resource,
   values: Map<DataSource["id"], unknown>
-): Resource => {
-  const request: Resource = {
+): ResourceRequest => {
+  const request: ResourceRequest = {
     id: resource.id,
     name: resource.name,
     url: computeExpression(resource.url, values),
@@ -453,7 +459,7 @@ const computeResource = (
 const $computedResources = computed(
   [$resources, $loaderVariableValues],
   (resources, values) => {
-    const computedResources: Resource[] = [];
+    const computedResources: ResourceRequest[] = [];
     for (const resource of resources.values()) {
       computedResources.push(computeResource(resource, values));
     }
@@ -467,7 +473,7 @@ export const $areResourcesLoading = computed(
   (resourcesLoadingCount) => resourcesLoadingCount > 0
 );
 
-const loadResources = async (resourceRequests: Resource[]) => {
+const loadResources = async (resourceRequests: ResourceRequest[]) => {
   $resourcesLoadingCount.set($resourcesLoadingCount.get() + 1);
   const response = await fetch(restResourcesLoader(), {
     method: "POST",
@@ -511,8 +517,8 @@ export const subscribeResources = () => {
     (computedResources, invalidator) =>
       [computedResources, invalidator] as const
   ).subscribe(async ([computedResources]) => {
-    const matched = new Map<Resource["id"], Resource>();
-    const missing = new Map<Resource["id"], Resource>();
+    const matched = new Map<Resource["id"], ResourceRequest>();
+    const missing = new Map<Resource["id"], ResourceRequest>();
     for (const request of computedResources) {
       const cacheKey = JSON.stringify(request);
       if (cacheByKeys.has(cacheKey)) {

--- a/packages/sdk/src/resource-loader.ts
+++ b/packages/sdk/src/resource-loader.ts
@@ -1,6 +1,6 @@
-import type { Resource } from "./schema/resources";
+import type { ResourceRequest } from "./schema/resources";
 
-export const loadResource = async (resourceData: Resource) => {
+export const loadResource = async (resourceData: ResourceRequest) => {
   const { url, method, headers, body } = resourceData;
   const requestHeaders = new Headers(
     headers.map(({ name, value }): [string, string] => [name, value])
@@ -10,7 +10,12 @@ export const loadResource = async (resourceData: Resource) => {
     headers: requestHeaders,
   };
   if (method !== "get" && body !== undefined) {
-    requestInit.body = body;
+    if (typeof body === "string") {
+      requestInit.body = body;
+    }
+    if (typeof body === "object") {
+      requestInit.body = JSON.stringify(body);
+    }
   }
   try {
     // cloudflare workers fail when fetching url contains spaces

--- a/packages/sdk/src/schema/resources.ts
+++ b/packages/sdk/src/schema/resources.ts
@@ -28,6 +28,18 @@ export const Resource = z.object({
 
 export type Resource = z.infer<typeof Resource>;
 
+// evaluated variant of resource
+export const ResourceRequest = z.object({
+  id: ResourceId,
+  name: z.string(),
+  method: Method,
+  url: z.string(),
+  headers: z.array(Header),
+  body: z.optional(z.unknown()),
+});
+
+export type ResourceRequest = z.infer<typeof ResourceRequest>;
+
 export const Resources = z.map(ResourceId, Resource);
 
 export type Resources = z.infer<typeof Resources>;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Here optionally added support for json in resource body. This is necessary when use graphql apis or just json based rest api.

Expression editor for entering json value is shown whenever method post and content-type: application/json are specified.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
