### PR TITLE
fix: remove breakpoints menu shortcut

### DIFF
--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -139,9 +139,6 @@ export const Menu = () => {
           </Tooltip>
           <DropdownMenuItem onSelect={() => emitCommand("openBreakpointsMenu")}>
             Breakpoints
-            <DropdownMenuItemRightSlot>
-              <ShortcutHint value={["cmd", "b"]} />
-            </DropdownMenuItemRightSlot>
           </DropdownMenuItem>
           <ViewMenuItem />
           <DropdownMenuSeparator />

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -122,7 +122,6 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
     },
     {
       name: "openBreakpointsMenu",
-      defaultHotkeys: ["meta+b", "ctrl+b"],
       handler: () => {
         $breakpointsMenuView.set("initial");
       },


### PR DESCRIPTION
turns out we nobody needs it and it conflicts with cmd+b in text editing

## Steps for reproduction

1. hit cmd+b or ctrl+b and it shouldn't open the menu

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
