### PR TITLE
feat: reset shortcut hint for all style panel style info tooltips

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -11,6 +11,7 @@ import {
   type TooltipProps,
   Text,
   ScrollArea,
+  Shortcut,
 } from "@webstudio-is/design-system";
 import { ResetIcon } from "@webstudio-is/icons";
 import type {
@@ -271,7 +272,8 @@ export const TooltipContent = ({
           <Button
             color="dark"
             prefix={<ResetIcon />}
-            css={{ flexGrow: 1 }}
+            suffix={<Shortcut value={["option", "click"]} />}
+            css={{ flexGrow: 1, flexAlign: "center" }}
             onClick={onReset}
           >
             Reset value

--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -14,8 +14,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuPortal,
   Tooltip,
+  Shortcut,
 } from "@webstudio-is/design-system";
-import { ShortcutHint } from "./shortcut-hint";
 import {
   useIsShareDialogOpen,
   useIsPublishDialogOpen,
@@ -145,13 +145,13 @@ export const Menu = () => {
           <DropdownMenuItem onSelect={() => emitCommand("undo")}>
             Undo
             <DropdownMenuItemRightSlot>
-              <ShortcutHint value={["cmd", "z"]} />
+              <Shortcut value={["cmd", "z"]} />
             </DropdownMenuItemRightSlot>
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => emitCommand("redo")}>
             Redo
             <DropdownMenuItemRightSlot>
-              <ShortcutHint value={["shift", "cmd", "z"]} />
+              <Shortcut value={["shift", "cmd", "z"]} />
             </DropdownMenuItemRightSlot>
           </DropdownMenuItem>
           {/* https://github.com/webstudio-is/webstudio/issues/499
@@ -162,7 +162,7 @@ export const Menu = () => {
             }}
           >
             Copy
-            <DropdownMenuItemRightSlot><ShortcutHint value={["cmd", "c"]} /></DropdownMenuItemRightSlot>
+            <DropdownMenuItemRightSlot><Shortcut value={["cmd", "c"]} /></DropdownMenuItemRightSlot>
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => {
@@ -170,14 +170,14 @@ export const Menu = () => {
             }}
           >
             Paste
-            <DropdownMenuItemRightSlot><ShortcutHint value={["cmd", "v"]} /></DropdownMenuItemRightSlot>
+            <DropdownMenuItemRightSlot><Shortcut value={["cmd", "v"]} /></DropdownMenuItemRightSlot>
           </DropdownMenuItem>
 
           */}
           <DropdownMenuItem onSelect={() => emitCommand("deleteInstance")}>
             Delete
             <DropdownMenuItemRightSlot>
-              <ShortcutHint value={["backspace"]} />
+              <Shortcut value={["backspace"]} />
             </DropdownMenuItemRightSlot>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
@@ -185,7 +185,7 @@ export const Menu = () => {
           <DropdownMenuItem onSelect={() => emitCommand("togglePreview")}>
             Preview
             <DropdownMenuItemRightSlot>
-              <ShortcutHint value={["cmd", "shift", "p"]} />
+              <Shortcut value={["cmd", "shift", "p"]} />
             </DropdownMenuItemRightSlot>
           </DropdownMenuItem>
 

--- a/packages/design-system/src/components/separator.stories.tsx
+++ b/packages/design-system/src/components/separator.stories.tsx
@@ -1,9 +1,9 @@
-import { Separator } from "./separator";
+import { Shortcut } from "./shortcut";
 
 export default {
-  title: "Library/Separator",
+  title: "Library/Shortcut",
 };
 
-const SeparatorStory = () => <Separator />;
+const ShortcutStory = () => <Shortcut value={["cmd", "z"]} />;
 
-export { SeparatorStory as Separator };
+export { ShortcutStory as Shortcut };

--- a/packages/design-system/src/components/shortcut.stories.tsx
+++ b/packages/design-system/src/components/shortcut.stories.tsx
@@ -1,0 +1,9 @@
+import { Separator } from "./separator";
+
+export default {
+  title: "Library/Separator",
+};
+
+const SeparatorStory = () => <Separator />;
+
+export { SeparatorStory as Separator };

--- a/packages/design-system/src/components/shortcut.tsx
+++ b/packages/design-system/src/components/shortcut.tsx
@@ -1,4 +1,4 @@
-import { DeprecatedText2 } from "@webstudio-is/design-system";
+import { Text } from "./text";
 
 const isMac =
   typeof navigator === "object" ? /mac/i.test(navigator.platform) : false;
@@ -9,6 +9,7 @@ const shortcutSymbolMap: Record<string, string> = {
   shift: "⇧",
   option: "⌥",
   backspace: "⌫",
+  click: "+click",
 };
 
 const shortcutWinMap: Record<string, string> = {
@@ -32,10 +33,6 @@ const format = (value: ShortcutDefinition) => {
   );
 };
 
-export const ShortcutHint = ({ value }: { value: ShortcutDefinition }) => {
-  return (
-    <DeprecatedText2 css={{ letterSpacing: 1.5 }}>
-      {format(value)}
-    </DeprecatedText2>
-  );
+export const Shortcut = ({ value }: { value: ShortcutDefinition }) => {
+  return <Text color="subtle">{format(value)}</Text>;
 };

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -80,6 +80,7 @@ export * from "./components/scroll-area";
 export * from "./components/primitives/use-scrub";
 export * from "./components/primitives/numeric-input-arrow-keys";
 export * from "./components/primitives/list";
+export * from "./components/shortcut";
 
 // Deprecated
 


### PR DESCRIPTION
Currently user had no way to discover option/alt + click on label in style panel

<img width="246" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/e4c69f33-6b05-4f0c-9946-d062fc9d07c5">


## Steps for reproduction

1. click on any property value that is set in style panel
2. see the hint

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
