### PR TITLE
fix: fix code editor scrolling

### DIFF
--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -56,14 +56,18 @@ const editorContentStyle = css({
   },
   "& .cm-content": {
     padding: 0,
+    // makes sure you can click to focus when editor content is smaller than the container
+    minHeight: "100%",
   },
   "& .cm-line": {
     padding: 0,
   },
   "& .cm-editor": {
     width: "100%",
-    // makes sure you can click to focus when editor content is smaller than the container
-    height: "100%",
+    // avoid modifying height in .cm-content
+    // because it breaks scroll events and makes scrolling laggy
+    minHeight: "var(--ws-code-editor-min-height, auto)",
+    maxHeight: "var(--ws-code-editor-max-height, none)",
   },
 });
 

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -341,7 +341,9 @@ const emptyScope: Scope = {};
 const emptyAliases: Aliases = new Map();
 
 const wrapperStyle = css({
-  "& .cm-content": {
+  // do not override .cm-content here
+  // it may break scrolling
+  "& .cm-editor": {
     // 1 line is 16px
     // set and max 20 lines
     maxHeight: 320,

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -341,13 +341,9 @@ const emptyScope: Scope = {};
 const emptyAliases: Aliases = new Map();
 
 const wrapperStyle = css({
-  // avoid modifying height in .cm-content
-  // because it breaks scroll events and makes scrolling laggy
-  "& .cm-editor": {
-    // 1 line is 16px
-    // set and max 20 lines
-    maxHeight: 320,
-  },
+  // 1 line is 16px
+  // set and max 20 lines
+  "--ws-code-editor-max-height": "320px",
 });
 
 export const ExpressionEditor = ({

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -341,8 +341,8 @@ const emptyScope: Scope = {};
 const emptyAliases: Aliases = new Map();
 
 const wrapperStyle = css({
-  // do not override .cm-content here
-  // it may break scrolling
+  // avoid modifying height in .cm-content
+  // because it breaks scroll events and makes scrolling laggy
   "& .cm-editor": {
     // 1 line is 16px
     // set and max 20 lines

--- a/apps/builder/app/builder/shared/html-editor.tsx
+++ b/apps/builder/app/builder/shared/html-editor.tsx
@@ -68,8 +68,8 @@ const autocompletionStyle = css({
 
 const wrapperStyle = css({
   position: "relative",
-  // do not override .cm-content here
-  // it may break scrolling
+  // avoid modifying height in .cm-content
+  // because it breaks scroll events and makes scrolling laggy
   "& .cm-editor": {
     // 1 line is 16px
     // set min 10 lines and max 20 lines

--- a/apps/builder/app/builder/shared/html-editor.tsx
+++ b/apps/builder/app/builder/shared/html-editor.tsx
@@ -68,14 +68,10 @@ const autocompletionStyle = css({
 
 const wrapperStyle = css({
   position: "relative",
-  // avoid modifying height in .cm-content
-  // because it breaks scroll events and makes scrolling laggy
-  "& .cm-editor": {
-    // 1 line is 16px
-    // set min 10 lines and max 20 lines
-    minHeight: 160,
-    maxHeight: 320,
-  },
+  // 1 line is 16px
+  // set min 10 lines and max 20 lines
+  "--ws-code-editor-min-height": "160px",
+  "--ws-code-editor-max-height": "320px",
 });
 
 export const HtmlEditor = forwardRef<

--- a/apps/builder/app/builder/shared/html-editor.tsx
+++ b/apps/builder/app/builder/shared/html-editor.tsx
@@ -68,7 +68,9 @@ const autocompletionStyle = css({
 
 const wrapperStyle = css({
   position: "relative",
-  "& .cm-content": {
+  // do not override .cm-content here
+  // it may break scrolling
+  "& .cm-editor": {
     // 1 line is 16px
     // set min 10 lines and max 20 lines
     minHeight: 160,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2956

Here fixed the issue with scrolling code editor
by setting height on editor instead of content.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
