### PR TITLE
experimental: navigate to dynamic path without reload

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -96,8 +96,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set(["", "/script-test", "/world"]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
@@ -82,8 +82,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set(["", "/script-test", "/world"]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -124,8 +124,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set(["", "/script-test", "/world"]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -76,8 +76,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set([""]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -76,8 +76,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set([""]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -107,16 +107,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set([
-  "",
-  "/radix",
-  "/_route_with_symbols_",
-  "/form",
-  "/heading-with-id",
-  "/resources",
-  "/nested/nested-page",
-]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -220,16 +220,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set([
-  "",
-  "/radix",
-  "/_route_with_symbols_",
-  "/form",
-  "/heading-with-id",
-  "/resources",
-  "/nested/nested-page",
-]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -108,16 +108,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set([
-  "",
-  "/radix",
-  "/_route_with_symbols_",
-  "/form",
-  "/heading-with-id",
-  "/resources",
-  "/nested/nested-page",
-]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -104,16 +104,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set([
-  "",
-  "/radix",
-  "/_route_with_symbols_",
-  "/form",
-  "/heading-with-id",
-  "/resources",
-  "/nested/nested-page",
-]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -255,16 +255,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set([
-  "",
-  "/radix",
-  "/_route_with_symbols_",
-  "/form",
-  "/heading-with-id",
-  "/resources",
-  "/nested/nested-page",
-]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -116,16 +116,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set([
-  "",
-  "/radix",
-  "/_route_with_symbols_",
-  "/form",
-  "/heading-with-id",
-  "/resources",
-  "/nested/nested-page",
-]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -205,16 +205,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set([
-  "",
-  "/radix",
-  "/_route_with_symbols_",
-  "/form",
-  "/heading-with-id",
-  "/resources",
-  "/nested/nested-page",
-]);
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/packages/cli/__generated__/_index.tsx
+++ b/packages/cli/__generated__/_index.tsx
@@ -41,8 +41,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
 
-export const pagesPaths = new Set<string>();
-
 export const formsProperties = new Map<
   string,
   { method?: string; action?: string }

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -581,10 +581,7 @@ export const prebuild = async (options: {
     const props = new Map(pageData.build.props);
     const dataSources = new Map(pageData.build.dataSources);
     const resources = new Map(pageData.build.resources);
-    const utilsExport = generateUtilsExport({
-      pages: siteData.build.pages,
-      props,
-    });
+    const utilsExport = generateUtilsExport({ props });
     // generate new Page Params variable if does not exist
     // to allow always passing it from route template
     const pathParamsDataSourceId =

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -17,7 +17,6 @@ import {
   pageData,
   user,
   projectId,
-  pagesPaths,
   formsProperties,
   Page,
   imageAssets,
@@ -324,7 +323,6 @@ const Outlet = () => {
         imageLoader,
         assetBaseUrl,
         imageBaseUrl,
-        pagesPaths,
         resources,
       }}
     >

--- a/packages/react-sdk/src/context.tsx
+++ b/packages/react-sdk/src/context.tsx
@@ -1,5 +1,4 @@
 import { createContext, useContext } from "react";
-import type { Page } from "@webstudio-is/sdk";
 import type { ImageLoader } from "@webstudio-is/image";
 
 export type Params = {
@@ -32,12 +31,6 @@ export type Params = {
 export const ReactSdkContext = createContext<
   Params & {
     imageLoader: ImageLoader;
-    /**
-     * List of pages paths for link component
-     * to navigate without reloading on published sites
-     * always empty for builder which handle anchor clicks globally
-     */
-    pagesPaths: Set<Page["path"]>;
     // resources need to be any to support accessing unknown fields without extra checks
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resources: Record<string, any>;
@@ -46,7 +39,6 @@ export const ReactSdkContext = createContext<
   assetBaseUrl: "/",
   imageBaseUrl: "/",
   imageLoader: ({ src }) => src,
-  pagesPaths: new Set(),
   resources: {},
 });
 

--- a/packages/react-sdk/src/generator.test.ts
+++ b/packages/react-sdk/src/generator.test.ts
@@ -1,35 +1,9 @@
 import { expect, test } from "@jest/globals";
 import { generateUtilsExport } from "./generator";
 
-const createPage = (path: string) => ({
-  id: path,
-  path,
-  name: "",
-  title: "",
-  rootInstanceId: "",
-  meta: {},
-});
-
-const pages = {
-  meta: {},
-  pages: [],
-  folders: [
-    {
-      id: "root",
-      name: "Root",
-      slug: "",
-      children: [],
-    },
-  ],
-};
-
 test("generates forms properties", () => {
   expect(
     generateUtilsExport({
-      pages: {
-        ...pages,
-        homePage: createPage("1"),
-      },
       props: new Map([
         [
           "method1Id",
@@ -66,29 +40,20 @@ test("generates forms properties", () => {
       ]),
     })
   ).toMatchInlineSnapshot(`
+"
+  export const formsProperties = new Map<string, { method?: string, action?: string }>([["1",{"method":"post"}],["2",{"method":"get","action":"/index.php"}]])
   "
-    export const pagesPaths = new Set(["1"])
-
-    export const formsProperties = new Map<string, { method?: string, action?: string }>([["1",{"method":"post"}],["2",{"method":"get","action":"/index.php"}]])
-    "
-  `);
+`);
 });
 
 test("generates list of pages paths", () => {
   expect(
     generateUtilsExport({
-      pages: {
-        ...pages,
-        homePage: createPage("/path1"),
-        pages: [createPage("/path2"), createPage("/path3")],
-      },
       props: new Map(),
     })
   ).toMatchInlineSnapshot(`
+"
+  export const formsProperties = new Map<string, { method?: string, action?: string }>([])
   "
-    export const pagesPaths = new Set(["/path1","/path2","/path3"])
-
-    export const formsProperties = new Map<string, { method?: string, action?: string }>([])
-    "
-  `);
+`);
 });

--- a/packages/react-sdk/src/generator.ts
+++ b/packages/react-sdk/src/generator.ts
@@ -1,7 +1,6 @@
-import { getPagePath, type Pages, type Props } from "@webstudio-is/sdk";
+import type { Props } from "@webstudio-is/sdk";
 
 type PageData = {
-  pages: Pages;
   props: Props;
 };
 
@@ -9,18 +8,6 @@ type PageData = {
  * Generates data based utilities at build time
  */
 export const generateUtilsExport = (siteData: PageData) => {
-  // list of paths from pages to use framework link component
-  // for ui routes
-  const pagesPaths: string[] = [siteData.pages.homePage.path];
-  for (const page of siteData.pages.pages) {
-    const path = getPagePath(page.id, siteData.pages);
-    pagesPaths.push(path);
-  }
-
-  const generatedPagesPaths = `export const pagesPaths = new Set(${JSON.stringify(
-    pagesPaths
-  )})`;
-
   // method and action per instance extracted from props
   const formsProperties = new Map<
     string,
@@ -43,8 +30,6 @@ export const generateUtilsExport = (siteData: PageData) => {
   )})`;
 
   return `
-  ${generatedPagesPaths}
-
   ${generatedFormsProperties}
   `;
 };

--- a/packages/react-sdk/src/tree/create-elements-tree.tsx
+++ b/packages/react-sdk/src/tree/create-elements-tree.tsx
@@ -53,7 +53,6 @@ export const createElementsTree = ({
       value={{
         renderer,
         imageLoader,
-        pagesPaths: new Set(),
         assetBaseUrl,
         imageBaseUrl,
         resources: {},

--- a/packages/sdk-components-react-remix/src/shared/remix-link.tsx
+++ b/packages/sdk-components-react-remix/src/shared/remix-link.tsx
@@ -16,15 +16,15 @@ type Props = Omit<ComponentPropsWithoutRef<typeof Link>, "target"> & {
 
 export const wrapLinkComponent = (BaseLink: typeof Link) => {
   const Component = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
-    const { pagesPaths } = useContext(ReactSdkContext);
+    const { assetBaseUrl } = useContext(ReactSdkContext);
     const href = props.href;
 
     // use remix link when url references webstudio page
-    if (href !== undefined) {
-      const url = new URL(href, "https://any-valid.url");
-      if (pagesPaths.has(url.pathname === "/" ? "" : url.pathname)) {
-        return <RemixLink {...props} to={href} ref={ref} />;
-      }
+    if (
+      href === "" ||
+      (href?.startsWith("/") && href.startsWith(assetBaseUrl) === false)
+    ) {
+      return <RemixLink {...props} to={href} ref={ref} />;
     }
 
     const { prefetch, reloadDocument, replace, preventScrollReset, ...rest } =

--- a/packages/sdk-components-react-remix/src/shared/remix-link.tsx
+++ b/packages/sdk-components-react-remix/src/shared/remix-link.tsx
@@ -19,7 +19,8 @@ export const wrapLinkComponent = (BaseLink: typeof Link) => {
     const { assetBaseUrl } = useContext(ReactSdkContext);
     const href = props.href;
 
-    // use remix link when url references webstudio page
+    // use remix link for home page and all relative urls
+    // ignore asset paths which can be relative too
     if (
       href === "" ||
       (href?.startsWith("/") && href.startsWith(assetBaseUrl) === false)


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Here fixed the issue with navigating to dynamic paths. The page get full reload because provided path does not match pages list and remix link is not used.

Solved by using the following heuristic: use remix link when the path is relative and not asset. It will cover manually specified link href or computed with expression one.

Now we can remove pagePaths from generated code.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
