### PR TITLE
feat: Add ability to disable clone and copy for view links

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -44,6 +44,7 @@ import {
   $resources,
   subscribeResources,
   $marketplaceProduct,
+  $authTokenPermissions,
 } from "~/shared/nano-states";
 import { type Settings } from "./shared/client-settings";
 import { getBuildUrl } from "~/shared/router-utils";
@@ -57,6 +58,7 @@ import { ProjectSettings } from "./features/project-settings";
 import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 import { $isCloneDialogOpen, $userPlanFeatures } from "./shared/nano-states";
 import { CloneProjectDialog } from "~/shared/clone-project";
+import type { TokenPermissions } from "@webstudio-is/authorization-token";
 
 registerContainers();
 
@@ -228,6 +230,7 @@ export type BuilderProps = {
   assets: [Asset["id"], Asset][];
   authToken?: string;
   authPermit: AuthPermit;
+  authTokenPermissions: TokenPermissions;
   userPlanFeatures: UserPlanFeatures;
 };
 
@@ -239,6 +242,7 @@ export const Builder = ({
   authToken,
   authPermit,
   userPlanFeatures,
+  authTokenPermissions,
 }: BuilderProps) => {
   useMount(() => {
     // additional data stores
@@ -247,6 +251,7 @@ export const Builder = ({
     $authPermit.set(authPermit);
     $authToken.set(authToken);
     $userPlanFeatures.set(userPlanFeatures);
+    $authTokenPermissions.set(authTokenPermissions);
 
     // set initial containers value
     $assets.set(new Map(assets));

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -59,6 +59,7 @@ import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 import { $isCloneDialogOpen, $userPlanFeatures } from "./shared/nano-states";
 import { CloneProjectDialog } from "~/shared/clone-project";
 import type { TokenPermissions } from "@webstudio-is/authorization-token";
+import { useToastErrors } from "~/shared/error/toast-error";
 
 registerContainers();
 
@@ -268,6 +269,7 @@ export const Builder = ({
     $marketplaceProduct.set(build.marketplaceProduct);
   });
 
+  useToastErrors();
   useEffect(subscribeCommands, []);
   useEffect(subscribeResources, []);
 

--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -225,7 +225,7 @@ export const Menu = () => {
             sideOffset={10}
             content={
               authTokenPermission.canClone === false
-                ? "Cloning is disabled by the project owner"
+                ? "Cloning has been disabled by the project owner"
                 : undefined
             }
           >

--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -190,7 +190,11 @@ export const Menu = () => {
             </DropdownMenuItemRightSlot>
           </DropdownMenuItem>
 
-          <Tooltip side="right" content={disabledShareTooltipContent}>
+          <Tooltip
+            side="right"
+            sideOffset={10}
+            content={disabledShareTooltipContent}
+          >
             <DropdownMenuItem
               onSelect={() => {
                 setIsShareOpen(true);
@@ -201,7 +205,11 @@ export const Menu = () => {
             </DropdownMenuItem>
           </Tooltip>
 
-          <Tooltip side="right" content={disabledPublishTooltipContent}>
+          <Tooltip
+            side="right"
+            sideOffset={10}
+            content={disabledPublishTooltipContent}
+          >
             <DropdownMenuItem
               onSelect={() => {
                 setIsPublishOpen(true);
@@ -214,6 +222,7 @@ export const Menu = () => {
 
           <Tooltip
             side="right"
+            sideOffset={10}
             content={
               authTokenPermission.canClone === false
                 ? "Cloning is disabled by the project owner"

--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -29,7 +29,7 @@ import {
 } from "~/shared/theme";
 import { useClientSettings } from "~/builder/shared/client-settings";
 import { dashboardPath } from "~/shared/router-utils";
-import { $authPermit } from "~/shared/nano-states";
+import { $authPermit, $authTokenPermissions } from "~/shared/nano-states";
 import { emitCommand } from "~/builder/shared/commands";
 import { MenuButton } from "./menu-button";
 import { $isProjectSettingsOpen } from "~/shared/nano-states/seo";
@@ -98,6 +98,7 @@ export const Menu = () => {
   const [, setIsPublishOpen] = useIsPublishDialogOpen();
   const { hasProPlan } = useStore($userPlanFeatures);
   const authPermit = useStore($authPermit);
+  const authTokenPermission = useStore($authTokenPermissions);
 
   const isPublishEnabled = authPermit === "own" || authPermit === "admin";
 
@@ -210,13 +211,25 @@ export const Menu = () => {
               Publish
             </DropdownMenuItem>
           </Tooltip>
-          <DropdownMenuItem
-            onSelect={() => {
-              $isCloneDialogOpen.set(true);
-            }}
+
+          <Tooltip
+            side="right"
+            content={
+              authTokenPermission.canClone === false
+                ? "Cloning is disabled by the project owner"
+                : undefined
+            }
           >
-            Clone
-          </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => {
+                $isCloneDialogOpen.set(true);
+              }}
+              disabled={authTokenPermission.canClone === false}
+            >
+              Clone
+            </DropdownMenuItem>
+          </Tooltip>
+
           <DropdownMenuSeparator />
           <DropdownMenuItem
             onSelect={() => {

--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -1,3 +1,6 @@
+import { toastError } from "../error/toast-error";
+import { $authTokenPermissions } from "../nano-states";
+
 const isValidClipboardEvent = (event: ClipboardEvent) => {
   const selection = document.getSelection();
   if (selection?.type === "Range") {
@@ -39,6 +42,12 @@ type Plugin = {
 
 export const initCopyPaste = (plugins: Plugin[]) => {
   const handleCopy = (event: ClipboardEvent) => {
+    if ($authTokenPermissions.get().canCopy === false) {
+      toastError("Copying has been disabled by the project owner");
+      event.preventDefault();
+      return;
+    }
+
     if (
       event.clipboardData === null ||
       isValidClipboardEvent(event) === false

--- a/apps/builder/app/shared/error/toast-error.tsx
+++ b/apps/builder/app/shared/error/toast-error.tsx
@@ -1,0 +1,27 @@
+import { toast } from "@webstudio-is/design-system";
+import { useEffect } from "react";
+import { $toastErrors } from "../nano-states";
+
+let toastErrorsIndex = 0;
+
+/**
+ * To show errors exposed from the canvas | builder
+ */
+export const useToastErrors = () => {
+  useEffect(() => {
+    return $toastErrors.subscribe((toastErrors) => {
+      for (let i = toastErrorsIndex; i < toastErrors.length; i++) {
+        toast.error(toastErrors[i]);
+      }
+
+      toastErrorsIndex = toastErrors.length;
+    });
+  }, []);
+};
+
+export const toastError = (error: string) => {
+  $toastErrors.set([
+    ...$toastErrors.get(),
+    "Copying has been disabled by the project owner",
+  ]);
+};

--- a/apps/builder/app/shared/error/toast-error.tsx
+++ b/apps/builder/app/shared/error/toast-error.tsx
@@ -10,8 +10,12 @@ let toastErrorsIndex = 0;
 export const useToastErrors = () => {
   useEffect(() => {
     return $toastErrors.subscribe((toastErrors) => {
-      for (let i = toastErrorsIndex; i < toastErrors.length; i++) {
-        toast.error(toastErrors[i]);
+      for (
+        let errorIndex = toastErrorsIndex;
+        errorIndex < toastErrors.length;
+        errorIndex++
+      ) {
+        toast.error(toastErrors[errorIndex]);
       }
 
       toastErrorsIndex = toastErrors.length;

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -309,6 +309,8 @@ export const $authTokenPermissions = atom<TokenPermissions>({
 
 export const $authToken = atom<string | undefined>(undefined);
 
+export const $toastErrors = atom<string[]>([]);
+
 export type DragAndDropState = {
   isDragging: boolean;
   dropTarget?: ItemDropTarget;

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -28,6 +28,7 @@ import { $selectedPage } from "./pages";
 import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
 import type { Project } from "@webstudio-is/project";
 import type { MarketplaceProduct } from "@webstudio-is/project-build";
+import type { TokenPermissions } from "@webstudio-is/authorization-token";
 
 export const $project = atom<Project | undefined>();
 
@@ -301,6 +302,10 @@ export const $hoveredInstanceSelector = atom<undefined | InstanceSelector>(
 export const $isPreviewMode = atom<boolean>(false);
 
 export const $authPermit = atom<AuthPermit>("view");
+export const $authTokenPermissions = atom<TokenPermissions>({
+  canClone: true,
+  canCopy: true,
+});
 
 export const $authToken = atom<string | undefined>(undefined);
 

--- a/apps/builder/app/shared/share-project/share-project-container.tsx
+++ b/apps/builder/app/shared/share-project/share-project-container.tsx
@@ -31,9 +31,7 @@ const useShareProjectContainer = (projectId: Project["id"]) => {
     }
     const updatedLink = {
       projectId: projectId,
-      token: link.token,
-      relation: link.relation,
-      name: link.name,
+      ...link,
     };
     const updatedLinks = links.map((currentLink) => {
       if (currentLink.token === updatedLink.token) {

--- a/apps/builder/app/shared/share-project/share-project.stories.tsx
+++ b/apps/builder/app/shared/share-project/share-project.stories.tsx
@@ -18,16 +18,22 @@ const initialLinks: Array<LinkOptions> = [
     token: uuid(),
     name: "View Only",
     relation: "viewers",
+    canClone: false,
+    canCopy: false,
   },
   {
     token: uuid(),
     name: "View and Edit",
     relation: "editors",
+    canClone: false,
+    canCopy: false,
   },
   {
     token: uuid(),
     name: "Build",
     relation: "builders",
+    canClone: false,
+    canCopy: false,
   },
 ];
 
@@ -56,6 +62,8 @@ const useShareProject = (
         token: uuid(),
         name: "Custom Link",
         relation: "viewers",
+        canClone: false,
+        canCopy: false,
       },
     ]);
   };

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -150,52 +150,74 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
               checked={value.relation === "viewers"}
               onCheckedChange={handleCheckedChange("viewers")}
               title="View"
-              info="Recipients can view, copy instances and clone the project"
+              //info="Recipients can view, copy instances and clone the project"
+              info={
+                <Flex direction="column">
+                  Recipients can view, copy instances and clone the project.
+                  {hasProPlan !== true && (
+                    <>
+                      <br />
+                      <br />
+                      Upgrade to a Pro account to set additional permissions.
+                      <br /> <br />
+                      <Link
+                        className={buttonStyle({ color: "gradient" })}
+                        color="contrast"
+                        underline="none"
+                        href="https://webstudio.is/pricing"
+                        target="_blank"
+                      >
+                        Upgrade
+                      </Link>
+                    </>
+                  )}
+                </Flex>
+              }
             />
-            {value.relation === "viewers" && hasProPlan && (
+
+            <Grid
+              css={{
+                ml: theme.spacing[6],
+              }}
+            >
               <Grid
+                gap={1}
+                flow={"column"}
                 css={{
-                  ml: theme.spacing[6],
+                  alignItems: "center",
+                  justifyContent: "start",
                 }}
               >
-                <Grid
-                  gap={1}
-                  flow={"column"}
-                  css={{
-                    alignItems: "center",
-                    justifyContent: "start",
+                <Checkbox
+                  disabled={hasProPlan !== true}
+                  checked={value.canClone}
+                  onCheckedChange={(canClone) => {
+                    onChange({ ...value, canClone: Boolean(canClone) });
                   }}
-                >
-                  <Checkbox
-                    // disabled={overwritable === false}
-                    checked={value.canClone}
-                    onCheckedChange={(canClone) => {
-                      onChange({ ...value, canClone: Boolean(canClone) });
-                    }}
-                    id={`viewer-can-clone`}
-                  />
-                  <Label htmlFor={`viewer-can-clone`}>Can clone</Label>
-                </Grid>
-                <Grid
-                  gap={1}
-                  flow={"column"}
-                  css={{
-                    alignItems: "center",
-                    justifyContent: "start",
-                  }}
-                >
-                  <Checkbox
-                    // disabled={overwritable === false}
-                    checked={value.canCopy}
-                    onCheckedChange={(canCopy) => {
-                      onChange({ ...value, canCopy: Boolean(canCopy) });
-                    }}
-                    id={`viewer-can-copy`}
-                  />
-                  <Label htmlFor={`viewer-can-copy`}>Can copy</Label>
-                </Grid>
+                  id={`viewer-can-clone`}
+                />
+                <Label htmlFor={`viewer-can-clone`}>Can clone</Label>
               </Grid>
-            )}
+              <Grid
+                gap={1}
+                flow={"column"}
+                css={{
+                  alignItems: "center",
+                  justifyContent: "start",
+                }}
+              >
+                <Checkbox
+                  disabled={hasProPlan !== true}
+                  checked={value.canCopy}
+                  onCheckedChange={(canCopy) => {
+                    onChange({ ...value, canCopy: Boolean(canCopy) });
+                  }}
+                  id={`viewer-can-copy`}
+                />
+                <Label htmlFor={`viewer-can-copy`}>Can copy</Label>
+              </Grid>
+            </Grid>
+
             <Permission
               onCheckedChange={handleCheckedChange("builders")}
               checked={value.relation === "builders"}

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -196,16 +196,6 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
                 </Grid>
               </Grid>
             )}
-            {/*
-              Hide temporarily until we have a way to allow edit content but not edit tree, etc.
-
-              <Permission
-                onCheckedChange={handleCheckedChange("editors")}
-                checked={relation === "editors"}
-                title="Edit Content"
-                info="Recipients can view the project and edit content like text and images, but they will not be able to change the styles or structure of your project."
-              />
-            */}
             <Permission
               onCheckedChange={handleCheckedChange("builders")}
               checked={value.relation === "builders"}
@@ -281,8 +271,6 @@ export type LinkOptions = {
 };
 
 type SharedLinkItemType = {
-  // onChangeRelation: (permission: Relation) => void;
-  // onChangeName: (name: string) => void;
   value: LinkOptions;
   onChange: (value: LinkOptions) => void;
   onDelete: () => void;

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -21,6 +21,8 @@ import {
   Link,
   buttonStyle,
   IconButton,
+  Checkbox,
+  Grid,
 } from "@webstudio-is/design-system";
 import {
   CopyIcon,
@@ -81,27 +83,20 @@ const Permission = ({
 };
 
 type MenuProps = {
-  relation: Relation;
   name: string;
+  value: LinkOptions;
   hasProPlan: boolean;
-  onChangePermission: (relation: Relation) => void;
-  onChangeName: (name: string) => void;
+  onChange: (value: LinkOptions) => void;
   onDelete: () => void;
 };
 
-const Menu = ({
-  hasProPlan,
-  relation,
-  name,
-  onChangePermission,
-  onChangeName,
-  onDelete,
-}: MenuProps) => {
+const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [customLinkName, setCustomLinkName] = useState<string>(name);
+
   const handleCheckedChange = (relation: Relation) => (checked: boolean) => {
     if (checked) {
-      onChangePermission(relation);
+      onChange({ ...value, relation });
     }
   };
 
@@ -110,7 +105,7 @@ const Menu = ({
       return;
     }
 
-    onChangeName(customLinkName);
+    onChange({ ...value, name: customLinkName });
     setIsOpen(false);
   };
 
@@ -142,7 +137,7 @@ const Menu = ({
                   saveCustomLinkName();
                 }
               }}
-              onBlur={() => onChangeName(customLinkName)}
+              onBlur={() => onChange({ ...value, name: customLinkName })}
               placeholder="Share Project"
               name="Name"
               autoFocus
@@ -152,24 +147,68 @@ const Menu = ({
           <Item>
             <Label>Permissions</Label>
             <Permission
-              checked={relation === "viewers"}
+              checked={value.relation === "viewers"}
               onCheckedChange={handleCheckedChange("viewers")}
               title="View"
               info="Recipients can view, copy instances and clone the project"
             />
+            {value.relation === "viewers" && hasProPlan && (
+              <Grid
+                css={{
+                  ml: theme.spacing[6],
+                }}
+              >
+                <Grid
+                  gap={1}
+                  flow={"column"}
+                  css={{
+                    alignItems: "center",
+                    justifyContent: "start",
+                  }}
+                >
+                  <Checkbox
+                    // disabled={overwritable === false}
+                    checked={value.canClone}
+                    onCheckedChange={(canClone) => {
+                      onChange({ ...value, canClone: Boolean(canClone) });
+                    }}
+                    id={`viewer-can-clone`}
+                  />
+                  <Label htmlFor={`viewer-can-clone`}>Can clone</Label>
+                </Grid>
+                <Grid
+                  gap={1}
+                  flow={"column"}
+                  css={{
+                    alignItems: "center",
+                    justifyContent: "start",
+                  }}
+                >
+                  <Checkbox
+                    // disabled={overwritable === false}
+                    checked={value.canCopy}
+                    onCheckedChange={(canCopy) => {
+                      onChange({ ...value, canCopy: Boolean(canCopy) });
+                    }}
+                    id={`viewer-can-copy`}
+                  />
+                  <Label htmlFor={`viewer-can-copy`}>Can copy</Label>
+                </Grid>
+              </Grid>
+            )}
             {/*
-           Hide temporarily until we have a way to allow edit content but not edit tree, etc.
+              Hide temporarily until we have a way to allow edit content but not edit tree, etc.
 
-          <Permission
-            onCheckedChange={handleCheckedChange("editors")}
-            checked={relation === "editors"}
-            title="Edit Content"
-            info="Recipients can view the project and edit content like text and images, but they will not be able to change the styles or structure of your project."
-          />
-          */}
+              <Permission
+                onCheckedChange={handleCheckedChange("editors")}
+                checked={relation === "editors"}
+                title="Edit Content"
+                info="Recipients can view the project and edit content like text and images, but they will not be able to change the styles or structure of your project."
+              />
+            */}
             <Permission
               onCheckedChange={handleCheckedChange("builders")}
-              checked={relation === "builders"}
+              checked={value.relation === "builders"}
               title="Build"
               info="Recipients can make any changes but can not publish the project."
             />
@@ -177,7 +216,7 @@ const Menu = ({
             <Permission
               disabled={hasProPlan !== true}
               onCheckedChange={handleCheckedChange("administrators")}
-              checked={relation === "administrators"}
+              checked={value.relation === "administrators"}
               title="Admin"
               info={
                 <Flex direction="column">
@@ -237,11 +276,15 @@ export type LinkOptions = {
   token: string;
   name: string;
   relation: Relation;
+  canCopy: boolean;
+  canClone: boolean;
 };
 
-type SharedLinkItemType = LinkOptions & {
-  onChangeRelation: (permission: Relation) => void;
-  onChangeName: (name: string) => void;
+type SharedLinkItemType = {
+  // onChangeRelation: (permission: Relation) => void;
+  // onChangeName: (name: string) => void;
+  value: LinkOptions;
+  onChange: (value: LinkOptions) => void;
   onDelete: () => void;
   builderUrl: (props: {
     authToken: string;
@@ -251,16 +294,13 @@ type SharedLinkItemType = LinkOptions & {
 };
 
 const SharedLinkItem = ({
-  token,
-  name,
-  relation,
-  onChangeRelation,
-  onChangeName,
+  value,
+  onChange,
   onDelete,
   builderUrl,
   hasProPlan,
 }: SharedLinkItemType) => {
-  const [currentName, setCurrentName] = useState(name);
+  const [currentName, setCurrentName] = useState(value.name);
   const [isCopied, setIsCopied] = useState(false);
 
   return (
@@ -280,8 +320,8 @@ const SharedLinkItem = ({
           onClick={() => {
             navigator.clipboard.writeText(
               builderUrl({
-                authToken: token,
-                mode: relation === "viewers" ? "preview" : "edit",
+                authToken: value.token,
+                mode: value.relation === "viewers" ? "preview" : "edit",
               })
             );
             setIsCopied(true);
@@ -292,11 +332,10 @@ const SharedLinkItem = ({
       </Tooltip>
       <Menu
         name={currentName}
-        relation={relation}
-        onChangePermission={onChangeRelation}
-        onChangeName={(name) => {
-          setCurrentName(name);
-          onChangeName(name);
+        value={value}
+        onChange={(value) => {
+          setCurrentName(value.name);
+          onChange(value);
         }}
         onDelete={onDelete}
         hasProPlan={hasProPlan}
@@ -344,19 +383,14 @@ export const ShareProject = ({
   const items = links.map((link) => (
     <Fragment key={link.token}>
       <SharedLinkItem
-        onChangeRelation={(relation) => {
-          onChange({ ...link, relation });
-        }}
-        onChangeName={(name) => {
-          onChange({ ...link, name });
+        onChange={(value) => {
+          onChange(value);
         }}
         onDelete={() => {
           onDelete(link);
         }}
         builderUrl={builderUrl}
-        name={link.name}
-        relation={link.relation}
-        token={link.token}
+        value={link}
         hasProPlan={hasProPlan}
       />
       <Separator />

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -24,6 +24,8 @@ import {
   $selectedInstanceRenderState,
   $hoveredInstanceSelector,
   $isPreviewMode,
+  $authTokenPermissions,
+  $toastErrors,
   synchronizedCanvasStores,
   $synchronizedInstances,
   $synchronizedBreakpoints,
@@ -108,6 +110,9 @@ export const registerContainers = () => {
   );
   clientStores.set("hoveredInstanceSelector", $hoveredInstanceSelector);
   clientStores.set("isPreviewMode", $isPreviewMode);
+  clientStores.set("authTokenPermissions", $authTokenPermissions);
+  clientStores.set("toastErrors", $toastErrors);
+
   clientStores.set("selectedStyleSources", $selectedStyleSources);
   clientStores.set("selectedStyleState", $selectedStyleState);
   clientStores.set("dragAndDropState", $dragAndDropState);

--- a/packages/authorization-token/src/db/authorization-token.ts
+++ b/packages/authorization-token/src/db/authorization-token.ts
@@ -100,17 +100,14 @@ export const create = async (
 };
 
 export const update = async (
-  props: {
-    projectId: Project["id"];
-    token: AuthorizationToken["token"];
-    name: AuthorizationToken["name"];
-    relation: AuthorizationToken["relation"];
-  },
+  projectId: Project["id"],
+  props: Pick<AuthorizationToken, "token" | "relation"> &
+    Partial<AuthorizationToken>,
   context: AppContext
 ) => {
   // Only owner of the project can edit authorization tokens
   const canCreateToken = await authorizeProject.hasProjectPermit(
-    { projectId: props.projectId, permit: "own" },
+    { projectId, permit: "own" },
     context
   );
 
@@ -124,7 +121,7 @@ export const update = async (
     where: {
       // eslint-disable-next-line camelcase
       token_projectId: {
-        projectId: props.projectId,
+        projectId,
         token: props.token,
       },
     },
@@ -136,7 +133,7 @@ export const update = async (
 
   if (previousToken.relation !== props.relation) {
     await authorizeAuthorizationToken.patchToken(
-      { tokenId: props.token, projectId: props.projectId },
+      { tokenId: props.token, projectId },
       previousToken.relation,
       props.relation,
       context
@@ -147,13 +144,15 @@ export const update = async (
     where: {
       // eslint-disable-next-line camelcase
       token_projectId: {
-        projectId: props.projectId,
+        projectId: projectId,
         token: props.token,
       },
     },
     data: {
       name: props.name,
       relation: props.relation,
+      canClone: props.canClone,
+      canCopy: props.canCopy,
     },
   });
 

--- a/packages/authorization-token/src/index.server.ts
+++ b/packages/authorization-token/src/index.server.ts
@@ -1,2 +1,2 @@
-export * as db from "./db";
+export { db } from "./db";
 export * from "./trpc";

--- a/packages/authorization-token/src/index.ts
+++ b/packages/authorization-token/src/index.ts
@@ -1,1 +1,2 @@
 export type { AuthorizationTokensRouter } from "./trpc";
+export type { TokenPermissions } from "./db/authorization-token";

--- a/packages/authorization-token/src/trpc/authorization-tokens-router.ts
+++ b/packages/authorization-token/src/trpc/authorization-tokens-router.ts
@@ -60,15 +60,19 @@ export const authorizationTokenRouter = router({
         token: z.string(),
         name: z.string(),
         relation: TokenProjectRelation,
+        canClone: z.boolean(),
+        canCopy: z.boolean(),
       })
     )
     .mutation(async ({ input, ctx }) => {
       return await db.update(
+        input.projectId,
         {
-          projectId: input.projectId,
           token: input.token,
           name: input.name,
           relation: input.relation,
+          canClone: input.canClone,
+          canCopy: input.canCopy,
         },
         ctx
       );

--- a/packages/prisma-client/prisma/migrations/20240308131249_add-token-rights/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20240308131249_add-token-rights/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "AuthorizationToken" ADD COLUMN     "canClone" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "canCopy" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -215,6 +215,9 @@ model AuthorizationToken {
   relation  AuthorizationRelation @default(viewers)
   createdAt DateTime              @default(now())
 
+  canClone Boolean @default(true)
+  canCopy  Boolean @default(true)
+
   @@id([token, projectId])
   @@unique([token])
 }


### PR DESCRIPTION
## Description


### HAS MIGRATION, CAN'T BE TESTED ONLINE


Pro users can add additional permissions to auth tokens
<img width="358" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/df294ac3-e98c-465d-8115-f74ff075ff2d">

In case of cloning is disabled user will see

<img width="448" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/c77e5598-ba0a-4a40-82fc-3aab7c1d107f">

In case of copying

<img width="506" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/a92ec66f-0b7a-4666-aa20-911de51c9d28">





## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
