### PR TITLE
feat: Add `FunctionValue` to the css-engine to describe css functions effeciently.

### DIFF
--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -695,7 +695,8 @@ const traverseStyleValue = (
     value.type === "unparsed" ||
     value.type === "invalid" ||
     value.type === "unset" ||
-    value.type === "rgb"
+    value.type === "rgb" ||
+    value.type === "function"
   ) {
     callback(value);
     return;

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -132,6 +132,33 @@ describe("Convert WS CSS Values to native CSS strings", () => {
     expect(value).toBe("10px 20px 30px 40px");
   });
 
+  test("function", () => {
+    const translate3D = toValue({
+      type: "function",
+      name: "translate3d",
+      seperator: ",",
+      args: [
+        { type: "unit", value: 42, unit: "px" },
+        { type: "unit", value: -62, unit: "px" },
+        { type: "unit", value: -135, unit: "px" },
+      ],
+    });
+
+    const dropShadowValue = toValue({
+      type: "function",
+      name: "drop-shadow",
+      args: [
+        { type: "unit", value: 10, unit: "px" },
+        { type: "unit", value: 10, unit: "px" },
+        { type: "unit", value: 10, unit: "px" },
+        { type: "keyword", value: "red" },
+      ],
+    });
+
+    expect(translate3D).toBe("translate3d(42px, -62px, -135px)");
+    expect(dropShadowValue).toBe("drop-shadow(10px 10px 10px red)");
+  });
+
   test("sanitize url", () => {
     const assets = new Map<string, { path: string }>([
       ["1234567890", { path: `fo"o\\o.png` }],

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -136,23 +136,24 @@ describe("Convert WS CSS Values to native CSS strings", () => {
     const translate3D = toValue({
       type: "function",
       name: "translate3d",
-      seperator: ",",
-      args: [
-        { type: "unit", value: 42, unit: "px" },
-        { type: "unit", value: -62, unit: "px" },
-        { type: "unit", value: -135, unit: "px" },
-      ],
+      args: {
+        type: "keyword",
+        value: "42px, -62px, -135px",
+      },
     });
 
     const dropShadowValue = toValue({
       type: "function",
       name: "drop-shadow",
-      args: [
-        { type: "unit", value: 10, unit: "px" },
-        { type: "unit", value: 10, unit: "px" },
-        { type: "unit", value: 10, unit: "px" },
-        { type: "keyword", value: "red" },
-      ],
+      args: {
+        type: "tuple",
+        value: [
+          { type: "unit", value: 10, unit: "px" },
+          { type: "unit", value: 10, unit: "px" },
+          { type: "unit", value: 10, unit: "px" },
+          { type: "keyword", value: "red" },
+        ],
+      },
     });
 
     expect(translate3D).toBe("translate3d(42px, -62px, -135px)");

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -113,9 +113,7 @@ export const toValue = (
   }
 
   if (value.type === "function") {
-    return `${value.name}(${value.args
-      .map((arg) => toValue(arg, transformValue))
-      .join(value.seperator ? ", " : " ")})`;
+    return `${value.name}(${toValue(value.args, transformValue)})`;
   }
 
   return captureError(new Error("Unknown value type"), value);

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -112,5 +112,11 @@ export const toValue = (
     return value.value.map((value) => toValue(value, transformValue)).join(" ");
   }
 
+  if (value.type === "function") {
+    return `${value.name}(${value.args
+      .map((arg) => toValue(arg, transformValue))
+      .join(value.seperator ? ", " : " ")})`;
+  }
+
   return captureError(new Error("Unknown value type"), value);
 };

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -60,12 +60,12 @@ export const FunctionValue: z.ZodType<{
   type: "function";
   name: string;
   seperator?: string | undefined;
-  args: Array<StyleValue>;
+  args: StyleValue;
 }> = z.object({
   type: z.literal("function"),
   name: z.string(),
   seperator: z.string().optional(),
-  args: z.lazy(() => z.array(StyleValue)),
+  args: z.lazy(() => StyleValue),
 });
 
 export const ImageValue = z.object({

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -54,13 +54,19 @@ const RgbValue = z.object({
 });
 export type RgbValue = z.infer<typeof RgbValue>;
 
-export const FunctionValue = z.object({
+export type FunctionValue = z.infer<typeof FunctionValue>;
+
+export const FunctionValue: z.ZodType<{
+  type: "function";
+  name: string;
+  seperator?: string | undefined;
+  args: Array<StyleValue>;
+}> = z.object({
   type: z.literal("function"),
   name: z.string(),
+  seperator: z.string().optional(),
   args: z.lazy(() => z.array(StyleValue)),
 });
-
-export type FunctionValue = z.infer<typeof FunctionValue>;
 
 export const ImageValue = z.object({
   type: z.literal("image"),
@@ -95,6 +101,7 @@ export const TupleValueItem = z.union([
   KeywordValue,
   UnparsedValue,
   RgbValue,
+  FunctionValue,
 ]);
 export type TupleValueItem = z.infer<typeof TupleValueItem>;
 
@@ -135,6 +142,7 @@ const ValidStaticStyleValue = z.union([
   RgbValue,
   UnparsedValue,
   TupleValue,
+  FunctionValue,
 ]);
 
 export type ValidStaticStyleValue = z.infer<typeof ValidStaticStyleValue>;
@@ -157,7 +165,8 @@ export const isValidStaticStyleValue = (
     staticStyleValue.type === "fontFamily" ||
     staticStyleValue.type === "rgb" ||
     staticStyleValue.type === "unparsed" ||
-    staticStyleValue.type === "tuple"
+    staticStyleValue.type === "tuple" ||
+    staticStyleValue.type === "function"
   );
 };
 

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -59,12 +59,10 @@ export type FunctionValue = z.infer<typeof FunctionValue>;
 export const FunctionValue: z.ZodType<{
   type: "function";
   name: string;
-  seperator?: string | undefined;
   args: StyleValue;
 }> = z.object({
   type: z.literal("function"),
   name: z.string(),
-  seperator: z.string().optional(),
   args: z.lazy(() => StyleValue),
 });
 

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -54,6 +54,14 @@ const RgbValue = z.object({
 });
 export type RgbValue = z.infer<typeof RgbValue>;
 
+export const FunctionValue = z.object({
+  type: z.literal("function"),
+  name: z.string(),
+  args: z.lazy(() => z.array(StyleValue)),
+});
+
+export type FunctionValue = z.infer<typeof FunctionValue>;
+
 export const ImageValue = z.object({
   type: z.literal("image"),
   value: z.union([


### PR DESCRIPTION
## Description

This PR adds a new `FunctionValue` type to the `css-engine`. This helps in defining `blur(5px)`, `drop-shadow(10px 10px 10px red)` and `translate3d(42px, -62px, -135px)` type of functions more clearly. There is a flag in the `FunctionValue` with the name `seperator` which defined that type of separator to be used  while passing the function arguments. 
In `css-tree` they use a `Operator` node. But we don't have something similar to that in the schema. So, using a new flag to define it.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [x] added tests
