### PR TITLE
fix: Set disabled labels on permission checkboxes

### DIFF
--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -196,7 +196,12 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
                   }}
                   id={`viewer-can-clone`}
                 />
-                <Label htmlFor={`viewer-can-clone`}>Can clone</Label>
+                <Label
+                  htmlFor={`viewer-can-clone`}
+                  disabled={hasProPlan !== true}
+                >
+                  Can clone
+                </Label>
               </Grid>
               <Grid
                 gap={1}
@@ -214,7 +219,12 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
                   }}
                   id={`viewer-can-copy`}
                 />
-                <Label htmlFor={`viewer-can-copy`}>Can copy</Label>
+                <Label
+                  htmlFor={`viewer-can-copy`}
+                  disabled={hasProPlan !== true}
+                >
+                  Can copy
+                </Label>
               </Grid>
             </Grid>
 

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -31,6 +31,7 @@ import {
   HelpIcon,
 } from "@webstudio-is/icons";
 import { Fragment, useState, type ComponentProps, type ReactNode } from "react";
+import { useIds } from "../form-utils";
 
 const Item = (props: ComponentProps<typeof Flex>) => (
   <Flex
@@ -91,6 +92,7 @@ type MenuProps = {
 };
 
 const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
+  const ids = useIds(["name", "canClone", "canCopy"]);
   const [isOpen, setIsOpen] = useState(false);
   const [customLinkName, setCustomLinkName] = useState<string>(name);
 
@@ -127,8 +129,9 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
           sideOffset={0}
         >
           <Item>
-            <Label>Name</Label>
+            <Label htmlFor={ids.name}>Name</Label>
             <InputField
+              id={ids.name}
               color={customLinkName.length === 0 ? "error" : undefined}
               value={customLinkName}
               onChange={(event) => setCustomLinkName(event.target.value.trim())}
@@ -194,12 +197,9 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
                   onCheckedChange={(canClone) => {
                     onChange({ ...value, canClone: Boolean(canClone) });
                   }}
-                  id={`viewer-can-clone`}
+                  id={ids.canClone}
                 />
-                <Label
-                  htmlFor={`viewer-can-clone`}
-                  disabled={hasProPlan !== true}
-                >
+                <Label htmlFor={ids.canClone} disabled={hasProPlan !== true}>
                   Can clone
                 </Label>
               </Grid>
@@ -217,12 +217,9 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
                   onCheckedChange={(canCopy) => {
                     onChange({ ...value, canCopy: Boolean(canCopy) });
                   }}
-                  id={`viewer-can-copy`}
+                  id={ids.canCopy}
                 />
-                <Label
-                  htmlFor={`viewer-can-copy`}
-                  disabled={hasProPlan !== true}
-                >
+                <Label htmlFor={ids.canCopy} disabled={hasProPlan !== true}>
                   Can copy
                 </Label>
               </Grid>


### PR DESCRIPTION
## Description

<img width="189" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/c0635e53-e2a9-4f5b-86b1-4a6904eff2d3">

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
