### PR TITLE
fix: detect scroll collision for form error tooltips

### DIFF
--- a/packages/design-system/src/components/tooltip.stories.tsx
+++ b/packages/design-system/src/components/tooltip.stories.tsx
@@ -1,0 +1,63 @@
+import { InputErrorsTooltip, TooltipProvider } from "./tooltip";
+import { Button } from "./button";
+import { Box } from "./box";
+
+export default {
+  title: "Library/Tooltip",
+};
+
+const TooltipStory = () => {
+  return (
+    <TooltipProvider>
+      <Box>Some content</Box>
+      {/*
+      <InputErrorsTooltip errors={["Tooltip content"]}>
+        <Button>Hover me</Button>
+      </InputErrorsTooltip>
+  */}
+      <Box>Some content</Box>
+      <Box css={{ height: 100, width: 200, overflowY: "scroll" }}>
+        <Box css={{ height: 2000 }}>
+          <InputErrorsTooltip
+            errors={["Tooltip content"]}
+            side={"right"}
+            open={true}
+          >
+            <Button css={{ width: "100%", my: 10 }}>Hover me</Button>
+          </InputErrorsTooltip>
+          <br />
+          <br />
+          <InputErrorsTooltip
+            errors={["Tooltip content"]}
+            side={"right"}
+            open={true}
+          >
+            <Button css={{ width: "100%", my: 10 }}>Hover me</Button>
+          </InputErrorsTooltip>
+          <br />
+          <br />
+          <InputErrorsTooltip
+            errors={["Tooltip content"]}
+            side={"right"}
+            open={true}
+          >
+            <Button css={{ width: "100%", my: 10 }}>Hover me</Button>
+          </InputErrorsTooltip>
+          <br />
+          <br />
+          <InputErrorsTooltip
+            errors={["Tooltip content"]}
+            side={"right"}
+            open={true}
+          >
+            <Button css={{ width: "100%", my: 10 }}>Hover me</Button>
+          </InputErrorsTooltip>
+          <br />
+          <br />
+        </Box>
+      </Box>
+    </TooltipProvider>
+  );
+};
+
+export { TooltipStory as Tooltip };

--- a/packages/design-system/src/components/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip.tsx
@@ -182,11 +182,9 @@ export const InputErrorsTooltip = ({
           () => {
             const rect = nearestScrollableElement.getBoundingClientRect();
 
-            const collisionPadding = -8;
-
             setCollisionBoundary((prev) => {
-              const newY = rect.y + collisionPadding;
-              const newHeight = rect.height - 2 * collisionPadding;
+              const newY = rect.y;
+              const newHeight = rect.height;
 
               if (prev?.y === newY && prev.height === newHeight) {
                 return prev;
@@ -219,7 +217,7 @@ export const InputErrorsTooltip = ({
       <Tooltip
         {...rest}
         collisionBoundary={collisionBoundary as never}
-        collisionPadding={0}
+        collisionPadding={-8}
         hideWhenDetached={true}
         content={content ?? " "}
         open={errors !== undefined && errors.length !== 0}

--- a/packages/design-system/src/components/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip.tsx
@@ -1,5 +1,7 @@
 import type { Ref, ComponentProps, ReactNode, ReactElement } from "react";
-import { forwardRef, useEffect } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
+import { autoUpdate, getOverflowAncestors } from "@floating-ui/dom";
+
 import { styled } from "../stitches.config";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
@@ -138,19 +140,82 @@ export const InputErrorsTooltip = ({
   const content = errors?.map((error, index) => (
     <Text key={index}>{error}</Text>
   ));
+
+  const ref = useRef<HTMLDivElement>();
+  const [collisionBoundary, setCollisionBoundary] = useState<
+    | {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      }
+    | undefined
+  >(undefined);
+
+  useEffect(() => {
+    if (ref.current != null) {
+      const ancestors = getOverflowAncestors(ref.current, [], false);
+      if (ancestors.length === 2) {
+        // Only window and window viewport - do nothing
+        return;
+      }
+
+      const nearesScrollableElement = ancestors[0];
+
+      if (nearesScrollableElement instanceof HTMLElement) {
+        const cleanup = autoUpdate(
+          ancestors[1] as never,
+          nearesScrollableElement,
+          () => {
+            const rect = nearesScrollableElement.getBoundingClientRect();
+
+            const collisionPadding = -8;
+
+            setCollisionBoundary((prev) => {
+              const newY = rect.y + collisionPadding;
+              const newHeight = rect.height - 2 * collisionPadding;
+
+              if (prev?.y === newY && prev.height === newHeight) {
+                return prev;
+              }
+
+              const next = {
+                x: 0,
+                width: window.visualViewport?.width ?? 100000,
+                y: newY,
+                height: newHeight,
+              };
+
+              return next;
+            });
+          }
+        );
+
+        return cleanup;
+      }
+    }
+  }, []);
+
+  // We intentionally always pass non empty content to avoid optimization inside Tooltip
+  // where it renders {children} directly if content is empty.
+  // If this optimization accur, the input will remount which will cause focus loss
+  // and current value loss.
+
   return (
-    // We intentionally always pass non empty content to avoid optimization inside Tooltip
-    // where it renders {children} directly if content is empty.
-    // If this optimization accur, the input will remount which will cause focus loss
-    // and current value loss.
-    <Tooltip
-      {...rest}
-      content={content ?? " "}
-      open={errors !== undefined && errors.length !== 0}
-      side={side ?? "right"}
-      css={css}
-    >
-      {children}
-    </Tooltip>
+    <>
+      <Box ref={ref as never} css={{ display: "contents" }}></Box>
+      <Tooltip
+        {...rest}
+        collisionBoundary={collisionBoundary as never}
+        collisionPadding={0}
+        hideWhenDetached={true}
+        content={content ?? " "}
+        open={errors !== undefined && errors.length !== 0}
+        side={side ?? "right"}
+        css={css}
+      >
+        {children}
+      </Tooltip>
+    </>
   );
 };


### PR DESCRIPTION
## Description

fixes
<img width="907" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/686bc5c5-a502-42e9-b7a9-7b1c158d1945">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
