### PR TITLE
fix: Fix marketplace form thumb rendering for wrong proportions

### DIFF
--- a/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
@@ -39,21 +39,21 @@ import {
 } from "@webstudio-is/project";
 import { projectsPath } from "~/shared/router-utils";
 
-const imgStyle = css({
+const thumbnailStyle = css({
   borderRadius: theme.borderRadius[4],
   borderWidth: 1,
   borderStyle: "solid",
   borderColor: theme.colors.borderMain,
   aspectRatio: "1.91",
+  objectFit: "cover",
+});
+const imageLoader = createImageLoader({
+  imageBaseUrl: env.IMAGE_BASE_URL,
 });
 
 const defaultMarketplaceProduct: Partial<MarketplaceProduct> = {
   category: "sectionTemplates",
 };
-
-const imageLoader = createImageLoader({
-  imageBaseUrl: env.IMAGE_BASE_URL,
-});
 
 const trpc = createTrpcRemixProxy<ProjectRouter>((method) =>
   projectsPath(method, { authToken: $authToken.get() })
@@ -208,7 +208,7 @@ export const SectionMarketplace = () => {
           <InputErrorsTooltip errors={errors?.thumbnailAssetId}>
             <Image
               width={rawTheme.spacing[28]}
-              className={imgStyle()}
+              className={thumbnailStyle()}
               src={thumbnailUrl}
               loader={imageLoader}
             />


### PR DESCRIPTION
## Description

When uploading wrong proportions they should still render okay

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
