### PR TITLE
fix: Use empty alt attribute by default

### DIFF
--- a/packages/image/src/image-optimize.test.ts
+++ b/packages/image/src/image-optimize.test.ts
@@ -158,7 +158,7 @@ describe("Image optimizations not applied", () => {
       loader: createImageLoader({ imageBaseUrl: "/asset/image/" }),
     });
 
-    expect(imgAttr).toMatchInlineSnapshot(`null`);
+    expect(imgAttr).toMatchInlineSnapshot(`undefined`);
   });
 
   test("src is undefined", () => {
@@ -172,6 +172,6 @@ describe("Image optimizations not applied", () => {
       loader: createImageLoader({ imageBaseUrl: "/asset/image/" }),
     });
 
-    expect(imgAttr).toMatchInlineSnapshot(`null`);
+    expect(imgAttr).toMatchInlineSnapshot(`undefined`);
   });
 });

--- a/packages/image/src/image-optimize.ts
+++ b/packages/image/src/image-optimize.ts
@@ -238,11 +238,13 @@ export const getImageAttributes = (props: {
   quality: string | number | undefined;
   loader: ImageLoader;
   optimize: boolean;
-}): {
-  src: string;
-  srcSet?: string;
-  sizes?: string;
-} | null => {
+}):
+  | {
+      src: string;
+      srcSet?: string;
+      sizes?: string;
+    }
+  | undefined => {
   const width = getInt(props.width);
   const quality = Math.max(
     Math.min(getInt(props.quality) ?? DEFAULT_QUALITY, 100),
@@ -279,6 +281,4 @@ export const getImageAttributes = (props: {
 
     return resAttrs;
   }
-
-  return null;
 };

--- a/packages/image/src/image.tsx
+++ b/packages/image/src/image.tsx
@@ -33,6 +33,7 @@ export const Image = forwardRef<ElementRef<typeof defaultTag>, ImageProps>(
 
     return (
       <img
+        alt=""
         {...imageProps}
         {...imageAttributes}
         decoding={decoding}


### PR DESCRIPTION
https://discord.com/channels/955905230107738152/1217108594735190066

## Description

Images should either have an alt text or be decorative. By adding an empty alt by default, they are becoming decorative by default which seems logical, because if you can't explain what's in the picture to assistive tools, then they should be ignoring that picture

https://www.w3.org/WAI/tutorials/images/decorative/

## Steps for reproduction

1. by default see alt is empty (<img alt> is the same as. <img alt="">)
2. when set by the user its applied

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
