### PR TITLE
experimental: switch to system variable for params in builder

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -264,8 +264,8 @@ const $hiddenDataSourceIds = computed(
     }
     if (pages) {
       for (const page of pages.pages) {
-        if (page.pathParamsDataSourceId) {
-          dataSourceIds.delete(page.pathParamsDataSourceId);
+        if (page.systemDataSourceId) {
+          dataSourceIds.delete(page.systemDataSourceId);
         }
       }
     }

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
@@ -327,6 +327,12 @@ const $pageRootVariableValues = computed(
       if (variable.type === "parameter") {
         const value = dataSourceVariables.get(variable.id);
         variableValues.set(variable.id, value);
+        if (variable.id === page.systemDataSourceId && value === undefined) {
+          variableValues.set(variable.id, {
+            params: {},
+            search: {},
+          });
+        }
       }
       if (variable.type === "resource") {
         const value = resourceValues.get(variable.resourceId);
@@ -428,10 +434,6 @@ export const duplicatePage = (pageId: Page["id"]) => {
       availableDataSources: new Set(),
     });
     const newRootInstanceId = newInstanceIds.get(page.rootInstanceId);
-    const newPathParamsDataSourceId =
-      page.pathParamsDataSourceId === undefined
-        ? undefined
-        : newDataSourceIds.get(page.pathParamsDataSourceId);
     // @todo simplify after releasing migration with system variable
     const newSystemDataSourceId =
       page.systemDataSourceId === undefined
@@ -445,7 +447,6 @@ export const duplicatePage = (pageId: Page["id"]) => {
       ...page,
       id: newPageId,
       rootInstanceId: newRootInstanceId,
-      pathParamsDataSourceId: newPathParamsDataSourceId,
       systemDataSourceId: newSystemDataSourceId,
       // @todo create new data source
       name: newName,

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -358,6 +358,15 @@ export const $variableValuesByInstanceSelector = computed(
           if (variable.type === "parameter") {
             const value = dataSourceVariables.get(variable.id);
             variableValues.set(variable.id, value);
+            if (
+              variable.id === page.systemDataSourceId &&
+              value === undefined
+            ) {
+              variableValues.set(variable.id, {
+                params: {},
+                search: {},
+              });
+            }
           }
           if (variable.type === "resource") {
             const value = resourceValues.get(variable.resourceId);

--- a/fixtures/webstudio-custom-template/.webstudio/data.json
+++ b/fixtures/webstudio-custom-template/.webstudio/data.json
@@ -26,7 +26,8 @@
           "description": "\"Page description f511c297-b44f-4e4b-96bd-d013da06bada\""
         },
         "rootInstanceId": "ibXgMoi9_ipHx1gVrvii0",
-        "path": ""
+        "path": "",
+        "systemDataSourceId": "gzU1wxmnHwY-x5jPet-3Y"
       },
       "pages": [
         {
@@ -45,7 +46,8 @@
             ]
           },
           "rootInstanceId": "LW98_-srDnnagkR10lsk4",
-          "path": "/script-test"
+          "path": "/script-test",
+          "systemDataSourceId": "pCHIauvdC2bIuiCOAhV9Z"
         },
         {
           "id": "lyz5sZaJ7WzLt71cX3VJ2",
@@ -61,7 +63,8 @@
             "custom": []
           },
           "rootInstanceId": "jDb2FuSK2-azIZxkH5XNv",
-          "path": "/world"
+          "path": "/world",
+          "systemDataSourceId": "E2nbgH6ec91fv6I4xF7DR"
         }
       ],
       "folders": [
@@ -515,7 +518,35 @@
         }
       ]
     ],
-    "dataSources": [],
+    "dataSources": [
+      [
+        "gzU1wxmnHwY-x5jPet-3Y",
+        {
+          "id": "gzU1wxmnHwY-x5jPet-3Y",
+          "scopeInstanceId": "ibXgMoi9_ipHx1gVrvii0",
+          "name": "system",
+          "type": "parameter"
+        }
+      ],
+      [
+        "pCHIauvdC2bIuiCOAhV9Z",
+        {
+          "id": "pCHIauvdC2bIuiCOAhV9Z",
+          "scopeInstanceId": "LW98_-srDnnagkR10lsk4",
+          "name": "system",
+          "type": "parameter"
+        }
+      ],
+      [
+        "E2nbgH6ec91fv6I4xF7DR",
+        {
+          "id": "E2nbgH6ec91fv6I4xF7DR",
+          "scopeInstanceId": "jDb2FuSK2-azIZxkH5XNv",
+          "name": "system",
+          "type": "parameter"
+        }
+      ]
+    ],
     "resources": [],
     "instances": [
       [
@@ -653,7 +684,8 @@
       "description": "\"Page description f511c297-b44f-4e4b-96bd-d013da06bada\""
     },
     "rootInstanceId": "ibXgMoi9_ipHx1gVrvii0",
-    "path": ""
+    "path": "",
+    "systemDataSourceId": "gzU1wxmnHwY-x5jPet-3Y"
   },
   "pages": [
     {
@@ -664,7 +696,8 @@
         "description": "\"Page description f511c297-b44f-4e4b-96bd-d013da06bada\""
       },
       "rootInstanceId": "ibXgMoi9_ipHx1gVrvii0",
-      "path": ""
+      "path": "",
+      "systemDataSourceId": "gzU1wxmnHwY-x5jPet-3Y"
     },
     {
       "id": "xT46WZKzCBTvUCIObMELW",
@@ -682,7 +715,8 @@
         ]
       },
       "rootInstanceId": "LW98_-srDnnagkR10lsk4",
-      "path": "/script-test"
+      "path": "/script-test",
+      "systemDataSourceId": "pCHIauvdC2bIuiCOAhV9Z"
     },
     {
       "id": "lyz5sZaJ7WzLt71cX3VJ2",
@@ -698,7 +732,8 @@
         "custom": []
       },
       "rootInstanceId": "jDb2FuSK2-azIZxkH5XNv",
-      "path": "/world"
+      "path": "/world",
+      "systemDataSourceId": "E2nbgH6ec91fv6I4xF7DR"
     }
   ],
   "assets": [

--- a/fixtures/webstudio-remix-netlify-edge-functions/.webstudio/data.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/.webstudio/data.json
@@ -20,7 +20,8 @@
         "title": "\"Home\"",
         "meta": {},
         "rootInstanceId": "MMimeobf_zi4ZkRGXapju",
-        "path": ""
+        "path": "",
+        "systemDataSourceId": "HdKSzlJZasGmZlW8b-va0"
       },
       "pages": [],
       "folders": [
@@ -134,7 +135,17 @@
       ]
     ],
     "props": [],
-    "dataSources": [],
+    "dataSources": [
+      [
+        "HdKSzlJZasGmZlW8b-va0",
+        {
+          "id": "HdKSzlJZasGmZlW8b-va0",
+          "scopeInstanceId": "MMimeobf_zi4ZkRGXapju",
+          "name": "system",
+          "type": "parameter"
+        }
+      ]
+    ],
     "resources": [],
     "instances": [
       [
@@ -196,7 +207,8 @@
     "title": "\"Home\"",
     "meta": {},
     "rootInstanceId": "MMimeobf_zi4ZkRGXapju",
-    "path": ""
+    "path": "",
+    "systemDataSourceId": "HdKSzlJZasGmZlW8b-va0"
   },
   "pages": [
     {
@@ -205,7 +217,8 @@
       "title": "\"Home\"",
       "meta": {},
       "rootInstanceId": "MMimeobf_zi4ZkRGXapju",
-      "path": ""
+      "path": "",
+      "systemDataSourceId": "HdKSzlJZasGmZlW8b-va0"
     }
   ],
   "assets": [],

--- a/fixtures/webstudio-remix-netlify-functions/.webstudio/data.json
+++ b/fixtures/webstudio-remix-netlify-functions/.webstudio/data.json
@@ -20,7 +20,8 @@
         "title": "\"Home\"",
         "meta": {},
         "rootInstanceId": "MMimeobf_zi4ZkRGXapju",
-        "path": ""
+        "path": "",
+        "systemDataSourceId": "HdKSzlJZasGmZlW8b-va0"
       },
       "pages": [],
       "folders": [
@@ -134,7 +135,17 @@
       ]
     ],
     "props": [],
-    "dataSources": [],
+    "dataSources": [
+      [
+        "HdKSzlJZasGmZlW8b-va0",
+        {
+          "id": "HdKSzlJZasGmZlW8b-va0",
+          "scopeInstanceId": "MMimeobf_zi4ZkRGXapju",
+          "name": "system",
+          "type": "parameter"
+        }
+      ]
+    ],
     "resources": [],
     "instances": [
       [
@@ -196,7 +207,8 @@
     "title": "\"Home\"",
     "meta": {},
     "rootInstanceId": "MMimeobf_zi4ZkRGXapju",
-    "path": ""
+    "path": "",
+    "systemDataSourceId": "HdKSzlJZasGmZlW8b-va0"
   },
   "pages": [
     {
@@ -205,7 +217,8 @@
       "title": "\"Home\"",
       "meta": {},
       "rootInstanceId": "MMimeobf_zi4ZkRGXapju",
-      "path": ""
+      "path": "",
+      "systemDataSourceId": "HdKSzlJZasGmZlW8b-va0"
     }
   ],
   "assets": [],

--- a/fixtures/webstudio-remix-vercel/.webstudio/data.json
+++ b/fixtures/webstudio-remix-vercel/.webstudio/data.json
@@ -29,7 +29,8 @@
           ]
         },
         "rootInstanceId": "On9cvWCxr5rdZtY9O1Bv0",
-        "path": ""
+        "path": "",
+        "systemDataSourceId": "ram6PSGTMg41lcfdoUGrV"
       },
       "pages": [
         {
@@ -42,7 +43,8 @@
             "socialImageAssetId": "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10"
           },
           "rootInstanceId": "uKWGyE9JY3cPwY-xI9vk6",
-          "path": "/radix"
+          "path": "/radix",
+          "systemDataSourceId": "WihU_iOb3p4rS3nJD6NvB"
         },
         {
           "id": "szYLvBduHPmbtqQKCDY0b",
@@ -52,7 +54,8 @@
             "description": "\"\""
           },
           "rootInstanceId": "EDEfpMPRqDejthtwkH7ws",
-          "path": "/_route_with_symbols_"
+          "path": "/_route_with_symbols_",
+          "systemDataSourceId": "_8Ok9oPHB3wlwjhX7Mlai"
         },
         {
           "id": "U1tRJl2ERr8_OFe0g9cN_",
@@ -62,7 +65,8 @@
             "description": "\"\""
           },
           "rootInstanceId": "a-4nDFkaWy4px1fn38XWJ",
-          "path": "/form"
+          "path": "/form",
+          "systemDataSourceId": "FNmfYcbf2VF3yudEbZwzx"
         },
         {
           "id": "-J9I4Oo6mONfQlf_3-OqG",
@@ -72,7 +76,8 @@
             "description": "\"\""
           },
           "rootInstanceId": "O-ljaGZQ0iRNTlEshMkgE",
-          "path": "/heading-with-id"
+          "path": "/heading-with-id",
+          "systemDataSourceId": "YR7MLRg2bNHQqYgUhm27J"
         },
         {
           "id": "TS39WeBd0Qr3QgbSlzdf2",
@@ -90,7 +95,8 @@
             ]
           },
           "rootInstanceId": "AWY2qZfpbykoiWELeJhse",
-          "path": "/resources"
+          "path": "/resources",
+          "systemDataSourceId": "wTJbVXFa4Mul6Qg5ZcooO"
         },
         {
           "id": "Pnz-BxUm6XmvFygk_XdEy",
@@ -108,7 +114,8 @@
             ]
           },
           "rootInstanceId": "L0ZXd5F9xk9Rsl9ORzIkJ",
-          "path": "/nested-page"
+          "path": "/nested-page",
+          "systemDataSourceId": "X05l8b5NS4KvFRiiloGqF"
         }
       ],
       "folders": [
@@ -2224,6 +2231,69 @@
           "scopeInstanceId": "WGSZGPAhyIuWhM1DJ7HbZ",
           "name": "collectionItem"
         }
+      ],
+      [
+        "ram6PSGTMg41lcfdoUGrV",
+        {
+          "id": "ram6PSGTMg41lcfdoUGrV",
+          "scopeInstanceId": "On9cvWCxr5rdZtY9O1Bv0",
+          "name": "system",
+          "type": "parameter"
+        }
+      ],
+      [
+        "WihU_iOb3p4rS3nJD6NvB",
+        {
+          "id": "WihU_iOb3p4rS3nJD6NvB",
+          "scopeInstanceId": "uKWGyE9JY3cPwY-xI9vk6",
+          "name": "system",
+          "type": "parameter"
+        }
+      ],
+      [
+        "_8Ok9oPHB3wlwjhX7Mlai",
+        {
+          "id": "_8Ok9oPHB3wlwjhX7Mlai",
+          "scopeInstanceId": "EDEfpMPRqDejthtwkH7ws",
+          "name": "system",
+          "type": "parameter"
+        }
+      ],
+      [
+        "FNmfYcbf2VF3yudEbZwzx",
+        {
+          "id": "FNmfYcbf2VF3yudEbZwzx",
+          "scopeInstanceId": "a-4nDFkaWy4px1fn38XWJ",
+          "name": "system",
+          "type": "parameter"
+        }
+      ],
+      [
+        "YR7MLRg2bNHQqYgUhm27J",
+        {
+          "id": "YR7MLRg2bNHQqYgUhm27J",
+          "scopeInstanceId": "O-ljaGZQ0iRNTlEshMkgE",
+          "name": "system",
+          "type": "parameter"
+        }
+      ],
+      [
+        "wTJbVXFa4Mul6Qg5ZcooO",
+        {
+          "id": "wTJbVXFa4Mul6Qg5ZcooO",
+          "scopeInstanceId": "AWY2qZfpbykoiWELeJhse",
+          "name": "system",
+          "type": "parameter"
+        }
+      ],
+      [
+        "X05l8b5NS4KvFRiiloGqF",
+        {
+          "id": "X05l8b5NS4KvFRiiloGqF",
+          "scopeInstanceId": "L0ZXd5F9xk9Rsl9ORzIkJ",
+          "name": "system",
+          "type": "parameter"
+        }
       ]
     ],
     "resources": [
@@ -3302,7 +3372,8 @@
       ]
     },
     "rootInstanceId": "On9cvWCxr5rdZtY9O1Bv0",
-    "path": ""
+    "path": "",
+    "systemDataSourceId": "ram6PSGTMg41lcfdoUGrV"
   },
   "pages": [
     {
@@ -3320,7 +3391,8 @@
         ]
       },
       "rootInstanceId": "On9cvWCxr5rdZtY9O1Bv0",
-      "path": ""
+      "path": "",
+      "systemDataSourceId": "ram6PSGTMg41lcfdoUGrV"
     },
     {
       "id": "xfvB4UThQXmQ_OubPYrkg",
@@ -3332,7 +3404,8 @@
         "socialImageAssetId": "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10"
       },
       "rootInstanceId": "uKWGyE9JY3cPwY-xI9vk6",
-      "path": "/radix"
+      "path": "/radix",
+      "systemDataSourceId": "WihU_iOb3p4rS3nJD6NvB"
     },
     {
       "id": "szYLvBduHPmbtqQKCDY0b",
@@ -3342,7 +3415,8 @@
         "description": "\"\""
       },
       "rootInstanceId": "EDEfpMPRqDejthtwkH7ws",
-      "path": "/_route_with_symbols_"
+      "path": "/_route_with_symbols_",
+      "systemDataSourceId": "_8Ok9oPHB3wlwjhX7Mlai"
     },
     {
       "id": "U1tRJl2ERr8_OFe0g9cN_",
@@ -3352,7 +3426,8 @@
         "description": "\"\""
       },
       "rootInstanceId": "a-4nDFkaWy4px1fn38XWJ",
-      "path": "/form"
+      "path": "/form",
+      "systemDataSourceId": "FNmfYcbf2VF3yudEbZwzx"
     },
     {
       "id": "-J9I4Oo6mONfQlf_3-OqG",
@@ -3362,7 +3437,8 @@
         "description": "\"\""
       },
       "rootInstanceId": "O-ljaGZQ0iRNTlEshMkgE",
-      "path": "/heading-with-id"
+      "path": "/heading-with-id",
+      "systemDataSourceId": "YR7MLRg2bNHQqYgUhm27J"
     },
     {
       "id": "TS39WeBd0Qr3QgbSlzdf2",
@@ -3380,7 +3456,8 @@
         ]
       },
       "rootInstanceId": "AWY2qZfpbykoiWELeJhse",
-      "path": "/resources"
+      "path": "/resources",
+      "systemDataSourceId": "wTJbVXFa4Mul6Qg5ZcooO"
     },
     {
       "id": "Pnz-BxUm6XmvFygk_XdEy",
@@ -3398,7 +3475,8 @@
         ]
       },
       "rootInstanceId": "L0ZXd5F9xk9Rsl9ORzIkJ",
-      "path": "/nested-page"
+      "path": "/nested-page",
+      "systemDataSourceId": "X05l8b5NS4KvFRiiloGqF"
     }
   ],
   "assets": [


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Here replaced Path Params variable with system variable in builder. Now system always prefilled with `{ params: {}, search: {} }` to let user always see the structure and not get confused with undefined.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
