### PR TITLE
experimental: switch matched dynamic paths

### DIFF
--- a/apps/builder/app/builder/features/address-bar.tsx
+++ b/apps/builder/app/builder/features/address-bar.tsx
@@ -27,6 +27,7 @@ import {
   $pages,
   $project,
   $selectedPage,
+  updateSystemParams,
 } from "~/shared/nano-states";
 import env from "~/shared/env";
 import {
@@ -66,11 +67,6 @@ export type System = {
   search: Record<string, string>;
 };
 
-const initialSystem: System = {
-  params: {},
-  search: {},
-};
-
 const $selectedPagePathParams = computed(
   [$selectedPage, $dataSourceVariables],
   (selectedPage, dataSourceVariables) => {
@@ -97,18 +93,8 @@ const updatePathParam = (name: string, value: string) => {
   }
   newParams[name] = value;
   const page = $selectedPage.get();
-  if (page?.systemDataSourceId) {
-    const dataSourceVariables = new Map($dataSourceVariables.get());
-    const system = dataSourceVariables.get(page.systemDataSourceId) as
-      | undefined
-      | System;
-    const newSystem: System = {
-      ...initialSystem,
-      ...system,
-      params: newParams,
-    };
-    dataSourceVariables.set(page.systemDataSourceId, newSystem);
-    $dataSourceVariables.set(dataSourceVariables);
+  if (page) {
+    updateSystemParams(page, newParams);
   }
 };
 

--- a/apps/builder/app/builder/shared/url-pattern.ts
+++ b/apps/builder/app/builder/shared/url-pattern.ts
@@ -1,5 +1,16 @@
 import { URLPattern } from "urlpattern-polyfill";
 
+const baseUrl = "http://url";
+
+export const matchPathnamePattern = (pattern: string, pathname: string) => {
+  try {
+    return new URLPattern({ pathname: pattern }).exec({ pathname })?.pathname
+      .groups;
+  } catch {
+    // empty block
+  }
+};
+
 // allowed syntax
 // :name - group without modifiers
 // :name? - group with optional modifier
@@ -80,8 +91,6 @@ export const compilePathnamePattern = (
   }
   return compiledPathname;
 };
-
-const baseUrl = "http://url";
 
 export const validatePathnamePattern = (pathname: string) => {
   try {

--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -1,5 +1,10 @@
 import { findPageByIdOrPath } from "@webstudio-is/sdk";
-import { $isPreviewMode, $pages } from "~/shared/nano-states";
+import { matchPathnamePattern } from "~/builder/shared/url-pattern";
+import {
+  $isPreviewMode,
+  $pages,
+  updateSystemParams,
+} from "~/shared/nano-states";
 import { switchPage } from "~/shared/pages";
 
 const isAbsoluteUrl = (href: string) => {
@@ -24,6 +29,14 @@ const handleLinkClick = (element: HTMLAnchorElement) => {
   }
 
   const pageHref = new URL(href, "https://any-valid.url");
+  for (const page of [pages.homePage, ...pages.pages]) {
+    const params = matchPathnamePattern(page.path, pageHref.pathname);
+    if (params) {
+      switchPage(page.id, pageHref.hash);
+      updateSystemParams(page, params);
+      break;
+    }
+  }
   const page = findPageByIdOrPath(pageHref.pathname, pages);
   if (page) {
     switchPage(page.id, pageHref.hash);

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -9,6 +9,7 @@ import type {
   DataSource,
   DataSources,
   Instance,
+  Page,
   Prop,
   Props,
   Resource,
@@ -17,6 +18,7 @@ import type {
   StyleSource,
   StyleSources,
   StyleSourceSelections,
+  System,
 } from "@webstudio-is/sdk";
 import type { Style } from "@webstudio-is/css-engine";
 import type { DragStartPayload } from "~/canvas/shared/use-drag-drop";
@@ -48,6 +50,22 @@ export const $dataSources = atom<DataSources>(new Map());
 export const $dataSourceVariables = atom<Map<DataSource["id"], unknown>>(
   new Map()
 );
+
+export const updateSystemParams = (page: Page, params: System["params"]) => {
+  if (page.systemDataSourceId === undefined) {
+    return;
+  }
+  const dataSourceVariables = new Map($dataSourceVariables.get());
+  const system = dataSourceVariables.get(page.systemDataSourceId) as
+    | undefined
+    | System;
+  dataSourceVariables.set(page.systemDataSourceId, {
+    search: {},
+    ...system,
+    params: params,
+  } satisfies System);
+  $dataSourceVariables.set(dataSourceVariables);
+};
 
 export const $resources = atom(new Map<Resource["id"], Resource>());
 export const $resourceValues = atom(new Map<Resource["id"], unknown>());


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Here added support for navigating to dynamic paths in preview mode by using URLPattern matcher. Matched params are filled into address bar to simplify accessing dynamic pages without manually entering params.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
