### PR TITLE
feat: TRPC caching support

### DIFF
--- a/apps/builder/app/shared/context.server.ts
+++ b/apps/builder/app/shared/context.server.ts
@@ -84,6 +84,23 @@ const createUserPlanContext = async (
   return planFeatures;
 };
 
+const createTrpcCache = () => {
+  const proceduresMaxAge = new Map<string, number>();
+  const setMaxAge = (path: string, value: number) => {
+    proceduresMaxAge.set(
+      path,
+      Math.min(proceduresMaxAge.get(path) ?? Number.MAX_SAFE_INTEGER, value)
+    );
+  };
+
+  const getMaxAge = (path: string) => proceduresMaxAge.get(path);
+
+  return {
+    setMaxAge,
+    getMaxAge,
+  };
+};
+
 /**
  * argument buildEnv==="prod" only if we are loading project with production build
  */
@@ -93,11 +110,14 @@ export const createContext = async (request: Request): Promise<AppContext> => {
   const deployment = createDeploymentContext(request);
   const entri = createEntriContext();
   const userPlanFeatures = await createUserPlanContext(request, authorization);
+  const trpcCache = createTrpcCache();
+
   return {
     authorization,
     domain,
     deployment,
     entri,
     userPlanFeatures,
+    trpcCache,
   };
 };

--- a/apps/builder/app/shared/marketplace/router.server.ts
+++ b/apps/builder/app/shared/marketplace/router.server.ts
@@ -1,12 +1,19 @@
 import { z } from "zod";
-import { procedure, router } from "@webstudio-is/trpc-interface/index.server";
+import {
+  procedure,
+  router,
+  createCacheMiddleware,
+} from "@webstudio-is/trpc-interface/index.server";
 import { getItems, getBuildProdData } from "./db.server";
 
+const cacheMiddleware = createCacheMiddleware(60 * 3); // 60 * 3 = 3 minutes cache
+const cachedProcedure = procedure.use(cacheMiddleware);
+
 export const marketplaceRouter = router({
-  getItems: procedure.query(async () => {
+  getItems: cachedProcedure.query(async () => {
     return await getItems();
   }),
-  getBuildData: procedure
+  getBuildData: cachedProcedure
     .input(
       z.object({
         projectId: z.string(),

--- a/packages/trpc-interface/src/context/context.server.ts
+++ b/packages/trpc-interface/src/context/context.server.ts
@@ -69,6 +69,11 @@ type UserPlanFeatures = {
   boolean | number
 >;
 
+type TrpcCache = {
+  setMaxAge: (path: string, value: number) => void;
+  getMaxAge: (path: string) => number | undefined;
+};
+
 /**
  * AppContext is a global context that is passed to all trpc/api queries/mutations
  * "authorization" is made inside the namespace because eventually there will be
@@ -80,4 +85,5 @@ export type AppContext = {
   deployment: DeploymentContext;
   entri: EntriContext;
   userPlanFeatures: UserPlanFeatures | undefined;
+  trpcCache: TrpcCache;
 };

--- a/packages/trpc-interface/src/context/router.server.ts
+++ b/packages/trpc-interface/src/context/router.server.ts
@@ -4,3 +4,12 @@ import type { AppContext } from "./context.server";
 export const { router, procedure, middleware, mergeRouters } = initTRPC
   .context<AppContext>()
   .create();
+
+export const createCacheMiddleware = (seconds: number) =>
+  middleware(async ({ meta, path, type, ctx, next }) => {
+    // tRPC batches multiple requests into a single network call.
+    // The `path` is used as key to find the least max age among all paths for caching
+    ctx.trpcCache.setMaxAge(path, seconds);
+
+    return next({ ctx });
+  });

--- a/packages/trpc-interface/src/index.server.ts
+++ b/packages/trpc-interface/src/index.server.ts
@@ -12,4 +12,5 @@ export {
   procedure,
   middleware,
   mergeRouters,
+  createCacheMiddleware,
 } from "./context/router.server";


### PR DESCRIPTION
## Description

trpc procedures can be cached if wrapped with

```js
const cacheMiddleware = createCacheMiddleware(60 * 3); // 60 * 3 = 3 minutes cache
const cachedProcedure = procedure.use(cacheMiddleware);
```

Implementation supports trpc batching.
1.  If any of calls inside trpc batch is not cacheable - nothing will be cached.
2. If all trpc batch calls can be cached then the least max age among all calls is selected for caching


- [ ] - Test caching on PR

## Steps for reproduction

Open marketplace, see trpc request has cache headers, see trpc request has cache HIT from vercel or cloudflare

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
