### PR TITLE
feat: Allow excluding a page from marketplace 

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/marketplace/templates.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/marketplace/templates.tsx
@@ -42,6 +42,11 @@ const getTemplatesDataByCategory = (data?: WebstudioData) => {
   const pages = [data.pages.homePage, ...data.pages.pages];
 
   for (const page of pages) {
+    // We allow user to hide the page in the marketplace.
+    if (page.meta.excludePageFromSearch === "true") {
+      continue;
+    }
+
     let category = page.meta.custom?.find(
       ({ property }) => property === marketplaceMeta.category
     )?.content;


### PR DESCRIPTION
When user has a template, but some pages are not meant for being inserted using a click from the marketplace sidebar, we need a way to exclude them.  Now user can do it from page settings using the same checkbox that also prevents crowling

<img width="444" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/86521e24-bbe3-4cb7-bfe2-b04bdf5d2418">

## Steps for reproduction

1. check the "exclude this page from search results" in page settings
2. see the page doesn't show up in the marketplace pages list

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
