### PR TITLE
refactor: transpile expression without code generation

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -78,6 +78,7 @@ const parseJsonValue = (code: string) => {
   try {
     code = transpileExpression({
       expression: code,
+      executable: true,
       replaceVariable: (id) => {
         ids.add(id);
       },

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -34,7 +34,7 @@ import {
   Tooltip,
   theme,
 } from "@webstudio-is/design-system";
-import { validateExpression } from "@webstudio-is/react-sdk";
+import { transpileExpression } from "@webstudio-is/react-sdk";
 import type { DataSource } from "@webstudio-is/sdk";
 import {
   ExpressionEditor,
@@ -76,11 +76,10 @@ const parseJsonValue = (code: string) => {
     return result;
   }
   try {
-    code = validateExpression(code, {
-      optional: true,
-      transformIdentifier: (id) => {
+    code = transpileExpression({
+      expression: code,
+      replaceVariable: (id) => {
         ids.add(id);
-        return id;
       },
     });
   } catch (error) {

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -53,6 +53,7 @@ const generateAction = (prop: Extract<Prop, { type: "action" }>) => {
     args = value.args;
     assignersCode += transpileExpression({
       expression: value.code,
+      executable: true,
       replaceVariable: (identifier, assignee) => {
         if (args?.includes(identifier)) {
           return;
@@ -145,6 +146,7 @@ export const computeExpression = (
     const usedVariables = new Map();
     const transpiled = transpileExpression({
       expression,
+      executable: true,
       replaceVariable: (identifier) => {
         const id = decodeDataSourceVariable(identifier);
         if (id) {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -41,6 +41,8 @@
     "@webstudio-is/icons": "workspace:^",
     "@webstudio-is/image": "workspace:*",
     "@webstudio-is/sdk": "workspace:*",
+    "acorn": "^8.11.3",
+    "acorn-walk": "^8.3.2",
     "change-case": "^5.0.2",
     "html-tags": "^3.3.1",
     "jsep": "^1.3.8",

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -47,6 +47,7 @@ const generateAction = ({
     args = value.args;
     assignersCode += transpileExpression({
       expression: value.code,
+      executable: true,
       replaceVariable: (identifier, assignee) => {
         if (args?.includes(identifier)) {
           return;

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -17,8 +17,8 @@ import {
 import { collectionComponent } from "./core-components";
 import {
   generateExpression,
-  validateExpression,
   decodeDataSourceVariable,
+  transpileExpression,
 } from "./expression";
 import type { IndexesWithinAncestors } from "./instance-utils";
 
@@ -45,12 +45,11 @@ const generateAction = ({
   let assignersCode = "";
   for (const value of prop.value) {
     args = value.args;
-    assignersCode += validateExpression(value.code, {
-      optional: true,
-      effectful: true,
-      transformIdentifier: (identifier, assignee) => {
+    assignersCode += transpileExpression({
+      expression: value.code,
+      replaceVariable: (identifier, assignee) => {
         if (args?.includes(identifier)) {
-          return identifier;
+          return;
         }
         const depId = decodeDataSourceVariable(identifier);
         const dep = depId ? dataSources.get(depId) : undefined;
@@ -64,7 +63,6 @@ const generateAction = ({
         }
         // eslint-disable-next-line no-console
         console.error(`Unknown dependency "${identifier}"`);
-        return identifier;
       },
     });
     assignersCode += `\n`;

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -1,9 +1,10 @@
-import { expect, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import {
   decodeDataSourceVariable,
   encodeDataSourceVariable,
   executeExpression,
   isLiteralExpression,
+  transpileExpression,
   validateExpression,
 } from "./expression";
 
@@ -171,6 +172,72 @@ test("transform identifiers", () => {
       transformIdentifier: (id) => `$ws$${id}`,
     })
   ).toEqual(`$ws$a + $ws$b`);
+});
+
+describe("transpile expression", () => {
+  test("preserve spaces and parentheses", () => {
+    expect(
+      transpileExpression({ expression: " 1 + (2 + 3) ", executable: true })
+    ).toEqual(" 1 + (2 + 3) ");
+  });
+
+  test("add optional chaining with dot syntax", () => {
+    expect(
+      transpileExpression({ expression: "a.b . c", executable: true })
+    ).toEqual("a?.b ?. c");
+  });
+
+  test("add optional chaining with computed", () => {
+    expect(
+      transpileExpression({ expression: "a['b'] [c]", executable: true })
+    ).toEqual("a?.['b'] ?.[c]");
+  });
+
+  test("skip optional chaining", () => {
+    expect(
+      transpileExpression({ expression: "a?.['b']?.c", executable: true })
+    ).toEqual("a?.['b']?.c");
+  });
+
+  test("replace variable", () => {
+    expect(
+      transpileExpression({
+        expression: "(a + c) * b",
+        replaceVariable: (identifier) => identifier + "_1",
+      })
+    ).toEqual("(a_1 + c_1) * b_1");
+    expect(
+      transpileExpression({
+        expression: "a = c",
+        replaceVariable: (identifier) => identifier + "_1",
+      })
+    ).toEqual("a_1 = c_1");
+  });
+
+  test("skip identifiers in nested member expressions", () => {
+    const identifiers: string[] = [];
+    const transpiled = transpileExpression({
+      expression: "a.b + c.d * e[f]",
+      replaceVariable: (identifier) => {
+        identifiers.push(identifier);
+        return identifier + "_1";
+      },
+    });
+    expect(identifiers).toEqual(["a", "c", "e", "f"]);
+    expect(transpiled).toEqual("a_1.b + c_1.d * e_1[f_1]");
+  });
+
+  test("inform identifier is an assignee", () => {
+    expect(
+      transpileExpression({
+        expression: "a = b",
+        replaceVariable: (identifier, assignee) => {
+          const suffix = assignee ? "_assignee" : "_assigner";
+          return identifier + suffix;
+        },
+      })
+    ).toEqual("a_assignee = b_assigner");
+  });
 });
 
 test("encode/decode variable names", () => {

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -238,6 +238,14 @@ describe("transpile expression", () => {
       })
     ).toEqual("a_assignee = b_assigner");
   });
+
+  test("transpile object literal without changes", () => {
+    expect(
+      transpileExpression({
+        expression: `{ ...name }`,
+      })
+    ).toEqual(`{ ...name }`);
+  });
 });
 
 test("encode/decode variable names", () => {

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -6,6 +6,8 @@ import type {
   AssignmentExpression,
 } from "@jsep-plugin/assignment";
 import type { ObjectExpression, Property } from "@jsep-plugin/object";
+import { parse, type Identifier } from "acorn";
+import { simple } from "acorn-walk";
 import type { DataSources, Scope } from "@webstudio-is/sdk";
 
 jsep.literals["undefined"] = "undefined";
@@ -205,6 +207,69 @@ export const isLiteralExpression = (expression: string) => {
   }
 };
 
+/**
+ * transpile expression into executable one
+ *
+ * add optional chaining operator to every member expression
+ * to access any field without runtime errors
+ *
+ * replace variable names if necessary
+ */
+export const transpileExpression = ({
+  expression,
+  executable = false,
+  replaceVariable,
+}: {
+  expression: string;
+  executable?: boolean;
+  replaceVariable?: (
+    identifier: string,
+    assignee: boolean
+  ) => string | undefined | void;
+}) => {
+  const root = parse(expression, {
+    ecmaVersion: "latest",
+  });
+  const replacements: [start: number, end: number, fragment: string][] = [];
+  const replaceIdentifier = (node: Identifier, assignee: boolean) => {
+    const newName = replaceVariable?.(node.name, assignee);
+    if (newName) {
+      replacements.push([node.start, node.end, newName]);
+    }
+  };
+  simple(root, {
+    Identifier: (node) => replaceIdentifier(node, false),
+    AssignmentExpression(node) {
+      simple(node.left, {
+        Identifier: (node) => replaceIdentifier(node, true),
+      });
+    },
+    MemberExpression(node) {
+      if (executable === false || node.optional) {
+        return;
+      }
+      // a . b -> a ?. b
+      if (node.computed === false) {
+        const dotIndex = expression.indexOf(".", node.object.end);
+        replacements.push([dotIndex, dotIndex, "?"]);
+      }
+      // a [b] -> a ?.[b]
+      if (node.computed === true) {
+        const dotIndex = expression.indexOf("[", node.object.end);
+        replacements.push([dotIndex, dotIndex, "?."]);
+      }
+    },
+  });
+  // order from the latest to the first insertion to not break other positions
+  replacements.sort(([leftStart], [rightStart]) => rightStart - leftStart);
+  for (const [start, end, fragment] of replacements) {
+    const before = expression.slice(0, start);
+    const after = expression.slice(end);
+    expression = before + fragment + after;
+  }
+  return expression;
+};
+
 const dataSourceVariablePrefix = "$ws$dataSource$";
 
 // data source id is generated with nanoid which has "-" in alphabeta
@@ -235,19 +300,16 @@ export const generateExpression = ({
   usedDataSources: DataSources;
   scope: Scope;
 }) => {
-  return validateExpression(expression, {
-    // parse any expression
-    effectful: true,
-    // transpile to safely executable member expressions
-    optional: true,
-    transformIdentifier: (identifier) => {
+  return transpileExpression({
+    expression,
+    executable: true,
+    replaceVariable: (identifier) => {
       const depId = decodeDataSourceVariable(identifier);
       const dep = depId ? dataSources.get(depId) : undefined;
       if (dep) {
         usedDataSources?.set(dep.id, dep);
         return scope.getName(dep.id, dep.name);
       }
-      return identifier;
     },
   });
 };

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -6,7 +6,7 @@ import type {
   AssignmentExpression,
 } from "@jsep-plugin/assignment";
 import type { ObjectExpression, Property } from "@jsep-plugin/object";
-import { parse, type Identifier } from "acorn";
+import { type Identifier, parseExpressionAt } from "acorn";
 import { simple } from "acorn-walk";
 import type { DataSources, Scope } from "@webstudio-is/sdk";
 
@@ -227,9 +227,7 @@ export const transpileExpression = ({
     assignee: boolean
   ) => string | undefined | void;
 }) => {
-  const root = parse(expression, {
-    ecmaVersion: "latest",
-  });
+  const root = parseExpressionAt(expression, 0, { ecmaVersion: "latest" });
   const replacements: [start: number, end: number, fragment: string][] = [];
   const replaceIdentifier = (node: Identifier, assignee: boolean) => {
     const newName = replaceVariable?.(node.name, assignee);

--- a/packages/react-sdk/src/resources-generator.test.ts
+++ b/packages/react-sdk/src/resources-generator.test.ts
@@ -49,7 +49,7 @@ test("generate resources loader", () => {
       headers: [
       { name: "Content-Type", value: "application/json" },
       ],
-      body: {body: true},
+      body: { body: true },
       }),
       ])
       return {
@@ -116,7 +116,7 @@ test("generate variable and use in resources loader", () => {
       headers: [
       { name: "Authorization", value: "Token " + AccessToken },
       ],
-      body: {body: true},
+      body: { body: true },
       }),
       ])
       return {
@@ -177,7 +177,7 @@ test("generate system variable and use in resources loader", () => {
       headers: [
       { name: "Content-Type", value: "application/json" },
       ],
-      body: {body: true},
+      body: { body: true },
       }),
       ])
       return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1625,6 +1625,12 @@ importers:
       '@webstudio-is/sdk':
         specifier: workspace:*
         version: link:../sdk
+      acorn:
+        specifier: ^8.11.3
+        version: 8.11.3
+      acorn-walk:
+        specifier: ^8.3.2
+        version: 8.3.2
       change-case:
         specifier: ^5.0.2
         version: 5.0.2
@@ -8725,6 +8731,11 @@ packages:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
 
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
   /acorn@7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
     engines: {node: '>=0.4.0'}
@@ -8734,6 +8745,12 @@ packages:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  /acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: false
 
   /address@1.2.0:
     resolution: {integrity: sha512-tNEZYz5G/zYunxFm7sfhAxkXEuLj3K6BKwv6ZURlsF6yiUQ65z0Q2wZW9L5cPUl9ocofGvXOdFYbFHp0+6MOig==}
@@ -9644,7 +9661,7 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
       '@types/estree': 1.0.1
-      acorn: 8.10.0
+      acorn: 8.11.3
       estree-walker: 3.0.3
       periscopic: 3.1.0
     dev: false
@@ -16505,7 +16522,7 @@ packages:
       '@ampproject/remapping': 2.2.1
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.18
-      acorn: 8.10.0
+      acorn: 8.11.3
       aria-query: 5.3.0
       axobject-query: 3.2.1
       code-red: 1.0.4


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Our code generation with jsep has a big problem of not preserving parenthesis entered by user. And jsep is not able to provide the information.

As a solution I suggest to switch parser to acorn. It is 10 times bigger than jsep but provides more strict parsing with location info for every node. Here I use it to transpile simply with string manipulation which does not touch spaces or parenthesis entered by user.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
