### PR TITLE
feat:  add more descriptions

### DIFF
--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -15,6 +15,7 @@ import {
   Flex,
   ScrollArea,
   Separator,
+  Tooltip,
 } from "@webstudio-is/design-system";
 import { StylePanel } from "~/builder/features/style-panel";
 import { SettingsPanelContainer } from "~/builder/features/settings-panel";
@@ -118,9 +119,25 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
             <Flex direction="column">
               <PanelTabsList>
                 {isStyleTabVisible && (
-                  <PanelTabsTrigger value="style">Style</PanelTabsTrigger>
+                  <Tooltip
+                    variant="wrapped"
+                    content="The Style panel allows manipulation of CSS visually."
+                  >
+                    <div>
+                      <PanelTabsTrigger value="style">Style</PanelTabsTrigger>
+                    </div>
+                  </Tooltip>
                 )}
-                <PanelTabsTrigger value="settings">Settings</PanelTabsTrigger>
+                <Tooltip
+                  variant="wrapped"
+                  content="The Settings panel allows for customizing component properties and HTML attributes."
+                >
+                  <div>
+                    <PanelTabsTrigger value="settings">
+                      Settings
+                    </PanelTabsTrigger>
+                  </div>
+                </Tooltip>
               </PanelTabsList>
               <Separator />
               <PanelTabsContent value="style" css={contentStyle} tabIndex={-1}>

--- a/apps/builder/app/builder/features/project-settings/project-settings.tsx
+++ b/apps/builder/app/builder/features/project-settings/project-settings.tsx
@@ -18,6 +18,7 @@ import { SectionRedirects } from "./section-redirects";
 import { useState } from "react";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { SectionMarketplace } from "./section-marketplace";
+import { leftPanelWidth, rightPanelWidth } from "./utils";
 
 const focusOutline = focusRingStyle();
 
@@ -28,9 +29,6 @@ if (isFeatureEnabled("marketplace")) {
 }
 
 type SectionName = (typeof sectionNames)[number];
-
-const leftPanelWidth = theme.spacing[26];
-const rightPanelWidth = theme.spacing[35];
 
 export const ProjectSettingsView = ({
   currentSection,

--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -20,6 +20,7 @@ import { useIds } from "~/shared/form-utils";
 import type { ProjectMeta, CompilerSettings } from "@webstudio-is/sdk";
 import { useState } from "react";
 import { serverSyncStore } from "~/shared/sync";
+import { sectionSpacing } from "./utils";
 
 const imgStyle = css({
   width: 72,
@@ -69,13 +70,7 @@ export const SectionGeneral = () => {
 
   return (
     <>
-      <Grid
-        gap={1}
-        css={{
-          mx: theme.spacing[5],
-          px: theme.spacing[5],
-        }}
-      >
+      <Grid gap={1} css={sectionSpacing}>
         <Text variant="titles">General</Text>
         <Label htmlFor={ids.siteName}>Site Name</Label>
         <InputField
@@ -91,7 +86,7 @@ export const SectionGeneral = () => {
 
       <Separator />
 
-      <Grid gap={2} css={{ mx: theme.spacing[5], px: theme.spacing[5] }}>
+      <Grid gap={2} css={sectionSpacing}>
         <Label>Favicon</Label>
         <Grid flow="column" gap={3}>
           <Image
@@ -115,7 +110,7 @@ export const SectionGeneral = () => {
 
       <Separator />
 
-      <Grid gap={2} css={{ mx: theme.spacing[5], px: theme.spacing[5] }}>
+      <Grid gap={2} css={sectionSpacing}>
         <Label htmlFor={ids.code}>Custom Code</Label>
         <Text color="subtle">
           Custom code and scripts will be added at the end of the &lt;head&gt;
@@ -158,7 +153,7 @@ const CompilerSection = () => {
   };
 
   return (
-    <Grid gap={2} css={{ mx: theme.spacing[5], px: theme.spacing[5] }}>
+    <Grid gap={2} css={sectionSpacing}>
       <Label htmlFor={ids.atomicStyles}>Compiler</Label>
       <CheckboxAndLabel>
         <Checkbox

--- a/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
@@ -15,6 +15,7 @@ import {
   PanelBanner,
   Select,
   rawTheme,
+  Box,
 } from "@webstudio-is/design-system";
 import { ImageControl } from "./image-control";
 import { $assets, $marketplaceProduct, $project } from "~/shared/nano-states";
@@ -29,6 +30,7 @@ import {
 import { serverSyncStore } from "~/shared/sync";
 import { MarketplaceApprovalStatus } from "@webstudio-is/project";
 import { trpcClient } from "~/shared/trpc/trpc-client";
+import { rightPanelWidth, sectionSpacing } from "./utils";
 
 const thumbnailStyle = css({
   borderRadius: theme.borderRadius[4],
@@ -161,7 +163,6 @@ export const SectionMarketplace = () => {
       );
     };
   };
-  const sectionSpacing = { mx: theme.spacing[5], px: theme.spacing[5] };
 
   return (
     <>
@@ -189,6 +190,11 @@ export const SectionMarketplace = () => {
           getLabel={(category: MarketplaceProduct["category"]) =>
             marketplaceCategories.get(category)?.label
           }
+          getDescription={(category: MarketplaceProduct["category"]) => (
+            <Box css={{ width: rightPanelWidth }}>
+              {marketplaceCategories.get(category)?.description}
+            </Box>
+          )}
           onChange={handleSave("category")}
           value={data.category}
           defaultValue={defaultMarketplaceProduct.category}

--- a/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
@@ -187,7 +187,7 @@ export const SectionMarketplace = () => {
           css={{ zIndex: theme.zIndices[1] }}
           options={Array.from(marketplaceCategories.keys())}
           getLabel={(category: MarketplaceProduct["category"]) =>
-            marketplaceCategories.get(category)
+            marketplaceCategories.get(category)?.label
           }
           onChange={handleSave("category")}
           value={data.category}

--- a/apps/builder/app/builder/features/project-settings/section-redirects.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-redirects.tsx
@@ -27,6 +27,7 @@ import { $pages, $project } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
 import { flushSync } from "react-dom";
 import { getPublishedUrl } from "~/shared/router-utils";
+import { sectionSpacing } from "./utils";
 
 export const SectionRedirects = () => {
   const [redirects, setRedirects] = useState(
@@ -150,7 +151,7 @@ export const SectionRedirects = () => {
 
   return (
     <>
-      <Grid gap={2} css={{ mx: theme.spacing[5], px: theme.spacing[5] }}>
+      <Grid gap={2} css={sectionSpacing}>
         <Text variant="titles">Redirects</Text>
         <Text color="subtle">
           Redirects old URLs to new ones so that you don’t lose any traffic or
@@ -215,12 +216,7 @@ export const SectionRedirects = () => {
       </Grid>
 
       {redirectKeys.length > 0 ? (
-        <Grid
-          css={{
-            p: theme.spacing[5],
-            mx: theme.spacing[5],
-          }}
-        >
+        <Grid css={sectionSpacing}>
           <List asChild>
             <Flex direction="column" gap="1">
               {redirects.map((redirect, index) => {

--- a/apps/builder/app/builder/features/project-settings/utils.ts
+++ b/apps/builder/app/builder/features/project-settings/utils.ts
@@ -1,0 +1,8 @@
+import { theme, type CSS } from "@webstudio-is/design-system";
+
+export const leftPanelWidth = theme.spacing[26];
+export const rightPanelWidth = theme.spacing[35];
+export const sectionSpacing: CSS = {
+  mx: theme.spacing[5],
+  px: theme.spacing[5],
+};

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -135,6 +135,8 @@ const systemPropsMeta: { name: string; meta: PropMeta }[] = [
       control: "boolean",
       type: "boolean",
       defaultValue: true,
+      description:
+        "Removes the instance from the DOM. Breakpoints have no effect on this setting.",
     },
   },
 ];

--- a/apps/builder/app/builder/features/sidebar-left/panels/marketplace/overview.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/marketplace/overview.tsx
@@ -9,6 +9,7 @@ import {
   PanelTabsList,
   PanelTabsTrigger,
   ScrollArea,
+  Tooltip,
 } from "@webstudio-is/design-system";
 import { EllipsesIcon } from "@webstudio-is/icons";
 import type { MarketplaceOverviewItem } from "~/shared/marketplace/types";
@@ -116,9 +117,16 @@ export const Overview = ({
               return;
             }
             return (
-              <PanelTabsTrigger key={category} value={category}>
-                {marketplaceCategories.get(category)}
-              </PanelTabsTrigger>
+              <Tooltip
+                variant="wrapped"
+                content={marketplaceCategories.get(category)?.description}
+              >
+                <div>
+                  <PanelTabsTrigger key={category} value={category}>
+                    {marketplaceCategories.get(category)?.label}
+                  </PanelTabsTrigger>
+                </div>
+              </Tooltip>
             );
           })}
         </PanelTabsList>

--- a/apps/builder/app/builder/features/sidebar-left/panels/marketplace/overview.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/marketplace/overview.tsx
@@ -118,11 +118,12 @@ export const Overview = ({
             }
             return (
               <Tooltip
+                key={category}
                 variant="wrapped"
                 content={marketplaceCategories.get(category)?.description}
               >
                 <div>
-                  <PanelTabsTrigger key={category} value={category}>
+                  <PanelTabsTrigger value={category}>
                     {marketplaceCategories.get(category)?.label}
                   </PanelTabsTrigger>
                 </div>

--- a/packages/design-system/src/components/select.stories.tsx
+++ b/packages/design-system/src/components/select.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentStory } from "@storybook/react";
+import type { StoryFn } from "@storybook/react";
 import { GapVerticalIcon } from "@webstudio-is/icons";
 import { useState } from "react";
 import { NestedIconLabel } from "./nested-icon-label";
@@ -8,7 +8,7 @@ export default {
   component: Select,
 };
 
-export const Simple: ComponentStory<typeof Select> = () => {
+export const Simple: StoryFn<typeof Select> = () => {
   const options = ["Apple", "Banana", "Orange"];
   const [value, setValue] = useState(options[0]);
   return (
@@ -16,7 +16,7 @@ export const Simple: ComponentStory<typeof Select> = () => {
   );
 };
 
-export const Placeholder: ComponentStory<typeof Select> = () => {
+export const Placeholder: StoryFn<typeof Select> = () => {
   return (
     <Select
       placeholder="Select fruit"
@@ -25,11 +25,11 @@ export const Placeholder: ComponentStory<typeof Select> = () => {
   );
 };
 
-export const Disabled: ComponentStory<typeof Select> = () => {
+export const Disabled: StoryFn<typeof Select> = () => {
   return <Select disabled options={["Apple", "Banana", "Orange"]} />;
 };
 
-export const FullWidth: ComponentStory<typeof Select> = () => {
+export const FullWidth: StoryFn<typeof Select> = () => {
   return (
     <div style={{ width: 200 }}>
       <Select
@@ -42,7 +42,7 @@ export const FullWidth: ComponentStory<typeof Select> = () => {
   );
 };
 
-export const WithNestedLabelIcon: ComponentStory<typeof Select> = () => {
+export const WithNestedLabelIcon: StoryFn<typeof Select> = () => {
   return (
     <Select
       prefix={
@@ -57,7 +57,7 @@ export const WithNestedLabelIcon: ComponentStory<typeof Select> = () => {
   );
 };
 
-export const WithComplexItems: ComponentStory<typeof Select> = () => {
+export const WithComplexItems: StoryFn<typeof Select> = () => {
   const items = {
     apple: { icon: "🍎" },
     banana: { icon: "🍌" },
@@ -82,7 +82,34 @@ export const WithComplexItems: ComponentStory<typeof Select> = () => {
   );
 };
 
-export const Boundaries: ComponentStory<typeof Select> = () => {
+export const WithDescriptions: StoryFn<typeof Select> = () => {
+  const options = [
+    { label: "Apple", description: "An apple fruit" },
+    { label: "Banana", description: "A banana fruit" },
+    { label: "Orange", description: "An orange fruit" },
+    { label: "Pear", description: "A pear fruit" },
+    { label: "Grape", description: "A grape fruit" },
+  ];
+  const [value, setValue] = useState<(typeof options)[number]>(options[0]);
+
+  return (
+    <Select
+      name="fruit"
+      options={options}
+      value={value}
+      getValue={(value) => value.label}
+      onChange={setValue}
+      getLabel={(option) => {
+        return option.label;
+      }}
+      getDescription={(option) => {
+        return option.description;
+      }}
+    />
+  );
+};
+
+export const Boundaries: StoryFn<typeof Select> = () => {
   const items = Array(100)
     .fill(0)
     .map((_, index) => `Item ${index}`);

--- a/packages/design-system/src/components/select.tsx
+++ b/packages/design-system/src/components/select.tsx
@@ -5,7 +5,10 @@ import {
   type ComponentProps,
   useMemo,
   forwardRef,
+  useState,
 } from "react";
+import { ChevronDownIcon, ChevronUpIcon } from "@webstudio-is/icons";
+import { styled, theme } from "../stitches.config";
 import {
   menuCss,
   menuItemCss,
@@ -15,8 +18,7 @@ import {
   MenuCheckedIcon,
 } from "./menu";
 import { SelectButton } from "./select-button";
-import { styled, theme } from "../stitches.config";
-import { ChevronDownIcon, ChevronUpIcon } from "@webstudio-is/icons";
+import { Text } from "./text";
 
 export const SelectContent = styled(Primitive.Content, menuCss);
 
@@ -75,6 +77,8 @@ export const SelectItem = forwardRef(SelectItemBase);
 
 export type SelectOption = string;
 
+const Description = styled(Text, menuItemCss);
+
 type TriggerPassThroughProps = Omit<
   ComponentProps<typeof Primitive.Trigger>,
   "onChange" | "value" | "defaultValue" | "asChild" | "prefix"
@@ -95,10 +99,12 @@ export type SelectProps<Option = SelectOption> = {
   ? {
       getLabel?: (option: Option) => string | undefined;
       getValue?: (option: Option) => string | undefined;
+      getDescription?: (option: Option) => string | undefined;
     }
   : {
       getLabel: (option: Option) => string | undefined;
       getValue: (option: Option) => string | undefined;
+      getDescription?: (option: Option) => string | undefined;
     }) &
   TriggerPassThroughProps;
 
@@ -107,7 +113,7 @@ const defaultGetValue = (option: unknown) => {
     return option;
   }
   throw new Error(
-    `Cannot automatically convert ${typeof option} to string. Provide a getValue/getLabel`
+    `Cannot automatically convert ${typeof option} to string. Provide a getValue/getLabel/getDescription`
   );
 };
 
@@ -123,6 +129,7 @@ const SelectBase = <Option,>(
     open,
     getLabel = defaultGetValue,
     getValue = defaultGetValue,
+    getDescription = defaultGetValue,
     name,
     children,
     prefix,
@@ -137,6 +144,12 @@ const SelectBase = <Option,>(
     }
     return map;
   }, [options, getValue]);
+  const [highlightedItem, setHighlightedItem] = useState<Option | undefined>();
+
+  const itemForDescription = highlightedItem ?? value ?? defaultValue;
+  const description = itemForDescription
+    ? getDescription(itemForDescription)
+    : undefined;
 
   return (
     <Primitive.Root
@@ -173,17 +186,21 @@ const SelectBase = <Option,>(
                   textValue={getLabel(option)}
                   onMouseEnter={() => {
                     onItemHighlight?.(option);
+                    setHighlightedItem(option);
                   }}
                   onMouseLeave={() => {
                     onItemHighlight?.();
+                    setHighlightedItem(undefined);
                   }}
                   onFocus={() => {
                     onItemHighlight?.(option);
+                    setHighlightedItem(option);
                   }}
                 >
                   {getLabel(option)}
                 </SelectItem>
               ))}
+            {description && <Description hint>{description}</Description>}
           </SelectViewport>
           <SelectScrollDownButton>
             <ChevronDownIcon />

--- a/packages/design-system/src/components/select.tsx
+++ b/packages/design-system/src/components/select.tsx
@@ -18,7 +18,6 @@ import {
   MenuCheckedIcon,
 } from "./menu";
 import { SelectButton } from "./select-button";
-import { Text } from "./text";
 
 export const SelectContent = styled(Primitive.Content, menuCss);
 
@@ -77,7 +76,7 @@ export const SelectItem = forwardRef(SelectItemBase);
 
 export type SelectOption = string;
 
-const Description = styled(Text, menuItemCss);
+const Description = styled(menuItemCss);
 
 type TriggerPassThroughProps = Omit<
   ComponentProps<typeof Primitive.Trigger>,
@@ -95,16 +94,15 @@ export type SelectProps<Option = SelectOption> = {
   onOpenChange?: (open: boolean) => void;
   placeholder?: string;
   children?: ReactNode;
+  getDescription?: (option: Option) => ReactNode | undefined;
 } & (Option extends string
   ? {
       getLabel?: (option: Option) => string | undefined;
       getValue?: (option: Option) => string | undefined;
-      getDescription?: (option: Option) => string | undefined;
     }
   : {
       getLabel: (option: Option) => string | undefined;
       getValue: (option: Option) => string | undefined;
-      getDescription?: (option: Option) => string | undefined;
     }) &
   TriggerPassThroughProps;
 
@@ -129,7 +127,7 @@ const SelectBase = <Option,>(
     open,
     getLabel = defaultGetValue,
     getValue = defaultGetValue,
-    getDescription = defaultGetValue,
+    getDescription,
     name,
     children,
     prefix,
@@ -148,7 +146,7 @@ const SelectBase = <Option,>(
 
   const itemForDescription = highlightedItem ?? value ?? defaultValue;
   const description = itemForDescription
-    ? getDescription(itemForDescription)
+    ? getDescription?.(itemForDescription)
     : undefined;
 
   return (
@@ -200,11 +198,11 @@ const SelectBase = <Option,>(
                   {getLabel(option)}
                 </SelectItem>
               ))}
-            {description && <Description hint>{description}</Description>}
           </SelectViewport>
           <SelectScrollDownButton>
             <ChevronDownIcon />
           </SelectScrollDownButton>
+          {description && <Description hint>{description}</Description>}
         </SelectContent>
       </Primitive.Portal>
     </Primitive.Root>

--- a/packages/project-build/src/shared/marketplace.ts
+++ b/packages/project-build/src/shared/marketplace.ts
@@ -20,8 +20,22 @@ export type MarketplaceProduct = z.infer<typeof MarketplaceProduct>;
 
 export const marketplaceCategories = new Map<
   MarketplaceProduct["category"],
-  string
+  { label: string; description: string }
 >([
-  ["sectionTemplates", "Sections"],
-  ["pageTemplates", "Pages"],
+  [
+    "sectionTemplates",
+    {
+      label: "Sections",
+      description:
+        "Section templates are pre-designed layouts for quickly creating pages from sections.",
+    },
+  ],
+  [
+    "pageTemplates",
+    {
+      label: "Pages",
+      description:
+        "Page templates are pre-designed single or multi-page layouts for entire pages.",
+    },
+  ],
 ]);


### PR DESCRIPTION
1. added description to show property (People are often confused why breakpoints have no impact on this)
2. added descriptions to right sidebar tabs
3. added descriptions to marketplace tabs
4. show marketplace category descriptions in select box
5. added ability to select component to render the hint/description

<img width="686" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/db0483e9-9b84-42bf-a3fd-00c65863c02d">
<img width="280" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/eedb86a2-459b-4c0e-85e6-3dd5a55a405b">
<img width="281" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/b966b922-554a-4ac0-8566-f99741b76d97">


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
