### PR TITLE
refactor: switch to acorn expressions everywhere

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -19,7 +19,7 @@ import { MinusIcon, PlusIcon } from "@webstudio-is/icons";
 import type { DataSource } from "@webstudio-is/sdk";
 import {
   decodeDataSourceVariable,
-  validateExpression,
+  getExpressionIdentifiers,
 } from "@webstudio-is/react-sdk";
 import {
   $dataSources,
@@ -83,20 +83,12 @@ const $usedVariables = computed(
   (instances, props, resources) => {
     const usedVariables = new Set<DataSource["id"]>();
     const collectExpressionVariables = (expression: string) => {
-      try {
-        validateExpression(expression, {
-          // parse any expression
-          effectful: true,
-          transformIdentifier: (identifier) => {
-            const id = decodeDataSourceVariable(identifier);
-            if (id !== undefined) {
-              usedVariables.add(id);
-            }
-            return identifier;
-          },
-        });
-      } catch {
-        // empty block
+      const identifiers = getExpressionIdentifiers(expression);
+      for (const identifier of identifiers) {
+        const id = decodeDataSourceVariable(identifier);
+        if (id !== undefined) {
+          usedVariables.add(id);
+        }
       }
     };
     for (const instance of instances.values()) {

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
@@ -4,7 +4,7 @@ import { createRootFolder } from "@webstudio-is/project-build";
 import {
   decodeDataSourceVariable,
   encodeDataSourceVariable,
-  validateExpression,
+  transpileExpression,
 } from "@webstudio-is/react-sdk";
 import {
   type Page,
@@ -395,12 +395,12 @@ const replaceDataSources = (
   expression: string,
   replacements: Map<DataSource["id"], DataSource["id"]>
 ) => {
-  return validateExpression(expression, {
-    effectful: true,
-    transformIdentifier: (identifier) => {
+  return transpileExpression({
+    expression,
+    replaceVariable: (identifier) => {
       const dataSourceId = decodeDataSourceVariable(identifier);
       if (dataSourceId === undefined) {
-        return identifier;
+        return;
       }
       return encodeDataSourceVariable(
         replacements.get(dataSourceId) ?? dataSourceId

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -37,8 +37,8 @@ import {
 } from "@webstudio-is/design-system";
 import {
   decodeDataSourceVariable,
+  getExpressionIdentifiers,
   lintExpression,
-  validateExpression,
 } from "@webstudio-is/react-sdk";
 import { ExpressionEditor, formatValuePreview } from "./expression-editor";
 import { useSideOffset } from "./floating-panel";
@@ -61,26 +61,6 @@ export const evaluateExpressionWithinScope = (
   }
 };
 
-const getUsedIdentifiers = (expression: string) => {
-  const identifiers = new Set<string>();
-  // prevent parsing empty expression
-  if (expression === "") {
-    return identifiers;
-  }
-  // avoid parsing error
-  try {
-    validateExpression(expression, {
-      transformIdentifier: (identifier) => {
-        identifiers.add(identifier);
-        return identifier;
-      },
-    });
-  } catch {
-    //
-  }
-  return identifiers;
-};
-
 const BindingPanel = ({
   scope,
   aliases,
@@ -97,7 +77,10 @@ const BindingPanel = ({
   onSave: (value: string, invalid: boolean) => void;
 }) => {
   const [expression, setExpression] = useState(value);
-  const usedIdentifiers = useMemo(() => getUsedIdentifiers(value), [value]);
+  const usedIdentifiers = useMemo(
+    () => getExpressionIdentifiers(value),
+    [value]
+  );
   const [errors, setErrors] = useState<string[]>([]);
   const [touched, setTouched] = useState(false);
   const scopeEntries = Object.entries(scope);

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -38,7 +38,7 @@ import { javascript } from "@codemirror/lang-javascript";
 import { theme, textVariants, css } from "@webstudio-is/design-system";
 import {
   decodeDataSourceVariable,
-  validateExpression,
+  transpileExpression,
 } from "@webstudio-is/react-sdk";
 import { CodeEditor } from "./code-editor";
 
@@ -417,27 +417,19 @@ export const ExpressionEditor = ({
         value={value}
         onChange={(value) => {
           try {
-            let hasReplacements = false;
             // replace unknown webstudio variables with undefined
             // to prevent invalid compilation
-            const newExpression = validateExpression(value, {
-              effectful: true,
-              transformIdentifier: (identifier) => {
+            value = transpileExpression({
+              expression: value,
+              replaceVariable: (identifier) => {
                 if (
                   decodeDataSourceVariable(identifier) &&
                   aliases.has(identifier) === false
                 ) {
-                  hasReplacements = true;
                   return `undefined`;
                 }
-                return identifier;
               },
             });
-            // reformat only when something is replaced
-            // to break user interaction
-            if (hasReplacements) {
-              value = newExpression;
-            }
           } catch {
             // empty block
           }

--- a/fixtures/webstudio-custom-template/.webstudio/data.json
+++ b/fixtures/webstudio-custom-template/.webstudio/data.json
@@ -1,10 +1,10 @@
 {
   "build": {
-    "id": "3c68e999-d7d1-4064-a898-a39948ee4316",
+    "id": "7c038d94-8a94-4ecb-a048-69da407986f2",
     "projectId": "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    "version": 132,
-    "createdAt": "2024-03-05T15:38:45.184Z",
-    "updatedAt": "2024-03-05T15:38:45.184Z",
+    "version": 147,
+    "createdAt": "2024-03-17T18:28:52.083Z",
+    "updatedAt": "2024-03-17T18:28:52.083Z",
     "pages": {
       "meta": {
         "siteName": "Fixture Site",
@@ -27,7 +27,7 @@
         },
         "rootInstanceId": "ibXgMoi9_ipHx1gVrvii0",
         "path": "",
-        "systemDataSourceId": "gzU1wxmnHwY-x5jPet-3Y"
+        "systemDataSourceId": "_yJ0UuBlq2PEEobk8o_ku"
       },
       "pages": [
         {
@@ -47,7 +47,7 @@
           },
           "rootInstanceId": "LW98_-srDnnagkR10lsk4",
           "path": "/script-test",
-          "systemDataSourceId": "pCHIauvdC2bIuiCOAhV9Z"
+          "systemDataSourceId": "Mlo1vx1bhMUxPcNRfzESD"
         },
         {
           "id": "lyz5sZaJ7WzLt71cX3VJ2",
@@ -64,7 +64,7 @@
           },
           "rootInstanceId": "jDb2FuSK2-azIZxkH5XNv",
           "path": "/world",
-          "systemDataSourceId": "E2nbgH6ec91fv6I4xF7DR"
+          "systemDataSourceId": "Zl0ZwsVkVbga9LehMyyQx"
         }
       ],
       "folders": [
@@ -448,6 +448,557 @@
             ]
           }
         }
+      ],
+      [
+        "tYL7DJNi2pIpMoHAxdNq8:mIDIDBHsdlix3RVZAVmv7:position:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "tYL7DJNi2pIpMoHAxdNq8",
+          "property": "position",
+          "value": {
+            "type": "keyword",
+            "value": "relative"
+          }
+        }
+      ],
+      [
+        "tYL7DJNi2pIpMoHAxdNq8:mIDIDBHsdlix3RVZAVmv7:aspectRatio:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "tYL7DJNi2pIpMoHAxdNq8",
+          "property": "aspectRatio",
+          "value": {
+            "type": "keyword",
+            "value": "640/360"
+          }
+        }
+      ],
+      [
+        "tYL7DJNi2pIpMoHAxdNq8:mIDIDBHsdlix3RVZAVmv7:width:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "tYL7DJNi2pIpMoHAxdNq8",
+          "property": "width",
+          "value": {
+            "type": "unit",
+            "value": 100,
+            "unit": "%"
+          }
+        }
+      ],
+      [
+        "ixkvvPZFAtSwSpcU7iwQh:mIDIDBHsdlix3RVZAVmv7:position:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ixkvvPZFAtSwSpcU7iwQh",
+          "property": "position",
+          "value": {
+            "type": "keyword",
+            "value": "absolute"
+          }
+        }
+      ],
+      [
+        "ixkvvPZFAtSwSpcU7iwQh:mIDIDBHsdlix3RVZAVmv7:objectFit:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ixkvvPZFAtSwSpcU7iwQh",
+          "property": "objectFit",
+          "value": {
+            "type": "keyword",
+            "value": "cover"
+          }
+        }
+      ],
+      [
+        "ixkvvPZFAtSwSpcU7iwQh:mIDIDBHsdlix3RVZAVmv7:width:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ixkvvPZFAtSwSpcU7iwQh",
+          "property": "width",
+          "value": {
+            "type": "unit",
+            "value": 100,
+            "unit": "%"
+          }
+        }
+      ],
+      [
+        "ixkvvPZFAtSwSpcU7iwQh:mIDIDBHsdlix3RVZAVmv7:height:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ixkvvPZFAtSwSpcU7iwQh",
+          "property": "height",
+          "value": {
+            "type": "unit",
+            "value": 100,
+            "unit": "%"
+          }
+        }
+      ],
+      [
+        "ixkvvPZFAtSwSpcU7iwQh:mIDIDBHsdlix3RVZAVmv7:borderTopLeftRadius:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ixkvvPZFAtSwSpcU7iwQh",
+          "property": "borderTopLeftRadius",
+          "value": {
+            "type": "unit",
+            "value": 20,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ixkvvPZFAtSwSpcU7iwQh:mIDIDBHsdlix3RVZAVmv7:borderTopRightRadius:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ixkvvPZFAtSwSpcU7iwQh",
+          "property": "borderTopRightRadius",
+          "value": {
+            "type": "unit",
+            "value": 20,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ixkvvPZFAtSwSpcU7iwQh:mIDIDBHsdlix3RVZAVmv7:borderBottomLeftRadius:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ixkvvPZFAtSwSpcU7iwQh",
+          "property": "borderBottomLeftRadius",
+          "value": {
+            "type": "unit",
+            "value": 20,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ixkvvPZFAtSwSpcU7iwQh:mIDIDBHsdlix3RVZAVmv7:borderBottomRightRadius:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ixkvvPZFAtSwSpcU7iwQh",
+          "property": "borderBottomRightRadius",
+          "value": {
+            "type": "unit",
+            "value": 20,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ixkvvPZFAtSwSpcU7iwQh:mIDIDBHsdlix3RVZAVmv7:objectPosition:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ixkvvPZFAtSwSpcU7iwQh",
+          "property": "objectPosition",
+          "value": {
+            "type": "keyword",
+            "value": "cover"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:position:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "position",
+          "value": {
+            "type": "keyword",
+            "value": "absolute"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:width:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "width",
+          "value": {
+            "type": "unit",
+            "value": 140,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:height:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "height",
+          "value": {
+            "type": "unit",
+            "value": 80,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:top:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "top",
+          "value": {
+            "type": "unit",
+            "value": 50,
+            "unit": "%"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:left:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "left",
+          "value": {
+            "type": "unit",
+            "value": 50,
+            "unit": "%"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:marginTop:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "marginTop",
+          "value": {
+            "type": "unit",
+            "value": -40,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:marginLeft:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "marginLeft",
+          "value": {
+            "type": "unit",
+            "value": -70,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:display:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "display",
+          "value": {
+            "type": "keyword",
+            "value": "flex"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:alignItems:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "alignItems",
+          "value": {
+            "type": "keyword",
+            "value": "center"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:justifyContent:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "justifyContent",
+          "value": {
+            "type": "keyword",
+            "value": "center"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:borderTopStyle:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "borderTopStyle",
+          "value": {
+            "type": "keyword",
+            "value": "none"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:borderRightStyle:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "borderRightStyle",
+          "value": {
+            "type": "keyword",
+            "value": "none"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:borderBottomStyle:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "borderBottomStyle",
+          "value": {
+            "type": "keyword",
+            "value": "none"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:borderLeftStyle:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "borderLeftStyle",
+          "value": {
+            "type": "keyword",
+            "value": "none"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:borderTopLeftRadius:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "borderTopLeftRadius",
+          "value": {
+            "type": "unit",
+            "value": 5,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:borderTopRightRadius:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "borderTopRightRadius",
+          "value": {
+            "type": "unit",
+            "value": 5,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:borderBottomLeftRadius:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "borderBottomLeftRadius",
+          "value": {
+            "type": "unit",
+            "value": 5,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:borderBottomRightRadius:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "borderBottomRightRadius",
+          "value": {
+            "type": "unit",
+            "value": 5,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:cursor:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "cursor",
+          "value": {
+            "type": "keyword",
+            "value": "pointer"
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:backgroundColor:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "backgroundColor",
+          "value": {
+            "type": "rgb",
+            "r": 18,
+            "g": 18,
+            "b": 18,
+            "alpha": 1
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:color:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "property": "color",
+          "value": {
+            "type": "rgb",
+            "r": 255,
+            "g": 255,
+            "b": 255,
+            "alpha": 1
+          }
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR:mIDIDBHsdlix3RVZAVmv7:backgroundColor::hover",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "ApzUnwi68P0pA75K1vbPR",
+          "state": ":hover",
+          "property": "backgroundColor",
+          "value": {
+            "type": "rgb",
+            "r": 0,
+            "g": 173,
+            "b": 239,
+            "alpha": 1
+          }
+        }
+      ],
+      [
+        "FCu7u7zKAdzeUgaXaNtNm:mIDIDBHsdlix3RVZAVmv7:width:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "FCu7u7zKAdzeUgaXaNtNm",
+          "property": "width",
+          "value": {
+            "type": "unit",
+            "value": 60,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "FCu7u7zKAdzeUgaXaNtNm:mIDIDBHsdlix3RVZAVmv7:height:",
+        {
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "styleSourceId": "FCu7u7zKAdzeUgaXaNtNm",
+          "property": "height",
+          "value": {
+            "type": "unit",
+            "value": 60,
+            "unit": "px"
+          }
+        }
+      ],
+      [
+        "8v4JU2TDZLCT4lVpVhiUW:mIDIDBHsdlix3RVZAVmv7:position:",
+        {
+          "styleSourceId": "8v4JU2TDZLCT4lVpVhiUW",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "position",
+          "value": {
+            "type": "keyword",
+            "value": "absolute"
+          }
+        }
+      ],
+      [
+        "8v4JU2TDZLCT4lVpVhiUW:mIDIDBHsdlix3RVZAVmv7:top:",
+        {
+          "styleSourceId": "8v4JU2TDZLCT4lVpVhiUW",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "top",
+          "value": {
+            "type": "unit",
+            "unit": "%",
+            "value": 50
+          }
+        }
+      ],
+      [
+        "8v4JU2TDZLCT4lVpVhiUW:mIDIDBHsdlix3RVZAVmv7:left:",
+        {
+          "styleSourceId": "8v4JU2TDZLCT4lVpVhiUW",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "left",
+          "value": {
+            "type": "unit",
+            "unit": "%",
+            "value": 50
+          }
+        }
+      ],
+      [
+        "8v4JU2TDZLCT4lVpVhiUW:mIDIDBHsdlix3RVZAVmv7:width:",
+        {
+          "styleSourceId": "8v4JU2TDZLCT4lVpVhiUW",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "width",
+          "value": {
+            "type": "unit",
+            "unit": "px",
+            "value": 70
+          }
+        }
+      ],
+      [
+        "8v4JU2TDZLCT4lVpVhiUW:mIDIDBHsdlix3RVZAVmv7:height:",
+        {
+          "styleSourceId": "8v4JU2TDZLCT4lVpVhiUW",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "height",
+          "value": {
+            "type": "unit",
+            "unit": "px",
+            "value": 70
+          }
+        }
+      ],
+      [
+        "8v4JU2TDZLCT4lVpVhiUW:mIDIDBHsdlix3RVZAVmv7:marginTop:",
+        {
+          "styleSourceId": "8v4JU2TDZLCT4lVpVhiUW",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "marginTop",
+          "value": {
+            "type": "unit",
+            "unit": "px",
+            "value": -35
+          }
+        }
+      ],
+      [
+        "8v4JU2TDZLCT4lVpVhiUW:mIDIDBHsdlix3RVZAVmv7:marginLeft:",
+        {
+          "styleSourceId": "8v4JU2TDZLCT4lVpVhiUW",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "marginLeft",
+          "value": {
+            "type": "unit",
+            "unit": "px",
+            "value": -35
+          }
+        }
       ]
     ],
     "styleSources": [
@@ -470,6 +1021,41 @@
         {
           "type": "local",
           "id": "mOA5iiy4M-QrmmO22O02y"
+        }
+      ],
+      [
+        "tYL7DJNi2pIpMoHAxdNq8",
+        {
+          "type": "local",
+          "id": "tYL7DJNi2pIpMoHAxdNq8"
+        }
+      ],
+      [
+        "ixkvvPZFAtSwSpcU7iwQh",
+        {
+          "type": "local",
+          "id": "ixkvvPZFAtSwSpcU7iwQh"
+        }
+      ],
+      [
+        "ApzUnwi68P0pA75K1vbPR",
+        {
+          "type": "local",
+          "id": "ApzUnwi68P0pA75K1vbPR"
+        }
+      ],
+      [
+        "FCu7u7zKAdzeUgaXaNtNm",
+        {
+          "type": "local",
+          "id": "FCu7u7zKAdzeUgaXaNtNm"
+        }
+      ],
+      [
+        "8v4JU2TDZLCT4lVpVhiUW",
+        {
+          "type": "local",
+          "id": "8v4JU2TDZLCT4lVpVhiUW"
         }
       ]
     ],
@@ -494,6 +1080,41 @@
           "instanceId": "ibXgMoi9_ipHx1gVrvii0",
           "values": ["mOA5iiy4M-QrmmO22O02y"]
         }
+      ],
+      [
+        "ZkDuD4HlHP3pDdp0SXJuh",
+        {
+          "instanceId": "ZkDuD4HlHP3pDdp0SXJuh",
+          "values": ["tYL7DJNi2pIpMoHAxdNq8"]
+        }
+      ],
+      [
+        "wxd8Wul8dl2yPRFFedNn6",
+        {
+          "instanceId": "wxd8Wul8dl2yPRFFedNn6",
+          "values": ["ixkvvPZFAtSwSpcU7iwQh"]
+        }
+      ],
+      [
+        "9hBBPGSf7hB30ZkSHKjNd",
+        {
+          "instanceId": "9hBBPGSf7hB30ZkSHKjNd",
+          "values": ["ApzUnwi68P0pA75K1vbPR"]
+        }
+      ],
+      [
+        "D__QElBIIQtamhJN3a4FI",
+        {
+          "instanceId": "D__QElBIIQtamhJN3a4FI",
+          "values": ["FCu7u7zKAdzeUgaXaNtNm"]
+        }
+      ],
+      [
+        "o8sAMUoaOraWYZClEfRgl",
+        {
+          "instanceId": "o8sAMUoaOraWYZClEfRgl",
+          "values": ["8v4JU2TDZLCT4lVpVhiUW"]
+        }
       ]
     ],
     "props": [
@@ -516,31 +1137,141 @@
           "type": "page",
           "value": "nfzls_SkTc9jKYyxcZ8Lw"
         }
+      ],
+      [
+        "5o774rM2fqVYhXm5ZSVHK",
+        {
+          "id": "5o774rM2fqVYhXm5ZSVHK",
+          "instanceId": "wxd8Wul8dl2yPRFFedNn6",
+          "name": "alt",
+          "type": "string",
+          "value": "Vimeo video preview image"
+        }
+      ],
+      [
+        "2e_opKEWGaCwfU9goKhL1",
+        {
+          "id": "2e_opKEWGaCwfU9goKhL1",
+          "instanceId": "wxd8Wul8dl2yPRFFedNn6",
+          "name": "sizes",
+          "type": "string",
+          "value": "100vw"
+        }
+      ],
+      [
+        "A5QmGCZRWs8UDa64ZfLt1",
+        {
+          "id": "A5QmGCZRWs8UDa64ZfLt1",
+          "instanceId": "9hBBPGSf7hB30ZkSHKjNd",
+          "name": "aria-label",
+          "type": "string",
+          "value": "Play button"
+        }
+      ],
+      [
+        "XfG3W6G3TluxiNMs7pI9A",
+        {
+          "id": "XfG3W6G3TluxiNMs7pI9A",
+          "instanceId": "D__QElBIIQtamhJN3a4FI",
+          "name": "aria-hidden",
+          "type": "string",
+          "value": "true"
+        }
+      ],
+      [
+        "vxkUoSK7DDwfK0C3Y4cQE",
+        {
+          "id": "vxkUoSK7DDwfK0C3Y4cQE",
+          "instanceId": "iEc6hab-WardXZc5P9wJu",
+          "name": "code",
+          "type": "string",
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 22 22\" fill=\"currentColor\" width=\"100%\" height=\"100%\" style=\"display: block;\"><path d=\"M4.766 5.765c0-.725 0-1.088.178-1.288a.93.93 0 0 1 .648-.294c.294-.015.65.186 1.359.588l9.234 5.235c.586.332.88.498.982.708.09.183.09.389 0 .572-.102.21-.396.376-.982.708l-9.234 5.235c-.71.402-1.065.603-1.359.588a.93.93 0 0 1-.648-.294c-.178-.2-.178-.563-.178-1.288V5.765Z\"/></svg>"
+        }
+      ],
+      [
+        "HarVIKqJbGBdqOYfD12Oy",
+        {
+          "id": "HarVIKqJbGBdqOYfD12Oy",
+          "instanceId": "ZkDuD4HlHP3pDdp0SXJuh",
+          "name": "url",
+          "type": "string",
+          "value": "https://player.vimeo.com/video/831343124"
+        }
+      ],
+      [
+        "UOz9lmjTCpyqgwHS9se8s",
+        {
+          "id": "UOz9lmjTCpyqgwHS9se8s",
+          "instanceId": "ZkDuD4HlHP3pDdp0SXJuh",
+          "name": "showPreview",
+          "type": "boolean",
+          "value": true
+        }
+      ],
+      [
+        "EKvJtc95E_1T_DYMRsaOR",
+        {
+          "id": "EKvJtc95E_1T_DYMRsaOR",
+          "instanceId": "wxd8Wul8dl2yPRFFedNn6",
+          "name": "src",
+          "type": "asset",
+          "value": "cd1e9fad-8df1-45c6-800f-05fda2d2469f"
+        }
+      ],
+      [
+        "sA69O2yOITdCdJq7fHtGe",
+        {
+          "id": "sA69O2yOITdCdJq7fHtGe",
+          "instanceId": "9hBBPGSf7hB30ZkSHKjNd",
+          "name": "data-ws-show",
+          "type": "boolean",
+          "value": true
+        }
+      ],
+      [
+        "Aw5e3-tzDR1bLN2yDJaJd",
+        {
+          "id": "Aw5e3-tzDR1bLN2yDJaJd",
+          "instanceId": "BeQ7sgDlUizFvf4aHqOsh",
+          "name": "code",
+          "type": "string",
+          "value": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"e2CRglijn891\" shape-rendering=\"geometricPrecision\" text-rendering=\"geometricPrecision\" viewBox=\"0 0 128 128\" fill=\"currentColor\" width=\"100%\" height=\"100%\" style=\"display: block;\"><style>@keyframes e2CRglijn892_tr__tr{0%{transform:translate(64px,64px) rotate(90deg);animation-timing-function:cubic-bezier(.42,0,.58,1)}50%{transform:translate(64px,64px) rotate(810deg);animation-timing-function:cubic-bezier(.42,0,.58,1)}to{transform:translate(64px,64px) rotate(1530deg)}}@keyframes e2CRglijn892_s_p{0%,to{stroke:#39fbbb}25%{stroke:#4a4efa}50%{stroke:#e63cfe}75%{stroke:#ffae3c}}@keyframes e2CRglijn892_s_do{0%{stroke-dashoffset:251.89}2.5%,52.5%{stroke-dashoffset:263.88;animation-timing-function:cubic-bezier(.42,0,.58,1)}25%,75%{stroke-dashoffset:131.945}to{stroke-dashoffset:251.885909}}#e2CRglijn892_tr{animation:e2CRglijn892_tr__tr 3000ms linear infinite normal forwards}#e2CRglijn892{animation-name:e2CRglijn892_s_p,e2CRglijn892_s_do;animation-duration:3000ms;animation-fill-mode:forwards;animation-timing-function:linear;animation-direction:normal;animation-iteration-count:infinite}</style><g id=\"e2CRglijn892_tr\" transform=\"translate(64,64) rotate(90)\"><circle id=\"e2CRglijn892\" r=\"42\" fill=\"none\" stroke=\"#39fbbb\" stroke-dasharray=\"263.89\" stroke-dashoffset=\"251.89\" stroke-linecap=\"round\" stroke-width=\"16\" transform=\"scale(-1,1) translate(0,0)\"/></g></svg>"
+        }
+      ],
+      [
+        "HccBQDPiEV84beaGE77Ko",
+        {
+          "id": "HccBQDPiEV84beaGE77Ko",
+          "instanceId": "BeQ7sgDlUizFvf4aHqOsh",
+          "name": "executeScriptOnCanvas",
+          "type": "boolean",
+          "value": false
+        }
       ]
     ],
     "dataSources": [
       [
-        "gzU1wxmnHwY-x5jPet-3Y",
+        "_yJ0UuBlq2PEEobk8o_ku",
         {
-          "id": "gzU1wxmnHwY-x5jPet-3Y",
+          "id": "_yJ0UuBlq2PEEobk8o_ku",
           "scopeInstanceId": "ibXgMoi9_ipHx1gVrvii0",
           "name": "system",
           "type": "parameter"
         }
       ],
       [
-        "pCHIauvdC2bIuiCOAhV9Z",
+        "Mlo1vx1bhMUxPcNRfzESD",
         {
-          "id": "pCHIauvdC2bIuiCOAhV9Z",
+          "id": "Mlo1vx1bhMUxPcNRfzESD",
           "scopeInstanceId": "LW98_-srDnnagkR10lsk4",
           "name": "system",
           "type": "parameter"
         }
       ],
       [
-        "E2nbgH6ec91fv6I4xF7DR",
+        "Zl0ZwsVkVbga9LehMyyQx",
         {
-          "id": "E2nbgH6ec91fv6I4xF7DR",
+          "id": "Zl0ZwsVkVbga9LehMyyQx",
           "scopeInstanceId": "jDb2FuSK2-azIZxkH5XNv",
           "name": "system",
           "type": "parameter"
@@ -563,6 +1294,10 @@
             {
               "type": "id",
               "value": "QzTSoZnbGD6luZ5xcv893"
+            },
+            {
+              "type": "id",
+              "value": "ZkDuD4HlHP3pDdp0SXJuh"
             }
           ]
         }
@@ -668,6 +1403,101 @@
             }
           ]
         }
+      ],
+      [
+        "ZkDuD4HlHP3pDdp0SXJuh",
+        {
+          "type": "instance",
+          "id": "ZkDuD4HlHP3pDdp0SXJuh",
+          "component": "Vimeo",
+          "children": [
+            {
+              "type": "id",
+              "value": "wxd8Wul8dl2yPRFFedNn6"
+            },
+            {
+              "type": "id",
+              "value": "o8sAMUoaOraWYZClEfRgl"
+            },
+            {
+              "type": "id",
+              "value": "9hBBPGSf7hB30ZkSHKjNd"
+            }
+          ]
+        }
+      ],
+      [
+        "wxd8Wul8dl2yPRFFedNn6",
+        {
+          "type": "instance",
+          "id": "wxd8Wul8dl2yPRFFedNn6",
+          "component": "VimeoPreviewImage",
+          "children": []
+        }
+      ],
+      [
+        "9hBBPGSf7hB30ZkSHKjNd",
+        {
+          "type": "instance",
+          "id": "9hBBPGSf7hB30ZkSHKjNd",
+          "component": "VimeoPlayButton",
+          "children": [
+            {
+              "type": "id",
+              "value": "D__QElBIIQtamhJN3a4FI"
+            }
+          ]
+        }
+      ],
+      [
+        "D__QElBIIQtamhJN3a4FI",
+        {
+          "type": "instance",
+          "id": "D__QElBIIQtamhJN3a4FI",
+          "component": "Box",
+          "label": "Play Icon",
+          "children": [
+            {
+              "type": "id",
+              "value": "iEc6hab-WardXZc5P9wJu"
+            }
+          ]
+        }
+      ],
+      [
+        "iEc6hab-WardXZc5P9wJu",
+        {
+          "type": "instance",
+          "id": "iEc6hab-WardXZc5P9wJu",
+          "component": "HtmlEmbed",
+          "label": "Play SVG",
+          "children": []
+        }
+      ],
+      [
+        "o8sAMUoaOraWYZClEfRgl",
+        {
+          "type": "instance",
+          "id": "o8sAMUoaOraWYZClEfRgl",
+          "component": "VimeoSpinner",
+          "label": "Spinner",
+          "children": [
+            {
+              "type": "id",
+              "value": "BeQ7sgDlUizFvf4aHqOsh"
+            }
+          ]
+        }
+      ],
+      [
+        "BeQ7sgDlUizFvf4aHqOsh",
+        {
+          "type": "instance",
+          "id": "BeQ7sgDlUizFvf4aHqOsh",
+          "component": "HtmlEmbed",
+          "label": "Spinner SVG",
+          "children": []
+        }
       ]
     ],
     "deployment": {
@@ -685,7 +1515,7 @@
     },
     "rootInstanceId": "ibXgMoi9_ipHx1gVrvii0",
     "path": "",
-    "systemDataSourceId": "gzU1wxmnHwY-x5jPet-3Y"
+    "systemDataSourceId": "_yJ0UuBlq2PEEobk8o_ku"
   },
   "pages": [
     {
@@ -697,7 +1527,7 @@
       },
       "rootInstanceId": "ibXgMoi9_ipHx1gVrvii0",
       "path": "",
-      "systemDataSourceId": "gzU1wxmnHwY-x5jPet-3Y"
+      "systemDataSourceId": "_yJ0UuBlq2PEEobk8o_ku"
     },
     {
       "id": "xT46WZKzCBTvUCIObMELW",
@@ -716,7 +1546,7 @@
       },
       "rootInstanceId": "LW98_-srDnnagkR10lsk4",
       "path": "/script-test",
-      "systemDataSourceId": "pCHIauvdC2bIuiCOAhV9Z"
+      "systemDataSourceId": "Mlo1vx1bhMUxPcNRfzESD"
     },
     {
       "id": "lyz5sZaJ7WzLt71cX3VJ2",
@@ -733,7 +1563,7 @@
       },
       "rootInstanceId": "jDb2FuSK2-azIZxkH5XNv",
       "path": "/world",
-      "systemDataSourceId": "E2nbgH6ec91fv6I4xF7DR"
+      "systemDataSourceId": "Zl0ZwsVkVbga9LehMyyQx"
     }
   ],
   "assets": [

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml].ts
@@ -2,15 +2,15 @@ export const sitemap = {
   pages: [
     {
       path: "",
-      lastModified: "2024-03-05T15:38:45.184Z",
+      lastModified: "2024-03-17T18:28:52.083Z",
     },
     {
       path: "/script-test",
-      lastModified: "2024-03-05T15:38:45.184Z",
+      lastModified: "2024-03-17T18:28:52.083Z",
     },
     {
       path: "/world",
-      lastModified: "2024-03-05T15:38:45.184Z",
+      lastModified: "2024-03-17T18:28:52.083Z",
     },
   ],
 };

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -15,7 +15,15 @@ import {
   Body as Body,
   Link as Link,
 } from "@webstudio-is/sdk-components-react-remix";
-import { Heading as Heading } from "@webstudio-is/sdk-components-react";
+import {
+  Heading as Heading,
+  Vimeo as Vimeo,
+  VimeoPreviewImage as VimeoPreviewImage,
+  VimeoPlayButton as VimeoPlayButton,
+  Box as Box,
+  HtmlEmbed as HtmlEmbed,
+  VimeoSpinner as VimeoSpinner,
+} from "@webstudio-is/sdk-components-react";
 
 import type { PageData } from "~/routes/_index";
 export const imageAssets: ImageAsset[] = [
@@ -114,6 +122,57 @@ const Page = ({}: { system: any }) => {
       >
         {"Goto Scr"}
       </Link>
+      <Vimeo
+        data-ws-id="ZkDuD4HlHP3pDdp0SXJuh"
+        data-ws-component="Vimeo"
+        url={"https://player.vimeo.com/video/831343124"}
+        showPreview={true}
+        className="ca1m5u0 ciuvvr7 cuk1bdz"
+      >
+        <VimeoPreviewImage
+          data-ws-id="wxd8Wul8dl2yPRFFedNn6"
+          data-ws-component="VimeoPreviewImage"
+          alt={"Vimeo video preview image"}
+          sizes={"100vw"}
+          src={"/custom-folder/home_wsKvRSqvkajPPBeycZ-C8.svg"}
+          className="c1eccbi0 cc32szi cuk1bdz c1ge5ofh c1fwh0y5 ch160p4 c1jxoq3x cewch87 c1la265j"
+        />
+        <VimeoSpinner
+          data-ws-id="o8sAMUoaOraWYZClEfRgl"
+          data-ws-component="VimeoSpinner"
+          className="c1eccbi0 ce5jzw0 cq3eebu c1319rdz c1x7j4n5 c176tfq4 c1qg633k"
+        >
+          <HtmlEmbed
+            data-ws-id="BeQ7sgDlUizFvf4aHqOsh"
+            data-ws-component="HtmlEmbed"
+            code={
+              '<svg xmlns="http://www.w3.org/2000/svg" id="e2CRglijn891" shape-rendering="geometricPrecision" text-rendering="geometricPrecision" viewBox="0 0 128 128" fill="currentColor" width="100%" height="100%" style="display: block;"><style>@keyframes e2CRglijn892_tr__tr{0%{transform:translate(64px,64px) rotate(90deg);animation-timing-function:cubic-bezier(.42,0,.58,1)}50%{transform:translate(64px,64px) rotate(810deg);animation-timing-function:cubic-bezier(.42,0,.58,1)}to{transform:translate(64px,64px) rotate(1530deg)}}@keyframes e2CRglijn892_s_p{0%,to{stroke:#39fbbb}25%{stroke:#4a4efa}50%{stroke:#e63cfe}75%{stroke:#ffae3c}}@keyframes e2CRglijn892_s_do{0%{stroke-dashoffset:251.89}2.5%,52.5%{stroke-dashoffset:263.88;animation-timing-function:cubic-bezier(.42,0,.58,1)}25%,75%{stroke-dashoffset:131.945}to{stroke-dashoffset:251.885909}}#e2CRglijn892_tr{animation:e2CRglijn892_tr__tr 3000ms linear infinite normal forwards}#e2CRglijn892{animation-name:e2CRglijn892_s_p,e2CRglijn892_s_do;animation-duration:3000ms;animation-fill-mode:forwards;animation-timing-function:linear;animation-direction:normal;animation-iteration-count:infinite}</style><g id="e2CRglijn892_tr" transform="translate(64,64) rotate(90)"><circle id="e2CRglijn892" r="42" fill="none" stroke="#39fbbb" stroke-dasharray="263.89" stroke-dashoffset="251.89" stroke-linecap="round" stroke-width="16" transform="scale(-1,1) translate(0,0)"/></g></svg>'
+            }
+            executeScriptOnCanvas={false}
+          />
+        </VimeoSpinner>
+        <VimeoPlayButton
+          data-ws-id="9hBBPGSf7hB30ZkSHKjNd"
+          data-ws-component="VimeoPlayButton"
+          aria-label={"Play button"}
+          className="c1eccbi0 c1yx3ait c1scl4ay ce5jzw0 cq3eebu cxar3by c1fiqkhd c1b095zn cyw79s9 c2f7s8e c9bs64c c6lou2r c16c73ai c1fisnnh c82rye8 c1xaktbd c1xplc5b c5admkk ccn3fhu cyn2bny c1xs2zvh c1be0m8p"
+        >
+          <Box
+            data-ws-id="D__QElBIIQtamhJN3a4FI"
+            data-ws-component="Box"
+            aria-hidden={"true"}
+            className="c14af118 c1xa5m0w"
+          >
+            <HtmlEmbed
+              data-ws-id="iEc6hab-WardXZc5P9wJu"
+              data-ws-component="HtmlEmbed"
+              code={
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.766 5.765c0-.725 0-1.088.178-1.288a.93.93 0 0 1 .648-.294c.294-.015.65.186 1.359.588l9.234 5.235c.586.332.88.498.982.708.09.183.09.389 0 .572-.102.21-.396.376-.982.708l-9.234 5.235c-.71.402-1.065.603-1.359.588a.93.93 0 0 1-.648-.294c-.178-.2-.178-.563-.178-1.288V5.765Z"/></svg>'
+              }
+            />
+          </Box>
+        </VimeoPlayButton>
+      </Vimeo>
     </Body>
   );
 };

--- a/fixtures/webstudio-custom-template/app/__generated__/index.css
+++ b/fixtures/webstudio-custom-template/app/__generated__/index.css
@@ -86,6 +86,131 @@ html {
     min-height: 1em;
     display: inline-block;
   }
+  div:where([data-ws-component="Vimeo"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
+  img:where([data-ws-component="VimeoPreviewImage"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+    max-width: 100%;
+    display: block;
+  }
+  button:where([data-ws-component="VimeoPlayButton"]) {
+    font-family: inherit;
+    font-size: 100%;
+    line-height: 1.15;
+    margin-top: 0;
+    margin-right: 0;
+    margin-bottom: 0;
+    margin-left: 0;
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    border-top-style: solid;
+    border-right-style: solid;
+    border-bottom-style: solid;
+    border-left-style: solid;
+    text-transform: none;
+  }
+  div:where([data-ws-component="Box"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
+  address:where([data-ws-component="Box"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
+  article:where([data-ws-component="Box"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
+  aside:where([data-ws-component="Box"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
+  figure:where([data-ws-component="Box"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
+  footer:where([data-ws-component="Box"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
+  header:where([data-ws-component="Box"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
+  main:where([data-ws-component="Box"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
+  nav:where([data-ws-component="Box"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
+  section:where([data-ws-component="Box"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
+  div:where([data-ws-component="VimeoSpinner"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
 }
 @media all {
   .c11x2bo2 {
@@ -134,5 +259,119 @@ html {
   }
   .c1jp5sfs {
     margin-left: 15px;
+  }
+  .ca1m5u0 {
+    position: relative;
+  }
+  .ciuvvr7 {
+    aspect-ratio: 640/360;
+  }
+  .cuk1bdz {
+    width: 100%;
+  }
+  .c1eccbi0 {
+    position: absolute;
+  }
+  .cc32szi {
+    object-fit: cover;
+  }
+  .c1ge5ofh {
+    height: 100%;
+  }
+  .c1fwh0y5 {
+    border-top-left-radius: 20px;
+  }
+  .ch160p4 {
+    border-top-right-radius: 20px;
+  }
+  .c1jxoq3x {
+    border-bottom-left-radius: 20px;
+  }
+  .cewch87 {
+    border-bottom-right-radius: 20px;
+  }
+  .c1la265j {
+    object-position: cover;
+  }
+  .c1yx3ait {
+    width: 140px;
+  }
+  .c1scl4ay {
+    height: 80px;
+  }
+  .ce5jzw0 {
+    top: 50%;
+  }
+  .cq3eebu {
+    left: 50%;
+  }
+  .cxar3by {
+    margin-top: -40px;
+  }
+  .c1fiqkhd {
+    margin-left: -70px;
+  }
+  .c1b095zn {
+    display: flex;
+  }
+  .cyw79s9 {
+    align-items: center;
+  }
+  .c2f7s8e {
+    justify-content: center;
+  }
+  .c9bs64c {
+    border-top-style: none;
+  }
+  .c6lou2r {
+    border-right-style: none;
+  }
+  .c16c73ai {
+    border-bottom-style: none;
+  }
+  .c1fisnnh {
+    border-left-style: none;
+  }
+  .c82rye8 {
+    border-top-left-radius: 5px;
+  }
+  .c1xaktbd {
+    border-top-right-radius: 5px;
+  }
+  .c1xplc5b {
+    border-bottom-left-radius: 5px;
+  }
+  .c5admkk {
+    border-bottom-right-radius: 5px;
+  }
+  .ccn3fhu {
+    cursor: pointer;
+  }
+  .cyn2bny {
+    background-color: rgba(18, 18, 18, 1);
+  }
+  .c1xs2zvh {
+    color: rgba(255, 255, 255, 1);
+  }
+  .c1be0m8p:hover {
+    background-color: rgba(0, 173, 239, 1);
+  }
+  .c14af118 {
+    width: 60px;
+  }
+  .c1xa5m0w {
+    height: 60px;
+  }
+  .c1319rdz {
+    width: 70px;
+  }
+  .c1x7j4n5 {
+    height: 70px;
+  }
+  .c176tfq4 {
+    margin-top: -35px;
+  }
+  .c1qg633k {
+    margin-left: -35px;
   }
 }

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -8,6 +8,7 @@ import {
   transpileExpression,
   validateExpression,
   type Diagnostic,
+  getExpressionIdentifiers,
 } from "./expression";
 
 test("allow literals and array expressions", () => {
@@ -358,6 +359,23 @@ test("transform identifiers", () => {
       transformIdentifier: (id) => `$ws$${id}`,
     })
   ).toEqual(`$ws$a + $ws$b`);
+});
+
+describe("get expression identifiers", () => {
+  test("find all identifiers", () => {
+    expect(getExpressionIdentifiers("a = b * c.d")).toEqual(
+      new Set(["a", "b", "c"])
+    );
+  });
+
+  test("deduplicate identifiers", () => {
+    expect(getExpressionIdentifiers("a = a + b")).toEqual(new Set(["a", "b"]));
+  });
+
+  test("not fail when invalid syntax", () => {
+    expect(getExpressionIdentifiers("")).toEqual(new Set());
+    expect(getExpressionIdentifiers("a = a +")).toEqual(new Set());
+  });
 });
 
 describe("transpile expression", () => {

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -310,6 +310,24 @@ export const isLiteralExpression = (expression: string) => {
   }
 };
 
+export const getExpressionIdentifiers = (expression: string) => {
+  const identifiers = new Set<string>();
+  try {
+    const root = parseExpressionAt(expression, 0, { ecmaVersion: "latest" });
+    simple(root, {
+      Identifier: (node) => identifiers.add(node.name),
+      AssignmentExpression(node) {
+        simple(node.left, {
+          Identifier: (node) => identifiers.add(node.name),
+        });
+      },
+    });
+  } catch {
+    // empty block
+  }
+  return identifiers;
+};
+
 /**
  * transpile expression into executable one
  *


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Here switched the rest of usages to acorn based expressions. Added getExpressionIdentifiers utility to extract used variables names to avoid using transpiler replaceVariable callback for this.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
