### PR TITLE
experimental: support search params in expressions

### DIFF
--- a/apps/builder/app/builder/features/address-bar.tsx
+++ b/apps/builder/app/builder/features/address-bar.tsx
@@ -27,7 +27,7 @@ import {
   $pages,
   $project,
   $selectedPage,
-  updateSystemParams,
+  updateSystem,
 } from "~/shared/nano-states";
 import env from "~/shared/env";
 import {
@@ -94,7 +94,7 @@ const updatePathParam = (name: string, value: string) => {
   newParams[name] = value;
   const page = $selectedPage.get();
   if (page) {
-    updateSystemParams(page, newParams);
+    updateSystem(page, { params: newParams });
   }
 };
 

--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -1,10 +1,6 @@
-import { findPageByIdOrPath } from "@webstudio-is/sdk";
+import { convertSearchParams, findPageByIdOrPath } from "@webstudio-is/sdk";
 import { matchPathnamePattern } from "~/builder/shared/url-pattern";
-import {
-  $isPreviewMode,
-  $pages,
-  updateSystemParams,
-} from "~/shared/nano-states";
+import { $isPreviewMode, $pages, updateSystem } from "~/shared/nano-states";
 import { switchPage } from "~/shared/pages";
 
 const isAbsoluteUrl = (href: string) => {
@@ -30,10 +26,13 @@ const handleLinkClick = (element: HTMLAnchorElement) => {
 
   const pageHref = new URL(href, "https://any-valid.url");
   for (const page of [pages.homePage, ...pages.pages]) {
-    const params = matchPathnamePattern(page.path, pageHref.pathname);
+    // URL always parses root page as /
+    // but webstudio stores home page as empty string
+    const params = matchPathnamePattern(page.path || "/", pageHref.pathname);
     if (params) {
+      const search = convertSearchParams(pageHref.searchParams);
       switchPage(page.id, pageHref.hash);
-      updateSystemParams(page, params);
+      updateSystem(page, { params, search });
       break;
     }
   }

--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -1,4 +1,4 @@
-import { convertSearchParams, findPageByIdOrPath } from "@webstudio-is/sdk";
+import { findPageByIdOrPath } from "@webstudio-is/sdk";
 import { matchPathnamePattern } from "~/builder/shared/url-pattern";
 import { $isPreviewMode, $pages, updateSystem } from "~/shared/nano-states";
 import { switchPage } from "~/shared/pages";
@@ -30,7 +30,7 @@ const handleLinkClick = (element: HTMLAnchorElement) => {
     // but webstudio stores home page as empty string
     const params = matchPathnamePattern(page.path || "/", pageHref.pathname);
     if (params) {
-      const search = convertSearchParams(pageHref.searchParams);
+      const search = Object.fromEntries(pageHref.searchParams);
       switchPage(page.id, pageHref.hash);
       updateSystem(page, { params, search });
       break;

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -51,7 +51,7 @@ export const $dataSourceVariables = atom<Map<DataSource["id"], unknown>>(
   new Map()
 );
 
-export const updateSystemParams = (page: Page, params: System["params"]) => {
+export const updateSystem = (page: Page, update: Partial<System>) => {
   if (page.systemDataSourceId === undefined) {
     return;
   }
@@ -59,11 +59,13 @@ export const updateSystemParams = (page: Page, params: System["params"]) => {
   const system = dataSourceVariables.get(page.systemDataSourceId) as
     | undefined
     | System;
-  dataSourceVariables.set(page.systemDataSourceId, {
+  const newSystem: System = {
     search: {},
+    params: {},
     ...system,
-    params: params,
-  } satisfies System);
+    ...update,
+  };
+  dataSourceVariables.set(page.systemDataSourceId, newSystem);
   $dataSourceVariables.set(dataSourceVariables);
 };
 

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
+import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -34,10 +34,11 @@ export type PageData = {
 };
 
 export const loader = async (arg: LoaderArgs) => {
+  const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: {},
+    search: convertSearchParams(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -55,7 +56,6 @@ export const loader = async (arg: LoaderArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const url = new URL(arg.request.url);
   url.host = host;
   url.protocol = "https";
 

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -10,7 +10,7 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import { convertSearchParams, type ProjectMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
@@ -38,7 +38,7 @@ export const loader = async (arg: LoaderArgs) => {
   const params = getRemixParams(arg.params);
   const system = {
     params,
-    search: convertSearchParams(url.searchParams),
+    search: Object.fromEntries(url.searchParams),
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });

--- a/packages/sdk/src/page-utils.test.ts
+++ b/packages/sdk/src/page-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "@jest/globals";
 import type { Pages } from "./schema/pages";
 import {
+  convertSearchParams,
   findPageByIdOrPath,
   findParentFolderByChildId,
   getPagePath,
@@ -117,5 +118,19 @@ describe("findParentFolderByChildId", () => {
     expect(
       findParentFolderByChildId("folderId-1-1-1", pages.folders)?.id
     ).toEqual("folderId-1-1");
+  });
+});
+
+test("convert search params", () => {
+  const searchParams = new URLSearchParams([
+    ["single1", "1"],
+    ["single2", "2"],
+    ["multiple", "3"],
+    ["multiple", "4"],
+  ]);
+  expect(convertSearchParams(searchParams)).toEqual({
+    single1: "1",
+    single2: "2",
+    multiple: "4",
   });
 });

--- a/packages/sdk/src/page-utils.test.ts
+++ b/packages/sdk/src/page-utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "@jest/globals";
 import type { Pages } from "./schema/pages";
 import {
-  convertSearchParams,
   findPageByIdOrPath,
   findParentFolderByChildId,
   getPagePath,
@@ -118,19 +117,5 @@ describe("findParentFolderByChildId", () => {
     expect(
       findParentFolderByChildId("folderId-1-1-1", pages.folders)?.id
     ).toEqual("folderId-1-1");
-  });
-});
-
-test("convert search params", () => {
-  const searchParams = new URLSearchParams([
-    ["single1", "1"],
-    ["single2", "2"],
-    ["multiple", "3"],
-    ["multiple", "4"],
-  ]);
-  expect(convertSearchParams(searchParams)).toEqual({
-    single1: "1",
-    single2: "2",
-    multiple: "4",
   });
 });

--- a/packages/sdk/src/page-utils.ts
+++ b/packages/sdk/src/page-utils.ts
@@ -73,3 +73,15 @@ export const getPagePath = (id: Folder["id"] | Page["id"], pages: Pages) => {
 
   return paths.reverse().join("/").replace(/\/+/g, "/");
 };
+
+/**
+ * convert URLSearchParams instance into key/value object
+ * to easily access from expressions
+ */
+export const convertSearchParams = (searchParams: URLSearchParams) => {
+  const search: Record<string, string> = {};
+  for (const [key, value] of searchParams) {
+    search[key] = value;
+  }
+  return search;
+};

--- a/packages/sdk/src/page-utils.ts
+++ b/packages/sdk/src/page-utils.ts
@@ -73,15 +73,3 @@ export const getPagePath = (id: Folder["id"] | Page["id"], pages: Pages) => {
 
   return paths.reverse().join("/").replace(/\/+/g, "/");
 };
-
-/**
- * convert URLSearchParams instance into key/value object
- * to easily access from expressions
- */
-export const convertSearchParams = (searchParams: URLSearchParams) => {
-  const search: Record<string, string> = {};
-  for (const [key, value] of searchParams) {
-    search[key] = value;
-  }
-  return search;
-};


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Here added support for search params in builder and compiler.

system.search contains an object computed from url.

In generated website loaders compute search params which allows to access them in resources.

In builder links with search params populate system.search.

<img width="180" alt="Screenshot 2024-03-18 at 21 09 05" src="https://github.com/webstudio-is/webstudio/assets/5635476/4efa7a38-511c-4360-a085-84da2527db74">
<br>
<img width="471" alt="Screenshot 2024-03-18 at 21 09 25" src="https://github.com/webstudio-is/webstudio/assets/5635476/af793a60-698a-485b-8606-dfacdaf633b7">
<br>
<img width="429" alt="Screenshot 2024-03-18 at 21 09 36" src="https://github.com/webstudio-is/webstudio/assets/5635476/a3c8c52e-f0a1-43ff-a464-f57b61b1f159">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
