### PR TITLE
refactor: move forms properties into server module

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
@@ -1,4 +1,36 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Script Test",
+    description: "",
+    excludePageFromSearch: false,
+    language: undefined,
+    socialImageAssetId: "",
+    socialImageUrl: undefined,
+    status: undefined,
+    redirect: undefined,
+    custom: [],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
   Link as Link,
@@ -49,26 +47,6 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Script Test",
-    description: "",
-    excludePageFromSearch: false,
-    language: undefined,
-    socialImageAssetId: "",
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [],
-  };
-};
-
 const Page = ({}: { system: any }) => {
   return (
     <Body
@@ -91,13 +69,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
@@ -1,4 +1,36 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Untitled",
+    description: "",
+    excludePageFromSearch: false,
+    language: "ru",
+    socialImageAssetId: undefined,
+    socialImageUrl: "",
+    status: 200,
+    redirect: "",
+    custom: [],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
@@ -46,26 +44,6 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Untitled",
-    description: "",
-    excludePageFromSearch: false,
-    language: "ru",
-    socialImageAssetId: undefined,
-    socialImageUrl: "",
-    status: 200,
-    redirect: "",
-    custom: [],
-  };
-};
-
 const Page = ({}: { system: any }) => {
   return (
     <Body data-ws-id="jDb2FuSK2-azIZxkH5XNv" data-ws-component="Body">
@@ -77,13 +55,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
@@ -1,4 +1,36 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Site Title",
+    description: "Page description f511c297-b44f-4e4b-96bd-d013da06bada",
+    excludePageFromSearch: undefined,
+    language: undefined,
+    socialImageAssetId: undefined,
+    socialImageUrl: undefined,
+    status: undefined,
+    redirect: undefined,
+    custom: [],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
   Link as Link,
@@ -80,26 +78,6 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
-
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Site Title",
-    description: "Page description f511c297-b44f-4e4b-96bd-d013da06bada",
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetId: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [],
-  };
-};
 
 const Page = ({}: { system: any }) => {
   return (
@@ -178,13 +156,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[script-test]._index";
-import { loadResources } from "../__generated__/[script-test]._index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/[script-test]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[world]._index";
-import { loadResources } from "../__generated__/[world]._index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/[world]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
-import { loadResources } from "../__generated__/_index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
@@ -1,4 +1,36 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Home",
+    description: undefined,
+    excludePageFromSearch: undefined,
+    language: undefined,
+    socialImageAssetId: undefined,
+    socialImageUrl: undefined,
+    status: undefined,
+    redirect: undefined,
+    custom: [],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Heading as Heading,
@@ -33,26 +31,6 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Home",
-    description: undefined,
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetId: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [],
-  };
-};
-
 const Page = ({}: { system: any }) => {
   return (
     <Body
@@ -71,13 +49,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
-import { loadResources } from "../__generated__/_index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
@@ -1,4 +1,36 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Home",
+    description: undefined,
+    excludePageFromSearch: undefined,
+    language: undefined,
+    socialImageAssetId: undefined,
+    socialImageUrl: undefined,
+    status: undefined,
+    redirect: undefined,
+    custom: [],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Heading as Heading,
@@ -33,26 +31,6 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Home",
-    description: undefined,
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetId: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [],
-  };
-};
-
 const Page = ({}: { system: any }) => {
   return (
     <Body
@@ -71,13 +49,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
-import { loadResources } from "../__generated__/_index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
@@ -1,4 +1,36 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "RouteWithSymbols",
+    description: "",
+    excludePageFromSearch: undefined,
+    language: undefined,
+    socialImageAssetId: undefined,
+    socialImageUrl: undefined,
+    status: undefined,
+    redirect: undefined,
+    custom: [],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Image as Image } from "@webstudio-is/sdk-components-react";
 
@@ -68,26 +66,6 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "RouteWithSymbols",
-    description: "",
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetId: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [],
-  };
-};
-
 const Page = ({}: { system: any }) => {
   return (
     <Body data-ws-id="EDEfpMPRqDejthtwkH7ws" data-ws-component="Body">
@@ -102,13 +80,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
@@ -1,4 +1,38 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "form",
+    description: "",
+    excludePageFromSearch: undefined,
+    language: undefined,
+    socialImageAssetId: undefined,
+    socialImageUrl: undefined,
+    status: undefined,
+    redirect: undefined,
+    custom: [],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([
+  ["isNSM3wXcnHFikwNPlEOL", { method: "get", action: "/custom" }],
+]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
   Form as Form,
@@ -76,26 +74,6 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
-
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "form",
-    description: "",
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetId: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [],
-  };
-};
 
 const Page = ({}: { system: any }) => {
   let [formState, set$formState] = useState<any>("initial");
@@ -215,13 +193,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([["isNSM3wXcnHFikwNPlEOL", { method: "get", action: "/custom" }]]);

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
@@ -1,4 +1,36 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "heading-with-id",
+    description: "",
+    excludePageFromSearch: undefined,
+    language: undefined,
+    socialImageAssetId: undefined,
+    socialImageUrl: undefined,
+    status: undefined,
+    redirect: undefined,
+    custom: [],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
@@ -68,26 +66,6 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "heading-with-id",
-    description: "",
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetId: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [],
-  };
-};
-
 const Page = ({}: { system: any }) => {
   return (
     <Body data-ws-id="O-ljaGZQ0iRNTlEshMkgE" data-ws-component="Body">
@@ -103,13 +81,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
@@ -1,4 +1,36 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Nested Page",
+    description: "",
+    excludePageFromSearch: false,
+    language: undefined,
+    socialImageAssetId: "",
+    socialImageUrl: undefined,
+    status: undefined,
+    redirect: undefined,
+    custom: [],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
@@ -68,26 +66,6 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Nested Page",
-    description: "",
-    excludePageFromSearch: false,
-    language: undefined,
-    socialImageAssetId: "",
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [],
-  };
-};
-
 const Page = ({}: { system: any }) => {
   return (
     <Body data-ws-id="L0ZXd5F9xk9Rsl9ORzIkJ" data-ws-component="Body">
@@ -99,13 +77,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
@@ -1,4 +1,37 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Radix Revelations: Unraveling the Feline Mystique",
+    description:
+      "Delve deep into the radix roots of feline behaviors. At KittyNoTouchy, we dissect the core essence, or 'radix', of what makes cats the enigmatic creatures they are. Join us as we explore the radix of their instincts, habits, and quirks.",
+    excludePageFromSearch: true,
+    language: undefined,
+    socialImageAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+    socialImageUrl: undefined,
+    status: undefined,
+    redirect: undefined,
+    custom: [],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Accordion as Accordion,
@@ -78,27 +76,6 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
-
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Radix Revelations: Unraveling the Feline Mystique",
-    description:
-      "Delve deep into the radix roots of feline behaviors. At KittyNoTouchy, we dissect the core essence, or 'radix', of what makes cats the enigmatic creatures they are. Join us as we explore the radix of their instincts, habits, and quirks.",
-    excludePageFromSearch: true,
-    language: undefined,
-    socialImageAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [],
-  };
-};
 
 const Page = ({}: { system: any }) => {
   let [accordionValue, set$accordionValue] = useState<any>("0");
@@ -250,13 +227,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
@@ -1,3 +1,7 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   const [list_1] = await Promise.all([
@@ -12,4 +16,32 @@ export const loadResources = async (_props: { system: System }) => {
   return {
     list_1,
   } as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "resources",
+    description: "",
+    excludePageFromSearch: false,
+    language: undefined,
+    socialImageAssetId: "",
+    socialImageUrl: undefined,
+    status: undefined,
+    redirect: undefined,
+    custom: [],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Box as Box,
@@ -71,26 +69,6 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "resources",
-    description: "",
-    excludePageFromSearch: false,
-    language: undefined,
-    socialImageAssetId: "",
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [],
-  };
-};
-
 const Page = ({}: { system: any }) => {
   let list = useResource("list_1");
   return (
@@ -111,13 +89,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
@@ -1,4 +1,42 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({
+  system,
+  resources,
+}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "The Ultimate Cat Protection Zone",
+    description:
+      "Dive into the world of felines and discover why some whiskers are best left untouched. From intriguing cat behaviors to protective measures, \nKittyGuardedZone is your go-to hub for all things 'hands-off' in the cat realm.",
+    excludePageFromSearch: undefined,
+    language: undefined,
+    socialImageAssetId: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+    socialImageUrl: undefined,
+    status: undefined,
+    redirect: undefined,
+    custom: [
+      {
+        property: "fb:app_id",
+        content: "app_id_app_id_app_id",
+      },
+    ],
+  };
+};
+
+type FormProperties = { method?: string; action?: string };
+export const formsProperties = new Map<string, FormProperties>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -7,10 +7,8 @@ import type {
   FontAsset,
   ImageAsset,
   ProjectMeta,
-  System,
 } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
   Link as Link,
@@ -76,32 +74,6 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
-
-export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "The Ultimate Cat Protection Zone",
-    description:
-      "Dive into the world of felines and discover why some whiskers are best left untouched. From intriguing cat behaviors to protective measures, \nKittyGuardedZone is your go-to hub for all things 'hands-off' in the cat realm.",
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetId: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [
-      {
-        property: "fb:app_id",
-        content: "app_id_app_id_app_id",
-      },
-    ],
-  };
-};
 
 const Page = ({}: { system: any }) => {
   return (
@@ -200,13 +172,3 @@ const Page = ({}: { system: any }) => {
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[_route_with_symbols_]._index";
-import { loadResources } from "../__generated__/[_route_with_symbols_]._index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/[_route_with_symbols_]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[form]._index";
-import { loadResources } from "../__generated__/[form]._index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/[form]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[heading-with-id]._index";
-import { loadResources } from "../__generated__/[heading-with-id]._index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/[heading-with-id]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[nested].[nested-page]._index";
-import { loadResources } from "../__generated__/[nested].[nested-page]._index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/[nested].[nested-page]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[radix]._index";
-import { loadResources } from "../__generated__/[radix]._index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/[radix]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[resources]._index";
-import { loadResources } from "../__generated__/[resources]._index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/[resources]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
-import { loadResources } from "../__generated__/_index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/packages/cli/__generated__/_index.server.tsx
+++ b/packages/cli/__generated__/_index.server.tsx
@@ -1,6 +1,26 @@
-import type { System } from "@webstudio-is/sdk";
+import type { PageMeta, System } from "@webstudio-is/sdk";
 
 export const loadResources = async (_props: { system: System }) => {
   const [] = await Promise.all([]);
   return {} as Record<string, unknown>;
+};
+
+export const getPageMeta = ({}: {
+  system: System;
+  resources: Record<string, any>;
+}): PageMeta => {
+  return {
+    title: "Page title",
+    custom: [],
+  };
+};
+
+export const formsProperties = new Map<
+  string,
+  { method?: string; action?: string }
+>([]);
+
+type Params = Record<string, string | undefined>;
+export const getRemixParams = ({ ...params }: Params): Params => {
+  return params;
 };

--- a/packages/cli/__generated__/_index.tsx
+++ b/packages/cli/__generated__/_index.tsx
@@ -1,9 +1,8 @@
 /**
  * The only intent of this file is to support typings inside ../templates/route-template for easier development.
  **/
-import type { ImageAsset, FontAsset, System } from "@webstudio-is/sdk";
+import type { ImageAsset, FontAsset } from "@webstudio-is/sdk";
 import type { PageData } from "../templates/defaults/__templates__/route-template";
-import type { PageMeta } from "@webstudio-is/react-sdk";
 
 export const imageAssets: ImageAsset[] = [];
 
@@ -20,31 +19,11 @@ export const user: { email: string | null } | undefined = {
 };
 export const projectId = "project-id";
 
-export const getPageMeta = ({}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Page title",
-    custom: [],
-  };
-};
-
 const Page = (_props: { system: any }) => {
   return <></>;
 };
 
 export { Page };
-
-type Params = Record<string, string | undefined>;
-export const getRemixParams = ({ ...params }: Params): Params => {
-  return params;
-};
-
-export const formsProperties = new Map<
-  string,
-  { method?: string; action?: string }
->([]);
 
 export const pageFontAssets: FontAsset[] = [];
 export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -17,15 +17,17 @@ import {
   pageData,
   user,
   projectId,
-  formsProperties,
   Page,
   imageAssets,
-  getRemixParams,
-  getPageMeta,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../../../__generated__/_index";
-import { loadResources } from "../../../__generated__/_index.server";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+} from "../../../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -19,11 +19,8 @@ export * from "./props";
 export * from "./context";
 export { getIndexesWithinAncestors } from "./instance-utils";
 export * from "./hook";
-export { generateUtilsExport } from "./generator";
 export {
   generateWebstudioComponent,
   generateJsxElement,
   generateJsxChildren,
 } from "./component-generator";
-export { generateResourcesLoader } from "./resources-generator";
-export * from "./page-meta-generator";

--- a/packages/sdk/src/forms-generator.test.ts
+++ b/packages/sdk/src/forms-generator.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "@jest/globals";
-import { generateUtilsExport } from "./generator";
+import { generateFormsProperties } from "./forms-generator";
 
 test("generates forms properties", () => {
   expect(
-    generateUtilsExport({
-      props: new Map([
+    generateFormsProperties(
+      new Map([
         [
           "method1Id",
           {
@@ -37,23 +37,17 @@ test("generates forms properties", () => {
             value: "/index.php",
           },
         ],
-      ]),
-    })
+      ])
+    )
   ).toMatchInlineSnapshot(`
+"type FormProperties = { method?: string, action?: string }
+export const formsProperties = new Map<string, FormProperties>([["1",{"method":"post"}],["2",{"method":"get","action":"/index.php"}]])
 "
-  export const formsProperties = new Map<string, { method?: string, action?: string }>([["1",{"method":"post"}],["2",{"method":"get","action":"/index.php"}]])
-  "
 `);
-});
 
-test("generates list of pages paths", () => {
-  expect(
-    generateUtilsExport({
-      props: new Map(),
-    })
-  ).toMatchInlineSnapshot(`
+  expect(generateFormsProperties(new Map())).toMatchInlineSnapshot(`
+"type FormProperties = { method?: string, action?: string }
+export const formsProperties = new Map<string, FormProperties>([])
 "
-  export const formsProperties = new Map<string, { method?: string, action?: string }>([])
-  "
 `);
 });

--- a/packages/sdk/src/forms-generator.ts
+++ b/packages/sdk/src/forms-generator.ts
@@ -1,19 +1,15 @@
-import type { Props } from "@webstudio-is/sdk";
-
-type PageData = {
-  props: Props;
-};
+import type { Props } from "./schema/props";
 
 /**
  * Generates data based utilities at build time
  */
-export const generateUtilsExport = (siteData: PageData) => {
+export const generateFormsProperties = (props: Props) => {
   // method and action per instance extracted from props
   const formsProperties = new Map<
     string,
     { method?: string; action?: string }
   >();
-  for (const prop of siteData.props.values()) {
+  for (const prop of props.values()) {
     if (prop.type === "string") {
       if (prop.name === "action" || prop.name === "method") {
         let properties = formsProperties.get(prop.instanceId);
@@ -25,11 +21,9 @@ export const generateUtilsExport = (siteData: PageData) => {
       }
     }
   }
-  const generatedFormsProperties = `export const formsProperties = new Map<string, { method?: string, action?: string }>(${JSON.stringify(
-    Array.from(formsProperties.entries())
-  )})`;
-
-  return `
-  ${generatedFormsProperties}
-  `;
+  const entriesString = JSON.stringify(Array.from(formsProperties.entries()));
+  let generated = "";
+  generated += `type FormProperties = { method?: string, action?: string }\n`;
+  generated += `export const formsProperties = new Map<string, FormProperties>(${entriesString})\n`;
+  return generated;
 };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -16,3 +16,6 @@ export * from "./page-utils";
 export * from "./scope";
 export * from "./resource-loader";
 export * from "./expression";
+export * from "./forms-generator";
+export * from "./resources-generator";
+export * from "./page-meta-generator";

--- a/packages/sdk/src/page-meta-generator.test.ts
+++ b/packages/sdk/src/page-meta-generator.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@jest/globals";
-import { createScope } from "@webstudio-is/sdk";
+import { createScope } from "./scope";
 import { generatePageMeta } from "./page-meta-generator";
 
 const toMap = <T extends { id: string }>(list: T[]) =>

--- a/packages/sdk/src/page-meta-generator.ts
+++ b/packages/sdk/src/page-meta-generator.ts
@@ -1,5 +1,8 @@
-import type { Asset, DataSources, Page, Scope } from "@webstudio-is/sdk";
-import { createScope, generateExpression } from "@webstudio-is/sdk";
+import type { Asset } from "./schema/assets";
+import type { DataSources } from "./schema/data-sources";
+import type { Page } from "./schema/pages";
+import { type Scope, createScope } from "./scope";
+import { generateExpression } from "./expression";
 
 export type PageMeta = {
   title: string;

--- a/packages/sdk/src/resources-generator.test.ts
+++ b/packages/sdk/src/resources-generator.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@jest/globals";
 import stripIndent from "strip-indent";
-import { createScope, type Page } from "@webstudio-is/sdk";
+import type { Page } from "./schema/pages";
+import { createScope } from "./scope";
 import { generateResourcesLoader } from "./resources-generator";
 
 const clear = (input: string) =>

--- a/packages/sdk/src/resources-generator.ts
+++ b/packages/sdk/src/resources-generator.ts
@@ -1,5 +1,8 @@
-import type { DataSources, Page, Resources, Scope } from "@webstudio-is/sdk";
-import { generateExpression } from "@webstudio-is/sdk";
+import type { DataSources } from "./schema/data-sources";
+import type { Page } from "./schema/pages";
+import type { Resources } from "./schema/resources";
+import type { Scope } from "./scope";
+import { generateExpression } from "./expression";
 
 export const generateResourcesLoader = ({
   scope,


### PR DESCRIPTION
Here moved forms properties, page meta and remix params into server module as used only in loader and never executed on client. Especially forms properties may contain user credentials and remix does not guarantee it to not appear in client side bundle.

Also moved those into sdk as universal generators.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
