### PR TITLE
refactor: move generated data into server module

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -34,3 +39,34 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "Fixture Site",
+  faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
+  code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
+};
+
+export const imageAssets: ImageAsset[] = [
+  {
+    id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
+    name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
+    description: null,
+    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
+    size: 3350,
+    type: "image",
+    format: "svg",
+    createdAt: "2023-10-30T20:35:47.113Z",
+    meta: { width: 16, height: 16 },
+  },
+];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -2,50 +2,12 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
   Link as Link,
 } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-    name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
-    description: null,
-    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    size: 3350,
-    type: "image",
-    format: "svg",
-    createdAt: "2023-10-30T20:35:47.113Z",
-    meta: { width: 16, height: 16 },
-  },
-];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: {
-    siteName: "Fixture Site",
-    faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-    code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
-  },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
 const Page = ({}: { system: any }) => {
   return (

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -34,3 +39,34 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "Fixture Site",
+  faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
+  code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
+};
+
+export const imageAssets: ImageAsset[] = [
+  {
+    id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
+    name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
+    description: null,
+    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
+    size: 3350,
+    type: "image",
+    format: "svg",
+    createdAt: "2023-10-30T20:35:47.113Z",
+    meta: { width: 16, height: 16 },
+  },
+];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
@@ -2,47 +2,9 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-    name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
-    description: null,
-    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    size: 3350,
-    type: "image",
-    format: "svg",
-    createdAt: "2023-10-30T20:35:47.113Z",
-    meta: { width: 16, height: 16 },
-  },
-];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: {
-    siteName: "Fixture Site",
-    faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-    code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
-  },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
 const Page = ({}: { system: any }) => {
   return (

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -34,3 +39,58 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "Fixture Site",
+  faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
+  code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
+};
+
+export const imageAssets: ImageAsset[] = [
+  {
+    id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
+    name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
+    description: null,
+    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
+    size: 3350,
+    type: "image",
+    format: "svg",
+    createdAt: "2023-10-30T20:35:47.113Z",
+    meta: { width: 16, height: 16 },
+  },
+];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [
+  {
+    id: "a8fb692a-5970-4014-ad4d-45c6f1edea36",
+    name: "CormorantGaramond-Medium_-nWJ-OtHncaW9xDHQ9hSA_CBl88Oo59QKH_z9pCWva2.woff2",
+    description: null,
+    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
+    size: 156212,
+    type: "font",
+    createdAt: "2024-02-22T05:36:52.004Z",
+    format: "woff2",
+    meta: { family: "Cormorant Garamond", style: "normal", weight: 500 },
+  },
+];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [
+  {
+    id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
+    name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
+    description: null,
+    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
+    size: 3350,
+    type: "image",
+    format: "svg",
+    createdAt: "2023-10-30T20:35:47.113Z",
+    meta: { width: 16, height: 16 },
+  },
+];

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -2,12 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
@@ -22,62 +16,6 @@ import {
   HtmlEmbed as HtmlEmbed,
   VimeoSpinner as VimeoSpinner,
 } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-    name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
-    description: null,
-    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    size: 3350,
-    type: "image",
-    format: "svg",
-    createdAt: "2023-10-30T20:35:47.113Z",
-    meta: { width: 16, height: 16 },
-  },
-];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [
-  {
-    id: "a8fb692a-5970-4014-ad4d-45c6f1edea36",
-    name: "CormorantGaramond-Medium_-nWJ-OtHncaW9xDHQ9hSA_CBl88Oo59QKH_z9pCWva2.woff2",
-    description: null,
-    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    size: 156212,
-    type: "font",
-    createdAt: "2024-02-22T05:36:52.004Z",
-    format: "woff2",
-    meta: { family: "Cormorant Garamond", style: "normal", weight: 500 },
-  },
-];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [
-  {
-    id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-    name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
-    description: null,
-    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    size: 3350,
-    type: "image",
-    format: "svg",
-    createdAt: "2023-10-30T20:35:47.113Z",
-    meta: { width: 16, height: 16 },
-  },
-];
-
-export const pageData: PageData = {
-  project: {
-    siteName: "Fixture Site",
-    faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-    code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
-  },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
 const Page = ({}: { system: any }) => {
   return (

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/[script-test]._index";
+import { Page } from "../__generated__/[script-test]._index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/[script-test]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/[world]._index";
+import { Page } from "../__generated__/[world]._index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/[world]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/_index";
+import { Page } from "../__generated__/_index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -34,3 +39,22 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "",
+  faviconAssetId: "",
+  code: "",
+};
+
+export const imageAssets: ImageAsset[] = [];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -2,34 +2,12 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Heading as Heading,
   Text as Text,
 } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: { siteName: "", faviconAssetId: "", code: "" },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
 const Page = ({}: { system: any }) => {
   return (

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/_index";
+import { Page } from "../__generated__/_index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -34,3 +39,22 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "",
+  faviconAssetId: "",
+  code: "",
+};
+
+export const imageAssets: ImageAsset[] = [];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -2,34 +2,12 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Heading as Heading,
   Text as Text,
 } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: { siteName: "", faviconAssetId: "", code: "" },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
 const Page = ({}: { system: any }) => {
   return (

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/_index";
+import { Page } from "../__generated__/_index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -34,3 +39,56 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "KittyGuardedZone",
+  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+  code: "<script>console.log('KittyGuardedZone')</script>\n",
+};
+
+export const imageAssets: ImageAsset[] = [
+  {
+    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 268326,
+    type: "image",
+    format: "png",
+    createdAt: "2023-10-30T13:51:08.416Z",
+    meta: { width: 790, height: 786 },
+  },
+  {
+    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
+    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 2906,
+    type: "image",
+    format: "webp",
+    createdAt: "2023-09-12T09:44:22.120Z",
+    meta: { width: 100, height: 100 },
+  },
+  {
+    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 210614,
+    type: "image",
+    format: "jpeg",
+    createdAt: "2023-09-06T11:28:43.031Z",
+    meta: { width: 1024, height: 1024 },
+  },
+];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -2,69 +2,9 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Image as Image } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: {
-    siteName: "KittyGuardedZone",
-    faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    code: "<script>console.log('KittyGuardedZone')</script>\n",
-  },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 const Page = ({}: { system: any }) => {
   return (

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -36,3 +41,56 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "KittyGuardedZone",
+  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+  code: "<script>console.log('KittyGuardedZone')</script>\n",
+};
+
+export const imageAssets: ImageAsset[] = [
+  {
+    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 268326,
+    type: "image",
+    format: "png",
+    createdAt: "2023-10-30T13:51:08.416Z",
+    meta: { width: 790, height: 786 },
+  },
+  {
+    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
+    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 2906,
+    type: "image",
+    format: "webp",
+    createdAt: "2023-09-12T09:44:22.120Z",
+    meta: { width: 100, height: 100 },
+  },
+  {
+    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 210614,
+    type: "image",
+    format: "jpeg",
+    createdAt: "2023-09-06T11:28:43.031Z",
+    meta: { width: 1024, height: 1024 },
+  },
+];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -2,12 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
@@ -20,60 +14,6 @@ import {
   Button as Button,
   Heading as Heading,
 } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: {
-    siteName: "KittyGuardedZone",
-    faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    code: "<script>console.log('KittyGuardedZone')</script>\n",
-  },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 const Page = ({}: { system: any }) => {
   let [formState, set$formState] = useState<any>("initial");

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -34,3 +39,56 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "KittyGuardedZone",
+  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+  code: "<script>console.log('KittyGuardedZone')</script>\n",
+};
+
+export const imageAssets: ImageAsset[] = [
+  {
+    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 268326,
+    type: "image",
+    format: "png",
+    createdAt: "2023-10-30T13:51:08.416Z",
+    meta: { width: 790, height: 786 },
+  },
+  {
+    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
+    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 2906,
+    type: "image",
+    format: "webp",
+    createdAt: "2023-09-12T09:44:22.120Z",
+    meta: { width: 100, height: 100 },
+  },
+  {
+    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 210614,
+    type: "image",
+    format: "jpeg",
+    createdAt: "2023-09-06T11:28:43.031Z",
+    meta: { width: 1024, height: 1024 },
+  },
+];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -2,69 +2,9 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: {
-    siteName: "KittyGuardedZone",
-    faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    code: "<script>console.log('KittyGuardedZone')</script>\n",
-  },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 const Page = ({}: { system: any }) => {
   return (

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -34,3 +39,56 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "KittyGuardedZone",
+  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+  code: "<script>console.log('KittyGuardedZone')</script>\n",
+};
+
+export const imageAssets: ImageAsset[] = [
+  {
+    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 268326,
+    type: "image",
+    format: "png",
+    createdAt: "2023-10-30T13:51:08.416Z",
+    meta: { width: 790, height: 786 },
+  },
+  {
+    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
+    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 2906,
+    type: "image",
+    format: "webp",
+    createdAt: "2023-09-12T09:44:22.120Z",
+    meta: { width: 100, height: 100 },
+  },
+  {
+    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 210614,
+    type: "image",
+    format: "jpeg",
+    createdAt: "2023-09-06T11:28:43.031Z",
+    meta: { width: 1024, height: 1024 },
+  },
+];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -2,69 +2,9 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: {
-    siteName: "KittyGuardedZone",
-    faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    code: "<script>console.log('KittyGuardedZone')</script>\n",
-  },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 const Page = ({}: { system: any }) => {
   return (

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -35,3 +40,56 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "KittyGuardedZone",
+  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+  code: "<script>console.log('KittyGuardedZone')</script>\n",
+};
+
+export const imageAssets: ImageAsset[] = [
+  {
+    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 268326,
+    type: "image",
+    format: "png",
+    createdAt: "2023-10-30T13:51:08.416Z",
+    meta: { width: 790, height: 786 },
+  },
+  {
+    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
+    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 2906,
+    type: "image",
+    format: "webp",
+    createdAt: "2023-09-12T09:44:22.120Z",
+    meta: { width: 100, height: 100 },
+  },
+  {
+    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 210614,
+    type: "image",
+    format: "jpeg",
+    createdAt: "2023-09-06T11:28:43.031Z",
+    meta: { width: 1024, height: 1024 },
+  },
+];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -2,12 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
@@ -22,60 +16,6 @@ import {
   Box as Box,
   HtmlEmbed as HtmlEmbed,
 } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: {
-    siteName: "KittyGuardedZone",
-    faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    code: "<script>console.log('KittyGuardedZone')</script>\n",
-  },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 const Page = ({}: { system: any }) => {
   let [accordionValue, set$accordionValue] = useState<any>("0");

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   const [list_1] = await Promise.all([
@@ -45,3 +50,56 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "KittyGuardedZone",
+  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+  code: "<script>console.log('KittyGuardedZone')</script>\n",
+};
+
+export const imageAssets: ImageAsset[] = [
+  {
+    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 268326,
+    type: "image",
+    format: "png",
+    createdAt: "2023-10-30T13:51:08.416Z",
+    meta: { width: 790, height: 786 },
+  },
+  {
+    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
+    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 2906,
+    type: "image",
+    format: "webp",
+    createdAt: "2023-09-12T09:44:22.120Z",
+    meta: { width: 100, height: 100 },
+  },
+  {
+    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 210614,
+    type: "image",
+    format: "jpeg",
+    createdAt: "2023-09-06T11:28:43.031Z",
+    meta: { width: 1024, height: 1024 },
+  },
+];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -2,72 +2,12 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Box as Box,
   HtmlEmbed as HtmlEmbed,
 } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: {
-    siteName: "KittyGuardedZone",
-    faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    code: "<script>console.log('KittyGuardedZone')</script>\n",
-  },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 const Page = ({}: { system: any }) => {
   let list = useResource("list_1");

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+} from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -40,3 +45,56 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
+
+export const user: { email: string | null } | undefined = {
+  email: "hello@webstudio.is",
+};
+
+export const projectMeta: ProjectMeta = {
+  siteName: "KittyGuardedZone",
+  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+  code: "<script>console.log('KittyGuardedZone')</script>\n",
+};
+
+export const imageAssets: ImageAsset[] = [
+  {
+    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 268326,
+    type: "image",
+    format: "png",
+    createdAt: "2023-10-30T13:51:08.416Z",
+    meta: { width: 790, height: 786 },
+  },
+  {
+    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
+    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 2906,
+    type: "image",
+    format: "webp",
+    createdAt: "2023-09-12T09:44:22.120Z",
+    meta: { width: 100, height: 100 },
+  },
+  {
+    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
+    description: null,
+    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+    size: 210614,
+    type: "image",
+    format: "jpeg",
+    createdAt: "2023-09-06T11:28:43.031Z",
+    meta: { width: 1024, height: 1024 },
+  },
+];
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -2,12 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type {
-  Asset,
-  FontAsset,
-  ImageAsset,
-  ProjectMeta,
-} from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 import {
   Body as Body,
@@ -20,60 +14,6 @@ import {
   Image as Image,
   Text as Text,
 } from "@webstudio-is/sdk-components-react";
-
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
-
-export const pageBackgroundImageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: {
-    siteName: "KittyGuardedZone",
-    faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    code: "<script>console.log('KittyGuardedZone')</script>\n",
-  },
-};
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
-export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
 const Page = ({}: { system: any }) => {
   return (

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/[_route_with_symbols_]._index";
+import { Page } from "../__generated__/[_route_with_symbols_]._index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/[_route_with_symbols_]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/[form]._index";
+import { Page } from "../__generated__/[form]._index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/[form]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/[heading-with-id]._index";
+import { Page } from "../__generated__/[heading-with-id]._index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/[heading-with-id]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/[nested].[nested-page]._index";
+import { Page } from "../__generated__/[nested].[nested-page]._index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/[nested].[nested-page]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/[radix]._index";
+import { Page } from "../__generated__/[radix]._index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/[radix]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/[resources]._index";
+import { Page } from "../__generated__/[resources]._index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/[resources]._index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../__generated__/_index";
+import { Page } from "../__generated__/_index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({

--- a/packages/cli/__generated__/_index.server.tsx
+++ b/packages/cli/__generated__/_index.server.tsx
@@ -1,4 +1,13 @@
-import type { PageMeta, System } from "@webstudio-is/sdk";
+/**
+ * The only intent of this file is to support typings inside ../templates/route-template for easier development.
+ **/
+import type {
+  ImageAsset,
+  FontAsset,
+  ProjectMeta,
+  PageMeta,
+  System,
+} from "@webstudio-is/sdk";
 
 export const loadResources = async (_props: { system: System }) => {
   const [] = await Promise.all([]);
@@ -24,3 +33,21 @@ type Params = Record<string, string | undefined>;
 export const getRemixParams = ({ ...params }: Params): Params => {
   return params;
 };
+
+export const projectId = "project-id";
+
+export const user: { email: string | null } | undefined = {
+  email: "email@domain",
+};
+
+export const projectMeta: undefined | ProjectMeta = {
+  siteName: "",
+  faviconAssetId: "",
+  code: "",
+};
+
+export const imageAssets: ImageAsset[] = [];
+
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/packages/cli/__generated__/_index.tsx
+++ b/packages/cli/__generated__/_index.tsx
@@ -1,29 +1,8 @@
 /**
  * The only intent of this file is to support typings inside ../templates/route-template for easier development.
  **/
-import type { ImageAsset, FontAsset } from "@webstudio-is/sdk";
-import type { PageData } from "../templates/defaults/__templates__/route-template";
-
-export const imageAssets: ImageAsset[] = [];
-
-export const pageData: PageData = {
-  project: {
-    siteName: "",
-    faviconAssetId: "",
-    code: "",
-  },
-};
-
-export const user: { email: string | null } | undefined = {
-  email: "email@domain",
-};
-export const projectId = "project-id";
-
 const Page = (_props: { system: any }) => {
   return <></>;
 };
 
 export { Page };
-
-export const pageFontAssets: FontAsset[] = [];
-export const pageBackgroundImageAssets: ImageAsset[] = [];

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -61,7 +61,6 @@ import {
   isFileExists,
 } from "./fs-utils";
 import type * as sharedConstants from "~/constants.mjs";
-import type { PageData } from "../templates/defaults/__templates__/route-template";
 
 const limit = pLimit(10);
 
@@ -515,13 +514,6 @@ export const prebuild = async (options: {
       "useState",
       "Fragment",
       "useResource",
-      "PageData",
-      "Asset",
-      "ProjectMeta",
-      "fontAssets",
-      "pageData",
-      "user",
-      "projectId",
       "Page",
       "_props",
     ]);
@@ -569,10 +561,6 @@ export const prebuild = async (options: {
     const pageData = siteDataByPage[pageId];
     const pageFontAssets = fontAssetsByPage[pageId];
     const pageBackgroundImageAssets = backgroundImageAssetsByPage[pageId];
-    // serialize data only used in runtime
-    const renderedPageData: PageData = {
-      project: siteData.build.pages.meta,
-    };
 
     const rootInstanceId = pageData.page.rootInstanceId;
     const instances = new Map(pageData.build.instances);
@@ -605,25 +593,10 @@ export const prebuild = async (options: {
 
     const pageExports = `/* eslint-disable */
 /* This is a auto generated file for building the project */ \n
+
 import { Fragment, useState } from "react";
-import type { Asset, FontAsset, ImageAsset, ProjectMeta } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 ${componentImports}
-import type { PageData } from "~/routes/_index";
-export const imageAssets: ImageAsset[] = ${JSON.stringify(imageAssets)}
-
-// Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = ${JSON.stringify(pageFontAssets)}
-
-export const pageBackgroundImageAssets: ImageAsset[] = ${JSON.stringify(
-      pageBackgroundImageAssets
-    )}
-
-export const pageData: PageData = ${JSON.stringify(renderedPageData)};
-export const user: { email: string | null } | undefined = ${JSON.stringify(
-      siteData.user
-    )};
-export const projectId = "${siteData.build.projectId}";
 
 ${pageComponent}
 
@@ -632,7 +605,7 @@ export { Page }
     const serverExports = `/* eslint-disable */
 /* This is a auto generated file for building the project */ \n
 
-import type { PageMeta } from "@webstudio-is/sdk";
+import type { ImageAsset, FontAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 ${generateResourcesLoader({
   scope,
   page: pageData.page,
@@ -649,6 +622,26 @@ ${generatePageMeta({
 ${generateFormsProperties(props)}
 
 ${generateRemixParams(pageData.page.path)}
+
+export const projectId = "${siteData.build.projectId}";
+
+export const user: { email: string | null } | undefined = ${JSON.stringify(
+      siteData.user
+    )};
+
+export const projectMeta: ProjectMeta = ${JSON.stringify(
+      siteData.build.pages.meta
+    )};
+
+export const imageAssets: ImageAsset[] = ${JSON.stringify(imageAssets)}
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = ${JSON.stringify(pageFontAssets)}
+
+export const pageBackgroundImageAssets: ImageAsset[] = ${JSON.stringify(
+      pageBackgroundImageAssets
+    )}
+
 `;
 
     /*

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -10,30 +10,23 @@ import {
   redirect,
 } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
-import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
-import {
-  pageData,
-  user,
-  projectId,
-  Page,
-  imageAssets,
-  pageFontAssets,
-  pageBackgroundImageAssets,
-} from "../../../__generated__/_index";
+import { Page } from "../../../__generated__/_index";
 import {
   formsProperties,
   loadResources,
   getPageMeta,
   getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+  imageAssets,
+  pageFontAssets,
+  pageBackgroundImageAssets,
 } from "../../../__generated__/_index.server";
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
-
-export type PageData = {
-  project?: ProjectMeta;
-};
 
 export const loader = async (arg: LoaderArgs) => {
   const url = new URL(arg.request.url);
@@ -98,7 +91,6 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     return metas;
   }
   const { pageMeta } = data;
-  const { project } = pageData;
 
   if (data.url) {
     metas.push({
@@ -120,16 +112,16 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (project?.siteName) {
+  if (projectMeta?.siteName) {
     metas.push({
       property: "og:site_name",
-      content: project.siteName,
+      content: projectMeta.siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: project.siteName,
+        name: projectMeta.siteName,
         url: origin,
       },
     });
@@ -188,12 +180,9 @@ export const links: LinksFunction = () => {
     href: css,
   });
 
-  const { project } = pageData;
-
-  if (project?.faviconAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === project.faviconAssetId
-    );
+  if (projectMeta?.faviconAssetId) {
+    const faviconAssetId = projectMeta?.faviconAssetId;
+    const imageAsset = imageAssets.find((asset) => asset.id === faviconAssetId);
 
     if (imageAsset) {
       result.push({


### PR DESCRIPTION
Here another case to potentionally optimize client bundle by moving data used only in loaders, actions, meta and links into .server.tsx module to guarantee splitting from client bundle.

Also removed circular PageData type dependecy between route and generated modules.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
