### PR TITLE
fix: Style updates on all instances upon change

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
@@ -86,6 +86,7 @@ export const useStyleData = ({ selectedInstance }: UseStyleData) => {
             ephemeralStyles.push({
               instanceId: selectedInstance.id,
               breakpointId: selectedBreakpoint.id,
+              styleSourceId: styleSourceSelector.styleSourceId,
               state: styleSourceSelector.state,
               property: update.property,
               value: update.value,

--- a/apps/builder/app/canvas/stores.ts
+++ b/apps/builder/app/canvas/stores.ts
@@ -7,6 +7,7 @@ export const $ephemeralStyles = atom<
     instanceId: Instance["id"];
     breakpointId: StyleDecl["breakpointId"];
     state: StyleDecl["state"];
+    styleSourceId: StyleDecl["styleSourceId"];
     property: StyleDecl["property"];
     value: StyleDecl["value"];
   }>


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/2988

## Description

When a token value is modified, the change will be immediately visible across all N instances using the same token

## Steps for reproduction

Create token, use it on 2 instances, change token styles, local styles etc to see it work


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
