### PR TITLE
fix: initially label shouldn't have a hover effect

### DIFF
--- a/packages/design-system/src/components/label.tsx
+++ b/packages/design-system/src/components/label.tsx
@@ -32,6 +32,7 @@ const StyledLabel = styled(RadixLabel, {
   border: "1px solid transparent",
   borderRadius: theme.borderRadius[3],
   transition: "200ms color, 200ms background-color",
+  color: theme.colors.foregroundMain,
 
   // https://github.com/webstudio-is/webstudio/issues/1271#issuecomment-1478436340
   "&:focus-visible": {
@@ -110,7 +111,6 @@ const StyledLabel = styled(RadixLabel, {
   },
 
   defaultVariants: {
-    color: "default",
     sectionTitle: false,
   },
 });


### PR DESCRIPTION
## Description

In the previous PR I forgot to stop using default variant when label has no specified variant, because hover effect is only meant for those button labels.

## Steps for reproduction

1. open share dialog
2. see the items have no hover effect

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
