### PR TITLE
experimental: support currentcolor in style object model

### DIFF
--- a/apps/builder/app/shared/style-object-model.test.ts
+++ b/apps/builder/app/shared/style-object-model.test.ts
@@ -211,3 +211,115 @@ test("inherit style from ancestors", () => {
       .computedValue
   ).toEqual({ type: "keyword", value: "auto" });
 });
+
+test("support currentcolor keyword", () => {
+  const styles: StyleDecl[] = [
+    {
+      breakpointId: "base",
+      styleSourceId: "level1Local",
+      property: "color",
+      value: { type: "keyword", value: "blue" },
+    },
+    {
+      breakpointId: "base",
+      styleSourceId: "level2Local",
+      property: "borderTopColor",
+      // support lower case
+      value: { type: "keyword", value: "currentcolor" },
+    },
+    {
+      breakpointId: "base",
+      styleSourceId: "level2Local",
+      property: "backgroundColor",
+      // support camel case
+      value: { type: "keyword", value: "currentColor" },
+    },
+  ];
+  const model: StyleObjectModel = {
+    styleSourcesByInstanceId: new Map([
+      ["level2", ["level2Local"]],
+      ["level1", ["level1Local"]],
+    ]),
+    styleByStyleSourceId: getStyleByStyleSourceId(styles),
+  };
+  const styleSelector: StyleSelector = {
+    instanceSelector: ["level2", "level1"],
+  };
+  expect(
+    getComputedStyleDecl({ model, styleSelector, property: "borderTopColor" })
+  ).toEqual(
+    expect.objectContaining({
+      computedValue: { type: "keyword", value: "currentcolor" },
+      usedValue: { type: "keyword", value: "blue" },
+    })
+  );
+  expect(
+    getComputedStyleDecl({ model, styleSelector, property: "backgroundColor" })
+  ).toEqual(
+    expect.objectContaining({
+      computedValue: { type: "keyword", value: "currentColor" },
+      usedValue: { type: "keyword", value: "blue" },
+    })
+  );
+});
+
+test("in color property currentcolor is inherited", () => {
+  const styles: StyleDecl[] = [
+    {
+      breakpointId: "base",
+      styleSourceId: "level1Local",
+      property: "color",
+      value: { type: "keyword", value: "blue" },
+    },
+    {
+      breakpointId: "base",
+      styleSourceId: "level2Local",
+      property: "color",
+      value: { type: "keyword", value: "currentcolor" },
+    },
+  ];
+  const model: StyleObjectModel = {
+    styleSourcesByInstanceId: new Map([
+      ["level2", ["level2Local"]],
+      ["level1", ["level1Local"]],
+    ]),
+    styleByStyleSourceId: getStyleByStyleSourceId(styles),
+  };
+  const styleSelector: StyleSelector = {
+    instanceSelector: ["level2", "level1"],
+  };
+  expect(
+    getComputedStyleDecl({ model, styleSelector, property: "color" })
+  ).toEqual(
+    expect.objectContaining({
+      computedValue: { type: "keyword", value: "currentcolor" },
+      usedValue: { type: "keyword", value: "blue" },
+    })
+  );
+});
+
+test("in root color property currentcolor is initial", () => {
+  const styles: StyleDecl[] = [
+    {
+      breakpointId: "base",
+      styleSourceId: "bodyLocal",
+      property: "color",
+      value: { type: "keyword", value: "currentcolor" },
+    },
+  ];
+  const model: StyleObjectModel = {
+    styleSourcesByInstanceId: new Map([["body", ["bodyLocal"]]]),
+    styleByStyleSourceId: getStyleByStyleSourceId(styles),
+  };
+  const styleSelector: StyleSelector = {
+    instanceSelector: ["body"],
+  };
+  expect(
+    getComputedStyleDecl({ model, styleSelector, property: "color" })
+  ).toEqual(
+    expect.objectContaining({
+      computedValue: { type: "keyword", value: "currentcolor" },
+      usedValue: { type: "keyword", value: "black" },
+    })
+  );
+});


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1536

Here added currentcolor keyword support. It is case insensitive and resolved as a new "used value", while "computed value" still contains currentcolor.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
