### PR TITLE
experimental: support custom properties

### DIFF
--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -697,7 +697,8 @@ const traverseStyleValue = (
     value.type === "invalid" ||
     value.type === "unset" ||
     value.type === "rgb" ||
-    value.type === "function"
+    value.type === "function" ||
+    value.type === "guaranteedInvalid"
   ) {
     callback(value);
     return;

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -195,4 +195,11 @@ describe("Convert WS CSS Values to native CSS strings", () => {
 
     expect(value).toMatchInlineSnapshot(`"url("fo\\"o\\\\o.png")"`);
   });
+
+  test("guaranteed-invalid", () => {
+    const value = toValue({
+      type: "guaranteedInvalid",
+    });
+    expect(value).toBe("");
+  });
 });

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -116,5 +116,10 @@ export const toValue = (
     return `${value.name}(${toValue(value.args, transformValue)})`;
   }
 
+  // https://www.w3.org/TR/css-variables-1/#guaranteed-invalid
+  if (value.type === "guaranteedInvalid") {
+    return "";
+  }
+
   return captureError(new Error("Unknown value type"), value);
 };

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -81,6 +81,7 @@ export const ImageValue = z.object({
 export type ImageValue = z.infer<typeof ImageValue>;
 
 // initial value of custom properties
+// https://www.w3.org/TR/css-variables-1/#guaranteed-invalid
 export const GuaranteedInvalidValue = z.object({
   type: z.literal("guaranteedInvalid"),
 });

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -80,6 +80,12 @@ export const ImageValue = z.object({
 
 export type ImageValue = z.infer<typeof ImageValue>;
 
+// initial value of custom properties
+export const GuaranteedInvalidValue = z.object({
+  type: z.literal("guaranteedInvalid"),
+});
+export type GuaranteedInvalidValue = z.infer<typeof GuaranteedInvalidValue>;
+
 // We want to be able to render the invalid value
 // and show it is invalid visually, without saving it to the db
 export const InvalidValue = z.object({
@@ -142,6 +148,7 @@ const ValidStaticStyleValue = z.union([
   UnparsedValue,
   TupleValue,
   FunctionValue,
+  GuaranteedInvalidValue,
 ]);
 
 export type ValidStaticStyleValue = z.infer<typeof ValidStaticStyleValue>;
@@ -165,7 +172,8 @@ export const isValidStaticStyleValue = (
     staticStyleValue.type === "rgb" ||
     staticStyleValue.type === "unparsed" ||
     staticStyleValue.type === "tuple" ||
-    staticStyleValue.type === "function"
+    staticStyleValue.type === "function" ||
+    staticStyleValue.type === "guaranteedInvalid"
   );
 };
 


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1536

Here added support for css custom properties in style object model. Added guaranteed-invalid value to schema to represent initial value of custom properties.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
