### PR TITLE
fix: Remove keywords for transition delay and duration, enable sorting layers

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   toValue,
   type InvalidValue,
@@ -50,25 +50,18 @@ export const TransitionContent = ({
     IntermediateStyleValue | InvalidValue | undefined
   >({ type: "intermediate", value: transition });
 
+  useEffect(() => {
+    setIntermediateValue({ type: "intermediate", value: transition });
+  }, [transition]);
+
   const { property, timing, delay, duration } =
-    useMemo<ExtractedTransitionProperties>(() => {
-      setIntermediateValue({ type: "intermediate", value: transition });
-      return extractTransitionProperties(layer);
-    }, [layer, transition]);
+    useMemo<ExtractedTransitionProperties>(
+      () => extractTransitionProperties(layer),
+      [layer]
+    );
 
   const transitionDurationConfig = styleConfigByName("transitionDuration");
-  const transitionDurationKeywords = transitionDurationConfig.items.map(
-    (item) => ({
-      type: "keyword" as const,
-      value: item.name,
-    })
-  );
-
   const transitionDelayConfig = styleConfigByName("transitionDelay");
-  const transitionDelayKeywords = transitionDelayConfig.items.map((item) => ({
-    type: "keyword" as const,
-    value: item.name,
-  }));
 
   const handleChange = (value: string) => {
     setIntermediateValue({
@@ -157,7 +150,7 @@ export const TransitionContent = ({
           styleSource="local"
           /* Browser default for transition-duration */
           value={duration ?? { type: "unit", value: 0, unit: "ms" }}
-          keywords={transitionDurationKeywords}
+          keywords={[]}
           deleteProperty={() => {
             handlePropertyUpdate({ duration });
           }}
@@ -194,8 +187,8 @@ export const TransitionContent = ({
           styleSource="local"
           /* Browser default for transition-delay */
           value={delay ?? { type: "unit", value: 0, unit: "ms" }}
-          label={transitionDurationConfig.label}
-          keywords={transitionDelayKeywords}
+          label={transitionDelayConfig.label}
+          keywords={[]}
           deleteProperty={() => handlePropertyUpdate({ delay })}
           setValue={(value) => {
             if (value === undefined) {

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   toValue,
   type InvalidValue,
@@ -52,10 +52,6 @@ export const TransitionContent = ({
   const [intermediateValue, setIntermediateValue] = useState<
     IntermediateStyleValue | InvalidValue | undefined
   >({ type: "intermediate", value: transition });
-
-  useEffect(() => {
-    setIntermediateValue({ type: "intermediate", value: transition });
-  }, [transition]);
 
   const { property, timing, delay, duration } =
     useMemo<ExtractedTransitionProperties>(

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-layer.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-layer.tsx
@@ -54,7 +54,7 @@ export const TransitionLayer = <T extends TupleValue>(props: LayerProps<T>) => {
     >
       <CssValueListItem
         id={id}
-        draggable={true}
+        draggable
         active={isHighlighted}
         index={index}
         label={<Label truncate>{label}</Label>}

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-layer.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-layer.tsx
@@ -54,6 +54,7 @@ export const TransitionLayer = <T extends TupleValue>(props: LayerProps<T>) => {
     >
       <CssValueListItem
         id={id}
+        draggable={true}
         active={isHighlighted}
         index={index}
         label={<Label truncate>{label}</Label>}


### PR DESCRIPTION
Update: this PR is not fixing it fully, there is still an issue when cleaning up field and pressing arrow down it goes into keywords mode.

@JayaKrishnaNamburu will fix it with the next PR

## Description

- Remove keyword values for `transition-delay` and `transition-duration`. Keywords are valid if they are directly applied as individual properties. But when they are used under `transition` shorthand. The `keyword` values actually make the property invalid. For more reference (https://www.w3.org/TR/css-transitions-1/#propdef-transition-duration)
-  Add `draggable` for the  `CSSValueListItem` to show the drag indicator for individual layers.
- Set intermediate values only when the layer is changed.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review
- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)