### PR TITLE
fix: resolve social image asset at build time

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -46,28 +46,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
   code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
 };
-
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "ff546bd2-9bb1-4717-a180-1a1fc05565dd",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_1JqSy_0Wy9fY5mXNZSLJ0.jpeg",
-    description: null,
-    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    size: 210614,
-    type: "image",
-    format: "jpg",
-    createdAt: "2024-03-26T18:31:04.086Z",
-    meta: { width: 1024, height: 1024 },
-  },
-  {
-    id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-    name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
-    description: null,
-    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    size: 3350,
-    type: "image",
-    format: "svg",
-    createdAt: "2023-10-30T20:35:47.113Z",
-    meta: { width: 16, height: 16 },
-  },
-];

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -25,6 +25,8 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 16, height: 16 },
 };
 
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -46,28 +46,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
   code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
 };
-
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "ff546bd2-9bb1-4717-a180-1a1fc05565dd",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_1JqSy_0Wy9fY5mXNZSLJ0.jpeg",
-    description: null,
-    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    size: 210614,
-    type: "image",
-    format: "jpg",
-    createdAt: "2024-03-26T18:31:04.086Z",
-    meta: { width: 1024, height: 1024 },
-  },
-  {
-    id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-    name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
-    description: null,
-    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    size: 3350,
-    type: "image",
-    format: "svg",
-    createdAt: "2023-10-30T20:35:47.113Z",
-    meta: { width: 16, height: 16 },
-  },
-];

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
@@ -19,6 +19,8 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 16, height: 16 },
 };
 
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -46,28 +46,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
   code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
 };
-
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "ff546bd2-9bb1-4717-a180-1a1fc05565dd",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_1JqSy_0Wy9fY5mXNZSLJ0.jpeg",
-    description: null,
-    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    size: 210614,
-    type: "image",
-    format: "jpg",
-    createdAt: "2024-03-26T18:31:04.086Z",
-    meta: { width: 1024, height: 1024 },
-  },
-  {
-    id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-    name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
-    description: null,
-    projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    size: 3350,
-    type: "image",
-    format: "svg",
-    createdAt: "2023-10-30T20:35:47.113Z",
-    meta: { width: 16, height: 16 },
-  },
-];

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -31,6 +31,8 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 16, height: 16 },
 };
 
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [
   {

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[script-test]._index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/[script-test]._index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[world]._index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/[world]._index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -46,5 +46,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "",
   code: "",
 };
-
-export const imageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -12,6 +12,8 @@ import {
 
 export const favIconAsset: ImageAsset | undefined = undefined;
 
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -46,5 +46,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "",
   code: "",
 };
-
-export const imageAssets: ImageAsset[] = [];

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -12,6 +12,8 @@ import {
 
 export const favIconAsset: ImageAsset | undefined = undefined;
 
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -46,39 +46,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   code: "<script>console.log('KittyGuardedZone')</script>\n",
 };
-
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -19,6 +19,8 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -48,39 +48,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   code: "<script>console.log('KittyGuardedZone')</script>\n",
 };
-
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -28,6 +28,8 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -46,39 +46,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   code: "<script>console.log('KittyGuardedZone')</script>\n",
 };
-
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -19,6 +19,8 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -46,39 +46,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   code: "<script>console.log('KittyGuardedZone')</script>\n",
 };
-
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -19,6 +19,8 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -47,39 +47,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   code: "<script>console.log('KittyGuardedZone')</script>\n",
 };
-
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -30,6 +30,18 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
+export const socialImageAsset: ImageAsset | undefined = {
+  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
+  description: null,
+  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+  size: 268326,
+  type: "image",
+  format: "png",
+  createdAt: "2023-10-30T13:51:08.416Z",
+  meta: { width: 790, height: 786 },
+};
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   const [list_1] = await Promise.all([
@@ -57,39 +57,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   code: "<script>console.log('KittyGuardedZone')</script>\n",
 };
-
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -22,6 +22,8 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ImageAsset, ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -52,39 +52,3 @@ export const projectMeta: ProjectMeta = {
   faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   code: "<script>console.log('KittyGuardedZone')</script>\n",
 };
-
-export const imageAssets: ImageAsset[] = [
-  {
-    id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-    name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 268326,
-    type: "image",
-    format: "png",
-    createdAt: "2023-10-30T13:51:08.416Z",
-    meta: { width: 790, height: 786 },
-  },
-  {
-    id: "9a8bc926-7804-4d3f-af81-69196b1d2ed8",
-    name: "small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 2906,
-    type: "image",
-    format: "webp",
-    createdAt: "2023-09-12T09:44:22.120Z",
-    meta: { width: 100, height: 100 },
-  },
-  {
-    id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-    name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-    description: null,
-    projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    size: 210614,
-    type: "image",
-    format: "jpeg",
-    createdAt: "2023-09-06T11:28:43.031Z",
-    meta: { width: 1024, height: 1024 },
-  },
-];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -28,6 +28,18 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
+export const socialImageAsset: ImageAsset | undefined = {
+  id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+  name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
+  description: null,
+  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
+  size: 210614,
+  type: "image",
+  format: "jpeg",
+  createdAt: "2023-09-06T11:28:43.031Z",
+  meta: { width: 1024, height: 1024 },
+};
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[_route_with_symbols_]._index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/[_route_with_symbols_]._index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[form]._index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/[form]._index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[heading-with-id]._index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/[heading-with-id]._index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[nested].[nested-page]._index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/[nested].[nested-page]._index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[radix]._index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/[radix]._index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[resources]._index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/[resources]._index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",

--- a/packages/cli/__generated__/_index.server.tsx
+++ b/packages/cli/__generated__/_index.server.tsx
@@ -1,12 +1,7 @@
 /**
  * The only intent of this file is to support typings inside ../templates/route-template for easier development.
  **/
-import type {
-  ImageAsset,
-  ProjectMeta,
-  PageMeta,
-  System,
-} from "@webstudio-is/sdk";
+import type { ProjectMeta, PageMeta, System } from "@webstudio-is/sdk";
 
 export const loadResources = async (_props: { system: System }) => {
   const [] = await Promise.all([]);
@@ -44,5 +39,3 @@ export const projectMeta: undefined | ProjectMeta = {
   faviconAssetId: "",
   code: "",
 };
-
-export const imageAssets: ImageAsset[] = [];

--- a/packages/cli/__generated__/_index.tsx
+++ b/packages/cli/__generated__/_index.tsx
@@ -6,6 +6,8 @@ import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 
 export const favIconAsset: ImageAsset | undefined = undefined;
 
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -15,6 +15,7 @@ import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
   favIconAsset,
+  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../../../__generated__/_index";
@@ -26,7 +27,6 @@ import {
   projectId,
   user,
   projectMeta,
-  imageAssets,
 } from "../../../__generated__/_index.server";
 
 import css from "../__generated__/index.css";
@@ -150,21 +150,15 @@ export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (pageMeta.socialImageAssetId) {
-    const imageAsset = imageAssets.find(
-      (asset) => asset.id === pageMeta.socialImageAssetId
-    );
-
-    if (imageAsset) {
-      metas.push({
-        property: "og:image",
-        content: `https://${data.host}${imageLoader({
-          src: imageAsset.name,
-          // Do not transform social image (not enough information do we need to do this)
-          format: "raw",
-        })}`,
-      });
-    }
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
   } else if (pageMeta.socialImageUrl) {
     metas.push({
       property: "og:image",


### PR DESCRIPTION
This fixes the issue with looking for social image asset in server only image assets array. Data is generated client side but only for social image similar to favicon asset.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
