### PR TITLE
fix: update package.json dependencies with cli

### DIFF
--- a/fixtures/webstudio-custom-template/package.json
+++ b/fixtures/webstudio-custom-template/package.json
@@ -9,7 +9,7 @@
     "size-test": "rm -rf ./public && remix build && size-limit",
     "fixtures:link": "webstudio link --link 'https://main.prs.webstudio.is/builder/0d856812-61d8-4014-a20a-82e01c0eb8ee?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f'",
     "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "webstudio build --template ./custom-template --template ./custom-template-stage --preview && pnpm prettier --write ./app/ ./package.json"
+    "fixtures:build": "webstudio build --template internal --template ./custom-template --template ./custom-template-stage --preview && pnpm prettier --write ./app/ ./package.json"
   },
   "private": true,
   "sideEffects": false,

--- a/fixtures/webstudio-remix-netlify-edge-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc",
     "fixtures:link": "webstudio link --link 'https://main.prs.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93&'",
     "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "webstudio build --template netlify-edge-functions --preview && pnpm prettier --write ./app/ ./package.json"
+    "fixtures:build": "webstudio build --template internal --template netlify-edge-functions --preview && pnpm prettier --write ./app/ ./package.json"
   },
   "dependencies": {
     "@netlify/functions": "^1.3.0",

--- a/fixtures/webstudio-remix-netlify-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-functions/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc",
     "fixtures:link": "webstudio link --link 'https://main.prs.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
     "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "webstudio build --template netlify-functions --preview && pnpm prettier --write ./app/ ./package.json"
+    "fixtures:build": "webstudio build --template internal --template netlify-functions --preview && pnpm prettier --write ./app/ ./package.json"
   },
   "dependencies": {
     "@netlify/functions": "^1.3.0",

--- a/fixtures/webstudio-remix-vercel/package.json
+++ b/fixtures/webstudio-remix-vercel/package.json
@@ -6,7 +6,7 @@
     "typecheck": "tsc",
     "fixtures:link": "webstudio link --link 'https://main.prs.webstudio.is/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview'",
     "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "webstudio build --template vercel --preview && pnpm prettier --write ./app/ ./package.json"
+    "fixtures:build": "webstudio build --template internal --template vercel --preview && pnpm prettier --write ./app/ ./package.json"
   },
   "private": true,
   "sideEffects": false,

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -123,7 +123,7 @@ export const downloadAsset = async (
   }
 };
 
-const mergeJsonFiles = async (sourcePath: string, destinationPath: string) => {
+const mergeJsonInto = async (sourcePath: string, destinationPath: string) => {
   const sourceJson = await readFile(sourcePath, "utf8");
   const destinationJson = await readFile(destinationPath, "utf8").catch(
     (error) => {
@@ -139,7 +139,7 @@ const mergeJsonFiles = async (sourcePath: string, destinationPath: string) => {
     }
   );
   const content = JSON.stringify(
-    merge(JSON.parse(sourceJson), JSON.parse(destinationJson)),
+    merge(JSON.parse(destinationJson), JSON.parse(sourceJson)),
     null,
     "  "
   );
@@ -191,7 +191,7 @@ const copyTemplates = async (template: string = "defaults") => {
   });
 
   if ((await isFileExists(join(templatePath, "package.json"))) === true) {
-    await mergeJsonFiles(
+    await mergeJsonInto(
       join(templatePath, "package.json"),
       join(cwd(), "package.json")
     );

--- a/packages/cli/templates/internal/package.json
+++ b/packages/cli/templates/internal/package.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "@webstudio-is/react-sdk": "workspace:*",
+    "@webstudio-is/sdk-components-react-radix": "workspace:*",
+    "@webstudio-is/sdk-components-react-remix": "workspace:*",
+    "@webstudio-is/sdk-components-react": "workspace:*",
+    "@webstudio-is/form-handlers": "workspace:*",
+    "@webstudio-is/image": "workspace:*",
+    "@webstudio-is/sdk": "workspace:*"
+  }
+}


### PR DESCRIPTION
Here improved CLI build command to upgrade dependencies in user package.json whenever we change them in template.

For our own dependencies added "internal" template with `workspace:*`

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
