### PR TITLE
fix: Allow multiple folders to have an empty slug

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/folder-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/folder-settings.tsx
@@ -40,7 +40,7 @@ import { nanoid } from "nanoid";
 import { serverSyncStore } from "~/shared/sync";
 import { useEffectEvent } from "~/shared/hook-utils/effect-event";
 import {
-  isSlugUsed,
+  isSlugAvailable,
   registerFolderChildMutable,
   deleteFolderWithChildrenMutable,
   deletePageMutable,
@@ -81,7 +81,7 @@ const validateValues = (
   }
   if (pages !== undefined && values.slug !== undefined) {
     if (
-      isSlugUsed(
+      isSlugAvailable(
         values.slug,
         pages.folders,
         values.parentFolderId,

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
@@ -169,13 +169,17 @@ export const reparentOrphansMutable = (pages: Pages) => {
  * Returns true if folder's slug is unique within it's future parent folder.
  * Needed to verify if the folder can be nested under the parent folder without modifying slug.
  */
-export const isSlugUsed = (
+export const isSlugAvailable = (
   slug: string,
   folders: Array<Folder>,
   parentFolderId: Folder["id"],
   // undefined folder id means new folder
   folderId?: Folder["id"]
 ) => {
+  // Empty slug can appear any amount of times.
+  if (slug === "") {
+    return true;
+  }
   const foldersMap = new Map(folders.map((folder) => [folder.id, folder]));
   const parentFolder = foldersMap.get(parentFolderId);
   // Should be impossible because at least root folder is always found.


### PR DESCRIPTION
Fixes. https://discord.com/channels/955905230107738152/1223709963025907854

Empty slug is not a slug, it's an absence of one, so there can be any amount of folders with empty slug


## Steps for reproduction

1. add 2 folders with empty slug
2. expect no error

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
