### PR TITLE
refactor: prepare remix types

### DIFF
--- a/apps/builder/app/routes/$.tsx
+++ b/apps/builder/app/routes/$.tsx
@@ -1,7 +1,7 @@
-import { Links, Meta } from "@remix-run/react";
-import { redirect } from "@remix-run/node";
-import type { LoaderArgs } from "@remix-run/node";
+import { type LoaderFunctionArgs, redirect } from "@remix-run/server-runtime";
 import {
+  Links,
+  Meta,
   isRouteErrorResponse,
   useLoaderData,
   useRouteError,
@@ -14,7 +14,7 @@ import { Canvas } from "~/canvas";
 import { ErrorMessage } from "~/shared/error";
 import { dashboardPath, isCanvas } from "~/shared/router-utils";
 
-export const loader = async ({ request }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
   // See remix.config.ts for the publicPath value
   const publicPath = "/build/";

--- a/apps/builder/app/routes/_index.tsx
+++ b/apps/builder/app/routes/_index.tsx
@@ -3,7 +3,7 @@
 // see https://github.com/remix-run/remix/issues/2098#issuecomment-1049262218 .
 // To solve this, we're re-exporting the $.tsx route API in index.tsx
 
-import type { LoaderArgs } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import CatchAllContnet, {
   loader as catchAllloader,
   ErrorBoundary as CatchAllErrorBoundary,
@@ -12,7 +12,7 @@ import CatchAllContnet, {
 // We're wrapping functions in order for them to be distinct from the ones in $.tsx.
 // If they are the same, Remix may get confused, and don't load data on page transitions.
 
-export const loader = (args: LoaderArgs) => catchAllloader(args);
+export const loader = (args: LoaderFunctionArgs) => catchAllloader(args);
 export const ErrorBoundary = () => <CatchAllErrorBoundary />;
 const Content = () => <CatchAllContnet />;
 export default Content;

--- a/apps/builder/app/routes/auth.dev.tsx
+++ b/apps/builder/app/routes/auth.dev.tsx
@@ -1,4 +1,4 @@
-import { type ActionArgs, redirect } from "@remix-run/node";
+import { type ActionFunctionArgs, redirect } from "@remix-run/server-runtime";
 import { authenticator } from "~/services/auth.server";
 import { loginPath } from "~/shared/router-utils";
 import { AUTH_PROVIDERS } from "~/shared/session";
@@ -8,7 +8,7 @@ export default function Dev() {
   return null;
 }
 
-export const action = async ({ request }: ActionArgs) => {
+export const action = async ({ request }: ActionFunctionArgs) => {
   const returnTo = await returnToPath(request);
 
   try {

--- a/apps/builder/app/routes/auth.github.callback.tsx
+++ b/apps/builder/app/routes/auth.github.callback.tsx
@@ -1,10 +1,10 @@
-import { type LoaderArgs, redirect } from "@remix-run/node";
+import { type LoaderFunctionArgs, redirect } from "@remix-run/server-runtime";
 import { authenticator } from "~/services/auth.server";
 import { loginPath } from "~/shared/router-utils";
 import { AUTH_PROVIDERS } from "~/shared/session";
 import { returnToPath } from "~/services/cookie.server";
 
-export const loader = async ({ request }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   const returnTo = await returnToPath(request);
   const url = new URL(request.url);
   const error = url.searchParams.get("error");

--- a/apps/builder/app/routes/auth.github.tsx
+++ b/apps/builder/app/routes/auth.github.tsx
@@ -1,4 +1,4 @@
-import { type ActionArgs, redirect } from "@remix-run/node";
+import { type ActionFunctionArgs, redirect } from "@remix-run/server-runtime";
 import { authenticator } from "~/services/auth.server";
 import { loginPath } from "~/shared/router-utils";
 import { sentryException } from "~/shared/sentry";
@@ -9,7 +9,7 @@ export default function GH() {
   return null;
 }
 
-export const action = async ({ request }: ActionArgs) => {
+export const action = async ({ request }: ActionFunctionArgs) => {
   const returnTo = await returnToPath(request);
 
   try {

--- a/apps/builder/app/routes/auth.google.callback.tsx
+++ b/apps/builder/app/routes/auth.google.callback.tsx
@@ -1,9 +1,9 @@
-import type { LoaderArgs } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { authenticator } from "~/services/auth.server";
 import { loginPath } from "~/shared/router-utils";
 import { returnToPath } from "~/services/cookie.server";
 
-export const loader = async ({ request }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   const returnTo = await returnToPath(request);
 
   return authenticator.authenticate("google", request, {

--- a/apps/builder/app/routes/auth.google.tsx
+++ b/apps/builder/app/routes/auth.google.tsx
@@ -1,4 +1,8 @@
-import { type ActionArgs, type LoaderArgs, redirect } from "@remix-run/node";
+import {
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  redirect,
+} from "@remix-run/server-runtime";
 import { authenticator } from "~/services/auth.server";
 import { loginPath } from "~/shared/router-utils";
 import { sentryException } from "~/shared/sentry";
@@ -9,9 +13,9 @@ export default function Google() {
   return null;
 }
 
-export const loader = (_args: LoaderArgs) => redirect("/login");
+export const loader = (_args: LoaderFunctionArgs) => redirect("/login");
 
-export const action = async ({ request }: ActionArgs) => {
+export const action = async ({ request }: ActionFunctionArgs) => {
   const returnTo = await returnToPath(request);
 
   try {

--- a/apps/builder/app/routes/builder.$projectId.tsx
+++ b/apps/builder/app/routes/builder.$projectId.tsx
@@ -4,7 +4,11 @@ import {
   isRouteErrorResponse,
 } from "@remix-run/react";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
-import { redirect, type LoaderArgs, json } from "@remix-run/node";
+import {
+  type LoaderFunctionArgs,
+  redirect,
+  json,
+} from "@remix-run/server-runtime";
 import { loadBuildByProjectId } from "@webstudio-is/project-build/index.server";
 import { db as domainDb } from "@webstudio-is/domain/index.server";
 import { db } from "@webstudio-is/project/index.server";
@@ -26,7 +30,7 @@ export { links };
 export const loader = async ({
   params,
   request,
-}: LoaderArgs): Promise<BuilderProps> => {
+}: LoaderFunctionArgs): Promise<BuilderProps> => {
   const context = await createContext(request);
 
   try {

--- a/apps/builder/app/routes/builder.tsx
+++ b/apps/builder/app/routes/builder.tsx
@@ -1,13 +1,13 @@
 import type {
-  LoaderArgs,
-  V2_MetaFunction as MetaFunction,
-} from "@remix-run/node";
+  LoaderFunctionArgs,
+  V2_ServerRuntimeMetaFunction as MetaFunction,
+} from "@remix-run/server-runtime";
 import { Root } from "~/shared/remix";
 import env from "~/env/env.public.server";
 import { getThemeData } from "~/shared/theme";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
 
-export const loader = async ({ request }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   return {
     env,
     theme: await getThemeData(request),

--- a/apps/builder/app/routes/cgi.image.$name.ts
+++ b/apps/builder/app/routes/cgi.image.$name.ts
@@ -1,12 +1,13 @@
 import { createReadStream } from "node:fs";
 import { join } from "node:path";
-import { type LoaderArgs, Response } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
+import { Response } from "@remix-run/node";
 import env from "~/env/env.server";
 
 // this route used as proxy for images to cloudflare endpoint
 // https://developers.cloudflare.com/fundamentals/get-started/reference/cdn-cgi-endpoint/
 
-export const loader = async ({ params, request }: LoaderArgs) => {
+export const loader = async ({ params, request }: LoaderFunctionArgs) => {
   const { name } = params;
   if (name === undefined) {
     throw Error("Name is undefined");

--- a/apps/builder/app/routes/dashboard._index.tsx
+++ b/apps/builder/app/routes/dashboard._index.tsx
@@ -1,7 +1,6 @@
 import { type ComponentProps } from "react";
 import { useLoaderData, useRouteError } from "@remix-run/react";
-import type { LoaderArgs } from "@remix-run/node";
-import { redirect } from "@remix-run/node";
+import { type LoaderFunctionArgs, redirect } from "@remix-run/server-runtime";
 import { dashboardProjectRouter } from "@webstudio-is/dashboard/index.server";
 import { Dashboard } from "~/dashboard";
 import { findAuthenticatedUser } from "~/services/auth.server";
@@ -12,7 +11,7 @@ import { createContext } from "~/shared/context.server";
 import env from "~/env/env.server";
 export const loader = async ({
   request,
-}: LoaderArgs): Promise<ComponentProps<typeof Dashboard>> => {
+}: LoaderFunctionArgs): Promise<ComponentProps<typeof Dashboard>> => {
   const user = await findAuthenticatedUser(request);
 
   if (user === null) {

--- a/apps/builder/app/routes/dashboard.tsx
+++ b/apps/builder/app/routes/dashboard.tsx
@@ -1,12 +1,12 @@
 import type {
-  LoaderArgs,
-  V2_MetaFunction as MetaFunction,
-} from "@remix-run/node";
+  LoaderFunctionArgs,
+  V2_ServerRuntimeMetaFunction as MetaFunction,
+} from "@remix-run/server-runtime";
 import { Root } from "~/shared/remix";
 import env from "~/env/env.public.server";
 import { getThemeData } from "~/shared/theme";
 
-export const loader = async ({ request }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   return {
     env,
     theme: await getThemeData(request),

--- a/apps/builder/app/routes/login._index.tsx
+++ b/apps/builder/app/routes/login._index.tsx
@@ -1,10 +1,10 @@
 import type { ComponentProps } from "react";
 import {
-  type LoaderArgs,
+  type LoaderFunctionArgs,
   type TypedResponse,
   redirect,
   json,
-} from "@remix-run/node";
+} from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import env from "~/env/env.server";
@@ -21,7 +21,9 @@ const comparePathnames = (pathnameOrUrlA: string, pathnameOrUrlB: string) => {
 
 export const loader = async ({
   request,
-}: LoaderArgs): Promise<TypedResponse<ComponentProps<typeof Login>>> => {
+}: LoaderFunctionArgs): Promise<
+  TypedResponse<ComponentProps<typeof Login>>
+> => {
   const user = await findAuthenticatedUser(request);
 
   const url = new URL(request.url);

--- a/apps/builder/app/routes/login.tsx
+++ b/apps/builder/app/routes/login.tsx
@@ -1,12 +1,12 @@
 import type {
-  LoaderArgs,
-  V2_MetaFunction as MetaFunction,
-} from "@remix-run/node";
+  LoaderFunctionArgs,
+  V2_ServerRuntimeMetaFunction as MetaFunction,
+} from "@remix-run/server-runtime";
 import { Root } from "~/shared/remix";
 import env from "~/env/env.public.server";
 import { getThemeData } from "~/shared/theme";
 
-export const loader = async ({ request }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   return {
     env,
     theme: await getThemeData(request),

--- a/apps/builder/app/routes/logout.tsx
+++ b/apps/builder/app/routes/logout.tsx
@@ -1,4 +1,4 @@
-import type { ActionArgs } from "@remix-run/node";
+import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import { authenticator } from "~/services/auth.server";
 import { loginPath } from "~/shared/router-utils";
 
@@ -6,6 +6,6 @@ export default function Logout() {
   return null;
 }
 
-export const loader = async ({ request }: ActionArgs) => {
+export const loader = async ({ request }: ActionFunctionArgs) => {
   await authenticator.logout(request, { redirectTo: loginPath({}) });
 };

--- a/apps/builder/app/routes/n8n.$.tsx
+++ b/apps/builder/app/routes/n8n.$.tsx
@@ -1,10 +1,13 @@
-import { redirect } from "@remix-run/node";
+import {
+  type LoaderFunctionArgs,
+  json,
+  redirect,
+} from "@remix-run/server-runtime";
 import { isRouteErrorResponse, useRouteError } from "@remix-run/react";
 import { z } from "zod";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import { loginPath } from "~/shared/router-utils";
 import env from "~/env/env.server";
-import { type LoaderArgs, json } from "@remix-run/server-runtime";
 import cookie from "cookie";
 
 const zN8NResponse = z.union([
@@ -23,7 +26,7 @@ const zWebhookEnv = z.object({
   N8N_WEBHOOK_TOKEN: z.string(),
 });
 
-export const loader = async ({ request, params }: LoaderArgs) => {
+export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const user = await findAuthenticatedUser(request);
 
   if (user === null) {

--- a/apps/builder/app/routes/n8n.tsx
+++ b/apps/builder/app/routes/n8n.tsx
@@ -1,12 +1,12 @@
 import type {
-  LoaderArgs,
-  V2_MetaFunction as MetaFunction,
-} from "@remix-run/node";
+  LoaderFunctionArgs,
+  V2_ServerRuntimeMetaFunction as MetaFunction,
+} from "@remix-run/server-runtime";
 import { Root } from "~/shared/remix";
 import env from "~/env/env.public.server";
 import { getThemeData } from "~/shared/theme";
 
-export const loader = async ({ request }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   return {
     env,
     theme: await getThemeData(request),

--- a/apps/builder/app/routes/rest.ai._index.ts
+++ b/apps/builder/app/routes/rest.ai._index.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ActionArgs } from "@remix-run/node";
+import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import {
   copywriter,
   operations,
@@ -40,7 +40,7 @@ export const config = {
   maxDuration: 180, // seconds
 };
 
-export const action = async ({ request }: ActionArgs) => {
+export const action = async ({ request }: ActionFunctionArgs) => {
   // @todo Reinstate isFeatureEnabled('ai')
 
   if (env.OPENAI_KEY === undefined) {

--- a/apps/builder/app/routes/rest.ai.audio.transcriptions.ts
+++ b/apps/builder/app/routes/rest.ai.audio.transcriptions.ts
@@ -1,4 +1,4 @@
-import type { ActionArgs } from "@remix-run/node";
+import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import { z } from "zod";
 
 const zTranscription = z.object({
@@ -6,7 +6,7 @@ const zTranscription = z.object({
 });
 
 // @todo: move to AI package
-export const action = async ({ request }: ActionArgs) => {
+export const action = async ({ request }: ActionFunctionArgs) => {
   // @todo: validate request
   const formData = await request.formData();
   formData.append("model", "whisper-1");

--- a/apps/builder/app/routes/rest.ai.detect.ts
+++ b/apps/builder/app/routes/rest.ai.detect.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ActionArgs } from "@remix-run/node";
+import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import {
   commandDetect,
   createGptModel,
@@ -16,7 +16,7 @@ export const RequestParamsSchema = z.object({
   prompt: z.string().max(1200),
 });
 
-export const action = async ({ request }: ActionArgs) => {
+export const action = async ({ request }: ActionFunctionArgs) => {
   // @todo Reinstate isFeatureEnabled('ai')
 
   if (env.OPENAI_KEY === undefined) {

--- a/apps/builder/app/routes/rest.assets.$name.tsx
+++ b/apps/builder/app/routes/rest.assets.$name.tsx
@@ -1,4 +1,4 @@
-import type { ActionArgs } from "@remix-run/node";
+import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import type { Asset } from "@webstudio-is/sdk";
 import { uploadFile } from "@webstudio-is/asset-uploader/index.server";
 import type { ActionData } from "~/builder/shared/assets";
@@ -6,7 +6,7 @@ import { sentryException } from "~/shared/sentry";
 import { createAssetClient } from "~/shared/asset-client";
 
 export const action = async (
-  props: ActionArgs
+  props: ActionFunctionArgs
 ): Promise<ActionData | Array<Asset> | undefined> => {
   const { request, params } = props;
 

--- a/apps/builder/app/routes/rest.assets.tsx
+++ b/apps/builder/app/routes/rest.assets.tsx
@@ -1,4 +1,7 @@
-import type { ActionArgs, LoaderArgs } from "@remix-run/node";
+import type {
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
+} from "@remix-run/server-runtime";
 import type { Asset } from "@webstudio-is/sdk";
 import { MaxAssets } from "@webstudio-is/asset-uploader";
 import {
@@ -12,7 +15,7 @@ import env from "~/env/env.server";
 export const loader = async ({
   params,
   request,
-}: LoaderArgs): Promise<Array<Asset>> => {
+}: LoaderFunctionArgs): Promise<Array<Asset>> => {
   if (params.projectId === undefined) {
     throw new Error("Project id undefined");
   }
@@ -20,7 +23,7 @@ export const loader = async ({
   return await loadAssetsByProject(params.projectId, context);
 };
 
-export const action = async (props: ActionArgs) => {
+export const action = async (props: ActionFunctionArgs) => {
   const { request } = props;
 
   const context = await createContext(request);

--- a/apps/builder/app/routes/rest.build.$buildId.tsx
+++ b/apps/builder/app/routes/rest.build.$buildId.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderArgs } from "@remix-run/node";
+import { json, type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import type { Data } from "@webstudio-is/http-client";
 import { db as projectDb } from "@webstudio-is/project/index.server";
 import { sentryException } from "~/shared/sentry";
@@ -9,7 +9,7 @@ import { getUserById, type User } from "~/shared/db/user.server";
 export const loader = async ({
   params,
   request,
-}: LoaderArgs): Promise<
+}: LoaderFunctionArgs): Promise<
   Data & { user: { email: User["email"] } | undefined } & {
     projectDomain: string;
   }

--- a/apps/builder/app/routes/rest.buildId.$projectId.tsx
+++ b/apps/builder/app/routes/rest.buildId.$projectId.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderArgs } from "@remix-run/node";
+import { json, type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { db as projectDb } from "@webstudio-is/project/index.server";
 import { sentryException } from "~/shared/sentry";
 import { createContext } from "~/shared/context.server";
@@ -6,7 +6,7 @@ import { createContext } from "~/shared/context.server";
 export const loader = async ({
   params,
   request,
-}: LoaderArgs): Promise<{ buildId: string | null }> => {
+}: LoaderFunctionArgs): Promise<{ buildId: string | null }> => {
   try {
     const projectId = params.projectId;
 

--- a/apps/builder/app/routes/rest.current.products.ts
+++ b/apps/builder/app/routes/rest.current.products.ts
@@ -1,4 +1,8 @@
-import { json, redirect, type LoaderArgs } from "@remix-run/server-runtime";
+import {
+  json,
+  redirect,
+  type LoaderFunctionArgs,
+} from "@remix-run/server-runtime";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import { loginPath } from "~/shared/router-utils";
 import { prisma } from "@webstudio-is/prisma-client";
@@ -7,7 +11,7 @@ import { prisma } from "@webstudio-is/prisma-client";
  * Created for ebugging purposes, to check that payments and products are working
  * Showing current user's checkouts with products.
  */
-export const loader = async ({ request, params }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   const user = await findAuthenticatedUser(request);
 
   if (user === null) {

--- a/apps/builder/app/routes/rest.patch.ts
+++ b/apps/builder/app/routes/rest.patch.ts
@@ -1,5 +1,5 @@
 import { applyPatches } from "immer";
-import type { ActionArgs } from "@remix-run/node";
+import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import type { SyncItem } from "immerhin";
 import { prisma } from "@webstudio-is/prisma-client";
 import {
@@ -45,7 +45,7 @@ type PatchData = {
   version: number;
 };
 
-export const action = async ({ request }: ActionArgs) => {
+export const action = async ({ request }: ActionFunctionArgs) => {
   try {
     const {
       buildId,

--- a/apps/builder/app/routes/rest.resources-loader.ts
+++ b/apps/builder/app/routes/rest.resources-loader.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import type { ActionArgs } from "@remix-run/node";
+import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import { loadResource, ResourceRequest } from "@webstudio-is/sdk";
 
-export const action = async ({ request }: ActionArgs) => {
+export const action = async ({ request }: ActionFunctionArgs) => {
   const computedResources = z
     .array(ResourceRequest)
     .parse(await request.json());

--- a/apps/builder/app/routes/rest.theme.$setting.ts
+++ b/apps/builder/app/routes/rest.theme.$setting.ts
@@ -1,7 +1,7 @@
-import { json, type LoaderArgs } from "@remix-run/node";
+import { json, type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { themeCookieParser } from "~/shared/theme";
 
-export const loader = async ({ params }: LoaderArgs) => {
+export const loader = async ({ params }: LoaderFunctionArgs) => {
   const { setting } = params;
   const headers = {
     "Set-Cookie": await themeCookieParser.serialize(setting),

--- a/apps/builder/app/routes/trpc.$.ts
+++ b/apps/builder/app/routes/trpc.$.ts
@@ -1,11 +1,11 @@
 // eslint-disable-next-line import/no-internal-modules
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
-import type { ActionArgs } from "@remix-run/node";
+import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import { createContext } from "~/shared/context.server";
 import { appRouter } from "~/services/trcp-router.server";
 
-export const action = async ({ request }: ActionArgs) => {
+export const action = async ({ request }: ActionFunctionArgs) => {
   const authenticatedUser = await findAuthenticatedUser(request);
 
   if (authenticatedUser === null) {

--- a/apps/builder/app/routes/vercel-deploy-workaround.tsx
+++ b/apps/builder/app/routes/vercel-deploy-workaround.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction } from "@remix-run/node";
+import type { LinksFunction } from "@remix-run/server-runtime";
 
 import { Root } from "~/shared/remix";
 import interFont from "@fontsource-variable/inter/index.css";

--- a/apps/builder/remix.env.d.ts
+++ b/apps/builder/remix.env.d.ts
@@ -1,2 +1,9 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node/globals" />
+
+import type { LoaderArgs, ActionArgs } from "@remix-run/server-runtime";
+
+declare module "@remix-run/server-runtime" {
+  export type LoaderFunctionArgs = LoaderArgs;
+  export type ActionFunctionArgs = ActionArgs;
+}

--- a/fixtures/webstudio-custom-template/app/routes/[hello]._index.ts
+++ b/fixtures/webstudio-custom-template/app/routes/[hello]._index.ts
@@ -1,5 +1,5 @@
-import { type LoaderArgs, redirect } from "@remix-run/server-runtime";
+import { type LoaderFunctionArgs, redirect } from "@remix-run/server-runtime";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   return redirect("/world", 301);
 };

--- a/fixtures/webstudio-custom-template/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[robots.txt].tsx
@@ -1,6 +1,6 @@
-import type { LoaderArgs } from "@remix-run/server-runtime";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap.xml].tsx
@@ -1,7 +1,7 @@
-import type { LoaderArgs } from "@remix-run/server-runtime";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { sitemap } from "../__generated__/[sitemap.xml]";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-custom-template/remix.env.d.ts
+++ b/fixtures/webstudio-custom-template/remix.env.d.ts
@@ -1,2 +1,9 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
+
+import type { LoaderArgs, ActionArgs } from "@remix-run/server-runtime";
+
+declare module "@remix-run/server-runtime" {
+  export type LoaderFunctionArgs = LoaderArgs;
+  export type ActionFunctionArgs = ActionArgs;
+}

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[robots.txt].tsx
@@ -1,6 +1,6 @@
-import type { LoaderArgs } from "@remix-run/server-runtime";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[sitemap.xml].tsx
@@ -1,7 +1,7 @@
-import type { LoaderArgs } from "@remix-run/server-runtime";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { sitemap } from "../__generated__/[sitemap.xml]";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-remix-netlify-edge-functions/remix.env.d.ts
+++ b/fixtures/webstudio-remix-netlify-edge-functions/remix.env.d.ts
@@ -1,2 +1,9 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
+
+import type { LoaderArgs, ActionArgs } from "@remix-run/server-runtime";
+
+declare module "@remix-run/server-runtime" {
+  export type LoaderFunctionArgs = LoaderArgs;
+  export type ActionFunctionArgs = ActionArgs;
+}

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[robots.txt].tsx
@@ -1,6 +1,6 @@
-import type { LoaderArgs } from "@remix-run/server-runtime";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[sitemap.xml].tsx
@@ -1,7 +1,7 @@
-import type { LoaderArgs } from "@remix-run/server-runtime";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { sitemap } from "../__generated__/[sitemap.xml]";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-remix-netlify-functions/remix.env.d.ts
+++ b/fixtures/webstudio-remix-netlify-functions/remix.env.d.ts
@@ -1,2 +1,9 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
+
+import type { LoaderArgs, ActionArgs } from "@remix-run/server-runtime";
+
+declare module "@remix-run/server-runtime" {
+  export type LoaderFunctionArgs = LoaderArgs;
+  export type ActionFunctionArgs = ActionArgs;
+}

--- a/fixtures/webstudio-remix-vercel/app/framework.ts
+++ b/fixtures/webstudio-remix-vercel/app/framework.ts
@@ -1,9 +1,0 @@
-/* eslint-disable camelcase */
-
-export {
-  type V2_MetaFunction,
-  type LinksFunction,
-  type LinkDescriptor,
-  type ActionArgs,
-  json,
-} from "@remix-run/node";

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-remix-vercel/app/routes/[robots.txt].tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[robots.txt].tsx
@@ -1,6 +1,6 @@
-import type { LoaderArgs } from "@remix-run/server-runtime";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||

--- a/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml].tsx
@@ -1,7 +1,7 @@
-import type { LoaderArgs } from "@remix-run/server-runtime";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { sitemap } from "../__generated__/[sitemap.xml]";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/fixtures/webstudio-remix-vercel/remix.env.d.ts
+++ b/fixtures/webstudio-remix-vercel/remix.env.d.ts
@@ -1,2 +1,9 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
+
+import type { LoaderArgs, ActionArgs } from "@remix-run/server-runtime";
+
+declare module "@remix-run/server-runtime" {
+  export type LoaderFunctionArgs = LoaderArgs;
+  export type ActionFunctionArgs = ActionArgs;
+}

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -713,9 +713,9 @@ export const projectMeta: ProjectMeta =
       const redirectPagePath = generateRemixRoute(redirect.old);
       const redirectFileName = `${redirectPagePath}.ts`;
 
-      const content = `import { type LoaderArgs, redirect } from "@remix-run/server-runtime";
+      const content = `import { type LoaderFunctionArgs, redirect } from "@remix-run/server-runtime";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   return redirect("${redirect.new}", ${redirect.status ?? 301});
 };
 `;

--- a/packages/cli/templates/defaults/__templates__/route-template.tsx
+++ b/packages/cli/templates/defaults/__templates__/route-template.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import {
-  type V2_ServerRuntimeMetaFunction,
+  type V2_ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
   type LinkDescriptor,
-  type ActionArgs,
-  type LoaderArgs,
-  type HeadersArgs,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
   json,
   redirect,
 } from "@remix-run/server-runtime";
@@ -32,7 +32,7 @@ import {
 import css from "../__generated__/index.css";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
 
-export const loader = async (arg: LoaderArgs) => {
+export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
   const params = getRemixParams(arg.params);
   const system = {
@@ -83,15 +83,15 @@ export const loader = async (arg: LoaderArgs) => {
   );
 };
 
-export const headers = ({ loaderHeaders }: HeadersArgs) => {
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return {
     "Cache-Control": "public, max-age=0, must-revalidate",
-    "x-ws-language": loaderHeaders.get("x-ws-language"),
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
   };
 };
 
-export const meta: V2_ServerRuntimeMetaFunction<typeof loader> = ({ data }) => {
-  const metas: ReturnType<V2_ServerRuntimeMetaFunction> = [];
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
   if (data === undefined) {
     return metas;
   }
@@ -240,7 +240,7 @@ const getMethod = (value: string | undefined) => {
   }
 };
 
-export const action = async ({ request, context }: ActionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
 
   const formId = getFormId(formData);

--- a/packages/cli/templates/defaults/app/routes/[robots.txt].tsx
+++ b/packages/cli/templates/defaults/app/routes/[robots.txt].tsx
@@ -1,6 +1,6 @@
-import type { LoaderArgs } from "@remix-run/server-runtime";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||

--- a/packages/cli/templates/defaults/app/routes/[sitemap.xml].tsx
+++ b/packages/cli/templates/defaults/app/routes/[sitemap.xml].tsx
@@ -1,7 +1,7 @@
-import type { LoaderArgs } from "@remix-run/server-runtime";
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { sitemap } from "../__generated__/[sitemap.xml]";
 
-export const loader = (arg: LoaderArgs) => {
+export const loader = (arg: LoaderFunctionArgs) => {
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||

--- a/packages/cli/templates/defaults/remix.env.d.ts
+++ b/packages/cli/templates/defaults/remix.env.d.ts
@@ -1,2 +1,9 @@
 /// <reference types="@remix-run/dev" />
 /// <reference types="@remix-run/node" />
+
+import type { LoaderArgs, ActionArgs } from "@remix-run/server-runtime";
+
+declare module "@remix-run/server-runtime" {
+  export type LoaderFunctionArgs = LoaderArgs;
+  export type ActionFunctionArgs = ActionArgs;
+}


### PR DESCRIPTION
Here replaced LoaderArgs and ActionArgs with LoaderFunctionArgs and ActionFunctionArgs to simplify bump with remix v2 which changed named of these types.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
