### PR TITLE
fix: forbid empty expressions

### DIFF
--- a/packages/sdk/src/expression.test.ts
+++ b/packages/sdk/src/expression.test.ts
@@ -18,8 +18,13 @@ describe("lint expression", () => {
     message,
   });
 
-  test("supports empty expression", () => {
-    expect(lintExpression({ expression: `` })).toEqual([]);
+  test("forbid empty expression", () => {
+    expect(lintExpression({ expression: `` })).toEqual([
+      error(0, 0, `Expression cannot be empty`),
+    ]);
+    expect(lintExpression({ expression: `  ` })).toEqual([
+      error(0, 0, `Expression cannot be empty`),
+    ]);
   });
 
   test("output parse error as diagnostic", () => {
@@ -304,6 +309,16 @@ describe("transpile expression", () => {
         expression: `{ ...name }`,
       })
     ).toEqual(`{ ...name }`);
+  });
+
+  test("output more readable syntax error", () => {
+    let errorString = "";
+    try {
+      transpileExpression({ expression: `` });
+    } catch (error) {
+      errorString = (error as Error).message;
+    }
+    expect(errorString).toEqual(`Unexpected token (1:0) in ""`);
   });
 });
 

--- a/packages/sdk/src/expression.ts
+++ b/packages/sdk/src/expression.ts
@@ -36,6 +36,12 @@ export const lintExpression = ({
   };
   // allow empty expression
   if (expression.trim().length === 0) {
+    diagnostics.push({
+      from: 0,
+      to: 0,
+      severity: "error",
+      message: "Expression cannot be empty",
+    });
     return diagnostics;
   }
   try {
@@ -181,7 +187,14 @@ export const transpileExpression = ({
     assignee: boolean
   ) => string | undefined | void;
 }) => {
-  const root = parseExpressionAt(expression, 0, { ecmaVersion: "latest" });
+  let root;
+  try {
+    root = parseExpressionAt(expression, 0, { ecmaVersion: "latest" });
+  } catch (error) {
+    const message = (error as Error).message;
+    // throw new error to trace error in our code instead of acorn
+    throw Error(`${message} in ${JSON.stringify(expression)}`);
+  }
   const replacements: [start: number, end: number, fragment: string][] = [];
   const replaceIdentifier = (node: Identifier, assignee: boolean) => {
     const newName = replaceVariable?.(node.name, assignee);


### PR DESCRIPTION
Empty expressions lead to publish errors.
Need to lint them away. Also improved parsing error to more easily see the source of it.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
