### PR TITLE
experimental: hide new form component behind flag

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -25,6 +25,7 @@ import { MetaIcon } from "~/builder/shared/meta-icon";
 import { $registeredComponentMetas } from "~/shared/nano-states";
 import { getMetaMaps } from "./get-meta-maps";
 import { getInstanceLabel } from "~/shared/instance-utils";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
   const metaByComponentName = useStore($registeredComponentMetas);
@@ -63,6 +64,12 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
                     (meta: WsComponentMeta, index) => {
                       const component = componentNamesByMeta.get(meta);
                       if (component === undefined) {
+                        return;
+                      }
+                      if (
+                        isFeatureEnabled("filters") === false &&
+                        component === "RemixForm"
+                      ) {
                         return;
                       }
                       return (

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -6,3 +6,4 @@ export const aiRadixComponents = false;
 export const cms = false;
 export const marketplace = false;
 export const pageTemplates = false;
+export const filters = false;

--- a/packages/sdk-components-react-remix/src/server-form.ws.ts
+++ b/packages/sdk-components-react-remix/src/server-form.ws.ts
@@ -8,7 +8,7 @@ import { props } from "./__generated__/server-form.props";
 
 export const meta: WsComponentMeta = {
   ...baseMeta,
-  label: "Server Form",
+  label: "Form",
   states: [
     { selector: "[data-state=error]", label: "Error" },
     { selector: "[data-state=success]", label: "Success" },


### PR DESCRIPTION
Here added new "filters" flag which hides new form component form components panel and renamed server form back to just form until we agree on name.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
