### PR TITLE
refactor: move publisher host into loader

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -40,11 +40,11 @@ import {
   $styleSourceSelections,
   $styleSources,
   $styles,
-  $domains,
   $resources,
   subscribeResources,
   $marketplaceProduct,
   $authTokenPermissions,
+  $publisherHost,
 } from "~/shared/nano-states";
 import { type Settings } from "./shared/client-settings";
 import { getBuildUrl } from "~/shared/router-utils";
@@ -226,7 +226,7 @@ const NavigatorPanel = ({
 
 export type BuilderProps = {
   project: Project;
-  domains: string[];
+  publisherHost: string;
   build: Build;
   assets: [Asset["id"], Asset][];
   authToken?: string;
@@ -237,7 +237,7 @@ export type BuilderProps = {
 
 export const Builder = ({
   project,
-  domains,
+  publisherHost,
   build,
   assets,
   authToken,
@@ -248,7 +248,7 @@ export const Builder = ({
   useMount(() => {
     // additional data stores
     $project.set(project);
-    $domains.set(domains);
+    $publisherHost.set(publisherHost);
     $authPermit.set(authPermit);
     $authToken.set(authToken);
     $userPlanFeatures.set(userPlanFeatures);

--- a/apps/builder/app/builder/features/address-bar.tsx
+++ b/apps/builder/app/builder/features/address-bar.tsx
@@ -23,31 +23,16 @@ import {
 } from "@webstudio-is/sdk";
 import {
   $dataSourceVariables,
-  $domains,
   $pages,
-  $project,
+  $publishedUrl,
   $selectedPage,
   updateSystem,
 } from "~/shared/nano-states";
-import env from "~/shared/env";
 import {
   compilePathnamePattern,
   isPathnamePattern,
   tokenizePathnamePattern,
 } from "~/builder/shared/url-pattern";
-
-export const $publishedOrigin = computed(
-  [$project, $domains],
-  (project, domains) => {
-    const customDomain: string | undefined = domains[0];
-    const projectDomain = `${project?.domain}.${
-      env.PUBLISHER_HOST ?? "wstd.work"
-    }`;
-    const domain = customDomain ?? projectDomain;
-    const publishedUrl = new URL(`https://${domain}`);
-    return publishedUrl.origin;
-  }
-);
 
 const $selectedPagePath = computed([$selectedPage, $pages], (page, pages) => {
   if (pages === undefined || page === undefined) {
@@ -134,13 +119,13 @@ const useCopyUrl = (pageUrl: string) => {
 
 const AddressBar = () => {
   const id = useId();
-  const publishedOrigin = useStore($publishedOrigin);
+  const publishedUrl = useStore($publishedUrl);
   const path = useStore($selectedPagePath);
   const pathParams = useStore($selectedPagePathParams);
   const tokens = tokenizePathnamePattern(path);
   const compiledPath = compilePathnamePattern(tokens, pathParams ?? {});
   const { tooltipProps, buttonProps } = useCopyUrl(
-    `${publishedOrigin}${compiledPath}`
+    `${publishedUrl}${compiledPath}`
   );
 
   const errors = new Map<string, string>();
@@ -198,8 +183,8 @@ const AddressBar = () => {
 export const AddressBarPopover = () => {
   const [isOpen, setIsOpen] = useState(false);
   const path = useStore($selectedPagePath);
-  const publishedOrigin = useStore($publishedOrigin);
-  const { tooltipProps, buttonProps } = useCopyUrl(`${publishedOrigin}${path}`);
+  const publishedUrl = useStore($publishedUrl);
+  const { tooltipProps, buttonProps } = useCopyUrl(`${publishedUrl}${path}`);
 
   // show only copy button when path is static
   if (isPathnamePattern(path) === false) {

--- a/apps/builder/app/builder/features/project-settings/section-redirects.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-redirects.tsx
@@ -23,13 +23,13 @@ import {
 } from "@webstudio-is/sdk";
 import { useStore } from "@nanostores/react";
 import { getExistingRoutePaths } from "../sidebar-left/panels/pages/page-utils";
-import { $pages, $project } from "~/shared/nano-states";
+import { $pages, $publishedUrl } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
 import { flushSync } from "react-dom";
-import { getPublishedUrl } from "~/shared/router-utils";
 import { sectionSpacing } from "./utils";
 
 export const SectionRedirects = () => {
+  const publishedUrl = useStore($publishedUrl);
   const [redirects, setRedirects] = useState(
     () => $pages.get()?.redirects ?? []
   );
@@ -42,8 +42,6 @@ export const SectionRedirects = () => {
   const pages = useStore($pages);
   const existingPaths = getExistingRoutePaths(pages);
   const oldPathRef = useRef<HTMLInputElement>(null);
-  const projectData = useStore($project);
-  const publishedUrl = new URL(getPublishedUrl(projectData?.domain ?? ""));
 
   const redirectKeys = Object.keys(redirects);
   const isValidRedirects =

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -69,6 +69,7 @@ import {
   $dataSources,
   computeExpression,
   $dataSourceVariables,
+  $publishedUrl,
 } from "~/shared/nano-states";
 import {
   BindingControl,
@@ -98,7 +99,7 @@ import {
   toTreeData,
 } from "./page-utils";
 import { Form } from "./form";
-import { type System, $publishedOrigin } from "~/builder/features/address-bar";
+import type { System } from "~/builder/features/address-bar";
 import { $userPlanFeatures } from "~/builder/shared/nano-states";
 import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 
@@ -569,10 +570,10 @@ const usePageUrl = (values: Values, systemDataSourceId?: DataSource["id"]) => {
       : (dataSourceVariables.get(systemDataSourceId) as System);
   const pathParams = storedSystem?.params ?? {};
 
-  const publishedOrigin = useStore($publishedOrigin);
+  const publishedUrl = useStore($publishedUrl);
   const tokens = tokenizePathnamePattern(path);
   const compiledPath = compilePathnamePattern(tokens, pathParams);
-  return `${publishedOrigin}${compiledPath}`;
+  return `${publishedUrl}${compiledPath}`;
 };
 
 const FormFields = ({

--- a/apps/builder/app/builder/features/topbar/domains.tsx
+++ b/apps/builder/app/builder/features/topbar/domains.tsx
@@ -20,13 +20,14 @@ import {
 } from "@webstudio-is/icons";
 import type { DomainStatus } from "@webstudio-is/prisma-client";
 import { CollapsibleDomainSection } from "./collapsible-domain-section";
-import env from "~/shared/env";
 import { useCallback, useEffect, useState } from "react";
 import type { PublishStatus } from "@webstudio-is/prisma-client";
 // eslint-disable-next-line import/no-internal-modules
 import formatDistance from "date-fns/formatDistance";
 import { Entri } from "./entri";
 import { trpcClient } from "~/shared/trpc/trpc-client";
+import { useStore } from "@nanostores/react";
+import { $publisherHost } from "~/shared/nano-states";
 
 export type Domain = {
   projectId: Project["id"];
@@ -338,10 +339,9 @@ const DomainItem = (props: {
     domainUpdatedAt,
   ]);
 
+  const publisherHost = useStore($publisherHost);
   const cnameEntryName = getCname(props.projectDomain.domain.domain);
-  const cnameEntryValue = `${props.projectDomain.cname}.customers.${
-    env.PUBLISHER_HOST ?? "wstd.work"
-  }`;
+  const cnameEntryValue = `${props.projectDomain.cname}.customers.${publisherHost}`;
 
   const txtEntryName =
     cnameEntryName === "@"

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -32,8 +32,7 @@ import {
   useIsPublishDialogOpen,
 } from "../../shared/nano-states";
 import { validateProjectDomain, type Project } from "@webstudio-is/project";
-import { getPublishedUrl } from "~/shared/router-utils";
-import { $authPermit } from "~/shared/nano-states";
+import { $authPermit, $publishedUrl } from "~/shared/nano-states";
 import {
   Domains,
   getPublishStatusAndText,
@@ -81,6 +80,7 @@ const ChangeProjectDomain = ({
   isPublishing,
 }: ChangeProjectDomainProps) => {
   const id = useId();
+  const publishedUrl = useStore($publishedUrl);
 
   const {
     send: updateProjectDomain,
@@ -107,8 +107,6 @@ const ChangeProjectDomain = ({
   useEffect(() => {
     refreshProject();
   }, [refreshProject]);
-
-  const publishedUrl = new URL(getPublishedUrl(project.domain));
 
   const handleUpdateProjectDomain = () => {
     const validationResult = validateProjectDomain(domain);
@@ -145,7 +143,7 @@ const ChangeProjectDomain = ({
 
   return (
     <CollapsibleDomainSection
-      title={publishedUrl.host}
+      title={new URL(publishedUrl).host}
       suffix={
         <Grid flow="column">
           <Tooltip content={error !== undefined ? error : statusText}>
@@ -169,12 +167,12 @@ const ChangeProjectDomain = ({
               )}
             </Flex>
           </Tooltip>
-          <Tooltip content={`Proceed to ${publishedUrl.href}`}>
+          <Tooltip content={`Proceed to ${publishedUrl}`}>
             <IconButton
               tabIndex={-1}
               disabled={error !== undefined || status !== "PUBLISHED"}
               onClick={(event) => {
-                window.open(publishedUrl.href, "_blank");
+                window.open(publishedUrl, "_blank");
                 event.preventDefault();
               }}
             >

--- a/apps/builder/app/dashboard/dashboard.stories.tsx
+++ b/apps/builder/app/dashboard/dashboard.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentStory } from "@storybook/react";
+import type { StoryFn } from "@storybook/react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { Dashboard } from "./dashboard";
 import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
@@ -34,19 +34,20 @@ const userPlanFeatures: UserPlanFeatures = {
   maxDomainsAllowedPerUser: 5,
 };
 
-export const Empty: ComponentStory<typeof Dashboard> = () => {
+export const Empty: StoryFn<typeof Dashboard> = () => {
   const router = createRouter(
     <Dashboard
       user={user}
       projects={[]}
       projectTemplates={[]}
       userPlanFeatures={userPlanFeatures}
+      publisherHost={"https://wstd.work"}
     />
   );
   return <RouterProvider router={router} />;
 };
 
-export const WithProjects: ComponentStory<typeof Dashboard> = () => {
+export const WithProjects: StoryFn<typeof Dashboard> = () => {
   const projects = [
     {
       id: "0",
@@ -67,6 +68,7 @@ export const WithProjects: ComponentStory<typeof Dashboard> = () => {
       projects={projects}
       projectTemplates={projects}
       userPlanFeatures={userPlanFeatures}
+      publisherHost={"https://wstd.work"}
     />
   );
   return <RouterProvider router={router} />;

--- a/apps/builder/app/dashboard/dashboard.tsx
+++ b/apps/builder/app/dashboard/dashboard.tsx
@@ -47,6 +47,7 @@ type DashboardProps = {
   projects: Array<DashboardProject>;
   projectTemplates: Array<DashboardProject>;
   userPlanFeatures: UserPlanFeatures;
+  publisherHost: string;
 };
 
 export const Dashboard = ({
@@ -54,6 +55,7 @@ export const Dashboard = ({
   projects,
   projectTemplates,
   userPlanFeatures,
+  publisherHost,
 }: DashboardProps) => {
   globalStyles();
   return (
@@ -68,6 +70,7 @@ export const Dashboard = ({
             projects={projects}
             projectTemplates={projectTemplates}
             hasProPlan={userPlanFeatures.hasProPlan}
+            publisherHost={publisherHost}
           />
         </Section>
       </Main>

--- a/apps/builder/app/dashboard/projects/project-card.tsx
+++ b/apps/builder/app/dashboard/projects/project-card.tsx
@@ -15,8 +15,8 @@ import {
   Link,
 } from "@webstudio-is/design-system";
 import { InfoCircleIcon, EllipsesIcon } from "@webstudio-is/icons";
-import { type KeyboardEvent, useEffect, useRef, useState } from "react";
-import { builderPath, getPublishedUrl } from "~/shared/router-utils";
+import { type KeyboardEvent, useRef, useState } from "react";
+import { builderPath } from "~/shared/router-utils";
 import {
   RenameProjectDialog,
   DeleteProjectDialog,
@@ -42,29 +42,19 @@ const titleStyle = css({
 
 const infoIconStyle = css({ flexShrink: 0 });
 
-const usePublishedLink = ({ domain }: { domain: string }) => {
-  const [url, setUrl] = useState<URL>();
-
-  useEffect(() => {
-    // It uses `window.location` to detect the default values when running locally localhost,
-    // so it needs an effect to avoid hydration errors.
-    setUrl(new URL(getPublishedUrl(domain)));
-  }, [domain]);
-
-  return { url };
-};
-
 const PublishedLink = ({
   domain,
+  publisherHost,
   tabIndex,
 }: {
   domain: string;
+  publisherHost: string;
   tabIndex: number;
 }) => {
-  const { url } = usePublishedLink({ domain });
+  const publishedUrl = `https://${domain}.${publisherHost}`;
   return (
     <Link
-      href={url?.href}
+      href={publishedUrl}
       target="_blank"
       rel="noreferrer"
       tabIndex={tabIndex}
@@ -72,7 +62,7 @@ const PublishedLink = ({
       underline="hover"
       css={truncate()}
     >
-      {url?.host}
+      {new URL(publishedUrl).host}
     </Link>
   );
 };
@@ -162,7 +152,11 @@ const formatDate = (date: string) => {
   });
 };
 
-type ProjectCardProps = { project: DashboardProject; hasProPlan: boolean };
+type ProjectCardProps = {
+  project: DashboardProject;
+  hasProPlan: boolean;
+  publisherHost: string;
+};
 
 export const ProjectCard = ({
   project: {
@@ -175,6 +169,7 @@ export const ProjectCard = ({
     previewImageAsset,
   },
   hasProPlan,
+  publisherHost,
 }: ProjectCardProps) => {
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -234,7 +229,11 @@ export const ProjectCard = ({
             </Tooltip>
           </Flex>
           {isPublished ? (
-            <PublishedLink domain={domain} tabIndex={-1} />
+            <PublishedLink
+              publisherHost={publisherHost}
+              domain={domain}
+              tabIndex={-1}
+            />
           ) : (
             <Text color="subtle">Not Published</Text>
           )}
@@ -278,6 +277,7 @@ export const ProjectCard = ({
 
 export const ProjectTemplateCard = ({
   project,
+  publisherHost,
 }: Omit<ProjectCardProps, "hasProPlan">) => {
   const { thumbnailRef, handleKeyDown } = useProjectCard();
   const [isDuplicateDialogOpen, setIsDuplicateDialogOpen] = useState(false);
@@ -311,7 +311,11 @@ export const ProjectTemplateCard = ({
             {title}
           </Text>
           {isPublished ? (
-            <PublishedLink domain={domain} tabIndex={-1} />
+            <PublishedLink
+              publisherHost={publisherHost}
+              domain={domain}
+              tabIndex={-1}
+            />
           ) : (
             <Text color="subtle">Not Published</Text>
           )}

--- a/apps/builder/app/dashboard/projects/projects.tsx
+++ b/apps/builder/app/dashboard/projects/projects.tsx
@@ -9,12 +9,14 @@ type ProjectsProps = {
   projects: Array<DashboardProject>;
   projectTemplates: Array<DashboardProject>;
   hasProPlan: boolean;
+  publisherHost: string;
 };
 
 export const Projects = ({
   projects,
   projectTemplates,
   hasProPlan,
+  publisherHost,
 }: ProjectsProps) => {
   return (
     <Panel>
@@ -38,6 +40,7 @@ export const Projects = ({
                 project={project}
                 key={project.id}
                 hasProPlan={hasProPlan}
+                publisherHost={publisherHost}
               />
             );
           })}
@@ -58,7 +61,13 @@ export const Projects = ({
             }}
           >
             {projectTemplates.map((project) => {
-              return <ProjectTemplateCard project={project} key={project.id} />;
+              return (
+                <ProjectTemplateCard
+                  project={project}
+                  publisherHost={publisherHost}
+                  key={project.id}
+                />
+              );
             })}
           </Grid>
         </Flex>

--- a/apps/builder/app/env/env.public.server.ts
+++ b/apps/builder/app/env/env.public.server.ts
@@ -10,8 +10,6 @@ import serverEnv from "./env.server";
 const env = {
   DEPLOYMENT_ENVIRONMENT: serverEnv.DEPLOYMENT_ENVIRONMENT,
   FEATURES: process.env.FEATURES,
-  BUILDER_HOST: process.env.BUILDER_HOST,
-  PUBLISHER_HOST: process.env.PUBLISHER_HOST || null,
 
   IMAGE_BASE_URL: serverEnv.IMAGE_BASE_URL,
   ASSET_BASE_URL: serverEnv.ASSET_BASE_URL,

--- a/apps/builder/app/env/env.server.ts
+++ b/apps/builder/app/env/env.server.ts
@@ -93,6 +93,8 @@ const env = {
 
   N8N_WEBHOOK_URL: process.env.N8N_WEBHOOK_URL,
   N8N_WEBHOOK_TOKEN: process.env.N8N_WEBHOOK_TOKEN,
+
+  PUBLISHER_HOST: process.env.PUBLISHER_HOST || "wstd.work",
 };
 
 export type ServerEnv = typeof env;

--- a/apps/builder/app/routes/dashboard._index.tsx
+++ b/apps/builder/app/routes/dashboard._index.tsx
@@ -44,6 +44,7 @@ export const loader = async ({
     projects,
     projectTemplates,
     userPlanFeatures,
+    publisherHost: env.PUBLISHER_HOST,
   };
 };
 

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -34,7 +34,12 @@ import type { TokenPermissions } from "@webstudio-is/authorization-token";
 
 export const $project = atom<Project | undefined>();
 
-export const $domains = atom<string[]>([]);
+export const $publisherHost = atom<string>("https://wstd.work");
+
+export const $publishedUrl = computed(
+  [$project, $publisherHost],
+  (project, publisherHost) => `https://${project?.domain}.${publisherHost}`
+);
 
 export const $rootInstance = computed(
   [$instances, $selectedPage],

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -34,7 +34,7 @@ import type { TokenPermissions } from "@webstudio-is/authorization-token";
 
 export const $project = atom<Project | undefined>();
 
-export const $publisherHost = atom<string>("https://wstd.work");
+export const $publisherHost = atom<string>("wstd.work");
 
 export const $publishedUrl = computed(
   [$project, $publisherHost],

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -1,7 +1,6 @@
 import type { AUTH_PROVIDERS } from "~/shared/session";
 import type { Project } from "@webstudio-is/project";
 import type { ThemeSetting } from "~/shared/theme";
-import env from "~/shared/env";
 import { $authToken } from "../nano-states";
 
 const searchParams = (params: Record<string, string | undefined | null>) => {
@@ -157,19 +156,6 @@ export const getBuildUrl = ({ project }: { project: Project }) => {
   searchParams.set("projectId", project.id);
 
   return `/?${searchParams.toString()}`;
-};
-
-export const getPublishedUrl = (domain: string) => {
-  const protocol = typeof location === "object" ? location.protocol : "https:";
-
-  const publisherHost = env.PUBLISHER_HOST ?? "";
-
-  // We use location.host to get the hostname and port in development mode and to not break local testing.
-  const localhost = typeof location === "object" ? location.host : "";
-
-  const host = publisherHost || env.BUILDER_HOST || localhost;
-
-  return `${protocol}//${domain}.${host}`;
 };
 
 export const restAi = (subEndpoint?: "detect" | "audio/transcriptions") =>

--- a/apps/builder/env-check.js
+++ b/apps/builder/env-check.js
@@ -35,11 +35,6 @@ if (process.env.DEPLOYMENT_ENVIRONMENT === "production") {
       "👉 In production DEPLOYMENT_URL is required for website functionality. Please set it to your production URL."
     );
   }
-  if (!process.env.BUILDER_HOST) {
-    errors.push(
-      "👉 In production BUILDER_HOST is required for website functionality. Please set it to your production URL of the builder."
-    );
-  }
   if (!process.env.PUBLISHER_HOST) {
     errors.push(
       "👉 In production PUBLISHER_HOST is required for website functionality. Please set it to your production URL of the builder."


### PR DESCRIPTION
Here refactored ours envs.

- deleted BUILDER_HOST as unused
- moved PUBLISHER_HOST into loader and shared in UI with atom

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
