### PR TITLE
feat: Show 50 tokens in style source search

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -235,6 +235,9 @@ type StyleSourceInputProps<Item extends IntermediateItem> = {
 
 const newItemId = "__NEW__";
 
+// Maximum amount of tokens we show in the combobox
+const maxSuggestedTokens = 50;
+
 const matchOrSuggestToCreate = (
   search: string,
   items: IntermediateItem[],
@@ -262,7 +265,9 @@ const matchOrSuggestToCreate = (
     });
   }
   // skip already added values
-  return matched.filter((item) => item.isAdded === false).slice(0, 5);
+  return matched
+    .filter((item) => item.isAdded === false)
+    .slice(0, maxSuggestedTokens);
 };
 
 const markAddedValues = <Item extends IntermediateItem>(


### PR DESCRIPTION
We were only show matching 5 tokens for no reason at all, why not show user more options as they narrow down the search?

https://discord.com/channels/955905230107738152/1225627427972055112


## Steps for reproduction

1. when you see a lit of tokens now you will see up to 50 and it will be scrollable

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
