### PR TITLE
refactor: move image base url into loader

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -8,6 +8,7 @@ import type { Build } from "@webstudio-is/project-build";
 import type { Project } from "@webstudio-is/project";
 import { theme, Box, type CSS, Flex, Grid } from "@webstudio-is/design-system";
 import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
+import { createImageLoader } from "@webstudio-is/image";
 import { registerContainers, useBuilderStore } from "~/shared/sync";
 import { useSyncServer } from "./shared/sync/sync-server";
 import {
@@ -45,6 +46,7 @@ import {
   $marketplaceProduct,
   $authTokenPermissions,
   $publisherHost,
+  $imageLoader,
 } from "~/shared/nano-states";
 import { type Settings } from "./shared/client-settings";
 import { getBuildUrl } from "~/shared/router-utils";
@@ -227,6 +229,7 @@ const NavigatorPanel = ({
 export type BuilderProps = {
   project: Project;
   publisherHost: string;
+  imageBaseUrl: string;
   build: Build;
   assets: [Asset["id"], Asset][];
   authToken?: string;
@@ -238,6 +241,7 @@ export type BuilderProps = {
 export const Builder = ({
   project,
   publisherHost,
+  imageBaseUrl,
   build,
   assets,
   authToken,
@@ -249,6 +253,7 @@ export const Builder = ({
     // additional data stores
     $project.set(project);
     $publisherHost.set(publisherHost);
+    $imageLoader.set(createImageLoader({ imageBaseUrl }));
     $authPermit.set(authPermit);
     $authToken.set(authToken);
     $userPlanFeatures.set(userPlanFeatures);

--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -13,9 +13,8 @@ import {
   css,
 } from "@webstudio-is/design-system";
 import { ImageControl } from "./image-control";
-import { $assets, $pages } from "~/shared/nano-states";
-import env from "~/shared/env";
-import { Image, createImageLoader } from "@webstudio-is/image";
+import { $assets, $imageLoader, $pages } from "~/shared/nano-states";
+import { Image } from "@webstudio-is/image";
 import { useIds } from "~/shared/form-utils";
 import type { ProjectMeta, CompilerSettings } from "@webstudio-is/sdk";
 import { useState } from "react";
@@ -45,10 +44,7 @@ export const SectionGeneral = () => {
   const assets = useStore($assets);
   const asset = assets.get(meta.faviconAssetId ?? "");
   const favIconUrl = asset ? `${asset.name}` : undefined;
-
-  const imageLoader = createImageLoader({
-    imageBaseUrl: env.IMAGE_BASE_URL,
-  });
+  const imageLoader = useStore($imageLoader);
 
   const handleSave = <Setting extends keyof ProjectMeta>(setting: Setting) => {
     return (value: ProjectMeta[Setting]) => {

--- a/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
@@ -18,9 +18,13 @@ import {
   Box,
 } from "@webstudio-is/design-system";
 import { ImageControl } from "./image-control";
-import { $assets, $marketplaceProduct, $project } from "~/shared/nano-states";
-import env from "~/shared/env";
-import { Image, createImageLoader } from "@webstudio-is/image";
+import {
+  $assets,
+  $imageLoader,
+  $marketplaceProduct,
+  $project,
+} from "~/shared/nano-states";
+import { Image } from "@webstudio-is/image";
 import { useIds } from "~/shared/form-utils";
 import { useState } from "react";
 import {
@@ -45,9 +49,6 @@ const thumbnailStyle = css({
       },
     },
   },
-});
-const imageLoader = createImageLoader({
-  imageBaseUrl: env.IMAGE_BASE_URL,
 });
 
 const defaultMarketplaceProduct: Partial<MarketplaceProduct> = {
@@ -115,6 +116,7 @@ const useMarketplaceApprovalStatus = () => {
 
 export const SectionMarketplace = () => {
   const project = useStore($project);
+  const imageLoader = useStore($imageLoader);
   const approval = useMarketplaceApprovalStatus();
   const [data, setData] = useState(() => $marketplaceProduct.get());
   const ids = useIds([

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.stories.tsx
@@ -12,12 +12,7 @@ import {
   registerComponentLibrary,
   $selectedPageId,
 } from "~/shared/nano-states";
-import { setMockEnv } from "~/shared/env";
-// eslint-disable-next-line import/no-internal-modules
-import catPath from "./props-panel.stories.assets/cat.jpg";
 import { createDefaultPages } from "@webstudio-is/project-build";
-
-setMockEnv({ ASSET_BASE_URL: catPath.replace("cat.jpg", "") });
 
 let id = 0;
 const unique = () => `${++id}`;

--- a/apps/builder/app/builder/features/sidebar-left/panels/marketplace/card.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/marketplace/card.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from "react";
+import { useStore } from "@nanostores/react";
 import {
   Flex,
   Text,
@@ -6,16 +8,11 @@ import {
   css,
   rawTheme,
 } from "@webstudio-is/design-system";
-import env from "~/shared/env";
-import { Image, createImageLoader } from "@webstudio-is/image";
-import { forwardRef } from "react";
+import { Image } from "@webstudio-is/image";
 import { SpinnerIcon } from "@webstudio-is/icons";
+import { $imageLoader } from "~/shared/nano-states";
 
 const focusOutline = focusRingStyle();
-
-const imageLoader = createImageLoader({
-  imageBaseUrl: env.IMAGE_BASE_URL,
-});
 
 const imageContainerStyle = css({
   position: "relative",
@@ -57,6 +54,7 @@ type ThumbnailProps = {
 };
 
 const Thumbnail = ({ image, state }: ThumbnailProps) => {
+  const imageLoader = useStore($imageLoader);
   return (
     <div className={imageContainerStyle()}>
       {image === "" || image === undefined ? (

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/search-preview.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/search-preview.tsx
@@ -1,7 +1,8 @@
+import { useStore } from "@nanostores/react";
 import { Box, Flex, Grid } from "@webstudio-is/design-system";
-import { Image, createImageLoader } from "@webstudio-is/image";
+import { Image } from "@webstudio-is/image";
+import { $imageLoader } from "~/shared/nano-states";
 import { formatUrl, truncateByWords, truncate } from "./social-utils";
-import env from "~/shared/env";
 
 /**
  * Full description with links https://developers.google.com/search/docs/appearance/visual-elements-gallery
@@ -66,7 +67,7 @@ const VerticalThreePointIcon = () => (
 );
 
 export const SearchPreview = (props: SearchPreviewProps) => {
-  const loader = createImageLoader({ imageBaseUrl: env.IMAGE_BASE_URL });
+  const imageLoader = useStore($imageLoader);
 
   return (
     <Grid
@@ -98,7 +99,7 @@ export const SearchPreview = (props: SearchPreviewProps) => {
           <Image
             width={18}
             height={18}
-            loader={loader}
+            loader={imageLoader}
             src={props.faviconUrl}
           />
         </Flex>

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/social-preview.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/social-preview.tsx
@@ -1,7 +1,8 @@
 import { Box, Grid, Label, css, theme } from "@webstudio-is/design-system";
-import { Image, createImageLoader } from "@webstudio-is/image";
-import env from "~/shared/env";
+import { Image } from "@webstudio-is/image";
 import { truncateByWords, truncate } from "./social-utils";
+import { useStore } from "@nanostores/react";
+import { $imageLoader } from "~/shared/nano-states";
 
 type SocialPreviewProps = {
   ogImageUrl?: string;
@@ -32,9 +33,7 @@ export const SocialPreview = ({
   ogTitle,
   ogUrl,
 }: SocialPreviewProps) => {
-  const imageLoader = createImageLoader({
-    imageBaseUrl: env.IMAGE_BASE_URL,
-  });
+  const imageLoader = useStore($imageLoader);
 
   return (
     <Grid gap={1}>

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
@@ -1,14 +1,10 @@
 import { useStore } from "@nanostores/react";
 import type { Assets } from "@webstudio-is/sdk";
-import {
-  Image as WebstudioImage,
-  createImageLoader,
-} from "@webstudio-is/image";
+import { Image as WebstudioImage } from "@webstudio-is/image";
 import { styled, theme } from "@webstudio-is/design-system";
-import { $assets } from "~/shared/nano-states";
+import { $assets, $imageLoader } from "~/shared/nano-states";
 import type { StyleInfo } from "../../shared/style-info";
 import brokenImage from "~/shared/images/broken-image-placeholder.svg";
-import env from "~/shared/env";
 import { layeredBackgroundProps } from "./background-layers";
 import { toValue } from "@webstudio-is/css-engine";
 import { toPascalCase } from "../../shared/keyword-utils";
@@ -87,6 +83,7 @@ export const getLayerName = (layerStyle: StyleInfo, assets: Assets) => {
 
 export const LayerThumbnail = (props: { layerStyle: StyleInfo }) => {
   const assets = useStore($assets);
+  const imageLoader = useStore($imageLoader);
   const backgroundImageStyle = props.layerStyle.backgroundImage?.value;
 
   if (
@@ -98,12 +95,10 @@ export const LayerThumbnail = (props: { layerStyle: StyleInfo }) => {
       return null;
     }
 
-    const loader = createImageLoader({ imageBaseUrl: env.IMAGE_BASE_URL });
-
     return (
       <StyledWebstudioImage
         key={asset.id}
-        loader={loader}
+        loader={imageLoader}
         src={asset.name}
         width={theme.spacing[10]}
         optimize={true}

--- a/apps/builder/app/builder/shared/image-manager/image.tsx
+++ b/apps/builder/app/builder/shared/image-manager/image.tsx
@@ -1,12 +1,9 @@
-import { useMemo } from "react";
+import { useStore } from "@nanostores/react";
 import { styled } from "@webstudio-is/design-system";
-import {
-  Image as WebstudioImage,
-  createImageLoader,
-} from "@webstudio-is/image";
-import env from "~/shared/env";
+import { Image as WebstudioImage } from "@webstudio-is/image";
 import type { AssetContainer } from "../assets";
 import brokenImage from "~/shared/images/broken-image-placeholder.svg";
+import { $imageLoader } from "~/shared/nano-states";
 
 type ImageProps = {
   assetContainer: AssetContainer;
@@ -43,14 +40,11 @@ const StyledWebstudioImage = styled(WebstudioImage, {
 export const Image = ({ assetContainer, alt, width }: ImageProps) => {
   const { asset } = assetContainer;
   const optimize = assetContainer.status === "uploaded";
+  const imageLoader = useStore($imageLoader);
 
   // Avoid image flickering on switching from preview to asset (during upload)
   // Possible optimisation, we can set it to "sync" only if asset.path has changed or add isNew prop to UploadedAssetContainer
   const decoding = "sync";
-
-  const loader = useMemo(() => {
-    return createImageLoader({ imageBaseUrl: env.IMAGE_BASE_URL });
-  }, []);
 
   const src =
     assetContainer.status === "uploading"
@@ -60,7 +54,7 @@ export const Image = ({ assetContainer, alt, width }: ImageProps) => {
   return (
     <StyledWebstudioImage
       key={asset.id}
-      loader={loader}
+      loader={imageLoader}
       decoding={decoding}
       src={src}
       width={width}

--- a/apps/builder/app/dashboard/dashboard.stories.tsx
+++ b/apps/builder/app/dashboard/dashboard.stories.tsx
@@ -42,6 +42,7 @@ export const Empty: StoryFn<typeof Dashboard> = () => {
       projectTemplates={[]}
       userPlanFeatures={userPlanFeatures}
       publisherHost={"https://wstd.work"}
+      imageBaseUrl=""
     />
   );
   return <RouterProvider router={router} />;
@@ -69,6 +70,7 @@ export const WithProjects: StoryFn<typeof Dashboard> = () => {
       projectTemplates={projects}
       userPlanFeatures={userPlanFeatures}
       publisherHost={"https://wstd.work"}
+      imageBaseUrl=""
     />
   );
   return <RouterProvider router={router} />;

--- a/apps/builder/app/dashboard/dashboard.tsx
+++ b/apps/builder/app/dashboard/dashboard.tsx
@@ -48,6 +48,7 @@ type DashboardProps = {
   projectTemplates: Array<DashboardProject>;
   userPlanFeatures: UserPlanFeatures;
   publisherHost: string;
+  imageBaseUrl: string;
 };
 
 export const Dashboard = ({
@@ -56,6 +57,7 @@ export const Dashboard = ({
   projectTemplates,
   userPlanFeatures,
   publisherHost,
+  imageBaseUrl,
 }: DashboardProps) => {
   globalStyles();
   return (
@@ -71,6 +73,7 @@ export const Dashboard = ({
             projectTemplates={projectTemplates}
             hasProPlan={userPlanFeatures.hasProPlan}
             publisherHost={publisherHost}
+            imageBaseUrl={imageBaseUrl}
           />
         </Section>
       </Main>

--- a/apps/builder/app/dashboard/projects/project-card.tsx
+++ b/apps/builder/app/dashboard/projects/project-card.tsx
@@ -16,6 +16,7 @@ import {
 } from "@webstudio-is/design-system";
 import { InfoCircleIcon, EllipsesIcon } from "@webstudio-is/icons";
 import { type KeyboardEvent, useRef, useState } from "react";
+import type { ImageLoader } from "@webstudio-is/image";
 import { builderPath } from "~/shared/router-utils";
 import {
   RenameProjectDialog,
@@ -156,6 +157,7 @@ type ProjectCardProps = {
   project: DashboardProject;
   hasProPlan: boolean;
   publisherHost: string;
+  imageLoader: ImageLoader;
 };
 
 export const ProjectCard = ({
@@ -170,6 +172,7 @@ export const ProjectCard = ({
   },
   hasProPlan,
   publisherHost,
+  imageLoader,
 }: ProjectCardProps) => {
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -191,6 +194,7 @@ export const ProjectCard = ({
             to={linkPath}
             name={previewImageAsset.name}
             ref={thumbnailRef}
+            imageLoader={imageLoader}
           />
         ) : (
           <ThumbnailLinkWithAbbr
@@ -278,6 +282,7 @@ export const ProjectCard = ({
 export const ProjectTemplateCard = ({
   project,
   publisherHost,
+  imageLoader,
 }: Omit<ProjectCardProps, "hasProPlan">) => {
   const { thumbnailRef, handleKeyDown } = useProjectCard();
   const [isDuplicateDialogOpen, setIsDuplicateDialogOpen] = useState(false);
@@ -294,6 +299,7 @@ export const ProjectTemplateCard = ({
             onClick={() => {
               setIsDuplicateDialogOpen(true);
             }}
+            imageLoader={imageLoader}
           />
         ) : (
           <ThumbnailWithAbbr

--- a/apps/builder/app/dashboard/projects/projects.tsx
+++ b/apps/builder/app/dashboard/projects/projects.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from "react";
 import { Flex, Grid, Text, rawTheme } from "@webstudio-is/design-system";
+import type { DashboardProject } from "@webstudio-is/dashboard";
+import { createImageLoader } from "@webstudio-is/image";
 import { EmptyState } from "./empty-state";
 import { Panel } from "../shared/panel";
-import type { DashboardProject } from "@webstudio-is/dashboard";
 import { ProjectCard, ProjectTemplateCard } from "./project-card";
 import { CreateProject } from "./project-dialogs";
 
@@ -10,6 +12,7 @@ type ProjectsProps = {
   projectTemplates: Array<DashboardProject>;
   hasProPlan: boolean;
   publisherHost: string;
+  imageBaseUrl: string;
 };
 
 export const Projects = ({
@@ -17,7 +20,12 @@ export const Projects = ({
   projectTemplates,
   hasProPlan,
   publisherHost,
+  imageBaseUrl,
 }: ProjectsProps) => {
+  const imageLoader = useMemo(
+    () => createImageLoader({ imageBaseUrl }),
+    [imageBaseUrl]
+  );
   return (
     <Panel>
       <Flex direction="column" gap="3">
@@ -41,6 +49,7 @@ export const Projects = ({
                 key={project.id}
                 hasProPlan={hasProPlan}
                 publisherHost={publisherHost}
+                imageLoader={imageLoader}
               />
             );
           })}
@@ -66,6 +75,7 @@ export const Projects = ({
                   project={project}
                   publisherHost={publisherHost}
                   key={project.id}
+                  imageLoader={imageLoader}
                 />
               );
             })}

--- a/apps/builder/app/dashboard/projects/thumbnail.tsx
+++ b/apps/builder/app/dashboard/projects/thumbnail.tsx
@@ -1,8 +1,7 @@
 import { forwardRef } from "react";
 import { Link } from "@remix-run/react";
-import { Image, createImageLoader } from "@webstudio-is/image";
+import { Image, type ImageLoader } from "@webstudio-is/image";
 import { css, theme, textVariants } from "@webstudio-is/design-system";
-import env from "~/shared/env";
 
 const abbrStyle = css(textVariants.brandThumbnailLargeDefault, {
   display: "flex",
@@ -53,10 +52,6 @@ export const ThumbnailWithAbbr = forwardRef<
 
 ThumbnailWithAbbr.displayName = "ThumbnailWithAbbr";
 
-const imageLoader = createImageLoader({
-  imageBaseUrl: env.IMAGE_BASE_URL,
-});
-
 const imageContainerStyle = css({
   position: "relative",
   background: theme.colors.brandBackgroundProjectCardFront,
@@ -78,8 +73,8 @@ const imageStyle = css({
 
 export const ThumbnailLinkWithImage = forwardRef<
   HTMLAnchorElement,
-  { name: string; to: string }
->(({ name, to }, ref) => {
+  { name: string; to: string; imageLoader: ImageLoader }
+>(({ name, to, imageLoader }, ref) => {
   return (
     <Link ref={ref} to={to} className={imageContainerStyle()} tabIndex={-1}>
       <Image src={name} loader={imageLoader} className={imageStyle()} />
@@ -90,8 +85,12 @@ ThumbnailLinkWithImage.displayName = "ThumbnailLinkWithImage";
 
 export const ThumbnailWithImage = forwardRef<
   HTMLDivElement,
-  { name: string; onClick: React.MouseEventHandler<HTMLDivElement> }
->(({ name, onClick }, ref) => {
+  {
+    name: string;
+    onClick: React.MouseEventHandler<HTMLDivElement>;
+    imageLoader: ImageLoader;
+  }
+>(({ name, onClick, imageLoader }, ref) => {
   return (
     <div
       ref={ref}

--- a/apps/builder/app/env/env.public.server.ts
+++ b/apps/builder/app/env/env.public.server.ts
@@ -1,17 +1,9 @@
 /**
- * .server.ts extension is required for this file to work with env-getter utility
- **/
-import serverEnv from "./env.server";
-
-/**
  * Environment variables we want to send to the UI inlined in the document.
  * Never use a private key here, because it will become public.
  **/
 const env = {
   FEATURES: process.env.FEATURES,
-
-  IMAGE_BASE_URL: serverEnv.IMAGE_BASE_URL,
-  ASSET_BASE_URL: serverEnv.ASSET_BASE_URL,
 } as const;
 
 export default env;

--- a/apps/builder/app/routes/$.tsx
+++ b/apps/builder/app/routes/$.tsx
@@ -8,7 +8,7 @@ import {
 } from "@remix-run/react";
 import type { Params } from "@webstudio-is/react-sdk";
 import { createImageLoader } from "@webstudio-is/image";
-import env from "~/env/env.public.server";
+import env from "~/env/env.server";
 import { Canvas } from "~/canvas";
 import { ErrorMessage } from "~/shared/error";
 import { dashboardPath, isCanvas } from "~/shared/router-utils";

--- a/apps/builder/app/routes/builder.$projectId.tsx
+++ b/apps/builder/app/routes/builder.$projectId.tsx
@@ -95,6 +95,7 @@ export const loader = async ({
     return {
       project,
       publisherHost,
+      imageBaseUrl: env.IMAGE_BASE_URL,
       build: devBuild,
       assets: assets.map((asset) => [asset.id, asset]),
       authToken,

--- a/apps/builder/app/routes/dashboard._index.tsx
+++ b/apps/builder/app/routes/dashboard._index.tsx
@@ -45,6 +45,7 @@ export const loader = async ({
     projectTemplates,
     userPlanFeatures,
     publisherHost: env.PUBLISHER_HOST,
+    imageBaseUrl: env.IMAGE_BASE_URL,
   };
 };
 

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -21,6 +21,10 @@ import type {
   System,
 } from "@webstudio-is/sdk";
 import type { Style } from "@webstudio-is/css-engine";
+import type { Project } from "@webstudio-is/project";
+import type { MarketplaceProduct } from "@webstudio-is/project-build";
+import type { TokenPermissions } from "@webstudio-is/authorization-token";
+import { createImageLoader, type ImageLoader } from "@webstudio-is/image";
 import type { DragStartPayload } from "~/canvas/shared/use-drag-drop";
 import { shallowComputed } from "../store-utils";
 import { type InstanceSelector } from "../tree-utils";
@@ -28,13 +32,14 @@ import type { htmlTags as HtmlTags } from "html-tags";
 import { $instances, $selectedInstanceSelector } from "./instances";
 import { $selectedPage } from "./pages";
 import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
-import type { Project } from "@webstudio-is/project";
-import type { MarketplaceProduct } from "@webstudio-is/project-build";
-import type { TokenPermissions } from "@webstudio-is/authorization-token";
 
 export const $project = atom<Project | undefined>();
 
 export const $publisherHost = atom<string>("wstd.work");
+
+export const $imageLoader = atom<ImageLoader>(
+  createImageLoader({ imageBaseUrl: "" })
+);
 
 export const $publishedUrl = computed(
   [$project, $publisherHost],


### PR DESCRIPTION
Here moved IMAGE_BASE_URL and ASSET_BASE_URL env variables into loader. Builder now can access image loader with atom.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
