### PR TITLE
refactor: replace env.d.ts with tsconfig types

### DIFF
--- a/apps/builder/env.d.ts
+++ b/apps/builder/env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types="vite/client" />
-/// <reference types="@remix-run/node" />

--- a/apps/builder/tsconfig.json
+++ b/apps/builder/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@webstudio-is/tsconfig/base.json",
   "include": [
-    "env.d.ts",
     "app",
     "**/*.ts",
     "**/*.tsx",
@@ -10,6 +9,7 @@
   ],
 
   "compilerOptions": {
+    "types": ["@remix-run/node", "vite/client"],
     "paths": {
       "~/*": ["app/*"]
     },

--- a/fixtures/webstudio-custom-template/env.d.ts
+++ b/fixtures/webstudio-custom-template/env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types="vite/client" />
-/// <reference types="@remix-run/node" />

--- a/fixtures/webstudio-custom-template/tsconfig.json
+++ b/fixtures/webstudio-custom-template/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "include": ["env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mjs"],
+  "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "types": ["@remix-run/node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",

--- a/fixtures/webstudio-remix-netlify-edge-functions/env.d.ts
+++ b/fixtures/webstudio-remix-netlify-edge-functions/env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types="vite/client" />
-/// <reference types="@remix-run/node" />

--- a/fixtures/webstudio-remix-netlify-edge-functions/tsconfig.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "include": ["env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mjs"],
+  "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "types": ["@remix-run/node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",

--- a/fixtures/webstudio-remix-netlify-functions/env.d.ts
+++ b/fixtures/webstudio-remix-netlify-functions/env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types="vite/client" />
-/// <reference types="@remix-run/node" />

--- a/fixtures/webstudio-remix-netlify-functions/tsconfig.json
+++ b/fixtures/webstudio-remix-netlify-functions/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "include": ["env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mjs"],
+  "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "types": ["@remix-run/node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",

--- a/fixtures/webstudio-remix-vercel/env.d.ts
+++ b/fixtures/webstudio-remix-vercel/env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types="vite/client" />
-/// <reference types="@remix-run/node" />

--- a/fixtures/webstudio-remix-vercel/tsconfig.json
+++ b/fixtures/webstudio-remix-vercel/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "include": ["env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mjs"],
+  "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "types": ["@remix-run/node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",

--- a/packages/cli/templates/defaults/env.d.ts
+++ b/packages/cli/templates/defaults/env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types="vite/client" />
-/// <reference types="@remix-run/node" />

--- a/packages/cli/templates/defaults/tsconfig.json
+++ b/packages/cli/templates/defaults/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "include": ["env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mjs"],
+  "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "types": ["@remix-run/node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
+    "types": ["vite/client"],
     "module": "esnext",
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
Latest remix template stopped generating additional file for types.

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
