### PR TITLE
build: remove unused build scripts

### DIFF
--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -5,7 +5,7 @@
   "description": "Webstudio Builder UI as a service",
   "type": "module",
   "scripts": {
-    "generate-metas": "pnpm tsx scripts/generate-metas.mts",
+    "generate-metas": "pnpm tsx --conditions=webstudio scripts/generate-metas.mts",
     "prebuild": "which remix",
     "build": "pnpm generate-metas && remix vite:build",
     "start": "remix-serve build/server/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -10,10 +10,7 @@
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
     "checks": "pnpm typecheck && pnpm test",
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && pnpm build:prompts && esbuild 'src/**/*.ts' --outdir=lib",
-    "build:prompts": "tsx ./bin/build-prompts.ts \"./src/chains/**/*.prompt.md\"",
-    "dts": "tsc --project tsconfig.dts.json"
+    "build:prompts": "tsx ./bin/build-prompts.ts \"./src/chains/**/*.prompt.md\""
   },
   "devDependencies": {
     "@webstudio-is/jest-config": "workspace:^",
@@ -24,20 +21,12 @@
   },
   "exports": {
     ".": {
-      "webstudio": "./src/index.ts",
-      "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js"
+      "webstudio": "./src/index.ts"
     },
     "./index.server": {
-      "webstudio": "./src/index.server.ts",
-      "types": "./lib/types/index.server.d.ts",
-      "import": "./lib/index.server.js"
+      "webstudio": "./src/index.server.ts"
     }
   },
-  "files": [
-    "lib/*",
-    "!*.test.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "sideEffects": false,
   "dependencies": {

--- a/packages/ai/tsconfig.dts.json
+++ b/packages/ai/tsconfig.dts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -8,10 +8,7 @@
   "scripts": {
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "checks": "pnpm typecheck && pnpm test",
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
-    "dts": "tsc --project tsconfig.dts.json"
+    "checks": "pnpm typecheck && pnpm test"
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.0.0",
@@ -37,20 +34,12 @@
   },
   "exports": {
     ".": {
-      "webstudio": "./src/index.ts",
-      "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js"
+      "webstudio": "./src/index.ts"
     },
     "./index.server": {
-      "webstudio": "./src/index.server.ts",
-      "types": "./lib/types/index.server.d.ts",
-      "import": "./lib/index.server.js"
+      "webstudio": "./src/index.server.ts"
     }
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "private": true,
   "sideEffects": false

--- a/packages/asset-uploader/tsconfig.dts.json
+++ b/packages/asset-uploader/tsconfig.dts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -7,10 +7,7 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc",
-    "checks": "pnpm typecheck",
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
-    "dts": "tsc --project tsconfig.dts.json"
+    "checks": "pnpm typecheck"
   },
   "dependencies": {
     "@webstudio-is/prisma-client": "workspace:*",
@@ -23,20 +20,12 @@
   },
   "exports": {
     ".": {
-      "webstudio": "./src/index.ts",
-      "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js"
+      "webstudio": "./src/index.ts"
     },
     "./index.server": {
-      "webstudio": "./src/index.server.ts",
-      "types": "./lib/types/index.server.d.ts",
-      "import": "./lib/index.server.js"
+      "webstudio": "./src/index.server.ts"
     }
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "private": true,
   "sideEffects": false

--- a/packages/authorization-token/tsconfig.dts.json
+++ b/packages/authorization-token/tsconfig.dts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -8,11 +8,8 @@
   "scripts": {
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "build:mdn-data": "tsx ./bin/mdn-data.ts ./src/__generated__ &&  prettier --write \"./src/__generated__/\" \"../css-engine/src/__generated__/\"",
     "build:descriptions": "tsx ./bin/property-value-descriptions.ts",
-    "dts": "tsc --project tsconfig.dts.json",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "devDependencies": {
@@ -31,14 +28,8 @@
     "zod": "^3.19.1"
   },
   "exports": {
-    "webstudio": "./src/index.ts",
-    "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js"
+    "webstudio": "./src/index.ts"
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "private": true,
   "sideEffects": false,

--- a/packages/css-data/tsconfig.dts.json
+++ b/packages/css-data/tsconfig.dts.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "src",
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -7,10 +7,7 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc",
-    "checks": "pnpm typecheck",
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
-    "dts": "tsc --project tsconfig.dts.json"
+    "checks": "pnpm typecheck"
   },
   "dependencies": {
     "@webstudio-is/prisma-client": "workspace:*",
@@ -24,20 +21,12 @@
   },
   "exports": {
     ".": {
-      "webstudio": "./src/index.ts",
-      "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js"
+      "webstudio": "./src/index.ts"
     },
     "./index.server": {
-      "webstudio": "./src/index.server.ts",
-      "types": "./lib/types/index.server.d.ts",
-      "import": "./lib/index.server.js"
+      "webstudio": "./src/index.server.ts"
     }
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "private": true,
   "sideEffects": false

--- a/packages/dashboard/tsconfig.dts.json
+++ b/packages/dashboard/tsconfig.dts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -6,10 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
     "build-figma-tokens": "tsx ./bin/transform-figma-tokens.ts",
-    "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck && pnpm test",
@@ -77,14 +74,8 @@
     "warn-once": "^0.1.1"
   },
   "exports": {
-    "webstudio": "./src/index.ts",
-    "import": "./lib/index.js",
-    "types": "./lib/types/index.d.ts"
+    "webstudio": "./src/index.ts"
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "private": true,
   "sideEffects": false

--- a/packages/design-system/tsconfig.dts.json
+++ b/packages/design-system/tsconfig.dts.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "exclude": ["**/*.stories.tsx"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -7,10 +7,7 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc",
-    "checks": "pnpm typecheck",
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
-    "dts": "tsc --project tsconfig.dts.json"
+    "checks": "pnpm typecheck"
   },
   "dependencies": {
     "@webstudio-is/prisma-client": "workspace:*",
@@ -25,20 +22,12 @@
   },
   "exports": {
     ".": {
-      "webstudio": "./src/index.ts",
-      "import": "./lib/index.js",
-      "types": "./lib/types/index.d.ts"
+      "webstudio": "./src/index.ts"
     },
     "./index.server": {
-      "webstudio": "./src/index.server.ts",
-      "import": "./lib/index.server.js",
-      "types": "./lib/types/index.server.d.ts"
+      "webstudio": "./src/index.server.ts"
     }
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "private": true,
   "sideEffects": false

--- a/packages/domain/tsconfig.dts.json
+++ b/packages/domain/tsconfig.dts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -7,24 +7,15 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc",
-    "checks": "pnpm typecheck",
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
-    "dts": "tsc --project tsconfig.dts.json"
+    "checks": "pnpm typecheck"
   },
   "dependencies": {},
   "devDependencies": {
     "@webstudio-is/tsconfig": "workspace:*"
   },
   "exports": {
-    "webstudio": "./src/index.ts",
-    "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js"
+    "webstudio": "./src/index.ts"
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "private": true,
   "sideEffects": false

--- a/packages/feature-flags/tsconfig.dts.json
+++ b/packages/feature-flags/tsconfig.dts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/generate-arg-types/package.json
+++ b/packages/generate-arg-types/package.json
@@ -6,7 +6,6 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc",
     "checks": "pnpm typecheck"
   },
@@ -22,10 +21,6 @@
     "tsx": "^4.7.2",
     "typescript": "5.2.2"
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "bin": {
     "generate-arg-types": "./src/cli.ts"
   },

--- a/packages/generate-arg-types/tsconfig.dts.json
+++ b/packages/generate-arg-types/tsconfig.dts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/html-data/package.json
+++ b/packages/html-data/package.json
@@ -7,24 +7,15 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc",
-    "checks": "pnpm typecheck",
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
-    "dts": "tsc --project tsconfig.dts.json"
+    "checks": "pnpm typecheck"
   },
   "devDependencies": {
     "@webstudio-is/tsconfig": "workspace:*"
   },
   "peerDependencies": {},
   "exports": {
-    "webstudio": "./src/index.ts",
-    "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js"
+    "webstudio": "./src/index.ts"
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "private": true,
   "sideEffects": false,

--- a/packages/html-data/tsconfig.dts.json
+++ b/packages/html-data/tsconfig.dts.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "src",
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/jsx-utils/package.json
+++ b/packages/jsx-utils/package.json
@@ -9,10 +9,7 @@
   "scripts": {
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "checks": "pnpm typecheck && pnpm test",
-    "dev": "pnpm build --watch",
-    "build": "esbuild 'src/**/*.ts' --outdir=lib",
-    "dts": "tsc --project tsconfig.dts.json"
+    "checks": "pnpm typecheck && pnpm test"
   },
   "devDependencies": {
     "@webstudio-is/jest-config": "workspace:^",
@@ -23,20 +20,12 @@
   },
   "exports": {
     ".": {
-      "webstudio": "./src/index.ts",
-      "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js"
+      "webstudio": "./src/index.ts"
     },
     "./index.server": {
-      "webstudio": "./src/index.server.ts",
-      "types": "./lib/types/index.server.d.ts",
-      "import": "./lib/index.server.js"
+      "webstudio": "./src/index.server.ts"
     }
   },
-  "files": [
-    "lib/*",
-    "!*.test.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "sideEffects": false,
   "dependencies": {

--- a/packages/jsx-utils/tsconfig.dts.json
+++ b/packages/jsx-utils/tsconfig.dts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -9,28 +9,17 @@
   "type": "module",
   "exports": {
     ".": {
-      "webstudio": "./src/index.ts",
-      "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js"
+      "webstudio": "./src/index.ts"
     },
     "./index.server": {
-      "webstudio": "./src/index.server.ts",
-      "types": "./lib/types/index.server.d.ts",
-      "import": "./lib/index.server.js"
+      "webstudio": "./src/index.server.ts"
     }
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "sideEffects": false,
   "scripts": {
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "checks": "pnpm typecheck && pnpm test",
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
-    "dts": "tsc --project tsconfig.dts.json"
+    "checks": "pnpm typecheck && pnpm test"
   },
   "dependencies": {
     "@webstudio-is/prisma-client": "workspace:*",

--- a/packages/project-build/tsconfig.dts.json
+++ b/packages/project-build/tsconfig.dts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -7,10 +7,7 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc",
-    "checks": "pnpm typecheck",
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
-    "dts": "tsc --project tsconfig.dts.json"
+    "checks": "pnpm typecheck"
   },
   "dependencies": {
     "@trpc/server": "^10.38.1",
@@ -30,20 +27,12 @@
   },
   "exports": {
     ".": {
-      "webstudio": "./src/index.ts",
-      "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js"
+      "webstudio": "./src/index.ts"
     },
     "./index.server": {
-      "webstudio": "./src/index.server.ts",
-      "types": "./lib/types/index.server.d.ts",
-      "import": "./lib/index.server.js"
+      "webstudio": "./src/index.server.ts"
     }
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "private": true,
   "sideEffects": false

--- a/packages/project/tsconfig.dts.json
+++ b/packages/project/tsconfig.dts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -8,10 +8,7 @@
   "scripts": {
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "checks": "pnpm typecheck",
-    "dev": "pnpm build --watch",
-    "build": "rm -rf lib && esbuild 'src/**/*.ts' 'src/**/*.tsx' --outdir=lib",
-    "dts": "tsc --project tsconfig.dts.json"
+    "checks": "pnpm typecheck"
   },
   "dependencies": {
     "@trpc/client": "^10.38.1",
@@ -29,15 +26,9 @@
   },
   "exports": {
     "./index.server": {
-      "webstudio": "./src/index.server.ts",
-      "import": "./lib/index.server.js",
-      "types": "./lib/types/index.server.d.ts"
+      "webstudio": "./src/index.server.ts"
     }
   },
-  "files": [
-    "lib/*",
-    "!*.{test,stories}.*"
-  ],
   "license": "AGPL-3.0-or-later",
   "private": true,
   "sideEffects": false

--- a/packages/trpc-interface/tsconfig.dts.json
+++ b/packages/trpc-interface/tsconfig.dts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "declarationDir": "lib/types"
-  }
-}


### PR DESCRIPTION
dev, build and dts are not necessary in not published packages and can be removed. Builder vite setup is able to access webstudio export conditions. Only prisma client need to be built before builder.

This will reduce CI time which runs build many times in various workflows.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
