### PR TITLE
refactor: drop fetch polyfills

### DIFF
--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -97,7 +97,6 @@
     "nanoevents": "^8.0.0",
     "nanoid": "^5.0.1",
     "nanostores": "^0.9.3",
-    "node-fetch": "^3.3.1",
     "pretty-bytes": "^6.1.1",
     "prismjs": "^1.29.0",
     "react": "^18.2.0",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -39,7 +39,6 @@
     "mdast-util-from-markdown": "^2.0.0",
     "openai": "^4.8.0",
     "unist-util-visit-parents": "^6.0.1",
-    "web-streams-polyfill": "^3.2.1",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.21.4"
   }

--- a/packages/ai/src/models/gpt.ts
+++ b/packages/ai/src/models/gpt.ts
@@ -90,20 +90,6 @@ export const createCompletionStream = (
         apiKey: config.apiKey,
         organization: config.organization,
       });
-      // Use polyfilled TransformStream because in Webstudio Builder
-      // globalThis.fetch is overriden to @remix-run/web-fetch.
-      //
-      // @remix-run/web-fetch uses @remix-run/web-stream which polyfills ReadableStream
-      // which has a runtime check on a private polyfill (web-streams-polyfill) property in .pipeThrough
-      // Since `ai`'s OpenAIStream passes a non-polyfilled TransformStream the check above fails.
-      //
-      // To temporarily fix this we override TransformStream to use the web-streams-polyfill one which is
-      // compatible with the one returned by @remix-run/web-fetch.
-      //
-      // @todo Remove this when https://github.com/remix-run/web-std-io/pull/42 is merged and
-      // and Webstudio upgrades to that version.
-      const { TransformStream } = await import("web-streams-polyfill");
-      globalThis.TransformStream = TransformStream;
 
       const response = await openai.chat.completions.create({
         stream: true,

--- a/packages/trpc-interface/src/shared/client.ts
+++ b/packages/trpc-interface/src/shared/client.ts
@@ -5,7 +5,6 @@ import {
   type SharedRouter,
 } from "./shared-router";
 import { callerLink } from "../trpc-caller-link";
-import fetch from "node-fetch";
 
 type SharedClientOptions = {
   url: string;
@@ -21,7 +20,6 @@ export const createTrpcProxyServiceClient = (
       links: [
         httpBatchLink({
           url: options.url,
-          fetch: fetch as never,
           headers: () => ({
             Authorization: options.token,
             // We use this header for SaaS preview service discovery proxy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,9 +290,6 @@ importers:
       nanostores:
         specifier: ^0.9.3
         version: 0.9.3
-      node-fetch:
-        specifier: ^3.3.1
-        version: 3.3.1
       pretty-bytes:
         specifier: ^6.1.1
         version: 6.1.1
@@ -718,9 +715,6 @@ importers:
       unist-util-visit-parents:
         specifier: ^6.0.1
         version: 6.0.1
-      web-streams-polyfill:
-        specifier: ^3.2.1
-        version: 3.2.1
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -9390,11 +9384,6 @@ packages:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
     engines: {node: '>= 6'}
 
-  /data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-    dev: false
-
   /data-urls@3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
@@ -10477,14 +10466,6 @@ packages:
     dependencies:
       pend: 1.2.0
 
-  /fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.2.1
-    dev: false
-
   /fetch-retry@5.0.3:
     resolution: {integrity: sha512-uJQyMrX5IJZkhoEUBQ3EjxkeiZkppBd5jS/fMTJmfZxLSiaQjv2zD0kTvuvkSH89uFvgSlB6ueGpjD3HWN7Bxw==}
 
@@ -10652,13 +10633,6 @@ packages:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
-    dev: false
-
-  /formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
-    dependencies:
-      fetch-blob: 3.2.0
     dev: false
 
   /forwarded@0.2.0:
@@ -13537,15 +13511,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-
-  /node-fetch@3.3.1:
-    resolution: {integrity: sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
-    dev: false
 
   /node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}


### PR DESCRIPTION
Remix Vite no longer polyfills streams and fetch.
Should be safe to drop them.

Stream polyfills broke ai, fetch broke trpc.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
