### PR TITLE
feat: Only show navigator helper lines on hover

### DIFF
--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -73,14 +73,14 @@ const ItemButton = styled("button", {
   position: "relative",
 });
 
-const nestingLinesDisplayVar = "--ws-tree-node-nesting-lines-display";
+const nestingLinesVisibilityVar = "--ws-tree-node-nesting-lines-visibility";
 
 export const showNestingLineVars = () => ({
-  [nestingLinesDisplayVar]: "visible",
+  [nestingLinesVisibilityVar]: "visible",
 });
 
 const NestingLine = styled(Box, {
-  visibility: `var(${nestingLinesDisplayVar}, hidden)`,
+  visibility: `var(${nestingLinesVisibilityVar}, hidden)`,
   width: Math.ceil(INDENT / 2),
   marginRight: Math.floor(INDENT / 2),
   height: ITEM_HEIGHT,

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -73,7 +73,14 @@ const ItemButton = styled("button", {
   position: "relative",
 });
 
+const nestingLinesDisplayVar = "--ws-tree-node-nesting-lines-display";
+
+export const showNestingLineVars = () => ({
+  [nestingLinesDisplayVar]: "visible",
+});
+
 const NestingLine = styled(Box, {
+  visibility: `var(${nestingLinesDisplayVar}, hidden)`,
   width: Math.ceil(INDENT / 2),
   marginRight: Math.floor(INDENT / 2),
   height: ITEM_HEIGHT,
@@ -98,7 +105,7 @@ const NestingLines = ({
         <NestingLine key={index} isSelected={isSelected} />
       ))}
     </>
-  ) : null;
+  ) : undefined;
 
 const CollapsibleTrigger = styled("button", {
   all: "unset",

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -2,7 +2,12 @@ import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useState, useMemo, useRef, useCallback, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { ListPositionIndicator } from "../list-position-indicator";
-import { TreeNode, INDENT, type TreeItemRenderProps } from "./tree-node";
+import {
+  TreeNode,
+  INDENT,
+  type TreeItemRenderProps,
+  showNestingLineVars,
+} from "./tree-node";
 import {
   useHold,
   useDrop,
@@ -291,6 +296,7 @@ export const Tree = <Data extends { id: string }>({
         css={{
           // To not intersect last element with the scroll
           marginBottom: theme.spacing[7],
+          "&:hover": showNestingLineVars(),
         }}
       >
         <TreeNode


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3132

## Description

Only show navigator helper lines on hover

## Steps for reproduction

1. open navigator
2. expect helper lines to be only showed when hovering navigator

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
