### PR TITLE
fix: introduce distance threshold before scrub begins to avoid accidental scrub when user clicks

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/resize-handles.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/resize-handles.tsx
@@ -105,7 +105,7 @@ const useScrub = ({ side }: { side: "right" | "left" }) => {
 
     const disposeScrubControl = numericScrubControl(ref.current, {
       getInitialValue() {
-        return $canvasWidth.get();
+        return $canvasWidth.get() || 0;
       },
       getValue(state, movement) {
         const value =

--- a/apps/builder/app/builder/features/workspace/canvas-tools/resize-handles.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/resize-handles.tsx
@@ -105,7 +105,7 @@ const useScrub = ({ side }: { side: "right" | "left" }) => {
 
     const disposeScrubControl = numericScrubControl(ref.current, {
       getInitialValue() {
-        return $canvasWidth.get() || 0;
+        return $canvasWidth.get() ?? 0;
       },
       getValue(state, movement) {
         const value =


### PR DESCRIPTION
closes https://github.com/webstudio-is/webstudio/issues/3117

Now threshold is 3 px, so if you click and move under 3 px, there won't be scrub registered

https://web.descript.com/66aafa2f-3e4c-4e96-b739-171dc7b09e84/afc85


## Steps for reproduction

1. scrub any field in style panel 
2. try to move mouse under 3 px and let it go
3. expect no change

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
