### PR TITLE
fix: Hide active sidebar tab when switching to preview mode

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -37,7 +37,7 @@ const useHideActiveTabOnPreview = () => {
 
   useEffect(() => {
     return $isPreviewMode.subscribe((isPreviewMode) => {
-      // First time user switches to preview mode we want to hide any active sidebar panel.
+      // When user switches to preview mode we want to hide any active sidebar panel.
       if (isPreviewMode && previousRef.current === false) {
         $activeSidebarPanel.set("none");
       }

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -33,15 +33,12 @@ const useActiveTab = () => {
 };
 
 const useHideActiveTabOnPreview = () => {
-  const previousRef = useRef($isPreviewMode.get());
-
   useEffect(() => {
     return $isPreviewMode.subscribe((isPreviewMode) => {
       // When user switches to preview mode we want to hide any active sidebar panel.
-      if (isPreviewMode && previousRef.current === false) {
+      if (isPreviewMode) {
         $activeSidebarPanel.set("none");
       }
-      previousRef.current = isPreviewMode;
     });
   }, []);
 };

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Box, Tooltip, rawTheme } from "@webstudio-is/design-system";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
 import { $dragAndDropState, $isPreviewMode } from "~/shared/nano-states";

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Box, Tooltip, rawTheme } from "@webstudio-is/design-system";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
 import { $dragAndDropState, $isPreviewMode } from "~/shared/nano-states";
@@ -30,6 +30,20 @@ const useActiveTab = () => {
     nextTab = "none";
   }
   return [nextTab, $activeSidebarPanel.set] as const;
+};
+
+const useHideActiveTabOnPreview = () => {
+  const previousRef = useRef($isPreviewMode.get());
+
+  useEffect(() => {
+    return $isPreviewMode.subscribe((isPreviewMode) => {
+      // First time user switches to preview mode we want to hide any active sidebar panel.
+      if (isPreviewMode && previousRef.current === false) {
+        $activeSidebarPanel.set("none");
+      }
+      previousRef.current = isPreviewMode;
+    });
+  }, []);
 };
 
 const AiTabTrigger = () => {
@@ -97,6 +111,7 @@ type SidebarLeftProps = {
 
 export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
   const [activeTab, setActiveTab] = useActiveTab();
+  useHideActiveTabOnPreview();
   const dragAndDropState = useStore($dragAndDropState);
   const { TabContent } = panels.get(activeTab) ?? none;
   const isPreviewMode = useStore($isPreviewMode);


### PR DESCRIPTION
Close https://github.com/webstudio-is/webstudio/issues/3140

## Steps for reproduction

1. open any tab on the left side
2. switch to preview mode
3. expect all tabs to be closed
4. try opening and closing pages from top bar button

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
