### PR TITLE
feat: Use html editor for custom code in the project settings

### DIFF
--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -5,7 +5,6 @@ import {
   Label,
   theme,
   Text,
-  TextArea,
   Separator,
   Button,
   CheckboxAndLabel,
@@ -20,6 +19,7 @@ import type { ProjectMeta, CompilerSettings } from "@webstudio-is/sdk";
 import { useState } from "react";
 import { serverSyncStore } from "~/shared/sync";
 import { sectionSpacing } from "./utils";
+import { HtmlEditor } from "~/builder/shared/html-editor";
 
 const imgStyle = css({
   width: 72,
@@ -40,7 +40,7 @@ export const SectionGeneral = () => {
   const [meta, setMeta] = useState(
     () => $pages.get()?.meta ?? defaultMetaSettings
   );
-  const ids = useIds(["siteName", "code"]);
+  const ids = useIds(["siteName"]);
   const assets = useStore($assets);
   const asset = assets.get(meta.faviconAssetId ?? "");
   const favIconUrl = asset ? `${asset.name}` : undefined;
@@ -107,19 +107,12 @@ export const SectionGeneral = () => {
       <Separator />
 
       <Grid gap={2} css={sectionSpacing}>
-        <Label htmlFor={ids.code}>Custom Code</Label>
+        <Label>Custom Code</Label>
         <Text color="subtle">
           Custom code and scripts will be added at the end of the &lt;head&gt;
           tag to every page across the published project.
         </Text>
-        <TextArea
-          id={ids.code}
-          rows={5}
-          autoGrow
-          maxRows={10}
-          value={meta.code ?? ""}
-          onChange={handleSave("code")}
-        />
+        <HtmlEditor value={meta.code ?? ""} onChange={handleSave("code")} />
       </Grid>
 
       <Separator />

--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -25,6 +25,20 @@ import { CrossIcon, MaximizeIcon, MinimizeIcon } from "@webstudio-is/icons";
 
 const ExternalChange = Annotation.define<boolean>();
 
+const minHeightVar = "--ws-code-editor-min-height";
+const maxHeightVar = "--ws-code-editor-max-height";
+
+export const getMinMaxHeightVars = ({
+  minHeight,
+  maxHeight,
+}: {
+  minHeight: string;
+  maxHeight: string;
+}) => ({
+  [minHeightVar]: minHeight,
+  [maxHeightVar]: maxHeight,
+});
+
 const editorContentStyle = css({
   ...textVariants.mono,
   // fit editor into parent if stretched
@@ -66,8 +80,8 @@ const editorContentStyle = css({
     width: "100%",
     // avoid modifying height in .cm-content
     // because it breaks scroll events and makes scrolling laggy
-    minHeight: "var(--ws-code-editor-min-height, auto)",
-    maxHeight: "var(--ws-code-editor-max-height, none)",
+    minHeight: `var(${minHeightVar}, auto)`,
+    maxHeight: `var(${maxHeightVar}, none)`,
   },
 });
 

--- a/apps/builder/app/builder/shared/html-editor.tsx
+++ b/apps/builder/app/builder/shared/html-editor.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo, type ReactNode } from "react";
+import { forwardRef, useMemo, type ComponentProps } from "react";
 import {
   keymap,
   drawSelection,
@@ -22,7 +22,7 @@ import {
 } from "@codemirror/autocomplete";
 import { html } from "@codemirror/lang-html";
 import { theme, textVariants, css } from "@webstudio-is/design-system";
-import { CodeEditor } from "./code-editor";
+import { CodeEditor, getMinMaxHeightVars } from "./code-editor";
 
 const autocompletionStyle = css({
   "&.cm-tooltip.cm-tooltip-autocomplete": {
@@ -70,68 +70,47 @@ const wrapperStyle = css({
   position: "relative",
   // 1 line is 16px
   // set min 10 lines and max 20 lines
-  "--ws-code-editor-min-height": "160px",
-  "--ws-code-editor-max-height": "320px",
+  ...getMinMaxHeightVars({ minHeight: "160px", maxHeight: "320px" }),
 });
 
 export const HtmlEditor = forwardRef<
   HTMLDivElement,
-  {
-    readOnly?: boolean;
-    invalid?: boolean;
-    value: string;
-    title?: ReactNode;
-    onChange: (newValue: string) => void;
-    onBlur?: (event: FocusEvent) => void;
-  }
->(
-  (
-    { readOnly = false, invalid = false, value, title, onChange, onBlur },
-    ref
-  ) => {
-    const extensions = useMemo(
-      () => [
-        highlightActiveLine(),
-        highlightSpecialChars(),
-        history(),
-        drawSelection(),
-        dropCursor(),
-        indentOnInput(),
-        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
-        html({}),
-        bracketMatching(),
-        closeBrackets(),
-        // render autocomplete in body
-        // to prevent popover scroll overflow
-        tooltips({ parent: document.body }),
-        autocompletion({
-          icons: false,
-          tooltipClass: () => autocompletionStyle.toString(),
-        }),
-        keymap.of([
-          ...closeBracketsKeymap,
-          ...defaultKeymap,
-          ...historyKeymap,
-          ...completionKeymap,
-        ]),
-      ],
-      []
-    );
+  Omit<ComponentProps<typeof CodeEditor>, "extensions">
+>((props, ref) => {
+  const extensions = useMemo(
+    () => [
+      highlightActiveLine(),
+      highlightSpecialChars(),
+      history(),
+      drawSelection(),
+      dropCursor(),
+      indentOnInput(),
+      syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+      html({}),
+      bracketMatching(),
+      closeBrackets(),
+      // render autocomplete in body
+      // to prevent popover scroll overflow
+      tooltips({ parent: document.body }),
+      autocompletion({
+        icons: false,
+        tooltipClass: () => autocompletionStyle.toString(),
+      }),
+      keymap.of([
+        ...closeBracketsKeymap,
+        ...defaultKeymap,
+        ...historyKeymap,
+        ...completionKeymap,
+      ]),
+    ],
+    []
+  );
 
-    return (
-      <div className={wrapperStyle()} ref={ref}>
-        <CodeEditor
-          title={title}
-          extensions={extensions}
-          readOnly={readOnly}
-          invalid={invalid}
-          value={value}
-          onChange={onChange}
-          onBlur={onBlur}
-        />
-      </div>
-    );
-  }
-);
+  return (
+    <div className={wrapperStyle()} ref={ref}>
+      <CodeEditor {...props} extensions={extensions} />
+    </div>
+  );
+});
 
 HtmlEditor.displayName = "HtmlEditor";


### PR DESCRIPTION
closes https://github.com/webstudio-is/webstudio/issues/3116

## Description

Original reason was to identify syntax errors as user has already been hit by this, I don't think our current syntax highlighter does a good job for css there though,  case study:

```html
<style>
.class {
)
.class1 {
}
</style>
```

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
