### PR TITLE
fix: disable hoverable content for tooltips in add components

### DIFF
--- a/packages/design-system/src/components/component-card.tsx
+++ b/packages/design-system/src/components/component-card.tsx
@@ -70,6 +70,7 @@ export const ComponentCard = forwardRef<HTMLDivElement, ComponentCardProps>(
   ({ icon, label, className, state, description, ...props }, ref) => {
     return (
       <Tooltip
+        disableHoverableContent
         content={description ?? label}
         css={{ maxWidth: theme.spacing[28] }}
       >


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/2184

This is quite important - allows user to go over to the next item without being stuck on the tooltip if they happen to hover it

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
