### PR TITLE
fix: prevent breaking canvas when delete link in rich text

### DIFF
--- a/apps/builder/app/canvas/features/text-editor/index.ts
+++ b/apps/builder/app/canvas/features/text-editor/index.ts
@@ -1,3 +1,1 @@
 export { TextEditor } from "./text-editor";
-// React.lazy requires default export
-export { TextEditor as default } from "./text-editor";

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -48,7 +48,10 @@ import { setDataCollapsed } from "~/canvas/collapsed";
 import { getIsVisuallyHidden } from "~/shared/visually-hidden";
 import { serverSyncStore } from "~/shared/sync";
 
-const TextEditor = lazy(() => import("../text-editor"));
+const TextEditor = lazy(async () => {
+  const { TextEditor } = await import("../text-editor");
+  return { default: TextEditor };
+});
 
 const ContentEditable = ({
   renderComponentWithRef,

--- a/packages/sdk-components-react-remix/src/shared/remix-link.tsx
+++ b/packages/sdk-components-react-remix/src/shared/remix-link.tsx
@@ -16,7 +16,7 @@ type Props = Omit<ComponentPropsWithoutRef<typeof Link>, "target"> & {
 
 export const wrapLinkComponent = (BaseLink: typeof Link) => {
   const Component = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
-    const { assetBaseUrl } = useContext(ReactSdkContext);
+    const { assetBaseUrl, renderer } = useContext(ReactSdkContext);
     const href = props.href;
 
     // use remix link for home page and all relative urls
@@ -25,7 +25,12 @@ export const wrapLinkComponent = (BaseLink: typeof Link) => {
       href === "" ||
       (href?.startsWith("/") && href.startsWith(assetBaseUrl) === false)
     ) {
-      return <RemixLink {...props} to={href} ref={ref} />;
+      // remix links behave in unexpected way when delete in content editable
+      // always render simple <a> in canvas and preview
+      // since remix links do not affect it
+      if (renderer !== "canvas" && renderer !== "preview") {
+        return <RemixLink {...props} to={href} ref={ref} />;
+      }
     }
 
     const { prefetch, reloadDocument, replace, preventScrollReset, ...rest } =


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/3127

Here fixed the issue with deleting remix link while editing rich text with lexical. Some quirky remix logic broke react rendering. Fixed by rendering plain link while in builder.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
