### PR TITLE
feat: Use a green outline color for Slot instances

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
@@ -28,7 +28,10 @@ export const HoveredInstanceOutline = () => {
   }
   const rect = applyScale(outline.rect, scale);
   return (
-    <Outline rect={rect}>
+    <Outline
+      rect={rect}
+      variant={outline.instance.component === "Slot" ? "component" : "default"}
+    >
       <Label instance={outline.instance} instanceRect={rect} />
     </Outline>
   );

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/label.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/label.tsx
@@ -56,7 +56,6 @@ const LabelContainer = styled(
     lineHeight: 1,
     minWidth: theme.spacing[13],
     whiteSpace: "nowrap",
-    backgroundColor: theme.colors.blue9,
   },
   {
     variants: {
@@ -71,7 +70,16 @@ const LabelContainer = styled(
           bottom: `-${theme.spacing[10]}`,
         },
       },
+      variant: {
+        default: {
+          backgroundColor: theme.colors.backgroundInfoMain,
+        },
+        component: {
+          backgroundColor: theme.colors.backgroundSuccessMain,
+        },
+      },
     },
+    defaultVariants: { variant: "default" },
   }
 );
 
@@ -88,7 +96,11 @@ export const Label = ({ instance, instanceRect }: LabelProps) => {
     return <></>;
   }
   return (
-    <LabelContainer position={position} ref={labelRef}>
+    <LabelContainer
+      position={position}
+      variant={instance.component === "Slot" ? "component" : "default"}
+      ref={labelRef}
+    >
       <MetaIcon size="1em" icon={meta.icon} />
       {getInstanceLabel(instance, meta)}
     </LabelContainer>

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
@@ -25,21 +25,27 @@ const baseStyle = css({
   boxSizing: "border-box",
   position: "absolute",
   pointerEvents: "none",
-  outline: `1px solid ${theme.colors.blue9}`,
-  outlineOffset: -1,
   top: 0,
   left: 0,
   variants: {
     variant: {
+      default: {
+        outline: `1px solid ${theme.colors.backgroundInfoMain}`,
+        outlineOffset: -1,
+      },
       collaboration: {
-        outline: "none",
         [angleVar]: `0deg`,
         border: `1px solid`,
         borderImage: `conic-gradient(from var(${angleVar}), #39FBBB 0%, #4A4EFA 12.5%, #E63CFE 25%, #FFAE3C 37.5%, #39FBBB 50%, #4A4EFA 62.5%, #E63CFE 75%, #FFAE3C 87.5%) 1`,
         animation: `2s ${angleKeyframes} linear infinite`,
       },
+      component: {
+        outline: `1px solid ${theme.colors.backgroundSuccessMain}`,
+        outlineOffset: -1,
+      },
     },
   },
+  defaultVariants: { variant: "default" },
 });
 
 const useDynamicStyle = (rect?: Rect) => {
@@ -58,7 +64,7 @@ const useDynamicStyle = (rect?: Rect) => {
 type OutlineProps = {
   children?: JSX.Element;
   rect?: Rect;
-  variant?: "collaboration";
+  variant?: "default" | "collaboration" | "component";
 };
 
 export const Outline = ({ children, rect, variant }: OutlineProps) => {

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
@@ -27,7 +27,10 @@ export const SelectedInstanceOutline = () => {
   }
   const rect = applyScale(outline.rect, scale);
   return (
-    <Outline rect={rect}>
+    <Outline
+      rect={rect}
+      variant={outline.instance.component === "Slot" ? "component" : "default"}
+    >
       <Label instance={outline.instance} instanceRect={rect} />
     </Outline>
   );


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3152

<img width="176" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/c23986bd-085f-4568-a4c1-aba84f8ab723">


## Description

1. Slots are different and need a different outline color
2. Use a blue color from design system

## Steps for reproduction

1. click button
3. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
