### PR TITLE
fix: Fix flex child inputs order

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
@@ -246,25 +246,11 @@ const FlexChildSectionSizingPopover = ({
       content={
         <Grid
           css={{
-            gridTemplateColumns: "1.5fr 1fr 1fr",
+            gridTemplateColumns: "1fr 1fr 1.5fr",
             gap: theme.spacing[9],
             padding: theme.spacing[9],
           }}
         >
-          <Grid css={{ gridTemplateColumns: "auto", gap: theme.spacing[3] }}>
-            <PropertyName
-              style={currentStyle}
-              properties={["flexBasis"]}
-              label="Basis"
-              onReset={() => deleteProperty("flexBasis")}
-            />
-            <TextControl
-              property="flexBasis"
-              currentStyle={currentStyle}
-              setProperty={setProperty}
-              deleteProperty={deleteProperty}
-            />
-          </Grid>
           <Grid css={{ gridTemplateColumns: "auto", gap: theme.spacing[3] }}>
             <PropertyName
               style={currentStyle}
@@ -288,6 +274,20 @@ const FlexChildSectionSizingPopover = ({
             />
             <TextControl
               property="flexShrink"
+              currentStyle={currentStyle}
+              setProperty={setProperty}
+              deleteProperty={deleteProperty}
+            />
+          </Grid>
+          <Grid css={{ gridTemplateColumns: "auto", gap: theme.spacing[3] }}>
+            <PropertyName
+              style={currentStyle}
+              properties={["flexBasis"]}
+              label="Basis"
+              onReset={() => deleteProperty("flexBasis")}
+            />
+            <TextControl
+              property="flexBasis"
               currentStyle={currentStyle}
               setProperty={setProperty}
               deleteProperty={deleteProperty}


### PR DESCRIPTION
## Description

To match the css flex order: flex-basis, grow, shrink

<img width="265" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/3206f3d2-64fd-4639-aded-ad23fbf7e04b">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
