### PR TITLE
fix: Fix stale descriptions combobox 

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/advanced/add.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/add.tsx
@@ -21,11 +21,7 @@ const matchOrSuggestToCreate = (
     return matched;
   }
 
-  if (
-    search.trim() !== "" &&
-    itemToString(matched[0]).toLocaleLowerCase() !==
-      search.toLocaleLowerCase().trim()
-  ) {
+  if (search.trim().startsWith("--")) {
     matched.unshift({
       value: search.trim(),
       label: `Create "${search.trim()}"`,
@@ -60,9 +56,7 @@ export const Add = ({
       }}
       match={matchOrSuggestToCreate}
       getDescription={(item) => {
-        let description = `Please look up ${
-          item?.value ? `"${toKebabCase(item?.value)}"` : "property"
-        } in MDN.`;
+        let description = `Unknown CSS property.`;
         if (item && item.value in propertyDescriptions) {
           description =
             propertyDescriptions[

--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -436,8 +436,17 @@ export const Combobox = <Item,>({
   });
 
   const [description, setDescription] = useState<ReactNode>(
-    getDescription?.(combobox.items[props.defaultHighlightedIndex ?? -1])
+    getDescription?.(combobox.items[combobox.highlightedIndex])
   );
+
+  useEffect(() => {
+    // When nothing is selected and user has typed, we need to show the description of the highlighted item
+    if (combobox.selectedItem === null) {
+      setDescription(
+        getDescription?.(combobox.items[combobox.highlightedIndex])
+      );
+    }
+  }, [combobox.items, combobox.highlightedIndex, combobox.selectedItem]);
 
   return (
     <ComboboxRoot open={combobox.isOpen}>


### PR DESCRIPTION
## Description

- when user is typing a new property but isn't selecting or hovering, default selected one changes and we need to update the description
- we allowed to create a property we don't know, now we don't

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
