### PR TITLE
fix: Fix upgrade tooltip

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -344,20 +344,27 @@ const PathField = ({
                 <>
                   <Text>
                     Path is a subset of the URL that looks like this:
-                    &quot;/blog&quot;. To make the path dynamic and use it with
-                    CMS, you can use parameters and other features. CMS features
-                    are part of the Pro plan.
+                    &quot;/blog&quot;.
                   </Text>
-                  <Link
-                    className={buttonStyle({ color: "gradient" })}
-                    css={{ marginTop: theme.spacing[5], width: "100%" }}
-                    color="contrast"
-                    underline="none"
-                    target="_blank"
-                    href="https://webstudio.is/pricing"
-                  >
-                    Upgrade
-                  </Link>
+                  {allowDynamicData && isFeatureEnabled("cms") && (
+                    <>
+                      <Text>
+                        To make the path dynamic and use it with CMS, you can
+                        use parameters and other features. CMS features are part
+                        of the Pro plan.
+                      </Text>
+                      <Link
+                        className={buttonStyle({ color: "gradient" })}
+                        css={{ marginTop: theme.spacing[5], width: "100%" }}
+                        color="contrast"
+                        underline="none"
+                        target="_blank"
+                        href="https://webstudio.is/pricing"
+                      >
+                        Upgrade
+                      </Link>
+                    </>
+                  )}
                 </>
               }
               variant="wrapped"

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -335,7 +335,7 @@ const PathField = ({
                     Path is a subset of the URL that looks like this:
                     &quot;/blog&quot;.
                   </Text>
-                  {allowDynamicData && isFeatureEnabled("cms") && (
+                  {allowDynamicData === false && isFeatureEnabled("cms") && (
                     <>
                       <Text>
                         To make the path dynamic and use it with CMS, you can


### PR DESCRIPTION
## Description

Page settings path shows upgrade tooltip to a pro account

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
