### PR TITLE
fix: Allow same page path in different folders if those have a slug

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -240,7 +240,14 @@ const validateValues = (
     return parsedResult.error.formErrors.fieldErrors;
   }
   if (pages !== undefined && values.path !== undefined) {
-    if (isPathAvailable(pages, values, pageId) === false) {
+    if (
+      isPathAvailable({
+        pages,
+        path: values.path,
+        parentFolderId: values.parentFolderId,
+        pageId,
+      }) === false
+    ) {
       errors.path = errors.path ?? [];
       errors.path.push("All paths must be unique");
     }

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -96,6 +96,7 @@ import {
   duplicatePage,
   isRootId,
   toTreeData,
+  isPathAvailable,
 } from "./page-utils";
 import { Form } from "./form";
 import type { System } from "~/builder/features/address-bar";
@@ -205,25 +206,6 @@ const PageValues = SharedPageValues.extend({
   path: isFeatureEnabled("cms") ? PagePath : LegacyPagePath,
 });
 
-const isPathUnique = (
-  pages: Pages,
-  // undefined page id means new page
-  pageId: undefined | Page["id"],
-  path: string
-) => {
-  const list = [];
-  const set = new Set();
-  list.push(path);
-  set.add(path);
-  for (const page of pages.pages) {
-    if (page.id !== pageId) {
-      list.push(page.path);
-      set.add(page.path);
-    }
-  }
-  return list.length === set.size;
-};
-
 const validateValues = (
   pages: undefined | Pages,
   // undefined page id means new page
@@ -258,7 +240,7 @@ const validateValues = (
     return parsedResult.error.formErrors.fieldErrors;
   }
   if (pages !== undefined && values.path !== undefined) {
-    if (isPathUnique(pages, pageId, values.path) === false) {
+    if (isPathAvailable(pages, values, pageId) === false) {
       errors.path = errors.path ?? [];
       errors.path.push("All paths must be unique");
     }

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
@@ -22,6 +22,7 @@ import {
   duplicatePage,
   $editingPagesItemId,
   $pageRootScope,
+  isPathAvailable,
 } from "./page-utils";
 import {
   $dataSourceVariables,
@@ -361,6 +362,87 @@ describe("isSlugAvailable", () => {
 
   test("empty folder slug can be defined multiple times", () => {
     expect(isSlugAvailable("", folders, "rootInstanceId")).toBe(true);
+  });
+});
+
+describe("isPathAvailable", () => {
+  const pages = createDefaultPages({
+    rootInstanceId: "rootInstanceId",
+    systemDataSourceId: "systemDataSourceId",
+    homePageId: "homePageId",
+  });
+  pages.folders.push({
+    id: "folderId1",
+    name: "Folder 1",
+    slug: "slug1",
+    children: ["pageId1"],
+  });
+  pages.folders.push({
+    id: "folderId2",
+    name: "Folder 2",
+    slug: "slug2",
+    children: ["pageId2"],
+  });
+  pages.folders.push({
+    id: "folderId3",
+    name: "Folder 3",
+    slug: "/",
+    children: ["pageId3"],
+  });
+  pages.pages.push({
+    id: "pageId1",
+    meta: {},
+    name: "Page 1",
+    path: "/page",
+    rootInstanceId: "rootInstanceId",
+    systemDataSourceId: "systemDataSourceId",
+    title: `"Page 1"`,
+  });
+  pages.pages.push({
+    id: "pageId2",
+    meta: {},
+    name: "Page 2",
+    path: "/page",
+    rootInstanceId: "rootInstanceId",
+    systemDataSourceId: "systemDataSourceId",
+    title: `"Page 2"`,
+  });
+  pages.pages.push({
+    id: "pageId3",
+    meta: {},
+    name: "Page 3",
+    path: "/page",
+    rootInstanceId: "rootInstanceId",
+    systemDataSourceId: "systemDataSourceId",
+    title: `"Page 3"`,
+  });
+
+  test("/slug2/page existing page", () => {
+    expect(
+      isPathAvailable(
+        pages,
+        { path: "/page", parentFolderId: "folderId2" },
+        "pageId2"
+      )
+    ).toBe(true);
+  });
+
+  test("/slug2/page new page", () => {
+    expect(
+      isPathAvailable(pages, { path: "/page", parentFolderId: "folderId2" })
+    ).toBe(false);
+  });
+
+  test("/slug2/page1 new page", () => {
+    expect(
+      isPathAvailable(pages, { path: "/page1", parentFolderId: "folderId2" })
+    ).toBe(true);
+  });
+
+  test("/page new page", () => {
+    expect(
+      isPathAvailable(pages, { path: "/page", parentFolderId: "folderId3" })
+    ).toBe(false);
   });
 });
 

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
@@ -49,6 +49,7 @@ const createPages = () => {
 
   function f(id: string, children?: Array<Page | Folder>): Folder;
   function f(id: string, slug: string, children?: Array<Page | Folder>): Folder;
+  // @eslint-ignore-next-line func-style
   function f(id: string, slug?: unknown, children?: unknown) {
     if (Array.isArray(slug)) {
       children = slug;

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
@@ -49,7 +49,7 @@ const createPages = () => {
 
   function f(id: string, children?: Array<Page | Folder>): Folder;
   function f(id: string, slug: string, children?: Array<Page | Folder>): Folder;
-  // @eslint-ignore-next-line func-style
+  // eslint-disable-next-line func-style
   function f(id: string, slug?: unknown, children?: unknown) {
     if (Array.isArray(slug)) {
       children = slug;

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
@@ -194,6 +194,31 @@ export const isSlugAvailable = (
   );
 };
 
+export const isPathAvailable = (
+  pages: Pages,
+  {
+    path,
+    parentFolderId,
+  }: { path: Page["path"]; parentFolderId: Folder["id"] },
+  // undefined page id means new page
+  pageId?: Page["id"]
+) => {
+  const map = new Map<Page["path"], Page>();
+  const allPages = [pages.homePage, ...pages.pages];
+  for (const page of allPages) {
+    map.set(getPagePath(page.id, pages), page);
+  }
+  const folderPath = getPagePath(parentFolderId, pages);
+  // When slug is empty, folderPath is "/".
+  const pagePath = folderPath === "/" ? path : `${folderPath}${path}`;
+  const existingPage = map.get(pagePath);
+  // We found another page that has the same path and the current page.
+  if (pageId && existingPage?.id === pageId) {
+    return true;
+  }
+  return existingPage === undefined;
+};
+
 /**
  * - Register a folder or a page inside children of a given parent folder.
  * - Fallback to a root folder.

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
@@ -194,15 +194,18 @@ export const isSlugAvailable = (
   );
 };
 
-export const isPathAvailable = (
-  pages: Pages,
-  {
-    path,
-    parentFolderId,
-  }: { path: Page["path"]; parentFolderId: Folder["id"] },
+export const isPathAvailable = ({
+  pages,
+  path,
+  parentFolderId,
+  pageId,
+}: {
+  pages: Pages;
+  path: Page["path"];
+  parentFolderId: Folder["id"];
   // undefined page id means new page
-  pageId?: Page["id"]
-) => {
+  pageId?: Page["id"];
+}) => {
   const map = new Map<Page["path"], Page>();
   const allPages = [pages.homePage, ...pages.pages];
   for (const page of allPages) {

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -144,12 +144,7 @@ export const Pages = z.object({
   compiler: CompilerSettings.optional(),
   redirects: z.array(PageRedirect).optional(),
   homePage: HomePage,
-  pages: z
-    .array(Page)
-    .refine(
-      (array) => new Set(array.map((page) => page.path)).size === array.length,
-      "All paths must be unique"
-    ),
+  pages: z.array(Page),
   folders: z
     .array(Folder)
     .refine((folders) => folders.length > 0, "Folders can't be empty"),


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3025

## Description

Allow having the same page path if the full path is different through folder slug

## Steps for reproduction

Case 1
1. create a folder with slug /1 and another with slug /2
2. create page with path /p in folder 1
3. create page with path /p in folder 2
4. see that this is allowed


Case 2
1. create a foder 1 with empty slug and folder 2 with empty slug
2. create page with path /p in folder 1
3. create page with path /p in folder 2
4. see that this is not allowed


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
