### PR TITLE
fix: Make all small icon buttons clickable area bigger than they visually are

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -92,7 +92,6 @@ const ItemSuffix = ({
         onClick={() => onEdit(isEditing ? undefined : itemId)}
         ref={buttonRef}
         icon={isEditing ? <ChevronRightIcon /> : <EllipsesIcon />}
-        //size="2"
         variant={isParentSelected ? "contrast" : "normal"}
       />
     </Tooltip>

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -1,17 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useStore } from "@nanostores/react";
 import {
-  DeprecatedIconButton,
   TreeItemLabel,
   TreeItemBody,
   TreeNode,
   type TreeItemRenderProps,
   type ItemSelector,
-  styled,
   Tooltip,
   Box,
   Button,
-  theme,
+  SmallIconButton,
 } from "@webstudio-is/design-system";
 import {
   ChevronRightIcon,
@@ -46,19 +44,6 @@ import { useMount } from "~/shared/hook-utils/use-mount";
 import { ROOT_FOLDER_ID, type Folder } from "@webstudio-is/sdk";
 import { atom } from "nanostores";
 import { isPathnamePattern } from "~/builder/shared/url-pattern";
-
-const MenuButton = styled(DeprecatedIconButton, {
-  color: theme.colors.hint,
-  "&:hover, &:focus-visible": { color: theme.colors.hiContrast },
-  variants: {
-    isParentSelected: {
-      true: {
-        color: theme.colors.loContrast,
-        "&:hover, &:focus-visible": { color: theme.colors.slate7 },
-      },
-    },
-  },
-});
 
 const ItemSuffix = ({
   isParentSelected,
@@ -101,14 +86,15 @@ const ItemSuffix = ({
 
   return (
     <Tooltip content={menuLabel} disableHoverableContent>
-      <MenuButton
+      <SmallIconButton
         aria-label={menuLabel}
-        isParentSelected={isParentSelected}
+        state={isParentSelected ? "open" : undefined}
         onClick={() => onEdit(isEditing ? undefined : itemId)}
         ref={buttonRef}
-      >
-        {isEditing ? <ChevronRightIcon /> : <EllipsesIcon />}
-      </MenuButton>
+        icon={isEditing ? <ChevronRightIcon /> : <EllipsesIcon />}
+        //size="2"
+        variant={isParentSelected ? "contrast" : "normal"}
+      />
     </Tooltip>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -610,6 +610,7 @@ export const CssValueInput = ({
       {...getToggleButtonProps()}
       data-state={isOpen ? "open" : "closed"}
       tabIndex={-1}
+      size={size}
     />
   );
 

--- a/packages/design-system/src/components/nested-input-button.tsx
+++ b/packages/design-system/src/components/nested-input-button.tsx
@@ -57,7 +57,7 @@ const style = css({
       },
     },
   },
-  defaultVariants: { size: 1 },
+  defaultVariants: { size: 2 },
 });
 
 export const NestedInputButton = forwardRef(

--- a/packages/design-system/src/components/primitives/small-button.tsx
+++ b/packages/design-system/src/components/primitives/small-button.tsx
@@ -49,6 +49,7 @@ const perVariantStyle = (variant: (typeof smallButtonVariants)[number]) => ({
   "&[data-focused=true], &:focus-visible": {
     borderRadius: theme.borderRadius[3],
     outline: `2px solid ${focusColors[variant]}`,
+    outlineOffset: -2,
     "&:disabled, &[data-disabled]": {
       outline: "none",
     },
@@ -57,8 +58,9 @@ const perVariantStyle = (variant: (typeof smallButtonVariants)[number]) => ({
 
 const style = css({
   all: "unset",
-  width: theme.spacing[9],
-  height: theme.spacing[9],
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
   "&:disabled, &[data-disabled]": {
     color: theme.colors.foregroundDisabled,
   },
@@ -68,15 +70,27 @@ const style = css({
       contrast: perVariantStyle("contrast"),
       destructive: perVariantStyle("destructive"),
     },
+    size: {
+      1: {
+        width: theme.spacing[9],
+        height: theme.spacing[9],
+      },
+      2: {
+        width: theme.spacing[12],
+        height: theme.spacing[12],
+      },
+    },
   },
   defaultVariants: {
     variant: "normal",
+    size: 1,
   },
 });
 
 type Props = {
   children: ReactNode;
   variant?: (typeof smallButtonVariants)[number];
+  size?: "1" | "2";
   "data-state"?: (typeof smallButtonStates)[number];
   "data-focused"?: boolean;
   css?: CSS;
@@ -84,13 +98,13 @@ type Props = {
 
 export const SmallButton = forwardRef(
   (
-    { variant, children, css, className, ...restProps }: Props,
+    { variant, size, children, css, className, ...restProps }: Props,
     ref: Ref<HTMLButtonElement>
   ) => {
     return (
       <button
         {...restProps}
-        className={style({ css, className, variant })}
+        className={style({ css, className, variant, size })}
         ref={ref}
       >
         {children}

--- a/packages/design-system/src/components/primitives/small-button.tsx
+++ b/packages/design-system/src/components/primitives/small-button.tsx
@@ -49,7 +49,6 @@ const perVariantStyle = (variant: (typeof smallButtonVariants)[number]) => ({
   "&[data-focused=true], &:focus-visible": {
     borderRadius: theme.borderRadius[3],
     outline: `2px solid ${focusColors[variant]}`,
-    outlineOffset: -2,
     "&:disabled, &[data-disabled]": {
       outline: "none",
     },
@@ -61,6 +60,15 @@ const style = css({
   display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
+  width: theme.spacing[9],
+  height: theme.spacing[9],
+  position: "relative",
+  // We want to bleed outside of the 16px icon size because its too small
+  "&::after": {
+    content: '""',
+    position: "absolute",
+    inset: `-${theme.spacing[4]}`,
+  },
   "&:disabled, &[data-disabled]": {
     color: theme.colors.foregroundDisabled,
   },
@@ -70,27 +78,15 @@ const style = css({
       contrast: perVariantStyle("contrast"),
       destructive: perVariantStyle("destructive"),
     },
-    size: {
-      1: {
-        width: theme.spacing[9],
-        height: theme.spacing[9],
-      },
-      2: {
-        width: theme.spacing[12],
-        height: theme.spacing[12],
-      },
-    },
   },
   defaultVariants: {
     variant: "normal",
-    size: 1,
   },
 });
 
 type Props = {
   children: ReactNode;
   variant?: (typeof smallButtonVariants)[number];
-  size?: "1" | "2";
   "data-state"?: (typeof smallButtonStates)[number];
   "data-focused"?: boolean;
   css?: CSS;
@@ -98,13 +94,13 @@ type Props = {
 
 export const SmallButton = forwardRef(
   (
-    { variant, size, children, css, className, ...restProps }: Props,
+    { variant, children, css, className, ...restProps }: Props,
     ref: Ref<HTMLButtonElement>
   ) => {
     return (
       <button
         {...restProps}
-        className={style({ css, className, variant, size })}
+        className={style({ css, className, variant })}
         ref={ref}
       >
         {children}

--- a/packages/design-system/src/components/primitives/small-button.tsx
+++ b/packages/design-system/src/components/primitives/small-button.tsx
@@ -57,9 +57,6 @@ const perVariantStyle = (variant: (typeof smallButtonVariants)[number]) => ({
 
 const style = css({
   all: "unset",
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
   width: theme.spacing[9],
   height: theme.spacing[9],
   position: "relative",

--- a/packages/design-system/src/components/small-icon-button.tsx
+++ b/packages/design-system/src/components/small-icon-button.tsx
@@ -9,7 +9,6 @@ import {
   type ComponentProps,
   type ReactNode,
 } from "react";
-import type { CSS } from "../stitches.config";
 
 import { SmallButton, smallButtonVariants } from "./primitives/small-button";
 
@@ -24,13 +23,11 @@ export const smallIconButtonStates = ["open"] as const;
 
 type Props = {
   icon: ReactNode;
-  variant?: (typeof smallIconButtonVariants)[number];
   state?: (typeof smallIconButtonStates)[number];
   focused?: boolean;
-  css?: CSS;
   // might be set when <SmallIconButton> is asChild
   "data-state"?: (typeof smallIconButtonStates)[number];
-} & Omit<ComponentProps<"button">, "children">;
+} & Omit<ComponentProps<typeof SmallButton>, "children">;
 
 export const SmallIconButton = forwardRef(
   (

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -267,7 +267,7 @@ export const TreeItemBody = <Data extends { id: string }>({
   isExpanded,
   children,
   suffix,
-  suffixWidth = suffix ? theme.spacing[12] : "0px",
+  suffixWidth = suffix ? theme.spacing[9] : "0px",
   alwaysShowSuffix = false,
   forceFocus = false,
   selectionEvent = "click",

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -27,7 +27,7 @@ const ITEM_HEIGHT = 32;
 const ICONS_SIZE = 16;
 const ITEM_PADDING_LEFT = 8;
 // extra padding on the right to make sure scrollbar doesn't obscure anything
-const ITEM_PADDING_RIGHT = 8;
+const ITEM_PADDING_RIGHT = 14;
 
 export const getPlacementIndicatorAlignment = (depth: number) => {
   return depth * INDENT + ITEM_PADDING_LEFT;

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -27,7 +27,7 @@ const ITEM_HEIGHT = 32;
 const ICONS_SIZE = 16;
 const ITEM_PADDING_LEFT = 8;
 // extra padding on the right to make sure scrollbar doesn't obscure anything
-const ITEM_PADDING_RIGHT = 14;
+const ITEM_PADDING_RIGHT = 8;
 
 export const getPlacementIndicatorAlignment = (depth: number) => {
   return depth * INDENT + ITEM_PADDING_LEFT;
@@ -52,7 +52,7 @@ const getItemButtonCssVars = ({
     };
   }
   return {
-    [itemButtonVars.paddingRight]: `${ITEM_PADDING_RIGHT}px`,
+    [itemButtonVars.paddingRight]: ITEM_PADDING_RIGHT,
   };
 };
 const ItemButton = styled("button", {
@@ -145,7 +145,7 @@ const getSuffixContainerCssVars = ({
 const SuffixContainer = styled(Flex, {
   position: "absolute",
   alignItems: "center",
-  right: `${ITEM_PADDING_RIGHT}px`,
+  right: ITEM_PADDING_RIGHT,
   top: 0,
   bottom: 0,
   defaultVariants: { align: "center" },
@@ -267,7 +267,7 @@ export const TreeItemBody = <Data extends { id: string }>({
   isExpanded,
   children,
   suffix,
-  suffixWidth = suffix ? theme.spacing[9] : "0px",
+  suffixWidth = suffix ? theme.spacing[12] : "0px",
   alwaysShowSuffix = false,
   forceFocus = false,
   selectionEvent = "click",


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3155

## Description

We had way too small icon buttons in many cases 16px, now they got 28px clickable surface while they still look like 16px

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
