### PR TITLE
feat: Show chevron on hover in all section titles

### DIFF
--- a/packages/design-system/src/components/section-title.tsx
+++ b/packages/design-system/src/components/section-title.tsx
@@ -13,13 +13,13 @@ import {
   createContext,
   useContext,
 } from "react";
+import { ChevronRightIcon } from "@webstudio-is/icons";
 import { theme, css, styled, type CSS } from "../stitches.config";
 import { Button } from "./button";
 import { ArrowFocus } from "./primitives/arrow-focus";
 import { Label, isLabelButton } from "./label";
 import { focusRingStyle } from "./focus-ring";
-import { ChevronRightIcon } from "@webstudio-is/icons";
-import { Flex } from "..";
+import { Flex } from "./flex";
 
 const buttonContentColor = "--ws-section-title-button-content-color";
 const labelTextColor = "--ws-section-title-label-content-color";
@@ -153,7 +153,7 @@ export const SectionTitle = forwardRef(
                   {children}
 
                   {finalDots.length > 0 && (
-                    <Flex>
+                    <Flex shrink={false}>
                       {finalDots.map((color) => (
                         <div key={color} className={dotStyle({ color })} />
                       ))}

--- a/packages/design-system/src/components/section-title.tsx
+++ b/packages/design-system/src/components/section-title.tsx
@@ -18,9 +18,12 @@ import { Button } from "./button";
 import { ArrowFocus } from "./primitives/arrow-focus";
 import { Label, isLabelButton } from "./label";
 import { focusRingStyle } from "./focus-ring";
+import { ChevronRightIcon } from "@webstudio-is/icons";
+import { Flex } from "..";
 
 const buttonContentColor = "--ws-section-title-button-content-color";
 const labelTextColor = "--ws-section-title-label-content-color";
+const chevronOpacity = "--ws-section-title-chevron-display";
 
 const StyledButton = styled(Button, {});
 
@@ -51,6 +54,9 @@ const labelContainerStyle = css({
 
 const titleButtonStyle = css(titleButtonLayoutStyle, {
   "&:focus-visible": focusRingStyle(),
+  "&:hover": {
+    [chevronOpacity]: 1,
+  },
 });
 
 const suffixSlotStyle = css({
@@ -63,8 +69,18 @@ const invisibleSuffixStyle = css({
   visibility: "hidden",
 });
 
-const dotsSlotStyle = css({
-  display: "flex",
+const chevronStyle = css({
+  opacity: `var(${chevronOpacity}, 0)`,
+  marginLeft: `-${theme.spacing[8]}`,
+  transition: "transform 150ms, opacity 200ms",
+  variants: {
+    state: {
+      open: {
+        transform: "rotate(90deg)",
+      },
+      closed: {},
+    },
+  },
 });
 
 const dotStyle = css({
@@ -113,7 +129,8 @@ export const SectionTitle = forwardRef(
       <context.Provider value={{ state }}>
         <ArrowFocus
           render={({ handleKeyDown }) => (
-            <div
+            <Flex
+              align="center"
               className={containerStyle({ className, css })}
               data-state={state}
               onKeyDown={handleKeyDown}
@@ -123,7 +140,9 @@ export const SectionTitle = forwardRef(
                 data-state={state}
                 ref={ref}
                 {...props}
-              ></button>
+              >
+                <ChevronRightIcon className={chevronStyle({ state })} />
+              </button>
 
               {/*
                 If the label is itself a button, we don't want to nest a button inside another button.
@@ -134,11 +153,11 @@ export const SectionTitle = forwardRef(
                   {children}
 
                   {finalDots.length > 0 && (
-                    <div className={dotsSlotStyle()}>
+                    <Flex>
                       {finalDots.map((color) => (
                         <div key={color} className={dotStyle({ color })} />
                       ))}
-                    </div>
+                    </Flex>
                   )}
 
                   {suffix && (
@@ -149,7 +168,7 @@ export const SectionTitle = forwardRef(
               </div>
 
               {suffix && <div className={suffixSlotStyle()}>{suffix}</div>}
-            </div>
+            </Flex>
           )}
         />
       </context.Provider>

--- a/packages/design-system/src/components/section-title.tsx
+++ b/packages/design-system/src/components/section-title.tsx
@@ -73,6 +73,7 @@ const chevronStyle = css({
   opacity: `var(${chevronOpacity}, 0)`,
   marginLeft: `-${theme.spacing[8]}`,
   transition: "transform 150ms, opacity 200ms",
+  color: theme.colors.backgroundIconSubtle,
   variants: {
     state: {
       open: {


### PR DESCRIPTION
## Description

We have been hestitating adding those because they pollute the screen but on hover only seems like a reasonable compromise




https://github.com/webstudio-is/webstudio/assets/52824/0772d724-358e-44ec-910f-348c96fd1b93



## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
