### PR TITLE
feat: inspect variable value

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -59,6 +59,7 @@ import { BindingPopoverProvider } from "~/builder/shared/binding-popover";
 import { useSideOffset } from "~/builder/shared/floating-panel";
 import {
   EditorDialog,
+  EditorDialogButton,
   EditorDialogControl,
 } from "~/builder/shared/code-editor";
 import { ResourceForm } from "./resource-panel";
@@ -209,13 +210,18 @@ const StringForm = forwardRef<
           value={value}
           onChange={setValue}
         />
-        <EditorDialog title={`Variable "${nameField.value || "Unnamed"}"`}>
-          <TextArea
-            grow={true}
-            id={valueId}
-            value={value}
-            onChange={setValue}
-          />
+        <EditorDialog
+          title={`Variable "${nameField.value || "Unnamed"}"`}
+          content={
+            <TextArea
+              grow={true}
+              id={valueId}
+              value={value}
+              onChange={setValue}
+            />
+          }
+        >
+          <EditorDialogButton />
         </EditorDialog>
       </EditorDialogControl>
     </Flex>

--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -1,10 +1,15 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { computed } from "nanostores";
 import { useStore } from "@nanostores/react";
 import {
   Button,
   CssValueListArrowFocus,
   CssValueListItem,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
   Flex,
   Label,
   SectionTitle,
@@ -12,10 +17,9 @@ import {
   SectionTitleLabel,
   SmallIconButton,
   Text,
-  Tooltip,
   theme,
 } from "@webstudio-is/design-system";
-import { EyeconOpenIcon, MinusIcon, PlusIcon } from "@webstudio-is/icons";
+import { EllipsesIcon, PlusIcon } from "@webstudio-is/icons";
 import type { DataSource } from "@webstudio-is/sdk";
 import {
   decodeDataSourceVariable,
@@ -158,6 +162,76 @@ const EmptyVariables = () => {
   );
 };
 
+const VariablesItem = ({
+  variable,
+  index,
+  value,
+  isUsedVariable,
+}: {
+  variable: DataSource;
+  index: number;
+  value: unknown;
+  isUsedVariable: boolean;
+}) => {
+  const label =
+    value === undefined
+      ? variable.name
+      : `${variable.name}: ${formatValuePreview(value)}`;
+  const [inspectDialogOpen, setInspectDialogOpen] = useState(false);
+  return (
+    <VariablePopoverTrigger key={variable.id} variable={variable}>
+      <CssValueListItem
+        id={variable.id}
+        index={index}
+        label={<Label truncate>{label}</Label>}
+        buttons={
+          <>
+            <ValuePreviewDialog
+              open={inspectDialogOpen}
+              onOpenChange={setInspectDialogOpen}
+              title={`Inspect "${variable.name}" value`}
+              value={value}
+            >
+              {undefined}
+            </ValuePreviewDialog>
+            <DropdownMenu modal>
+              <DropdownMenuTrigger asChild>
+                {/* a11y is completely broken here
+                  focus is not restored to button invoker
+                  @todo fix it eventually and consider restoring from closed value preview dialog
+              */}
+                <SmallIconButton
+                  tabIndex={-1}
+                  aria-label="Open variable menu"
+                  icon={<EllipsesIcon />}
+                  onClick={() => {}}
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuContent
+                  css={{ width: theme.spacing[28] }}
+                  onCloseAutoFocus={(event) => event.preventDefault()}
+                >
+                  <DropdownMenuItem onSelect={() => setInspectDialogOpen(true)}>
+                    Inspect
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    // allow to delete only unused variables
+                    disabled={variable.type === "parameter" || isUsedVariable}
+                    onSelect={() => deleteVariable(variable.id)}
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenuPortal>
+            </DropdownMenu>
+          </>
+        }
+      />
+    </VariablePopoverTrigger>
+  );
+};
+
 const VariablesList = () => {
   const availableVariables = useStore($instanceVariables);
   const variableValues = useStore($instanceVariableValues);
@@ -171,59 +245,14 @@ const VariablesList = () => {
     <CssValueListArrowFocus>
       {availableVariables.map((variable, index) => {
         const value = variableValues.get(variable.id);
-        const label =
-          value === undefined
-            ? variable.name
-            : `${variable.name}: ${formatValuePreview(value)}`;
         return (
-          <VariablePopoverTrigger key={variable.id} variable={variable}>
-            <CssValueListItem
-              id={variable.id}
-              index={index}
-              label={<Label truncate>{label}</Label>}
-              buttons={
-                <>
-                  <Tooltip content="Inspect variable value" side="bottom">
-                    <ValuePreviewDialog
-                      title={`Inspect "${variable.name}" value`}
-                      value={JSON.stringify(value, null, 2)}
-                    >
-                      <SmallIconButton
-                        tabIndex={-1}
-                        aria-label="Inspect variable value"
-                        variant="normal"
-                        icon={<EyeconOpenIcon />}
-                        onClick={() => {}}
-                      />
-                    </ValuePreviewDialog>
-                  </Tooltip>
-                  <Tooltip
-                    content={
-                      variable.type === "parameter"
-                        ? "Variable is managed by the component and cannot be deleted"
-                        : usedVariables.has(variable.id)
-                        ? "Variable is used in bindings and cannot be deleted"
-                        : "Delete variable"
-                    }
-                    side="bottom"
-                  >
-                    <SmallIconButton
-                      tabIndex={-1}
-                      // allow to delete only unused variables
-                      disabled={
-                        variable.type === "parameter" ||
-                        usedVariables.has(variable.id)
-                      }
-                      aria-label="Delete variable"
-                      variant="destructive"
-                      icon={<MinusIcon />}
-                      onClick={() => deleteVariable(variable.id)}
-                    />
-                  </Tooltip>
-                </>
-              }
-            />
-          </VariablePopoverTrigger>
+          <VariablesItem
+            key={variable.id}
+            value={value}
+            variable={variable}
+            index={index}
+            isUsedVariable={usedVariables.has(variable.id)}
+          />
         );
       })}
     </CssValueListArrowFocus>

--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip,
   theme,
 } from "@webstudio-is/design-system";
-import { MinusIcon, PlusIcon } from "@webstudio-is/icons";
+import { EyeconOpenIcon, MinusIcon, PlusIcon } from "@webstudio-is/icons";
 import type { DataSource } from "@webstudio-is/sdk";
 import {
   decodeDataSourceVariable,
@@ -34,7 +34,10 @@ import {
   CollapsibleSectionRoot,
   useOpenState,
 } from "~/builder/shared/collapsible-section";
-import { formatValuePreview } from "~/builder/shared/expression-editor";
+import {
+  ValuePreviewDialog,
+  formatValuePreview,
+} from "~/builder/shared/expression-editor";
 import {
   VariablePopoverProvider,
   VariablePopoverTrigger,
@@ -179,29 +182,45 @@ const VariablesList = () => {
               index={index}
               label={<Label truncate>{label}</Label>}
               buttons={
-                <Tooltip
-                  content={
-                    variable.type === "parameter"
-                      ? "Variable is managed by the component and cannot be deleted"
-                      : usedVariables.has(variable.id)
-                      ? "Variable is used in bindings and cannot be deleted"
-                      : "Delete variable"
-                  }
-                  side="bottom"
-                >
-                  <SmallIconButton
-                    tabIndex={-1}
-                    // allow to delete only unused variables
-                    disabled={
-                      variable.type === "parameter" ||
-                      usedVariables.has(variable.id)
+                <>
+                  <Tooltip content="Inspect variable value" side="bottom">
+                    <ValuePreviewDialog
+                      title={`Inspect "${variable.name}" value`}
+                      value={JSON.stringify(value, null, 2)}
+                    >
+                      <SmallIconButton
+                        tabIndex={-1}
+                        aria-label="Inspect variable value"
+                        variant="normal"
+                        icon={<EyeconOpenIcon />}
+                        onClick={() => {}}
+                      />
+                    </ValuePreviewDialog>
+                  </Tooltip>
+                  <Tooltip
+                    content={
+                      variable.type === "parameter"
+                        ? "Variable is managed by the component and cannot be deleted"
+                        : usedVariables.has(variable.id)
+                        ? "Variable is used in bindings and cannot be deleted"
+                        : "Delete variable"
                     }
-                    aria-label="Delete variable"
-                    variant="destructive"
-                    icon={<MinusIcon />}
-                    onClick={() => deleteVariable(variable.id)}
-                  />
-                </Tooltip>
+                    side="bottom"
+                  >
+                    <SmallIconButton
+                      tabIndex={-1}
+                      // allow to delete only unused variables
+                      disabled={
+                        variable.type === "parameter" ||
+                        usedVariables.has(variable.id)
+                      }
+                      aria-label="Delete variable"
+                      variant="destructive"
+                      icon={<MinusIcon />}
+                      onClick={() => deleteVariable(variable.id)}
+                    />
+                  </Tooltip>
+                </>
               }
             />
           </VariablePopoverTrigger>

--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -259,7 +259,7 @@ export const EditorDialogControl = ({ children }: { children: ReactNode }) => {
   return <div className={editorDialogControlStyle()}>{children}</div>;
 };
 
-export const EditorDialogButton = forwardRef<HTMLButtonElement, {}>(
+export const EditorDialogButton = forwardRef<HTMLButtonElement>(
   (_props, ref) => {
     return (
       <SmallIconButton

--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode, useState } from "react";
+import { useEffect, useRef, type ReactNode, useState, forwardRef } from "react";
 import {
   Annotation,
   EditorState,
@@ -140,7 +140,7 @@ type EditorContentProps = {
   onBlur?: (event: FocusEvent) => void;
 };
 
-const EditorContent = ({
+export const BaseCodeEditor = ({
   extensions,
   readOnly = false,
   autoFocus = false,
@@ -259,11 +259,30 @@ export const EditorDialogControl = ({ children }: { children: ReactNode }) => {
   return <div className={editorDialogControlStyle()}>{children}</div>;
 };
 
+export const EditorDialogButton = forwardRef<HTMLButtonElement, {}>(
+  (_props, ref) => {
+    return (
+      <SmallIconButton
+        ref={ref}
+        icon={<MaximizeIcon />}
+        css={{
+          position: "absolute",
+          top: 6,
+          right: 4,
+          visibility: `var(--ws-code-editor-maximize-icon-visibility, hidden)`,
+        }}
+      />
+    );
+  }
+);
+
 export const EditorDialog = ({
   title,
+  content,
   children,
 }: {
   title?: ReactNode;
+  content: ReactNode;
   children: ReactNode;
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -272,17 +291,7 @@ export const EditorDialog = ({
   const padding = rawTheme.spacing[7];
   return (
     <Dialog>
-      <DialogTrigger asChild>
-        <SmallIconButton
-          icon={<MaximizeIcon />}
-          css={{
-            position: "absolute",
-            top: 6,
-            right: 4,
-            visibility: `var(--ws-code-editor-maximize-icon-visibility, hidden)`,
-          }}
-        />
-      </DialogTrigger>
+      <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
         // Left Aside panels (e.g., Pages, Components) use zIndex: theme.zIndices[1].
         // For a dialog to appear above these panels, both overlay and content should also have zIndex: theme.zIndices[1].
@@ -303,7 +312,7 @@ export const EditorDialog = ({
             boxSizing: "content-box",
           }}
         >
-          {children}
+          {content}
         </Grid>
         {/* Title is at the end intentionally,
          * to make the close button last in the tab order
@@ -340,11 +349,13 @@ export const CodeEditor = ({
 }: EditorContentProps & {
   title?: ReactNode;
 }) => {
-  const content = <EditorContent {...editorContentProps} />;
+  const content = <BaseCodeEditor {...editorContentProps} />;
   return (
     <EditorDialogControl>
       {content}
-      <EditorDialog title={title}>{content}</EditorDialog>
+      <EditorDialog title={title} content={content}>
+        <EditorDialogButton />
+      </EditorDialog>
     </EditorDialogControl>
   );
 };

--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -275,12 +275,17 @@ export const EditorDialogButton = forwardRef<HTMLButtonElement, {}>(
     );
   }
 );
+EditorDialogButton.displayName = "EditorDialogButton";
 
 export const EditorDialog = ({
+  open,
+  onOpenChange,
   title,
   content,
   children,
 }: {
+  open?: boolean;
+  onOpenChange?: (newOpen: boolean) => void;
   title?: ReactNode;
   content: ReactNode;
   children: ReactNode;
@@ -290,7 +295,7 @@ export const EditorDialog = ({
   const height = isExpanded ? "80vh" : "480px";
   const padding = rawTheme.spacing[7];
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
         // Left Aside panels (e.g., Pages, Components) use zIndex: theme.zIndices[1].
@@ -345,15 +350,24 @@ export const EditorDialog = ({
 
 export const CodeEditor = ({
   title,
+  open,
+  onOpenChange,
   ...editorContentProps
 }: EditorContentProps & {
   title?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (newOpen: boolean) => void;
 }) => {
   const content = <BaseCodeEditor {...editorContentProps} />;
   return (
     <EditorDialogControl>
       {content}
-      <EditorDialog title={title} content={content}>
+      <EditorDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        title={title}
+        content={content}
+      >
         <EditorDialogButton />
       </EditorDialog>
     </EditorDialogControl>

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 import { matchSorter } from "match-sorter";
 import type { SyntaxNode } from "@lezer/common";
 import { Facet } from "@codemirror/state";
@@ -31,7 +31,7 @@ import {
   decodeDataSourceVariable,
   transpileExpression,
 } from "@webstudio-is/sdk";
-import { CodeEditor } from "./code-editor";
+import { BaseCodeEditor, CodeEditor, EditorDialog } from "./code-editor";
 
 export const formatValue = (value: unknown) => {
   if (Array.isArray(value)) {
@@ -431,5 +431,32 @@ export const ExpressionEditor = ({
         onBlur={onBlur}
       />
     </div>
+  );
+};
+
+export const ValuePreviewDialog = ({
+  title,
+  value,
+  children,
+}: {
+  title?: ReactNode;
+  value: string;
+  children: ReactNode;
+}) => {
+  const extensions = useMemo(() => [javascript({})], []);
+  return (
+    <EditorDialog
+      title={title}
+      content={
+        <BaseCodeEditor
+          readOnly={true}
+          extensions={extensions}
+          value={value}
+          onChange={() => {}}
+        />
+      }
+    >
+      {children}
+    </EditorDialog>
   );
 };

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -434,27 +434,40 @@ export const ExpressionEditor = ({
   );
 };
 
+// compute value as json lazily only when dialog is open
+// by spliting into separate component which is invoked
+// only when dialog content is rendered
+const ValuePreviewEditor = ({ value }: { value: unknown }) => {
+  const extensions = useMemo(() => [javascript({})], []);
+  return (
+    <BaseCodeEditor
+      readOnly={true}
+      extensions={extensions}
+      value={JSON.stringify(value, null, 2)}
+      onChange={() => {}}
+    />
+  );
+};
+
 export const ValuePreviewDialog = ({
   title,
   value,
   children,
+  open,
+  onOpenChange,
 }: {
   title?: ReactNode;
-  value: string;
+  value: unknown;
+  open?: boolean;
+  onOpenChange?: (newOpen: boolean) => void;
   children: ReactNode;
 }) => {
-  const extensions = useMemo(() => [javascript({})], []);
   return (
     <EditorDialog
+      open={open}
+      onOpenChange={onOpenChange}
       title={title}
-      content={
-        <BaseCodeEditor
-          readOnly={true}
-          extensions={extensions}
-          value={value}
-          onChange={() => {}}
-        />
-      }
+      content={<ValuePreviewEditor value={value} />}
     >
       {children}
     </EditorDialog>


### PR DESCRIPTION
Here added "Eye" button to inspect variable values in big editor. Useful to preview resource and parameter variables which are not specified by user.

<img width="1189" alt="Screenshot 2024-04-16 at 18 50 41" src="https://github.com/webstudio-is/webstudio/assets/5635476/1a4707a0-b4dc-43a1-a16c-33447ffd0c22">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
