### PR TITLE
fix: expand code editor when click on maximize button

### DIFF
--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, type ReactNode, useState, forwardRef } from "react";
+import {
+  useEffect,
+  useRef,
+  type ReactNode,
+  useState,
+  forwardRef,
+  type ComponentProps,
+} from "react";
 import {
   Annotation,
   EditorState,
@@ -259,22 +266,24 @@ export const EditorDialogControl = ({ children }: { children: ReactNode }) => {
   return <div className={editorDialogControlStyle()}>{children}</div>;
 };
 
-export const EditorDialogButton = forwardRef<HTMLButtonElement>(
-  (_props, ref) => {
-    return (
-      <SmallIconButton
-        ref={ref}
-        icon={<MaximizeIcon />}
-        css={{
-          position: "absolute",
-          top: 6,
-          right: 4,
-          visibility: `var(--ws-code-editor-maximize-icon-visibility, hidden)`,
-        }}
-      />
-    );
-  }
-);
+export const EditorDialogButton = forwardRef<
+  HTMLButtonElement,
+  Partial<ComponentProps<typeof SmallIconButton>>
+>((props, ref) => {
+  return (
+    <SmallIconButton
+      {...props}
+      ref={ref}
+      icon={<MaximizeIcon />}
+      css={{
+        position: "absolute",
+        top: 6,
+        right: 4,
+        visibility: `var(--ws-code-editor-maximize-icon-visibility, hidden)`,
+      }}
+    />
+  );
+});
 EditorDialogButton.displayName = "EditorDialogButton";
 
 export const EditorDialog = ({


### PR DESCRIPTION
Was broken while implementing "inspect variable" feature. asChild pattern used by radix is not very type safe.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
