### PR TITLE
fix: Fix binding button covering too much of the control

### DIFF
--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -257,6 +257,7 @@ const BindingButton = forwardRef<
       <SmallIconButton
         ref={ref}
         data-variant={variant}
+        bleed={false}
         css={{
           // hide by default
           opacity: `var(${bindingOpacityProperty}, 0)`,

--- a/packages/design-system/src/components/primitives/small-button.tsx
+++ b/packages/design-system/src/components/primitives/small-button.tsx
@@ -60,12 +60,6 @@ const style = css({
   width: theme.spacing[9],
   height: theme.spacing[9],
   position: "relative",
-  // We want to bleed outside of the 16px icon size because its too small
-  "&::after": {
-    content: '""',
-    position: "absolute",
-    inset: `-${theme.spacing[4]}`,
-  },
   "&:disabled, &[data-disabled]": {
     color: theme.colors.foregroundDisabled,
   },
@@ -75,15 +69,27 @@ const style = css({
       contrast: perVariantStyle("contrast"),
       destructive: perVariantStyle("destructive"),
     },
+    bleed: {
+      true: {
+        // We want to bleed outside of the 16px icon size because its too small
+        "&::after": {
+          content: '""',
+          position: "absolute",
+          inset: `-${theme.spacing[4]}`,
+        },
+      },
+    },
   },
   defaultVariants: {
     variant: "normal",
+    bleed: true,
   },
 });
 
 type Props = {
   children: ReactNode;
   variant?: (typeof smallButtonVariants)[number];
+  bleed?: boolean;
   "data-state"?: (typeof smallButtonStates)[number];
   "data-focused"?: boolean;
   css?: CSS;
@@ -91,13 +97,13 @@ type Props = {
 
 export const SmallButton = forwardRef(
   (
-    { variant, children, css, className, ...restProps }: Props,
+    { variant, children, css, className, bleed, ...restProps }: Props,
     ref: Ref<HTMLButtonElement>
   ) => {
     return (
       <button
         {...restProps}
-        className={style({ css, className, variant })}
+        className={style({ css, className, variant, bleed })}
         ref={ref}
       >
         {children}


### PR DESCRIPTION
## Description

Made the bleed option for binding button 

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
