### PR TITLE
experimental: support GET forms in preview

### DIFF
--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -24,7 +24,7 @@ const switchPageAndUpdateSystem = (href: string, formData?: FormData) => {
     if (params) {
       // populate search params with form data values if available
       if (formData) {
-        for (const [key, value] of formData?.entries()) {
+        for (const [key, value] of formData.entries()) {
           pageHref.searchParams.set(key, value.toString());
         }
       }

--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -101,7 +101,7 @@ export const subscribeInterceptedEvents = () => {
       }
       // use attribute instead of form.action to get raw unresolved value
       // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-action
-      let action = form.getAttribute("action") ?? "";
+      const action = form.getAttribute("action") ?? "";
       // lower case just for safety
       const method = form.method.toLowerCase();
       if (method === "get" && isAbsoluteUrl(action) === false) {

--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -72,7 +72,9 @@ export const subscribeInterceptedEvents = () => {
       }
       // use attribute instead of form.action to get raw unresolved value
       const action = form.getAttribute("action") ?? "";
-      if (form.method === "get" && isAbsoluteUrl(action) === false) {
+      // lower case just for safety
+      const method = form.method.toLowerCase();
+      if (method === "get" && isAbsoluteUrl(action) === false) {
         switchPageAndUpdateSystem(action, new FormData(form));
       }
     }

--- a/packages/sdk-components-react-remix/src/remix-form.tsx
+++ b/packages/sdk-components-react-remix/src/remix-form.tsx
@@ -12,7 +12,11 @@ export const RemixForm = forwardRef<
       method?: Lowercase<NonNullable<FormProps["method"]>>;
     }
 >((props, ref) => {
-  return <Form {...props} ref={ref} />;
+  // remix casts action to relative url
+  if (props.action === "" || props.action?.startsWith("/")) {
+    return <Form {...props} ref={ref} />;
+  }
+  return <form {...props} ref={ref} />;
 });
 
 RemixForm.displayName = "Form";


### PR DESCRIPTION
Here added support for sending get requests to pages and update search params in preview.

The logic is same we use for links but instead of href search params system is updated with form fields.

This is essential filters feature to support testing without publishing.

Also modified form component to fallback to native form when absolute action is used
to avoid casting it to relative path.

## Steps for reproduction

1. create form
2. set current page url
3. add select
4. add button
5. go to preview
6. click the button
7. go to canvas
8. select body
9. inspect system variable

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview