### PR TITLE
fix: Don't modify the text case in select boxes

### DIFF
--- a/packages/design-system/src/components/select.tsx
+++ b/packages/design-system/src/components/select.tsx
@@ -241,6 +241,7 @@ const SelectBase = <Option,>(
                       onItemHighlight?.(undefined);
                       setHighlightedItem(undefined);
                     }}
+                    text="sentence"
                     {...rest}
                   >
                     {getLabel(option)}


### PR DESCRIPTION
## Description

Menu is still upper case by default and Select is based on menu styles, but needs to have the right text variant

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
