### PR TITLE
fix: avoid error while running any patch

### DIFF
--- a/apps/builder/app/routes/rest.patch.ts
+++ b/apps/builder/app/routes/rest.patch.ts
@@ -1,4 +1,4 @@
-import { applyPatches } from "immer";
+import { applyPatches, enableMapSet, enablePatches } from "immer";
 import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import type { SyncItem } from "immerhin";
 import { prisma } from "@webstudio-is/prisma-client";
@@ -46,6 +46,9 @@ type PatchData = {
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {
+  enableMapSet();
+  enablePatches();
+
   try {
     const {
       buildId,


### PR DESCRIPTION
Here enabled patches, map and set in immer which were broken after moving canvas and builder to client side.