### PR TITLE
refactor: cleanup system variable

### DIFF
--- a/apps/builder/app/builder/features/address-bar.tsx
+++ b/apps/builder/app/builder/features/address-bar.tsx
@@ -20,6 +20,7 @@ import {
   findParentFolderByChildId,
   ROOT_FOLDER_ID,
   getPagePath,
+  type System,
 } from "@webstudio-is/sdk";
 import {
   $dataSourceVariables,
@@ -47,15 +48,10 @@ const $selectedPagePath = computed([$selectedPage, $pages], (page, pages) => {
     .replace(/\/+/g, "/");
 });
 
-export type System = {
-  params: Record<string, string>;
-  search: Record<string, string>;
-};
-
 const $selectedPagePathParams = computed(
   [$selectedPage, $dataSourceVariables],
   (selectedPage, dataSourceVariables) => {
-    if (selectedPage?.systemDataSourceId === undefined) {
+    if (selectedPage === undefined) {
       return {};
     }
     const system = dataSourceVariables.get(selectedPage.systemDataSourceId) as

--- a/apps/builder/app/builder/features/project-settings/project-settings.stories.tsx
+++ b/apps/builder/app/builder/features/project-settings/project-settings.stories.tsx
@@ -33,6 +33,7 @@ export const Redirects = () => {
       title: `"My Title"`,
       meta: {},
       rootInstanceId: "body",
+      systemDataSourceId: "",
     },
     pages: [],
     folders: [],

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -265,7 +265,7 @@ const $hiddenDataSourceIds = computed(
         dataSourceIds.add(dataSource.id);
       }
     }
-    if (page?.systemDataSourceId && isFeatureEnabled("filters")) {
+    if (page && isFeatureEnabled("filters")) {
       dataSourceIds.delete(page.systemDataSourceId);
     }
     return dataSourceIds;

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -27,6 +27,7 @@ import {
   ProjectNewRedirectPath,
   DataSource,
   isLiteralExpression,
+  type System,
 } from "@webstudio-is/sdk";
 import {
   theme,
@@ -99,7 +100,6 @@ import {
   isPathAvailable,
 } from "./page-utils";
 import { Form } from "./form";
-import type { System } from "~/builder/features/address-bar";
 import { $userPlanFeatures } from "~/builder/shared/nano-states";
 import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 import { useUnmount } from "~/shared/hook-utils/use-mount";

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
@@ -630,8 +630,7 @@ describe("duplicate page", () => {
           type: "parameter",
         },
         {
-          // @todo remove cast after releasing system variable migration
-          id: newPage.systemDataSourceId!,
+          id: newPage.systemDataSourceId,
           scopeInstanceId: newPage.rootInstanceId,
           name: "system",
           type: "parameter",

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
@@ -690,6 +690,7 @@ describe("duplicate page", () => {
       title: `"My Title"`,
       meta: {},
       rootInstanceId: expect.not.stringMatching("body"),
+      systemDataSourceId: "pageSystem",
     });
   });
 
@@ -811,6 +812,12 @@ describe("duplicate page", () => {
           type: "variable",
           value: { type: "string", value: "value" },
         },
+        {
+          id: "systemId",
+          scopeInstanceId: "body",
+          name: "system",
+          type: "parameter",
+        },
       ])
     );
     $pages.set({
@@ -831,13 +838,15 @@ describe("duplicate page", () => {
           ],
         },
         rootInstanceId: "body",
-        systemDataSourceId: "system",
+        systemDataSourceId: "systemId",
       },
       pages: [],
       folders: [],
     });
     duplicatePage("pageId");
-    const [_oldDataSource, newDataSource] = $dataSources.get().values();
+    const [_oldDataSource, _systemDataSource, newDataSource] = $dataSources
+      .get()
+      .values();
     const newVariableName = encodeDataSourceVariable(newDataSource.id);
     expect(newVariableName).not.toEqual("$ws$dataSource$variableId");
     expect($pages.get()?.pages[0]).toEqual({
@@ -857,7 +866,7 @@ describe("duplicate page", () => {
         ],
       },
       rootInstanceId: expect.not.stringMatching("body"),
-      systemDataSourceId: expect.not.stringMatching("system"),
+      systemDataSourceId: expect.not.stringMatching("systemId"),
     });
   });
 });

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
@@ -470,13 +470,12 @@ export const duplicatePage = (pageId: Page["id"]) => {
       availableDataSources: new Set(),
     });
     const newRootInstanceId = newInstanceIds.get(page.rootInstanceId);
-    // @todo simplify after releasing migration with system variable
-    const newSystemDataSourceId =
-      page.systemDataSourceId === undefined
-        ? undefined
-        : newDataSourceIds.get(page.systemDataSourceId);
+    const newSystemDataSourceId = newDataSourceIds.get(page.systemDataSourceId);
 
-    if (newRootInstanceId === undefined) {
+    if (
+      newRootInstanceId === undefined ||
+      newSystemDataSourceId === undefined
+    ) {
       return;
     }
     const newPage = {
@@ -484,7 +483,6 @@ export const duplicatePage = (pageId: Page["id"]) => {
       id: newPageId,
       rootInstanceId: newRootInstanceId,
       systemDataSourceId: newSystemDataSourceId,
-      // @todo create new data source
       name: newName,
       path: deduplicatePath(pages, page),
       title: replaceDataSources(page.title, newDataSourceIds),

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
@@ -470,12 +470,10 @@ export const duplicatePage = (pageId: Page["id"]) => {
       availableDataSources: new Set(),
     });
     const newRootInstanceId = newInstanceIds.get(page.rootInstanceId);
-    const newSystemDataSourceId = newDataSourceIds.get(page.systemDataSourceId);
+    const newSystemDataSourceId =
+      newDataSourceIds.get(page.systemDataSourceId) ?? page.systemDataSourceId;
 
-    if (
-      newRootInstanceId === undefined ||
-      newSystemDataSourceId === undefined
-    ) {
+    if (newRootInstanceId === undefined) {
       return;
     }
     const newPage = {

--- a/apps/builder/app/builder/shared/url-pattern.ts
+++ b/apps/builder/app/builder/shared/url-pattern.ts
@@ -73,7 +73,7 @@ export const tokenizePathnamePattern = (pathname: string) => {
 
 export const compilePathnamePattern = (
   tokens: Token[],
-  values: Record<string, string>
+  values: Record<string, undefined | string>
 ) => {
   let compiledPathname = "";
   for (const token of tokens) {

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -62,9 +62,6 @@ export const $dataSourceVariables = atom<Map<DataSource["id"], unknown>>(
 );
 
 export const updateSystem = (page: Page, update: Partial<System>) => {
-  if (page.systemDataSourceId === undefined) {
-    return;
-  }
   const dataSourceVariables = new Map($dataSourceVariables.get());
   const system = dataSourceVariables.get(page.systemDataSourceId) as
     | undefined

--- a/packages/react-sdk/src/props.test.ts
+++ b/packages/react-sdk/src/props.test.ts
@@ -1,8 +1,8 @@
 import { test, expect } from "@jest/globals";
-import type { Prop } from "@webstudio-is/sdk";
+import type { Pages, Prop } from "@webstudio-is/sdk";
 import { normalizeProps } from "./props";
 
-const pagesBase = {
+const pagesBase: Pages = {
   meta: {},
   homePage: {
     id: "home",
@@ -10,6 +10,7 @@ const pagesBase = {
     name: "Home",
     title: "Home",
     rootInstanceId: "instance-1",
+    systemDataSourceId: "",
     meta: {},
   },
   pages: [],
@@ -88,6 +89,7 @@ test("normalize page prop with path into string", () => {
             name: "Page",
             title: "Page",
             rootInstanceId: "instance-1",
+            systemDataSourceId: "",
             meta: {},
           },
         ],
@@ -138,6 +140,7 @@ test("normalize page prop with path and hash into string", () => {
           name: "Page",
           title: "Page",
           rootInstanceId: "instance-1",
+          systemDataSourceId: "",
           meta: {},
         },
       ],

--- a/packages/sdk/src/page-meta-generator.test.ts
+++ b/packages/sdk/src/page-meta-generator.test.ts
@@ -14,6 +14,7 @@ test("generate minimal static page meta factory", () => {
         name: "",
         path: "",
         rootInstanceId: "",
+        systemDataSourceId: "",
         title: `"Page title"`,
         meta: {},
       },
@@ -53,6 +54,7 @@ test("generate complete static page meta factory", () => {
         name: "",
         path: "",
         rootInstanceId: "",
+        systemDataSourceId: "",
         title: `"Page title"`,
         meta: {
           description: `"Page description"`,
@@ -111,6 +113,7 @@ test("generate asset url instead of id", () => {
         name: "",
         path: "",
         rootInstanceId: "",
+        systemDataSourceId: "",
         title: `"Page title"`,
         meta: {
           socialImageUrl: `"https://my-image"`,
@@ -152,6 +155,7 @@ test("generate custom meta ignoring empty property name", () => {
         name: "",
         path: "",
         rootInstanceId: "",
+        systemDataSourceId: "",
         title: `"Page title"`,
         meta: {
           custom: [
@@ -200,6 +204,7 @@ test("generate page meta factory with variables", () => {
         name: "",
         path: "",
         rootInstanceId: "",
+        systemDataSourceId: "",
         title: `$ws$dataSource$variableId`,
         meta: {},
       },
@@ -296,6 +301,7 @@ test("generate page meta factory with resources", () => {
         name: "",
         path: "",
         rootInstanceId: "",
+        systemDataSourceId: "",
         title: `$ws$dataSource$resourceVariableId.data.title`,
         meta: {},
       },

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -64,8 +64,7 @@ const commonPageFields = {
       .optional(),
   }),
   rootInstanceId: z.string(),
-  // @todo make required after releasing migration
-  systemDataSourceId: z.optional(z.string()),
+  systemDataSourceId: z.string(),
 } as const;
 
 export const HomePagePath = z


### PR DESCRIPTION
Use sdk type for system variable and make it required in pages since it was added to all pages with migration.