### PR TITLE
fix: Suppoort min() and other functions in advanced section

### DIFF
--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -107,22 +107,19 @@ describe("Parse CSS value", () => {
 
   describe("Tuples", () => {
     test("backgroundPosition", () => {
-      expect(parseCssValue("backgroundPosition", "left top"))
-        .toMatchInlineSnapshot(`
-{
-  "type": "tuple",
-  "value": [
-    {
-      "type": "keyword",
-      "value": "left",
-    },
-    {
-      "type": "keyword",
-      "value": "top",
-    },
-  ],
-}
-`);
+      expect(parseCssValue("backgroundPosition", "left top")).toEqual({
+        type: "tuple",
+        value: [
+          {
+            type: "keyword",
+            value: "left",
+          },
+          {
+            type: "keyword",
+            value: "top",
+          },
+        ],
+      });
     });
   });
 

--- a/packages/css-data/src/parse-css-value.ts
+++ b/packages/css-data/src/parse-css-value.ts
@@ -34,19 +34,22 @@ export const isValidDeclaration = (
 
   const matchResult = csstree.lexer.matchProperty(cssPropertyName, ast);
 
-  const isValidDeclaration = matchResult.matched != null;
+  let isValidDeclaration = matchResult.matched != null;
 
-  // @todo remove after fix https://github.com/csstree/csstree/issues/246
-  if (isValidDeclaration && typeof CSSStyleValue !== "undefined") {
+  // @todo remove after csstree fixes
+  // - https://github.com/csstree/csstree/issues/246
+  // - https://github.com/csstree/csstree/issues/164
+  if (typeof CSSStyleValue !== "undefined") {
     try {
       CSSStyleValue.parse(cssPropertyName, value);
+      isValidDeclaration = true;
     } catch {
       warnOnce(
         true,
         `Css property "${property}" with value "${value}" is invalid according to CSSStyleValue.parse
           but valid according to csstree.lexer.matchProperty.`
       );
-      return false;
+      isValidDeclaration = false;
     }
   }
 
@@ -66,7 +69,7 @@ export const parseCssValue = (
     return invalidValue;
   }
 
-  if (!isValidDeclaration(property, input)) {
+  if (isValidDeclaration(property, input) === false) {
     return invalidValue;
   }
 


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3203

If DOM parser is available, let it do the parsing and don't rely on csstree if possible for validation

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
