### PR TITLE
refactor: replace uuid with crypto.randomUUID()

### DIFF
--- a/apps/builder/app/shared/share-project/share-project.stories.tsx
+++ b/apps/builder/app/shared/share-project/share-project.stories.tsx
@@ -1,5 +1,4 @@
-import { v4 as uuid } from "uuid";
-import type { ComponentStory } from "@storybook/react";
+import type { StoryFn } from "@storybook/react";
 import {
   Button,
   FloatingPanelPopover,
@@ -15,21 +14,21 @@ export default {
 
 const initialLinks: Array<LinkOptions> = [
   {
-    token: uuid(),
+    token: crypto.randomUUID(),
     name: "View Only",
     relation: "viewers",
     canClone: false,
     canCopy: false,
   },
   {
-    token: uuid(),
+    token: crypto.randomUUID(),
     name: "View and Edit",
     relation: "editors",
     canClone: false,
     canCopy: false,
   },
   {
-    token: uuid(),
+    token: crypto.randomUUID(),
     name: "Build",
     relation: "builders",
     canClone: false,
@@ -59,7 +58,7 @@ const useShareProject = (
     setLinks([
       ...links,
       {
-        token: uuid(),
+        token: crypto.randomUUID(),
         name: "Custom Link",
         relation: "viewers",
         canClone: false,
@@ -82,7 +81,7 @@ const useShareProject = (
   return { links, onChange, onDelete, onCreate };
 };
 
-export const Empty: ComponentStory<typeof ShareProject> = () => {
+export const Empty: StoryFn<typeof ShareProject> = () => {
   const props = useShareProject();
   return (
     <FloatingPanelPopover modal open>
@@ -104,7 +103,7 @@ export const Empty: ComponentStory<typeof ShareProject> = () => {
   );
 };
 
-export const WithLinks: ComponentStory<typeof ShareProject> = () => {
+export const WithLinks: StoryFn<typeof ShareProject> = () => {
   const props = useShareProject(initialLinks);
   return (
     <FloatingPanelPopover modal open>
@@ -126,7 +125,7 @@ export const WithLinks: ComponentStory<typeof ShareProject> = () => {
   );
 };
 
-export const WithAsyncLinks: ComponentStory<typeof ShareProject> = () => {
+export const WithAsyncLinks: StoryFn<typeof ShareProject> = () => {
   const props = useShareProject(initialLinks, true);
   return (
     <FloatingPanelPopover modal open>

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -120,7 +120,6 @@
     "untruncate-json": "^0.0.1",
     "urlpattern-polyfill": "^9.0.0",
     "use-debounce": "^9.0.4",
-    "uuid": "^9.0.0",
     "warn-once": "^0.1.1",
     "zod": "^3.22.4"
   },
@@ -139,7 +138,6 @@
     "@types/prismjs": "^1.26.0",
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
-    "@types/uuid": "^8.3.4",
     "@webstudio-is/jest-config": "workspace:*",
     "@webstudio-is/storybook-config": "workspace:*",
     "@webstudio-is/tsconfig": "workspace:*",

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -12,11 +12,9 @@
   "dependencies": {
     "@webstudio-is/prisma-client": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
-    "uuid": "^9.0.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/uuid": "^8.3.4",
     "@webstudio-is/tsconfig": "workspace:*",
     "typescript": "5.4.5"
   },

--- a/packages/authorization-token/src/db/authorization-token.ts
+++ b/packages/authorization-token/src/db/authorization-token.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from "uuid";
 import {
   prisma,
   type AuthorizationToken,
@@ -65,7 +64,7 @@ export type TokenPermissions = typeof tokenDefaultPermissions;
 
 export const getTokenPermissions = async (
   props: { projectId: Project["id"]; token: AuthorizationToken["token"] },
-  context: AppContext
+  _context: AppContext
 ): Promise<TokenPermissions> => {
   const dbToken = await prisma.authorizationToken.findUnique({
     where: {
@@ -101,7 +100,7 @@ export const create = async (
   },
   context: AppContext
 ) => {
-  const tokenId = uuid();
+  const tokenId = crypto.randomUUID();
 
   // Only owner of the project can create authorization tokens
   const canCreateToken = await authorizeProject.hasProjectPermit(

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -14,11 +14,9 @@
     "@webstudio-is/project": "workspace:*",
     "@webstudio-is/project-build": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
-    "uuid": "^9.0.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/uuid": "^8.3.4",
     "@webstudio-is/tsconfig": "workspace:*",
     "typescript": "5.4.5"
   },

--- a/packages/domain/src/db/cname-from-user-id.ts
+++ b/packages/domain/src/db/cname-from-user-id.ts
@@ -1,5 +1,3 @@
-import { webcrypto as crypto } from "node:crypto";
-
 export const cnameFromUserId = async (userId: string) => {
   const vowels = ["a", "e", "i", "o", "u"];
   const consonants = [

--- a/packages/domain/src/db/domain.ts
+++ b/packages/domain/src/db/domain.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from "uuid";
 import {
   prisma,
   type Project,
@@ -128,7 +127,7 @@ export const create = async (
     },
   });
 
-  const txtRecord = uuid();
+  const txtRecord = crypto.randomUUID();
 
   // Create project domain relation
   await prisma.projectDomain.create({

--- a/packages/prisma-client/prisma/migrations/20220909124542_builds-data/migration.ts
+++ b/packages/prisma-client/prisma/migrations/20220909124542_builds-data/migration.ts
@@ -1,5 +1,4 @@
 import { PrismaClient, Prisma } from "./client";
-import { v4 as uuid } from "uuid";
 import { z } from "zod";
 
 const TreeHistorySchema = z.array(z.string());
@@ -46,7 +45,7 @@ export default () => {
 
         const pages = PagesSchema.parse({
           homePage: {
-            id: uuid(),
+            id: crypto.randomUUID(),
             name: "Home",
             path: "",
             title: "Home",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -17,11 +17,9 @@
     "@webstudio-is/trpc-interface": "workspace:*",
     "nanoid": "^5.0.1",
     "slugify": "^1.6.6",
-    "uuid": "^9.0.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/uuid": "^8.3.4",
     "@webstudio-is/tsconfig": "workspace:*",
     "typescript": "5.4.5"
   },

--- a/packages/project/src/db/project.ts
+++ b/packages/project/src/db/project.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from "uuid";
 import { prisma, Prisma } from "@webstudio-is/prisma-client";
 import { cloneAssets } from "@webstudio-is/asset-uploader/index.server";
 import {
@@ -53,7 +52,7 @@ export const create = async (
     throw new Error("The user must be authenticated to create a project");
   }
 
-  const projectId = uuid();
+  const projectId = crypto.randomUUID();
   await authorizeProject.registerProjectOwner({ projectId }, context);
 
   const project = await prisma.$transaction(async (client) => {
@@ -165,7 +164,7 @@ export const clone = async (
     throw new Error("The user must be authenticated to clone the project");
   }
 
-  const newProjectId = uuid();
+  const newProjectId = crypto.randomUUID();
   await authorizeProject.registerProjectOwner(
     { projectId: newProjectId },
     context

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -15,7 +15,6 @@
     "@trpc/server": "^10.38.1",
     "@webstudio-is/prisma-client": "workspace:*",
     "ts-custom-error": "^3.3.1",
-    "uuid": "^9.0.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,9 +369,6 @@ importers:
       use-debounce:
         specifier: ^9.0.4
         version: 9.0.4(react@18.3.0-canary-14898b6a9-20240318)
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
       warn-once:
         specifier: ^0.1.1
         version: 0.1.1
@@ -421,9 +418,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.25
         version: 18.2.25
-      '@types/uuid':
-        specifier: ^8.3.4
-        version: 8.3.4
       '@webstudio-is/jest-config':
         specifier: workspace:*
         version: link:../../packages/jest-config
@@ -923,16 +917,10 @@ importers:
       '@webstudio-is/trpc-interface':
         specifier: workspace:*
         version: link:../trpc-interface
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
       zod:
         specifier: ^3.22.4
         version: 3.22.4
     devDependencies:
-      '@types/uuid':
-        specifier: ^8.3.4
-        version: 8.3.4
       '@webstudio-is/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -1394,16 +1382,10 @@ importers:
       '@webstudio-is/trpc-interface':
         specifier: workspace:*
         version: link:../trpc-interface
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
       zod:
         specifier: ^3.22.4
         version: 3.22.4
     devDependencies:
-      '@types/uuid':
-        specifier: ^8.3.4
-        version: 8.3.4
       '@webstudio-is/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -1755,16 +1737,10 @@ importers:
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
       zod:
         specifier: ^3.22.4
         version: 3.22.4
     devDependencies:
-      '@types/uuid':
-        specifier: ^8.3.4
-        version: 8.3.4
       '@webstudio-is/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -2180,9 +2156,6 @@ importers:
       ts-custom-error:
         specifier: ^3.3.1
         version: 3.3.1
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -5008,9 +4981,6 @@ packages:
 
   '@types/unist@3.0.0':
     resolution: {integrity: sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==}
-
-  '@types/uuid@8.3.4':
-    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
 
   '@types/yargs-parser@21.0.0':
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -9712,10 +9682,6 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-
-  uuid@9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
 
   uuid@9.0.1:
@@ -14466,8 +14432,6 @@ snapshots:
   '@types/unist@2.0.6': {}
 
   '@types/unist@3.0.0': {}
-
-  '@types/uuid@8.3.4': {}
 
   '@types/yargs-parser@21.0.0': {}
 
@@ -20377,8 +20341,6 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@8.3.2: {}
-
-  uuid@9.0.0: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
crypto.randomUUID() is globally available in node and browser environments. Uuid package is no longer necessary for our cases.