### PR TITLE
chore: disable console.log

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -74,11 +74,5 @@ module.exports = {
         "unicorn/filename-case": "off",
       },
     },
-    {
-      files: ["**/cli/**/*.{js,ts,tsx}"],
-      rules: {
-        "no-console": "off",
-      },
-    },
   ],
 };


### PR DESCRIPTION
We should never keep console.log, but use console.info and console.error if we need logging in prod/cli

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
