### PR TITLE
fix: Fix page settings icon button color

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -92,7 +92,6 @@ const ItemSuffix = ({
         onClick={() => onEdit(isEditing ? undefined : itemId)}
         ref={buttonRef}
         icon={isEditing ? <ChevronRightIcon /> : <EllipsesIcon />}
-        variant={isParentSelected ? "contrast" : "normal"}
       />
     </Tooltip>
   );


### PR DESCRIPTION
## Description

Wrong color was used on the active item 

<img width="45" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/89f839b3-468f-4c4e-9b73-649c8b5ee2d1">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
