### PR TITLE
chore: Use textarea for large Resource URLs

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -544,8 +544,10 @@ export const ResourceForm = forwardRef<
           <InputErrorsTooltip
             errors={urlField.error ? [urlField.error] : undefined}
           >
-            <InputField
+            <TextArea
+              grow
               id={urlId}
+              rows={1}
               // expressions with variables cannot be edited
               disabled={isLiteralExpression(urlField.value) === false}
               color={urlField.error ? "error" : undefined}
@@ -553,8 +555,7 @@ export const ResourceForm = forwardRef<
                 evaluateExpressionWithinScope(urlField.value, scope)
               )}
               // update text value as string literal
-              onChange={(event) => {
-                const value = event.target.value;
+              onChange={(value) => {
                 const curl = parseCurl(value);
                 if (curl) {
                   // update all feilds when curl is paste into url field


### PR DESCRIPTION
## Description

URL input was hard to use when url gets long

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
