### PR TITLE
refactor: Only use scrub distanceThreshold on inputs

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/width-input.tsx
+++ b/apps/builder/app/builder/features/breakpoints/width-input.tsx
@@ -45,6 +45,7 @@ const useEnhancedInput = ({
   };
 
   const { scrubRef, inputRef } = useScrub({
+    distanceThreshold: 2,
     value,
     onChange: handleChange,
     onChangeComplete: handleChangeComplete,

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -159,6 +159,7 @@ const useScrub = ({
     };
 
     return numericScrubControl(scrubRefCurrent, {
+      distanceThreshold: 2,
       getAcceleration() {
         if (valueRef.current.type === "unit") {
           return scrubUnitAcceleration.get(valueRef.current.unit);
@@ -548,7 +549,6 @@ export const CssValueInput = ({
 
   const [scrubRef, inputRef] = useScrub({
     value,
-    distanceThreshold: 2,
     property,
     onChange: props.onChange,
     onChangeComplete: (value) => onChangeComplete(value, "scrub-end"),

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -548,6 +548,7 @@ export const CssValueInput = ({
 
   const [scrubRef, inputRef] = useScrub({
     value,
+    distanceThreshold: 2,
     property,
     onChange: props.onChange,
     onChangeComplete: (value) => onChangeComplete(value, "scrub-end"),

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -78,7 +78,7 @@ export const numericScrubControl = (
     onStart,
     getValue = getValueDefault,
     direction = "horizontal",
-    distanceThreshold = 3,
+    distanceThreshold = 0,
     onValueInput,
     onValueChange,
     onStatusChange,

--- a/packages/design-system/src/components/primitives/use-scrub.ts
+++ b/packages/design-system/src/components/primitives/use-scrub.ts
@@ -69,7 +69,7 @@ export const useScrub = ({
       },
       shouldHandleEvent: shouldHandleEventRef.current,
     });
-  }, []);
+  }, [distanceThreshold]);
 
   return { scrubRef, inputRef };
 };

--- a/packages/design-system/src/components/primitives/use-scrub.ts
+++ b/packages/design-system/src/components/primitives/use-scrub.ts
@@ -7,11 +7,13 @@ import { unstable_batchedUpdates as unstableBatchedUpdates } from "react-dom";
 
 export const useScrub = ({
   value,
+  distanceThreshold,
   onChange,
   onChangeComplete,
   shouldHandleEvent,
 }: {
   value: NumericScrubValue;
+  distanceThreshold?: number;
   onChange: (value: NumericScrubValue) => void;
   onChangeComplete?: (value: NumericScrubValue) => void;
   shouldHandleEvent?: (node: EventTarget) => boolean;
@@ -41,6 +43,7 @@ export const useScrub = ({
     }
 
     return numericScrubControl(scrubRefCurrent, {
+      distanceThreshold,
       getInitialValue: () => {
         return valueRef.current;
       },


### PR DESCRIPTION
I just noticed that using scrub on any other things but inputs became less responsive because of the threshold and its not needed anywhere but in the inputs in 2 places

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
