### PR TITLE
feat: Sitemap resource

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -443,7 +443,7 @@ export const ResourceForm = forwardRef<
         return "URL is required";
       }
       try {
-        new URL(evaluatedValue);
+        // new URL(evaluatedValue);
       } catch {
         return "URL is invalid";
       }

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -12,6 +12,7 @@ import type { DataSource, Resource } from "@webstudio-is/sdk";
 import {
   encodeDataSourceVariable,
   isLiteralExpression,
+  isLocalResource,
 } from "@webstudio-is/sdk";
 import {
   Box,
@@ -443,8 +444,12 @@ export const ResourceForm = forwardRef<
         return "URL is required";
       }
       try {
-        // new URL(evaluatedValue);
+        new URL(evaluatedValue);
       } catch {
+        if (isLocalResource(evaluatedValue, "sitemap.xml")) {
+          return;
+        }
+
         return "URL is invalid";
       }
     },

--- a/apps/builder/app/routes/rest.resources-loader.ts
+++ b/apps/builder/app/routes/rest.resources-loader.ts
@@ -1,12 +1,31 @@
 import { z } from "zod";
 import type { ActionFunctionArgs } from "@remix-run/server-runtime";
-import { loadResource, ResourceRequest } from "@webstudio-is/sdk";
+import {
+  loadResource,
+  isLocalResource,
+  ResourceRequest,
+} from "@webstudio-is/sdk";
+import { loader as siteMapLoader } from "../shared/$resources/sitemap.xml.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
+  const customFetch: typeof fetch = (input, init) => {
+    if (typeof input !== "string") {
+      return fetch(input, init);
+    }
+
+    if (isLocalResource(input, "sitemap.xml")) {
+      return siteMapLoader({ request });
+    }
+
+    return fetch(input, init);
+  };
+
   const computedResources = z
     .array(ResourceRequest)
     .parse(await request.json());
-  const responses = await Promise.all(computedResources.map(loadResource));
+  const responses = await Promise.all(
+    computedResources.map((resource) => loadResource(customFetch, resource))
+  );
   const output: [ResourceRequest["id"], unknown][] = [];
   responses.forEach((response, index) => {
     const request = computedResources[index];

--- a/apps/builder/app/routes/rest.resources-loader.ts
+++ b/apps/builder/app/routes/rest.resources-loader.ts
@@ -8,6 +8,7 @@ import {
 import { loader as siteMapLoader } from "../shared/$resources/sitemap.xml.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
+  // Hope Remix will have customFetch by default, see https://kit.svelte.dev/docs/load#making-fetch-requests
   const customFetch: typeof fetch = (input, init) => {
     if (typeof input !== "string") {
       return fetch(input, init);

--- a/apps/builder/app/shared/$resources/sitemap.xml.server.ts
+++ b/apps/builder/app/shared/$resources/sitemap.xml.server.ts
@@ -3,6 +3,12 @@ import { prisma } from "@webstudio-is/prisma-client";
 import { parsePages } from "@webstudio-is/project-build/index.server";
 import { getStaticSiteMapXml } from "@webstudio-is/sdk";
 
+/**
+ * This should be a route in SvelteKit, as it can be fetched server-side without an actual HTTP request.
+ * Consider moving it to routes if Remix supports similar functionality in the future.
+ * Note: Fetching own routes using request.origin is prohibited on Cloudflare Workers.
+ * Note: We are not moving this to routes to avoid generating an additional 30MB function on deploy.
+ */
 export const loader = async ({ request }: { request: Request }) => {
   const referer = request.headers.get("referer");
 

--- a/apps/builder/app/shared/$resources/sitemap.xml.server.ts
+++ b/apps/builder/app/shared/$resources/sitemap.xml.server.ts
@@ -1,0 +1,48 @@
+import { json } from "@remix-run/server-runtime";
+import { prisma } from "@webstudio-is/prisma-client";
+import { parsePages } from "@webstudio-is/project-build/index.server";
+import { getStaticSiteMapXml } from "@webstudio-is/sdk";
+
+export const loader = async ({ request }: { request: Request }) => {
+  const referer = request.headers.get("referer");
+
+  if (referer == null) {
+    throw json({ message: "No referer" }, { status: 400 });
+  }
+
+  const segments = new URL(referer).pathname.slice(1).split("/");
+
+  if (segments.length !== 2) {
+    throw json({ message: "Invalid referer" }, { status: 400 });
+  }
+
+  if (segments[0] !== "builder") {
+    throw json({ message: "Invalid referer" }, { status: 400 });
+  }
+
+  const projectId = segments[1];
+
+  // get pages from the database
+  const build = await prisma.build.findFirst({
+    where: {
+      projectId,
+      deployment: null,
+    },
+    select: {
+      pages: true,
+      updatedAt: true,
+    },
+  });
+
+  if (build === null) {
+    throw json({ message: "Build not found" }, { status: 404 });
+  }
+
+  const pages = parsePages(build.pages);
+
+  const allPages = [pages.homePage, ...pages.pages];
+
+  const siteMap = getStaticSiteMapXml(allPages, build.updatedAt.toISOString());
+
+  return json(siteMap);
+};

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/[sitemap.xml].ts
@@ -1,8 +1,6 @@
-export const sitemap = {
-  pages: [
-    {
-      path: "",
-      lastModified: "2024-02-01T08:34:11.957Z",
-    },
-  ],
-};
+export const sitemap = [
+  {
+    path: "",
+    lastModified: "2024-02-01",
+  },
+];

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/_index.server.tsx
@@ -2,7 +2,7 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-cloudflare-template/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/[sitemap.xml].tsx
@@ -7,7 +7,7 @@ export const loader = (arg: LoaderFunctionArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const urls = sitemap.pages.map((page) => {
+  const urls = sitemap.map((page) => {
     const url = new URL(`https://${host}${page.path}`);
 
     return `

--- a/fixtures/webstudio-custom-template/.webstudio/data.json
+++ b/fixtures/webstudio-custom-template/.webstudio/data.json
@@ -1,10 +1,10 @@
 {
   "build": {
-    "id": "95cd49ef-0f89-4e45-9c3f-137e3584343e",
+    "id": "a7480f00-e7b3-467d-a3f0-45d8b339fe11",
     "projectId": "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-    "version": 219,
-    "createdAt": "2024-04-04T14:33:58.620Z",
-    "updatedAt": "2024-04-04T14:33:58.620Z",
+    "version": 228,
+    "createdAt": "2024-04-23T17:26:49.325Z",
+    "updatedAt": "2024-04-23T17:26:49.325Z",
     "pages": {
       "meta": {
         "siteName": "Fixture Site",
@@ -66,6 +66,23 @@
           "rootInstanceId": "jDb2FuSK2-azIZxkH5XNv",
           "systemDataSourceId": "Zl0ZwsVkVbga9LehMyyQx",
           "path": "/world"
+        },
+        {
+          "id": "2HLHiU2IwQkvfO0Uuodgo",
+          "name": "sitemap-html",
+          "title": "\"Untitled\"",
+          "meta": {
+            "description": "\"\"",
+            "excludePageFromSearch": "false",
+            "language": "\"\"",
+            "socialImageUrl": "\"\"",
+            "status": "200",
+            "redirect": "\"\"",
+            "custom": []
+          },
+          "rootInstanceId": "rve0BYRbzAkSCr3Lq-wzi",
+          "systemDataSourceId": "6AKzkKHNkIHWUGJDCoXNz",
+          "path": "/sitemap-html"
         }
       ],
       "folders": [
@@ -76,7 +93,8 @@
           "children": [
             "nfzls_SkTc9jKYyxcZ8Lw",
             "xT46WZKzCBTvUCIObMELW",
-            "lyz5sZaJ7WzLt71cX3VJ2"
+            "lyz5sZaJ7WzLt71cX3VJ2",
+            "2HLHiU2IwQkvfO0Uuodgo"
           ]
         }
       ]
@@ -1164,6 +1182,125 @@
             "value": 0
           }
         }
+      ],
+      [
+        "3JNfFwmMATeV1bH2RfBgF:mIDIDBHsdlix3RVZAVmv7:color:",
+        {
+          "styleSourceId": "3JNfFwmMATeV1bH2RfBgF",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "color",
+          "value": {
+            "type": "rgb",
+            "r": 36,
+            "g": 12,
+            "b": 233,
+            "alpha": 1
+          }
+        }
+      ],
+      [
+        "nS9BC-b89uRhQ6jI-6el4:mIDIDBHsdlix3RVZAVmv7:color:",
+        {
+          "styleSourceId": "nS9BC-b89uRhQ6jI-6el4",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "color",
+          "value": {
+            "type": "rgb",
+            "r": 8,
+            "g": 137,
+            "b": 17,
+            "alpha": 1
+          }
+        }
+      ],
+      [
+        "iBzrDKfBww47SfmKZnSMO:mIDIDBHsdlix3RVZAVmv7:color:",
+        {
+          "styleSourceId": "iBzrDKfBww47SfmKZnSMO",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "color",
+          "value": {
+            "type": "rgb",
+            "r": 208,
+            "g": 24,
+            "b": 79,
+            "alpha": 1
+          }
+        }
+      ],
+      [
+        "y72KMNELJQv7WCC2EVikH:mIDIDBHsdlix3RVZAVmv7:marginLeft:",
+        {
+          "styleSourceId": "y72KMNELJQv7WCC2EVikH",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "marginLeft",
+          "value": {
+            "type": "unit",
+            "unit": "px",
+            "value": 20
+          }
+        }
+      ],
+      [
+        "y72KMNELJQv7WCC2EVikH:mIDIDBHsdlix3RVZAVmv7:display:",
+        {
+          "styleSourceId": "y72KMNELJQv7WCC2EVikH",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "display",
+          "value": {
+            "type": "keyword",
+            "value": "flex"
+          }
+        }
+      ],
+      [
+        "crYPhCE3T9eEs-5p-HERt:mIDIDBHsdlix3RVZAVmv7:marginLeft:",
+        {
+          "styleSourceId": "crYPhCE3T9eEs-5p-HERt",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "marginLeft",
+          "value": {
+            "type": "unit",
+            "unit": "px",
+            "value": 20
+          }
+        }
+      ],
+      [
+        "crYPhCE3T9eEs-5p-HERt:mIDIDBHsdlix3RVZAVmv7:display:",
+        {
+          "styleSourceId": "crYPhCE3T9eEs-5p-HERt",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "display",
+          "value": {
+            "type": "keyword",
+            "value": "flex"
+          }
+        }
+      ],
+      [
+        "CPXm9ByL_tFAhAz2Yjh_g:mIDIDBHsdlix3RVZAVmv7:fontWeight:",
+        {
+          "styleSourceId": "CPXm9ByL_tFAhAz2Yjh_g",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "fontWeight",
+          "value": {
+            "type": "keyword",
+            "value": "600"
+          }
+        }
+      ],
+      [
+        "5eoCM_8Q2H8ijgCjCDE08:mIDIDBHsdlix3RVZAVmv7:fontWeight:",
+        {
+          "styleSourceId": "5eoCM_8Q2H8ijgCjCDE08",
+          "breakpointId": "mIDIDBHsdlix3RVZAVmv7",
+          "property": "fontWeight",
+          "value": {
+            "type": "keyword",
+            "value": "600"
+          }
+        }
       ]
     ],
     "styleSources": [
@@ -1243,6 +1380,58 @@
           "type": "local",
           "id": "jGTUoz0ux0EK-bikmqnw7"
         }
+      ],
+      [
+        "3JNfFwmMATeV1bH2RfBgF",
+        {
+          "type": "token",
+          "id": "3JNfFwmMATeV1bH2RfBgF",
+          "name": "color:url"
+        }
+      ],
+      [
+        "nS9BC-b89uRhQ6jI-6el4",
+        {
+          "type": "token",
+          "id": "nS9BC-b89uRhQ6jI-6el4",
+          "name": "color:loc"
+        }
+      ],
+      [
+        "iBzrDKfBww47SfmKZnSMO",
+        {
+          "type": "token",
+          "id": "iBzrDKfBww47SfmKZnSMO",
+          "name": "color:lastmod"
+        }
+      ],
+      [
+        "y72KMNELJQv7WCC2EVikH",
+        {
+          "type": "local",
+          "id": "y72KMNELJQv7WCC2EVikH"
+        }
+      ],
+      [
+        "CPXm9ByL_tFAhAz2Yjh_g",
+        {
+          "type": "local",
+          "id": "CPXm9ByL_tFAhAz2Yjh_g"
+        }
+      ],
+      [
+        "crYPhCE3T9eEs-5p-HERt",
+        {
+          "type": "local",
+          "id": "crYPhCE3T9eEs-5p-HERt"
+        }
+      ],
+      [
+        "5eoCM_8Q2H8ijgCjCDE08",
+        {
+          "type": "local",
+          "id": "5eoCM_8Q2H8ijgCjCDE08"
+        }
       ]
     ],
     "styleSourceSelections": [
@@ -1321,6 +1510,76 @@
         {
           "instanceId": "COafOppxs73Ne4O0Geik0",
           "values": ["jGTUoz0ux0EK-bikmqnw7"]
+        }
+      ],
+      [
+        "FD1zWHCq5TVsTSBKWbtV3",
+        {
+          "instanceId": "FD1zWHCq5TVsTSBKWbtV3",
+          "values": ["3JNfFwmMATeV1bH2RfBgF"]
+        }
+      ],
+      [
+        "eSgI63Vtow0HYHYWUXn3U",
+        {
+          "instanceId": "eSgI63Vtow0HYHYWUXn3U",
+          "values": ["y72KMNELJQv7WCC2EVikH"]
+        }
+      ],
+      [
+        "YT4punX-Bdhl0Dw8l6kum",
+        {
+          "instanceId": "YT4punX-Bdhl0Dw8l6kum",
+          "values": ["nS9BC-b89uRhQ6jI-6el4"]
+        }
+      ],
+      [
+        "85KbQ_KRH5fQsA0pDR9G9",
+        {
+          "instanceId": "85KbQ_KRH5fQsA0pDR9G9",
+          "values": ["CPXm9ByL_tFAhAz2Yjh_g"]
+        }
+      ],
+      [
+        "qdI0BY3e4j8USqw370Qrs",
+        {
+          "instanceId": "qdI0BY3e4j8USqw370Qrs",
+          "values": ["nS9BC-b89uRhQ6jI-6el4"]
+        }
+      ],
+      [
+        "rRH1A7WUjY-_pfauYCmKU",
+        {
+          "instanceId": "rRH1A7WUjY-_pfauYCmKU",
+          "values": ["crYPhCE3T9eEs-5p-HERt"]
+        }
+      ],
+      [
+        "6NZJcVjrr4WHS6eqNG1SF",
+        {
+          "instanceId": "6NZJcVjrr4WHS6eqNG1SF",
+          "values": ["iBzrDKfBww47SfmKZnSMO"]
+        }
+      ],
+      [
+        "i0u7W1XIPYHdwcD4bmm4Z",
+        {
+          "instanceId": "i0u7W1XIPYHdwcD4bmm4Z",
+          "values": ["5eoCM_8Q2H8ijgCjCDE08"]
+        }
+      ],
+      [
+        "NR5D_PEUVi_P7Agy2g1Zr",
+        {
+          "instanceId": "NR5D_PEUVi_P7Agy2g1Zr",
+          "values": ["iBzrDKfBww47SfmKZnSMO"]
+        }
+      ],
+      [
+        "Q1mx0RlJAIT37qXjHlt95",
+        {
+          "instanceId": "Q1mx0RlJAIT37qXjHlt95",
+          "values": ["3JNfFwmMATeV1bH2RfBgF"]
         }
       ]
     ],
@@ -1544,38 +1803,110 @@
           "type": "number",
           "value": 1024
         }
+      ],
+      [
+        "fBGXDGATUkuv7EEF6Q7Oq",
+        {
+          "id": "fBGXDGATUkuv7EEF6Q7Oq",
+          "instanceId": "fN6n7cnYEEOejAQTZHd46",
+          "name": "data",
+          "type": "expression",
+          "value": "$ws$dataSource$kysfQMiYfpyLK8Z0BwHTn.data"
+        }
+      ],
+      [
+        "brJHBwmzzpg0rp5ZyU_VP",
+        {
+          "id": "brJHBwmzzpg0rp5ZyU_VP",
+          "instanceId": "fN6n7cnYEEOejAQTZHd46",
+          "name": "item",
+          "type": "parameter",
+          "value": "Jli9j5EFM9nbJJKyjmG5N"
+        }
       ]
     ],
     "dataSources": [
       [
         "_yJ0UuBlq2PEEobk8o_ku",
         {
+          "type": "parameter",
           "id": "_yJ0UuBlq2PEEobk8o_ku",
           "scopeInstanceId": "ibXgMoi9_ipHx1gVrvii0",
-          "name": "system",
-          "type": "parameter"
+          "name": "system"
         }
       ],
       [
         "Mlo1vx1bhMUxPcNRfzESD",
         {
+          "type": "parameter",
           "id": "Mlo1vx1bhMUxPcNRfzESD",
           "scopeInstanceId": "LW98_-srDnnagkR10lsk4",
-          "name": "system",
-          "type": "parameter"
+          "name": "system"
         }
       ],
       [
         "Zl0ZwsVkVbga9LehMyyQx",
         {
+          "type": "parameter",
           "id": "Zl0ZwsVkVbga9LehMyyQx",
           "scopeInstanceId": "jDb2FuSK2-azIZxkH5XNv",
-          "name": "system",
-          "type": "parameter"
+          "name": "system"
+        }
+      ],
+      [
+        "6AKzkKHNkIHWUGJDCoXNz",
+        {
+          "type": "parameter",
+          "id": "6AKzkKHNkIHWUGJDCoXNz",
+          "scopeInstanceId": "rve0BYRbzAkSCr3Lq-wzi",
+          "name": "system"
+        }
+      ],
+      [
+        "kysfQMiYfpyLK8Z0BwHTn",
+        {
+          "type": "resource",
+          "id": "kysfQMiYfpyLK8Z0BwHTn",
+          "scopeInstanceId": "rve0BYRbzAkSCr3Lq-wzi",
+          "name": "sitemap.xml",
+          "resourceId": "Y_ZBU-mHnSXigZ1IXI02s"
+        }
+      ],
+      [
+        "Jli9j5EFM9nbJJKyjmG5N",
+        {
+          "type": "parameter",
+          "id": "Jli9j5EFM9nbJJKyjmG5N",
+          "scopeInstanceId": "fN6n7cnYEEOejAQTZHd46",
+          "name": "url"
+        }
+      ],
+      [
+        "-tLBLywqXy2NSb7eonEuq",
+        {
+          "type": "variable",
+          "id": "-tLBLywqXy2NSb7eonEuq",
+          "scopeInstanceId": "rve0BYRbzAkSCr3Lq-wzi",
+          "name": "origin",
+          "value": {
+            "type": "string",
+            "value": "https://my-site.cc"
+          }
         }
       ]
     ],
-    "resources": [],
+    "resources": [
+      [
+        "Y_ZBU-mHnSXigZ1IXI02s",
+        {
+          "id": "Y_ZBU-mHnSXigZ1IXI02s",
+          "name": "sitemap.xml",
+          "method": "get",
+          "url": "\"/$resources/sitemap.xml\"",
+          "headers": []
+        }
+      ]
+    ],
     "instances": [
       [
         "ibXgMoi9_ipHx1gVrvii0",
@@ -1909,6 +2240,228 @@
             }
           ]
         }
+      ],
+      [
+        "rve0BYRbzAkSCr3Lq-wzi",
+        {
+          "type": "instance",
+          "id": "rve0BYRbzAkSCr3Lq-wzi",
+          "component": "Body",
+          "children": [
+            {
+              "type": "id",
+              "value": "fN6n7cnYEEOejAQTZHd46"
+            }
+          ]
+        }
+      ],
+      [
+        "fN6n7cnYEEOejAQTZHd46",
+        {
+          "type": "instance",
+          "id": "fN6n7cnYEEOejAQTZHd46",
+          "component": "ws:collection",
+          "label": "SitemapXml",
+          "children": [
+            {
+              "type": "id",
+              "value": "qNCcAfJQFIBEGM99hOGcj"
+            }
+          ]
+        }
+      ],
+      [
+        "qNCcAfJQFIBEGM99hOGcj",
+        {
+          "type": "instance",
+          "id": "qNCcAfJQFIBEGM99hOGcj",
+          "component": "Box",
+          "label": "url",
+          "children": [
+            {
+              "type": "id",
+              "value": "FD1zWHCq5TVsTSBKWbtV3"
+            },
+            {
+              "type": "id",
+              "value": "eSgI63Vtow0HYHYWUXn3U"
+            },
+            {
+              "type": "id",
+              "value": "rRH1A7WUjY-_pfauYCmKU"
+            },
+            {
+              "type": "id",
+              "value": "Q1mx0RlJAIT37qXjHlt95"
+            }
+          ]
+        }
+      ],
+      [
+        "FD1zWHCq5TVsTSBKWbtV3",
+        {
+          "type": "instance",
+          "id": "FD1zWHCq5TVsTSBKWbtV3",
+          "component": "Text",
+          "label": "<url>",
+          "children": [
+            {
+              "type": "text",
+              "value": "<url>"
+            }
+          ]
+        }
+      ],
+      [
+        "eSgI63Vtow0HYHYWUXn3U",
+        {
+          "type": "instance",
+          "id": "eSgI63Vtow0HYHYWUXn3U",
+          "component": "Box",
+          "label": "loc",
+          "children": [
+            {
+              "type": "id",
+              "value": "YT4punX-Bdhl0Dw8l6kum"
+            },
+            {
+              "type": "id",
+              "value": "85KbQ_KRH5fQsA0pDR9G9"
+            },
+            {
+              "type": "id",
+              "value": "qdI0BY3e4j8USqw370Qrs"
+            }
+          ]
+        }
+      ],
+      [
+        "YT4punX-Bdhl0Dw8l6kum",
+        {
+          "type": "instance",
+          "id": "YT4punX-Bdhl0Dw8l6kum",
+          "component": "Text",
+          "label": "<loc>",
+          "children": [
+            {
+              "type": "text",
+              "value": "<loc>"
+            }
+          ]
+        }
+      ],
+      [
+        "85KbQ_KRH5fQsA0pDR9G9",
+        {
+          "type": "instance",
+          "id": "85KbQ_KRH5fQsA0pDR9G9",
+          "component": "Text",
+          "label": "value",
+          "children": [
+            {
+              "type": "expression",
+              "value": "$ws$dataSource$__DASH__tLBLywqXy2NSb7eonEuq + $ws$dataSource$Jli9j5EFM9nbJJKyjmG5N.path"
+            }
+          ]
+        }
+      ],
+      [
+        "qdI0BY3e4j8USqw370Qrs",
+        {
+          "type": "instance",
+          "id": "qdI0BY3e4j8USqw370Qrs",
+          "component": "Text",
+          "label": "</loc>",
+          "children": [
+            {
+              "type": "text",
+              "value": "</loc>"
+            }
+          ]
+        }
+      ],
+      [
+        "rRH1A7WUjY-_pfauYCmKU",
+        {
+          "type": "instance",
+          "id": "rRH1A7WUjY-_pfauYCmKU",
+          "component": "Box",
+          "label": "lastmod",
+          "children": [
+            {
+              "type": "id",
+              "value": "6NZJcVjrr4WHS6eqNG1SF"
+            },
+            {
+              "type": "id",
+              "value": "i0u7W1XIPYHdwcD4bmm4Z"
+            },
+            {
+              "type": "id",
+              "value": "NR5D_PEUVi_P7Agy2g1Zr"
+            }
+          ]
+        }
+      ],
+      [
+        "6NZJcVjrr4WHS6eqNG1SF",
+        {
+          "type": "instance",
+          "id": "6NZJcVjrr4WHS6eqNG1SF",
+          "component": "Text",
+          "label": "<lastmod>",
+          "children": [
+            {
+              "type": "text",
+              "value": "<lastmod>"
+            }
+          ]
+        }
+      ],
+      [
+        "i0u7W1XIPYHdwcD4bmm4Z",
+        {
+          "type": "instance",
+          "id": "i0u7W1XIPYHdwcD4bmm4Z",
+          "component": "Text",
+          "label": "value",
+          "children": [
+            {
+              "type": "expression",
+              "value": "$ws$dataSource$Jli9j5EFM9nbJJKyjmG5N.lastModified"
+            }
+          ]
+        }
+      ],
+      [
+        "NR5D_PEUVi_P7Agy2g1Zr",
+        {
+          "type": "instance",
+          "id": "NR5D_PEUVi_P7Agy2g1Zr",
+          "component": "Text",
+          "label": "</lastmod>",
+          "children": [
+            {
+              "type": "text",
+              "value": "</lastmod>"
+            }
+          ]
+        }
+      ],
+      [
+        "Q1mx0RlJAIT37qXjHlt95",
+        {
+          "type": "instance",
+          "id": "Q1mx0RlJAIT37qXjHlt95",
+          "component": "Text",
+          "label": "</url>",
+          "children": [
+            {
+              "type": "text",
+              "value": "</url>"
+            }
+          ]
+        }
       ]
     ],
     "deployment": {
@@ -1977,6 +2530,23 @@
       "rootInstanceId": "jDb2FuSK2-azIZxkH5XNv",
       "systemDataSourceId": "Zl0ZwsVkVbga9LehMyyQx",
       "path": "/world"
+    },
+    {
+      "id": "2HLHiU2IwQkvfO0Uuodgo",
+      "name": "sitemap-html",
+      "title": "\"Untitled\"",
+      "meta": {
+        "description": "\"\"",
+        "excludePageFromSearch": "false",
+        "language": "\"\"",
+        "socialImageUrl": "\"\"",
+        "status": "200",
+        "redirect": "\"\"",
+        "custom": []
+      },
+      "rootInstanceId": "rve0BYRbzAkSCr3Lq-wzi",
+      "systemDataSourceId": "6AKzkKHNkIHWUGJDCoXNz",
+      "path": "/sitemap-html"
     }
   ],
   "assets": [

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
@@ -2,7 +2,7 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap-html]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap-html]._index.server.tsx
@@ -3,8 +3,34 @@
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
+import { sitemap } from "./[sitemap.xml]";
 export const loadResources = async (_props: { system: System }) => {
-  return {} as Record<string, unknown>;
+  const customFetch: typeof fetch = (input, init) => {
+    if (typeof input !== "string") {
+      return fetch(input, init);
+    }
+
+    if (isLocalResource(input, "sitemap.xml")) {
+      // @todo: dynamic import sitemap ???
+      const response = new Response(JSON.stringify(sitemap));
+      response.headers.set("content-type", "application/json; charset=utf-8");
+      return Promise.resolve(response);
+    }
+
+    return fetch(input, init);
+  };
+  const [sitemapxml_1] = await Promise.all([
+    loadResource(customFetch, {
+      id: "Y_ZBU-mHnSXigZ1IXI02s",
+      name: "sitemap.xml",
+      url: "/$resources/sitemap.xml",
+      method: "get",
+      headers: [],
+    }),
+  ]);
+  return {
+    sitemapxml_1,
+  } as Record<string, unknown>;
 };
 
 export const getPageMeta = ({
@@ -18,7 +44,7 @@ export const getPageMeta = ({
     title: "Untitled",
     description: "",
     excludePageFromSearch: false,
-    language: "ru",
+    language: "",
     socialImageAssetId: undefined,
     socialImageUrl: "",
     status: 200,

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap-html]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap-html]._index.tsx
@@ -1,0 +1,112 @@
+/* eslint-disable */
+/* This is a auto generated file for building the project */
+
+import { Fragment, useState } from "react";
+import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
+import { useResource } from "@webstudio-is/react-sdk";
+import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
+import { Box as Box, Text as Text } from "@webstudio-is/sdk-components-react";
+
+export const favIconAsset: ImageAsset | undefined = {
+  id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
+  name: "home_wsKvRSqvkajPPBeycZ-C8.svg",
+  description: null,
+  projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
+  size: 3350,
+  type: "image",
+  format: "svg",
+  createdAt: "2023-10-30T20:35:47.113Z",
+  meta: { width: 16, height: 16 },
+};
+
+export const socialImageAsset: ImageAsset | undefined = undefined;
+
+// Font assets on current page (can be preloaded)
+export const pageFontAssets: FontAsset[] = [];
+
+export const pageBackgroundImageAssets: ImageAsset[] = [];
+
+const Page = ({}: { system: any }) => {
+  let [origin, set$origin] = useState<any>("https://my-site.cc");
+  let sitemapxml = useResource("sitemapxml_1");
+  return (
+    <Body data-ws-id="rve0BYRbzAkSCr3Lq-wzi" data-ws-component="Body">
+      {sitemapxml?.data?.map((url: any, index: number) => (
+        <Fragment key={index}>
+          <Box data-ws-id="qNCcAfJQFIBEGM99hOGcj" data-ws-component="Box">
+            <Text
+              data-ws-id="FD1zWHCq5TVsTSBKWbtV3"
+              data-ws-component="Text"
+              className="c1cymde0"
+            >
+              {"<url>"}
+            </Text>
+            <Box
+              data-ws-id="eSgI63Vtow0HYHYWUXn3U"
+              data-ws-component="Box"
+              className="c1mhrh2o c1b095zn"
+            >
+              <Text
+                data-ws-id="YT4punX-Bdhl0Dw8l6kum"
+                data-ws-component="Text"
+                className="c15pkvqb"
+              >
+                {"<loc>"}
+              </Text>
+              <Text
+                data-ws-id="85KbQ_KRH5fQsA0pDR9G9"
+                data-ws-component="Text"
+                className="cjqm8t8"
+              >
+                {origin + url?.path}
+              </Text>
+              <Text
+                data-ws-id="qdI0BY3e4j8USqw370Qrs"
+                data-ws-component="Text"
+                className="c15pkvqb"
+              >
+                {"</loc>"}
+              </Text>
+            </Box>
+            <Box
+              data-ws-id="rRH1A7WUjY-_pfauYCmKU"
+              data-ws-component="Box"
+              className="c1mhrh2o c1b095zn"
+            >
+              <Text
+                data-ws-id="6NZJcVjrr4WHS6eqNG1SF"
+                data-ws-component="Text"
+                className="c12yyvw2"
+              >
+                {"<lastmod>"}
+              </Text>
+              <Text
+                data-ws-id="i0u7W1XIPYHdwcD4bmm4Z"
+                data-ws-component="Text"
+                className="cjqm8t8"
+              >
+                {url?.lastModified}
+              </Text>
+              <Text
+                data-ws-id="NR5D_PEUVi_P7Agy2g1Zr"
+                data-ws-component="Text"
+                className="c12yyvw2"
+              >
+                {"</lastmod>"}
+              </Text>
+            </Box>
+            <Text
+              data-ws-id="Q1mx0RlJAIT37qXjHlt95"
+              data-ws-component="Text"
+              className="c1cymde0"
+            >
+              {"</url>"}
+            </Text>
+          </Box>
+        </Fragment>
+      ))}
+    </Body>
+  );
+};
+
+export { Page };

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml].ts
@@ -1,16 +1,14 @@
-export const sitemap = {
-  pages: [
-    {
-      path: "",
-      lastModified: "2024-04-04T14:33:58.620Z",
-    },
-    {
-      path: "/script-test",
-      lastModified: "2024-04-04T14:33:58.620Z",
-    },
-    {
-      path: "/world",
-      lastModified: "2024-04-04T14:33:58.620Z",
-    },
-  ],
-};
+export const sitemap = [
+  {
+    path: "",
+    lastModified: "2024-04-04",
+  },
+  {
+    path: "/script-test",
+    lastModified: "2024-04-04",
+  },
+  {
+    path: "/world",
+    lastModified: "2024-04-04",
+  },
+];

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml].ts
@@ -1,14 +1,18 @@
 export const sitemap = [
   {
     path: "",
-    lastModified: "2024-04-04",
+    lastModified: "2024-04-23",
   },
   {
     path: "/script-test",
-    lastModified: "2024-04-04",
+    lastModified: "2024-04-23",
   },
   {
     path: "/world",
-    lastModified: "2024-04-04",
+    lastModified: "2024-04-23",
+  },
+  {
+    path: "/sitemap-html",
+    lastModified: "2024-04-23",
   },
 ];

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
@@ -2,7 +2,7 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-custom-template/app/__generated__/index.css
+++ b/fixtures/webstudio-custom-template/app/__generated__/index.css
@@ -223,6 +223,15 @@ html {
     display: block;
     height: auto;
   }
+  div:where([data-ws-component="Text"]) {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+    min-height: 1em;
+  }
 }
 @media all {
   .c11x2bo2 {
@@ -409,5 +418,20 @@ html {
   }
   .c15iig68 {
     flex-basis: 0px;
+  }
+  .c1cymde0 {
+    color: rgba(36, 12, 233, 1);
+  }
+  .c1mhrh2o {
+    margin-left: 20px;
+  }
+  .c15pkvqb {
+    color: rgba(8, 137, 17, 1);
+  }
+  .cjqm8t8 {
+    font-weight: 600;
+  }
+  .c12yyvw2 {
+    color: rgba(208, 24, 79, 1);
   }
 }

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
@@ -1,0 +1,323 @@
+/* eslint-disable camelcase */
+import {
+  type ServerRuntimeMetaFunction as MetaFunction,
+  type LinksFunction,
+  type LinkDescriptor,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type HeadersFunction,
+  json,
+  redirect,
+} from "@remix-run/server-runtime";
+import { useLoaderData } from "@remix-run/react";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
+import {
+  Page,
+  favIconAsset,
+  socialImageAsset,
+  pageFontAssets,
+  pageBackgroundImageAssets,
+} from "../__generated__/[sitemap-html]._index";
+import {
+  formsProperties,
+  loadResources,
+  getPageMeta,
+  getRemixParams,
+  projectId,
+  user,
+  projectMeta,
+} from "../__generated__/[sitemap-html]._index.server";
+
+import css from "../__generated__/index.css?url";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+
+export const loader = async (arg: LoaderFunctionArgs) => {
+  const url = new URL(arg.request.url);
+  const params = getRemixParams(arg.params);
+  const system = {
+    params,
+    search: Object.fromEntries(url.searchParams),
+  };
+  const resources = await loadResources({ system });
+  const pageMeta = getPageMeta({ system, resources });
+
+  if (pageMeta.redirect) {
+    const status =
+      pageMeta.status === 301 || pageMeta.status === 302
+        ? pageMeta.status
+        : 302;
+    return redirect(pageMeta.redirect, status);
+  }
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
+  // typecheck
+  arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
+
+  return json(
+    {
+      host,
+      url: url.href,
+      excludeFromSearch: arg.context.EXCLUDE_FROM_SEARCH,
+      system,
+      resources,
+      pageMeta,
+      projectMeta,
+    },
+    // No way for current information to change, so add cache for 10 minutes
+    // In case of CRM Data, this should be set to 0
+    {
+      status: pageMeta.status,
+      headers: {
+        "Cache-Control": "public, max-age=600",
+        "x-ws-language": pageMeta.language ?? "en",
+      },
+    }
+  );
+};
+
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
+  return {
+    "Cache-Control": "public, max-age=0, must-revalidate",
+    "x-ws-language": loaderHeaders.get("x-ws-language") ?? "",
+  };
+};
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const metas: ReturnType<MetaFunction> = [];
+  if (data === undefined) {
+    return metas;
+  }
+  const { pageMeta, projectMeta } = data;
+
+  if (data.url) {
+    metas.push({
+      property: "og:url",
+      content: data.url,
+    });
+  }
+
+  if (pageMeta.title) {
+    metas.push({ title: pageMeta.title });
+
+    metas.push({
+      property: "og:title",
+      content: pageMeta.title,
+    });
+  }
+
+  metas.push({ property: "og:type", content: "website" });
+
+  const origin = `https://${data.host}`;
+
+  if (projectMeta?.siteName) {
+    metas.push({
+      property: "og:site_name",
+      content: projectMeta.siteName,
+    });
+    metas.push({
+      "script:ld+json": {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        name: projectMeta.siteName,
+        url: origin,
+      },
+    });
+  }
+
+  if (pageMeta.excludePageFromSearch || data.excludeFromSearch) {
+    metas.push({
+      name: "robots",
+      content: "noindex, nofollow",
+    });
+  }
+
+  if (pageMeta.description) {
+    metas.push({
+      name: "description",
+      content: pageMeta.description,
+    });
+    metas.push({
+      property: "og:description",
+      content: pageMeta.description,
+    });
+  }
+
+  if (socialImageAsset) {
+    metas.push({
+      property: "og:image",
+      content: `https://${data.host}${imageLoader({
+        src: socialImageAsset.name,
+        // Do not transform social image (not enough information do we need to do this)
+        format: "raw",
+      })}`,
+    });
+  } else if (pageMeta.socialImageUrl) {
+    metas.push({
+      property: "og:image",
+      content: pageMeta.socialImageUrl,
+    });
+  }
+
+  metas.push(...pageMeta.custom);
+
+  return metas;
+};
+
+export const links: LinksFunction = () => {
+  const result: LinkDescriptor[] = [];
+
+  result.push({
+    rel: "stylesheet",
+    href: css,
+  });
+
+  if (favIconAsset) {
+    result.push({
+      rel: "icon",
+      href: imageLoader({
+        src: favIconAsset.name,
+        width: 128,
+        quality: 100,
+        format: "auto",
+      }),
+      type: undefined,
+    });
+  } else {
+    result.push({
+      rel: "icon",
+      href: "/favicon.ico",
+      type: "image/x-icon",
+    });
+
+    result.push({
+      rel: "shortcut icon",
+      href: "/favicon.ico",
+      type: "image/x-icon",
+    });
+  }
+
+  for (const asset of pageFontAssets) {
+    result.push({
+      rel: "preload",
+      href: `${assetBaseUrl}${asset.name}`,
+      as: "font",
+      crossOrigin: "anonymous",
+    });
+  }
+
+  for (const backgroundImageAsset of pageBackgroundImageAssets) {
+    result.push({
+      rel: "preload",
+      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      as: "image",
+    });
+  }
+
+  return result;
+};
+
+const getRequestHost = (request: Request): string =>
+  request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
+
+const getMethod = (value: string | undefined) => {
+  if (value === undefined) {
+    return "post";
+  }
+
+  switch (value.toLowerCase()) {
+    case "get":
+      return "get";
+    default:
+      return "post";
+  }
+};
+
+export const action = async ({ request, context }: ActionFunctionArgs) => {
+  const formData = await request.formData();
+
+  const formId = getFormId(formData);
+  if (formId === undefined) {
+    // We're throwing rather than returning { success: false }
+    // because this isn't supposed to happen normally: bug or malicious user
+    throw json("Form not found", { status: 404 });
+  }
+
+  const formProperties = formsProperties.get(formId);
+
+  // form properties are not defined when defaults are used
+  const { action, method } = formProperties ?? {};
+
+  const email = user?.email;
+
+  if (email == null) {
+    return { success: false };
+  }
+
+  // wrapped in try/catch just in cases new URL() throws
+  // (should not happen)
+  let pageUrl: URL;
+  try {
+    pageUrl = new URL(request.url);
+    pageUrl.host = getRequestHost(request);
+  } catch {
+    return { success: false };
+  }
+
+  if (action !== undefined) {
+    try {
+      // Test that action is full URL
+      new URL(action);
+    } catch {
+      return json(
+        {
+          success: false,
+          error: "Invalid action URL, must be valid http/https protocol",
+        },
+        { status: 200 }
+      );
+    }
+  }
+
+  const formInfo = {
+    formData,
+    projectId,
+    action: action ?? null,
+    method: getMethod(method),
+    pageUrl: pageUrl.toString(),
+    toEmail: email,
+    fromEmail: pageUrl.hostname + "@webstudio.email",
+  } as const;
+
+  const result = await n8nHandler({
+    formInfo,
+    hookUrl: context.N8N_FORM_EMAIL_HOOK,
+  });
+
+  return result;
+};
+
+const Outlet = () => {
+  const { system, resources } = useLoaderData<typeof loader>();
+  return (
+    <ReactSdkContext.Provider
+      value={{
+        imageLoader,
+        assetBaseUrl,
+        imageBaseUrl,
+        resources,
+      }}
+    >
+      <Page system={system} />
+    </ReactSdkContext.Provider>
+  );
+};
+
+export default Outlet;

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap.xml].tsx
@@ -7,7 +7,7 @@ export const loader = (arg: LoaderFunctionArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const urls = sitemap.pages.map((page) => {
+  const urls = sitemap.map((page) => {
     const url = new URL(`https://${host}${page.path}`);
 
     return `

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/[sitemap.xml].ts
@@ -1,8 +1,6 @@
-export const sitemap = {
-  pages: [
-    {
-      path: "",
-      lastModified: "2024-02-01T08:34:11.957Z",
-    },
-  ],
-};
+export const sitemap = [
+  {
+    path: "",
+    lastModified: "2024-02-01",
+  },
+];

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
@@ -2,7 +2,7 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[sitemap.xml].tsx
@@ -7,7 +7,7 @@ export const loader = (arg: LoaderFunctionArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const urls = sitemap.pages.map((page) => {
+  const urls = sitemap.map((page) => {
     const url = new URL(`https://${host}${page.path}`);
 
     return `

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/[sitemap.xml].ts
@@ -1,8 +1,6 @@
-export const sitemap = {
-  pages: [
-    {
-      path: "",
-      lastModified: "2024-02-01T08:34:11.957Z",
-    },
-  ],
-};
+export const sitemap = [
+  {
+    path: "",
+    lastModified: "2024-02-01",
+  },
+];

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
@@ -2,7 +2,7 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[sitemap.xml].tsx
@@ -7,7 +7,7 @@ export const loader = (arg: LoaderFunctionArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const urls = sitemap.pages.map((page) => {
+  const urls = sitemap.map((page) => {
     const url = new URL(`https://${host}${page.path}`);
 
     return `

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
@@ -2,7 +2,7 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
@@ -2,7 +2,7 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
@@ -2,7 +2,7 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
@@ -2,7 +2,7 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
@@ -2,7 +2,7 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
@@ -2,10 +2,25 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
+import { sitemap } from "./[sitemap.xml]";
 export const loadResources = async (_props: { system: System }) => {
+  const customFetch: typeof fetch = (input, init) => {
+    if (typeof input !== "string") {
+      return fetch(input, init);
+    }
+
+    if (isLocalResource(input, "sitemap.xml")) {
+      // @todo: dynamic import sitemap ???
+      const response = new Response(JSON.stringify(sitemap));
+      response.headers.set("content-type", "application/json; charset=utf-8");
+      return Promise.resolve(response);
+    }
+
+    return fetch(input, init);
+  };
   const [list_1] = await Promise.all([
-    loadResource({
+    loadResource(customFetch, {
       id: "1vX6SQdaCjJN6MvJlG_cQ",
       name: "list",
       url: "https://gist.githubusercontent.com/TrySound/56507c301ec85669db5f1541406a9259/raw/a49548730ab592c86b9e7781f5b29beec4765494/collection.json",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml].ts
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml].ts
@@ -1,28 +1,26 @@
-export const sitemap = {
-  pages: [
-    {
-      path: "",
-      lastModified: "2024-02-01T08:34:52.398Z",
-    },
-    {
-      path: "/_route_with_symbols_",
-      lastModified: "2024-02-01T08:34:52.398Z",
-    },
-    {
-      path: "/form",
-      lastModified: "2024-02-01T08:34:52.398Z",
-    },
-    {
-      path: "/heading-with-id",
-      lastModified: "2024-02-01T08:34:52.398Z",
-    },
-    {
-      path: "/resources",
-      lastModified: "2024-02-01T08:34:52.398Z",
-    },
-    {
-      path: "/nested-page",
-      lastModified: "2024-02-01T08:34:52.398Z",
-    },
-  ],
-};
+export const sitemap = [
+  {
+    path: "",
+    lastModified: "2024-02-01",
+  },
+  {
+    path: "/_route_with_symbols_",
+    lastModified: "2024-02-01",
+  },
+  {
+    path: "/form",
+    lastModified: "2024-02-01",
+  },
+  {
+    path: "/heading-with-id",
+    lastModified: "2024-02-01",
+  },
+  {
+    path: "/resources",
+    lastModified: "2024-02-01",
+  },
+  {
+    path: "/nested-page",
+    lastModified: "2024-02-01",
+  },
+];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
@@ -2,7 +2,7 @@
 /* This is a auto generated file for building the project */
 
 import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
-import { loadResource, type System } from "@webstudio-is/sdk";
+import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml].tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml].tsx
@@ -7,7 +7,7 @@ export const loader = (arg: LoaderFunctionArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const urls = sitemap.pages.map((page) => {
+  const urls = sitemap.map((page) => {
     const url = new URL(`https://${host}${page.path}`);
 
     return `

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -43,10 +43,10 @@ import {
   findTreeInstanceIds,
   getPagePath,
   parseComponentName,
-  executeExpression,
   generateFormsProperties,
   generateResourcesLoader,
   generatePageMeta,
+  getStaticSiteMapXml,
 } from "@webstudio-is/sdk";
 import type { Data } from "@webstudio-is/http-client";
 import { createImageLoader } from "@webstudio-is/image";
@@ -682,19 +682,7 @@ export const projectMeta: ProjectMeta =
     join(generatedDir, "[sitemap.xml].ts"),
     `
       export const sitemap = ${JSON.stringify(
-        {
-          pages: siteData.pages
-            // ignore pages with excludePageFromSearch bound to variables
-            // because there is no data from cms available at build time
-            .filter(
-              (page) =>
-                executeExpression(page.meta.excludePageFromSearch) !== true
-            )
-            .map((page) => ({
-              path: page.path,
-              lastModified: siteData.build.updatedAt,
-            })),
-        },
+        getStaticSiteMapXml(siteData.pages, siteData.build.updatedAt),
         null,
         2
       )};

--- a/packages/cli/templates/defaults/app/__generated__/[sitemap.xml].ts
+++ b/packages/cli/templates/defaults/app/__generated__/[sitemap.xml].ts
@@ -1,11 +1,9 @@
 /**
  * The only intent of this file is to support typings inside ../routes/[sitemap.xml].tsx for easier development.
  **/
-export const sitemap = {
-  pages: [
-    {
-      path: "",
-      lastModified: "2021-10-13T12:00:00.000Z",
-    },
-  ],
-};
+export const sitemap = [
+  {
+    path: "",
+    lastModified: "2021-10-13T12:00:00.000Z",
+  },
+];

--- a/packages/cli/templates/defaults/app/routes/[sitemap.xml].tsx
+++ b/packages/cli/templates/defaults/app/routes/[sitemap.xml].tsx
@@ -7,7 +7,7 @@ export const loader = (arg: LoaderFunctionArgs) => {
     arg.request.headers.get("host") ||
     "";
 
-  const urls = sitemap.pages.map((page) => {
+  const urls = sitemap.map((page) => {
     const url = new URL(`https://${host}${page.path}`);
 
     return `

--- a/packages/sdk/src/page-utils.ts
+++ b/packages/sdk/src/page-utils.ts
@@ -1,3 +1,4 @@
+import { executeExpression } from "./expression";
 import type { Folder, Page, Pages } from "./schema/pages";
 
 export const ROOT_FOLDER_ID = "root";
@@ -72,4 +73,19 @@ export const getPagePath = (id: Folder["id"] | Page["id"], pages: Pages) => {
   }
 
   return paths.reverse().join("/").replace(/\/+/g, "/");
+};
+
+export const getStaticSiteMapXml = (pages: Page[], updatedAt: string) => {
+  return (
+    pages
+      // ignore pages with excludePageFromSearch bound to variables
+      // because there is no data from cms available at build time
+      .filter(
+        (page) => executeExpression(page.meta.excludePageFromSearch) !== true
+      )
+      .map((page) => ({
+        path: page.path,
+        lastModified: updatedAt.split("T")[0],
+      }))
+  );
 };

--- a/packages/sdk/src/resource-loader.ts
+++ b/packages/sdk/src/resource-loader.ts
@@ -1,6 +1,9 @@
 import type { ResourceRequest } from "./schema/resources";
 
-export const loadResource = async (resourceData: ResourceRequest) => {
+export const loadResource = async (
+  customFetch: typeof fetch,
+  resourceData: ResourceRequest
+) => {
   const { url, method, headers, body } = resourceData;
   const requestHeaders = new Headers(
     headers.map(({ name, value }): [string, string] => [name, value])
@@ -20,7 +23,7 @@ export const loadResource = async (resourceData: ResourceRequest) => {
   try {
     // cloudflare workers fail when fetching url contains spaces
     // even though new URL suppose to trim them on parsing by spec
-    const response = await fetch(url.trim(), requestInit);
+    const response = await customFetch(url.trim(), requestInit);
     let data;
     if (
       response.ok &&

--- a/packages/sdk/src/resources-generator.test.ts
+++ b/packages/sdk/src/resources-generator.test.ts
@@ -1,11 +1,7 @@
 import { expect, test } from "@jest/globals";
-import stripIndent from "strip-indent";
 import type { Page } from "./schema/pages";
 import { createScope } from "./scope";
 import { generateResourcesLoader } from "./resources-generator";
-
-const clear = (input: string) =>
-  stripIndent(input).trimStart().replace(/ +$/, "");
 
 const toMap = <T extends { id: string }>(list: T[]) =>
   new Map(list.map((item) => [item.id, item] as const));
@@ -35,30 +31,45 @@ test("generate resources loader", () => {
         },
       ]),
     })
-  ).toEqual(
-    clear(`
-      import { loadResource, type System } from "@webstudio-is/sdk";
-      export const loadResources = async (_props: { system: System }) => {
-      const [
-      variableName,
-      ] = await Promise.all([
-      loadResource({
-      id: "resourceId",
-      name: "resourceName",
-      url: "https://my-json.com",
-      method: "post",
-      headers: [
-      { name: "Content-Type", value: "application/json" },
-      ],
-      body: { body: true },
-      }),
-      ])
-      return {
-      variableName,
-      } as Record<string, unknown>
+  ).toMatchInlineSnapshot(`
+"import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
+import { sitemap } from "./[sitemap.xml]";
+export const loadResources = async (_props: { system: System }) => {
+
+    const customFetch: typeof fetch = (input, init) => {
+      if (typeof input !== "string") {
+        return fetch(input, init);
       }
-    `)
-  );
+
+      if (isLocalResource(input, "sitemap.xml")) {
+        // @todo: dynamic import sitemap ???
+        const response = new Response(JSON.stringify(sitemap));
+        response.headers.set('content-type',  'application/json; charset=utf-8');
+        return Promise.resolve(response);
+      }
+
+      return fetch(input, init);
+    };
+    const [
+variableName,
+] = await Promise.all([
+loadResource(customFetch, {
+id: "resourceId",
+name: "resourceName",
+url: "https://my-json.com",
+method: "post",
+headers: [
+{ name: "Content-Type", value: "application/json" },
+],
+body: { body: true },
+}),
+])
+return {
+variableName,
+} as Record<string, unknown>
+}
+"
+`);
 });
 
 test("generate variable and use in resources loader", () => {
@@ -97,35 +108,51 @@ test("generate variable and use in resources loader", () => {
               value: `"Token " + $ws$dataSource$variableTokenId`,
             },
           ],
+
           body: `{ body: true }`,
         },
       ]),
     })
-  ).toEqual(
-    clear(`
-      import { loadResource, type System } from "@webstudio-is/sdk";
-      export const loadResources = async (_props: { system: System }) => {
-      let AccessToken = "my-token"
-      const [
-      variableName,
-      ] = await Promise.all([
-      loadResource({
-      id: "resourceId",
-      name: "resourceName",
-      url: "https://my-json.com/",
-      method: "post",
-      headers: [
-      { name: "Authorization", value: "Token " + AccessToken },
-      ],
-      body: { body: true },
-      }),
-      ])
-      return {
-      variableName,
-      } as Record<string, unknown>
+  ).toMatchInlineSnapshot(`
+"import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
+import { sitemap } from "./[sitemap.xml]";
+export const loadResources = async (_props: { system: System }) => {
+let AccessToken = "my-token"
+
+    const customFetch: typeof fetch = (input, init) => {
+      if (typeof input !== "string") {
+        return fetch(input, init);
       }
-    `)
-  );
+
+      if (isLocalResource(input, "sitemap.xml")) {
+        // @todo: dynamic import sitemap ???
+        const response = new Response(JSON.stringify(sitemap));
+        response.headers.set('content-type',  'application/json; charset=utf-8');
+        return Promise.resolve(response);
+      }
+
+      return fetch(input, init);
+    };
+    const [
+variableName,
+] = await Promise.all([
+loadResource(customFetch, {
+id: "resourceId",
+name: "resourceName",
+url: "https://my-json.com/",
+method: "post",
+headers: [
+{ name: "Authorization", value: "Token " + AccessToken },
+],
+body: { body: true },
+}),
+])
+return {
+variableName,
+} as Record<string, unknown>
+}
+"
+`);
 });
 
 test("generate system variable and use in resources loader", () => {
@@ -162,31 +189,46 @@ test("generate system variable and use in resources loader", () => {
         },
       ]),
     })
-  ).toEqual(
-    clear(`
-      import { loadResource, type System } from "@webstudio-is/sdk";
-      export const loadResources = async (_props: { system: System }) => {
-      const system = _props.system
-      const [
-      variableName,
-      ] = await Promise.all([
-      loadResource({
-      id: "resourceId",
-      name: "resourceName",
-      url: "https://my-json.com/" + system?.params?.slug,
-      method: "post",
-      headers: [
-      { name: "Content-Type", value: "application/json" },
-      ],
-      body: { body: true },
-      }),
-      ])
-      return {
-      variableName,
-      } as Record<string, unknown>
+  ).toMatchInlineSnapshot(`
+"import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
+import { sitemap } from "./[sitemap.xml]";
+export const loadResources = async (_props: { system: System }) => {
+const system = _props.system
+
+    const customFetch: typeof fetch = (input, init) => {
+      if (typeof input !== "string") {
+        return fetch(input, init);
       }
-    `)
-  );
+
+      if (isLocalResource(input, "sitemap.xml")) {
+        // @todo: dynamic import sitemap ???
+        const response = new Response(JSON.stringify(sitemap));
+        response.headers.set('content-type',  'application/json; charset=utf-8');
+        return Promise.resolve(response);
+      }
+
+      return fetch(input, init);
+    };
+    const [
+variableName,
+] = await Promise.all([
+loadResource(customFetch, {
+id: "resourceId",
+name: "resourceName",
+url: "https://my-json.com/" + system?.params?.slug,
+method: "post",
+headers: [
+{ name: "Content-Type", value: "application/json" },
+],
+body: { body: true },
+}),
+])
+return {
+variableName,
+} as Record<string, unknown>
+}
+"
+`);
 });
 
 test("generate empty resources loader", () => {
@@ -197,15 +239,14 @@ test("generate empty resources loader", () => {
       dataSources: new Map(),
       resources: new Map(),
     })
-  ).toEqual(
-    clear(`
-      import { loadResource, type System } from "@webstudio-is/sdk";
-      export const loadResources = async (_props: { system: System }) => {
-      return {
-      } as Record<string, unknown>
-      }
-    `)
-  );
+  ).toMatchInlineSnapshot(`
+"import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
+export const loadResources = async (_props: { system: System }) => {
+return {
+} as Record<string, unknown>
+}
+"
+`);
 });
 
 test("prevent generating unused variables", () => {
@@ -225,7 +266,7 @@ test("prevent generating unused variables", () => {
       resources: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"import { loadResource, type System } from "@webstudio-is/sdk";
+"import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
 return {
 } as Record<string, unknown>
@@ -253,7 +294,7 @@ test("prevent generating unused system variable", () => {
       resources: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"import { loadResource, type System } from "@webstudio-is/sdk";
+"import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
 return {
 } as Record<string, unknown>

--- a/packages/sdk/src/schema/resources.ts
+++ b/packages/sdk/src/schema/resources.ts
@@ -43,3 +43,12 @@ export type ResourceRequest = z.infer<typeof ResourceRequest>;
 export const Resources = z.map(ResourceId, Resource);
 
 export type Resources = z.infer<typeof Resources>;
+
+const LOCAL_RESOURCE_PREFIX = "$resources";
+
+/**
+ * Prevents fetch cycles by prefixing local resources.
+ */
+export const isLocalResource = (pathname: string, resourceName: string) =>
+  pathname.split("/").filter(Boolean).join("/") ===
+  `${LOCAL_RESOURCE_PREFIX}/${resourceName}`;


### PR DESCRIPTION
## Description

## First Part 

Here is only new local resource `/$resources/sitemap.xml` support

It can't be implemented as route for now as we have 2 issues:
1. Cloudflare does not allow server fetches from same domain
2. Remix does not have fetch like sveltekit allowing to bypass real http roundtrip when fetching local resources

The idea is to write/use it like any route in case of anything of above will be solved.

Most PR Size is generated new fixture page.
Move SiteData into the resource.

Here is example of rendering this resource using html.

Project to play:
https://sitemap.staging.webstudio.is/builder/cab934af-8615-411a-99c1-5822a98eac74 

Published site:
https://sitemap-saas-t6j12.wstd.work/

<img width="785" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/b62af518-37bb-4daa-9f57-9145b4c77364">

## Next steps:

- Add `origin` to the system, or even better add `system.hostUrl` with origin, hostname etc
- Add xml element and hardcoded sitemap.xml page

## Steps for reproduction

1. click button
4. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
