### PR TITLE
refactor: drop background-clip workarounds

### DIFF
--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -169,11 +169,6 @@ const subscribeEphemeralStyle = (params: Params) => {
         continue;
       }
 
-      // We don't want to wrap backgroundClip into a var, because it's not supported by CSS variables
-      if (property === "backgroundClip") {
-        continue;
-      }
-
       // Variable names are equal, no need to update
       if (
         propertyValue?.type === "var" &&
@@ -371,16 +366,9 @@ export const useCssRules = ({
         deletedProperties.delete(property);
       }
 
-      // We don't want to wrap backgroundClip into a var, because it's not supported by CSS variables
-      // It's fine because we don't need to update it dynamically via CSS variables during preview changes
-      // we renrender it anyway when CSS update happens
-      if (property === "backgroundClip") {
-        rule.styleMap.set(property, value);
-      } else {
-        const varValue = toVarValue(styleSourceId, property, value);
-        if (varValue) {
-          rule.styleMap.set(property, varValue);
-        }
+      const varValue = toVarValue(styleSourceId, property, value);
+      if (varValue) {
+        rule.styleMap.set(property, varValue);
       }
     }
 

--- a/packages/css-engine/src/core/to-property.ts
+++ b/packages/css-engine/src/core/to-property.ts
@@ -2,9 +2,9 @@ import hyphenate from "hyphenate-style-name";
 import type { StyleProperty } from "../schema";
 
 export const toProperty = (property: StyleProperty) => {
-  // Currently its a non-standard property and is only officially supported via -webkit- prefix.
-  // Safari illegally supports it without the prefix.
+  // chrome started to support unprefixed background-clip in December 2023
   // https://caniuse.com/background-clip-text
+  // @todo stop prerfixed maybe one year later
   if (property === "backgroundClip") {
     return "-webkit-background-clip";
   }


### PR DESCRIPTION
Seems like unprefixed background-clip: text is supported in all browsers including chrome (since december 2023) and no longer need to have workarounds with var().

Though still left prefix in css engine to have better support for published sites.