### PR TITLE
fix: save resources on reload

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -625,7 +625,18 @@ export const VariablePopoverTrigger = forwardRef<
                       prefix={<RefreshIcon />}
                       color="ghost"
                       disabled={areResourcesLoading}
-                      onClick={() => invalidateResource(variable.resourceId)}
+                      onClick={() => {
+                        if (panelRef.current) {
+                          if (panelRef.current.allErrorsVisible === false) {
+                            panelRef.current.showAllErrors();
+                            return;
+                          }
+                          if (panelRef.current.valid) {
+                            panelRef.current.save();
+                          }
+                        }
+                        invalidateResource(variable.resourceId);
+                      }}
                     />
                   </Tooltip>
                 </>

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -559,10 +559,6 @@ export const subscribeResources = () => {
       }
     }
 
-    if (missing.size === 0) {
-      return;
-    }
-
     // preset undefined to prevent loading already requested data
     for (const request of missing.values()) {
       const cacheKey = JSON.stringify(request);


### PR DESCRIPTION
Here fixed the issue with resources not refreshed while editing and clicking on refresh button. Also fixed cached value not restored after closing resource panel.