### PR TITLE
fix: support -d argument in curl parser

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/curl.test.ts
+++ b/apps/builder/app/builder/features/settings-panel/curl.test.ts
@@ -88,6 +88,14 @@ test("support text body", () => {
     headers: [],
     body: `{"param":"value"}`,
   });
+  expect(
+    parseCurl(`curl https://my-url/hello-world -d '{"param":"value"}'`)
+  ).toEqual({
+    url: "https://my-url/hello-world",
+    method: "post",
+    headers: [],
+    body: `{"param":"value"}`,
+  });
 });
 
 test("support text body with explicit method", () => {

--- a/apps/builder/app/builder/features/settings-panel/curl.ts
+++ b/apps/builder/app/builder/features/settings-panel/curl.ts
@@ -35,6 +35,7 @@ export const parseCurl = (curl: string): undefined | CurlRequest => {
     alias: {
       X: ["request"],
       H: ["header"],
+      d: ["data"],
     },
     string: ["request", "data"],
     array: ["header", "H"],


### PR DESCRIPTION
This fixes the issue with pasting curl command with -d argument for body which I forgot to support.