### PR TITLE
chore: Only allow dragging dialog using title

### DIFF
--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -303,7 +303,6 @@ export const EditorDialog = ({
     <Dialog open={open} onOpenChange={onOpenChange} modal={false}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
-        draggable
         resize="auto"
         width={640}
         height={480}
@@ -328,12 +327,17 @@ export const EditorDialog = ({
          * to make the close button last in the tab order
          */}
         <DialogTitle
+          draggable
           suffix={
             <Flex gap="1">
               <Button
                 color="ghost"
                 prefix={isMaximized ? <MinimizeIcon /> : <MaximizeIcon />}
                 aria-label="Expand"
+                onMouseDown={(event) => {
+                  // Prevent dragging dialog
+                  event.preventDefault();
+                }}
                 onClick={() => setIsMaximized(isMaximized ? false : true)}
               />
               <DialogClose asChild>
@@ -341,6 +345,10 @@ export const EditorDialog = ({
                   color="ghost"
                   prefix={<CrossIcon />}
                   aria-label="Close"
+                  onMouseDown={(event) => {
+                    // Prevent dragging dialog
+                    event.preventDefault();
+                  }}
                 />
               </DialogClose>
             </Flex>

--- a/packages/design-system/src/components/dialog.tsx
+++ b/packages/design-system/src/components/dialog.tsx
@@ -13,6 +13,7 @@ import { floatingPanelStyle, CloseButton, TitleSlot } from "./floating-panel";
 import { Flex } from "./flex";
 import { useDisableCanvasPointerEvents } from "../utilities";
 import type { CSSProperties } from "@stitches/react";
+import { mergeRefs } from "@react-aria/utils";
 
 export const Dialog = Primitive.Root;
 export const DialogTrigger = Primitive.Trigger;
@@ -34,7 +35,6 @@ if (placeholderImage) {
 }
 
 type UseDraggableProps = {
-  isDraggable?: boolean;
   isMaximized?: boolean;
   width?: number;
   height?: number;
@@ -43,7 +43,6 @@ type UseDraggableProps = {
 };
 
 const useDraggable = ({
-  isDraggable = false,
   isMaximized = false,
   width,
   height,
@@ -56,13 +55,17 @@ const useDraggable = ({
   }>();
   const { enableCanvasPointerEvents, disableCanvasPointerEvents } =
     useDisableCanvasPointerEvents();
+  const draggableRef = useRef<HTMLElement | null>(null);
 
   const handleDragStart: DragEventHandler = (event) => {
+    const target = draggableRef.current;
+    if (target === null) {
+      return;
+    }
     disableCanvasPointerEvents();
     if (placeholderImage) {
       event.dataTransfer.setDragImage(placeholderImage, 0, 0);
     }
-    const target = event.target as HTMLElement;
     const rect = target.getBoundingClientRect();
     target.style.left = `${rect.left}px`;
     target.style.top = `${rect.top}px`;
@@ -74,10 +77,13 @@ const useDraggable = ({
   };
 
   const handleDrag: DragEventHandler = (event) => {
+    const target = draggableRef.current;
+
     if (
       event.pageX <= 0 ||
       event.pageY <= 0 ||
-      initialDataRef.current === undefined
+      initialDataRef.current === undefined ||
+      target === null
     ) {
       return;
     }
@@ -89,7 +95,6 @@ const useDraggable = ({
     let top = Math.max(rect.y - movementY, 0);
     // We want some part of the dialog to be visible but otherwise let it go off screen.
     top = Math.min(top, window.innerHeight - 40);
-    const target = event.target as HTMLElement;
     target.style.left = `${left}px`;
     target.style.top = `${top}px`;
   };
@@ -116,8 +121,8 @@ const useDraggable = ({
     onDragStart: handleDragStart,
     onDrag: handleDrag,
     onDragEnd: enableCanvasPointerEvents,
-    draggable: isDraggable,
     style,
+    draggableRef,
   };
 };
 
@@ -128,7 +133,6 @@ export const DialogContent = forwardRef(
       className,
       css,
       resize,
-      isDraggable,
       isMaximized,
       width,
       height,
@@ -142,8 +146,7 @@ export const DialogContent = forwardRef(
       },
     forwardedRef: Ref<HTMLDivElement>
   ) => {
-    const draggableProps = useDraggable({
-      isDraggable,
+    const { draggableRef, ...draggableProps } = useDraggable({
       width,
       height,
       minWidth,
@@ -154,10 +157,10 @@ export const DialogContent = forwardRef(
       <Primitive.Portal>
         <Primitive.Overlay className={overlayStyle()} />
         <Primitive.Content
-          className={contentStyle({ className, css, resize, isDraggable })}
+          className={contentStyle({ className, css, resize })}
           {...draggableProps}
           {...props}
-          ref={forwardedRef}
+          ref={mergeRefs(forwardedRef, draggableRef)}
         >
           {children}
         </Primitive.Content>
@@ -171,13 +174,14 @@ export const DialogTitle = ({
   children,
   closeLabel = "Close dialog",
   suffix,
-}: {
-  children: ReactNode;
+  ...rest
+}: ComponentProps<typeof PanelTitle> & {
   suffix?: ReactNode;
   closeLabel?: string;
 }) => (
   <TitleSlot>
     <PanelTitle
+      {...rest}
       suffix={
         suffix ?? (
           <DialogClose asChild>

--- a/packages/design-system/src/components/panel-title.tsx
+++ b/packages/design-system/src/components/panel-title.tsx
@@ -3,16 +3,19 @@
  * https://www.figma.com/file/sfCE7iLS0k25qCxiifQNLE/%F0%9F%93%9A-Webstudio-Library?node-id=2647-10046
  */
 
-import { forwardRef, type ReactNode, type Ref } from "react";
+import {
+  forwardRef,
+  type ComponentProps,
+  type ReactNode,
+  type Ref,
+} from "react";
 import { theme, styled, type CSS } from "../stitches.config";
 import { truncate } from "../utilities";
 import { textVariants } from "./text";
 import { Box } from "./box";
 
-type TitleProps = {
-  children: ReactNode;
+type TitleProps = ComponentProps<"div"> & {
   suffix?: ReactNode;
-  className?: string;
   css?: CSS;
 };
 
@@ -41,10 +44,10 @@ export const TitleSuffixSpacer = styled("div", {
 
 export const PanelTitle = forwardRef(
   (
-    { children, suffix, className, css }: TitleProps,
+    { children, suffix, className, css, ...rest }: TitleProps,
     ref: Ref<HTMLDivElement>
   ) => (
-    <Container className={className} css={css} ref={ref}>
+    <Container className={className} css={css} {...rest} ref={ref}>
       <Box css={truncate()}>{children}</Box>
       {suffix && <SuffixSlot>{suffix}</SuffixSlot>}
     </Container>


### PR DESCRIPTION
## Description

Previously it was possible to drag dialog also using content, now only using title

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
