### PR TITLE
build: Update action versions

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -10,7 +10,7 @@ runs:
     - uses: pnpm/action-setup@v3
     - uses: actions/setup-node@v4
       with:
-        node-version: "20.x"
+        node-version: 20
         cache: pnpm
     - run: pnpm install --frozen-lockfile --ignore-scripts
       shell: bash

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -7,8 +7,8 @@ runs:
   using: "composite"
 
   steps:
-    - uses: pnpm/action-setup@v2.2.4
-    - uses: actions/setup-node@v3
+    - uses: pnpm/action-setup@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: "20.x"
         cache: pnpm

--- a/.github/workflows/build-figma-tokens.yml
+++ b/.github/workflows/build-figma-tokens.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # We don't need a token to push from an action,
           # but we need it if want the commit to trigger other workflows as normal

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -71,7 +71,7 @@ jobs:
       sdk-components-react-radix: ${{ steps.deployed-url.outputs.sdk-components-react-radix }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2 # we need to fetch at least parent commit to satisfy Chromatic
           ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2 # we need to fetch at least parent commit to satisfy Chromatic
           ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit

--- a/.github/workflows/cli-r2.yaml
+++ b/.github/workflows/cli-r2.yaml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }} # HEAD commit instead of merge commit
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v3
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           cache: pnpm
@@ -81,11 +81,11 @@ jobs:
     needs: build
 
     steps:
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v3
         with:
           version: "9"
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
 

--- a/.github/workflows/cli-r2.yaml
+++ b/.github/workflows/cli-r2.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: 20
           cache: pnpm
 
       - name: pnpm instal
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: 20
 
       - name: Copy atrifact via http
         run: curl -o cloudflare-template.tar.zst ${{ secrets.ARTEFACT_BUCKET_URL }}/public/cloudflare-template/${{ github.ref_name }}.tar.zst

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -29,7 +29,7 @@ jobs:
       AUTH_SECRET: test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
 

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -21,7 +21,7 @@ jobs:
       AUTH_SECRET: test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       AUTH_SECRET: test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/ci-setup
 
       - run: pnpm -r build

--- a/.github/workflows/re-create-figma-tokens-branch.yml
+++ b/.github/workflows/re-create-figma-tokens-branch.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Re-create branch
         run: |

--- a/.github/workflows/vercel-deploy-staging.yml
+++ b/.github/workflows/vercel-deploy-staging.yml
@@ -35,12 +35,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
 
-      - uses: pnpm/action-setup@v2.2.4
-      - uses: actions/setup-node@v3
+      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           cache: pnpm

--- a/.github/workflows/vercel-deploy-staging.yml
+++ b/.github/workflows/vercel-deploy-staging.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: pnpm/action-setup@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: 20
           cache: pnpm
 
       - uses: ./.github/actions/vercel

--- a/.github/workflows/vis-reg-tests.yml
+++ b/.github/workflows/vis-reg-tests.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         #with:
         #ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
 
@@ -40,7 +40,7 @@ jobs:
       DATABASE_URL: postgres://
       AUTH_SECRET: test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         #with:
         #ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
 
@@ -55,17 +55,17 @@ jobs:
           LOST_PIXEL_CONFIG_DIR: apps/builder
           LOST_PIXEL_API_KEY: 8b76db6c-b9f0-46d1-982f-70900a02690a
   finalize:
-      needs: [builder, design-system]
-      runs-on: ubuntu-latest
+    needs: [builder, design-system]
+    runs-on: ubuntu-latest
 
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-        - name: Lost Pixel Finalize
-          uses: lost-pixel/lost-pixel@v3.16.0
-          env:
-            LOST_PIXEL_CONFIG_DIR: apps/builder
-            LOST_PIXEL_API_KEY: 8b76db6c-b9f0-46d1-982f-70900a02690a
-          with:
-            FINALIZE: true
+      - name: Lost Pixel Finalize
+        uses: lost-pixel/lost-pixel@v3.16.0
+        env:
+          LOST_PIXEL_CONFIG_DIR: apps/builder
+          LOST_PIXEL_API_KEY: 8b76db6c-b9f0-46d1-982f-70900a02690a
+        with:
+          FINALIZE: true


### PR DESCRIPTION
## Description

preview-worker-deployment
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, pnpm/action-setup@v2.2.4, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
