### PR TITLE
fix: fix style panel list item covering the border of the panel

### DIFF
--- a/packages/design-system/src/components/css-value-list-item.tsx
+++ b/packages/design-system/src/components/css-value-list-item.tsx
@@ -57,7 +57,7 @@ const ItemButton = styled("button", {
   alignItems: "center",
   justifyContent: "start",
   userSelect: "none",
-  backgroundColor: theme.colors.backgroundPanel,
+  backgroundColor: "inherit",
   padding: 0,
 
   paddingRight: sharedPaddingRight,


### PR DESCRIPTION
For some reason the box shadow border of the right panel can not render on top specifically that button when it has a background color defined, inherit solves the issue nicely but WTF.

<img width="98" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/1888ba1f-7b37-4e25-a432-d2e7a7fe39dc">

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
