### PR TITLE
fix: Remove @see @link and @deprecated from html properties descriptions

### DIFF
--- a/packages/generate-arg-types/src/arg-types.ts
+++ b/packages/generate-arg-types/src/arg-types.ts
@@ -17,6 +17,13 @@ export const propsToArgTypes = (
       .filter(([propName]) => propName.startsWith("data-ws-") === false)
       // Exclude props that are in the exclude list
       .filter(([propName]) => exclude.includes(propName) === false)
+      .map(([propName, propItem]) => {
+        // Remove @see and @deprecated from description also {@link ...} is removed as it always go after @see
+        propItem.description = propItem.description
+          .split("\n@see")[0]
+          .split("\n@deprecated")[0];
+        return [propName, propItem] as const;
+      })
       .reduce(
         (result, current) => {
           const [propName, prop] = current;

--- a/packages/sdk-components-react-radix/src/__generated__/accordion.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/accordion.props.ts
@@ -32,14 +32,14 @@ export const propsAccordion: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const propsAccordion: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const propsAccordion: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const propsAccordion: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const propsAccordion: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const propsAccordion: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const propsAccordion: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const propsAccordion: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const propsAccordion: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const propsAccordion: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const propsAccordion: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -470,7 +465,7 @@ export const propsAccordion: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -487,7 +482,7 @@ export const propsAccordion: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -511,13 +506,6 @@ export const propsAccordion: Record<string, PropMeta> = {
     type: "string",
     defaultValue: "vertical",
     options: ["horizontal", "vertical"],
-  },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
   },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
@@ -632,14 +620,14 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -647,42 +635,41 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -696,35 +683,35 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -732,7 +719,7 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -753,7 +740,7 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -767,14 +754,14 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -795,7 +782,7 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -845,7 +832,7 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -859,28 +846,27 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -913,42 +899,40 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -974,8 +958,7 @@ export const propsAccordionItem: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1062,7 +1045,7 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1079,7 +1062,7 @@ export const propsAccordionItem: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1096,13 +1079,6 @@ export const propsAccordionItem: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1216,14 +1192,14 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1231,42 +1207,41 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1280,35 +1255,35 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1316,7 +1291,7 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1337,7 +1312,7 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1351,14 +1326,14 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -1379,7 +1354,7 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1429,7 +1404,7 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -1443,28 +1418,27 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -1497,42 +1471,40 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -1558,8 +1530,7 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1639,7 +1610,7 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1656,7 +1627,7 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1673,13 +1644,6 @@ export const propsAccordionHeader: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1786,14 +1750,14 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1801,42 +1765,41 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1850,35 +1813,35 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1886,7 +1849,7 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1907,7 +1870,7 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1921,14 +1884,14 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -1949,7 +1912,7 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1999,7 +1962,7 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -2013,28 +1976,27 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -2067,42 +2029,40 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -2128,8 +2088,7 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -2256,7 +2215,7 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -2273,7 +2232,7 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -2297,13 +2256,6 @@ export const propsAccordionTrigger: Record<string, PropMeta> = {
       "This name is important when submitting form data to the server, as it identifies the data associated with the input. When multiple inputs share the same name attribute, they are treated as part of the same group (e.g., radio buttons or checkboxes).",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -2417,14 +2369,14 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -2432,42 +2384,41 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2481,35 +2432,35 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -2517,7 +2468,7 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -2538,7 +2489,7 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -2552,14 +2503,14 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -2580,7 +2531,7 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2630,7 +2581,7 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -2644,28 +2595,27 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -2698,42 +2648,40 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -2759,8 +2707,7 @@ export const propsAccordionContent: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -2840,7 +2787,7 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -2857,7 +2804,7 @@ export const propsAccordionContent: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -2874,13 +2821,6 @@ export const propsAccordionContent: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/__generated__/checkbox.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/checkbox.props.ts
@@ -32,14 +32,14 @@ export const propsCheckbox: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const propsCheckbox: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const propsCheckbox: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const propsCheckbox: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const propsCheckbox: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const propsCheckbox: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const propsCheckbox: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const propsCheckbox: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const propsCheckbox: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const propsCheckbox: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const propsCheckbox: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -509,7 +504,7 @@ export const propsCheckbox: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -526,7 +521,7 @@ export const propsCheckbox: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -550,13 +545,6 @@ export const propsCheckbox: Record<string, PropMeta> = {
       "This name is important when submitting form data to the server, as it identifies the data associated with the input. When multiple inputs share the same name attribute, they are treated as part of the same group (e.g., radio buttons or checkboxes).",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -677,14 +665,14 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -692,42 +680,41 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -741,35 +728,35 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -777,7 +764,7 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -798,7 +785,7 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -812,14 +799,14 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -840,7 +827,7 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -890,7 +877,7 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -904,28 +891,27 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -958,42 +944,40 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -1019,8 +1003,7 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1100,7 +1083,7 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1117,7 +1100,7 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1134,13 +1117,6 @@ export const propsCheckboxIndicator: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/__generated__/collapsible.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/collapsible.props.ts
@@ -32,14 +32,14 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const propsCollapsible: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const propsCollapsible: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -461,7 +456,7 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -478,7 +473,7 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -501,13 +496,6 @@ export const propsCollapsible: Record<string, PropMeta> = {
     type: "boolean",
     description:
       "Show or hide the content of this component on the canvas. This will not affect the initial state of the component.",
-  },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
   },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
@@ -616,14 +604,14 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -631,42 +619,41 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -680,35 +667,35 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -716,7 +703,7 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -737,7 +724,7 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -751,14 +738,14 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -779,7 +766,7 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -829,7 +816,7 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -843,28 +830,27 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -897,42 +883,40 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -958,8 +942,7 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1039,7 +1022,7 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1056,7 +1039,7 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1073,13 +1056,6 @@ export const propsCollapsibleContent: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.props.ts
@@ -42,14 +42,14 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -57,42 +57,41 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -106,35 +105,35 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -142,7 +141,7 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -163,7 +162,7 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -177,14 +176,14 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -205,7 +204,7 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -255,7 +254,7 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -269,28 +268,27 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -323,42 +321,40 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -384,8 +380,7 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -465,7 +460,7 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -482,7 +477,7 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -499,13 +494,6 @@ export const propsDialogOverlay: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -612,14 +600,14 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -627,42 +615,41 @@ export const propsDialogContent: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -676,35 +663,35 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -712,7 +699,7 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -733,7 +720,7 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -747,14 +734,14 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -775,7 +762,7 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -825,7 +812,7 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -839,28 +826,27 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -893,42 +879,40 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -954,8 +938,7 @@ export const propsDialogContent: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1035,7 +1018,7 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1052,7 +1035,7 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1069,13 +1052,6 @@ export const propsDialogContent: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1182,14 +1158,14 @@ export const propsDialogClose: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1197,42 +1173,41 @@ export const propsDialogClose: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1246,35 +1221,35 @@ export const propsDialogClose: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1282,7 +1257,7 @@ export const propsDialogClose: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1303,7 +1278,7 @@ export const propsDialogClose: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1317,14 +1292,14 @@ export const propsDialogClose: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -1345,7 +1320,7 @@ export const propsDialogClose: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1395,7 +1370,7 @@ export const propsDialogClose: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -1409,28 +1384,27 @@ export const propsDialogClose: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -1463,42 +1437,40 @@ export const propsDialogClose: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -1524,8 +1496,7 @@ export const propsDialogClose: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1652,7 +1623,7 @@ export const propsDialogClose: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1669,7 +1640,7 @@ export const propsDialogClose: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1693,13 +1664,6 @@ export const propsDialogClose: Record<string, PropMeta> = {
       "This name is important when submitting form data to the server, as it identifies the data associated with the input. When multiple inputs share the same name attribute, they are treated as part of the same group (e.g., radio buttons or checkboxes).",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1813,14 +1777,14 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1828,42 +1792,41 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1877,35 +1840,35 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1913,7 +1876,7 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1934,7 +1897,7 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1948,14 +1911,14 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -1976,7 +1939,7 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2026,7 +1989,7 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -2040,28 +2003,27 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -2094,42 +2056,40 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -2155,8 +2115,7 @@ export const propsDialogTitle: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -2236,7 +2195,7 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -2253,7 +2212,7 @@ export const propsDialogTitle: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -2270,13 +2229,6 @@ export const propsDialogTitle: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -2331,7 +2283,6 @@ export const propsDialogTitle: Record<string, PropMeta> = {
     required: false,
     control: "select",
     type: "string",
-    defaultValue: "h1",
     options: ["h2", "h3", "h1", "h4", "h5", "h6"],
   },
   title: {
@@ -2390,14 +2341,14 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -2405,42 +2356,41 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2454,35 +2404,35 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -2490,7 +2440,7 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -2511,7 +2461,7 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -2525,14 +2475,14 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -2553,7 +2503,7 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2603,7 +2553,7 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -2617,28 +2567,27 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -2671,42 +2620,40 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -2732,8 +2679,7 @@ export const propsDialogDescription: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -2813,7 +2759,7 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -2830,7 +2776,7 @@ export const propsDialogDescription: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -2847,13 +2793,6 @@ export const propsDialogDescription: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/__generated__/label.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/label.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -468,7 +463,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -485,7 +480,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -502,13 +497,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/__generated__/navigation-menu.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/navigation-menu.props.ts
@@ -32,14 +32,14 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -237,7 +236,7 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -251,28 +250,27 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -305,42 +303,40 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -366,8 +362,7 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -455,7 +450,7 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -472,7 +467,7 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -489,13 +484,6 @@ export const propsNavigationMenu: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -616,14 +604,14 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -631,42 +619,41 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -680,35 +667,35 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -716,7 +703,7 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -737,7 +724,7 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -751,14 +738,14 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -779,7 +766,7 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -829,7 +816,7 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -843,28 +830,27 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -897,42 +883,40 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -958,8 +942,7 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1039,7 +1022,7 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1056,7 +1039,7 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1073,13 +1056,6 @@ export const propsNavigationMenuList: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1186,14 +1162,14 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1201,42 +1177,41 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1250,35 +1225,35 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1286,7 +1261,7 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1307,7 +1282,7 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1321,14 +1296,14 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -1349,7 +1324,7 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1399,7 +1374,7 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -1413,28 +1388,27 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -1467,42 +1441,40 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -1528,8 +1500,7 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1609,7 +1580,7 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1626,7 +1597,7 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1643,13 +1614,6 @@ export const propsNavigationMenuViewport: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1756,14 +1720,14 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1771,42 +1735,41 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1820,35 +1783,35 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1856,7 +1819,7 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1877,7 +1840,7 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1891,14 +1854,14 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -1919,7 +1882,7 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1969,7 +1932,7 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -1983,28 +1946,27 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -2037,42 +1999,40 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -2098,8 +2058,7 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -2186,7 +2145,7 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -2203,7 +2162,7 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -2220,13 +2179,6 @@ export const propsNavigationMenuContent: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -2333,14 +2285,14 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -2348,42 +2300,41 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2397,35 +2348,35 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -2433,7 +2384,7 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -2454,7 +2405,7 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -2468,14 +2419,14 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -2496,7 +2447,7 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2546,7 +2497,7 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -2560,28 +2511,27 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -2614,42 +2564,40 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -2675,8 +2623,7 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -2756,7 +2703,7 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -2773,7 +2720,7 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -2790,13 +2737,6 @@ export const propsNavigationMenuItem: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/__generated__/popover.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.props.ts
@@ -57,14 +57,14 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -72,42 +72,41 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -121,35 +120,35 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -157,7 +156,7 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -178,7 +177,7 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -192,14 +191,14 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -220,7 +219,7 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -270,7 +269,7 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -284,28 +283,27 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -338,42 +336,40 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -399,8 +395,7 @@ export const propsPopoverContent: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -488,7 +483,7 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -505,7 +500,7 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -522,13 +517,6 @@ export const propsPopoverContent: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -621,6 +609,12 @@ export const propsPopoverContent: Record<string, PropMeta> = {
     control: "radio",
     type: "string",
     options: ["on", "off"],
+  },
+  updatePositionStrategy: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["always", "optimized"],
   },
   vocab: { required: false, control: "text", type: "string" },
 };

--- a/packages/sdk-components-react-radix/src/__generated__/radio-group.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/radio-group.props.ts
@@ -32,14 +32,14 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const propsRadioGroup: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -462,7 +457,7 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -479,7 +474,7 @@ export const propsRadioGroup: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -515,13 +510,6 @@ export const propsRadioGroup: Record<string, PropMeta> = {
     control: "radio",
     type: "string",
     options: ["horizontal", "vertical"],
-  },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
   },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
@@ -643,14 +631,14 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -658,42 +646,41 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -707,35 +694,35 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -743,7 +730,7 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -764,7 +751,7 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -778,14 +765,14 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -806,7 +793,7 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -856,7 +843,7 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -870,28 +857,27 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -924,42 +910,40 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -985,8 +969,7 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1120,7 +1103,7 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1137,7 +1120,7 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1154,13 +1137,6 @@ export const propsRadioGroupItem: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1288,14 +1264,14 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1303,42 +1279,41 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1352,35 +1327,35 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1388,7 +1363,7 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1409,7 +1384,7 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1423,14 +1398,14 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -1451,7 +1426,7 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1501,7 +1476,7 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -1515,28 +1490,27 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -1569,42 +1543,40 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -1630,8 +1602,7 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1711,7 +1682,7 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1728,7 +1699,7 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1745,13 +1716,6 @@ export const propsRadioGroupIndicator: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/__generated__/select.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/select.props.ts
@@ -83,14 +83,14 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -98,42 +98,41 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -147,35 +146,35 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -183,7 +182,7 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -204,7 +203,7 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -218,14 +217,14 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -246,7 +245,7 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -296,7 +295,7 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -310,28 +309,27 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -364,42 +362,40 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -425,8 +421,7 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -553,7 +548,7 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -570,7 +565,7 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -594,13 +589,6 @@ export const propsSelectTrigger: Record<string, PropMeta> = {
       "This name is important when submitting form data to the server, as it identifies the data associated with the input. When multiple inputs share the same name attribute, they are treated as part of the same group (e.g., radio buttons or checkboxes).",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -714,14 +702,14 @@ export const propsSelectValue: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -729,42 +717,41 @@ export const propsSelectValue: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -778,35 +765,35 @@ export const propsSelectValue: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -814,7 +801,7 @@ export const propsSelectValue: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -835,7 +822,7 @@ export const propsSelectValue: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -849,14 +836,14 @@ export const propsSelectValue: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -877,7 +864,7 @@ export const propsSelectValue: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -927,7 +914,7 @@ export const propsSelectValue: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -941,28 +928,27 @@ export const propsSelectValue: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -995,42 +981,40 @@ export const propsSelectValue: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -1056,8 +1040,7 @@ export const propsSelectValue: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1137,7 +1120,7 @@ export const propsSelectValue: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1154,7 +1137,7 @@ export const propsSelectValue: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1292,14 +1275,14 @@ export const propsSelectContent: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1307,42 +1290,41 @@ export const propsSelectContent: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1356,35 +1338,35 @@ export const propsSelectContent: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1392,7 +1374,7 @@ export const propsSelectContent: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1413,7 +1395,7 @@ export const propsSelectContent: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1427,14 +1409,14 @@ export const propsSelectContent: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -1455,7 +1437,7 @@ export const propsSelectContent: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1505,7 +1487,7 @@ export const propsSelectContent: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -1519,28 +1501,27 @@ export const propsSelectContent: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -1573,42 +1554,40 @@ export const propsSelectContent: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -1634,8 +1613,7 @@ export const propsSelectContent: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1718,7 +1696,7 @@ export const propsSelectContent: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1735,7 +1713,7 @@ export const propsSelectContent: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1752,13 +1730,6 @@ export const propsSelectContent: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1838,6 +1809,12 @@ export const propsSelectContent: Record<string, PropMeta> = {
     type: "string",
     options: ["on", "off"],
   },
+  updatePositionStrategy: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["always", "optimized"],
+  },
   vocab: { required: false, control: "text", type: "string" },
 };
 export const propsSelectViewport: Record<string, PropMeta> = {
@@ -1872,14 +1849,14 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1887,42 +1864,41 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1936,35 +1912,35 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1972,7 +1948,7 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1993,7 +1969,7 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -2007,14 +1983,14 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -2035,7 +2011,7 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2085,7 +2061,7 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -2099,28 +2075,27 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -2153,42 +2128,40 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -2214,8 +2187,7 @@ export const propsSelectViewport: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -2295,7 +2267,7 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -2312,7 +2284,7 @@ export const propsSelectViewport: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -2329,13 +2301,6 @@ export const propsSelectViewport: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -2442,14 +2407,14 @@ export const propsSelectItem: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -2457,42 +2422,41 @@ export const propsSelectItem: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2506,35 +2470,35 @@ export const propsSelectItem: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -2542,7 +2506,7 @@ export const propsSelectItem: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -2563,7 +2527,7 @@ export const propsSelectItem: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -2577,14 +2541,14 @@ export const propsSelectItem: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -2605,7 +2569,7 @@ export const propsSelectItem: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2655,7 +2619,7 @@ export const propsSelectItem: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -2669,28 +2633,27 @@ export const propsSelectItem: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -2723,42 +2686,40 @@ export const propsSelectItem: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -2784,8 +2745,7 @@ export const propsSelectItem: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -2871,7 +2831,7 @@ export const propsSelectItem: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -2888,7 +2848,7 @@ export const propsSelectItem: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -2905,13 +2865,6 @@ export const propsSelectItem: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -3026,14 +2979,14 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -3041,42 +2994,41 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -3090,35 +3042,35 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -3126,7 +3078,7 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -3147,7 +3099,7 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -3161,14 +3113,14 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -3189,7 +3141,7 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -3239,7 +3191,7 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -3253,28 +3205,27 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -3307,42 +3258,40 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -3368,8 +3317,7 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -3449,7 +3397,7 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -3466,7 +3414,7 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -3483,13 +3431,6 @@ export const propsSelectItemIndicator: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -3596,14 +3537,14 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -3611,42 +3552,41 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -3660,35 +3600,35 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -3696,7 +3636,7 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -3717,7 +3657,7 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -3731,14 +3671,14 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -3759,7 +3699,7 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -3809,7 +3749,7 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -3823,28 +3763,27 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -3877,42 +3816,40 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -3938,8 +3875,7 @@ export const propsSelectItemText: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -4019,7 +3955,7 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -4036,7 +3972,7 @@ export const propsSelectItemText: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -4053,13 +3989,6 @@ export const propsSelectItemText: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.props.ts
@@ -42,14 +42,14 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -57,42 +57,41 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -106,35 +105,35 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -142,7 +141,7 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -163,7 +162,7 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -177,14 +176,14 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -205,7 +204,7 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -255,7 +254,7 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -269,28 +268,27 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -323,42 +321,40 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -384,8 +380,7 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -465,7 +460,7 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -482,7 +477,7 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -499,13 +494,6 @@ export const propsSheetOverlay: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -613,14 +601,14 @@ export const propsSheetClose: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -628,42 +616,41 @@ export const propsSheetClose: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -677,35 +664,35 @@ export const propsSheetClose: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -713,7 +700,7 @@ export const propsSheetClose: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -734,7 +721,7 @@ export const propsSheetClose: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -748,14 +735,14 @@ export const propsSheetClose: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -776,7 +763,7 @@ export const propsSheetClose: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -826,7 +813,7 @@ export const propsSheetClose: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -840,28 +827,27 @@ export const propsSheetClose: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -894,42 +880,40 @@ export const propsSheetClose: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -955,8 +939,7 @@ export const propsSheetClose: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1083,7 +1066,7 @@ export const propsSheetClose: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1100,7 +1083,7 @@ export const propsSheetClose: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1124,13 +1107,6 @@ export const propsSheetClose: Record<string, PropMeta> = {
       "This name is important when submitting form data to the server, as it identifies the data associated with the input. When multiple inputs share the same name attribute, they are treated as part of the same group (e.g., radio buttons or checkboxes).",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1245,14 +1221,14 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1260,42 +1236,41 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1309,35 +1284,35 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1345,7 +1320,7 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1366,7 +1341,7 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1380,14 +1355,14 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -1408,7 +1383,7 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1458,7 +1433,7 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -1472,28 +1447,27 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -1526,42 +1500,40 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -1587,8 +1559,7 @@ export const propsSheetTitle: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1668,7 +1639,7 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1685,7 +1656,7 @@ export const propsSheetTitle: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1702,13 +1673,6 @@ export const propsSheetTitle: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1823,14 +1787,14 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1838,42 +1802,41 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1887,35 +1850,35 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1923,7 +1886,7 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1944,7 +1907,7 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1958,14 +1921,14 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -1986,7 +1949,7 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2036,7 +1999,7 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -2050,28 +2013,27 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -2104,42 +2066,40 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -2165,8 +2125,7 @@ export const propsSheetDescription: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -2246,7 +2205,7 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -2263,7 +2222,7 @@ export const propsSheetDescription: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -2280,13 +2239,6 @@ export const propsSheetDescription: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -2394,14 +2346,14 @@ export const propsSheetContent: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -2409,42 +2361,41 @@ export const propsSheetContent: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2458,35 +2409,35 @@ export const propsSheetContent: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -2494,7 +2445,7 @@ export const propsSheetContent: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -2515,7 +2466,7 @@ export const propsSheetContent: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -2529,14 +2480,14 @@ export const propsSheetContent: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -2557,7 +2508,7 @@ export const propsSheetContent: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2607,7 +2558,7 @@ export const propsSheetContent: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -2621,28 +2572,27 @@ export const propsSheetContent: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -2675,42 +2625,40 @@ export const propsSheetContent: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -2736,8 +2684,7 @@ export const propsSheetContent: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -2817,7 +2764,7 @@ export const propsSheetContent: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -2834,7 +2781,7 @@ export const propsSheetContent: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -2851,13 +2798,6 @@ export const propsSheetContent: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/__generated__/switch.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/switch.props.ts
@@ -32,14 +32,14 @@ export const propsSwitch: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const propsSwitch: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const propsSwitch: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const propsSwitch: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const propsSwitch: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const propsSwitch: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const propsSwitch: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const propsSwitch: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const propsSwitch: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const propsSwitch: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const propsSwitch: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -509,7 +504,7 @@ export const propsSwitch: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -526,7 +521,7 @@ export const propsSwitch: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -550,13 +545,6 @@ export const propsSwitch: Record<string, PropMeta> = {
       "This name is important when submitting form data to the server, as it identifies the data associated with the input. When multiple inputs share the same name attribute, they are treated as part of the same group (e.g., radio buttons or checkboxes).",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -677,14 +665,14 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -692,42 +680,41 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -741,35 +728,35 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -777,7 +764,7 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -798,7 +785,7 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -812,14 +799,14 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -840,7 +827,7 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -890,7 +877,7 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -904,28 +891,27 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -958,42 +944,40 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -1019,8 +1003,7 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1100,7 +1083,7 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1117,7 +1100,7 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1134,13 +1117,6 @@ export const propsSwitchThumb: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/__generated__/tabs.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/tabs.props.ts
@@ -40,14 +40,14 @@ export const propsTabs: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -55,42 +55,41 @@ export const propsTabs: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -104,35 +103,35 @@ export const propsTabs: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -140,7 +139,7 @@ export const propsTabs: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -161,7 +160,7 @@ export const propsTabs: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -175,14 +174,14 @@ export const propsTabs: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -203,7 +202,7 @@ export const propsTabs: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -253,7 +252,7 @@ export const propsTabs: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -267,28 +266,27 @@ export const propsTabs: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -321,42 +319,40 @@ export const propsTabs: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -382,8 +378,7 @@ export const propsTabs: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -463,7 +458,7 @@ export const propsTabs: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -480,7 +475,7 @@ export const propsTabs: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -504,13 +499,6 @@ export const propsTabs: Record<string, PropMeta> = {
     control: "radio",
     type: "string",
     options: ["horizontal", "vertical"],
-  },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
   },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
@@ -624,14 +612,14 @@ export const propsTabsList: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -639,42 +627,41 @@ export const propsTabsList: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -688,35 +675,35 @@ export const propsTabsList: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -724,7 +711,7 @@ export const propsTabsList: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -745,7 +732,7 @@ export const propsTabsList: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -759,14 +746,14 @@ export const propsTabsList: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -787,7 +774,7 @@ export const propsTabsList: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -837,7 +824,7 @@ export const propsTabsList: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -851,28 +838,27 @@ export const propsTabsList: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -905,42 +891,40 @@ export const propsTabsList: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -966,8 +950,7 @@ export const propsTabsList: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1047,7 +1030,7 @@ export const propsTabsList: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1064,7 +1047,7 @@ export const propsTabsList: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1088,13 +1071,6 @@ export const propsTabsList: Record<string, PropMeta> = {
       "Indicates whether the media should start playing from the start when it's finished.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1201,14 +1177,14 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1216,42 +1192,41 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1265,35 +1240,35 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1301,7 +1276,7 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1322,7 +1297,7 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1336,14 +1311,14 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -1364,7 +1339,7 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1414,7 +1389,7 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -1428,28 +1403,27 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -1482,42 +1456,40 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -1543,8 +1515,7 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -1671,7 +1642,7 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -1688,7 +1659,7 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -1712,13 +1683,6 @@ export const propsTabsTrigger: Record<string, PropMeta> = {
       "This name is important when submitting form data to the server, as it identifies the data associated with the input. When multiple inputs share the same name attribute, they are treated as part of the same group (e.g., radio buttons or checkboxes).",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -1839,14 +1803,14 @@ export const propsTabsContent: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -1854,42 +1818,41 @@ export const propsTabsContent: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -1903,35 +1866,35 @@ export const propsTabsContent: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -1939,7 +1902,7 @@ export const propsTabsContent: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -1960,7 +1923,7 @@ export const propsTabsContent: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -1974,14 +1937,14 @@ export const propsTabsContent: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -2002,7 +1965,7 @@ export const propsTabsContent: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -2052,7 +2015,7 @@ export const propsTabsContent: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -2066,28 +2029,27 @@ export const propsTabsContent: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -2120,42 +2082,40 @@ export const propsTabsContent: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -2181,8 +2141,7 @@ export const propsTabsContent: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -2262,7 +2221,7 @@ export const propsTabsContent: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -2279,7 +2238,7 @@ export const propsTabsContent: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -2296,13 +2255,6 @@ export const propsTabsContent: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.props.ts
@@ -70,14 +70,14 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -85,42 +85,41 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -134,35 +133,35 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -170,7 +169,7 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -191,7 +190,7 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -205,14 +204,14 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -233,7 +232,7 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -283,7 +282,7 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -297,28 +296,27 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -351,42 +349,40 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -412,8 +408,7 @@ export const propsTooltipContent: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -501,7 +496,7 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -518,7 +513,7 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -535,13 +530,6 @@ export const propsTooltipContent: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
@@ -634,6 +622,12 @@ export const propsTooltipContent: Record<string, PropMeta> = {
     control: "radio",
     type: "string",
     options: ["on", "off"],
+  },
+  updatePositionStrategy: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["always", "optimized"],
   },
   vocab: { required: false, control: "text", type: "string" },
 };

--- a/packages/sdk-components-react-remix/src/__generated__/body.props.ts
+++ b/packages/sdk-components-react-remix/src/__generated__/body.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see {@link https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute}",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see {@link https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is}",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",

--- a/packages/sdk-components-react-remix/src/__generated__/link.props.ts
+++ b/packages/sdk-components-react-remix/src/__generated__/link.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -468,7 +463,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see {@link https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute}",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -485,7 +480,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see {@link https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is}",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",

--- a/packages/sdk-components-react-remix/src/__generated__/remix-form.props.ts
+++ b/packages/sdk-components-react-remix/src/__generated__/remix-form.props.ts
@@ -45,14 +45,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -60,42 +60,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -109,35 +108,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -145,7 +144,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -166,7 +165,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -180,14 +179,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -208,7 +207,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -258,7 +257,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -272,28 +271,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -326,42 +324,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -387,8 +383,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -488,7 +483,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see {@link https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute}",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -505,7 +500,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see {@link https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is}",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",

--- a/packages/sdk-components-react-remix/src/__generated__/rich-text-link.props.ts
+++ b/packages/sdk-components-react-remix/src/__generated__/rich-text-link.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -468,7 +463,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see {@link https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute}",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -485,7 +480,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see {@link https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is}",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",

--- a/packages/sdk-components-react-remix/src/__generated__/webhook-form.props.ts
+++ b/packages/sdk-components-react-remix/src/__generated__/webhook-form.props.ts
@@ -45,14 +45,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -60,42 +60,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -109,35 +108,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -145,7 +144,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -166,7 +165,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -180,14 +179,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -208,7 +207,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -258,7 +257,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -272,28 +271,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -326,42 +324,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -387,8 +383,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -488,7 +483,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see {@link https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute}",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -505,7 +500,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see {@link https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is}",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",

--- a/packages/sdk-components-react/src/__generated__/blockquote.props.ts
+++ b/packages/sdk-components-react/src/__generated__/blockquote.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -463,7 +458,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -480,7 +475,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -497,13 +492,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/body.props.ts
+++ b/packages/sdk-components-react/src/__generated__/body.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/bold.props.ts
+++ b/packages/sdk-components-react/src/__generated__/bold.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/box.props.ts
+++ b/packages/sdk-components-react/src/__generated__/box.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/button.props.ts
+++ b/packages/sdk-components-react/src/__generated__/button.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -503,7 +498,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -520,7 +515,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -544,13 +539,6 @@ export const props: Record<string, PropMeta> = {
       "This name is important when submitting form data to the server, as it identifies the data associated with the input. When multiple inputs share the same name attribute, they are treated as part of the same group (e.g., radio buttons or checkboxes).",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/checkbox.props.ts
+++ b/packages/sdk-components-react/src/__generated__/checkbox.props.ts
@@ -45,14 +45,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -60,42 +60,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -109,35 +108,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -145,7 +144,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -166,7 +165,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -180,14 +179,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -208,7 +207,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -258,7 +257,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -272,28 +271,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -326,42 +324,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -387,8 +383,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -406,13 +401,6 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     description:
       "Sets whether input is automatically capitalized when entered by user.",
-  },
-  autoComplete: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Indicates whether controls in this form can by default have their valuesautomatically completed by the browser.",
   },
   autoCorrect: { required: false, control: "text", type: "string" },
   autoFocus: {
@@ -544,24 +532,24 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
     options: [
       "search",
       "text",
-      "none",
-      "tel",
-      "url",
       "email",
+      "tel",
+      "none",
+      "url",
       "numeric",
       "decimal",
     ],
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -736,7 +724,7 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "radio",
     type: "string",
-    options: ["on", "off"],
+    options: ["off", "on"],
   },
   value: {
     required: false,

--- a/packages/sdk-components-react/src/__generated__/code-text.props.ts
+++ b/packages/sdk-components-react/src/__generated__/code-text.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/form.props.ts
+++ b/packages/sdk-components-react/src/__generated__/form.props.ts
@@ -45,14 +45,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -60,42 +60,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -109,35 +108,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -145,7 +144,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -166,7 +165,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -180,14 +179,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -208,7 +207,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -258,7 +257,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -272,28 +271,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -326,42 +324,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -387,8 +383,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -483,7 +478,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -500,7 +495,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -537,13 +532,6 @@ export const props: Record<string, PropMeta> = {
     type: "boolean",
     description:
       "This attribute indicates that the form shouldn't be validated when submitted.",
-  },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
   },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/heading.props.ts
+++ b/packages/sdk-components-react/src/__generated__/heading.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/image.props.ts
+++ b/packages/sdk-components-react/src/__generated__/image.props.ts
@@ -39,14 +39,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -54,42 +54,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -103,35 +102,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -139,7 +138,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -160,7 +159,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -174,14 +173,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -202,7 +201,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -252,7 +251,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -266,28 +265,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -320,42 +318,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -381,8 +377,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -461,6 +456,12 @@ export const props: Record<string, PropMeta> = {
     type: "boolean",
     description: "Defines whether the element can be dragged.",
   },
+  fetchPriority: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["high", "low", "auto"],
+  },
   height: {
     required: false,
     control: "number",
@@ -483,7 +484,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -500,7 +501,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -527,13 +528,6 @@ export const props: Record<string, PropMeta> = {
   },
   nonce: { required: false, control: "text", type: "string" },
   optimize: { required: false, control: "boolean", type: "boolean" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   quality: { required: false, control: "number", type: "number" },
@@ -544,9 +538,9 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: [
       "",
+      "origin",
       "no-referrer",
       "no-referrer-when-downgrade",
-      "origin",
       "origin-when-cross-origin",
       "same-origin",
       "strict-origin",

--- a/packages/sdk-components-react/src/__generated__/input.props.ts
+++ b/packages/sdk-components-react/src/__generated__/input.props.ts
@@ -45,14 +45,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -60,42 +60,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -109,35 +108,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -145,7 +144,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -166,7 +165,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -180,14 +179,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -208,7 +207,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -258,7 +257,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -272,28 +271,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -326,42 +324,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -387,8 +383,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -406,13 +401,6 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     description:
       "Sets whether input is automatically capitalized when entered by user.",
-  },
-  autoComplete: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Indicates whether controls in this form can by default have their valuesautomatically completed by the browser.",
   },
   autoCorrect: { required: false, control: "text", type: "string" },
   autoFocus: {
@@ -544,7 +532,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -561,7 +549,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -761,7 +749,7 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "radio",
     type: "string",
-    options: ["on", "off"],
+    options: ["off", "on"],
   },
   vocab: { required: false, control: "text", type: "string" },
   width: {

--- a/packages/sdk-components-react/src/__generated__/italic.props.ts
+++ b/packages/sdk-components-react/src/__generated__/italic.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/label.props.ts
+++ b/packages/sdk-components-react/src/__generated__/label.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -469,7 +464,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -486,7 +481,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -503,13 +498,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/link.props.ts
+++ b/packages/sdk-components-react/src/__generated__/link.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -468,7 +463,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -485,7 +480,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -515,13 +510,6 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     description:
       "The ping attribute specifies a space-separated list of URLs to be notified if a user follows the hyperlink.",
-  },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
   },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/list-item.props.ts
+++ b/packages/sdk-components-react/src/__generated__/list-item.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/list.props.ts
+++ b/packages/sdk-components-react/src/__generated__/list.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -497,13 +492,6 @@ export const props: Record<string, PropMeta> = {
     control: "boolean",
     type: "boolean",
     defaultValue: false,
-  },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
   },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/paragraph.props.ts
+++ b/packages/sdk-components-react/src/__generated__/paragraph.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/radio-button.props.ts
+++ b/packages/sdk-components-react/src/__generated__/radio-button.props.ts
@@ -45,14 +45,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -60,42 +60,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -109,35 +108,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -145,7 +144,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -166,7 +165,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -180,14 +179,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -208,7 +207,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -258,7 +257,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -272,28 +271,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -326,42 +324,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -387,8 +383,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -406,13 +401,6 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     description:
       "Sets whether input is automatically capitalized when entered by user.",
-  },
-  autoComplete: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Indicates whether controls in this form can by default have their valuesautomatically completed by the browser.",
   },
   autoCorrect: { required: false, control: "text", type: "string" },
   autoFocus: {
@@ -544,24 +532,24 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
     options: [
       "search",
       "text",
-      "none",
-      "tel",
-      "url",
       "email",
+      "tel",
+      "none",
+      "url",
       "numeric",
       "decimal",
     ],
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -736,7 +724,7 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "radio",
     type: "string",
-    options: ["on", "off"],
+    options: ["off", "on"],
   },
   value: {
     required: false,

--- a/packages/sdk-components-react/src/__generated__/rich-text-link.props.ts
+++ b/packages/sdk-components-react/src/__generated__/rich-text-link.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -468,7 +463,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -485,7 +480,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -515,13 +510,6 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     description:
       "The ping attribute specifies a space-separated list of URLs to be notified if a user follows the hyperlink.",
-  },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
   },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/separator.props.ts
+++ b/packages/sdk-components-react/src/__generated__/separator.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/span.props.ts
+++ b/packages/sdk-components-react/src/__generated__/span.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/subscript.props.ts
+++ b/packages/sdk-components-react/src/__generated__/subscript.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/superscript.props.ts
+++ b/packages/sdk-components-react/src/__generated__/superscript.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/text.props.ts
+++ b/packages/sdk-components-react/src/__generated__/text.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/textarea.props.ts
+++ b/packages/sdk-components-react/src/__generated__/textarea.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -482,7 +477,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -499,7 +494,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",

--- a/packages/sdk-components-react/src/__generated__/vimeo-play-button.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo-play-button.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -503,7 +498,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -520,7 +515,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -544,13 +539,6 @@ export const props: Record<string, PropMeta> = {
       "This name is important when submitting form data to the server, as it identifies the data associated with the input. When multiple inputs share the same name attribute, they are treated as part of the same group (e.g., radio buttons or checkboxes).",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/vimeo-preview-image.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo-preview-image.props.ts
@@ -39,14 +39,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -54,42 +54,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -103,35 +102,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -139,7 +138,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -160,7 +159,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -174,14 +173,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -202,7 +201,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -252,7 +251,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -266,28 +265,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -320,42 +318,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -381,8 +377,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -461,6 +456,12 @@ export const props: Record<string, PropMeta> = {
     type: "boolean",
     description: "Defines whether the element can be dragged.",
   },
+  fetchPriority: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["high", "low", "auto"],
+  },
   height: {
     required: false,
     control: "number",
@@ -483,7 +484,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -500,7 +501,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -526,13 +527,6 @@ export const props: Record<string, PropMeta> = {
   },
   nonce: { required: false, control: "text", type: "string" },
   optimize: { required: false, control: "boolean", type: "boolean" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   quality: { required: false, control: "number", type: "number" },
@@ -543,9 +537,9 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: [
       "",
+      "origin",
       "no-referrer",
       "no-referrer-when-downgrade",
-      "origin",
       "origin-when-cross-origin",
       "same-origin",
       "strict-origin",

--- a/packages/sdk-components-react/src/__generated__/vimeo-spinner.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo-spinner.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -456,7 +451,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -473,7 +468,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -490,13 +485,6 @@ export const props: Record<string, PropMeta> = {
     description: "Defines the language used in the element.",
   },
   nonce: { required: false, control: "text", type: "string" },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react/src/__generated__/vimeo.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo.props.ts
@@ -32,14 +32,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-braillelabel": {
     description:
-      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-brailleroledescription": {
     description:
-      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.",
     required: false,
     control: "text",
     type: "string",
@@ -47,42 +47,41 @@ export const props: Record<string, PropMeta> = {
   "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
-      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colcount": {
     description:
-      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+      "Defines the total number of columns in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindex": {
     description:
-      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-colindextext": {
-    description:
-      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    description: "Defines a human readable text alternative of aria-colindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-colspan": {
     description:
-      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-controls": {
     description:
-      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -96,35 +95,35 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-describedby": {
     description:
-      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+      "Identifies the element (or elements) that describes the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-description": {
     description:
-      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+      "Defines a string value that describes or annotates the current element.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-details": {
     description:
-      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+      "Identifies the element that provides a detailed, extended description for the object.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-disabled": {
     description:
-      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-dropeffect": {
     description:
-      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+      "Indicates what functions can be performed when a dragged object is released on the drop target.",
     required: false,
     control: "select",
     type: "string",
@@ -132,7 +131,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-errormessage": {
     description:
-      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+      "Identifies the element that provides an error message for the object.",
     required: false,
     control: "text",
     type: "string",
@@ -153,7 +152,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-grabbed": {
     description:
-      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.',
     required: false,
     control: "boolean",
     type: "boolean",
@@ -167,14 +166,14 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-hidden": {
     description:
-      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+      "Indicates whether the element is exposed to an accessibility API.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-invalid": {
     description:
-      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+      "Indicates the entered value does not conform to the format expected by the application.",
     required: false,
     control: "text",
     type: "string",
@@ -195,7 +194,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-labelledby": {
     description:
-      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+      "Identifies the element (or elements) that labels the current element.",
     required: false,
     control: "text",
     type: "string",
@@ -245,7 +244,7 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-owns": {
     description:
-      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.",
     required: false,
     control: "text",
     type: "string",
@@ -259,28 +258,27 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-posinset": {
     description:
-      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-pressed": {
-    description:
-      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    description: 'Indicates the current "pressed" state of toggle buttons.',
     required: false,
     control: "text",
     type: "string",
   },
   "aria-readonly": {
     description:
-      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+      "Indicates that the element is not editable, but is otherwise operable.",
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-relevant": {
     description:
-      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
     required: false,
     control: "select",
     type: "string",
@@ -313,42 +311,40 @@ export const props: Record<string, PropMeta> = {
   },
   "aria-rowcount": {
     description:
-      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+      "Defines the total number of rows in a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindex": {
     description:
-      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-rowindextext": {
-    description:
-      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    description: "Defines a human readable text alternative of aria-rowindex.",
     required: false,
     control: "text",
     type: "string",
   },
   "aria-rowspan": {
     description:
-      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.",
     required: false,
     control: "number",
     type: "number",
   },
   "aria-selected": {
-    description:
-      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    description: 'Indicates the current "selected" state of various widgets.',
     required: false,
     control: "boolean",
     type: "boolean",
   },
   "aria-setsize": {
     description:
-      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.",
     required: false,
     control: "number",
     type: "number",
@@ -374,8 +370,7 @@ export const props: Record<string, PropMeta> = {
     type: "number",
   },
   "aria-valuenow": {
-    description:
-      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    description: "Defines the current value for a range widget.",
     required: false,
     control: "number",
     type: "number",
@@ -502,7 +497,7 @@ export const props: Record<string, PropMeta> = {
   },
   inputMode: {
     description:
-      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+      "Hints at the type of data that might be entered by the user while editing the element or its contents",
     required: false,
     control: "select",
     type: "string",
@@ -526,7 +521,7 @@ export const props: Record<string, PropMeta> = {
   },
   is: {
     description:
-      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+      "Specify that a standard HTML element should behave like a defined custom built-in element",
     required: false,
     control: "text",
     type: "string",
@@ -583,13 +578,6 @@ export const props: Record<string, PropMeta> = {
     control: "boolean",
     type: "boolean",
     defaultValue: false,
-  },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
   },
   playsinline: {
     description:


### PR DESCRIPTION
## Description

Format of descriptions has changed
```
Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext {@link .....}
```

Remove for now. 

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
