### PR TITLE
fix: Allow users to redirect to home page in redirects

### DIFF
--- a/apps/builder/app/builder/features/project-settings/section-redirects.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-redirects.tsx
@@ -89,6 +89,10 @@ export const SectionRedirects = () => {
         If the new path doesn't exist, it's not a valid redirect.
       */
 
+      if (newPath === "/") {
+        return [];
+      }
+
       if (newPath.startsWith("/") === true) {
         if (existingPaths.has(newPath) === false) {
           return ["This path doesn't exist in the project"];

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -114,6 +114,11 @@ export type ProjectMeta = z.infer<typeof ProjectMeta>;
 
 export const ProjectNewRedirectPath = PagePath.or(
   z.string().refine((data) => {
+    // Users should be able to redirect from any old-path to the home page in the new project.
+    if (data === "/") {
+      return true;
+    }
+
     try {
       new URL(data);
       return true;


### PR DESCRIPTION
## Description

fixes #3224 
Allow users to set `/` in new-path. So, from any old-path users can redirect to the home page.

## Steps for reproduction
1. Go to Project Settings -> redirects.
2. Enter a `old-path` and set the `/` in the new path.
3. Deploy the project
4. And when we use the `old-path` in the URL, the project should take the route to the home page.

## Code Review

- [ ] hi @kof, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
