### PR TITLE
refactor: reimplement canvas style renderer

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -37,6 +37,7 @@ const initialPropertyNames = new Set<StyleProperty>([
 
 const usePropertyNames = (currentStyle: StyleInfo) => {
   const selectedInstanceSelector = useStore($selectedInstanceSelector);
+  // @todo switch to style object model to show also inherited styles
   const styles = useInstanceStyles(selectedInstanceSelector?.[0]);
   // Ordererd recent properties for sorting.
   const recent = useRef<Set<StyleProperty>>(new Set());

--- a/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
@@ -85,7 +85,6 @@ export const useStyleData = (selectedInstance: Instance) => {
         for (const update of updates) {
           if (update.operation === "set") {
             ephemeralStyles.push({
-              instanceId: selectedInstance.id,
               breakpointId: selectedBreakpoint.id,
               styleSourceId: styleSourceSelector.styleSourceId,
               state: styleSourceSelector.state,

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -120,7 +120,7 @@ const useElementsTree = (
   ]);
 };
 
-const DesignMode = ({ params }: { params: Params }) => {
+const DesignMode = () => {
   useManageDesignModeStyles();
   useDragAndDrop();
   // We need to initialize this in both canvas and builder,
@@ -233,9 +233,7 @@ export const Canvas = ({ params, imageLoader }: CanvasProps) => {
         // Call hooks after render to ensure effects are last.
         // Helps improve outline calculations as all styles are then applied.
       }
-      {isPreviewMode === false && isInitialized && (
-        <DesignMode params={params} />
-      )}
+      {isPreviewMode === false && isInitialized && <DesignMode />}
     </>
   );
 };

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -26,7 +26,11 @@ import {
   serverSyncStore,
   useCanvasStore,
 } from "~/shared/sync";
-import { useManageDesignModeStyles, GlobalStyles } from "./shared/styles";
+import {
+  useManageDesignModeStyles,
+  GlobalStyles,
+  subscribeStyles,
+} from "./shared/styles";
 import {
   WebstudioComponentCanvas,
   WebstudioComponentPreview,
@@ -172,6 +176,8 @@ export const Canvas = ({ params, imageLoader }: CanvasProps) => {
     // required to compute asset and page props for rendering
     $params.set(params);
   });
+
+  useEffect(subscribeStyles, []);
 
   useEffect(subscribeComponentHooks, []);
 

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useState } from "react";
+import { useMemo, useEffect, useState, useLayoutEffect } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import { useStore } from "@nanostores/react";
 import type { Instances } from "@webstudio-is/sdk";
@@ -30,6 +30,7 @@ import {
   useManageDesignModeStyles,
   GlobalStyles,
   subscribeStyles,
+  mountStyles,
 } from "./shared/styles";
 import {
   WebstudioComponentCanvas,
@@ -176,6 +177,10 @@ export const Canvas = ({ params, imageLoader }: CanvasProps) => {
     // required to compute asset and page props for rendering
     $params.set(params);
   });
+
+  useLayoutEffect(() => {
+    mountStyles();
+  }, []);
 
   useEffect(subscribeStyles, []);
 

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -36,10 +36,8 @@ import {
   $selectedInstanceRenderState,
   $selectedInstanceSelector,
   $selectedPage,
-  useInstanceStyles,
 } from "~/shared/nano-states";
 import { $textEditingInstanceSelector } from "~/shared/nano-states";
-import { useCssRules } from "~/canvas/shared/styles";
 import {
   type InstanceSelector,
   areInstanceSelectorsEqual,
@@ -259,8 +257,6 @@ export const WebstudioComponentCanvas = forwardRef<
 >(({ instance, instanceSelector, components, ...restProps }, ref) => {
   const rootRef = useRef<null | HTMLDivElement>(null);
   const instanceId = instance.id;
-  const instanceStyles = useInstanceStyles(instanceId);
-  useCssRules({ instanceId: instance.id, instanceStyles });
   const instances = useStore($instances);
 
   const textEditingInstanceSelector = useStore($textEditingInstanceSelector);
@@ -413,8 +409,6 @@ export const WebstudioComponentPreview = forwardRef<
   WebstudioComponentProps
 >(({ instance, instanceSelector, components, ...restProps }, ref) => {
   const instances = useStore($instances);
-  const instanceStyles = useInstanceStyles(instance.id);
-  useCssRules({ instanceId: instance.id, instanceStyles });
   const { [showAttribute]: show = true, ...instanceProps } =
     useInstanceProps(instanceSelector);
   const props = {

--- a/apps/builder/app/canvas/stores.ts
+++ b/apps/builder/app/canvas/stores.ts
@@ -1,9 +1,7 @@
 import { atom } from "nanostores";
-import type { Instance, StyleDecl } from "@webstudio-is/sdk";
+import type { StyleDecl } from "@webstudio-is/sdk";
 import type { Params } from "@webstudio-is/react-sdk";
 
-export const $ephemeralStyles = atom<
-  Array<StyleDecl & { instanceId: Instance["id"] }>
->([]);
+export const $ephemeralStyles = atom<Array<StyleDecl>>([]);
 
 export const $params = atom<undefined | Params>();

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -101,6 +101,9 @@ export const $propsIndex = computed($props, (props) => {
 
 export const $styles = atom<Styles>(new Map());
 
+/**
+ * @deprecated
+ */
 export const useInstanceStyles = (instanceId: undefined | Instance["id"]) => {
   const instance$styles = useMemo(() => {
     return shallowComputed([$stylesIndex], (stylesIndex) => {

--- a/apps/builder/app/shared/shim.test.ts
+++ b/apps/builder/app/shared/shim.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@jest/globals";
+import { setDifference } from "./shim";
+
+test("set difference", () => {
+  // this set is bigger than other
+  expect(setDifference(new Set([1, 2, 3, 4]), new Set([3, 4, 5]))).toEqual(
+    new Set([1, 2])
+  );
+  // this set is smaller than other
+  expect(setDifference(new Set([1, 2, 3]), new Set([2, 3, 4, 5]))).toEqual(
+    new Set([1])
+  );
+});

--- a/apps/builder/app/shared/shim.ts
+++ b/apps/builder/app/shared/shim.ts
@@ -1,0 +1,17 @@
+export const setDifference = <Item>(current: Set<Item>, other: Set<Item>) => {
+  const result = new Set<Item>(current);
+  if (current.size <= other.size) {
+    for (const item of current) {
+      if (other.has(item)) {
+        result.delete(item);
+      }
+    }
+  } else {
+    for (const item of other) {
+      if (current.has(item)) {
+        result.delete(item);
+      }
+    }
+  }
+  return result;
+};

--- a/packages/css-data/src/parse-css-value.ts
+++ b/packages/css-data/src/parse-css-value.ts
@@ -36,11 +36,6 @@ export const isValidDeclaration = (
       CSSStyleValue.parse(cssPropertyName, value);
       return true;
     } catch {
-      warnOnce(
-        true,
-        `Css property "${property}" with value "${value}" is invalid according to CSSStyleValue.parse
-          but valid according to csstree.lexer.matchProperty.`
-      );
       return false;
     }
   }

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -72,7 +72,7 @@ export class MixinRule {
 export class NestingRule {
   #selector: string;
   #mixinRules = new Map<string, MixinRule>();
-  #mixins: string[] = [];
+  #mixins = new Set<string>();
   // use map to avoid duplicated properties
   #declarations = new Map<string, Declaration>();
   // cached generated rule by breakpoint
@@ -87,8 +87,12 @@ export class NestingRule {
   getSelector() {
     return this.#selector;
   }
+  addMixin(mixin: string) {
+    this.#mixins.add(mixin);
+    this.#cache.clear();
+  }
   applyMixins(mixins: string[]) {
-    this.#mixins = mixins;
+    this.#mixins = new Set(mixins);
     this.#cache.clear();
   }
   setDeclaration(declaration: Declaration) {

--- a/packages/css-engine/src/core/style-sheet.ts
+++ b/packages/css-engine/src/core/style-sheet.ts
@@ -118,6 +118,8 @@ export class StyleSheet {
   }
   clear() {
     this.#mediaRules.clear();
+    this.#mixinRules.clear();
+    this.nestingRules.clear();
     this.#plainRules.clear();
     this.#fontFaceRules = [];
   }

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -154,6 +154,30 @@ const ValidStaticStyleValue = z.union([
 
 export type ValidStaticStyleValue = z.infer<typeof ValidStaticStyleValue>;
 
+/**
+ * All StyleValue types that going to need wrapping into a CSS variable when rendered
+ * on canvas inside builder.
+ * Values like InvalidValue, UnsetValue, VarValue don't need to be wrapped
+ */
+export const isValidStaticStyleValue = (
+  styleValue: StyleValue
+): styleValue is ValidStaticStyleValue => {
+  // guard against invalid checks
+  const staticStyleValue = styleValue as ValidStaticStyleValue;
+  return (
+    staticStyleValue.type === "image" ||
+    staticStyleValue.type === "layers" ||
+    staticStyleValue.type === "unit" ||
+    staticStyleValue.type === "keyword" ||
+    staticStyleValue.type === "fontFamily" ||
+    staticStyleValue.type === "rgb" ||
+    staticStyleValue.type === "unparsed" ||
+    staticStyleValue.type === "tuple" ||
+    staticStyleValue.type === "function" ||
+    staticStyleValue.type === "guaranteedInvalid"
+  );
+};
+
 const VarValue = z.object({
   type: z.literal("var"),
   value: z.string(),

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -154,30 +154,6 @@ const ValidStaticStyleValue = z.union([
 
 export type ValidStaticStyleValue = z.infer<typeof ValidStaticStyleValue>;
 
-/**
- * All StyleValue types that going to need wrapping into a CSS variable when rendered
- * on canvas inside builder.
- * Values like InvalidValue, UnsetValue, VarValue don't need to be wrapped
- */
-export const isValidStaticStyleValue = (
-  styleValue: StyleValue
-): styleValue is ValidStaticStyleValue => {
-  // guard against invalid checks
-  const staticStyleValue = styleValue as ValidStaticStyleValue;
-  return (
-    staticStyleValue.type === "image" ||
-    staticStyleValue.type === "layers" ||
-    staticStyleValue.type === "unit" ||
-    staticStyleValue.type === "keyword" ||
-    staticStyleValue.type === "fontFamily" ||
-    staticStyleValue.type === "rgb" ||
-    staticStyleValue.type === "unparsed" ||
-    staticStyleValue.type === "tuple" ||
-    staticStyleValue.type === "function" ||
-    staticStyleValue.type === "guaranteedInvalid"
-  );
-};
-
 const VarValue = z.object({
   type: z.literal("var"),
   value: z.string(),


### PR DESCRIPTION
Here refactored canvas styles with nesting rules which allow to update each declaration incrementally and closer to our data format.

Things to test
- initial rendering
- updating values
- ephemeral values
- selecting state, rendered as separate stylesheet

Added shim.ts to contain simplified polyfills for future methods like Set.prototype.difference which I use here to find added and deleted styles.

Removed warning from parseCssValue which pollutes log with outdated messages.

Additionally fixed old bugs
- support ephemeral styles with selector state, for example hover was not updated on on canvas while updating ephemeral styles
- remove ephemeral custom property from body (bug appeared when added support ephemeral styles in tokens)