### PR TITLE
feat: Add system.origin

### DIFF
--- a/apps/builder/app/builder/features/address-bar.tsx
+++ b/apps/builder/app/builder/features/address-bar.tsx
@@ -25,7 +25,7 @@ import {
 import {
   $dataSourceVariables,
   $pages,
-  $publishedUrl,
+  $publishedOrigin,
   $selectedPage,
   updateSystem,
 } from "~/shared/nano-states";
@@ -115,13 +115,13 @@ const useCopyUrl = (pageUrl: string) => {
 
 const AddressBar = () => {
   const id = useId();
-  const publishedUrl = useStore($publishedUrl);
+  const publishedOrigin = useStore($publishedOrigin);
   const path = useStore($selectedPagePath);
   const pathParams = useStore($selectedPagePathParams);
   const tokens = tokenizePathnamePattern(path);
   const compiledPath = compilePathnamePattern(tokens, pathParams ?? {});
   const { tooltipProps, buttonProps } = useCopyUrl(
-    `${publishedUrl}${compiledPath}`
+    `${publishedOrigin}${compiledPath}`
   );
 
   const errors = new Map<string, string>();
@@ -179,8 +179,8 @@ const AddressBar = () => {
 export const AddressBarPopover = () => {
   const [isOpen, setIsOpen] = useState(false);
   const path = useStore($selectedPagePath);
-  const publishedUrl = useStore($publishedUrl);
-  const { tooltipProps, buttonProps } = useCopyUrl(`${publishedUrl}${path}`);
+  const publishedOrigin = useStore($publishedOrigin);
+  const { tooltipProps, buttonProps } = useCopyUrl(`${publishedOrigin}${path}`);
 
   // show only copy button when path is static
   if (isPathnamePattern(path) === false) {

--- a/apps/builder/app/builder/features/project-settings/section-redirects.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-redirects.tsx
@@ -23,13 +23,13 @@ import {
 } from "@webstudio-is/sdk";
 import { useStore } from "@nanostores/react";
 import { getExistingRoutePaths } from "../sidebar-left/panels/pages/page-utils";
-import { $pages, $publishedUrl } from "~/shared/nano-states";
+import { $pages, $publishedOrigin } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
 import { flushSync } from "react-dom";
 import { sectionSpacing } from "./utils";
 
 export const SectionRedirects = () => {
-  const publishedUrl = useStore($publishedUrl);
+  const publishedOrigin = useStore($publishedOrigin);
   const [redirects, setRedirects] = useState(
     () => $pages.get()?.redirects ?? []
   );
@@ -237,7 +237,7 @@ export const SectionRedirects = () => {
                             underline="hover"
                             href={new URL(
                               redirect.old,
-                              publishedUrl
+                              publishedOrigin
                             ).toString()}
                             css={truncate()}
                             target="_blank"
@@ -254,7 +254,7 @@ export const SectionRedirects = () => {
                             underline="hover"
                             href={new URL(
                               redirect.new,
-                              publishedUrl
+                              publishedOrigin
                             ).toString()}
                             css={truncate()}
                             target="_blank"

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -69,7 +69,7 @@ import {
   $dataSources,
   computeExpression,
   $dataSourceVariables,
-  $publishedUrl,
+  $publishedOrigin,
 } from "~/shared/nano-states";
 import {
   BindingControl,
@@ -566,10 +566,10 @@ const usePageUrl = (values: Values, systemDataSourceId?: DataSource["id"]) => {
       : (dataSourceVariables.get(systemDataSourceId) as System);
   const pathParams = storedSystem?.params ?? {};
 
-  const publishedUrl = useStore($publishedUrl);
+  const publishedOrigin = useStore($publishedOrigin);
   const tokens = tokenizePathnamePattern(path);
   const compiledPath = compilePathnamePattern(tokens, pathParams);
-  return `${publishedUrl}${compiledPath}`;
+  return `${publishedOrigin}${compiledPath}`;
 };
 
 const FormFields = ({

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -32,7 +32,7 @@ import {
   useIsPublishDialogOpen,
 } from "../../shared/nano-states";
 import { validateProjectDomain, type Project } from "@webstudio-is/project";
-import { $authPermit, $publishedUrl } from "~/shared/nano-states";
+import { $authPermit, $publishedOrigin } from "~/shared/nano-states";
 import {
   Domains,
   getPublishStatusAndText,
@@ -80,7 +80,7 @@ const ChangeProjectDomain = ({
   isPublishing,
 }: ChangeProjectDomainProps) => {
   const id = useId();
-  const publishedUrl = useStore($publishedUrl);
+  const publishedOrigin = useStore($publishedOrigin);
 
   const {
     send: updateProjectDomain,
@@ -143,7 +143,7 @@ const ChangeProjectDomain = ({
 
   return (
     <CollapsibleDomainSection
-      title={new URL(publishedUrl).host}
+      title={new URL(publishedOrigin).host}
       suffix={
         <Grid flow="column">
           <Tooltip content={error !== undefined ? error : statusText}>
@@ -167,12 +167,12 @@ const ChangeProjectDomain = ({
               )}
             </Flex>
           </Tooltip>
-          <Tooltip content={`Proceed to ${publishedUrl}`}>
+          <Tooltip content={`Proceed to ${publishedOrigin}`}>
             <IconButton
               tabIndex={-1}
               disabled={error !== undefined || status !== "PUBLISHED"}
               onClick={(event) => {
-                window.open(publishedUrl, "_blank");
+                window.open(publishedOrigin, "_blank");
                 event.preventDefault();
               }}
             >

--- a/apps/builder/app/dashboard/projects/project-card.tsx
+++ b/apps/builder/app/dashboard/projects/project-card.tsx
@@ -52,10 +52,10 @@ const PublishedLink = ({
   publisherHost: string;
   tabIndex: number;
 }) => {
-  const publishedUrl = `https://${domain}.${publisherHost}`;
+  const publishedOrigin = `https://${domain}.${publisherHost}`;
   return (
     <Link
-      href={publishedUrl}
+      href={publishedOrigin}
       target="_blank"
       rel="noreferrer"
       tabIndex={tabIndex}
@@ -63,7 +63,7 @@ const PublishedLink = ({
       underline="hover"
       css={truncate()}
     >
-      {new URL(publishedUrl).host}
+      {new URL(publishedOrigin).host}
     </Link>
   );
 };

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -41,7 +41,7 @@ export const $imageLoader = atom<ImageLoader>(
   createImageLoader({ imageBaseUrl: "" })
 );
 
-export const $publishedUrl = computed(
+export const $publishedOrigin = computed(
   [$project, $publisherHost],
   (project, publisherHost) => `https://${project?.domain}.${publisherHost}`
 );
@@ -69,6 +69,9 @@ export const updateSystem = (page: Page, update: Partial<System>) => {
   const newSystem: System = {
     search: {},
     params: {},
+    url: {
+      origin: "",
+    },
     ...system,
     ...update,
   };

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -66,12 +66,12 @@ export const updateSystem = (page: Page, update: Partial<System>) => {
   const system = dataSourceVariables.get(page.systemDataSourceId) as
     | undefined
     | System;
+
   const newSystem: System = {
     search: {},
     params: {},
-    url: {
-      origin: "",
-    },
+    // This value seems like doesn't matter
+    origin: "",
     ...system,
     ...update,
   };

--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -911,7 +911,12 @@ test("prefill default system variable value", () => {
     new Map([
       [
         JSON.stringify(["body"]),
-        new Map<string, unknown>([["systemId", { params: {}, search: {} }]]),
+        new Map<string, unknown>([
+          [
+            "systemId",
+            { params: {}, search: {}, origin: "https://undefined.wstd.work" },
+          ],
+        ]),
       ],
     ])
   );

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -26,6 +26,7 @@ import {
   $assets,
   $resources,
   $resourceValues,
+  $publishedOrigin,
 } from "./nano-states";
 import { $selectedPage, $pages } from "./pages";
 import { groupBy } from "../array-utils";
@@ -299,6 +300,7 @@ export const $variableValuesByInstanceSelector = computed(
     $dataSources,
     $dataSourceVariables,
     $resourceValues,
+    $publishedOrigin,
   ],
   (
     instances,
@@ -306,7 +308,8 @@ export const $variableValuesByInstanceSelector = computed(
     page,
     dataSources,
     dataSourceVariables,
-    resourceValues
+    resourceValues,
+    publishedOrigin
   ) => {
     const propsByInstanceId = groupBy(
       props.values(),
@@ -364,6 +367,10 @@ export const $variableValuesByInstanceSelector = computed(
               variableValues.set(variable.id, {
                 params: {},
                 search: {},
+                // @todo: use same logic as usePageUrl from page-settings.tsx for the whole url
+                url: {
+                  origin: publishedOrigin,
+                },
               });
             }
           }

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -5,6 +5,7 @@ import type {
   Instance,
   Prop,
   ResourceRequest,
+  System,
 } from "@webstudio-is/sdk";
 import {
   decodeDataSourceVariable,
@@ -364,14 +365,13 @@ export const $variableValuesByInstanceSelector = computed(
               variable.id === page.systemDataSourceId &&
               value === undefined
             ) {
-              variableValues.set(variable.id, {
+              const systemDefaultValue: System = {
                 params: {},
                 search: {},
-                // @todo: use same logic as usePageUrl from page-settings.tsx for the whole url
-                url: {
-                  origin: publishedOrigin,
-                },
-              });
+                origin: publishedOrigin,
+              };
+
+              variableValues.set(variable.id, systemDefaultValue);
             }
           }
           if (variable.type === "resource") {

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-cloudflare-template/package.json
+++ b/fixtures/webstudio-cloudflare-template/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "fixtures:link": "webstudio link --link \"https://main.development.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93&\"",
     "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "webstudio build --template internal --template saas-helpers --template cloudflare --preview && pnpm prettier --write ./app/ ./package.json",
+    "fixtures:build": "webstudio build --template internal --template cloudflare --template saas-helpers  --preview && pnpm prettier --write ./app/ ./package.json",
     "build": "remix vite:build",
     "dev": "remix vite:dev",
     "typecheck": "tsc",

--- a/fixtures/webstudio-cloudflare-template/tsconfig.json
+++ b/fixtures/webstudio-cloudflare-template/tsconfig.json
@@ -26,6 +26,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
+    "customConditions": ["webstudio"],
 
     // Vite takes care of building everything, not tsc.
     "noEmit": true

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/packages/cli/templates/defaults/app/routes/template.tsx
+++ b/packages/cli/templates/defaults/app/routes/template.tsx
@@ -34,10 +34,22 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
+
+  const host =
+    arg.request.headers.get("x-forwarded-host") ||
+    arg.request.headers.get("host") ||
+    "";
+
+  url.host = host;
+  url.protocol = "https";
+
   const params = getRemixParams(arg.params);
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
+    url: {
+      origin: url.origin,
+    },
   };
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
@@ -49,14 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
         : 302;
     return redirect(pageMeta.redirect, status);
   }
-
-  const host =
-    arg.request.headers.get("x-forwarded-host") ||
-    arg.request.headers.get("host") ||
-    "";
-
-  url.host = host;
-  url.protocol = "https";
 
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;

--- a/packages/cli/templates/defaults/app/routes/template.tsx
+++ b/packages/cli/templates/defaults/app/routes/template.tsx
@@ -34,12 +34,10 @@ import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);
-
   const host =
     arg.request.headers.get("x-forwarded-host") ||
     arg.request.headers.get("host") ||
     "";
-
   url.host = host;
   url.protocol = "https";
 
@@ -47,10 +45,9 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   const system = {
     params,
     search: Object.fromEntries(url.searchParams),
-    url: {
-      origin: url.origin,
-    },
+    origin: url.origin,
   };
+
   const resources = await loadResources({ system });
   const pageMeta = getPageMeta({ system, resources });
 

--- a/packages/cli/templates/defaults/tsconfig.json
+++ b/packages/cli/templates/defaults/tsconfig.json
@@ -16,8 +16,6 @@
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "baseUrl": ".",
-    "customConditions": ["webstudio"],
-
     // Remix takes care of building everything in `remix build`.
     "noEmit": true,
     "skipLibCheck": true

--- a/packages/cli/templates/internal/tsconfig.json
+++ b/packages/cli/templates/internal/tsconfig.json
@@ -16,9 +16,6 @@
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "baseUrl": ".",
-    "paths": {
-      "~/*": ["./app/*"]
-    },
     "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.

--- a/packages/cli/templates/internal/tsconfig.json
+++ b/packages/cli/templates/internal/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "types": ["@remix-run/node", "vite/client"],
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "target": "ES2022",
+    "strict": true,
+    "allowJs": true,
+    "checkJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./app/*"]
+    },
+    "customConditions": ["webstudio"],
+
+    // Remix takes care of building everything in `remix build`.
+    "noEmit": true,
+    "skipLibCheck": true
+  }
+}

--- a/packages/cli/templates/saas-helpers/tsconfig.json
+++ b/packages/cli/templates/saas-helpers/tsconfig.json
@@ -26,9 +26,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
-    "paths": {
-      "~/*": ["./app/*"]
-    },
     "customConditions": ["webstudio"],
 
     // Vite takes care of building everything, not tsc.

--- a/packages/cli/templates/saas-helpers/tsconfig.json
+++ b/packages/cli/templates/saas-helpers/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/.server/**/*.ts",
+    "**/.server/**/*.tsx",
+    "**/.client/**/*.ts",
+    "**/.client/**/*.tsx"
+  ],
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "types": [
+      "@remix-run/cloudflare",
+      "vite/client",
+      "@cloudflare/workers-types/2023-07-01"
+    ],
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "target": "ES2022",
+    "strict": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./app/*"]
+    },
+    "customConditions": ["webstudio"],
+
+    // Vite takes care of building everything, not tsc.
+    "noEmit": true
+  }
+}

--- a/packages/sdk-components-react/src/xml-node.tsx
+++ b/packages/sdk-components-react/src/xml-node.tsx
@@ -1,4 +1,3 @@
-import { componentAttribute } from "@webstudio-is/react-sdk";
 import { Children, forwardRef, type ElementRef, type ReactNode } from "react";
 
 export const defaultTag = "div";
@@ -7,7 +6,7 @@ export const defaultTag = "div";
 type Props = {
   tag: string;
   children: ReactNode;
-} & Record<typeof componentAttribute, string>;
+};
 
 export const XmlNode = forwardRef<ElementRef<"div">, Props>(
   ({ tag = "", children, ...props }, ref) => {

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -3,6 +3,9 @@ import { z } from "zod";
 export type System = {
   params: Record<string, string | undefined>;
   search: Record<string, string | undefined>;
+  url: {
+    origin: string;
+  };
 };
 
 const MIN_TITLE_LENGTH = 2;

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -3,9 +3,7 @@ import { z } from "zod";
 export type System = {
   params: Record<string, string | undefined>;
   search: Record<string, string | undefined>;
-  url: {
-    origin: string;
-  };
+  origin: string;
 };
 
 const MIN_TITLE_LENGTH = 2;


### PR DESCRIPTION
## Description

review per commit.

- Add system.url.origin to the props, rename publishedUrl -> publishedOrigin
- Add system.url.origin to the published sites

Example on published site
https://saas-sitemapxml-x1g2n.wstd.work/

Example on builder
<img width="342" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/bea3c9b4-c7dc-4936-a56a-fa33327ab6d0">

We use because as of now system is not available on canvas
<img width="448" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/2eaa02b0-7566-492b-b98e-7af8a4f636e0">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
