### PR TITLE
chore: used wrong component, showed dialog inside dialog

### DIFF
--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -31,7 +31,11 @@ import {
   decodeDataSourceVariable,
   transpileExpression,
 } from "@webstudio-is/sdk";
-import { CodeEditorBase, EditorDialog } from "./code-editor-base";
+import {
+  CodeEditorBase,
+  EditorContent,
+  EditorDialog,
+} from "./code-editor-base";
 
 export const formatValue = (value: unknown) => {
   if (Array.isArray(value)) {
@@ -440,7 +444,7 @@ export const ExpressionEditor = ({
 const ValuePreviewEditor = ({ value }: { value: unknown }) => {
   const extensions = useMemo(() => [javascript({})], []);
   return (
-    <CodeEditorBase
+    <EditorContent
       readOnly={true}
       extensions={extensions}
       value={JSON.stringify(value, null, 2)}


### PR DESCRIPTION
Fixes this

<img width="710" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/69d6098c-f7a3-4286-abf8-bc074ad03681">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
