### PR TITLE
refactor: drop tsconfig paths

### DIFF
--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-cloudflare-template/package.json
+++ b/fixtures/webstudio-cloudflare-template/package.json
@@ -52,7 +52,6 @@
     "typescript": "5.4.5",
     "vite": "^5.2.8",
     "@cloudflare/workers-types": "^4.20240405.0",
-    "vite-tsconfig-paths": "^4.2.1",
     "wrangler": "^3.48.0",
     "miniflare": "^3.20231030.4"
   }

--- a/fixtures/webstudio-cloudflare-template/tsconfig.json
+++ b/fixtures/webstudio-cloudflare-template/tsconfig.json
@@ -26,9 +26,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
-    "paths": {
-      "~/*": ["./app/*"]
-    },
 
     // Vite takes care of building everything, not tsc.
     "noEmit": true

--- a/fixtures/webstudio-cloudflare-template/vite.config.ts
+++ b/fixtures/webstudio-cloudflare-template/vite.config.ts
@@ -3,13 +3,11 @@ import {
   cloudflareDevProxyVitePlugin as remixCloudflareDevProxy,
 } from "@remix-run/dev";
 import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig(({ mode }) => ({
   plugins: [
     // without this, remixCloudflareDevProxy trying to load workerd even for production (it's not needed for production)
     mode === "production" ? undefined : remixCloudflareDevProxy(),
     remix(),
-    tsconfigPaths(),
   ].filter(Boolean),
 }));

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/[script-test]._index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/[sitemap-html]._index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/[world]._index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-custom-template/tsconfig.json
+++ b/fixtures/webstudio-custom-template/tsconfig.json
@@ -16,9 +16,6 @@
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "baseUrl": ".",
-    "paths": {
-      "~/*": ["./app/*"]
-    },
     "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.

--- a/fixtures/webstudio-custom-template/vite.config.ts
+++ b/fixtures/webstudio-custom-template/vite.config.ts
@@ -1,15 +1,6 @@
-import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import { vitePlugin as remix } from "@remix-run/dev";
 
 export default defineConfig({
   plugins: [remix()],
-  resolve: {
-    alias: [
-      {
-        find: "~",
-        replacement: resolve("app"),
-      },
-    ],
-  },
 });

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-netlify-edge-functions/tsconfig.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/tsconfig.json
@@ -16,9 +16,6 @@
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "baseUrl": ".",
-    "paths": {
-      "~/*": ["./app/*"]
-    },
     "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.

--- a/fixtures/webstudio-remix-netlify-edge-functions/vite.config.ts
+++ b/fixtures/webstudio-remix-netlify-edge-functions/vite.config.ts
@@ -1,16 +1,7 @@
-import { resolve } from "node:path";
 import { vitePlugin as remix } from "@remix-run/dev";
 import { defineConfig } from "vite";
 import { netlifyPlugin } from "@netlify/remix-edge-adapter/plugin";
 
 export default defineConfig({
   plugins: [remix(), netlifyPlugin()],
-  resolve: {
-    alias: [
-      {
-        find: "~",
-        replacement: resolve("app"),
-      },
-    ],
-  },
 });

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-netlify-functions/tsconfig.json
+++ b/fixtures/webstudio-remix-netlify-functions/tsconfig.json
@@ -16,9 +16,6 @@
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "baseUrl": ".",
-    "paths": {
-      "~/*": ["./app/*"]
-    },
     "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.

--- a/fixtures/webstudio-remix-netlify-functions/vite.config.ts
+++ b/fixtures/webstudio-remix-netlify-functions/vite.config.ts
@@ -1,16 +1,7 @@
-import { resolve } from "node:path";
 import { vitePlugin as remix } from "@remix-run/dev";
 import { defineConfig } from "vite";
 import { netlifyPlugin } from "@netlify/remix-adapter/plugin";
 
 export default defineConfig({
   plugins: [remix(), netlifyPlugin()],
-  resolve: {
-    alias: [
-      {
-        find: "~",
-        replacement: resolve("app"),
-      },
-    ],
-  },
 });

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/[_route_with_symbols_]._index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/[form]._index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/[heading-with-id]._index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/[nested].[nested-page]._index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/[radix]._index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/[resources]._index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/tsconfig.json
+++ b/fixtures/webstudio-remix-vercel/tsconfig.json
@@ -16,9 +16,6 @@
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "baseUrl": ".",
-    "paths": {
-      "~/*": ["./app/*"]
-    },
     "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.

--- a/fixtures/webstudio-remix-vercel/vite.config.ts
+++ b/fixtures/webstudio-remix-vercel/vite.config.ts
@@ -1,15 +1,6 @@
-import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import { vitePlugin as remix } from "@remix-run/dev";
 
 export default defineConfig({
   plugins: [remix()],
-  resolve: {
-    alias: [
-      {
-        find: "~",
-        replacement: resolve("app"),
-      },
-    ],
-  },
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,7 +61,6 @@
     "@webstudio-is/tsconfig": "workspace:*",
     "tsx": "^4.7.2",
     "typescript": "5.4.5",
-    "vite-tsconfig-paths": "^4.3.2",
     "wrangler": "^3.48.0"
   }
 }

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -60,7 +60,7 @@ import {
   loadJSONFile,
   isFileExists,
 } from "./fs-utils";
-import type * as sharedConstants from "~/constants.mjs";
+import type * as sharedConstants from "../templates/defaults/app/constants.mjs";
 
 const limit = pLimit(10);
 
@@ -491,13 +491,11 @@ export const prebuild = async (options: {
 
   spinner.text = "Generating routes and pages";
 
-  const routeTemplatePath = normalize(
-    join(cwd(), "__templates__", "route-template.tsx")
-  );
+  const routeTemplatePath = normalize(join(cwd(), "app/routes/template.tsx"));
 
   const routeFileTemplate = await readFile(routeTemplatePath, "utf8");
 
-  await rm(dirname(routeTemplatePath), { recursive: true });
+  await rm(routeTemplatePath);
 
   for (const [pageId, pageComponents] of Object.entries(componentsByPage)) {
     const scope = createScope([

--- a/packages/cli/templates/cloudflare/package.json
+++ b/packages/cli/templates/cloudflare/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240405.0",
-    "vite-tsconfig-paths": "^4.2.1",
     "wrangler": "^3.48.0",
     "miniflare": "^3.20231030.4"
   }

--- a/packages/cli/templates/cloudflare/tsconfig.json
+++ b/packages/cli/templates/cloudflare/tsconfig.json
@@ -26,9 +26,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
-    "paths": {
-      "~/*": ["./app/*"]
-    },
 
     // Vite takes care of building everything, not tsc.
     "noEmit": true

--- a/packages/cli/templates/cloudflare/vite.config.ts
+++ b/packages/cli/templates/cloudflare/vite.config.ts
@@ -3,13 +3,11 @@ import {
   cloudflareDevProxyVitePlugin as remixCloudflareDevProxy,
 } from "@remix-run/dev";
 import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig(({ mode }) => ({
   plugins: [
     // without this, remixCloudflareDevProxy trying to load workerd even for production (it's not needed for production)
     mode === "production" ? undefined : remixCloudflareDevProxy(),
     remix(),
-    tsconfigPaths(),
   ].filter(Boolean),
 }));

--- a/packages/cli/templates/defaults/app/routes/template.tsx
+++ b/packages/cli/templates/defaults/app/routes/template.tsx
@@ -18,7 +18,7 @@ import {
   socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
-} from "../../../__generated__/_index";
+} from "../../../../__generated__/_index";
 import {
   formsProperties,
   loadResources,
@@ -27,10 +27,10 @@ import {
   projectId,
   user,
   projectMeta,
-} from "../../../__generated__/_index.server";
+} from "../../../../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "~/constants.mjs";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/packages/cli/templates/defaults/tsconfig.json
+++ b/packages/cli/templates/defaults/tsconfig.json
@@ -16,9 +16,6 @@
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "baseUrl": ".",
-    "paths": {
-      "~/*": ["./app/*"]
-    },
     "customConditions": ["webstudio"],
 
     // Remix takes care of building everything in `remix build`.

--- a/packages/cli/templates/defaults/vite.config.ts
+++ b/packages/cli/templates/defaults/vite.config.ts
@@ -1,15 +1,6 @@
-import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import { vitePlugin as remix } from "@remix-run/dev";
 
 export default defineConfig({
   plugins: [remix()],
-  resolve: {
-    alias: [
-      {
-        find: "~",
-        replacement: resolve("app"),
-      },
-    ],
-  },
 });

--- a/packages/cli/templates/netlify-edge-functions/vite.config.ts
+++ b/packages/cli/templates/netlify-edge-functions/vite.config.ts
@@ -1,16 +1,7 @@
-import { resolve } from "node:path";
 import { vitePlugin as remix } from "@remix-run/dev";
 import { defineConfig } from "vite";
 import { netlifyPlugin } from "@netlify/remix-edge-adapter/plugin";
 
 export default defineConfig({
   plugins: [remix(), netlifyPlugin()],
-  resolve: {
-    alias: [
-      {
-        find: "~",
-        replacement: resolve("app"),
-      },
-    ],
-  },
 });

--- a/packages/cli/templates/netlify-functions/vite.config.ts
+++ b/packages/cli/templates/netlify-functions/vite.config.ts
@@ -1,16 +1,7 @@
-import { resolve } from "node:path";
 import { vitePlugin as remix } from "@remix-run/dev";
 import { defineConfig } from "vite";
 import { netlifyPlugin } from "@netlify/remix-adapter/plugin";
 
 export default defineConfig({
   plugins: [remix(), netlifyPlugin()],
-  resolve: {
-    alias: [
-      {
-        find: "~",
-        replacement: resolve("app"),
-      },
-    ],
-  },
 });

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,9 +5,6 @@
     "types": ["vite/client"],
     "module": "esnext",
     "allowJs": true,
-    "checkJs": true,
-    "paths": {
-      "~/constants.mjs": ["./templates/defaults/app/constants.mjs"]
-    }
+    "checkJs": true
   }
 }

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -74,5 +74,11 @@ module.exports = {
         "unicorn/filename-case": "off",
       },
     },
+    {
+      files: ["**/packages/cli/**"],
+      rules: {
+        "import/no-internal-modules": "off",
+      },
+    },
   ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,9 +530,6 @@ importers:
       vite:
         specifier: ^5.2.8
         version: 5.2.8(@types/node@20.12.7)
-      vite-tsconfig-paths:
-        specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@5.2.8(@types/node@20.12.7))
       wrangler:
         specifier: ^3.48.0
         version: 3.50.0(@cloudflare/workers-types@4.20240405.0)
@@ -1039,9 +1036,6 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
-      vite-tsconfig-paths:
-        specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.5)(vite@5.2.8(@types/node@20.12.7))
       wrangler:
         specifier: ^3.48.0
         version: 3.50.0(@cloudflare/workers-types@4.20240405.0)
@@ -6678,9 +6672,6 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   goober@2.1.10:
     resolution: {integrity: sha512-7PpuQMH10jaTWm33sQgBQvz45pHR8N4l3Cu3WMGEWmHShAcTuuP7I+5/DwKo39fwti5A80WAjvqgz6SSlgWmGA==}
     peerDependencies:
@@ -9436,16 +9427,6 @@ packages:
   ts-toolbelt@6.15.5:
     resolution: {integrity: sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==}
 
-  tsconfck@3.0.3:
-    resolution: {integrity: sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
 
@@ -9765,14 +9746,6 @@ packages:
     resolution: {integrity: sha512-LmXb9saMGlrMZbXTvOveJKwMTBTNUH66c8rJnQ0ZPNX+myPEol64+szRzXtV5ORb0Hb/91yq+/D3oERoyAt6LA==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
-
-  vite-tsconfig-paths@4.3.2:
-    resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
 
   vite@4.4.9:
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
@@ -16589,8 +16562,6 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  globrex@0.1.2: {}
-
   goober@2.1.10(csstype@3.1.1):
     dependencies:
       csstype: 3.1.1
@@ -20115,10 +20086,6 @@ snapshots:
 
   ts-toolbelt@6.15.5: {}
 
-  tsconfck@3.0.3(typescript@5.4.5):
-    optionalDependencies:
-      typescript: 5.4.5
-
   tsconfig-paths@3.14.2:
     dependencies:
       '@types/json5': 0.0.29
@@ -20499,17 +20466,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-
-  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.2.8(@types/node@20.12.7)):
-    dependencies:
-      debug: 4.3.4
-      globrex: 0.1.2
-      tsconfck: 3.0.3(typescript@5.4.5)
-    optionalDependencies:
-      vite: 5.2.8(@types/node@20.12.7)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@4.4.9(@types/node@20.12.7):
     dependencies:


### PR DESCRIPTION
We use tsconfig paths option only to resolve single constants module. It requires additional plugin in vite and all other tools. At least in generated published sites it can be just dropped.

Moved __templates__/route-template.tsx to app/routes/template.tsx