### PR TITLE
fix: Fix share dialog saving behavior

### DIFF
--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -126,6 +126,7 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
             width: theme.spacing[24],
           }}
           sideOffset={0}
+          onInteractOutside={saveCustomLinkName}
         >
           <Item>
             <Label htmlFor={ids.name}>Name</Label>

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -107,8 +107,7 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
       return;
     }
 
-    onChange({ ...value, name: customLinkName });
-    setIsOpen(false);
+    onChange({ ...value, name: customLinkName.trim() });
   };
 
   return (
@@ -134,13 +133,14 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
               id={ids.name}
               color={customLinkName.length === 0 ? "error" : undefined}
               value={customLinkName}
-              onChange={(event) => setCustomLinkName(event.target.value.trim())}
+              onChange={(event) => setCustomLinkName(event.target.value)}
               onKeyDown={(event) => {
                 if (event.key === "Enter") {
                   saveCustomLinkName();
+                  setIsOpen(false);
                 }
               }}
-              onBlur={() => onChange({ ...value, name: customLinkName })}
+              onBlur={saveCustomLinkName}
               placeholder="Share Project"
               name="Name"
               autoFocus
@@ -432,12 +432,7 @@ export const ShareProject = ({
   );
 
   return (
-    <Flex
-      direction="column"
-      css={{
-        width: theme.spacing[33],
-      }}
-    >
+    <Flex direction="column" css={{ width: theme.spacing[33] }}>
       <Collapsible.Root open={items.length > 0}>
         <Collapsible.Content className={collapsibleStyle()}>
           {items}


### PR DESCRIPTION
## Description

1. You couldn't type space at the end of the shared link name 
2. When clicking outside it would save the value

## Steps for reproduction

1. click button
3. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
