### PR TITLE
fix: Canvas link click is not working for nested paths

### DIFF
--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -1,4 +1,4 @@
-import type { System } from "@webstudio-is/sdk";
+import { getPagePath, type System } from "@webstudio-is/sdk";
 import {
   compilePathnamePattern,
   matchPathnamePattern,
@@ -47,9 +47,8 @@ const switchPageAndUpdateSystem = (href: string, formData?: FormData) => {
   }
   const pageHref = new URL(href, "https://any-valid.url");
   for (const page of [pages.homePage, ...pages.pages]) {
-    // URL always parses root page as /
-    // but webstudio stores home page as empty string
-    const params = matchPathnamePattern(page.path || "/", pageHref.pathname);
+    const pagePath = getPagePath(page.id, pages);
+    const params = matchPathnamePattern(pagePath, pageHref.pathname);
     if (params) {
       // populate search params with form data values if available
       if (formData) {


### PR DESCRIPTION
## Description

When a path leads to a nested page inside folders, we were not building a full path with folders

## Steps for reproduction

1. create a link to a subpage from a folder
2. open preview mode
3. click on a link - expect it to switch
4. works when link is to a page from the root

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
