### PR TITLE
refactor: simplify stylesheet caching

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -117,7 +117,7 @@ const useElementsTree = (
 };
 
 const DesignMode = ({ params }: { params: Params }) => {
-  useManageDesignModeStyles(params);
+  useManageDesignModeStyles();
   useDragAndDrop();
   // We need to initialize this in both canvas and builder,
   // because the events will fire in either one, depending on where the focus is

--- a/packages/css-engine/src/core/index.ts
+++ b/packages/css-engine/src/core/index.ts
@@ -1,6 +1,5 @@
 export type {
   NestingRule,
-  AnyRule,
   StyleRule,
   MediaRule,
   PlaintextRule,

--- a/packages/css-engine/src/core/style-sheet-regular.test.ts
+++ b/packages/css-engine/src/core/style-sheet-regular.test.ts
@@ -53,13 +53,13 @@ describe("nesting rule", () => {
       property: "color",
       value: { type: "keyword", value: "transparent" },
     });
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`
 ".instance {
   width: auto;
   height: auto
 }"
 `);
-    expect(rule.generateRules({ breakpoint: "small" })).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "small" })).toMatchInlineSnapshot(`
 ".instance {
   color: transparent
 }"
@@ -87,7 +87,7 @@ describe("nesting rule", () => {
       property: "color",
       value: { type: "keyword", value: "transparent" },
     });
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`
 ".instance {
   width: auto;
   height: auto
@@ -113,7 +113,7 @@ describe("nesting rule", () => {
       property: "width",
       value: { type: "keyword", value: "auto" },
     });
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`
 ".instance {
   width: auto
 }
@@ -132,7 +132,7 @@ describe("nesting rule", () => {
       property: "width",
       value: { type: "keyword", value: "auto" },
     });
-    expect(rule.generateRules({ breakpoint: "base", indent: 4 }))
+    expect(rule.toString({ breakpoint: "base", indent: 4 }))
       .toMatchInlineSnapshot(`
 "    .instance {
       width: auto
@@ -149,7 +149,7 @@ describe("nesting rule", () => {
       property: "width",
       value: { type: "keyword", value: "auto" },
     });
-    expect(rule.generateRules({ breakpoint: "base", transformValue }))
+    expect(rule.toString({ breakpoint: "base", transformValue }))
       .toMatchInlineSnapshot(`
 ".instance {
   width: AUTO
@@ -166,7 +166,7 @@ describe("nesting rule", () => {
       property: "width",
       value: { type: "keyword", value: "auto" },
     });
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`
 ".instance {
   width: auto
 }"
@@ -178,7 +178,7 @@ describe("nesting rule", () => {
       property: "height",
       value: { type: "keyword", value: "auto" },
     });
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`
 ".instance {
   width: auto;
   height: auto
@@ -190,22 +190,21 @@ describe("nesting rule", () => {
       selector: "",
       property: "height",
     });
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`
 ".instance {
   width: auto
 }"
 `);
     // invalidate by indent
-    expect(rule.generateRules({ breakpoint: "base", indent: 2 }))
+    expect(rule.toString({ breakpoint: "base", indent: 2 }))
       .toMatchInlineSnapshot(`
 "  .instance {
     width: auto
   }"
 `);
     // invalidate by transform value
-    expect(
-      rule.generateRules({ breakpoint: "base", indent: 2, transformValue })
-    ).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "base", indent: 2, transformValue }))
+      .toMatchInlineSnapshot(`
 "  .instance {
     width: AUTO
   }"
@@ -215,7 +214,7 @@ describe("nesting rule", () => {
   test("generate breakpoint without declarations", () => {
     const sheet = createRegularStyleSheet();
     const rule = sheet.addNestingRule(".instance");
-    expect(rule.generateRules({ breakpoint: "base" })).toEqual("");
+    expect(rule.toString({ breakpoint: "base" })).toEqual("");
   });
 });
 
@@ -244,7 +243,7 @@ describe("mixin rule", () => {
       property: "height",
       value: { type: "keyword", value: "auto" },
     });
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`
 ".instance {
   width: fit-content;
   height: auto
@@ -270,7 +269,7 @@ describe("mixin rule", () => {
       property: "height",
       value: { type: "keyword", value: "auto" },
     });
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`
 ".instance:hover {
   height: auto;
   width: fit-content
@@ -288,11 +287,9 @@ describe("mixin rule", () => {
       property: "width",
       value: { type: "keyword", value: "auto" },
     });
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(
-      `""`
-    );
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`""`);
     rule.applyMixins(["local"]);
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`
 ".instance {
   width: auto
 }"
@@ -304,16 +301,14 @@ describe("mixin rule", () => {
     const rule = sheet.addNestingRule(".instance");
     const localMixin = sheet.addMixinRule("local");
     rule.applyMixins(["local"]);
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(
-      `""`
-    );
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`""`);
     localMixin.setDeclaration({
       breakpoint: "base",
       selector: "",
       property: "width",
       value: { type: "keyword", value: "auto" },
     });
-    expect(rule.generateRules({ breakpoint: "base" })).toMatchInlineSnapshot(`
+    expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`
 ".instance {
   width: auto
 }"
@@ -816,6 +811,21 @@ describe("Style Sheet Regular", () => {
     const assets = new Map<string, { path: string }>([
       ["1234", { path: "foo.png" }],
     ]);
+    sheet.setTransformer((styleValue) => {
+      if (styleValue.type === "image" && styleValue.value.type === "asset") {
+        const asset = assets.get(styleValue.value.value);
+        if (asset === undefined) {
+          return { type: "keyword", value: "none" };
+        }
+        return {
+          type: "image",
+          value: {
+            type: "url",
+            url: asset.path,
+          },
+        };
+      }
+    });
     const rule = sheet.addStyleRule(
       {
         style: {
@@ -829,22 +839,7 @@ describe("Style Sheet Regular", () => {
         },
         breakpoint: "0",
       },
-      ".c",
-      (styleValue) => {
-        if (styleValue.type === "image" && styleValue.value.type === "asset") {
-          const asset = assets.get(styleValue.value.value);
-          if (asset === undefined) {
-            return { type: "keyword", value: "none" };
-          }
-          return {
-            type: "image",
-            value: {
-              type: "url",
-              url: asset.path,
-            },
-          };
-        }
-      }
+      ".c"
     );
     rule.styleMap.delete("display");
     expect(sheet.cssText).toMatchInlineSnapshot(`

--- a/packages/css-engine/src/core/style-sheet-regular.ts
+++ b/packages/css-engine/src/core/style-sheet-regular.ts
@@ -1,29 +1,14 @@
 import { StyleRule } from "./rules";
-import type { TransformValue } from "./to-value";
 import { StyleSheet, type CssRule } from "./style-sheet";
 
 const defaultMediaRuleId = "__default-media-rule__";
 
 export class StyleSheetRegular extends StyleSheet {
-  addStyleRule(
-    rule: CssRule,
-    selectorText: string,
-    transformValue?: TransformValue
-  ) {
+  addStyleRule(rule: CssRule, selectorText: string) {
     const mediaRule = this.addMediaRule(rule.breakpoint || defaultMediaRuleId);
 
-    this.markAsDirty();
-    const styleRule = new StyleRule(
-      selectorText,
-      rule.style,
-      transformValue,
-      this.#onChangeRule
-    );
+    const styleRule = new StyleRule(selectorText, rule.style);
     mediaRule.insertRule(styleRule);
     return styleRule;
   }
-
-  #onChangeRule = () => {
-    this.markAsDirty();
-  };
 }

--- a/packages/css-engine/src/core/style-sheet.ts
+++ b/packages/css-engine/src/core/style-sheet.ts
@@ -25,27 +25,23 @@ export class StyleSheet {
   nestingRules: Map<string, NestingRule> = new Map();
   #fontFaceRules: Array<FontFaceRule> = [];
   #transformValue?: TransformValue;
-  #isDirty = false;
   #element: StyleElement;
   constructor(element: StyleElement) {
     this.#element = element;
   }
   setTransformer(transformValue: TransformValue) {
     this.#transformValue = transformValue;
-    this.#isDirty = true;
   }
   addMediaRule(id: string, options?: MediaRuleOptions) {
     let mediaRule = this.#mediaRules.get(id);
     if (mediaRule === undefined) {
       mediaRule = new MediaRule(id, options);
       this.#mediaRules.set(id, mediaRule);
-      this.#isDirty = true;
       return mediaRule;
     }
 
     if (options) {
       mediaRule.options = options;
-      this.#isDirty = true;
     }
 
     if (mediaRule === undefined) {
@@ -60,7 +56,6 @@ export class StyleSheet {
     if (rule !== undefined) {
       return rule;
     }
-    this.#isDirty = true;
     return this.#plainRules.set(cssText, new PlaintextRule(cssText));
   }
   addMixinRule(name: string) {
@@ -68,7 +63,6 @@ export class StyleSheet {
     if (rule === undefined) {
       rule = new MixinRule();
       this.#mixinRules.set(name, rule);
-      this.#isDirty = true;
     }
     return rule;
   }
@@ -77,16 +71,11 @@ export class StyleSheet {
     if (rule === undefined) {
       rule = new NestingRule(selector, this.#mixinRules);
       this.nestingRules.set(selector, rule);
-      this.#isDirty = true;
     }
     return rule;
   }
   addFontFaceRule(options: FontFaceOptions) {
-    this.#isDirty = true;
     return this.#fontFaceRules.push(new FontFaceRule(options));
-  }
-  markAsDirty() {
-    this.#isDirty = true;
   }
   generateWith({
     nestingRules,
@@ -95,10 +84,6 @@ export class StyleSheet {
     nestingRules: NestingRule[];
     transformValue?: TransformValue;
   }) {
-    if (this.#isDirty === false) {
-      return this.#cssText;
-    }
-    this.#isDirty = false;
     const css: Array<string> = [];
 
     css.push(...this.#fontFaceRules.map((rule) => rule.cssText));
@@ -135,7 +120,6 @@ export class StyleSheet {
     this.#mediaRules.clear();
     this.#plainRules.clear();
     this.#fontFaceRules = [];
-    this.#isDirty = true;
   }
   render() {
     this.#element.mount();


### PR DESCRIPTION
Here got rid of top level stylesheet caching in favor of managing caching by each rule. So nesting rule, font face and style rule based on their inputs and methods manage own cached css string.

In stylesheet all the work left is building media queries and concatenating all rules. This prevents hard to debug cached css after updates.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)