### PR TITLE
feat: allow non-latin characters in old-path redirects

### DIFF
--- a/apps/builder/app/builder/features/project-settings/section-redirects.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-redirects.tsx
@@ -17,9 +17,9 @@ import {
 import { ArrowRightIcon, TrashIcon } from "@webstudio-is/icons";
 import { useState, type ChangeEvent, useRef } from "react";
 import {
-  PagePath,
   PageRedirect,
   ProjectNewRedirectPath,
+  ProjectOldRedirectPath,
 } from "@webstudio-is/sdk";
 import { useStore } from "@nanostores/react";
 import { getExistingRoutePaths } from "../sidebar-left/panels/pages/page-utils";
@@ -58,7 +58,7 @@ export const SectionRedirects = () => {
   };
 
   const validateOldPath = (oldPath: string): string[] => {
-    const oldPathValidationResult = PagePath.safeParse(oldPath);
+    const oldPathValidationResult = ProjectOldRedirectPath.safeParse(oldPath);
 
     if (oldPathValidationResult.success === true) {
       if (oldPath.startsWith("/") === true) {

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -129,8 +129,20 @@ export const ProjectNewRedirectPath = PagePath.or(
   }, "Must be a valid URL")
 );
 
+export const ProjectOldRedirectPath = PagePath.or(
+  z
+    .string()
+    .refine(
+      (path) =>
+        new RegExp(/^(?:\/[-_a-zA-Z0-9*:?\\\p{L}\\p{N}\\p{M}\\\/]+)+$/gmu).test(
+          path
+        ),
+      "Only a-z, 0-9, -, _, /, :, ?, * and non-latin characters are allowed"
+    )
+);
+
 export const PageRedirect = z.object({
-  old: PagePath,
+  old: ProjectOldRedirectPath,
   new: ProjectNewRedirectPath,
   status: z.enum(["301", "302"]).optional(),
 });

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -134,7 +134,7 @@ export const ProjectOldRedirectPath = PagePath.or(
     .string()
     .refine(
       (path) =>
-        new RegExp(/^(?:\/[-_a-zA-Z0-9*:?\\\p{L}\\p{N}\\p{M}\\\/]+)+$/gmu).test(
+        new RegExp(/^(?:\/[-_a-zA-Z0-9*:?\\\p{L}\\p{N}\\p{M}\\/]+)+$/gmu).test(
           path
         ),
       "Only a-z, 0-9, -, _, /, :, ?, * and non-latin characters are allowed"


### PR DESCRIPTION
## Description

fixes #3225 

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
