### PR TITLE
fix: when navigator item is being edited, it can't be draggable

### DIFF
--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -213,6 +213,9 @@ export const Tree = <Data extends { id: string }>({
     shiftDistanceThreshold: INDENT,
 
     elementToData: (element) => {
+      if (element.hasAttribute("contenteditable")) {
+        return false;
+      }
       const dragItemSelector = getItemSelectorFromElement(element);
       // tree root is not draggable
       if (dragItemSelector.length === 1) {


### PR DESCRIPTION
closes https://github.com/webstudio-is/webstudio/issues/3285

## Description

when editing navigator item name, don't allow dragging, because it prevents text selection

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
