### PR TITLE
refactor: remove project meta from client

### DIFF
--- a/fixtures/webstudio-cloudflare-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/_index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -41,8 +41,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "",
-  faviconAssetId: "",
-  code: "",
-};
+export const customCode = "";

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
@@ -10,6 +10,8 @@ import {
   Text as Text,
 } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "";
+
 export const favIconAsset: ImageAsset | undefined = undefined;
 
 export const socialImageAsset: ImageAsset | undefined = undefined;

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -41,8 +41,5 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "Fixture Site",
-  faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-  code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
-};
+export const customCode =
+  '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">';

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -13,6 +13,8 @@ import {
   HtmlEmbed as HtmlEmbed,
 } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "Fixture Site";
+
 export const favIconAsset: ImageAsset | undefined = {
   id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
   name: "home_wsKvRSqvkajPPBeycZ-C8.svg",

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap-html]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap-html]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 import { sitemap } from "./[sitemap.xml]";
 export const loadResources = async (_props: { system: System }) => {
@@ -67,8 +67,5 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "Fixture Site",
-  faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-  code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
-};
+export const customCode =
+  '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">';

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap-html]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap-html]._index.tsx
@@ -7,6 +7,8 @@ import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Box as Box, Text as Text } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "Fixture Site";
+
 export const favIconAsset: ImageAsset | undefined = {
   id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
   name: "home_wsKvRSqvkajPPBeycZ-C8.svg",

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -41,8 +41,5 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "Fixture Site",
-  faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-  code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
-};
+export const customCode =
+  '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">';

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
@@ -7,6 +7,8 @@ import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "Fixture Site";
+
 export const favIconAsset: ImageAsset | undefined = {
   id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
   name: "home_wsKvRSqvkajPPBeycZ-C8.svg",

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -41,8 +41,5 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "Fixture Site",
-  faviconAssetId: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
-  code: '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">',
-};
+export const customCode =
+  '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">';

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -19,6 +19,8 @@ import {
   Image as Image,
 } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "Fixture Site";
+
 export const favIconAsset: ImageAsset | undefined = {
   id: "cd1e9fad-8df1-45c6-800f-05fda2d2469f",
   name: "home_wsKvRSqvkajPPBeycZ-C8.svg",

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/[script-test]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/[sitemap-html]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/[world]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -41,8 +41,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "",
-  faviconAssetId: "",
-  code: "",
-};
+export const customCode = "";

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -10,6 +10,8 @@ import {
   Text as Text,
 } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "";
+
 export const favIconAsset: ImageAsset | undefined = undefined;
 
 export const socialImageAsset: ImageAsset | undefined = undefined;

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -41,8 +41,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "",
-  faviconAssetId: "",
-  code: "",
-};
+export const customCode = "";

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -10,6 +10,8 @@ import {
   Text as Text,
 } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "";
+
 export const favIconAsset: ImageAsset | undefined = undefined;
 
 export const socialImageAsset: ImageAsset | undefined = undefined;

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
@@ -41,4 +41,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";
+export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -41,8 +41,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "KittyGuardedZone",
-  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  code: "<script>console.log('KittyGuardedZone')</script>\n",
-};
+export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -7,6 +7,8 @@ import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Image as Image } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "KittyGuardedZone";
+
 export const favIconAsset: ImageAsset | undefined = {
   id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
@@ -43,4 +43,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";
+export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -43,8 +43,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "KittyGuardedZone",
-  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  code: "<script>console.log('KittyGuardedZone')</script>\n",
-};
+export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -16,6 +16,8 @@ import {
   Heading as Heading,
 } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "KittyGuardedZone";
+
 export const favIconAsset: ImageAsset | undefined = {
   id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
@@ -41,4 +41,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";
+export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -41,8 +41,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "KittyGuardedZone",
-  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  code: "<script>console.log('KittyGuardedZone')</script>\n",
-};
+export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -7,6 +7,8 @@ import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "KittyGuardedZone";
+
 export const favIconAsset: ImageAsset | undefined = {
   id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
@@ -41,4 +41,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";
+export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -41,8 +41,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "KittyGuardedZone",
-  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  code: "<script>console.log('KittyGuardedZone')</script>\n",
-};
+export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -7,6 +7,8 @@ import { useResource } from "@webstudio-is/react-sdk";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "KittyGuardedZone";
+
 export const favIconAsset: ImageAsset | undefined = {
   id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
@@ -42,4 +42,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";
+export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -42,8 +42,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "KittyGuardedZone",
-  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  code: "<script>console.log('KittyGuardedZone')</script>\n",
-};
+export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -18,6 +18,8 @@ import {
   HtmlEmbed as HtmlEmbed,
 } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "KittyGuardedZone";
+
 export const favIconAsset: ImageAsset | undefined = {
   id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 import { sitemap } from "./[sitemap.xml]";
 export const loadResources = async (_props: { system: System }) => {
@@ -67,8 +67,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "KittyGuardedZone",
-  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  code: "<script>console.log('KittyGuardedZone')</script>\n",
-};
+export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
@@ -67,4 +67,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";
+export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -10,6 +10,8 @@ import {
   HtmlEmbed as HtmlEmbed,
 } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "KittyGuardedZone";
+
 export const favIconAsset: ImageAsset | undefined = {
   id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
@@ -47,4 +47,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";
+export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /* This is a auto generated file for building the project */
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 import { loadResource, isLocalResource, type System } from "@webstudio-is/sdk";
 export const loadResources = async (_props: { system: System }) => {
   return {} as Record<string, unknown>;
@@ -47,8 +47,4 @@ export const user: { email: string | null } | undefined = {
   email: "hello@webstudio.is",
 };
 
-export const projectMeta: ProjectMeta = {
-  siteName: "KittyGuardedZone",
-  faviconAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  code: "<script>console.log('KittyGuardedZone')</script>\n",
-};
+export const customCode = "<script>console.log('KittyGuardedZone')</script>\n";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -16,6 +16,8 @@ import {
   Text as Text,
 } from "@webstudio-is/sdk-components-react";
 
+export const siteName = "KittyGuardedZone";
+
 export const favIconAsset: ImageAsset | undefined = {
   id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
   name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/[_route_with_symbols_]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/[form]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/[heading-with-id]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/[nested].[nested-page]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/[radix]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/[resources]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });

--- a/packages/cli/__generated__/_index.server.tsx
+++ b/packages/cli/__generated__/_index.server.tsx
@@ -1,7 +1,7 @@
 /**
  * The only intent of this file is to support typings inside ../templates/route-template for easier development.
  **/
-import type { ProjectMeta, PageMeta, System } from "@webstudio-is/sdk";
+import type { PageMeta, System } from "@webstudio-is/sdk";
 
 export const loadResources = async (_props: { system: System }) => {
   const [] = await Promise.all([]);
@@ -34,8 +34,4 @@ export const user: { email: string | null } | undefined = {
   email: "email@domain",
 };
 
-export const projectMeta: undefined | ProjectMeta = {
-  siteName: "",
-  faviconAssetId: "",
-  code: "",
-};
+export const customCode = "";

--- a/packages/cli/__generated__/_index.tsx
+++ b/packages/cli/__generated__/_index.tsx
@@ -4,6 +4,8 @@
 
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 
+export const siteName = "";
+
 export const favIconAsset: ImageAsset | undefined = undefined;
 
 export const socialImageAsset: ImageAsset | undefined = undefined;

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -639,7 +639,7 @@ export const projectId = "${siteData.build.projectId}";
 export const user: { email: string | null } | undefined =
   ${JSON.stringify(siteData.user)};
 
-export const customCode = ${JSON.stringify(projectMeta?.code)};
+export const customCode = ${JSON.stringify(projectMeta?.code?.trim() ?? "")};
 `;
 
     /*

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -592,6 +592,8 @@ import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource } from "@webstudio-is/react-sdk";
 ${componentImports}
 
+export const siteName = ${JSON.stringify(projectMeta?.siteName)};
+
 export const favIconAsset: ImageAsset | undefined =
   ${JSON.stringify(favIconAsset)};
 
@@ -614,7 +616,7 @@ export { Page }
     const serverExports = `/* eslint-disable */
 /* This is a auto generated file for building the project */ \n
 
-import type { ProjectMeta, PageMeta } from "@webstudio-is/sdk";
+import type { PageMeta } from "@webstudio-is/sdk";
 ${generateResourcesLoader({
   scope,
   page: pageData.page,
@@ -637,8 +639,7 @@ export const projectId = "${siteData.build.projectId}";
 export const user: { email: string | null } | undefined =
   ${JSON.stringify(siteData.user)};
 
-export const projectMeta: ProjectMeta =
-  ${JSON.stringify(projectMeta)};
+export const customCode = ${JSON.stringify(projectMeta?.code)};
 `;
 
     /*

--- a/packages/cli/templates/defaults/app/routes/template.tsx
+++ b/packages/cli/templates/defaults/app/routes/template.tsx
@@ -14,6 +14,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { n8nHandler, getFormId } from "@webstudio-is/form-handlers";
 import {
   Page,
+  siteName,
   favIconAsset,
   socialImageAsset,
   pageFontAssets,
@@ -26,7 +27,6 @@ import {
   getRemixParams,
   projectId,
   user,
-  projectMeta,
 } from "../../../../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -70,7 +70,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       system,
       resources,
       pageMeta,
-      projectMeta,
     },
     // No way for current information to change, so add cache for 10 minutes
     // In case of CRM Data, this should be set to 0
@@ -96,7 +95,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (data === undefined) {
     return metas;
   }
-  const { pageMeta, projectMeta } = data;
+  const { pageMeta } = data;
 
   if (data.url) {
     metas.push({
@@ -118,16 +117,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
   const origin = `https://${data.host}`;
 
-  if (projectMeta?.siteName) {
+  if (siteName) {
     metas.push({
       property: "og:site_name",
-      content: projectMeta.siteName,
+      content: siteName,
     });
     metas.push({
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        name: projectMeta.siteName,
+        name: siteName,
         url: origin,
       },
     });


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3289

We need to put sensitive information into project meta so it should not be sent to client as whole object. Here split it into separate exports.

- added siteName to client bundle
- added customCode to server bundle (should be fixed in saas too)
- removed projectMeta from loader and from server bundle
