### PR TITLE
feat: allow customizing default contact email

### DIFF
--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -1,3 +1,4 @@
+import { useId, useState } from "react";
 import { useStore } from "@nanostores/react";
 import {
   Grid,
@@ -10,13 +11,15 @@ import {
   CheckboxAndLabel,
   Checkbox,
   css,
+  Flex,
+  Tooltip,
 } from "@webstudio-is/design-system";
+import { InfoCircleIcon } from "@webstudio-is/icons";
 import { ImageControl } from "./image-control";
-import { $assets, $imageLoader, $pages } from "~/shared/nano-states";
 import { Image } from "@webstudio-is/image";
-import { useIds } from "~/shared/form-utils";
 import type { ProjectMeta, CompilerSettings } from "@webstudio-is/sdk";
-import { useState } from "react";
+import { $assets, $imageLoader, $pages } from "~/shared/nano-states";
+import { useIds } from "~/shared/form-utils";
 import { serverSyncStore } from "~/shared/sync";
 import { sectionSpacing } from "./utils";
 import { CodeEditor } from "~/builder/shared/code-editor";
@@ -32,6 +35,7 @@ const imgStyle = css({
 
 const defaultMetaSettings: ProjectMeta = {
   siteName: "",
+  contactEmail: "",
   faviconAssetId: "",
   code: "",
 };
@@ -40,7 +44,8 @@ export const SectionGeneral = () => {
   const [meta, setMeta] = useState(
     () => $pages.get()?.meta ?? defaultMetaSettings
   );
-  const ids = useIds(["siteName"]);
+  const siteNameId = useId();
+  const contactEmailId = useId();
   const assets = useStore($assets);
   const asset = assets.get(meta.faviconAssetId ?? "");
   const favIconUrl = asset ? `${asset.name}` : undefined;
@@ -65,18 +70,49 @@ export const SectionGeneral = () => {
   };
 
   return (
-    <>
+    <Grid gap={2}>
+      <Text variant="titles" css={sectionSpacing}>
+        General
+      </Text>
+
       <Grid gap={1} css={sectionSpacing}>
-        <Text variant="titles">General</Text>
-        <Label htmlFor={ids.siteName}>Site Name</Label>
+        <Flex gap={1} align="center">
+          <Label htmlFor={siteNameId}>Site Name</Label>
+          <Tooltip
+            variant="wrapped"
+            content="Used in search results and social preview."
+          >
+            <InfoCircleIcon tabIndex={0} />
+          </Tooltip>
+        </Flex>
         <InputField
-          id={ids.siteName}
+          id={siteNameId}
+          placeholder="Current Site Name"
+          autoFocus={true}
           value={meta.siteName ?? ""}
           onChange={(event) => {
             handleSave("siteName")(event.target.value);
           }}
-          placeholder="Current Site Name"
-          autoFocus
+        />
+      </Grid>
+
+      <Grid gap={1} css={sectionSpacing}>
+        <Flex gap={1} align="center">
+          <Label htmlFor={contactEmailId}>Contact Email</Label>
+          <Tooltip
+            variant="wrapped"
+            content="Used as email recipient when submit webhook form without action."
+          >
+            <InfoCircleIcon tabIndex={0} />
+          </Tooltip>
+        </Flex>
+        <InputField
+          id={contactEmailId}
+          placeholder="email@address.com"
+          value={meta.contactEmail ?? ""}
+          onChange={(event) => {
+            handleSave("contactEmail")(event.target.value);
+          }}
         />
       </Grid>
 
@@ -118,7 +154,7 @@ export const SectionGeneral = () => {
       <Separator />
 
       <CompilerSection />
-    </>
+    </Grid>
   );
 };
 

--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { useId, useState } from "react";
 import { useStore } from "@nanostores/react";
 import {
@@ -13,6 +14,7 @@ import {
   css,
   Flex,
   Tooltip,
+  InputErrorsTooltip,
 } from "@webstudio-is/design-system";
 import { InfoCircleIcon } from "@webstudio-is/icons";
 import { ImageControl } from "./image-control";
@@ -40,12 +42,19 @@ const defaultMetaSettings: ProjectMeta = {
   code: "",
 };
 
+const Email = z.string().email();
+
 export const SectionGeneral = () => {
   const [meta, setMeta] = useState(
     () => $pages.get()?.meta ?? defaultMetaSettings
   );
   const siteNameId = useId();
   const contactEmailId = useId();
+  const contactEmailError =
+    (meta.contactEmail ?? "").trim().length === 0 ||
+    Email.safeParse(meta.contactEmail).success
+      ? undefined
+      : "Contact email is invalid.";
   const assets = useStore($assets);
   const asset = assets.get(meta.faviconAssetId ?? "");
   const favIconUrl = asset ? `${asset.name}` : undefined;
@@ -106,14 +115,19 @@ export const SectionGeneral = () => {
             <InfoCircleIcon tabIndex={0} />
           </Tooltip>
         </Flex>
-        <InputField
-          id={contactEmailId}
-          placeholder="email@address.com"
-          value={meta.contactEmail ?? ""}
-          onChange={(event) => {
-            handleSave("contactEmail")(event.target.value);
-          }}
-        />
+        <InputErrorsTooltip
+          errors={contactEmailError ? [contactEmailError] : undefined}
+        >
+          <InputField
+            id={contactEmailId}
+            color={contactEmailError ? "error" : undefined}
+            placeholder="email@address.com"
+            value={meta.contactEmail ?? ""}
+            onChange={(event) => {
+              handleSave("contactEmail")(event.target.value);
+            }}
+          />
+        </InputErrorsTooltip>
       </Grid>
 
       <Separator />

--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -80,7 +80,7 @@ export const SectionGeneral = () => {
           <Label htmlFor={siteNameId}>Site Name</Label>
           <Tooltip
             variant="wrapped"
-            content="Used in search results and social preview."
+            content="Used in search results and social previews."
           >
             <InfoCircleIcon tabIndex={0} />
           </Tooltip>
@@ -101,7 +101,7 @@ export const SectionGeneral = () => {
           <Label htmlFor={contactEmailId}>Contact Email</Label>
           <Tooltip
             variant="wrapped"
-            content="Used as email recipient when submit webhook form without action."
+            content="Used as the email recipient when submitting a webhook form without an action."
           >
             <InfoCircleIcon tabIndex={0} />
           </Tooltip>

--- a/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
@@ -167,9 +167,11 @@ export const SectionMarketplace = () => {
   };
 
   return (
-    <>
+    <Grid gap={2}>
+      <Text variant="titles" css={sectionSpacing}>
+        Marketplace
+      </Text>
       <Grid gap={1} css={sectionSpacing}>
-        <Text variant="titles">Marketplace</Text>
         <Label htmlFor={ids.name}>Product Name</Label>
         <InputErrorsTooltip errors={errors?.name}>
           <InputField
@@ -350,6 +352,6 @@ export const SectionMarketplace = () => {
           </Button>
         )}
       </Flex>
-    </>
+    </Grid>
   );
 };

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/_index.server.tsx
@@ -37,8 +37,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode = "";

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
@@ -37,9 +37,7 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode =
   '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">';

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap-html]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap-html]._index.server.tsx
@@ -63,9 +63,7 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode =
   '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">';

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
@@ -37,9 +37,7 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode =
   '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">';

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
@@ -37,9 +37,7 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "0d856812-61d8-4014-a20a-82e01c0eb8ee";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode =
   '<script>console.log(\'HELLO\')</script>\n<meta property="saas:test" content="test">';

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/[script-test]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap-html]._index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/[sitemap-html]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/[world]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
@@ -37,8 +37,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode = "";

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
@@ -37,8 +37,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "d845c167-ea07-4875-b08d-83e97c09dcce";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode = "";

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
@@ -37,8 +37,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
@@ -39,8 +39,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
@@ -37,8 +37,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
@@ -37,8 +37,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
@@ -38,8 +38,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
@@ -63,8 +63,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
@@ -43,8 +43,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const user: { email: string | null } | undefined = {
-  email: "hello@webstudio.is",
-};
+export const contactEmail = "hello@webstudio.is";
 
 export const customCode = "<script>console.log('KittyGuardedZone')</script>";

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/[_route_with_symbols_]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/[form]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/[heading-with-id]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/[nested].[nested-page]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/[radix]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/[resources]._index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/packages/cli/__generated__/_index.server.tsx
+++ b/packages/cli/__generated__/_index.server.tsx
@@ -30,8 +30,6 @@ export const getRemixParams = ({ ...params }: Params): Params => {
 
 export const projectId = "project-id";
 
-export const user: { email: string | null } | undefined = {
-  email: "email@domain",
-};
+export const contactEmail: undefined | string = undefined;
 
 export const customCode = "";

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -582,7 +582,8 @@ export const prebuild = async (options: {
 
     const projectMeta = siteData.build.pages.meta;
     const contactEmail: undefined | string =
-      projectMeta?.contactEmail ?? siteData.user?.email ?? undefined;
+      // fallback to user email when contact email is empty string
+      projectMeta?.contactEmail || siteData.user?.email || undefined;
     const pageMeta = pageData.page.meta;
     const favIconAsset = assets.get(projectMeta?.faviconAssetId ?? "");
     const socialImageAsset = assets.get(pageMeta.socialImageAssetId ?? "");

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -581,6 +581,8 @@ export const prebuild = async (options: {
     });
 
     const projectMeta = siteData.build.pages.meta;
+    const contactEmail: undefined | string =
+      projectMeta?.contactEmail ?? siteData.user?.email ?? undefined;
     const pageMeta = pageData.page.meta;
     const favIconAsset = assets.get(projectMeta?.faviconAssetId ?? "");
     const socialImageAsset = assets.get(pageMeta.socialImageAssetId ?? "");
@@ -636,8 +638,7 @@ ${generateRemixParams(pageData.page.path)}
 
 export const projectId = "${siteData.build.projectId}";
 
-export const user: { email: string | null } | undefined =
-  ${JSON.stringify(siteData.user)};
+export const contactEmail = ${JSON.stringify(contactEmail)};
 
 export const customCode = ${JSON.stringify(projectMeta?.code?.trim() ?? "")};
 `;

--- a/packages/cli/templates/defaults/app/routes/template.tsx
+++ b/packages/cli/templates/defaults/app/routes/template.tsx
@@ -26,7 +26,7 @@ import {
   getPageMeta,
   getRemixParams,
   projectId,
-  user,
+  contactEmail,
 } from "../../../../__generated__/_index.server";
 
 import css from "../__generated__/index.css?url";
@@ -255,9 +255,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   // form properties are not defined when defaults are used
   const { action, method } = formProperties ?? {};
 
-  const email = user?.email;
-
-  if (email == null) {
+  if (contactEmail === undefined) {
     return { success: false };
   }
 
@@ -292,7 +290,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     action: action ?? null,
     method: getMethod(method),
     pageUrl: pageUrl.toString(),
-    toEmail: email,
+    toEmail: contactEmail,
     fromEmail: pageUrl.hostname + "@webstudio.email",
   } as const;
 

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -108,6 +108,7 @@ const Page = z.object({
 const ProjectMeta = z.object({
   // All fields are optional to ensure consistency and allow for the addition of new fields without requiring migration
   siteName: z.string().optional(),
+  contactEmail: z.string().optional(),
   faviconAssetId: z.string().optional(),
   code: z.string().optional(),
 });


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/3289

Here added contact email fields to use it as recipient instead of owner email. This way users can host sites for many clients and use default webhook form behavior without implementing own n8n workflows.