### PR TITLE
refactor: drop require export condition

### DIFF
--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -40,8 +40,7 @@
   "exports": {
     "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/error-utils/package.json
+++ b/packages/error-utils/package.json
@@ -19,8 +19,7 @@
   "exports": {
     "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -26,8 +26,7 @@
   "exports": {
     "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -18,8 +18,7 @@
   "exports": {
     "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -25,8 +25,7 @@
   "exports": {
     "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -39,14 +39,12 @@
     ".": {
       "webstudio": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/index.js"
+      "import": "./lib/index.js"
     },
     "./svg": {
       "webstudio": "./src/__generated__/svg/index.ts",
       "types": "./lib/types/__generated__/svg/index.d.ts",
-      "import": "./lib/__generated__/svg/index.js",
-      "require": "./lib/__generated__/svg/index.js"
+      "import": "./lib/__generated__/svg/index.js"
     }
   },
   "files": [

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -40,8 +40,7 @@
   "exports": {
     "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -46,14 +46,12 @@
     ".": {
       "webstudio": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/index.js"
+      "import": "./lib/index.js"
     },
     "./css-normalize": {
       "webstudio": "./src/css/normalize.ts",
       "types": "./lib/types/css/normalize.d.ts",
-      "import": "./lib/css/normalize.js",
-      "require": "./lib/css/normalize.js"
+      "import": "./lib/css/normalize.js"
     }
   },
   "files": [

--- a/packages/sdk-components-react-radix/package.json
+++ b/packages/sdk-components-react-radix/package.json
@@ -16,26 +16,22 @@
     ".": {
       "webstudio": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
-      "import": "./lib/components.js",
-      "require": "./lib/components.js"
+      "import": "./lib/components.js"
     },
     "./metas": {
       "webstudio": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js",
-      "require": "./lib/metas.js"
+      "import": "./lib/metas.js"
     },
     "./props": {
       "webstudio": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js",
-      "require": "./lib/props.js"
+      "import": "./lib/props.js"
     },
     "./hooks": {
       "webstudio": "./src/hooks.ts",
       "types": "./lib/types/hooks.d.ts",
-      "import": "./lib/hooks.js",
-      "require": "./lib/hooks.js"
+      "import": "./lib/hooks.js"
     }
   },
   "scripts": {

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -16,20 +16,17 @@
     ".": {
       "webstudio": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
-      "import": "./lib/components.js",
-      "require": "./lib/components.js"
+      "import": "./lib/components.js"
     },
     "./metas": {
       "webstudio": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js",
-      "require": "./lib/metas.js"
+      "import": "./lib/metas.js"
     },
     "./props": {
       "webstudio": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js",
-      "require": "./lib/props.js"
+      "import": "./lib/props.js"
     }
   },
   "scripts": {

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -16,20 +16,17 @@
     ".": {
       "webstudio": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
-      "import": "./lib/components.js",
-      "require": "./lib/components.js"
+      "import": "./lib/components.js"
     },
     "./metas": {
       "webstudio": "./src/metas.ts",
       "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js",
-      "require": "./lib/metas.js"
+      "import": "./lib/metas.js"
     },
     "./props": {
       "webstudio": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js",
-      "require": "./lib/props.js"
+      "import": "./lib/props.js"
     }
   },
   "scripts": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -9,8 +9,7 @@
   "exports": {
     "webstudio": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
-    "import": "./lib/index.js",
-    "require": "./lib/index.js"
+    "import": "./lib/index.js"
   },
   "files": [
     "lib/*",


### PR DESCRIPTION
This hack was used to support classic remix compiler and no longer necessary.