### PR TITLE
feat: Add support for Xml Node attributes

### DIFF
--- a/packages/sdk-components-react/src/xml-node.tsx
+++ b/packages/sdk-components-react/src/xml-node.tsx
@@ -20,9 +20,20 @@ export const XmlNode = forwardRef<ElementRef<"div">, Props>(
       // Clear all non letter, number, underscore, dot, and dash
       .replaceAll(/[^\p{L}\p{N}\-._]+/gu, "");
 
+    const attributes = Object.entries(props)
+      .filter(
+        ([key]) =>
+          key.startsWith("data-") === false && key.startsWith("aria-") === false
+      )
+      .filter(([key]) => key !== "tabIndex")
+      .filter(([, value]) => typeof value !== "function")
+      .map(([key, value]) => `${key}=${JSON.stringify(value)}`);
+
     return (
       <div style={{ display: isTextChild ? "flex" : "contents" }} {...props}>
-        <div style={{ color: "rgb(16, 23, 233)" }}>&lt;{elementName}&gt;</div>
+        <div style={{ color: "rgb(16, 23, 233)" }}>
+          &lt;{[elementName, ...attributes].join(" ")}&gt;
+        </div>
         <div ref={ref} style={{ marginLeft: isTextChild ? 0 : "1rem" }}>
           {children}
         </div>


### PR DESCRIPTION
## Description

Example xmlns attribute in sitemap

<img width="510" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/6af329d7-2e7c-4d63-80a2-59e656dac8e0">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
