### PR TITLE
fix: prevent failing npm install on peer mismatch

### DIFF
--- a/packages/cli/templates/defaults/.npmrc
+++ b/packages/cli/templates/defaults/.npmrc
@@ -1,0 +1,1 @@
+force=true


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/pull/3300 https://github.com/webstudio-is/webstudio/issues/3284

Here's another fix. Instead of just passing --force flag to npm install command I added .npmrc with force=true which will affect not only webstudio init command but also subsequent npm install calls by user.