### PR TITLE
experimental: add descendent component

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -80,6 +80,12 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
                       ) {
                         return;
                       }
+                      if (
+                        isFeatureEnabled("internalComponents") === false &&
+                        meta.category === "internal"
+                      ) {
+                        return;
+                      }
                       return (
                         <ListItem
                           asChild

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -27,6 +27,7 @@ import {
   collectionComponent,
   type AnyComponent,
   textContentAttribute,
+  descendentComponent,
 } from "@webstudio-is/react-sdk";
 import {
   $propValuesByInstanceSelector,
@@ -328,6 +329,10 @@ export const WebstudioComponentCanvas = forwardRef<
     }
   }
 
+  if (instance.component === descendentComponent) {
+    return <></>;
+  }
+
   const Component =
     components.get(instance.component) ?? (StubComponent as AnyComponent);
 
@@ -446,6 +451,10 @@ export const WebstudioComponentPreview = forwardRef<
         );
       });
     }
+  }
+
+  if (instance.component === descendentComponent) {
+    return <></>;
   }
 
   const Component = components.get(instance.component);

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -25,7 +25,7 @@ import {
   normalizeProps,
   generateRemixRoute,
   generateRemixParams,
-  collectionComponent,
+  isCoreComponent,
 } from "@webstudio-is/react-sdk";
 import type {
   Instance,
@@ -369,7 +369,7 @@ export const prebuild = async (options: {
 
     componentsByPage[page.id] = new Set();
     for (const [_instanceId, instance] of instances) {
-      if (instance.component === collectionComponent) {
+      if (isCoreComponent(instance.component)) {
         continue;
       }
       componentsByPage[page.id].add(instance.component);
@@ -477,6 +477,8 @@ export const prebuild = async (options: {
   spinner.text = "Generating css file";
 
   const { cssText, classesMap } = generateCss({
+    instances: new Map(siteData.build.instances),
+    props: new Map(siteData.build.props),
     assets,
     breakpoints: new Map(siteData.build?.breakpoints),
     styles: new Map(siteData.build?.styles),

--- a/packages/css-engine/src/core/atomic.test.ts
+++ b/packages/css-engine/src/core/atomic.test.ts
@@ -175,3 +175,33 @@ test("distinct similar declarations from different breakpoints", () => {
 }"
 `);
 });
+
+test("support descendent suffix", () => {
+  const sheet = createRegularStyleSheet();
+  sheet.addMediaRule("x");
+  const rule1 = sheet.addNestingRule("instance");
+  rule1.setDeclaration({
+    breakpoint: "x",
+    selector: ":hover",
+    property: "display",
+    value: { type: "keyword", value: "block" },
+  });
+  const rule2 = sheet.addNestingRule("instance", " img");
+  rule2.setDeclaration({
+    breakpoint: "x",
+    selector: ":hover",
+    property: "display",
+    value: { type: "keyword", value: "block" },
+  });
+  expect(generateAtomic(sheet, { getKey: () => "" }).cssText)
+    .toMatchInlineSnapshot(`
+"@media all {
+  .c143pt9k:hover {
+    display: block
+  }
+  .cpdl2lp img:hover {
+    display: block
+  }
+}"
+`);
+});

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -71,6 +71,7 @@ export class MixinRule {
  */
 export class NestingRule {
   #selector: string;
+  #descendentSuffix: string;
   #mixinRules = new Map<string, MixinRule>();
   #mixins = new Set<string>();
   // use map to avoid duplicated properties
@@ -80,12 +81,24 @@ export class NestingRule {
     string,
     { generated: string; indent: number; transformValue?: TransformValue }
   >();
-  constructor(selector: string, mixinRules: Map<string, MixinRule>) {
+  constructor(
+    mixinRules: Map<string, MixinRule>,
+    selector: string,
+    descendentSuffix: string
+  ) {
     this.#selector = selector;
+    this.#descendentSuffix = descendentSuffix;
     this.#mixinRules = mixinRules;
   }
   getSelector() {
     return this.#selector;
+  }
+  setSelector(selector: string) {
+    this.#selector = selector;
+    this.#cache.clear();
+  }
+  getDescendentSuffix() {
+    return this.#descendentSuffix;
   }
   addMixin(mixin: string) {
     this.#mixins.add(mixin);
@@ -154,7 +167,7 @@ export class NestingRule {
         continue;
       }
       const { selector: nestedSelector, property, value } = declaration;
-      const selector = `${this.#selector}${nestedSelector}`;
+      const selector = this.#selector + this.#descendentSuffix + nestedSelector;
       const lines = linesBySelector.get(selector) ?? "";
       const propertyString = toProperty(property);
       const valueString = toValue(value, transformValue);

--- a/packages/css-engine/src/core/style-sheet-regular.test.ts
+++ b/packages/css-engine/src/core/style-sheet-regular.test.ts
@@ -934,4 +934,33 @@ describe("Style Sheet Regular", () => {
 }"
 `);
   });
+
+  test("support descendent suffix", () => {
+    const sheet = createRegularStyleSheet();
+    sheet.addMediaRule("base", {});
+    const rule1 = sheet.addNestingRule(".instance");
+    rule1.setDeclaration({
+      breakpoint: "base",
+      selector: ":hover",
+      property: "width",
+      value: { type: "keyword", value: "auto" },
+    });
+    const rule2 = sheet.addNestingRule(".instance", " img");
+    rule2.setDeclaration({
+      breakpoint: "base",
+      selector: ":hover",
+      property: "width",
+      value: { type: "keyword", value: "auto" },
+    });
+    expect(sheet.cssText).toMatchInlineSnapshot(`
+"@media all {
+  .instance:hover {
+    width: auto
+  }
+  .instance img:hover {
+    width: auto
+  }
+}"
+`);
+  });
 });

--- a/packages/css-engine/src/core/style-sheet.ts
+++ b/packages/css-engine/src/core/style-sheet.ts
@@ -66,11 +66,12 @@ export class StyleSheet {
     }
     return rule;
   }
-  addNestingRule(selector: string) {
-    let rule = this.nestingRules.get(selector);
+  addNestingRule(selector: string, descendentSuffix: string = "") {
+    const key = selector + descendentSuffix;
+    let rule = this.nestingRules.get(key);
     if (rule === undefined) {
-      rule = new NestingRule(selector, this.#mixinRules);
-      this.nestingRules.set(selector, rule);
+      rule = new NestingRule(this.#mixinRules, selector, descendentSuffix);
+      this.nestingRules.set(key, rule);
     }
     return rule;
   }

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -1,5 +1,6 @@
 // Only for development, is not supposed to be enabled at all.
 export const displayContents = false;
+export const internalComponents = false;
 export const unsupportedBrowsers = false;
 export const aiRadixComponents = false;
 export const cms = false;

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -7,7 +7,7 @@ import {
   type Prop,
 } from "@webstudio-is/sdk";
 import { showAttribute } from "./props";
-import { collectionComponent } from "./core-components";
+import { collectionComponent, descendentComponent } from "./core-components";
 import {
   generateJsxChildren,
   generateJsxElement,
@@ -939,6 +939,33 @@ return <Body
 data-ws-id="body"
 data-ws-component="Body"
 data-data={UsedVariableName} />
+}
+"
+`);
+});
+
+test("avoid generating descendent component", () => {
+  expect(
+    generateWebstudioComponent({
+      classesMap: new Map(),
+      scope: createScope(),
+      name: "Page",
+      rootInstanceId: "body",
+      parameters: [],
+      instances: toMap([
+        createInstance("body", "Body", [{ type: "id", value: "selector" }]),
+        createInstance("descendent", descendentComponent, []),
+      ]),
+      dataSources: new Map(),
+      props: new Map(),
+      indexesWithinAncestors: new Map(),
+    })
+  ).toMatchInlineSnapshot(`
+"const Page = () => {
+return <Body
+data-ws-id="body"
+data-ws-component="Body">
+</Body>
 }
 "
 `);

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -19,7 +19,7 @@ import {
   indexAttribute,
   showAttribute,
 } from "./props";
-import { collectionComponent } from "./core-components";
+import { collectionComponent, descendentComponent } from "./core-components";
 import type { IndexesWithinAncestors } from "./instance-utils";
 
 /**
@@ -251,6 +251,12 @@ export const generateJsxElement = ({
       generatedElement += children;
       generatedElement += `</${componentVariable}>\n`;
     }
+  }
+
+  // descendent component is used only for styling
+  // and should not be rendered
+  if (instance.component === descendentComponent) {
+    return "";
   }
 
   if (conditionValue) {

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -26,6 +26,7 @@ export const componentCategories = [
   "radix",
   "xml",
   "hidden",
+  "internal",
 ] as const;
 
 export const stateCategories = ["states", "component-states"] as const;

--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -1,4 +1,4 @@
-import { ListViewIcon } from "@webstudio-is/icons/svg";
+import { EmbedIcon, ListViewIcon } from "@webstudio-is/icons/svg";
 import type {
   WsComponentMeta,
   WsComponentPropsMeta,
@@ -58,10 +58,37 @@ const collectionPropsMeta: WsComponentPropsMeta = {
   initialProps: ["data"],
 };
 
+export const descendentComponent = "ws:descendent";
+
+const descendentMeta: WsComponentMeta = {
+  category: "internal",
+  type: "control",
+  label: "Descendent",
+  icon: EmbedIcon,
+};
+
+const descendentPropsMeta: WsComponentPropsMeta = {
+  props: {
+    selector: {
+      required: true,
+      control: "text",
+      type: "string",
+    },
+  },
+  initialProps: ["selector"],
+};
+
 export const coreMetas = {
   [collectionComponent]: collectionMeta,
+  [descendentComponent]: descendentMeta,
 };
 
 export const corePropsMetas = {
   [collectionComponent]: collectionPropsMeta,
+  [descendentComponent]: descendentPropsMeta,
 };
+
+// components with custom implementation
+// should not be imported as react component
+export const isCoreComponent = (component: string) =>
+  component === collectionComponent || component === descendentComponent;

--- a/packages/react-sdk/src/css/css.test.ts
+++ b/packages/react-sdk/src/css/css.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@jest/globals";
 import type { Breakpoint } from "@webstudio-is/sdk";
 import { generateCss, type CssConfig } from "./css";
+import { descendentComponent } from "../core-components";
 
 const toMap = <T extends { id: string }>(list: T[]) =>
   new Map(list.map((item) => [item.id, item] as const));
@@ -20,6 +21,8 @@ const generateAllCss = (config: Omit<CssConfig, "atomic">) => {
 test("generate css for one instance with two tokens", () => {
   const { cssText, atomicCssText, classesMap } = generateAllCss({
     assets: new Map(),
+    instances: new Map(),
+    props: new Map(),
     breakpoints: toMap<Breakpoint>([{ id: "base", label: "" }]),
     styleSourceSelections: new Map([
       ["box", { instanceId: "box", values: ["token", "local"] }],
@@ -68,6 +71,107 @@ test("generate css for one instance with two tokens", () => {
 Map {
   "box" => [
     "cawkhls",
+  ],
+}
+`);
+});
+
+test("generate descendant selector", () => {
+  const { cssText, atomicCssText, classesMap } = generateAllCss({
+    assets: new Map(),
+    instances: toMap([
+      {
+        id: "root",
+        type: "instance",
+        component: "Body",
+        children: [{ type: "id", value: "descendant" }],
+      },
+      {
+        id: "descendant",
+        type: "instance",
+        component: descendentComponent,
+        children: [],
+      },
+    ]),
+    props: toMap([
+      {
+        id: "1",
+        instanceId: "descendant",
+        name: "selector",
+        type: "string",
+        value: " a",
+      },
+    ]),
+    breakpoints: toMap<Breakpoint>([{ id: "base", label: "" }]),
+    styleSourceSelections: new Map([
+      ["root", { instanceId: "root", values: ["local"] }],
+      ["descendant", { instanceId: "descendant", values: ["local"] }],
+    ]),
+    styles: new Map([
+      [
+        "local:base:color",
+        {
+          styleSourceId: "local",
+          breakpointId: "base",
+          property: "color",
+          value: { type: "keyword", value: "blue" },
+        },
+      ],
+      [
+        "local:base:color::hover",
+        {
+          styleSourceId: "local",
+          breakpointId: "base",
+          state: ":hover",
+          property: "color",
+          value: { type: "keyword", value: "red" },
+        },
+      ],
+    ]),
+    componentMetas: new Map(),
+    assetBaseUrl: "",
+  });
+  expect(cssText).toMatchInlineSnapshot(`
+"html {margin: 0; display: grid; min-height: 100%}
+@media all {
+  [data-ws-id="root"] {
+    color: blue
+  }
+  [data-ws-id="root"]:hover {
+    color: red
+  }
+  [data-ws-id="root"] a {
+    color: blue
+  }
+  [data-ws-id="root"] a:hover {
+    color: red
+  }
+}"
+`);
+  expect(atomicCssText).toMatchInlineSnapshot(`
+"html {margin: 0; display: grid; min-height: 100%}
+@media all {
+  .c17hlgoh {
+    color: blue
+  }
+  .c92zrdl:hover {
+    color: red
+  }
+  .chhpmat a {
+    color: blue
+  }
+  .c32fhpn a:hover {
+    color: red
+  }
+}"
+`);
+  expect(classesMap).toMatchInlineSnapshot(`
+Map {
+  "root" => [
+    "c17hlgoh",
+    "c92zrdl",
+    "chhpmat",
+    "c32fhpn",
   ],
 }
 `);

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -8,16 +8,21 @@ import type {
   Assets,
   Breakpoints,
   Instance,
+  Instances,
+  Props,
   StyleSourceSelections,
   Styles,
 } from "@webstudio-is/sdk";
 import type { WsComponentMeta } from "../components/component-meta";
 import { idAttribute } from "../props";
+import { descendentComponent } from "../core-components";
 import { addGlobalRules } from "./global-rules";
 import { getPresetStyleRules } from "./style-rules";
 
 export type CssConfig = {
   assets: Assets;
+  instances: Instances;
+  props: Props;
   breakpoints: Breakpoints;
   styles: Styles;
   styleSourceSelections: StyleSourceSelections;
@@ -54,6 +59,8 @@ export const createImageValueTransformer =
 
 export const generateCss = ({
   assets,
+  instances,
+  props,
   breakpoints,
   styles,
   styleSourceSelections,
@@ -62,6 +69,21 @@ export const generateCss = ({
   atomic,
 }: CssConfig) => {
   const sheet = createRegularStyleSheet({ name: "ssr" });
+  const parentIdByInstanceId = new Map<Instance["id"], Instance["id"]>();
+  for (const instance of instances.values()) {
+    for (const child of instance.children) {
+      if (child.type === "id") {
+        parentIdByInstanceId.set(child.value, instance.id);
+      }
+    }
+  }
+
+  const descendentSelectorByInstanceId = new Map<Instance["id"], string>();
+  for (const prop of props.values()) {
+    if (prop.name === "selector" && prop.type === "string") {
+      descendentSelectorByInstanceId.set(prop.instanceId, prop.value);
+    }
+  }
 
   addGlobalRules(sheet, { assets, assetBaseUrl });
 
@@ -96,8 +118,22 @@ export const generateCss = ({
   }
 
   const instanceByRule = new Map<NestingRule, Instance["id"]>();
-  for (const { instanceId, values } of styleSourceSelections.values()) {
-    const rule = sheet.addNestingRule(`[${idAttribute}="${instanceId}"]`);
+  for (let { instanceId, values } of styleSourceSelections.values()) {
+    let descendentSuffix = "";
+    // render selector component as descendent selector
+    const instance = instances.get(instanceId);
+    if (instance?.component === descendentComponent) {
+      const parentId = parentIdByInstanceId.get(instanceId);
+      const descendentSelector = descendentSelectorByInstanceId.get(instanceId);
+      if (parentId && descendentSelector) {
+        descendentSuffix = descendentSelector;
+        instanceId = parentId;
+      }
+    }
+    const rule = sheet.addNestingRule(
+      `[${idAttribute}="${instanceId}"]`,
+      descendentSuffix
+    );
     rule.applyMixins(values);
     instanceByRule.set(rule, instanceId);
   }

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -118,7 +118,9 @@ export const generateCss = ({
   }
 
   const instanceByRule = new Map<NestingRule, Instance["id"]>();
-  for (let { instanceId, values } of styleSourceSelections.values()) {
+  for (const selection of styleSourceSelections.values()) {
+    let { instanceId } = selection;
+    const { values } = selection;
     let descendentSuffix = "";
     // render selector component as descendent selector
     const instance = instances.get(instanceId);

--- a/packages/sdk-cli/src/generate-stories.ts
+++ b/packages/sdk-cli/src/generate-stories.ts
@@ -130,6 +130,7 @@ export const generateStories = async () => {
           [instance.id, instance] satisfies [Instance["id"], Instance]
       ),
     ]);
+    const props = new Map(data.props.map((prop) => [prop.id, prop]));
     const components = new Set<Instance["component"]>();
     const usedMetas = new Map<Instance["component"], WsComponentMeta>();
     const bodyMeta = baseMetas.get("Body");
@@ -146,6 +147,8 @@ export const generateStories = async () => {
       }
     }
     const { cssText, classesMap } = generateCss({
+      instances,
+      props,
       assets: new Map(),
       breakpoints: new Map([
         [baseBreakpointId, { id: baseBreakpointId, label: "base" }],
@@ -178,7 +181,7 @@ export const generateStories = async () => {
       rootInstanceId,
       parameters: [],
       instances,
-      props: new Map(data.props.map((prop) => [prop.id, prop])),
+      props,
       dataSources: new Map(data.dataSources.map((prop) => [prop.id, prop])),
       indexesWithinAncestors: getIndexesWithinAncestors(usedMetas, instances, [
         rootInstanceId,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2903

Here added support for new `<ws:descendent />` component. It allows to style any children or descendents of components. Primary usage is for embed content which renders html and need to style tags.

Descendent component accepts "selector" prop which can be suffix like ` img`, ` .image` or `::first-child` pseudo-element.

Potentially it could be used as tag styling for any element.

Can be tested in any element by dropping "Descendent" component from "internal" category.