### PR TITLE
feat: Add doctype to new/edit page

### DIFF
--- a/packages/design-system/src/components/select.tsx
+++ b/packages/design-system/src/components/select.tsx
@@ -124,7 +124,7 @@ type TriggerPassThroughProps = Omit<
   Omit<ComponentProps<typeof SelectButton>, "onChange" | "value">;
 
 export type SelectProps<Option = SelectOption> = {
-  options: Option[];
+  options: readonly Option[];
   defaultValue?: Option;
   value?: Option;
   onChange?: (option: Option) => void;

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -42,6 +42,8 @@ export const PageTitle = z
     `Minimum ${MIN_TITLE_LENGTH} characters required`
   );
 
+export const documentTypes = ["html", "xml"] as const;
+
 const commonPageFields = {
   id: PageId,
   name: PageName,
@@ -55,6 +57,7 @@ const commonPageFields = {
     socialImageUrl: z.string().optional(),
     status: z.string().optional(),
     redirect: z.string().optional(),
+    documentType: z.optional(z.enum(documentTypes)),
     custom: z
       .array(
         z.object({
@@ -85,8 +88,8 @@ export const PagePath = z
   .refine((path) => path.endsWith("/") === false, "Can't end with a /")
   .refine((path) => path.includes("//") === false, "Can't contain repeating /")
   .refine(
-    (path) => /^[-_a-z0-9*:?\\/]*$/.test(path),
-    "Only a-z, 0-9, -, _, /, :, ? and * are allowed"
+    (path) => /^[-_a-z0-9*:?\\/.]*$/.test(path),
+    "Only a-z, 0-9, -, _, /, :, ?, . and * are allowed"
   )
   .refine(
     // We use /s for our system stuff like /s/css or /s/uploads


### PR DESCRIPTION
## Description

ref: #3308 

Use for review:

<img width="380" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/448e7413-aee1-41b5-b748-d20a80d48a44">


<img width="507" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/6ed2315f-fd7a-4d7e-b0fe-76d6ac3f87bc">

In case of xml is selected

- No way to make xml as home page
<img width="460" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/22864698-d9ca-41c7-8787-28e89389fc89">
<img width="475" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/b104b5f7-2787-41e2-be09-490357c2b1e9">

- Editing of social/etc is disabled

<img width="476" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/a53ec4d8-3a73-406f-b179-4270dfa3fb92">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
