### PR TITLE
feat: Add support for `text-shadow` property in style-panel

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
@@ -2,8 +2,10 @@ import {
   SectionTitle,
   SectionTitleButton,
   SectionTitleLabel,
+  Tooltip,
+  Text,
 } from "@webstudio-is/design-system";
-import { PlusIcon } from "@webstudio-is/icons";
+import { InfoCircleIcon, PlusIcon } from "@webstudio-is/icons";
 import type {
   LayersValue,
   StyleProperty,
@@ -82,7 +84,26 @@ export const Section = (props: SectionProps) => {
                 key={layersProps.index}
                 {...layersProps}
                 label={label}
-              ></ShadowLayer>
+                tooltip={
+                  <Tooltip
+                    variant="wrapped"
+                    content={
+                      <Text>
+                        Paste a box-shadow CSS code
+                        <br />
+                        without the property name, for
+                        <br />
+                        example:
+                        <br />
+                        <br />
+                        0px 2px 5px 0px rgba(0, 0, 0, 0.2)
+                      </Text>
+                    }
+                  >
+                    <InfoCircleIcon />
+                  </Tooltip>
+                }
+              />
             );
           }}
         />

--- a/apps/builder/app/builder/features/style-panel/sections/sections.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/sections.ts
@@ -13,6 +13,7 @@ import * as filter from "./filter/filter";
 import * as transitions from "./transitions/transitions";
 import * as outline from "./outline/outline";
 import * as advanced from "./advanced/advanced";
+import * as textShadows from "./text-shadows/text-shadows";
 import type { StyleProperty } from "@webstudio-is/css-engine";
 import type { SectionProps } from "./shared/section";
 
@@ -33,6 +34,7 @@ export const sections = new Map<
   ["backgrounds", backgrounds],
   ["borders", borders],
   ["boxShadows", boxShadows],
+  ["textShadows", textShadows],
   ["filter", filter],
   ["transitions", transitions],
   ["outline", outline],

--- a/apps/builder/app/builder/features/style-panel/sections/text-shadows/text-shadows.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/text-shadows/text-shadows.tsx
@@ -10,8 +10,10 @@ import {
   SectionTitle,
   SectionTitleButton,
   SectionTitleLabel,
+  Tooltip,
+  Text,
 } from "@webstudio-is/design-system";
-import { PlusIcon } from "@webstudio-is/icons";
+import { InfoCircleIcon, PlusIcon } from "@webstudio-is/icons";
 import { addLayer } from "../../style-layer-utils";
 import { parseShadow } from "@webstudio-is/css-data";
 import { getDots } from "../../shared/collapsible-section";
@@ -81,6 +83,25 @@ export const Section = (props: SectionProps) => {
               {...layersProps}
               key={layersProps.index}
               label={label}
+              tooltip={
+                <Tooltip
+                  variant="wrapped"
+                  content={
+                    <Text>
+                      Paste a text-shadow CSS code
+                      <br />
+                      without the property name, for
+                      <br />
+                      example:
+                      <br />
+                      <br />
+                      0px 2px 5px rgba(0, 0, 0, 0.2)
+                    </Text>
+                  }
+                >
+                  <InfoCircleIcon />
+                </Tooltip>
+              }
             ></ShadowLayer>
           )}
         />

--- a/apps/builder/app/builder/features/style-panel/sections/text-shadows/text-shadows.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/text-shadows/text-shadows.tsx
@@ -1,33 +1,33 @@
+import { CollapsibleSectionRoot } from "~/builder/shared/collapsible-section";
+import type { SectionProps } from "../shared/section";
+import type {
+  LayersValue,
+  StyleProperty,
+  TupleValue,
+} from "@webstudio-is/css-engine";
+import { useState } from "react";
 import {
   SectionTitle,
   SectionTitleButton,
   SectionTitleLabel,
 } from "@webstudio-is/design-system";
 import { PlusIcon } from "@webstudio-is/icons";
-import type {
-  LayersValue,
-  StyleProperty,
-  TupleValue,
-} from "@webstudio-is/css-engine";
-import { CollapsibleSectionRoot } from "~/builder/shared/collapsible-section";
-import { useState } from "react";
+import { addLayer } from "../../style-layer-utils";
+import { parseShadow } from "@webstudio-is/css-data";
 import { getDots } from "../../shared/collapsible-section";
 import { PropertyName } from "../../shared/property-name";
 import { getStyleSource } from "../../shared/style-info";
-import type { SectionProps } from "../shared/section";
 import { LayersList } from "../../style-layers-list";
-import { addLayer } from "../../style-layer-utils";
-import { parseShadow } from "@webstudio-is/css-data";
 import { ShadowLayer } from "../../shared/shadow-layer";
 
-export const properties = ["boxShadow"] satisfies Array<StyleProperty>;
+export const properties = ["textShadow"] satisfies Array<StyleProperty>;
 
 const property: StyleProperty = properties[0];
-const label = "Box Shadows";
-const INITIAL_BOX_SHADOW = "0px 2px 5px 0px rgba(0, 0, 0, 0.2)";
+const label = "Text Shadows";
+const INITIAL_TEXT_SHADOW = "0px 2px 5px rgba(0, 0, 0, 0.2)";
 
 export const Section = (props: SectionProps) => {
-  const { currentStyle, deleteProperty } = props;
+  const { currentStyle, createBatchUpdate, deleteProperty } = props;
   const [isOpen, setIsOpen] = useState(false);
   const layersStyleSource = getStyleSource(currentStyle[property]);
   const value = currentStyle[property]?.value;
@@ -40,16 +40,16 @@ export const Section = (props: SectionProps) => {
       onOpenChange={setIsOpen}
       trigger={
         <SectionTitle
-          dots={getDots(currentStyle, [property])}
+          dots={getDots(currentStyle, properties)}
           suffix={
             <SectionTitleButton
               prefix={<PlusIcon />}
               onClick={() => {
                 addLayer(
                   property,
-                  parseShadow("boxShadow", INITIAL_BOX_SHADOW),
+                  parseShadow("textShadow", INITIAL_TEXT_SHADOW),
                   currentStyle,
-                  props.createBatchUpdate
+                  createBatchUpdate
                 );
                 setIsOpen(true);
               }}
@@ -60,7 +60,7 @@ export const Section = (props: SectionProps) => {
             title={label}
             style={currentStyle}
             properties={properties}
-            description="Adds shadow effects around an element's frame."
+            description="Adds shadow effects around a text."
             label={
               <SectionTitleLabel color={layersStyleSource}>
                 {label}
@@ -76,15 +76,13 @@ export const Section = (props: SectionProps) => {
           property={property}
           layers={value}
           {...props}
-          renderLayer={(layersProps) => {
-            return (
-              <ShadowLayer
-                key={layersProps.index}
-                {...layersProps}
-                label={label}
-              ></ShadowLayer>
-            );
-          }}
+          renderLayer={(layersProps) => (
+            <ShadowLayer
+              {...layersProps}
+              key={layersProps.index}
+              label={label}
+            ></ShadowLayer>
+          )}
         />
       )}
     </CollapsibleSectionRoot>

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -1,0 +1,452 @@
+import {
+  toValue,
+  type InvalidValue,
+  type LayersValue,
+  type RgbValue,
+  type StyleValue,
+  type TupleValue,
+  type UnitValue,
+} from "@webstudio-is/css-engine";
+import {
+  extractShadowProperties,
+  parseShadow,
+  type ExtractedShadowProperties,
+} from "@webstudio-is/css-data";
+import {
+  Flex,
+  Grid,
+  Label,
+  Separator,
+  Text,
+  TextArea,
+  textVariants,
+  theme,
+  ToggleGroup,
+  ToggleGroupButton,
+  Tooltip,
+} from "@webstudio-is/design-system";
+import {
+  InfoCircleIcon,
+  ShadowInsetIcon,
+  ShadowNormalIcon,
+} from "@webstudio-is/icons";
+import { useMemo, useState } from "react";
+import type { IntermediateStyleValue } from "../shared/css-value-input";
+import { CssValueInputContainer } from "../shared/css-value-input";
+import { toPascalCase } from "../shared/keyword-utils";
+import { ColorControl } from "../controls";
+import type { DeleteProperty, SetProperty } from "../shared/use-style-data";
+
+/*
+  When it comes to checking and validating individual CSS properties for the box-shadow,
+  splitting them fails the validation. As it needs a minimum of 2 values to validate.
+  Instead, a workaround is to use a fallback CSS property
+  that can handle the same values as the input being validated.
+
+  Here's the box-shadow property with its components:
+
+  box-shadow: color, inset, offsetX, offsetY, blur, spread;
+  You can check more details from the spec
+  https://www.w3.org/TR/css-backgrounds-3/#box-shadow
+
+  offsetX: length, takes positive and negative values.
+  offsetY: length, takes positive and negative values.
+  blur: length, takes only positive values.
+  spread: length, takes both positive and negative values.
+
+  outline-offset: length, takes positive and negative values.
+  https://www.w3.org/TR/css-ui-4/#outline-offset
+
+  border-top-width: length, takes only positive values.
+  https://www.w3.org/TR/css-backgrounds-3/#propdef-border-top-width
+*/
+
+type BoxShadowContentProps = {
+  index: number;
+  layer: TupleValue;
+  shadow: string;
+  onEditLayer: (index: number, layers: LayersValue) => void;
+  deleteProperty: DeleteProperty;
+};
+
+const convertValuesToTupple = (
+  values: Partial<Record<keyof ExtractedShadowProperties, StyleValue>>
+): TupleValue => {
+  return {
+    type: "tuple",
+    value: (Object.values(values) as Array<StyleValue>).filter(
+      (item: StyleValue): item is UnitValue | RgbValue =>
+        item !== null && item !== undefined
+    ),
+  };
+};
+
+const boxShadowInsetValues = [
+  { value: "normal", Icon: ShadowNormalIcon },
+  { value: "inset", Icon: ShadowInsetIcon },
+] as const;
+
+export const ShadowContent = ({
+  layer,
+  index,
+  shadow,
+  onEditLayer,
+  deleteProperty,
+}: BoxShadowContentProps) => {
+  const [intermediateValue, setIntermediateValue] = useState<
+    IntermediateStyleValue | InvalidValue | undefined
+  >();
+  const layerValues = useMemo<ExtractedShadowProperties>(() => {
+    setIntermediateValue({ type: "intermediate", value: shadow });
+    return extractShadowProperties(layer);
+  }, [layer, shadow]);
+  const { offsetX, offsetY, blur, spread, color, inset } = layerValues;
+  const colorControlProp = color ?? {
+    type: "rgb",
+    r: 0,
+    g: 0,
+    b: 0,
+    alpha: 1,
+  };
+
+  const handleChange = (value: string) => {
+    setIntermediateValue({
+      type: "intermediate",
+      value,
+    });
+  };
+
+  const handleComplete = () => {
+    if (intermediateValue === undefined) {
+      return;
+    }
+    const layers = parseShadow("boxShadow", intermediateValue.value);
+    if (layers.type === "invalid") {
+      setIntermediateValue({
+        type: "invalid",
+        value: intermediateValue.value,
+      });
+      return;
+    }
+
+    onEditLayer(index, layers);
+  };
+
+  const handlePropertyChange = (
+    params: Partial<Record<keyof ExtractedShadowProperties, StyleValue>>
+  ) => {
+    const newLayer = convertValuesToTupple({ ...layerValues, ...params });
+    setIntermediateValue({
+      type: "intermediate",
+      value: toValue(newLayer),
+    });
+    onEditLayer(index, { type: "layers", value: [newLayer] });
+  };
+
+  const colorControlCallback: SetProperty = () => {
+    return (value) => {
+      handlePropertyChange({ color: value });
+    };
+  };
+
+  return (
+    <Flex direction="column">
+      <Grid
+        columns={2}
+        gap="2"
+        css={{
+          paddingTop: theme.spacing[5],
+          px: theme.spacing[9],
+        }}
+      >
+        <Flex direction="column">
+          <Tooltip
+            content={
+              <Flex gap="2" direction="column">
+                <Text variant="regularBold">X Offset</Text>
+                <Text variant="monoBold">offset-x</Text>
+                <Text>
+                  Sets the horizontal offset of the
+                  <br />
+                  shadow. Negative values place
+                  <br />
+                  the shadow to the left.
+                </Text>
+              </Flex>
+            }
+          >
+            <Label css={{ width: "fit-content" }}>X</Label>
+          </Tooltip>
+          <CssValueInputContainer
+            key="boxShadowOffsetX"
+            /*
+              outline-offset is a fake property for validating box-shadow's offsetX.
+            */
+            property="outlineOffset"
+            styleSource="local"
+            keywords={[]}
+            value={offsetX ?? { type: "unit", value: 0, unit: "px" }}
+            setValue={(value) => handlePropertyChange({ offsetX: value })}
+            deleteProperty={() =>
+              handlePropertyChange({
+                offsetX: offsetX ?? undefined,
+              })
+            }
+          />
+        </Flex>
+
+        <Flex direction="column">
+          <Tooltip
+            content={
+              <Flex gap="2" direction="column">
+                <Text variant="regularBold">Blur Radius</Text>
+                <Text variant="monoBold">blur-radius</Text>
+                <Text>
+                  The larger this value, the bigger
+                  <br />
+                  the blur, so the shadow becomes
+                  <br />
+                  bigger and lighter.
+                </Text>
+              </Flex>
+            }
+          >
+            <Label css={{ width: "fit-content" }}>Blur</Label>
+          </Tooltip>
+          <CssValueInputContainer
+            key="boxShadowBlur"
+            /*
+              border-top-width is a fake property for validating box-shadow's blur.
+            */
+            property="borderTopWidth"
+            styleSource="local"
+            keywords={[]}
+            value={blur ?? { type: "unit", value: 0, unit: "px" }}
+            setValue={(value) => handlePropertyChange({ blur: value })}
+            deleteProperty={() =>
+              handlePropertyChange({
+                blur: blur ?? undefined,
+              })
+            }
+          />
+        </Flex>
+
+        <Flex direction="column">
+          <Tooltip
+            content={
+              <Flex gap="2" direction="column">
+                <Text variant="regularBold">Y Offset</Text>
+                <Text variant="monoBold">offset-y</Text>
+                <Text>
+                  Sets the vertical offset of the
+                  <br />
+                  shadow. Negative values place
+                  <br />
+                  the shadow above.
+                </Text>
+              </Flex>
+            }
+          >
+            <Label css={{ width: "fit-content" }}>Y</Label>
+          </Tooltip>
+          <CssValueInputContainer
+            key="boxShadowOffsetY"
+            /*
+              outline-offset is a fake property for validating box-shadow's offsetY.
+            */
+            property="outlineOffset"
+            styleSource="local"
+            keywords={[]}
+            value={offsetY ?? { type: "unit", value: 0, unit: "px" }}
+            setValue={(value) => handlePropertyChange({ offsetY: value })}
+            deleteProperty={() =>
+              handlePropertyChange({
+                offsetY: offsetY ?? undefined,
+              })
+            }
+          />
+        </Flex>
+
+        <Flex direction="column">
+          <Tooltip
+            content={
+              <Flex gap="2" direction="column">
+                <Text variant="regularBold">Spread Radius</Text>
+                <Text variant="monoBold">spread-radius</Text>
+                <Text>
+                  Positive values will cause the
+                  <br />
+                  shadow to expand and grow
+                  <br />
+                  bigger, negative values will cause
+                  <br />
+                  the shadow to shrink.
+                </Text>
+              </Flex>
+            }
+          >
+            <Label css={{ width: "fit-content" }}>Spread</Label>
+          </Tooltip>
+          <CssValueInputContainer
+            key="boxShadowSpread"
+            /*
+              outline-offset is a fake property for validating box-shadow's spread.
+            */
+            property="outlineOffset"
+            styleSource="local"
+            keywords={[]}
+            value={spread ?? { type: "unit", value: 0, unit: "px" }}
+            setValue={(value) => handlePropertyChange({ spread: value })}
+            deleteProperty={() =>
+              handlePropertyChange({
+                spread: spread ?? undefined,
+              })
+            }
+          />
+        </Flex>
+      </Grid>
+
+      <Grid
+        gap="2"
+        css={{
+          px: theme.spacing[9],
+          marginTop: theme.spacing[5],
+          paddingBottom: theme.spacing[5],
+          gridTemplateColumns: "3fr 1fr",
+        }}
+      >
+        <Flex direction="column">
+          <Tooltip
+            content={
+              <Flex gap="2" direction="column">
+                <Text variant="regularBold">Color</Text>
+                <Text variant="monoBold">color</Text>
+                <Text>
+                  Sets the shadow color and
+                  <br />
+                  opacity.
+                </Text>
+              </Flex>
+            }
+          >
+            <Label css={{ width: "fit-content" }}>Color</Label>
+          </Tooltip>
+          <ColorControl
+            property="color"
+            currentStyle={{
+              color: {
+                value: colorControlProp,
+                currentColor: colorControlProp,
+              },
+            }}
+            setProperty={colorControlCallback}
+            deleteProperty={() =>
+              handlePropertyChange({ color: colorControlProp })
+            }
+          />
+        </Flex>
+
+        <Flex direction="column">
+          <Tooltip
+            content={
+              <Flex gap="2" direction="column">
+                <Text variant="regularBold">Inset</Text>
+                <Text variant="monoBold">inset</Text>
+                <Text>
+                  Changes the shadow from
+                  <br />
+                  an outer shadow (outset) to an
+                  <br />
+                  inner shadow (inset).
+                </Text>
+              </Flex>
+            }
+          >
+            <Label css={{ display: "inline" }}>Inset</Label>
+          </Tooltip>
+          <ToggleGroup
+            type="single"
+            value={inset?.value ?? "normal"}
+            defaultValue="inset"
+            onValueChange={(value) => {
+              if (value === "inset") {
+                handlePropertyChange({
+                  inset: { type: "keyword", value: "inset" },
+                });
+              } else {
+                handlePropertyChange({ inset: undefined });
+              }
+            }}
+          >
+            {boxShadowInsetValues.map(({ value, Icon }) => (
+              <Tooltip key={value} content={toPascalCase(value)}>
+                <ToggleGroupButton value={value}>
+                  <Icon />
+                </ToggleGroupButton>
+              </Tooltip>
+            ))}
+          </ToggleGroup>
+        </Flex>
+      </Grid>
+
+      <Separator css={{ gridColumn: "span 2" }} />
+      <Flex
+        direction="column"
+        css={{
+          px: theme.spacing[9],
+          paddingTop: theme.spacing[5],
+          paddingBottom: theme.spacing[9],
+          gap: theme.spacing[3],
+          minWidth: theme.spacing[30],
+        }}
+      >
+        <Label>
+          <Flex align={"center"} gap={1}>
+            Code
+            <Tooltip
+              variant="wrapped"
+              content={
+                <Text>
+                  Paste a box-shadow CSS code
+                  <br />
+                  without the property name, for
+                  <br />
+                  example:
+                  <br />
+                  <br />
+                  0px 2px 5px 0px rgba(0, 0, 0, 0.2)
+                </Text>
+              }
+            >
+              <InfoCircleIcon />
+            </Tooltip>
+          </Flex>
+        </Label>
+        <TextArea
+          rows={3}
+          name="description"
+          value={intermediateValue?.value ?? shadow ?? ""}
+          css={{ minHeight: theme.spacing[14], ...textVariants.mono }}
+          state={intermediateValue?.type === "invalid" ? "invalid" : undefined}
+          onChange={handleChange}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              handleComplete();
+              event.preventDefault();
+            }
+
+            if (event.key === "Escape") {
+              if (intermediateValue === undefined) {
+                return;
+              }
+
+              deleteProperty("boxShadow", { isEphemeral: true });
+              setIntermediateValue(undefined);
+              event.preventDefault();
+            }
+          }}
+        />
+      </Flex>
+    </Flex>
+  );
+};

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -3,6 +3,7 @@ import {
   type InvalidValue,
   type LayersValue,
   type RgbValue,
+  type StyleProperty,
   type StyleValue,
   type TupleValue,
   type UnitValue,
@@ -25,11 +26,7 @@ import {
   ToggleGroupButton,
   Tooltip,
 } from "@webstudio-is/design-system";
-import {
-  InfoCircleIcon,
-  ShadowInsetIcon,
-  ShadowNormalIcon,
-} from "@webstudio-is/icons";
+import { ShadowInsetIcon, ShadowNormalIcon } from "@webstudio-is/icons";
 import { useMemo, useState } from "react";
 import type { IntermediateStyleValue } from "../shared/css-value-input";
 import { CssValueInputContainer } from "../shared/css-value-input";
@@ -61,10 +58,12 @@ import type { DeleteProperty, SetProperty } from "../shared/use-style-data";
   https://www.w3.org/TR/css-backgrounds-3/#propdef-border-top-width
 */
 
-type BoxShadowContentProps = {
+type ShadowContentProps = {
   index: number;
   layer: TupleValue;
+  property: StyleProperty;
   shadow: string;
+  tooltip: JSX.Element;
   onEditLayer: (index: number, layers: LayersValue) => void;
   deleteProperty: DeleteProperty;
 };
@@ -89,10 +88,12 @@ const boxShadowInsetValues = [
 export const ShadowContent = ({
   layer,
   index,
+  property,
+  tooltip,
   shadow,
   onEditLayer,
   deleteProperty,
-}: BoxShadowContentProps) => {
+}: ShadowContentProps) => {
   const [intermediateValue, setIntermediateValue] = useState<
     IntermediateStyleValue | InvalidValue | undefined
   >();
@@ -267,43 +268,45 @@ export const ShadowContent = ({
           />
         </Flex>
 
-        <Flex direction="column">
-          <Tooltip
-            content={
-              <Flex gap="2" direction="column">
-                <Text variant="regularBold">Spread Radius</Text>
-                <Text variant="monoBold">spread-radius</Text>
-                <Text>
-                  Positive values will cause the
-                  <br />
-                  shadow to expand and grow
-                  <br />
-                  bigger, negative values will cause
-                  <br />
-                  the shadow to shrink.
-                </Text>
-              </Flex>
-            }
-          >
-            <Label css={{ width: "fit-content" }}>Spread</Label>
-          </Tooltip>
-          <CssValueInputContainer
-            key="boxShadowSpread"
-            /*
+        {property === "boxShadow" ? (
+          <Flex direction="column">
+            <Tooltip
+              content={
+                <Flex gap="2" direction="column">
+                  <Text variant="regularBold">Spread Radius</Text>
+                  <Text variant="monoBold">spread-radius</Text>
+                  <Text>
+                    Positive values will cause the
+                    <br />
+                    shadow to expand and grow
+                    <br />
+                    bigger, negative values will cause
+                    <br />
+                    the shadow to shrink.
+                  </Text>
+                </Flex>
+              }
+            >
+              <Label css={{ width: "fit-content" }}>Spread</Label>
+            </Tooltip>
+            <CssValueInputContainer
+              key="boxShadowSpread"
+              /*
               outline-offset is a fake property for validating box-shadow's spread.
             */
-            property="outlineOffset"
-            styleSource="local"
-            keywords={[]}
-            value={spread ?? { type: "unit", value: 0, unit: "px" }}
-            setValue={(value) => handlePropertyChange({ spread: value })}
-            deleteProperty={() =>
-              handlePropertyChange({
-                spread: spread ?? undefined,
-              })
-            }
-          />
-        </Flex>
+              property="outlineOffset"
+              styleSource="local"
+              keywords={[]}
+              value={spread ?? { type: "unit", value: 0, unit: "px" }}
+              setValue={(value) => handlePropertyChange({ spread: value })}
+              deleteProperty={() =>
+                handlePropertyChange({
+                  spread: spread ?? undefined,
+                })
+              }
+            />
+          </Flex>
+        ) : null}
       </Grid>
 
       <Grid
@@ -346,47 +349,49 @@ export const ShadowContent = ({
           />
         </Flex>
 
-        <Flex direction="column">
-          <Tooltip
-            content={
-              <Flex gap="2" direction="column">
-                <Text variant="regularBold">Inset</Text>
-                <Text variant="monoBold">inset</Text>
-                <Text>
-                  Changes the shadow from
-                  <br />
-                  an outer shadow (outset) to an
-                  <br />
-                  inner shadow (inset).
-                </Text>
-              </Flex>
-            }
-          >
-            <Label css={{ display: "inline" }}>Inset</Label>
-          </Tooltip>
-          <ToggleGroup
-            type="single"
-            value={inset?.value ?? "normal"}
-            defaultValue="inset"
-            onValueChange={(value) => {
-              if (value === "inset") {
-                handlePropertyChange({
-                  inset: { type: "keyword", value: "inset" },
-                });
-              } else {
-                handlePropertyChange({ inset: undefined });
+        {property === "boxShadow" ? (
+          <Flex direction="column">
+            <Tooltip
+              content={
+                <Flex gap="2" direction="column">
+                  <Text variant="regularBold">Inset</Text>
+                  <Text variant="monoBold">inset</Text>
+                  <Text>
+                    Changes the shadow from
+                    <br />
+                    an outer shadow (outset) to an
+                    <br />
+                    inner shadow (inset).
+                  </Text>
+                </Flex>
               }
-            }}
-          >
-            {boxShadowInsetValues.map(({ value, Icon }) => (
-              <Tooltip key={value} content={toPascalCase(value)}>
-                <ToggleGroupButton value={value}>
-                  <Icon />
-                </ToggleGroupButton>
-              </Tooltip>
-            ))}
-          </ToggleGroup>
-        </Flex>
+            >
+              <Label css={{ display: "inline" }}>Inset</Label>
+            </Tooltip>
+            <ToggleGroup
+              type="single"
+              value={inset?.value ?? "normal"}
+              defaultValue="inset"
+              onValueChange={(value) => {
+                if (value === "inset") {
+                  handlePropertyChange({
+                    inset: { type: "keyword", value: "inset" },
+                  });
+                } else {
+                  handlePropertyChange({ inset: undefined });
+                }
+              }}
+            >
+              {boxShadowInsetValues.map(({ value, Icon }) => (
+                <Tooltip key={value} content={toPascalCase(value)}>
+                  <ToggleGroupButton value={value}>
+                    <Icon />
+                  </ToggleGroupButton>
+                </Tooltip>
+              ))}
+            </ToggleGroup>
+          </Flex>
+        ) : null}
       </Grid>
 
       <Separator css={{ gridColumn: "span 2" }} />
@@ -403,23 +408,7 @@ export const ShadowContent = ({
         <Label>
           <Flex align={"center"} gap={1}>
             Code
-            <Tooltip
-              variant="wrapped"
-              content={
-                <Text>
-                  Paste a box-shadow CSS code
-                  <br />
-                  without the property name, for
-                  <br />
-                  example:
-                  <br />
-                  <br />
-                  0px 2px 5px 0px rgba(0, 0, 0, 0.2)
-                </Text>
-              }
-            >
-              <InfoCircleIcon />
-            </Tooltip>
+            {tooltip}
           </Flex>
         </Label>
         <TextArea

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-layer.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-layer.tsx
@@ -50,8 +50,17 @@ const useLayer = (layer: TupleValue) => {
 };
 
 export const ShadowLayer = <T extends TupleValue>(props: LayerProps<T>) => {
-  const { index, id, layer, isHighlighted, onDeleteLayer, onLayerHide, label } =
-    props;
+  const {
+    index,
+    id,
+    layer,
+    isHighlighted,
+    onDeleteLayer,
+    onLayerHide,
+    label,
+    tooltip,
+    property,
+  } = props;
   const properties = useLayer(layer);
   const { name, shadow, color } = properties;
 
@@ -61,8 +70,10 @@ export const ShadowLayer = <T extends TupleValue>(props: LayerProps<T>) => {
       content={
         <ShadowContent
           index={index}
+          property={property}
           shadow={shadow}
           layer={layer}
+          tooltip={tooltip}
           onEditLayer={props.onEditLayer}
           deleteProperty={props.deleteProperty}
         />

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-layer.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-layer.tsx
@@ -12,11 +12,11 @@ import {
 } from "@webstudio-is/icons";
 import { useMemo } from "react";
 import { FloatingPanel } from "~/builder/shared/floating-panel";
-import { BoxShadowContent } from "./box-shadow-content";
 import { colord, type RgbaColor } from "colord";
 import { toValue } from "@webstudio-is/css-engine";
-import { ColorThumb } from "../../shared/color-thumb";
-import type { LayerProps } from "../../style-layers-list";
+import { ColorThumb } from "../shared/color-thumb";
+import type { LayerProps } from "../style-layers-list";
+import { ShadowContent } from "./shadow-content";
 
 const useLayer = (layer: TupleValue) => {
   return useMemo(() => {
@@ -49,17 +49,17 @@ const useLayer = (layer: TupleValue) => {
   }, [layer]);
 };
 
-export const BoxShadowLayer = <T extends TupleValue>(props: LayerProps<T>) => {
-  const { index, id, layer, isHighlighted, onDeleteLayer, onLayerHide } = props;
+export const ShadowLayer = <T extends TupleValue>(props: LayerProps<T>) => {
+  const { index, id, layer, isHighlighted, onDeleteLayer, onLayerHide, label } =
+    props;
   const properties = useLayer(layer);
-
   const { name, shadow, color } = properties;
 
   return (
     <FloatingPanel
-      title="Box Shadow"
+      title={label}
       content={
-        <BoxShadowContent
+        <ShadowContent
           index={index}
           shadow={shadow}
           layer={layer}

--- a/apps/builder/app/builder/features/style-panel/style-layers-list.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-layers-list.tsx
@@ -26,6 +26,7 @@ export type LayerProps<LayerType> = {
   id: string;
   index: number;
   layer: LayerType;
+  label: string;
   isHighlighted: boolean;
   disabled?: boolean;
   onLayerHide: (index: number) => void;
@@ -33,6 +34,7 @@ export type LayerProps<LayerType> = {
   onEditLayer: (index: number, layers: LayersValue | TupleValue) => void;
   createBatchUpdate: CreateBatchUpdate;
   deleteProperty: DeleteProperty;
+  children: JSX.Element;
 };
 
 type LayerListProperties<LayerType, PropertyValueType> = SectionProps & {

--- a/apps/builder/app/builder/features/style-panel/style-layers-list.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-layers-list.tsx
@@ -25,8 +25,10 @@ import type {
 export type LayerProps<LayerType> = {
   id: string;
   index: number;
+  property: StyleProperty;
   layer: LayerType;
   label: string;
+  tooltip: JSX.Element;
   isHighlighted: boolean;
   disabled?: boolean;
   onLayerHide: (index: number) => void;


### PR DESCRIPTION
## Description

This PR adds support for using backdrop-filter property in the style-panel. Here are more details on the property to test it around.
https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow

## Steps for reproduction

1. Add an element to the canvas.
2. Click on the "+" icon in the style panel next to the `Text Shadows` section.
3. Edit the default filter that is added.
4. Swap the layers and publish the project.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)