### PR TITLE
feat: parse complex values with available parsers for sections

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -1,13 +1,8 @@
 import { useMemo, useRef, useState } from "react";
 import { Box, Flex, Text } from "@webstudio-is/design-system";
-import {
-  parseFilter,
-  parseShadow,
-  parseTransition,
-  properties as propertiesData,
-} from "@webstudio-is/css-data";
+import { properties as propertiesData } from "@webstudio-is/css-data";
 import { useStore } from "@nanostores/react";
-import type { StyleProperty, StyleValue } from "@webstudio-is/css-engine";
+import type { StyleProperty } from "@webstudio-is/css-engine";
 import {
   $selectedInstanceSelector,
   useInstanceStyles,
@@ -25,10 +20,7 @@ import { Add } from "./add";
 import { CollapsibleSection } from "../../shared/collapsible-section";
 import { sections } from "../sections";
 import { toKebabCase } from "../../shared/keyword-utils";
-import type {
-  DeleteProperty,
-  StyleUpdateOptions,
-} from "../../shared/use-style-data";
+import type { DeleteProperty } from "../../shared/use-style-data";
 
 const allPropertyNames = Object.keys(propertiesData).sort(
   Intl.Collator().compare
@@ -105,39 +97,6 @@ export const Section = ({
     return props.deleteProperty(property, options);
   };
 
-  const handleSetPropertyValue = (
-    property: StyleProperty,
-    styleValue: StyleValue,
-    options?: StyleUpdateOptions
-  ) => {
-    let parsedValue: StyleValue | undefined = undefined;
-    if (styleValue.type === "unparsed") {
-      if (property === "filter" || property === "backdropFilter") {
-        parsedValue = parseFilter(styleValue.value);
-      }
-
-      if (property === "boxShadow" || property === "textShadow") {
-        parsedValue = parseShadow(property, styleValue.value);
-      }
-
-      if (property === "transition") {
-        parsedValue = parseTransition(styleValue.value);
-      }
-    }
-
-    if (parsedValue) {
-      return setProperty(property)(
-        parsedValue.type === "invalid"
-          ? { type: "guaranteedInvalid" }
-          : parsedValue,
-        {
-          ...options,
-          listed: true,
-        }
-      );
-    }
-  };
-
   return (
     <CollapsibleSection
       label="Advanced"
@@ -201,8 +160,11 @@ export const Section = ({
                 styleSource={getStyleSource(currentStyle[property])}
                 keywords={keywords}
                 value={currentStyle[property]?.value}
-                setValue={(...params) =>
-                  handleSetPropertyValue(property, ...params)
+                setValue={(styleValue, options) =>
+                  setProperty(property)(styleValue, {
+                    ...options,
+                    listed: true,
+                  })
                 }
                 deleteProperty={deleteProperty}
               />

--- a/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
@@ -29,8 +29,11 @@ const INITIAL_BOX_SHADOW = "0px 2px 5px 0px rgba(0, 0, 0, 0.2)";
 export const Section = (props: SectionProps) => {
   const { currentStyle, deleteProperty } = props;
   const [isOpen, setIsOpen] = useState(true);
-  const layersStyleSource = getStyleSource(currentStyle[property]);
   const value = currentStyle[property]?.value;
+  const sectionStyleSource =
+    value?.type === "unparsed" || value?.type === "guaranteedInvalid"
+      ? undefined
+      : getStyleSource(currentStyle[property]);
 
   return (
     <CollapsibleSectionRoot
@@ -62,7 +65,7 @@ export const Section = (props: SectionProps) => {
             properties={properties}
             description="Adds shadow effects around an element's frame."
             label={
-              <SectionTitleLabel color={layersStyleSource}>
+              <SectionTitleLabel color={sectionStyleSource}>
                 {label}
               </SectionTitleLabel>
             }

--- a/apps/builder/app/builder/features/style-panel/sections/filter/filter.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/filter/filter.tsx
@@ -30,8 +30,11 @@ const INITIAL_FILTER = "blur(0px)";
 export const Section = (props: SectionProps) => {
   const { currentStyle, deleteProperty } = props;
   const [isOpen, setIsOpen] = useState(true);
-  const layerStyleSource = getStyleSource(currentStyle[property]);
   const value = currentStyle[property]?.value;
+  const sectionStyleSource =
+    value?.type === "unparsed" || value?.type === "guaranteedInvalid"
+      ? undefined
+      : getStyleSource(currentStyle[property]);
 
   return (
     <CollapsibleSectionRoot
@@ -41,7 +44,7 @@ export const Section = (props: SectionProps) => {
       onOpenChange={setIsOpen}
       trigger={
         <SectionTitle
-          dots={getDots(currentStyle, [property])}
+          dots={getDots(currentStyle, properties)}
           suffix={
             <Tooltip content={"Add a filter"}>
               <SectionTitleButton
@@ -65,7 +68,7 @@ export const Section = (props: SectionProps) => {
             properties={properties}
             description="Filter effects allow you to apply graphical effects like blurring, color shifting, and more to elements."
             label={
-              <SectionTitleLabel color={layerStyleSource}>
+              <SectionTitleLabel color={sectionStyleSource}>
                 {label}
               </SectionTitleLabel>
             }

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.tsx
@@ -32,8 +32,11 @@ const INITIAL_TRANSITION = "opacity 200ms ease";
 export const Section = (props: SectionProps) => {
   const { currentStyle, deleteProperty } = props;
   const [isOpen, setIsOpen] = useState(true);
-  const layersStyleSource = getStyleSource(currentStyle[property]);
   const value = currentStyle[property]?.value;
+  const sectionStyleSource =
+    value?.type === "unparsed" || value?.type === "guaranteedInvalid"
+      ? undefined
+      : getStyleSource(currentStyle[property]);
 
   const selectedOrLastStyleSourceSelector = useStore(
     $selectedOrLastStyleSourceSelector
@@ -82,7 +85,7 @@ export const Section = (props: SectionProps) => {
             description="Animate the transition between states on this instance."
             properties={properties}
             label={
-              <SectionTitleLabel color={layersStyleSource}>
+              <SectionTitleLabel color={sectionStyleSource}>
                 {label}
               </SectionTitleLabel>
             }

--- a/apps/builder/app/builder/features/style-panel/shared/collapsible-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/collapsible-section.tsx
@@ -26,7 +26,7 @@ export const getDots = (
       style?.value.type === "unparsed" ||
       style?.value.type === "guaranteedInvalid"
     ) {
-      return undefined;
+      return;
     }
 
     const source = getStyleSource(style);

--- a/apps/builder/app/builder/features/style-panel/shared/collapsible-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/collapsible-section.tsx
@@ -19,7 +19,17 @@ export const getDots = (
   const dots = new Set<"local" | "overwritten" | "remote">();
 
   for (const property of properties) {
-    const source = getStyleSource(currentStyle[property]);
+    const style = currentStyle[property];
+
+    // Unparsed values are not editable directly in the section, so we don't show the dot
+    if (
+      style?.value.type === "unparsed" ||
+      style?.value.type === "guaranteedInvalid"
+    ) {
+      return undefined;
+    }
+
+    const source = getStyleSource(style);
     if (source === "local" || source === "overwritten" || source === "remote") {
       dots.add(source);
     }

--- a/packages/css-data/src/parse-css-value.ts
+++ b/packages/css-data/src/parse-css-value.ts
@@ -10,6 +10,7 @@ import {
 } from "@webstudio-is/css-engine";
 import { keywordValues } from "./__generated__/keyword-values";
 import { units } from "./__generated__/units";
+import { parseFilter, parseShadow, parseTransition } from "./property-parsers";
 
 export const cssTryParseValue = (input: string) => {
   try {
@@ -76,6 +77,18 @@ export const parseCssValue = (
       `Can't parse css property "${property}" with value "${input}"`
     );
     return invalidValue;
+  }
+
+  if (property === "filter" || property === "backdropFilter") {
+    return parseFilter(input);
+  }
+
+  if (property === "boxShadow" || property === "textShadow") {
+    return parseShadow(property, input);
+  }
+
+  if (property === "transition") {
+    return parseTransition(input);
   }
 
   if (


### PR DESCRIPTION
## Description

fixes #3294 

This PR does two things,
- When users add complex values like `box-shadow`, `filter`, `transition`, `text-shadow`. They are parsed and added to the data layer accordingly. This will help the sections to properly handle them using the style-panel. 
- For projects that already have `unparsed` complex values in them. They are just showing a blue label as local state in the `ProeprtyName` component. We need to display default style, because even though the property is unparsed and valid. The sections can't take advantage of it to help it edit with UI.
<img width="235" alt="Screenshot 2024-05-07 at 21 21 33" src="https://github.com/webstudio-is/webstudio/assets/11075561/4b12f31e-0d59-4394-ae7d-7f0907b990d1">



## Steps for reproduction

1. Add a property like `filter`, `box-shadow` in the advanced tab.
2. Now, start editing the value in the style-panel.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
