### PR TITLE
fix: Buttons native disabled support

### DIFF
--- a/packages/design-system/src/components/button.stories.tsx
+++ b/packages/design-system/src/components/button.stories.tsx
@@ -83,6 +83,11 @@ export const Button = ({
             <ButtonComponent prefix={<TrashIcon />} color={color} disabled>
               {color} disabled
             </ButtonComponent>
+            <fieldset style={{ display: "contents" }} disabled>
+              <ButtonComponent prefix={<TrashIcon />} color={color}>
+                {color} disabled by fieldset
+              </ButtonComponent>
+            </fieldset>
           </StoryGrid>
         ))}
       </StoryGrid>

--- a/packages/design-system/src/components/button.tsx
+++ b/packages/design-system/src/components/button.tsx
@@ -96,7 +96,7 @@ const perColorStyle = (variant: ButtonColor) => ({
           ),
   },
 
-  "&[data-state=disabled]": {
+  "&:disabled:not([data-state=pending]), &[data-state=disabled]": {
     background: theme.colors.backgroundButtonDisabled,
     color: theme.colors.foregroundDisabled,
   },


### PR DESCRIPTION
## Description

See storybook, buttons inside disabled fieldset should be disabled. As of now buttons didn't support native disabled style

See pixel comparison

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
