### PR TITLE
fix: Do not show bind button if it disabled

### DIFF
--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -282,6 +282,9 @@ const BindingButton = forwardRef<
             "--dot-display": "none",
             "--plus-display": "block",
           },
+          "&:disabled": {
+            display: "none",
+          },
         }}
         {...props}
         icon={


### PR DESCRIPTION
## Description

Do not show bind button inside `<fieldset disabled`
That will mean that button itself is disabled and don't need to be shown

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
