### PR TITLE
fix: Form action in case of undefined should use Remix Form to avoid reload

### DIFF
--- a/packages/sdk-components-react-remix/src/remix-form.tsx
+++ b/packages/sdk-components-react-remix/src/remix-form.tsx
@@ -13,7 +13,11 @@ export const RemixForm = forwardRef<
     }
 >((props, ref) => {
   // remix casts action to relative url
-  if (props.action === "" || props.action?.startsWith("/")) {
+  if (
+    props.action === undefined ||
+    props.action === "" ||
+    props.action?.startsWith("/")
+  ) {
     return <Form {...props} ref={ref} />;
   }
   return <form {...props} ref={ref} />;


### PR DESCRIPTION
## Description

Form action in case of undefined should use Remix Form to avoid page reload

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
