### PR TITLE
fix: add sample link to content embed component

### DIFF
--- a/packages/sdk-components-react/src/content-embed.ws.ts
+++ b/packages/sdk-components-react/src/content-embed.ws.ts
@@ -47,6 +47,7 @@ const htmlSample = `
 <h4>Heading 4</h4>
 <h5>Heading 5</h5>
 <h6>Heading 6</h6>
+<p><a href="#">Links</a> connect your content to relevant resources.</p>
 <p><strong>Bold text</strong> makes your important points stand out.</p>
 <p><em>Italic text</em> is great for emphasizing terms.</p>
 <ol>


### PR DESCRIPTION
I forgot to add a link in the first revision. Will an href with "#" work?

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
