### PR TITLE
refactor: bump asset uploader dependencies

### DIFF
--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -11,21 +11,21 @@
     "checks": "pnpm typecheck && pnpm test"
   },
   "dependencies": {
-    "@aws-crypto/sha256-js": "^5.0.0",
-    "@smithy/signature-v4": "^2.0.2",
+    "@aws-crypto/sha256-js": "^5.2.0",
+    "@smithy/signature-v4": "^2.3.0",
     "@webstudio-is/fonts": "workspace:*",
     "@webstudio-is/prisma-client": "workspace:*",
     "@webstudio-is/sdk": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
     "fontkit": "^2.0.2",
-    "image-size": "^1.0.2",
+    "image-size": "^1.1.1",
     "immer": "^10.0.3",
     "nanoid": "^5.0.1",
     "warn-once": "^0.1.1"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
-    "@types/fontkit": "^2.0.3",
+    "@types/fontkit": "^2.0.7",
     "@types/node": "^20.12.7",
     "@webstudio-is/jest-config": "workspace:*",
     "@webstudio-is/tsconfig": "workspace:*",

--- a/packages/asset-uploader/src/utils/font-data.ts
+++ b/packages/asset-uploader/src/utils/font-data.ts
@@ -11,11 +11,12 @@ import {
 // @todo sumbit this to definitely typed, they are not up to date
 declare module "fontkit" {
   export interface Font {
-    type: string;
-    getName: (name: string) => string;
     variationAxes: VariationAxes;
   }
 }
+
+// same default fontkit uses internally
+const defaultLanguage = "en";
 
 export const parseSubfamily = (subfamily: string) => {
   const subfamilyLow = subfamily.toLowerCase();
@@ -68,10 +69,15 @@ type FontData = FontDataStatic | FontDataVariable;
 
 export const getFontData = (data: Uint8Array): FontData => {
   const font = createFontKit(data as Buffer);
+  if (font.type !== "TTF" && font.type !== "WOFF" && font.type !== "WOFF2") {
+    throw Error(`Unsupported font type ${font.type}`);
+  }
   const format = font.type.toLowerCase() as FontData["format"];
-  const originalFamily = font.getName("fontFamily");
+  const originalFamily = font.getName("fontFamily", defaultLanguage) ?? "";
   const subfamily =
-    font.getName("preferredSubfamily") ?? font.getName("fontSubfamily");
+    font.getName("preferredSubfamily", defaultLanguage) ??
+    font.getName("fontSubfamily", defaultLanguage) ??
+    "";
   const family = normalizeFamily(originalFamily, subfamily);
   const isVariable = Object.keys(font.variationAxes).length !== 0;
 

--- a/packages/fonts/src/constants.ts
+++ b/packages/fonts/src/constants.ts
@@ -13,7 +13,6 @@ export const FONT_FORMATS: Map<FontFormat, string> = new Map([
   ["woff", "woff"],
   ["woff2", "woff2"],
   ["ttf", "truetype"],
-  ["otf", "opentype"],
 ]);
 
 export const FONT_MIME_TYPES = Array.from(FONT_FORMATS.keys())

--- a/packages/fonts/src/schema.ts
+++ b/packages/fonts/src/schema.ts
@@ -5,7 +5,6 @@ export const FontFormat = z.union([
   z.literal("ttf"),
   z.literal("woff"),
   z.literal("woff2"),
-  z.literal("otf"),
 ]);
 export type FontFormat = z.infer<typeof FontFormat>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,11 +854,11 @@ importers:
   packages/asset-uploader:
     dependencies:
       '@aws-crypto/sha256-js':
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: ^5.2.0
+        version: 5.2.0
       '@smithy/signature-v4':
-        specifier: ^2.0.2
-        version: 2.0.2
+        specifier: ^2.3.0
+        version: 2.3.0
       '@webstudio-is/fonts':
         specifier: workspace:*
         version: link:../fonts
@@ -875,8 +875,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       image-size:
-        specifier: ^1.0.2
-        version: 1.0.2
+        specifier: ^1.1.1
+        version: 1.1.1
       immer:
         specifier: ^10.0.3
         version: 10.0.3
@@ -891,8 +891,8 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0
       '@types/fontkit':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.7
+        version: 2.0.7
       '@types/node':
         specifier: ^20.12.7
         version: 20.12.7
@@ -2202,25 +2202,16 @@ packages:
     resolution: {integrity: sha512-Xk1sIhyNC/esHGGVjL/niHLowM0csl/kFO5uawBy4IrWwy0o1G8LGt3jP6nmWGz+USxeeqbihAmp/oVZju6wug==}
     hasBin: true
 
-  '@aws-crypto/crc32@3.0.0':
-    resolution: {integrity: sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==}
-
-  '@aws-crypto/sha256-js@5.0.0':
-    resolution: {integrity: sha512-g+u9iKkaQVp9Mjoxq1IJSHj9NHGZF441+R/GIH0dn7u4mix5QQ4VqgpppHrNm1LzjUzb0BpcFGsBXP6cOVf+ZQ==}
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
     engines: {node: '>=16.0.0'}
 
-  '@aws-crypto/util@3.0.0':
-    resolution: {integrity: sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==}
-
-  '@aws-crypto/util@5.0.0':
-    resolution: {integrity: sha512-1GYqLdYRe96idcCltlqxdJ68OWE6ADT8qGLmVi7PVHKl8AxD2EWSbJSSevPq2eTx6vaPZpkr1RoZ3lcw/uGoEA==}
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
   '@aws-sdk/types@3.357.0':
     resolution: {integrity: sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==}
     engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-utf8-browser@3.259.0':
-    resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
 
   '@babel/code-frame@7.22.5':
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
@@ -4418,39 +4409,48 @@ packages:
     peerDependencies:
       size-limit: 9.0.0
 
-  '@smithy/eventstream-codec@2.0.2':
-    resolution: {integrity: sha512-PQZiKx7fMnNwx4zxcUCm82VjnqK6wV4MEHSmMy3taj5dKfXV782IjRGyaDT+8TsmNqVdZIkve5zLRAzh+7kOhA==}
-
   '@smithy/is-array-buffer@2.0.0':
     resolution: {integrity: sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/signature-v4@2.0.2':
-    resolution: {integrity: sha512-YMooDEw/UmGxcXY4qWnSXkbPFsRloluSvyXVT678YPDN/K2AS1GzKfRsvSU7fbccOB4WF8MHZf2UqcRGEltE3Q==}
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/types@2.1.0':
-    resolution: {integrity: sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==}
+  '@smithy/signature-v4@2.3.0':
+    resolution: {integrity: sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/types@2.12.0':
+    resolution: {integrity: sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==}
     engines: {node: '>=14.0.0'}
 
   '@smithy/util-buffer-from@2.0.0':
     resolution: {integrity: sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-hex-encoding@2.0.0':
-    resolution: {integrity: sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==}
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-middleware@2.0.0':
-    resolution: {integrity: sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==}
+  '@smithy/util-hex-encoding@2.2.0':
+    resolution: {integrity: sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-uri-escape@2.0.0':
-    resolution: {integrity: sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==}
+  '@smithy/util-middleware@2.2.0':
+    resolution: {integrity: sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-uri-escape@2.2.0':
+    resolution: {integrity: sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==}
     engines: {node: '>=14.0.0'}
 
   '@smithy/util-utf8@2.0.0':
     resolution: {integrity: sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
   '@stitches/react@1.3.1-1':
@@ -4856,8 +4856,8 @@ packages:
   '@types/find-cache-dir@3.2.1':
     resolution: {integrity: sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==}
 
-  '@types/fontkit@2.0.3':
-    resolution: {integrity: sha512-RA41XvRjS5M5h8XQDB0J6GDEijlGzWjPjiOQvlLEB2UJE4VWLMAyMRM8inrELYu9HHoddqm+/2VxG7o7ysHwVw==}
+  '@types/fontkit@2.0.7':
+    resolution: {integrity: sha512-f5BjGam6y3FrfEY2JxXwba66SYzqP+FREZh4UuBN1WDePl8EhTKjba3ZZQ2iORUufkrFt/c/UIugj0Uv/HEdRg==}
 
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
@@ -6803,9 +6803,9 @@ packages:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
 
-  image-size@1.0.2:
-    resolution: {integrity: sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==}
-    engines: {node: '>=14.0.0'}
+  image-size@1.1.1:
+    resolution: {integrity: sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==}
+    engines: {node: '>=16.x'}
     hasBin: true
 
   immer@10.0.3:
@@ -9390,6 +9390,9 @@ packages:
   tslib@2.6.0:
     resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
 
+  tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+
   tsx@4.7.2:
     resolution: {integrity: sha512-BCNd4kz6fz12fyrgCTEdZHGJ9fWTGeUzXmQysh0RVocDY3h4frk05ZNCXSy4kIenF7y/QnrdiVpTsyNRn6vlAw==}
     engines: {node: '>=18.0.0'}
@@ -10027,37 +10030,21 @@ snapshots:
     dependencies:
       default-browser-id: 3.0.0
 
-  '@aws-crypto/crc32@3.0.0':
+  '@aws-crypto/sha256-js@5.2.0':
     dependencies:
-      '@aws-crypto/util': 3.0.0
+      '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.357.0
-      tslib: 1.14.1
+      tslib: 2.6.2
 
-  '@aws-crypto/sha256-js@5.0.0':
-    dependencies:
-      '@aws-crypto/util': 5.0.0
-      '@aws-sdk/types': 3.357.0
-      tslib: 1.14.1
-
-  '@aws-crypto/util@3.0.0':
+  '@aws-crypto/util@5.2.0':
     dependencies:
       '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-utf8-browser': 3.259.0
-      tslib: 1.14.1
-
-  '@aws-crypto/util@5.0.0':
-    dependencies:
-      '@aws-sdk/types': 3.357.0
-      '@aws-sdk/util-utf8-browser': 3.259.0
-      tslib: 1.14.1
+      '@smithy/util-utf8': 2.0.0
+      tslib: 2.6.2
 
   '@aws-sdk/types@3.357.0':
     dependencies:
-      tslib: 2.6.0
-
-  '@aws-sdk/util-utf8-browser@3.259.0':
-    dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.2
 
   '@babel/code-frame@7.22.5':
     dependencies:
@@ -13065,53 +13052,60 @@ snapshots:
       semver: 7.5.4
       size-limit: 9.0.0
 
-  '@smithy/eventstream-codec@2.0.2':
-    dependencies:
-      '@aws-crypto/crc32': 3.0.0
-      '@smithy/types': 2.1.0
-      '@smithy/util-hex-encoding': 2.0.0
-      tslib: 2.6.0
-
   '@smithy/is-array-buffer@2.0.0':
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.2
 
-  '@smithy/signature-v4@2.0.2':
+  '@smithy/is-array-buffer@2.2.0':
     dependencies:
-      '@smithy/eventstream-codec': 2.0.2
-      '@smithy/is-array-buffer': 2.0.0
-      '@smithy/types': 2.1.0
-      '@smithy/util-hex-encoding': 2.0.0
-      '@smithy/util-middleware': 2.0.0
-      '@smithy/util-uri-escape': 2.0.0
-      '@smithy/util-utf8': 2.0.0
-      tslib: 2.6.0
+      tslib: 2.6.2
 
-  '@smithy/types@2.1.0':
+  '@smithy/signature-v4@2.3.0':
     dependencies:
-      tslib: 2.6.0
+      '@smithy/is-array-buffer': 2.2.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-hex-encoding': 2.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-uri-escape': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+
+  '@smithy/types@2.12.0':
+    dependencies:
+      tslib: 2.6.2
 
   '@smithy/util-buffer-from@2.0.0':
     dependencies:
       '@smithy/is-array-buffer': 2.0.0
-      tslib: 2.6.0
+      tslib: 2.6.2
 
-  '@smithy/util-hex-encoding@2.0.0':
+  '@smithy/util-buffer-from@2.2.0':
     dependencies:
-      tslib: 2.6.0
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.6.2
 
-  '@smithy/util-middleware@2.0.0':
+  '@smithy/util-hex-encoding@2.2.0':
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.2
 
-  '@smithy/util-uri-escape@2.0.0':
+  '@smithy/util-middleware@2.2.0':
     dependencies:
-      tslib: 2.6.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+
+  '@smithy/util-uri-escape@2.2.0':
+    dependencies:
+      tslib: 2.6.2
 
   '@smithy/util-utf8@2.0.0':
     dependencies:
       '@smithy/util-buffer-from': 2.0.0
-      tslib: 2.6.0
+      tslib: 2.6.2
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.6.2
 
   '@stitches/react@1.3.1-1(patch_hash=knml42mpr6mlzseo3d6gjljiq4)(react@18.3.0-canary-14898b6a9-20240318)':
     dependencies:
@@ -14267,7 +14261,7 @@ snapshots:
 
   '@types/find-cache-dir@3.2.1': {}
 
-  '@types/fontkit@2.0.3':
+  '@types/fontkit@2.0.7':
     dependencies:
       '@types/node': 20.12.7
 
@@ -16610,7 +16604,7 @@ snapshots:
 
   ignore@5.2.4: {}
 
-  image-size@1.0.2:
+  image-size@1.1.1:
     dependencies:
       queue: 6.0.2
 
@@ -19910,6 +19904,8 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.6.0: {}
+
+  tslib@2.6.2: {}
 
   tsx@4.7.2:
     dependencies:


### PR DESCRIPTION
fontkit types added missing pieces. Figured otf is interpreted as ttf so no need to have it as separate type.

Testing
- upload font
- upload image