### PR TITLE
feat: Hide style settings on non html pages

### DIFF
--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -25,6 +25,7 @@ import {
   $registeredComponentMetas,
   $dragAndDropState,
   $inspectorLastInputTime,
+  $selectedPage,
 } from "~/shared/nano-states";
 import { NavigatorTree } from "~/builder/shared/navigator-tree";
 import type { Settings } from "~/builder/shared/client-settings";
@@ -82,6 +83,7 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
   const [tab, setTab] = useState("style");
   const isDragging = useStore($isDragging);
   const metas = useStore($registeredComponentMetas);
+  const selectedPage = useStore($selectedPage);
 
   if (navigatorLayout === "docked" && isDragging) {
     return <NavigatorTree />;
@@ -101,7 +103,9 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
   }
 
   const meta = metas.get(selectedInstance.component);
-  const isStyleTabVisible = meta?.stylable ?? true;
+  const documentType = selectedPage?.meta.documentType ?? "html";
+
+  const isStyleTabVisible = documentType === "html" && (meta?.stylable ?? true);
 
   const availableTabs = [
     isStyleTabVisible ? "style" : undefined,


### PR DESCRIPTION
## Description

Do not show styles at all on non html page

## Steps for reproduction

Open any page with document type xml, see no style panel is present

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
