### PR TITLE
fix: avoid canvas failure when image/link props invalid

### DIFF
--- a/packages/sdk-components-react-remix/src/shared/remix-link.tsx
+++ b/packages/sdk-components-react-remix/src/shared/remix-link.tsx
@@ -17,13 +17,14 @@ type Props = Omit<ComponentPropsWithoutRef<typeof Link>, "target"> & {
 export const wrapLinkComponent = (BaseLink: typeof Link) => {
   const Component = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
     const { assetBaseUrl, renderer } = useContext(ReactSdkContext);
-    const href = props.href;
+    // cast to string when invalid value type is provided with binding
+    const href = String(props.href ?? "");
 
     // use remix link for home page and all relative urls
     // ignore asset paths which can be relative too
     if (
       href === "" ||
-      (href?.startsWith("/") && href.startsWith(assetBaseUrl) === false)
+      (href.startsWith("/") && href.startsWith(assetBaseUrl) === false)
     ) {
       // remix links behave in unexpected way when delete in content editable
       // always render simple <a> in canvas and preview

--- a/packages/sdk-components-react/src/image.tsx
+++ b/packages/sdk-components-react/src/image.tsx
@@ -37,6 +37,9 @@ type Props = Omit<ComponentPropsWithoutRef<typeof WebstudioImage>, "loader">;
 
 export const Image = forwardRef<ElementRef<typeof defaultTag>, Props>(
   ({ loading = "lazy", ...props }, ref) => {
+    // cast to string when invalid value type is provided with binding
+    const src = String(props.src ?? "");
+
     const { imageLoader, renderer, assetBaseUrl } = useContext(ReactSdkContext);
 
     if (renderer === "canvas") {
@@ -44,16 +47,13 @@ export const Image = forwardRef<ElementRef<typeof defaultTag>, Props>(
       loading = "eager";
     }
 
-    if (
-      props.src === undefined ||
-      props.src.startsWith(assetBaseUrl) === false
-    ) {
+    if (src.startsWith(assetBaseUrl) === false) {
       return (
         <img
-          key={props.src}
+          key={src}
           loading={loading}
           {...props}
-          src={props.src || imagePlaceholderSvg}
+          src={src || imagePlaceholderSvg}
           ref={ref}
         />
       );
@@ -61,7 +61,7 @@ export const Image = forwardRef<ElementRef<typeof defaultTag>, Props>(
 
     // webstudio pass resolved assetBaseUrl + asset.name
     // trim assetBaseUrl and pass only asset.name to image loader
-    const src = props.src.slice(assetBaseUrl.length);
+    const assetName = src.slice(assetBaseUrl.length);
 
     return (
       <WebstudioImage
@@ -74,11 +74,11 @@ export const Image = forwardRef<ElementRef<typeof defaultTag>, Props>(
          * In non-builder mode, key on images are usually also a good idea,
          * prevents showing outdated images on route change.
          **/
-        key={src}
+        key={assetName}
         loading={loading}
         {...props}
         loader={imageLoader}
-        src={src}
+        src={assetName}
         ref={ref}
       />
     );


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2798

Here fixed failing whole canvas when object is passed to image src or link href. Both src and href are casted to string same way html does with its props. It does not solve the issue universally but at least covers most popular ones.