### PR TITLE
chore: change layout for shadow UI

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -660,7 +660,7 @@ export const CssValueInput = ({
 
   return (
     <ComboboxRoot open={isOpen}>
-      <Box {...getComboboxProps()}>
+      <Box {...getComboboxProps()} css={{ width: "100%" }}>
         <ComboboxAnchor>
           <InputField
             size={size}

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -154,11 +154,12 @@ export const ShadowContent = ({
   return (
     <Flex direction="column">
       <Grid
-        columns={2}
         gap="2"
         css={{
-          paddingTop: theme.spacing[5],
           px: theme.spacing[9],
+          marginTop: theme.spacing[5],
+          gridTemplateColumns:
+            property === "boxShadow" ? "1fr 1fr" : "1fr 1fr 1fr",
         }}
       >
         <Flex direction="column">
@@ -180,8 +181,8 @@ export const ShadowContent = ({
           <CssValueInputContainer
             key="boxShadowOffsetX"
             /*
-              outline-offset is a fake property for validating box-shadow's offsetX.
-            */
+          outline-offset is a fake property for validating box-shadow's offsetX.
+        */
             property="outlineOffset"
             styleSource="local"
             keywords={[]}
@@ -190,40 +191,6 @@ export const ShadowContent = ({
             deleteProperty={() =>
               handlePropertyChange({
                 offsetX: offsetX ?? undefined,
-              })
-            }
-          />
-        </Flex>
-
-        <Flex direction="column">
-          <Tooltip
-            variant="wrapped"
-            content={
-              <Flex gap="2" direction="column">
-                <Text variant="regularBold">Blur Radius</Text>
-                <Text variant="monoBold">blur-radius</Text>
-                <Text>
-                  The larger this value, the bigger the blur, so the shadow
-                  becomes bigger and lighter.
-                </Text>
-              </Flex>
-            }
-          >
-            <Label css={{ width: "fit-content" }}>Blur</Label>
-          </Tooltip>
-          <CssValueInputContainer
-            key="boxShadowBlur"
-            /*
-              border-top-width is a fake property for validating box-shadow's blur.
-            */
-            property="borderTopWidth"
-            styleSource="local"
-            keywords={[]}
-            value={blur ?? { type: "unit", value: 0, unit: "px" }}
-            setValue={(value) => handlePropertyChange({ blur: value })}
-            deleteProperty={() =>
-              handlePropertyChange({
-                blur: blur ?? undefined,
               })
             }
           />
@@ -248,8 +215,8 @@ export const ShadowContent = ({
           <CssValueInputContainer
             key="boxShadowOffsetY"
             /*
-              outline-offset is a fake property for validating box-shadow's offsetY.
-            */
+          outline-offset is a fake property for validating box-shadow's offsetY.
+        */
             property="outlineOffset"
             styleSource="local"
             keywords={[]}
@@ -258,6 +225,40 @@ export const ShadowContent = ({
             deleteProperty={() =>
               handlePropertyChange({
                 offsetY: offsetY ?? undefined,
+              })
+            }
+          />
+        </Flex>
+
+        <Flex direction="column">
+          <Tooltip
+            variant="wrapped"
+            content={
+              <Flex gap="2" direction="column">
+                <Text variant="regularBold">Blur Radius</Text>
+                <Text variant="monoBold">blur-radius</Text>
+                <Text>
+                  The larger this value, the bigger the blur, so the shadow
+                  becomes bigger and lighter.
+                </Text>
+              </Flex>
+            }
+          >
+            <Label css={{ width: "fit-content" }}>Blur</Label>
+          </Tooltip>
+          <CssValueInputContainer
+            key="boxShadowBlur"
+            /*
+          border-top-width is a fake property for validating box-shadow's blur.
+        */
+            property="borderTopWidth"
+            styleSource="local"
+            keywords={[]}
+            value={blur ?? { type: "unit", value: 0, unit: "px" }}
+            setValue={(value) => handlePropertyChange({ blur: value })}
+            deleteProperty={() =>
+              handlePropertyChange({
+                blur: blur ?? undefined,
               })
             }
           />
@@ -284,7 +285,7 @@ export const ShadowContent = ({
               key="boxShadowSpread"
               /*
               outline-offset is a fake property for validating box-shadow's spread.
-            */
+          */
               property="outlineOffset"
               styleSource="local"
               keywords={[]}
@@ -306,7 +307,7 @@ export const ShadowContent = ({
           px: theme.spacing[9],
           marginTop: theme.spacing[5],
           paddingBottom: theme.spacing[5],
-          gridTemplateColumns: "3fr 1fr",
+          ...(property === "boxShadow" && { gridTemplateColumns: "3fr 1fr" }),
         }}
       >
         <Flex direction="column">

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -180,9 +180,7 @@ export const ShadowContent = ({
           </Tooltip>
           <CssValueInputContainer
             key="boxShadowOffsetX"
-            /*
-          outline-offset is a fake property for validating box-shadow's offsetX.
-        */
+            // outline-offset is a fake property for validating box-shadow's offsetX.
             property="outlineOffset"
             styleSource="local"
             keywords={[]}
@@ -214,9 +212,7 @@ export const ShadowContent = ({
           </Tooltip>
           <CssValueInputContainer
             key="boxShadowOffsetY"
-            /*
-          outline-offset is a fake property for validating box-shadow's offsetY.
-        */
+            // outline-offset is a fake property for validating box-shadow's offsetY.
             property="outlineOffset"
             styleSource="local"
             keywords={[]}
@@ -248,9 +244,7 @@ export const ShadowContent = ({
           </Tooltip>
           <CssValueInputContainer
             key="boxShadowBlur"
-            /*
-          border-top-width is a fake property for validating box-shadow's blur.
-        */
+            // border-top-width is a fake property for validating box-shadow's blur.
             property="borderTopWidth"
             styleSource="local"
             keywords={[]}
@@ -283,9 +277,7 @@ export const ShadowContent = ({
             </Tooltip>
             <CssValueInputContainer
               key="boxShadowSpread"
-              /*
-              outline-offset is a fake property for validating box-shadow's spread.
-          */
+              // outline-offset is a fake property for validating box-shadow's spread.
               property="outlineOffset"
               styleSource="local"
               keywords={[]}


### PR DESCRIPTION
## Description

Handle layout changes for individual shadow properties.
<img width="245" alt="Screenshot 2024-05-14 at 12 35 52" src="https://github.com/webstudio-is/webstudio/assets/11075561/5facc8d8-ff21-4399-ad3a-69b56b3b2df6">
<img width="242" alt="Screenshot 2024-05-14 at 12 35 45" src="https://github.com/webstudio-is/webstudio/assets/11075561/00295503-c4bd-43c3-8536-bb675b9074cc">

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
