### PR TITLE
fix: allow users to use hex and rgba values in css-filters

### DIFF
--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -69,31 +69,9 @@ describe("Parse CSS value", () => {
 
   describe("Unparesd valid values", () => {
     test("Simple valid function values", () => {
-      expect(parseCssValue("filter", "blur(4px)")).toEqual({
-        type: "unparsed",
-        value: "blur(4px)",
-      });
-
       expect(parseCssValue("width", "calc(4px + 16em)")).toEqual({
         type: "unparsed",
         value: "calc(4px + 16em)",
-      });
-    });
-
-    test("Multiple valid function values", () => {
-      expect(
-        parseCssValue(
-          "filter",
-          "blur(4px) drop-shadow(16px 16px 20px blue) opacity(25%)"
-        )
-      ).toEqual({
-        type: "unparsed",
-        value: "blur(4px) drop-shadow(16px 16px 20px blue) opacity(25%)",
-      });
-
-      expect(parseCssValue("filter", "blur(calc(4px + 16em))")).toEqual({
-        type: "unparsed",
-        value: "blur(calc(4px + 16em))",
       });
     });
 

--- a/packages/css-data/src/property-parsers/filter.test.ts
+++ b/packages/css-data/src/property-parsers/filter.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "@jest/globals";
+import { parseFilter } from "./filter";
+
+describe("parse filter", () => {
+  test("parse values and returns the valid style property values", () => {
+    expect(parseFilter("blur(4px)")).toMatchInlineSnapshot(`
+{
+  "type": "tuple",
+  "value": [
+    {
+      "args": {
+        "type": "tuple",
+        "value": [
+          {
+            "type": "unit",
+            "unit": "px",
+            "value": 4,
+          },
+        ],
+      },
+      "name": "blur",
+      "type": "function",
+    },
+  ],
+}
+`);
+
+    expect(parseFilter("drop-shadow(10px 10px 25px rgba(0, 0, 255, 1))"))
+      .toMatchInlineSnapshot(`
+{
+  "type": "tuple",
+  "value": [
+    {
+      "args": {
+        "type": "tuple",
+        "value": [
+          {
+            "type": "unit",
+            "unit": "px",
+            "value": 10,
+          },
+          {
+            "type": "unit",
+            "unit": "px",
+            "value": 10,
+          },
+          {
+            "type": "unit",
+            "unit": "px",
+            "value": 25,
+          },
+          {
+            "alpha": 1,
+            "b": 255,
+            "g": 0,
+            "r": 0,
+            "type": "rgb",
+          },
+        ],
+      },
+      "name": "drop-shadow",
+      "type": "function",
+    },
+  ],
+}
+`);
+
+    expect(parseFilter("drop-shadow(10px 10px 25px  #0000FF)"))
+      .toMatchInlineSnapshot(`
+{
+  "type": "tuple",
+  "value": [
+    {
+      "args": {
+        "type": "tuple",
+        "value": [
+          {
+            "type": "unit",
+            "unit": "px",
+            "value": 10,
+          },
+          {
+            "type": "unit",
+            "unit": "px",
+            "value": 10,
+          },
+          {
+            "type": "unit",
+            "unit": "px",
+            "value": 25,
+          },
+          {
+            "alpha": 1,
+            "b": 255,
+            "g": 0,
+            "r": 0,
+            "type": "rgb",
+          },
+        ],
+      },
+      "name": "drop-shadow",
+      "type": "function",
+    },
+  ],
+}
+`);
+  });
+
+  test("Multiple valid function values", () => {
+    expect(
+      parseFilter("blur(4px) drop-shadow(16px 16px 20px blue) opacity(25%)")
+    ).toMatchInlineSnapshot(`
+{
+  "type": "tuple",
+  "value": [
+    {
+      "args": {
+        "type": "tuple",
+        "value": [
+          {
+            "type": "unit",
+            "unit": "px",
+            "value": 4,
+          },
+        ],
+      },
+      "name": "blur",
+      "type": "function",
+    },
+    {
+      "args": {
+        "type": "tuple",
+        "value": [
+          {
+            "type": "unit",
+            "unit": "px",
+            "value": 16,
+          },
+          {
+            "type": "unit",
+            "unit": "px",
+            "value": 16,
+          },
+          {
+            "type": "unit",
+            "unit": "px",
+            "value": 20,
+          },
+          {
+            "type": "keyword",
+            "value": "blue",
+          },
+        ],
+      },
+      "name": "drop-shadow",
+      "type": "function",
+    },
+    {
+      "args": {
+        "type": "tuple",
+        "value": [
+          {
+            "type": "unit",
+            "unit": "%",
+            "value": 25,
+          },
+        ],
+      },
+      "name": "opacity",
+      "type": "function",
+    },
+  ],
+}
+`);
+  });
+
+  // parsers are used to use copied value. At the moment, we don't have support
+  // for complex functions in the UI like the one below like calc(4px + 16em)
+  test("Using complex functions inside filter function", () => {
+    expect(parseFilter("blur(calc(4px + 16em))")).toMatchInlineSnapshot(`
+{
+  "type": "tuple",
+  "value": [
+    {
+      "args": {
+        "type": "tuple",
+        "value": [],
+      },
+      "name": "blur",
+      "type": "function",
+    },
+  ],
+}
+`);
+  });
+});

--- a/packages/css-data/src/property-parsers/filter.ts
+++ b/packages/css-data/src/property-parsers/filter.ts
@@ -86,17 +86,16 @@ export const parseFilter = (input: string): TupleValue | InvalidValue => {
 
             if (arg.type === "Function" || arg.type === "Hash") {
               const colorValue = colord(csstree.generate(arg));
-              if (!colorValue.isValid()) {
-                return;
+              if (colorValue.isValid() === true) {
+                const rgb = colorValue.toRgb();
+                tuple.push({
+                  type: "rgb",
+                  alpha: rgb.a,
+                  r: rgb.r,
+                  g: rgb.g,
+                  b: rgb.b,
+                });
               }
-              const rgb = colorValue.toRgb();
-              tuple.push({
-                type: "rgb",
-                alpha: rgb.a,
-                r: rgb.r,
-                g: rgb.g,
-                b: rgb.b,
-              });
             }
           }
 

--- a/packages/css-data/src/property-parsers/filter.ts
+++ b/packages/css-data/src/property-parsers/filter.ts
@@ -6,6 +6,7 @@ import type {
   Unit,
 } from "@webstudio-is/css-engine";
 import { cssTryParseValue, isValidDeclaration } from "../parse-css-value";
+import { colord } from "colord";
 
 /*
   https://github.com/webstudio-is/webstudio/issues/1016
@@ -80,6 +81,21 @@ export const parseFilter = (input: string): TupleValue | InvalidValue => {
               tuple.push({
                 type: "keyword",
                 value: arg.value,
+              });
+            }
+
+            if (arg.type === "Function" || arg.type === "Hash") {
+              const colorValue = colord(csstree.generate(arg));
+              if (!colorValue.isValid()) {
+                return;
+              }
+              const rgb = colorValue.toRgb();
+              tuple.push({
+                type: "rgb",
+                alpha: rgb.a,
+                r: rgb.r,
+                g: rgb.g,
+                b: rgb.b,
               });
             }
           }

--- a/packages/css-data/src/property-parsers/shadows.ts
+++ b/packages/css-data/src/property-parsers/shadows.ts
@@ -86,17 +86,16 @@ export const parseShadow = (
 
             if (item.type === "Function" || item.type === "Hash") {
               const colorValue = colord(csstree.generate(item));
-              if (!colorValue.isValid()) {
-                return;
+              if (colorValue.isValid() === true) {
+                const rgb = colorValue.toRgb();
+                shadow.push({
+                  type: "rgb",
+                  alpha: rgb.a,
+                  r: rgb.r,
+                  g: rgb.g,
+                  b: rgb.b,
+                });
               }
-              const rgb = colorValue.toRgb();
-              shadow.push({
-                type: "rgb",
-                alpha: rgb.a,
-                r: rgb.r,
-                g: rgb.g,
-                b: rgb.b,
-              });
             }
 
             if (item.type === "Dimension") {


### PR DESCRIPTION
## Description

fixes #3355 

Allows filter parser to parse `rgba` and `hex` values when copy pasted. I added some tests for filters too, we added initiall before as the css filters parser returns false positives. But now, i added all the valid tests, so at least we can catch things like this in future.


## Steps for reproduction
- Use the following filter values to test them.
```
drop-shadow(10px 10px 25px blue)
drop-shadow(10px 10px 25px rgba(0, 0, 255, 1))
drop-shadow(10px 10px 25px  #0000FF)
```

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] added tests
