### PR TITLE
fix: Style non-XML sections as disabled on page edit/create

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -50,6 +50,7 @@ import {
   Link,
   buttonStyle,
   PanelBanner,
+  css,
 } from "@webstudio-is/design-system";
 import {
   ChevronDoubleLeftIcon,
@@ -576,6 +577,14 @@ const usePageUrl = (values: Values, systemDataSourceId?: DataSource["id"]) => {
   return `${publishedOrigin}${compiledPath}`;
 };
 
+const fieldsetStyle = css({
+  all: "unset",
+  display: "block",
+  "&:disabled": {
+    opacity: 0.4,
+  },
+});
+
 const FormFields = ({
   systemDataSourceId,
   autoSelect,
@@ -809,7 +818,7 @@ const FormFields = ({
          */}
         <fieldset
           disabled={values.documentType === "xml"}
-          style={{ display: "contents" }}
+          className={fieldsetStyle()}
         >
           <Grid gap={2} css={{ my: theme.spacing[5], mx: theme.spacing[8] }}>
             <Grid gap={2}>


### PR DESCRIPTION
## Description

ref #3343

Overlay or hidden support for headers etc to make it look more disabled

<img width="479" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/b390ff27-ad49-490b-bf22-d8acb15b792a">


## Steps for reproduction

Create/Edit Page, change type on XML

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
