### PR TITLE
refactor: define resource control explicitly

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -670,6 +670,7 @@ export const SystemResourceForm = forwardRef<
       const newResource: Resource = {
         id: resource?.id ?? nanoid(),
         name: nameField.value,
+        control: "system",
         url: localResource.value,
         method,
         headers: [],

--- a/packages/sdk/src/schema/resources.ts
+++ b/packages/sdk/src/schema/resources.ts
@@ -18,6 +18,7 @@ const Header = z.object({
 export const Resource = z.object({
   id: ResourceId,
   name: z.string(),
+  control: z.optional(z.union([z.literal("system"), z.literal("graphql")])),
   method: Method,
   // expression
   url: z.string(),


### PR DESCRIPTION
Here simplified detecting system resource control with explicit resource field. Without it ui falls back to http ui.

Will be useful for graphql ui later.

Also disabled system resource option for non-paid users

## Testing

- create sitemap resource
- close variable popover
- open again and see system control instead of default http control