### PR TITLE
feat: Warn user when they use browser zoom on canvas

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
@@ -8,7 +8,6 @@ import {
   ToolbarToggleGroup,
   ToolbarToggleItem,
   Tooltip,
-  rawTheme,
   theme,
 } from "@webstudio-is/design-system";
 import { AlertIcon, BpStarOffIcon, BpStarOnIcon } from "@webstudio-is/icons";

--- a/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
@@ -1,17 +1,22 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { Breakpoint, Breakpoints } from "@webstudio-is/sdk";
 import {
   EnhancedTooltip,
+  Flex,
   Text,
   Toolbar,
   ToolbarToggleGroup,
   ToolbarToggleItem,
+  Tooltip,
+  rawTheme,
+  theme,
 } from "@webstudio-is/design-system";
-import { BpStarOffIcon, BpStarOnIcon } from "@webstudio-is/icons";
+import { AlertIcon, BpStarOffIcon, BpStarOnIcon } from "@webstudio-is/icons";
 import { CascadeIndicator } from "./cascade-indicator";
 import { $selectedBreakpointId } from "~/shared/nano-states";
 import { groupBreakpoints, isBaseBreakpoint } from "~/shared/breakpoints";
 import { setInitialCanvasWidth } from "./use-set-initial-canvas-width";
+import { useWindowResizeDebounced } from "~/shared/dom-hooks";
 
 const getTooltipContent = (breakpoint: Breakpoint) => {
   if (isBaseBreakpoint(breakpoint)) {
@@ -44,6 +49,47 @@ const getTooltipContent = (breakpoint: Breakpoint) => {
       </Text>
     );
   }
+};
+
+// When browser zoom is used we can't guarantee that the displayed selected breakpoint is actually matching the media query on the canvas.
+// Actual media query will vary unpredictably, sometimes resulting in 1 px difference and we better warn user they are zooming.
+const ZoomWarning = () => {
+  const [zoom, setZoom] = useState<number>();
+
+  const updateZoom = () => {
+    setZoom(window.outerWidth / window.innerWidth);
+  };
+
+  useWindowResizeDebounced(updateZoom);
+
+  if (zoom === undefined) {
+    updateZoom();
+    return;
+  }
+
+  if (zoom === 1) {
+    return;
+  }
+
+  return (
+    <Tooltip
+      variant="wrapped"
+      content={`Your browser is at ${zoom.toFixed(
+        2
+      )} zoom level, and this may result in a mismatch between the breakpoints on the left and the actual media query on the canvas.`}
+    >
+      <Flex
+        align="center"
+        css={{
+          px: theme.spacing[5],
+          height: "100%",
+          color: theme.colors.backgroundAlertMain,
+        }}
+      >
+        <AlertIcon />
+      </Flex>
+    </Tooltip>
+  );
 };
 
 type BreakpointsSelector = {
@@ -80,7 +126,7 @@ export const BreakpointsSelector = ({
               <EnhancedTooltip
                 key={breakpoint.id}
                 content={getTooltipContent(breakpoint)}
-                css={{ maxWidth: 240 }}
+                variant="wrapped"
               >
                 <ToolbarToggleItem
                   variant="subtle"
@@ -111,6 +157,7 @@ export const BreakpointsSelector = ({
           breakpoints={breakpoints}
         />
       </ToolbarToggleGroup>
+      <ZoomWarning />
     </Toolbar>
   );
 };


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/3295

<img width="401" alt="image" src="https://github.com/webstudio-is/webstudio/assets/52824/f12226e2-45ea-4cf6-85ac-05a1a6d4b3ce">


## Description

User may be accidentally on a zoom and this will result in unpredictable media query application.
We show warning only when user has non 1 zoom level

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
