### PR TITLE
refactor: add object expression utilities

### DIFF
--- a/packages/sdk/src/expression.test.ts
+++ b/packages/sdk/src/expression.test.ts
@@ -8,6 +8,8 @@ import {
   lintExpression,
   transpileExpression,
   getExpressionIdentifiers,
+  parseObjectExpression,
+  generateObjectExpression,
 } from "./expression";
 
 describe("lint expression", () => {
@@ -319,6 +321,57 @@ describe("transpile expression", () => {
       errorString = (error as Error).message;
     }
     expect(errorString).toEqual(`Unexpected token (1:0) in ""`);
+  });
+});
+
+describe("object expression transformations", () => {
+  test("parse object expression", () => {
+    expect(parseObjectExpression(`{ a: 0, b: "", c: $c + 1 }`)).toEqual(
+      new Map([
+        ["a", `0`],
+        ["b", `""`],
+        ["c", `$c + 1`],
+      ])
+    );
+  });
+
+  test("parse unsupported syntax", () => {
+    expect(parseObjectExpression(``)).toEqual(new Map());
+    expect(parseObjectExpression(`0`)).toEqual(new Map());
+    expect(parseObjectExpression(`{ a: 0, ...spread }`)).toEqual(
+      new Map([["a", "0"]])
+    );
+    expect(parseObjectExpression(`{ a: 0, [b]: 0 }`)).toEqual(
+      new Map([["a", "0"]])
+    );
+    expect(parseObjectExpression(`{ "a-b": 0 }`)).toEqual(
+      new Map([["a-b", "0"]])
+    );
+  });
+
+  test("generate object expression", () => {
+    expect(
+      generateObjectExpression(
+        new Map([
+          ["a", `0`],
+          ["b-c", `""`],
+          ["d", `$d`],
+        ])
+      )
+    ).toMatchInlineSnapshot(`
+    "{
+      "a": 0,
+      "b-c": "",
+      "d": $d,
+    }"
+    `);
+  });
+
+  test("generate empty object expression", () => {
+    expect(generateObjectExpression(new Map())).toMatchInlineSnapshot(`
+    "{
+    }"
+    `);
   });
 });
 

--- a/packages/sdk/src/expression.ts
+++ b/packages/sdk/src/expression.ts
@@ -235,6 +235,62 @@ export const transpileExpression = ({
   return expression;
 };
 
+/**
+ * parse object expression into key value map
+ * where each value is expression
+ */
+export const parseObjectExpression = (expression: string) => {
+  const map = new Map<string, string>();
+  let root;
+  try {
+    root = parseExpressionAt(expression, 0, { ecmaVersion: "latest" });
+  } catch (error) {
+    return map;
+  }
+  if (root.type !== "ObjectExpression") {
+    return map;
+  }
+  for (const property of root.properties) {
+    if (property.type === "SpreadElement") {
+      continue;
+    }
+    if (property.computed) {
+      continue;
+    }
+    let key;
+    if (property.key.type === "Identifier") {
+      key = property.key.name;
+    } else if (
+      property.key.type === "Literal" &&
+      typeof property.key.value === "string"
+    ) {
+      key = property.key.value;
+    } else {
+      continue;
+    }
+    const valueExpression = expression.slice(
+      property.value.start,
+      property.value.end
+    );
+    map.set(key, valueExpression);
+  }
+  return map;
+};
+
+/**
+ * generate key value map into object expression
+ * after updating individual value expressions
+ */
+export const generateObjectExpression = (map: Map<string, string>) => {
+  let generated = "{\n";
+  for (const [key, valueExpression] of map) {
+    const keyExpression = JSON.stringify(key);
+    generated += `  ${keyExpression}: ${valueExpression},\n`;
+  }
+  generated += `}`;
+  return generated;
+};
+
 const dataSourceVariablePrefix = "$ws$dataSource$";
 
 // data source id is generated with nanoid which has "-" in alphabeta


### PR DESCRIPTION
Here added utilities to update expressions partially for example in graphql json body we need to update separately query and variables expressions but store as single body expression.