### PR TITLE
refactor: align text area error with input field

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -375,7 +375,7 @@ const BodyField = ({
               maxRows={10}
               // expressions with variables cannot be edited
               disabled={isBound}
-              state={bodyField.error ? "invalid" : undefined}
+              color={bodyField.error ? "error" : undefined}
               value={String(evaluatedBodyValue ?? "")}
               // update text value as string literal
               onChange={(newValue) =>

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -930,7 +930,7 @@ const FormFields = ({
                 )}
                 <InputErrorsTooltip errors={errors.description}>
                   <TextArea
-                    state={errors.description && "invalid"}
+                    color={errors.description ? "error" : undefined}
                     id={fieldIds.description}
                     name="description"
                     disabled={isLiteralExpression(values.description) === false}

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -94,7 +94,7 @@ export const BackgroundGradient = (
       maxRows={4}
       name="description"
       value={textAreaValue ?? ""}
-      state={intermediateValue?.type === "invalid" ? "invalid" : undefined}
+      color={intermediateValue?.type === "invalid" ? "error" : undefined}
       onChange={handleChange}
       onBlur={handleOnComplete}
       onKeyDown={(event) => {

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
@@ -223,7 +223,7 @@ export const TransitionContent = ({
           rows={3}
           name="description"
           css={{ minHeight: theme.spacing[14], ...textVariants.mono }}
-          state={intermediateValue?.type === "invalid" ? "invalid" : undefined}
+          color={intermediateValue?.type === "invalid" ? "error" : undefined}
           value={intermediateValue?.value ?? ""}
           onChange={handleChange}
           onBlur={handleComplete}

--- a/apps/builder/app/builder/features/style-panel/shared/filter-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/filter-content.tsx
@@ -89,7 +89,7 @@ export const FilterSectionContent = ({
         name="description"
         value={intermediateValue?.value ?? propertyValue ?? ""}
         css={{ minHeight: theme.spacing[14], ...textVariants.mono }}
-        state={intermediateValue?.type === "invalid" ? "invalid" : undefined}
+        color={intermediateValue?.type === "invalid" ? "error" : undefined}
         onChange={handleChange}
         onKeyDown={(event) => {
           if (event.key === "Enter") {

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -395,7 +395,7 @@ export const ShadowContent = ({
           name="description"
           value={intermediateValue?.value ?? propertyValue ?? ""}
           css={{ minHeight: theme.spacing[14], ...textVariants.mono }}
-          state={intermediateValue?.type === "invalid" ? "invalid" : undefined}
+          color={intermediateValue?.type === "invalid" ? "error" : undefined}
           onChange={handleChange}
           onKeyDown={(event) => {
             if (event.key === "Enter") {

--- a/packages/design-system/src/components/text-area.stories.tsx
+++ b/packages/design-system/src/components/text-area.stories.tsx
@@ -49,9 +49,9 @@ export const Demo = () => {
           <TextArea value={value} onChange={setValue} />
         </StoryGrid>
       </StorySection>
-      <StorySection title="Invalid">
+      <StorySection title="Error">
         <StoryGrid css={{ width: 200 }}>
-          <TextArea value={value} onChange={setValue} state="invalid" />
+          <TextArea value={value} onChange={setValue} color="error" />
         </StoryGrid>
       </StorySection>
       <StorySection title="Disabled">
@@ -59,14 +59,9 @@ export const Demo = () => {
           <TextArea value={value} onChange={setValue} disabled />
         </StoryGrid>
       </StorySection>
-      <StorySection title="Disabled invalid">
+      <StorySection title="Disabled error">
         <StoryGrid css={{ width: 200 }}>
-          <TextArea
-            value={value}
-            onChange={setValue}
-            state="invalid"
-            disabled
-          />
+          <TextArea value={value} onChange={setValue} color="error" disabled />
         </StoryGrid>
       </StorySection>
       <StorySection title="Focused (initialy)">

--- a/packages/design-system/src/components/text-area.tsx
+++ b/packages/design-system/src/components/text-area.tsx
@@ -26,13 +26,18 @@ const gridStyle = css({
   resize: "vertical",
   overflow: "auto",
   width: "100%",
-
   "&:focus-within": {
     borderColor: theme.colors.borderFocus,
     outline: `1px solid ${theme.colors.borderFocus}`,
   },
+  "&:has([data-color=error])": {
+    borderColor: theme.colors.borderDestructiveMain,
+    "&:focus-within": {
+      outlineColor: theme.colors.borderDestructiveMain,
+    },
+  },
   "&:has(textarea:disabled)": {
-    background: theme.colors.backgroundInputDisabled,
+    backgroundColor: theme.colors.backgroundInputDisabled,
   },
   variants: {
     grow: {
@@ -43,14 +48,6 @@ const gridStyle = css({
     variant: {
       regular: textVariants.regular,
       mono: textVariants.mono,
-    },
-    state: {
-      invalid: {
-        color: theme.colors.foregroundDestructive,
-        "&:not(:disabled):not(:focus-within)": {
-          borderColor: theme.colors.borderDestructiveMain,
-        },
-      },
     },
   },
   defaultVariants: {
@@ -100,7 +97,7 @@ type Props = Omit<
   css?: CSS;
   rows?: number;
   maxRows?: number;
-  state?: "invalid";
+  color?: "error";
   value?: string;
   defaultValue?: string;
   onChange?: (value: string) => void;
@@ -116,7 +113,7 @@ export const TextArea = forwardRef(
       className,
       rows = 3,
       maxRows,
-      state,
+      color,
       value,
       onChange,
       grow,
@@ -147,7 +144,6 @@ export const TextArea = forwardRef(
     return (
       <Grid
         className={gridStyle({
-          state,
           grow: grow || autoGrow,
           variant,
           css: { height, minHeight, maxHeight },
@@ -175,7 +171,6 @@ export const TextArea = forwardRef(
           <div
             className={commonStyle({
               css: { visibility: "hidden", ...css },
-              state,
               className,
               variant,
             })}
@@ -187,10 +182,10 @@ export const TextArea = forwardRef(
             spellCheck={false}
             className={textAreaStyle({
               css,
-              state,
               className,
               variant,
             })}
+            data-color={color}
             onChange={(event) => setTextValue(event.target.value)}
             value={textValue}
             rows={rows}


### PR DESCRIPTION
Here replaced state=invalid with color=error in textarea to align with input field and fixed focused input with error style.

<img width="233" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5635476/bf649fec-cfdc-423f-a668-977d23aa1738">
