### PR TITLE
experimental: add graphql resource control

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -62,7 +62,11 @@ import {
   EditorDialogButton,
   EditorDialogControl,
 } from "~/builder/shared/code-editor-base";
-import { ResourceForm, SystemResourceForm } from "./resource-panel";
+import {
+  GraphqlResourceForm,
+  ResourceForm,
+  SystemResourceForm,
+} from "./resource-panel";
 import { generateCurl } from "./curl";
 
 /**
@@ -103,13 +107,14 @@ const parseJsonValue = (code: string) => {
 };
 
 type VariableType =
+  | "parameter"
   | "string"
   | "number"
   | "boolean"
   | "json"
   | "resource"
-  | "system-resource"
-  | "parameter";
+  | "graphql-resource"
+  | "system-resource";
 
 const TypeField = ({
   value,
@@ -151,6 +156,18 @@ const TypeField = ({
       label: (
         <Flex direction="row" gap="2" align="center">
           Resource
+          {allowDynamicData === false && <ProBadge>Pro</ProBadge>}
+        </Flex>
+      ),
+      description:
+        "A Resource is a configuration for secure data fetching. You can safely use secrets in any field.",
+    },
+    {
+      value: "graphql-resource",
+      disabled: allowDynamicData === false,
+      label: (
+        <Flex direction="row" gap="2" align="center">
+          GraphQL
           {allowDynamicData === false && <ProBadge>Pro</ProBadge>}
         </Flex>
       ),
@@ -471,6 +488,9 @@ const VariablePanel = forwardRef<
       if (resource?.control === "system") {
         return "system-resource";
       }
+      if (resource?.control === "graphql") {
+        return "graphql-resource";
+      }
       return "resource";
     }
     if (variable?.type === "parameter") {
@@ -537,6 +557,20 @@ const VariablePanel = forwardRef<
         {nameFieldElement}
         <TypeField value={variableType} onChange={setVariableType} />
         <ResourceForm ref={ref} variable={variable} nameField={nameField} />
+      </>
+    );
+  }
+
+  if (variableType === "graphql-resource") {
+    return (
+      <>
+        {nameFieldElement}
+        <TypeField value={variableType} onChange={setVariableType} />
+        <GraphqlResourceForm
+          ref={ref}
+          variable={variable}
+          nameField={nameField}
+        />
       </>
     );
   }


### PR DESCRIPTION
Here added new "GraphQL" option into variable "type" select. It allows to switch to special resource subset with "query" and "variables" fields instead of single json body.

<img width="571" alt="Screenshot 2024-05-16 at 17 54 27" src="https://github.com/webstudio-is/webstudio/assets/5635476/db9ab321-18e9-4208-a46e-13bd7a88b6c7">
<img width="324" alt="Screenshot 2024-05-16 at 17 54 06" src="https://github.com/webstudio-is/webstudio/assets/5635476/07b9f6d4-117c-4974-b31c-a581bfdf4668">
