### PR TITLE
fix: strip backslashes from curl when paste

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/curl.test.ts
+++ b/apps/builder/app/builder/features/settings-panel/curl.test.ts
@@ -12,9 +12,9 @@ test("support url", () => {
   expect(parseCurl(`curl 'https://my-url/hello-world'`)).toEqual(result);
 });
 
-test("support multiline", () => {
+test("support multiline command with backslashes", () => {
   expect(
-    parseCurl(`curl \
+    parseCurl(`curl \\
       'https://my-url/hello-world'
   `)
   ).toEqual({
@@ -114,9 +114,7 @@ test("support text body with explicit method", () => {
 test("support json body", () => {
   expect(
     parseCurl(
-      `curl https://my-url/hello-world \
-        --header 'content-type: application/json' \
-        --data '{"param":"value"}'`
+      `curl https://my-url/hello-world --header 'content-type: application/json' --data '{"param":"value"}'`
     )
   ).toEqual({
     url: "https://my-url/hello-world",

--- a/apps/builder/app/builder/features/settings-panel/curl.ts
+++ b/apps/builder/app/builder/features/settings-panel/curl.ts
@@ -30,6 +30,9 @@ export type CurlRequest = Pick<
 >;
 
 export const parseCurl = (curl: string): undefined | CurlRequest => {
+  // remove backslash followed by newline
+  // https://github.com/astur/arrgv/issues/3
+  curl = curl.replaceAll(/\\(?=\s)/g, "");
   let argv;
   try {
     argv = arrgv(curl);


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/3375

The arguments parser we use missed a case with explicit backslashes and I missed it in our tests. Here removed it with regex.