### PR TITLE
feat: restore system params from history first entry

### DIFF
--- a/apps/builder/app/builder/features/address-bar.tsx
+++ b/apps/builder/app/builder/features/address-bar.tsx
@@ -38,6 +38,7 @@ import {
   $pages,
   $publishedOrigin,
   $selectedPage,
+  $selectedPageDefaultSystem,
   updateSystem,
 } from "~/shared/nano-states";
 import {
@@ -62,15 +63,15 @@ const $selectedPagePath = computed([$selectedPage, $pages], (page, pages) => {
 });
 
 const $selectedPagePathParams = computed(
-  [$selectedPage, $dataSourceVariables],
-  (selectedPage, dataSourceVariables) => {
+  [$selectedPageDefaultSystem, $selectedPage, $dataSourceVariables],
+  (defaultSystem, selectedPage, dataSourceVariables) => {
     if (selectedPage === undefined) {
-      return {};
+      return defaultSystem.params;
     }
     const system = dataSourceVariables.get(selectedPage.systemDataSourceId) as
       | undefined
       | System;
-    return system?.params;
+    return system?.params ?? defaultSystem.params;
   }
 );
 

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
@@ -351,9 +351,11 @@ const $editingPage = computed(
 
 const $editingPagePath = computed($editingPage, (page) => page?.path);
 
+const $editingPageHistory = computed($editingPage, (page) => page?.history);
+
 const $editingPageDefaultSystem = computed(
-  [$publishedOrigin, $editingPagePath],
-  (origin, path) => getPageDefaultSystem({ origin, path })
+  [$publishedOrigin, $editingPagePath, $editingPageHistory],
+  (origin, path, history) => getPageDefaultSystem({ origin, path, history })
 );
 
 const $pageRootVariableValues = computed(


### PR DESCRIPTION
We want users to get good first impression and show already working cms page when clone from marketplace. Here improved bindings logic to always use the first history entry as default.

<img width="616" alt="Screenshot 2024-05-20 at 13 41 17" src="https://github.com/webstudio-is/webstudio/assets/5635476/ab941caf-7a0d-4617-ad8f-003bfa914277">
