### PR TITLE
fix: show drop stub when collection is empty

### DIFF
--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -122,6 +122,20 @@ const MissingComponentStub = forwardRef<
 
 MissingComponentStub.displayName = "MissingComponentStub";
 
+const DroppableComponentStub = forwardRef<
+  HTMLDivElement,
+  { children?: ReactNode }
+>((props, ref) => {
+  return (
+    <div
+      {...props}
+      ref={ref}
+      style={{ display: props.children ? "contents" : "block" }}
+    />
+  );
+});
+DroppableComponentStub.displayName = "DroppableComponentStub";
+
 // this utility is temporary solution to compute instance selectors
 // for rich text subtree which cannot have slots so its safe to traverse ancestors
 // until editor instance is reached
@@ -308,6 +322,10 @@ export const WebstudioComponentCanvas = forwardRef<
     return <></>;
   }
 
+  let Component =
+    components.get(instance.component) ??
+    (MissingComponentStub as AnyComponent);
+
   if (instance.component === collectionComponent) {
     const data = instanceProps.data;
     // render stub component when no data or children
@@ -334,15 +352,12 @@ export const WebstudioComponentCanvas = forwardRef<
         );
       });
     }
+    Component = DroppableComponentStub as AnyComponent;
   }
 
   if (instance.component === descendantComponent) {
     return <></>;
   }
-
-  const Component =
-    components.get(instance.component) ??
-    (MissingComponentStub as AnyComponent);
 
   const props: {
     [componentAttribute]: string;


### PR DESCRIPTION
Empty stub was used as drop target in empty collection. Missing stub does not work for this case.

<img width="655" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5635476/2cea1b50-3493-4073-a9d7-9a686f8c5eb5">
