### PR TITLE
refactor: parse jsx ai output with acorn

### DIFF
--- a/packages/jsx-utils/package.json
+++ b/packages/jsx-utils/package.json
@@ -30,11 +30,11 @@
   "license": "AGPL-3.0-or-later",
   "sideEffects": false,
   "dependencies": {
-    "@babel/parser": "^7.23.0",
-    "@babel/types": "7.24.0",
     "@webstudio-is/css-data": "workspace:*",
     "@webstudio-is/react-sdk": "workspace:*",
     "@webstudio-is/sdk": "workspace:*",
+    "acorn": "^8.11.3",
+    "acorn-jsx": "^5.3.2",
     "json5": "^2.2.3",
     "zod": "^3.22.4"
   }

--- a/packages/jsx-utils/src/jsx.test.ts
+++ b/packages/jsx-utils/src/jsx.test.ts
@@ -129,3 +129,40 @@ const jsx = `
   Hello from Webstudio
 </Box>
 `;
+
+test("automatically wrap with fragment unwrapped jsx elements", async () => {
+  const jsx = `
+    <Box>Box 1</Box>
+    <Box>Box 2</Box>
+  `;
+  const parsed = await jsxToWSEmbedTemplate(jsx.trim());
+  expect(() => WsEmbedTemplate.parse(parsed)).not.toThrow();
+  expect(parsed).toMatchInlineSnapshot(`
+[
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Box 1",
+      },
+    ],
+    "component": "Box",
+    "props": [],
+    "styles": [],
+    "type": "instance",
+  },
+  {
+    "children": [
+      {
+        "type": "text",
+        "value": "Box 2",
+      },
+    ],
+    "component": "Box",
+    "props": [],
+    "styles": [],
+    "type": "instance",
+  },
+]
+`);
+});

--- a/packages/jsx-utils/src/parser.ts
+++ b/packages/jsx-utils/src/parser.ts
@@ -1,0 +1,107 @@
+import type {
+  Literal,
+  Node,
+  Expression,
+  Identifier,
+  SpreadElement,
+} from "acorn";
+import { Parser } from "acorn";
+import jsx from "acorn-jsx";
+
+// https://github.com/facebook/jsx/blob/main/AST.md
+// JSXSpreadChild is not implemented in acorn-jsx
+
+// JSX Names
+
+export type JSXIdentifier = Omit<Identifier, "type"> & {
+  type: "JSXIdentifier";
+};
+
+export type JSXMemberExpression = Omit<Node, "type"> & {
+  type: "JSXMemberExpression";
+  object: JSXMemberExpression | JSXIdentifier;
+  property: JSXIdentifier;
+};
+
+export type JSXNamespacedName = Omit<Node, "type"> & {
+  type: "JSXNamespacedName";
+  namespace: JSXIdentifier;
+  name: JSXIdentifier;
+};
+
+// JSX Expression Container
+
+export type JSXEmptyExpression = Omit<Node, "type"> & {
+  type: "JSXEmptyExpression";
+};
+
+export type JSXExpressionContainer = Omit<Node, "type"> & {
+  type: "JSXExpressionContainer";
+  expression: Expression | JSXEmptyExpression;
+};
+
+// JSX Attributes
+
+export type JSXAttribute = Omit<Node, "type"> & {
+  type: "JSXAttribute";
+  name: JSXIdentifier | JSXNamespacedName;
+  value: Literal | JSXExpressionContainer | JSXElement | JSXFragment | null;
+};
+
+export type JSXSpreadAttribute = Omit<SpreadElement, "type"> & {
+  type: "JSXSpreadAttribute";
+};
+
+// JSX Text
+
+export type JSXText = Omit<Node, "type"> & {
+  type: "JSXText";
+  value: string;
+  raw: string;
+};
+
+// JSX Element
+
+export type JSXOpeningElement = Omit<Node, "type"> & {
+  type: "JSXOpeningElement";
+  name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName;
+  attributes: Array<JSXAttribute | JSXSpreadAttribute>;
+  selfClosing: boolean;
+};
+
+export type JSXClosingElement = Omit<Node, "type"> & {
+  type: "JSXClosingElement";
+  name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName;
+};
+
+export type JSXElement = Omit<Node, "type"> & {
+  type: "JSXElement";
+  openingElement: JSXOpeningElement;
+  closingElement: JSXClosingElement | null;
+  children: [JSXText | JSXExpressionContainer | JSXElement | JSXFragment];
+};
+
+// JSX Fragment
+
+export type JSXOpeningFragment = Omit<Node, "type"> & {
+  type: "JSXOpeningFragment";
+};
+
+export type JSXClosingFragment = Omit<Node, "type"> & {
+  type: "JSXClosingFragment";
+};
+
+export type JSXFragment = Omit<Node, "type"> & {
+  type: "JSXFragment";
+  openingFragment: JSXOpeningFragment;
+  closingFragment: JSXClosingFragment;
+  children: Array<JSXText | JSXExpressionContainer | JSXElement | JSXFragment>;
+};
+
+const JsxParser = Parser.extend(jsx());
+
+export const parseExpression = (
+  code: string
+): Expression | JSXElement | JSXFragment => {
+  return JsxParser.parseExpressionAt(code, 0, { ecmaVersion: "latest" });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1611,12 +1611,6 @@ importers:
 
   packages/jsx-utils:
     dependencies:
-      '@babel/parser':
-        specifier: ^7.23.0
-        version: 7.23.0
-      '@babel/types':
-        specifier: 7.24.0
-        version: 7.24.0
       '@webstudio-is/css-data':
         specifier: workspace:*
         version: link:../css-data
@@ -1626,6 +1620,12 @@ importers:
       '@webstudio-is/sdk':
         specifier: workspace:*
         version: link:../sdk
+      acorn:
+        specifier: ^8.11.3
+        version: 8.11.3
+      acorn-jsx:
+        specifier: ^5.3.2
+        version: 5.3.2(acorn@8.11.3)
       json5:
         specifier: ^2.2.3
         version: 2.2.3


### PR DESCRIPTION
Babel is very big package. It brings a lot of transitive dependencies. A lot of projects like remix, storybook and jest depends on it.

Updating it is always a challenge because it usually lead to duplicates.

So here I switched to acorn we already use for expressions. JSX parsing is not builtin but available as a plugin. The only downside is lack of node types. Though very straightforward to get them from jsx estree extension spec.

See build sizes change

```diff
- 4716	build/server
+ 3992	build/server
6096	build/client
```

Additionally in this PR prevented "Fragment" component generation, it should not be used with anything except Slot.