### PR TITLE
refactor: Move text placeholders to meta templates

### DIFF
--- a/apps/builder/app/builder/features/ai/ai-fetch-result.ts
+++ b/apps/builder/app/builder/features/ai/ai-fetch-result.ts
@@ -295,7 +295,12 @@ const $jsx = computed(
       indexesWithinAncestors,
       children: generateJsxChildren({
         scope,
-        children: instance.children,
+        children: instance.children.filter((child) => {
+          if (child.type === "text" && child.placeholder === true) {
+            return false;
+          }
+          return true;
+        }),
         instances,
         props,
         dataSources,

--- a/apps/builder/app/builder/features/ai/ai-fetch-result.ts
+++ b/apps/builder/app/builder/features/ai/ai-fetch-result.ts
@@ -295,17 +295,13 @@ const $jsx = computed(
       indexesWithinAncestors,
       children: generateJsxChildren({
         scope,
-        children: instance.children.filter((child) => {
-          if (child.type === "text" && child.placeholder === true) {
-            return false;
-          }
-          return true;
-        }),
+        children: instance.children,
         instances,
         props,
         dataSources,
         usedDataSources: new Map(),
         indexesWithinAncestors,
+        excludePlaceholders: true,
       }),
     });
 

--- a/apps/builder/app/canvas/features/text-editor/interop.ts
+++ b/apps/builder/app/canvas/features/text-editor/interop.ts
@@ -190,11 +190,3 @@ export const $convertToLexical = (
     $writeLexical(p, rootInstance.children, instances, refs);
   }
 };
-
-export const $convertTextToLexical = (text: string) => {
-  const root = $getRoot();
-  const p = $createParagraphNode();
-  root.append(p);
-  const textNode = $createTextNode(text);
-  p.append(textNode);
-};

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -23,12 +23,7 @@ import type { Instance, Instances } from "@webstudio-is/sdk";
 import { idAttribute } from "@webstudio-is/react-sdk";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { ToolbarConnectorPlugin } from "./toolbar-connector";
-import {
-  type Refs,
-  $convertToLexical,
-  $convertToUpdates,
-  $convertTextToLexical,
-} from "./interop";
+import { type Refs, $convertToLexical, $convertToUpdates } from "./interop";
 import { colord } from "colord";
 import { useEffectEvent } from "~/shared/hook-utils/effect-event";
 
@@ -251,15 +246,7 @@ export const TextEditor = ({
       },
     },
     editorState: () => {
-      const textContent = (rootRef.current?.textContent ?? "").trim();
       const [rootInstanceId] = rootInstanceSelector;
-      if (textContent.length !== 0) {
-        const rootInstance = instances.get(rootInstanceId);
-        if (rootInstance && rootInstance.children.length === 0) {
-          $convertTextToLexical(textContent);
-          return;
-        }
-      }
       // text editor is unmounted when change properties in side panel
       // so assume new nodes don't need to preserve instance id
       // and store only initial references

--- a/packages/jsx-utils/src/heroicons/index.ts
+++ b/packages/jsx-utils/src/heroicons/index.ts
@@ -41,7 +41,7 @@ export const heroiconsToSvgEmbed = (
           ];
         } else {
           node.component = "Text";
-          node.children = [{ type: "text", value: "Icon" }];
+          node.children = [{ type: "text", value: "Icon", placeholder: true }];
         }
       }
     }

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -436,7 +436,7 @@ test("exclude text placeholders", () => {
     generateJsxChildren({
       scope: createScope(),
       children: [
-        { type: "text", value: "Some\ntext" },
+        { type: "text", value: "Text" },
         { type: "text", value: "Placeholder text", placeholder: true },
       ],
       instances: new Map(),
@@ -444,12 +444,11 @@ test("exclude text placeholders", () => {
       dataSources: new Map(),
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
+      excludePlaceholders: true,
     })
   ).toEqual(
     clear(`
-      {"Some"}
-      <br />
-      {"text"}
+      {"Text"}
     `)
   );
 });

--- a/packages/react-sdk/src/component-generator.test.ts
+++ b/packages/react-sdk/src/component-generator.test.ts
@@ -431,6 +431,29 @@ test("generate jsx children with text", () => {
   );
 });
 
+test("exclude text placeholders", () => {
+  expect(
+    generateJsxChildren({
+      scope: createScope(),
+      children: [
+        { type: "text", value: "Some\ntext" },
+        { type: "text", value: "Placeholder text", placeholder: true },
+      ],
+      instances: new Map(),
+      props: new Map(),
+      dataSources: new Map(),
+      usedDataSources: new Map(),
+      indexesWithinAncestors: new Map(),
+    })
+  ).toEqual(
+    clear(`
+      {"Some"}
+      <br />
+      {"text"}
+    `)
+  );
+});
+
 test("generate jsx children with expression", () => {
   expect(
     generateJsxChildren({

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -275,6 +275,7 @@ export const generateJsxChildren = ({
   usedDataSources,
   indexesWithinAncestors,
   classesMap,
+  excludePlaceholders,
 }: {
   scope: Scope;
   children: Instance["children"];
@@ -284,10 +285,14 @@ export const generateJsxChildren = ({
   usedDataSources: DataSources;
   indexesWithinAncestors: IndexesWithinAncestors;
   classesMap?: Map<string, Array<string>>;
+  excludePlaceholders?: boolean;
 }) => {
   let generatedChildren = "";
   for (const child of children) {
     if (child.type === "text") {
+      if (excludePlaceholders && child.placeholder === true) {
+        continue;
+      }
       // instance text can contain newlines
       // convert them too <br> tag
       generatedChildren += child.value
@@ -329,6 +334,7 @@ export const generateJsxChildren = ({
           dataSources,
           usedDataSources,
           indexesWithinAncestors,
+          excludePlaceholders,
         }),
       });
       continue;

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -288,9 +288,6 @@ export const generateJsxChildren = ({
   let generatedChildren = "";
   for (const child of children) {
     if (child.type === "text") {
-      if (child.placeholder) {
-        continue;
-      }
       // instance text can contain newlines
       // convert them too <br> tag
       generatedChildren += child.value

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -288,6 +288,9 @@ export const generateJsxChildren = ({
   let generatedChildren = "";
   for (const child of children) {
     if (child.type === "text") {
+      if (child.placeholder) {
+        continue;
+      }
       // instance text can contain newlines
       // convert them too <br> tag
       generatedChildren += child.value

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -23,6 +23,7 @@ import type { WsComponentMeta } from "./components/component-meta";
 const EmbedTemplateText = z.object({
   type: z.literal("text"),
   value: z.string(),
+  placeholder: z.boolean().optional(),
 });
 
 type EmbedTemplateText = z.infer<typeof EmbedTemplateText>;

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -361,6 +361,7 @@ const createInstancesFromTemplate = (
       parentChildren.push({
         type: "text",
         value: item.value,
+        placeholder: item.placeholder,
       });
     }
 

--- a/packages/sdk-components-react-radix/src/accordion.ws.ts
+++ b/packages/sdk-components-react-radix/src/accordion.ws.ts
@@ -156,7 +156,9 @@ export const metaAccordion: WsComponentMeta = {
           styles: accordionItemStyles,
           children: [
             createAccordionTrigger({
-              children: [{ type: "text", value: "Is it accessible?" }],
+              children: [
+                { type: "text", value: "Is it accessible?", placeholder: true },
+              ],
             }),
             {
               type: "instance",
@@ -166,6 +168,7 @@ export const metaAccordion: WsComponentMeta = {
                 {
                   type: "text",
                   value: "Yes. It adheres to the WAI-ARIA design pattern.",
+                  placeholder: true,
                 },
               ],
             },
@@ -178,7 +181,9 @@ export const metaAccordion: WsComponentMeta = {
           styles: accordionItemStyles,
           children: [
             createAccordionTrigger({
-              children: [{ type: "text", value: "Is it styled?" }],
+              children: [
+                { type: "text", value: "Is it styled?", placeholder: true },
+              ],
             }),
             {
               type: "instance",
@@ -189,6 +194,7 @@ export const metaAccordion: WsComponentMeta = {
                   type: "text",
                   value:
                     "Yes. It comes with default styles that matches the other components' aesthetic.",
+                  placeholder: true,
                 },
               ],
             },
@@ -201,7 +207,9 @@ export const metaAccordion: WsComponentMeta = {
           styles: accordionItemStyles,
           children: [
             createAccordionTrigger({
-              children: [{ type: "text", value: "Is it animated?" }],
+              children: [
+                { type: "text", value: "Is it animated?", placeholder: true },
+              ],
             }),
             {
               type: "instance",
@@ -212,6 +220,7 @@ export const metaAccordion: WsComponentMeta = {
                   type: "text",
                   value:
                     "Yes. It's animated by default, but you can disable it if you prefer.",
+                  placeholder: true,
                 },
               ],
             },

--- a/packages/sdk-components-react-radix/src/checkbox.ws.ts
+++ b/packages/sdk-components-react-radix/src/checkbox.ws.ts
@@ -126,7 +126,7 @@ export const metaCheckbox: WsComponentMeta = {
           component: "Text",
           label: "Checkbox Label",
           props: [{ name: "tag", type: "string", value: "span" }],
-          children: [{ type: "text", value: "Checkbox" }],
+          children: [{ type: "text", value: "Checkbox", placeholder: true }],
         },
       ],
     },

--- a/packages/sdk-components-react-radix/src/collapsible.ws.ts
+++ b/packages/sdk-components-react-radix/src/collapsible.ws.ts
@@ -58,7 +58,13 @@ export const metaCollapsible: WsComponentMeta = {
               type: "instance",
               component: "Button",
               styles: getButtonStyles("outline"),
-              children: [{ type: "text", value: "Click to toggle content" }],
+              children: [
+                {
+                  type: "text",
+                  value: "Click to toggle content",
+                  placeholder: true,
+                },
+              ],
             },
           ],
         },
@@ -69,7 +75,13 @@ export const metaCollapsible: WsComponentMeta = {
             {
               type: "instance",
               component: "Text",
-              children: [{ type: "text", value: "Collapsible Content" }],
+              children: [
+                {
+                  type: "text",
+                  value: "Collapsible Content",
+                  placeholder: true,
+                },
+              ],
             },
           ],
         },

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -177,7 +177,7 @@ export const DialogTitle = forwardRef<
 >(({ tag: Tag = defaultTag, children, ...props }, ref) => (
   <DialogPrimitive.DialogTitle asChild>
     <Tag ref={ref} {...props}>
-      {children ?? "Heading title you can edit"}
+      {children}
     </Tag>
   </DialogPrimitive.DialogTitle>
 ));

--- a/packages/sdk-components-react-radix/src/dialog.ws.ts
+++ b/packages/sdk-components-react-radix/src/dialog.ws.ts
@@ -202,7 +202,7 @@ export const metaDialog: WsComponentMeta = {
                       children: [
                         {
                           type: "text",
-                          value: "Dialog Title",
+                          value: "Dialog Title you can edit",
                           placeholder: true,
                         },
                       ],

--- a/packages/sdk-components-react-radix/src/dialog.ws.ts
+++ b/packages/sdk-components-react-radix/src/dialog.ws.ts
@@ -135,7 +135,7 @@ export const metaDialog: WsComponentMeta = {
               type: "instance",
               component: "Button",
               styles: getButtonStyles("outline"),
-              children: [{ type: "text", value: "Button" }],
+              children: [{ type: "text", value: "Button", placeholder: true }],
             },
           ],
         },
@@ -203,6 +203,7 @@ export const metaDialog: WsComponentMeta = {
                         {
                           type: "text",
                           value: "Dialog Title",
+                          placeholder: true,
                         },
                       ],
                     },
@@ -221,6 +222,7 @@ export const metaDialog: WsComponentMeta = {
                         {
                           type: "text",
                           value: "Dialog description text you can edit",
+                          placeholder: true,
                         },
                       ],
                     },
@@ -230,7 +232,13 @@ export const metaDialog: WsComponentMeta = {
                 {
                   type: "instance",
                   component: "Text",
-                  children: [{ type: "text", value: "The text you can edit" }],
+                  children: [
+                    {
+                      type: "text",
+                      value: "The text you can edit",
+                      placeholder: true,
+                    },
+                  ],
                 },
 
                 {

--- a/packages/sdk-components-react-radix/src/label.ws.ts
+++ b/packages/sdk-components-react-radix/src/label.ws.ts
@@ -33,7 +33,7 @@ export const meta: WsComponentMeta = {
         tc.leading("none"),
         // We are not supporting peer like styles yet
       ].flat(),
-      children: [{ type: "text", value: "Form Label" }],
+      children: [{ type: "text", value: "Form Label", placeholder: true }],
     },
   ],
 };

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -135,6 +135,7 @@ const navItem = (
               {
                 type: "text",
                 value: props.title,
+                placeholder: true,
               },
             ],
           },
@@ -154,6 +155,7 @@ const navItem = (
               {
                 type: "text",
                 value: props.description,
+                placeholder: true,
               },
             ],
           },
@@ -197,7 +199,7 @@ const menuItemLink = (props: {
               tc.noUnderline(),
               tc.text("current"),
             ].flat(),
-            children: [{ type: "text", value: props.title }],
+            children: [{ type: "text", value: props.title, placeholder: true }],
           },
         ],
       },
@@ -238,7 +240,9 @@ const menuItem = (props: {
               {
                 type: "instance",
                 component: "Text",
-                children: [{ type: "text", value: props.title }],
+                children: [
+                  { type: "text", value: props.title, placeholder: true },
+                ],
               },
               {
                 type: "instance",
@@ -368,6 +372,7 @@ export const metaNavigationMenu: WsComponentMeta = {
                     {
                       type: "text",
                       value: "",
+                      placeholder: true,
                     },
                   ],
                 },

--- a/packages/sdk-components-react-radix/src/popover.ws.ts
+++ b/packages/sdk-components-react-radix/src/popover.ws.ts
@@ -79,7 +79,7 @@ export const metaPopover: WsComponentMeta = {
               type: "instance",
               component: "Button",
               styles: getButtonStyles("outline"),
-              children: [{ type: "text", value: "Button" }],
+              children: [{ type: "text", value: "Button", placeholder: true }],
             },
           ],
         },
@@ -104,7 +104,13 @@ export const metaPopover: WsComponentMeta = {
             {
               type: "instance",
               component: "Text",
-              children: [{ type: "text", value: "The text you can edit" }],
+              children: [
+                {
+                  type: "text",
+                  value: "The text you can edit",
+                  placeholder: true,
+                },
+              ],
             },
           ],
         },

--- a/packages/sdk-components-react-radix/src/radio-group.ws.ts
+++ b/packages/sdk-components-react-radix/src/radio-group.ws.ts
@@ -77,7 +77,7 @@ const createRadioGroupItem = ({
     {
       type: "instance",
       component: "Text",
-      children: [{ type: "text", value: label }],
+      children: [{ type: "text", value: label, placeholder: true }],
     },
   ],
 });

--- a/packages/sdk-components-react-radix/src/select.ws.ts
+++ b/packages/sdk-components-react-radix/src/select.ws.ts
@@ -225,15 +225,21 @@ export const metaSelect: WsComponentMeta = {
               children: [
                 createSelectItem({
                   props: [{ name: "value", type: "string", value: "light" }],
-                  children: [{ type: "text", value: "Light" }],
+                  children: [
+                    { type: "text", value: "Light", placeholder: true },
+                  ],
                 }),
                 createSelectItem({
                   props: [{ name: "value", type: "string", value: "dark" }],
-                  children: [{ type: "text", value: "Dark" }],
+                  children: [
+                    { type: "text", value: "Dark", placeholder: true },
+                  ],
                 }),
                 createSelectItem({
                   props: [{ name: "value", type: "string", value: "system" }],
-                  children: [{ type: "text", value: "System" }],
+                  children: [
+                    { type: "text", value: "System", placeholder: true },
+                  ],
                 }),
               ],
             },

--- a/packages/sdk-components-react-radix/src/sheet.ws.ts
+++ b/packages/sdk-components-react-radix/src/sheet.ws.ts
@@ -148,6 +148,7 @@ export const meta: WsComponentMeta = {
                             {
                               type: "text",
                               value: "Sheet Title",
+                              placeholder: true,
                             },
                           ],
                         },
@@ -167,6 +168,7 @@ export const meta: WsComponentMeta = {
                             {
                               type: "text",
                               value: "Sheet description text you can edit",
+                              placeholder: true,
                             },
                           ],
                         },
@@ -177,7 +179,11 @@ export const meta: WsComponentMeta = {
                       type: "instance",
                       component: "Text",
                       children: [
-                        { type: "text", value: "The text you can edit" },
+                        {
+                          type: "text",
+                          value: "The text you can edit",
+                          placeholder: true,
+                        },
                       ],
                     },
                   ],

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -112,13 +112,15 @@ export const metaTabs: WsComponentMeta = {
               type: "instance",
               component: "TabsTrigger",
               styles: tabsTriggerStyles,
-              children: [{ type: "text", value: "Account" }],
+              children: [{ type: "text", value: "Account", placeholder: true }],
             },
             {
               type: "instance",
               component: "TabsTrigger",
               styles: tabsTriggerStyles,
-              children: [{ type: "text", value: "Password" }],
+              children: [
+                { type: "text", value: "Password", placeholder: true },
+              ],
             },
           ],
         },
@@ -127,14 +129,24 @@ export const metaTabs: WsComponentMeta = {
           component: "TabsContent",
           styles: tabsContentStyles,
           children: [
-            { type: "text", value: "Make changes to your account here." },
+            {
+              type: "text",
+              value: "Make changes to your account here.",
+              placeholder: true,
+            },
           ],
         },
         {
           type: "instance",
           component: "TabsContent",
           styles: tabsContentStyles,
-          children: [{ type: "text", value: "Change your password here." }],
+          children: [
+            {
+              type: "text",
+              value: "Change your password here.",
+              placeholder: true,
+            },
+          ],
         },
       ],
     },

--- a/packages/sdk-components-react-radix/src/tooltip.ws.ts
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.ts
@@ -80,7 +80,7 @@ export const metaTooltip: WsComponentMeta = {
               type: "instance",
               component: "Button",
               styles: getButtonStyles("outline"),
-              children: [{ type: "text", value: "Button" }],
+              children: [{ type: "text", value: "Button", placeholder: true }],
             },
           ],
         },
@@ -106,7 +106,13 @@ export const metaTooltip: WsComponentMeta = {
             {
               type: "instance",
               component: "Text",
-              children: [{ type: "text", value: "The text you can edit" }],
+              children: [
+                {
+                  type: "text",
+                  value: "The text you can edit",
+                  placeholder: true,
+                },
+              ],
             },
           ],
         },

--- a/packages/sdk-components-react-remix/src/webhook-form.ws.ts
+++ b/packages/sdk-components-react-remix/src/webhook-form.ws.ts
@@ -55,7 +55,7 @@ export const meta: WsComponentMeta = {
             {
               type: "instance",
               component: "Label",
-              children: [{ type: "text", value: "Name" }],
+              children: [{ type: "text", value: "Name", placeholder: true }],
             },
             {
               type: "instance",
@@ -66,7 +66,7 @@ export const meta: WsComponentMeta = {
             {
               type: "instance",
               component: "Label",
-              children: [{ type: "text", value: "Email" }],
+              children: [{ type: "text", value: "Email", placeholder: true }],
             },
             {
               type: "instance",
@@ -77,7 +77,7 @@ export const meta: WsComponentMeta = {
             {
               type: "instance",
               component: "Button",
-              children: [{ type: "text", value: "Submit" }],
+              children: [{ type: "text", value: "Submit", placeholder: true }],
             },
           ],
         },
@@ -94,7 +94,11 @@ export const meta: WsComponentMeta = {
             },
           ],
           children: [
-            { type: "text", value: "Thank you for getting in touch!" },
+            {
+              type: "text",
+              value: "Thank you for getting in touch!",
+              placeholder: true,
+            },
           ],
         },
 
@@ -109,7 +113,13 @@ export const meta: WsComponentMeta = {
               code: "formState === 'error'",
             },
           ],
-          children: [{ type: "text", value: "Sorry, something went wrong." }],
+          children: [
+            {
+              type: "text",
+              value: "Sorry, something went wrong.",
+              placeholder: true,
+            },
+          ],
         },
       ],
     },

--- a/packages/sdk-components-react/src/blockquote.tsx
+++ b/packages/sdk-components-react/src/blockquote.tsx
@@ -8,7 +8,7 @@ export const Blockquote = forwardRef<ElementRef<typeof defaultTag>, Props>(
   ({ children, ...props }, ref) => {
     return (
       <blockquote {...props} ref={ref}>
-        {children ?? "Blockquote you can edit"}
+        {children}
       </blockquote>
     );
   }

--- a/packages/sdk-components-react/src/blockquote.ws.ts
+++ b/packages/sdk-components-react/src/blockquote.ws.ts
@@ -69,6 +69,19 @@ export const meta: WsComponentMeta = {
   states: defaultStates,
   presetStyle,
   order: 3,
+  template: [
+    {
+      type: "instance",
+      component: "Blockquote",
+      children: [
+        {
+          type: "text",
+          value: "Blockquote text you can edit",
+          placeholder: true,
+        },
+      ],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/button.tsx
+++ b/packages/sdk-components-react/src/button.tsx
@@ -7,7 +7,7 @@ type ButtonProps = ComponentProps<typeof defaultTag>;
 export const Button = forwardRef<ElementRef<typeof defaultTag>, ButtonProps>(
   ({ type = "submit", children, ...props }, ref) => (
     <button type={type} {...props} ref={ref}>
-      {children ?? "Button you can edit"}
+      {children}
     </button>
   )
 );

--- a/packages/sdk-components-react/src/button.ws.ts
+++ b/packages/sdk-components-react/src/button.ws.ts
@@ -28,6 +28,19 @@ export const meta: WsComponentMeta = {
     { selector: ":enabled", label: "Enabled" },
   ],
   order: 2,
+  template: [
+    {
+      type: "instance",
+      component: "Button",
+      children: [
+        {
+          type: "text",
+          value: "Button text you can edit",
+          placeholder: true,
+        },
+      ],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/checkbox.ws.ts
+++ b/packages/sdk-components-react/src/checkbox.ws.ts
@@ -51,7 +51,7 @@ export const meta: WsComponentMeta = {
           component: "Text",
           label: "Checkbox Label",
           props: [{ type: "string", name: "tag", value: "span" }],
-          children: [{ type: "text", value: "Checkbox" }],
+          children: [{ type: "text", value: "Checkbox", placeholder: true }],
         },
       ],
     },

--- a/packages/sdk-components-react/src/heading.tsx
+++ b/packages/sdk-components-react/src/heading.tsx
@@ -13,7 +13,7 @@ export const Heading = forwardRef<ElementRef<typeof defaultTag>, Props>(
     const Tag = tag;
     return (
       <Tag {...props} ref={ref}>
-        {children ?? "Heading you can edit"}
+        {children}
       </Tag>
     );
   }

--- a/packages/sdk-components-react/src/heading.ws.ts
+++ b/packages/sdk-components-react/src/heading.ws.ts
@@ -32,6 +32,19 @@ export const meta: WsComponentMeta = {
   states: defaultStates,
   presetStyle,
   order: 1,
+  template: [
+    {
+      type: "instance",
+      component: "Heading",
+      children: [
+        {
+          type: "text",
+          value: "Heading text you can edit",
+          placeholder: true,
+        },
+      ],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/label.ws.ts
+++ b/packages/sdk-components-react/src/label.ws.ts
@@ -29,7 +29,7 @@ export const meta: WsComponentMeta = {
     {
       type: "instance",
       component: "Label",
-      children: [{ type: "text", value: "Form Label" }],
+      children: [{ type: "text", value: "Form Label", placeholder: true }],
     },
   ],
 };

--- a/packages/sdk-components-react/src/link.tsx
+++ b/packages/sdk-components-react/src/link.tsx
@@ -11,7 +11,7 @@ export const Link = forwardRef<HTMLAnchorElement, Props>(
   ({ children, ...props }, ref) => {
     return (
       <a {...props} href={props.href ?? "#"} ref={ref}>
-        {children ?? "Link text you can edit"}
+        {children}
       </a>
     );
   }

--- a/packages/sdk-components-react/src/link.ws.ts
+++ b/packages/sdk-components-react/src/link.ws.ts
@@ -45,6 +45,19 @@ export const meta: WsComponentMeta = {
       label: "Current page",
     },
   ],
+  template: [
+    {
+      type: "instance",
+      component: "Link",
+      children: [
+        {
+          type: "text",
+          value: "Link text you can edit",
+          placeholder: true,
+        },
+      ],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/list-item.tsx
+++ b/packages/sdk-components-react/src/list-item.tsx
@@ -8,7 +8,7 @@ export const ListItem = forwardRef<ElementRef<typeof defaultTag>, Props>(
   ({ children, ...props }, ref) => {
     return (
       <li {...props} ref={ref}>
-        {children ?? "List Item you can edit"}
+        {children}
       </li>
     );
   }

--- a/packages/sdk-components-react/src/list-item.ws.ts
+++ b/packages/sdk-components-react/src/list-item.ws.ts
@@ -23,6 +23,19 @@ export const meta: WsComponentMeta = {
   states: defaultStates,
   presetStyle,
   order: 4,
+  template: [
+    {
+      type: "instance",
+      component: "List Item",
+      children: [
+        {
+          type: "text",
+          value: "List Item text you can edit",
+          placeholder: true,
+        },
+      ],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/paragraph.tsx
+++ b/packages/sdk-components-react/src/paragraph.tsx
@@ -7,7 +7,7 @@ export const Paragraph = forwardRef<
   ComponentProps<typeof defaultTag>
 >(({ children, ...props }, ref) => (
   <p {...props} ref={ref}>
-    {children ?? "Paragraph you can edit"}
+    {children}
   </p>
 ));
 

--- a/packages/sdk-components-react/src/paragraph.ws.ts
+++ b/packages/sdk-components-react/src/paragraph.ws.ts
@@ -23,6 +23,19 @@ export const meta: WsComponentMeta = {
   states: defaultStates,
   presetStyle,
   order: 2,
+  template: [
+    {
+      type: "instance",
+      component: "Paragraph",
+      children: [
+        {
+          type: "text",
+          value: "Paragraph text you can edit",
+          placeholder: true,
+        },
+      ],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/radio-button.ws.ts
+++ b/packages/sdk-components-react/src/radio-button.ws.ts
@@ -52,7 +52,7 @@ export const meta: WsComponentMeta = {
           component: "Text",
           label: "Radio Label",
           props: [{ type: "string", name: "tag", value: "span" }],
-          children: [{ type: "text", value: "Radio" }],
+          children: [{ type: "text", value: "Radio", placeholder: true }],
         },
       ],
     },

--- a/packages/sdk-components-react/src/text.tsx
+++ b/packages/sdk-components-react/src/text.tsx
@@ -14,7 +14,7 @@ export const Text = forwardRef<ElementRef<typeof defaultTag>, Props>(
     const Tag = tag;
     return (
       <Tag {...props} ref={ref}>
-        {children ?? "The text you can edit"}
+        {children}
       </Tag>
     );
   }

--- a/packages/sdk-components-react/src/text.ws.ts
+++ b/packages/sdk-components-react/src/text.ws.ts
@@ -29,6 +29,19 @@ export const meta: WsComponentMeta = {
   states: defaultStates,
   presetStyle,
   order: 0,
+  template: [
+    {
+      type: "instance",
+      component: "Text",
+      children: [
+        {
+          type: "text",
+          value: "The text you can edit",
+          placeholder: true,
+        },
+      ],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk/src/schema/instances.ts
+++ b/packages/sdk/src/schema/instances.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const TextChild = z.object({
   type: z.literal("text"),
   value: z.string(),
+  placeholder: z.boolean().optional(),
 });
 
 export type TextChild = z.infer<typeof TextChild>;


### PR DESCRIPTION
## Description

Part of https://github.com/webstudio-is/webstudio/issues/3149 this allows us to understand if an instance has text child.
With this knowledge we can place instances into components that don't have text children and after them if they do.

## Steps for reproduction

1. insert text or paragraph
2. see there is expected placeholder text which is editable
3. select it, tell AI to change color or something
4. see it works and see in payload it didn't send placeholder text
5. try text editing on empty body - shouldn't allow it

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
