### PR TITLE
fix: support copying text from code editor

### DIFF
--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -72,6 +72,8 @@ const editorContentStyle = css({
   paddingBottom: 4,
   paddingRight: theme.spacing[2],
   paddingLeft: theme.spacing[3],
+  // required to support copying selected text
+  userSelect: "text",
   "&:focus-within": {
     borderColor: theme.colors.borderFocus,
     outline: `1px solid ${theme.colors.borderFocus}`,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3343

Copying text was broken because of user-select: none defined globally. Without contenteditable=true codemirror still simulates text selection but everything else stops working.

Testing

- try to copy anything from variable "inspect"