### PR TITLE
fix: prevent showing not matching history

### DIFF
--- a/apps/builder/app/builder/features/address-bar.tsx
+++ b/apps/builder/app/builder/features/address-bar.tsx
@@ -277,7 +277,7 @@ const AddressBar = forwardRef<
   let history = useStore($selectedPageHistory);
   history = useMemo(() => {
     return history.filter((item) => matchPathnamePattern(path, item));
-  }, [history]);
+  }, [history, path]);
   const [pathParams, setPathParams] = useState(
     () => $selectedPagePathParams.get() ?? {}
   );

--- a/apps/builder/app/builder/features/address-bar.tsx
+++ b/apps/builder/app/builder/features/address-bar.tsx
@@ -4,6 +4,7 @@ import { mergeRefs } from "@react-aria/utils";
 import {
   forwardRef,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ComponentProps,
@@ -273,7 +274,10 @@ const AddressBar = forwardRef<
 >(({ onSubmit }, ref) => {
   const publishedOrigin = useStore($publishedOrigin);
   const path = useStore($selectedPagePath);
-  const history = useStore($selectedPageHistory);
+  let history = useStore($selectedPageHistory);
+  history = useMemo(() => {
+    return history.filter((item) => matchPathnamePattern(path, item));
+  }, [history]);
   const [pathParams, setPathParams] = useState(
     () => $selectedPagePathParams.get() ?? {}
   );


### PR DESCRIPTION
We show all history at the moment even when path is changed. Here improved logic to exclude all paths from history not matching current page path pattern.

<img width="266" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5635476/ef4c5b39-fe61-44f8-8e10-580247b378b2">
