### PR TITLE
fix: try to avoid race conditions while loading resources

### DIFF
--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -151,6 +151,11 @@ const $unscopedVariableValues = computed(
   }
 );
 
+const $selectedPageSystemId = computed(
+  $selectedPage,
+  (page) => page?.systemDataSourceId
+);
+
 /**
  * similar to above but should not depend on resource values
  * because these values are used to load resources
@@ -161,10 +166,10 @@ const $loaderVariableValues = computed(
   [
     $dataSources,
     $dataSourceVariables,
-    $selectedPage,
+    $selectedPageSystemId,
     $selectedPageDefaultSystem,
   ],
-  (dataSources, dataSourceVariables, page, defaultSystem) => {
+  (dataSources, dataSourceVariables, systemId, defaultSystem) => {
     const values = new Map<string, unknown>();
     for (const [dataSourceId, dataSource] of dataSources) {
       if (dataSource.type === "variable") {
@@ -175,7 +180,7 @@ const $loaderVariableValues = computed(
       }
       if (dataSource.type === "parameter") {
         let value = dataSourceVariables.get(dataSourceId);
-        if (dataSource.id === page?.systemDataSourceId) {
+        if (dataSource.id === systemId) {
           value = mergeSystem(defaultSystem, value as undefined | System);
         }
         values.set(dataSourceId, value);
@@ -568,39 +573,47 @@ export const invalidateResource = (resourceId: Resource["id"]) => {
  * and store in cache
  */
 export const subscribeResources = () => {
+  let frameId: undefined | number;
   // subscribe changing resources or global invalidation
   return computed(
     [$computedResources, $invalidator],
     (computedResources, invalidator) =>
       [computedResources, invalidator] as const
-  ).subscribe(async ([computedResources]) => {
-    const matched = new Map<Resource["id"], ResourceRequest>();
-    const missing = new Map<Resource["id"], ResourceRequest>();
-    for (const request of computedResources) {
-      const cacheKey = JSON.stringify(request);
-      if (cacheByKeys.has(cacheKey)) {
-        matched.set(request.id, request);
-      } else {
-        missing.set(request.id, request);
+  ).subscribe(([computedResources]) => {
+    if (frameId) {
+      cancelAnimationFrame(frameId);
+    }
+    // batch updates into next frame
+    // to avoid issues with untransactioned updates in nanostores
+    frameId = requestAnimationFrame(async () => {
+      const matched = new Map<Resource["id"], ResourceRequest>();
+      const missing = new Map<Resource["id"], ResourceRequest>();
+      for (const request of computedResources) {
+        const cacheKey = JSON.stringify(request);
+        if (cacheByKeys.has(cacheKey)) {
+          matched.set(request.id, request);
+        } else {
+          missing.set(request.id, request);
+        }
       }
-    }
 
-    // preset undefined to prevent loading already requested data
-    for (const request of missing.values()) {
-      const cacheKey = JSON.stringify(request);
-      cacheByKeys.set(cacheKey, undefined);
-    }
+      // preset undefined to prevent loading already requested data
+      for (const request of missing.values()) {
+        const cacheKey = JSON.stringify(request);
+        cacheByKeys.set(cacheKey, undefined);
+      }
 
-    const result = await loadResources(Array.from(missing.values()));
-    const newResourceValues = new Map();
-    for (const request of computedResources) {
-      const cacheKey = JSON.stringify(request);
-      // read from cache or store in cache
-      const response = result.get(request.id) ?? cacheByKeys.get(cacheKey);
-      cacheByKeys.set(cacheKey, response);
-      newResourceValues.set(request.id, response);
-    }
-    // update resource values only when new resources are loaded
-    $resourceValues.set(newResourceValues);
+      const result = await loadResources(Array.from(missing.values()));
+      const newResourceValues = new Map();
+      for (const request of computedResources) {
+        const cacheKey = JSON.stringify(request);
+        // read from cache or store in cache
+        const response = result.get(request.id) ?? cacheByKeys.get(cacheKey);
+        cacheByKeys.set(cacheKey, response);
+        newResourceValues.set(request.id, response);
+      }
+      // update resource values only when new resources are loaded
+      $resourceValues.set(newResourceValues);
+    });
   });
 };


### PR DESCRIPTION
Our stores updates does not support transactions
which leads to a lot of updates with empty state.
Empty and valid states are both used to load resources and override each other. Here workarounded by scheduling loading to the next frame.