### PR TITLE
feat: improve CLI sync command

### DIFF
--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -98,5 +98,5 @@ You can find your config at ${GLOBAL_CONFIG_FILE}`);
     join(cwd(), LOCAL_CONFIG_FILE),
     JSON.stringify(localConfig, null, 2)
   );
-  log.success("The project is linked successfully.");
+  log.step("The project is linked successfully");
 };


### PR DESCRIPTION
@clack/prompts supports spinner out of the box
so we can replace ora with it too.

Here switched sync command to this spinner
and added handling server errors.


https://github.com/webstudio-is/webstudio/assets/5635476/f6984b7c-c782-4859-a58d-335a39340119

