### PR TITLE
fix: Fix focus bugs with text editing on canvas

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -43,6 +43,7 @@ import {
   $authTokenPermissions,
   $publisherHost,
   $imageLoader,
+  $textEditingInstanceSelector,
 } from "~/shared/nano-states";
 import { type Settings } from "./shared/client-settings";
 import { getBuildUrl } from "~/shared/router-utils";
@@ -58,6 +59,7 @@ import { $isCloneDialogOpen, $userPlanFeatures } from "./shared/nano-states";
 import { CloneProjectDialog } from "~/shared/clone-project";
 import type { TokenPermissions } from "@webstudio-is/authorization-token";
 import { useToastErrors } from "~/shared/error/toast-error";
+import { canvasApi } from "~/shared/canvas-api";
 
 registerContainers();
 
@@ -307,55 +309,91 @@ export const Builder = ({
     project,
   });
 
+  /**
+   * Prevents Lexical text editor from stealing focus during rendering.
+   * Sets the inert attribute on the canvas body element and disables the text editor.
+   *
+   * This must be done synchronously to avoid the following issue:
+   *
+   * 1. Text editor is in edit state.
+   * 2. User focuses on the builder (e.g., clicks any input).
+   * 3. The text editor blur event triggers, causing a rerender on data change (data saved in onBlur).
+   * 4. Text editor rerenders, stealing focus from the builder.
+   * 5. Inert attribute is set asynchronously, but focus is already lost.
+   *
+   * Synchronous focusing and setInert prevent the text editor from focusing on render.
+   * This cannot be handled inside the canvas because the text editor toolbar is in the builder and focus events in the canvas should be ignored.
+   */
+  const handleFocus = useCallback((event: React.FocusEvent) => {
+    // Ignore toolbar focus events. See the onFocus handler in text-toolbar.tsx
+    if (false === event.defaultPrevented) {
+      canvasApi.setInert();
+      $textEditingInstanceSelector.set(undefined);
+    }
+  }, []);
+
+  /**
+   * Prevent radix to steal focus during editing in the settings panel.
+   */
+  const handleInput = useCallback(() => {
+    canvasApi.setInert();
+  }, []);
+
   return (
     <TooltipProvider>
-      <ChromeWrapper isPreviewMode={isPreviewMode}>
-        <ProjectSettings />
-        <Topbar
-          gridArea="header"
-          project={project}
-          hasProPlan={userPlanFeatures.hasProPlan}
-        />
-        <Main>
-          <Workspace
-            onTransitionEnd={onTransitionEnd}
-            initialBreakpoints={build.breakpoints}
+      <div
+        style={{ display: "contents" }}
+        onFocus={handleFocus}
+        onInput={handleInput}
+      >
+        <ChromeWrapper isPreviewMode={isPreviewMode}>
+          <ProjectSettings />
+          <Topbar
+            gridArea="header"
+            project={project}
+            hasProPlan={userPlanFeatures.hasProPlan}
+          />
+          <Main>
+            <Workspace
+              onTransitionEnd={onTransitionEnd}
+              initialBreakpoints={build.breakpoints}
+            >
+              <CanvasIframe
+                ref={iframeRefCallback}
+                src={canvasUrl}
+                title={project.title}
+                css={{
+                  height: "100%",
+                  width: "100%",
+                  backgroundColor: "#fff",
+                }}
+              />
+            </Workspace>
+            <AiCommandBar isPreviewMode={isPreviewMode} />
+          </Main>
+          <NavigatorPanel
+            isPreviewMode={isPreviewMode}
+            navigatorLayout={navigatorLayout}
+          />
+          <SidePanel gridArea="sidebar">
+            <SidebarLeft publish={publish} />
+          </SidePanel>
+          <SidePanel
+            gridArea="inspector"
+            isPreviewMode={isPreviewMode}
+            css={{ overflow: "hidden" }}
           >
-            <CanvasIframe
-              ref={iframeRefCallback}
-              src={canvasUrl}
-              title={project.title}
-              css={{
-                height: "100%",
-                width: "100%",
-                backgroundColor: "#fff",
-              }}
-            />
-          </Workspace>
-          <AiCommandBar isPreviewMode={isPreviewMode} />
-        </Main>
-        <NavigatorPanel
-          isPreviewMode={isPreviewMode}
-          navigatorLayout={navigatorLayout}
-        />
-        <SidePanel gridArea="sidebar">
-          <SidebarLeft publish={publish} />
-        </SidePanel>
-        <SidePanel
-          gridArea="inspector"
-          isPreviewMode={isPreviewMode}
-          css={{ overflow: "hidden" }}
-        >
-          <Inspector navigatorLayout={navigatorLayout} />
-        </SidePanel>
-        {isPreviewMode === false && <Footer />}
-        <BlockingAlerts />
-        <CloneProjectDialog
-          isOpen={isCloneDialogOpen}
-          onOpenChange={$isCloneDialogOpen.set}
-          project={project}
-        />
-      </ChromeWrapper>
+            <Inspector navigatorLayout={navigatorLayout} />
+          </SidePanel>
+          {isPreviewMode === false && <Footer />}
+          <BlockingAlerts />
+          <CloneProjectDialog
+            isOpen={isCloneDialogOpen}
+            onOpenChange={$isCloneDialogOpen.set}
+            project={project}
+          />
+        </ChromeWrapper>
+      </div>
     </TooltipProvider>
   );
 };

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -323,17 +323,24 @@ export const Builder = ({
    *
    * Synchronous focusing and setInert prevent the text editor from focusing on render.
    * This cannot be handled inside the canvas because the text editor toolbar is in the builder and focus events in the canvas should be ignored.
+   *
+   * Use onPointerDown instead of onFocus because Radix focus lock triggers on text edit blur
+   * before the focusin event when editing text inside a Radix dialog.
    */
-  const handleFocus = useCallback((event: React.FocusEvent) => {
-    // Ignore toolbar focus events. See the onFocus handler in text-toolbar.tsx
-    if (false === event.defaultPrevented) {
-      canvasApi.setInert();
-      $textEditingInstanceSelector.set(undefined);
-    }
-  }, []);
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent | React.FocusEvent) => {
+      // Ignore toolbar focus events. See the onFocus handler in text-toolbar.tsx
+      if (false === event.defaultPrevented) {
+        canvasApi.setInert();
+        $textEditingInstanceSelector.set(undefined);
+      }
+    },
+    []
+  );
 
   /**
-   * Prevent radix to steal focus during editing in the settings panel.
+   * Prevent Radix from stealing focus during editing in the settings panel.
+   * For example, when the user modifies the text content of an H1 element inside a dialog.
    */
   const handleInput = useCallback(() => {
     canvasApi.setInert();
@@ -343,7 +350,7 @@ export const Builder = ({
     <TooltipProvider>
       <div
         style={{ display: "contents" }}
-        onFocus={handleFocus}
+        onPointerDown={handlePointerDown}
         onInput={handleInput}
       >
         <ChromeWrapper isPreviewMode={isPreviewMode}>

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -327,16 +327,13 @@ export const Builder = ({
    * Use onPointerDown instead of onFocus because Radix focus lock triggers on text edit blur
    * before the focusin event when editing text inside a Radix dialog.
    */
-  const handlePointerDown = useCallback(
-    (event: React.PointerEvent | React.FocusEvent) => {
-      // Ignore toolbar focus events. See the onFocus handler in text-toolbar.tsx
-      if (false === event.defaultPrevented) {
-        canvasApi.setInert();
-        $textEditingInstanceSelector.set(undefined);
-      }
-    },
-    []
-  );
+  const handlePointerDown = useCallback((event: React.PointerEvent) => {
+    // Ignore toolbar focus events. See the onFocus handler in text-toolbar.tsx
+    if (false === event.defaultPrevented) {
+      canvasApi.setInert();
+      $textEditingInstanceSelector.set(undefined);
+    }
+  }, []);
 
   /**
    * Prevent Radix from stealing focus during editing in the settings panel.

--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -24,7 +24,6 @@ import {
   $selectedInstance,
   $registeredComponentMetas,
   $dragAndDropState,
-  $inspectorLastInputTime,
   $selectedPage,
 } from "~/shared/nano-states";
 import { NavigatorTree } from "~/builder/shared/navigator-tree";
@@ -72,11 +71,6 @@ const contentStyle = {
 
 const $isDragging = computed([$dragAndDropState], (state) => state.isDragging);
 
-const handleInspectorInput = () => {
-  // Notify canvas of input changes, related to setInert on iframe
-  $inspectorLastInputTime.set(Date.now());
-};
-
 export const Inspector = ({ navigatorLayout }: InspectorProps) => {
   const selectedInstance = useStore($selectedInstance);
   const tabsRef = useRef<HTMLDivElement>(null);
@@ -120,63 +114,57 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
     >
       <FloatingPanelProvider container={tabsRef}>
         <BindingPopoverProvider value={{ containerRef: tabsRef }}>
-          <div style={{ display: "contents" }} onInput={handleInspectorInput}>
-            <PanelTabs
-              ref={tabsRef}
-              value={availableTabs.includes(tab) ? tab : availableTabs[0]}
-              onValueChange={setTab}
-              asChild
-            >
-              <Flex direction="column">
-                <PanelTabsList>
-                  {isStyleTabVisible && (
-                    <Tooltip
-                      variant="wrapped"
-                      content="The Style panel allows manipulation of CSS visually."
-                    >
-                      <div>
-                        <PanelTabsTrigger value="style">Style</PanelTabsTrigger>
-                      </div>
-                    </Tooltip>
-                  )}
+          <PanelTabs
+            ref={tabsRef}
+            value={availableTabs.includes(tab) ? tab : availableTabs[0]}
+            onValueChange={setTab}
+            asChild
+          >
+            <Flex direction="column">
+              <PanelTabsList>
+                {isStyleTabVisible && (
                   <Tooltip
                     variant="wrapped"
-                    content="The Settings panel allows for customizing component properties and HTML attributes."
+                    content="The Style panel allows manipulation of CSS visually."
                   >
                     <div>
-                      <PanelTabsTrigger value="settings">
-                        Settings
-                      </PanelTabsTrigger>
+                      <PanelTabsTrigger value="style">Style</PanelTabsTrigger>
                     </div>
                   </Tooltip>
-                </PanelTabsList>
-                <Separator />
-                <PanelTabsContent
-                  value="style"
-                  css={contentStyle}
-                  tabIndex={-1}
+                )}
+                <Tooltip
+                  variant="wrapped"
+                  content="The Settings panel allows for customizing component properties and HTML attributes."
                 >
+                  <div>
+                    <PanelTabsTrigger value="settings">
+                      Settings
+                    </PanelTabsTrigger>
+                  </div>
+                </Tooltip>
+              </PanelTabsList>
+              <Separator />
+              <PanelTabsContent value="style" css={contentStyle} tabIndex={-1}>
+                <InstanceInfo instance={selectedInstance} />
+                <StylePanel selectedInstance={selectedInstance} />
+              </PanelTabsContent>
+              <PanelTabsContent
+                value="settings"
+                css={contentStyle}
+                tabIndex={-1}
+              >
+                <ScrollArea>
                   <InstanceInfo instance={selectedInstance} />
-                  <StylePanel selectedInstance={selectedInstance} />
-                </PanelTabsContent>
-                <PanelTabsContent
-                  value="settings"
-                  css={contentStyle}
-                  tabIndex={-1}
-                >
-                  <ScrollArea>
-                    <InstanceInfo instance={selectedInstance} />
-                    <SettingsPanelContainer
-                      key={
-                        selectedInstance.id /* Re-render when instance changes */
-                      }
-                      selectedInstance={selectedInstance}
-                    />
-                  </ScrollArea>
-                </PanelTabsContent>
-              </Flex>
-            </PanelTabs>
-          </div>
+                  <SettingsPanelContainer
+                    key={
+                      selectedInstance.id /* Re-render when instance changes */
+                    }
+                    selectedInstance={selectedInstance}
+                  />
+                </ScrollArea>
+              </PanelTabsContent>
+            </Flex>
+          </PanelTabs>
         </BindingPopoverProvider>
       </FloatingPanelProvider>
     </EnhancedTooltipProvider>

--- a/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar.tsx
@@ -120,6 +120,10 @@ const Toolbar = ({ state, scale }: ToolbarProps) => {
       onClick={(event) => {
         event.stopPropagation();
       }}
+      onFocus={(event) => {
+        // We don't want the logic in the builder to make canvas inert to be triggered
+        event.preventDefault();
+      }}
     >
       <Tooltip content="Clear styles">
         <IconButton

--- a/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar.tsx
@@ -120,7 +120,8 @@ const Toolbar = ({ state, scale }: ToolbarProps) => {
       onClick={(event) => {
         event.stopPropagation();
       }}
-      onFocus={(event) => {
+      // We use onPointerDown here to prevent the canvas from being inert (see builder.tsx for more details)
+      onPointerDown={(event) => {
         // We don't want the logic in the builder to make canvas inert to be triggered
         event.preventDefault();
       }}

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -62,6 +62,7 @@ import { updateCollaborativeInstanceRect } from "./collaborative-instance";
 import { $params } from "./stores";
 import { useScrollNewInstanceIntoView } from "./shared/use-scroll-new-instance-into-view";
 import { subscribeInspectorEdits } from "./inspector-edits";
+import { initCanvasApi } from "~/shared/canvas-api";
 
 registerContainers();
 
@@ -176,6 +177,10 @@ export const Canvas = ({ params, imageLoader }: CanvasProps) => {
   useMount(() => {
     // required to compute asset and page props for rendering
     $params.set(params);
+  });
+
+  useMount(() => {
+    initCanvasApi();
   });
 
   useLayoutEffect(() => {

--- a/apps/builder/app/canvas/inspector-edits.ts
+++ b/apps/builder/app/canvas/inspector-edits.ts
@@ -1,12 +1,14 @@
-import { $inspectorLastInputTime, $props } from "~/shared/nano-states";
-import { setInert } from "./shared/inert";
+import { canvasApi } from "~/shared/canvas-api";
+import { $props } from "~/shared/nano-states";
 
 export const subscribeInspectorEdits = () => {
-  const unsubscribeInputTime = $inspectorLastInputTime.listen(setInert);
-  const unsubscribeProps = $props.listen(setInert);
+  /**
+   * Prevents Radix from stealing focus when the content inside a dialog changes.
+   * (Radix focus scope uses a MutationObserver)
+   */
+  const unsubscribeProps = $props.listen(canvasApi.setInert);
 
   return () => {
-    unsubscribeInputTime();
     unsubscribeProps();
   };
 };

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -36,7 +36,7 @@ import {
 } from "~/shared/nano-states";
 import { setDifference } from "~/shared/shim";
 import { $ephemeralStyles, $params } from "../stores";
-import { resetInert, setInert } from "./inert";
+import { canvasApi } from "~/shared/canvas-api";
 
 const userSheet = createRegularStyleSheet({ name: "user-styles" });
 const stateSheet = createRegularStyleSheet({ name: "state-styles" });
@@ -421,7 +421,7 @@ const subscribeEphemeralStyle = () => {
 
     // reset ephemeral styles
     if (ephemeralStyles.length === 0) {
-      resetInert();
+      canvasApi.resetInert();
       for (const styleDecl of appliedEphemeralDeclarations.values()) {
         // prematurely apply last known ephemeral update to user stylesheet
         // to avoid lag because of delay between deleting ephemeral style
@@ -442,7 +442,7 @@ const subscribeEphemeralStyle = () => {
 
     // add ephemeral styles
     if (ephemeralStyles.length > 0) {
-      setInert();
+      canvasApi.setInert();
       const selector = `[${idAttribute}="${instanceId}"]`;
       const rule = userSheet.addNestingRule(selector);
       let ephemetalSheetUpdated = false;

--- a/apps/builder/app/shared/canvas-api.ts
+++ b/apps/builder/app/shared/canvas-api.ts
@@ -1,5 +1,7 @@
 import { setInert, resetInert } from "../canvas/shared/inert";
 
+const apiWindowNamespace = "__webstudio__$__canvasApi";
+
 const _canvasApi = {
   setInert,
   resetInert,
@@ -7,7 +9,7 @@ const _canvasApi = {
 
 declare global {
   interface Window {
-    _canvasApi: typeof _canvasApi;
+    [apiWindowNamespace]: typeof _canvasApi;
   }
 }
 
@@ -27,8 +29,8 @@ const getIframeApi = () => {
     // Find first iframe with the API
     for (let i = 0; i < window.frames.length; ++i) {
       const frame = window.frames[i];
-      if (frame && frame._canvasApi) {
-        return frame._canvasApi;
+      if (frame && frame[apiWindowNamespace]) {
+        return frame[apiWindowNamespace];
       }
     }
 
@@ -66,6 +68,6 @@ export const canvasApi = new Proxy(_canvasApi, {
  */
 export const initCanvasApi = () => {
   if (isInIframe()) {
-    window._canvasApi = _canvasApi;
+    window[apiWindowNamespace] = _canvasApi;
   }
 };

--- a/apps/builder/app/shared/canvas-api.ts
+++ b/apps/builder/app/shared/canvas-api.ts
@@ -1,0 +1,71 @@
+import { setInert, resetInert } from "../canvas/shared/inert";
+
+const _canvasApi = {
+  setInert,
+  resetInert,
+};
+
+declare global {
+  interface Window {
+    _canvasApi: typeof _canvasApi;
+  }
+}
+
+const isInIframe = () => {
+  try {
+    return window.self !== window.top;
+  } catch (e) {
+    return true;
+  }
+};
+
+const getIframeApi = () => {
+  if (isInIframe()) {
+    // Inside the iframe, use the local window.api
+    return _canvasApi;
+  } else {
+    // Find first iframe with the API
+    for (let i = 0; i < window.frames.length; ++i) {
+      const frame = window.frames[i];
+      if (frame && frame._canvasApi) {
+        return frame._canvasApi;
+      }
+    }
+
+    throw new Error("Iframe or API not found");
+  }
+};
+
+const isKeyOf = <T>(key: unknown, obj: T): key is keyof T => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return key in obj;
+};
+
+/**
+ * Forwards the call from the builder to the iframe, invoking the original API in the iframe.
+ */
+export const canvasApi = new Proxy(_canvasApi, {
+  get(_target, prop) {
+    if (typeof prop === "symbol") {
+      throw new Error("Symbol properties are not supported");
+    }
+
+    const api = getIframeApi();
+
+    if (api && isKeyOf(prop, api)) {
+      return api[prop].bind(api);
+    } else {
+      throw new Error(`API method ${prop} not found`);
+    }
+  },
+});
+
+/**
+ * Initializes the canvas API in the iframe. Must be called in the iframe context.
+ */
+export const initCanvasApi = () => {
+  if (isInIframe()) {
+    window._canvasApi = _canvasApi;
+  }
+};

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -331,5 +331,3 @@ export const $dragAndDropState = atom<DragAndDropState>({
 });
 
 export const $marketplaceProduct = atom<undefined | MarketplaceProduct>();
-
-export const $inspectorLastInputTime = atom<number>(0);

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -38,7 +38,6 @@ import {
   $resources,
   $resourceValues,
   $marketplaceProduct,
-  $inspectorLastInputTime,
 } from "~/shared/nano-states";
 import { $ephemeralStyles } from "~/canvas/stores";
 
@@ -119,7 +118,6 @@ export const registerContainers = () => {
   clientStores.set("dragAndDropState", $dragAndDropState);
   clientStores.set("ephemeralStyles", $ephemeralStyles);
   clientStores.set("selectedInstanceStates", $selectedInstanceStates);
-  clientStores.set("inspectorLastInputTime", $inspectorLastInputTime);
 
   for (const [name, store] of $synchronizedBreakpoints) {
     clientStores.set(name, store);


### PR DESCRIPTION
## Description

closes #3021

Currently if we are in a text edit mode we sometimes can't focus on any input inside builder.
This fixes this.


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
