### PR TITLE
fix: use darker comment color

### DIFF
--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -108,9 +108,10 @@ const editorContentStyle = css({
 
 // https://thememirror.net/clouds
 const highlightStyle = HighlightStyle.define([
+  // darker comment variant from https://github.com/vadimdemedes/thememirror/blob/main/source/themes/ayu-light.ts#L17-L20
   {
     tag: tags.comment,
-    color: "#BCC8BA",
+    color: "#787b8099",
   },
   {
     tag: [tags.string, tags.special(tags.brace), tags.regexp],


### PR DESCRIPTION
Current codemirror theme has very light comment which is hard to read. Here switched to comment color from another theme.

<img width="386" alt="Screenshot 2024-05-31 at 11 48 44" src="https://github.com/webstudio-is/webstudio/assets/5635476/1bd47c24-8481-4c39-aace-696f90aa3901">
