### PR TITLE
build: Add host for vite config

### DIFF
--- a/apps/builder/vite.config.ts
+++ b/apps/builder/vite.config.ts
@@ -24,5 +24,8 @@ export default defineConfig(({ mode }) => ({
   ssr: {
     external: ["@webstudio-is/prisma-client"],
   },
+  server: {
+    host: "0.0.0.0",
+  },
   envPrefix: "GITHUB_",
 }));


### PR DESCRIPTION
## Description

For unknown reason port forwarding on Oleg's dev machine works only if `host: "0.0.0.0",`

Works on localhost on mine


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
