### PR TITLE
fix: Permission error when opening marketplace projects (marketplace projects need to add any view permission link)

### DIFF
--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -6,6 +6,7 @@ on:
       - "migrate"
       - "main"
       - "*.staging"
+      - "*.migrate"
 
 # Pending if other migration from the same branch is running
 concurrency: migrate-${{ github.ref_name }}
@@ -25,7 +26,7 @@ jobs:
     #   git commit --allow-empty -m "::migrate::test description"
     # Note:
     #   This setup is a temporary measure. The intention is to transition to a fully automated publish and release process via GitHub Actions in the future.
-    if: (github.ref_name == 'main') || ((github.ref_name == 'migrate' || endsWith(github.ref_name, '.staging')) && startsWith(github.event.head_commit.message, '::migrate::'))
+    if: (github.ref_name == 'main') || ((github.ref_name == 'migrate' || endsWith(github.ref_name, '.migrate') || endsWith(github.ref_name, '.staging')) && startsWith(github.event.head_commit.message, '::migrate::'))
 
     runs-on: ubuntu-latest
 

--- a/apps/builder/app/builder/features/sidebar-left/panels/marketplace/about.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/marketplace/about.tsx
@@ -24,6 +24,9 @@ export const About = ({
   if (item === undefined) {
     return;
   }
+
+  const hasAuthToken = item.authorizationToken != null;
+
   return (
     <>
       <Header
@@ -75,21 +78,38 @@ export const About = ({
         </Flex>
       </Flex>
       <Separator />
+
       <Flex gap="1" css={{ my: theme.spacing[5], mx: theme.spacing[8] }}>
-        <Link
-          className={buttonStyle({
-            color: "neutral",
-            css: { gap: theme.spacing[3] },
-          })}
-          underline="none"
-          href={builderUrl({
-            projectId: item.projectId,
-            origin: location.origin,
-          })}
-          target="_blank"
+        <Tooltip
+          content={
+            hasAuthToken
+              ? undefined
+              : 'The project does not have a shared link with "View" permission.'
+          }
         >
-          <ExternalLinkIcon aria-hidden /> Open project
-        </Link>
+          <Link
+            className={buttonStyle({
+              color: "neutral",
+              css: {
+                gap: theme.spacing[3],
+              },
+            })}
+            underline="none"
+            href={
+              hasAuthToken
+                ? builderUrl({
+                    projectId: item.projectId,
+                    origin: location.origin,
+                    authToken: item.authorizationToken,
+                  })
+                : undefined
+            }
+            target="_blank"
+            aria-disabled={hasAuthToken ? undefined : "true"}
+          >
+            <ExternalLinkIcon aria-hidden /> Open project
+          </Link>
+        </Tooltip>
       </Flex>
     </>
   );

--- a/apps/builder/app/builder/features/sidebar-left/panels/marketplace/marketplace.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/marketplace/marketplace.tsx
@@ -58,6 +58,7 @@ export const TabContent = ({ onSetActiveTab }: TabContentProps) => {
           <Templates
             projectId={activeOverviewItem.projectId}
             name={activeOverviewItem.name}
+            authorizationToken={activeOverviewItem.authorizationToken}
             productCategory={activeOverviewItem.category}
             data={toWebstudioData(buildData)}
             onOpenChange={(isOpen: boolean) => {

--- a/apps/builder/app/builder/features/sidebar-left/panels/marketplace/templates.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/marketplace/templates.tsx
@@ -8,6 +8,7 @@ import {
   Separator,
   theme,
   Link,
+  Tooltip,
 } from "@webstudio-is/design-system";
 import { ChevronLeftIcon, ExternalLinkIcon } from "@webstudio-is/icons";
 import {
@@ -28,6 +29,7 @@ import {
 import { insertPageCopyMutable } from "~/shared/page-utils";
 import { switchPage } from "~/shared/pages";
 import { Card } from "./card";
+import type { MarketplaceOverviewItem } from "~/shared/marketplace/types";
 
 /**
  * Insert page as a template.
@@ -133,12 +135,14 @@ export const Templates = ({
   name,
   projectId,
   productCategory,
+  authorizationToken,
   data,
   onOpenChange,
 }: {
   name: string;
   projectId: string;
   productCategory: MarketplaceProduct["category"];
+  authorizationToken: MarketplaceOverviewItem["authorizationToken"];
   data: WebstudioData;
   onOpenChange: (isOpen: boolean) => void;
 }) => {
@@ -150,6 +154,8 @@ export const Templates = ({
   if (templatesDataByCategory === undefined || data === undefined) {
     return;
   }
+
+  const hasAuthToken = authorizationToken != null;
 
   return (
     <Flex direction="column" css={{ height: "100%" }}>
@@ -169,17 +175,31 @@ export const Templates = ({
         >
           {name}
         </Button>
-        <Link
-          underline="none"
-          href={builderUrl({
-            projectId: projectId,
-            origin: location.origin,
-          })}
-          target="_blank"
-          aria-label="Open project in new tab"
+        <Tooltip
+          content={
+            hasAuthToken
+              ? undefined
+              : 'The project does not have a shared link with "View" permission.'
+          }
         >
-          <ExternalLinkIcon />
-        </Link>
+          <Link
+            underline="none"
+            href={
+              hasAuthToken
+                ? builderUrl({
+                    projectId: projectId,
+                    origin: location.origin,
+                    authToken: authorizationToken,
+                  })
+                : undefined
+            }
+            target="_blank"
+            aria-label="Open project in new tab"
+            aria-disabled={hasAuthToken ? undefined : "true"}
+          >
+            <ExternalLinkIcon />
+          </Link>
+        </Tooltip>
       </Flex>
       <Separator />
       <ScrollArea>

--- a/apps/builder/app/shared/context.server.ts
+++ b/apps/builder/app/shared/context.server.ts
@@ -7,7 +7,7 @@ import {
   getTokenPlanFeatures,
   getUserPlanFeatures,
 } from "./db/user-plan-features.server";
-import { getAllApprovedProjectIds } from "./marketplace/db.server";
+// import { getAllApprovedProjectIds } from "./marketplace/db.server";
 import { staticEnv } from "~/env/env.static.server";
 
 const createAuthorizationContext = async (
@@ -21,7 +21,6 @@ const createAuthorizationContext = async (
     url.hostname;
 
   const user = await authenticator.isAuthenticated(request);
-  const marketplaceProjectIds = await getAllApprovedProjectIds();
 
   const isServiceCall =
     request.headers.has("Authorization") &&
@@ -31,7 +30,6 @@ const createAuthorizationContext = async (
     userId: user?.id,
     authToken,
     isServiceCall,
-    marketplaceProjectIds,
     authorizeTrpc: trpcSharedClient.authorize,
   };
 

--- a/apps/builder/app/shared/context.server.ts
+++ b/apps/builder/app/shared/context.server.ts
@@ -7,7 +7,6 @@ import {
   getTokenPlanFeatures,
   getUserPlanFeatures,
 } from "./db/user-plan-features.server";
-// import { getAllApprovedProjectIds } from "./marketplace/db.server";
 import { staticEnv } from "~/env/env.static.server";
 
 const createAuthorizationContext = async (

--- a/apps/builder/app/shared/marketplace/db.server.ts
+++ b/apps/builder/app/shared/marketplace/db.server.ts
@@ -27,21 +27,11 @@ export const getBuildProdData = async (
   };
 };
 
-export const getAllApprovedProjectIds = async (): Promise<
-  Array<Project["id"]>
-> => {
-  const approvedMarketplaceProducts =
-    await prisma.approvedMarketplaceProduct.findMany();
-
-  return approvedMarketplaceProducts.map(
-    (approvedMarketplaceProduct) => approvedMarketplaceProduct.projectId
-  );
-};
-
 export const getItems = async (): Promise<Array<MarketplaceOverviewItem>> => {
   const approvedMarketplaceProducts =
     await prisma.approvedMarketplaceProduct.findMany();
-  const items = [];
+
+  const items: MarketplaceOverviewItem[] = [];
 
   for (const approvedMarketplaceProduct of approvedMarketplaceProducts) {
     const parsedProduct = MarketplaceProduct.safeParse(
@@ -55,6 +45,8 @@ export const getItems = async (): Promise<Array<MarketplaceOverviewItem>> => {
 
     items.push({
       projectId: approvedMarketplaceProduct.projectId,
+      authorizationToken:
+        approvedMarketplaceProduct.authorizationToken ?? undefined,
       ...parsedProduct.data,
     });
   }

--- a/apps/builder/app/shared/marketplace/types.ts
+++ b/apps/builder/app/shared/marketplace/types.ts
@@ -4,6 +4,7 @@ import type { Asset } from "@webstudio-is/sdk";
 
 export type MarketplaceOverviewItem = MarketplaceProduct & {
   projectId: Project["id"];
+  authorizationToken?: string | undefined;
   thumbnailAssetName?: Asset["name"];
 };
 

--- a/packages/design-system/src/components/button.tsx
+++ b/packages/design-system/src/components/button.tsx
@@ -96,10 +96,11 @@ const perColorStyle = (variant: ButtonColor) => ({
           ),
   },
 
-  "&:disabled:not([data-state=pending]), &[data-state=disabled]": {
-    background: theme.colors.backgroundButtonDisabled,
-    color: theme.colors.foregroundDisabled,
-  },
+  "&:disabled:not([data-state=pending]), &[data-state=disabled], &[aria-disabled=true], &[aria-disabled=true]:hover, &[aria-disabled=true]:visited":
+    {
+      background: theme.colors.backgroundButtonDisabled,
+      color: theme.colors.foregroundDisabled,
+    },
 
   "&[data-state=pending]": {
     cursor: "wait",

--- a/packages/design-system/src/components/link.tsx
+++ b/packages/design-system/src/components/link.tsx
@@ -3,6 +3,13 @@ import { textVariants } from "./text";
 
 export const Link = styled("a", {
   cursor: "pointer",
+  "&[aria-disabled=true]": {
+    cursor: "default",
+    color: theme.colors.foregroundDisabled,
+    "&:hover, &:visited": {
+      color: theme.colors.foregroundDisabled,
+    },
+  },
   variants: {
     variant: {
       inherit: {

--- a/packages/prisma-client/prisma/migrations/20240530162819_marketplace-token/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20240530162819_marketplace-token/migration.sql
@@ -1,0 +1,34 @@
+-- This is an empty migration.
+DROP VIEW "ApprovedMarketplaceProduct";
+
+CREATE VIEW "ApprovedMarketplaceProduct" AS
+SELECT DISTINCT ON (build."projectId")
+  build."projectId",
+  build."marketplaceProduct",
+  (
+    SELECT
+      token
+    FROM
+      "AuthorizationToken" auth
+    WHERE
+      auth."projectId" = build."projectId" AND
+      auth.relation = 'viewers'
+    ORDER BY
+      auth."token"
+    LIMIT 1
+  ) AS "authorizationToken"
+FROM
+  "Build" build
+WHERE
+  build.deployment IS NOT NULL -- published
+  AND build."projectId" IN (
+    SELECT
+      "id"
+    FROM
+      "Project"
+    WHERE ("isDeleted" = FALSE
+      AND "marketplaceApprovalStatus" = CAST('APPROVED'::text AS "MarketplaceApprovalStatus")))
+ORDER BY
+  build."projectId",
+  build."createdAt" DESC,
+  build.id;

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -337,6 +337,7 @@ view DashboardProject {
 }
 
 view ApprovedMarketplaceProduct {
-  projectId          String @id
+  projectId          String  @id
   marketplaceProduct String
+  authorizationToken String?
 }

--- a/packages/trpc-interface/src/authorize/project.server.ts
+++ b/packages/trpc-interface/src/authorize/project.server.ts
@@ -51,13 +51,6 @@ export const hasProjectPermit = async (
       return true;
     }
 
-    const isInMarketplace =
-      context.authorization.marketplaceProjectIds.includes(props.projectId);
-
-    if (props.permit === "view" && isInMarketplace) {
-      return true;
-    }
-
     // Check if the user is allowed to access the project
     if (authorization.userId !== undefined) {
       checks.push(

--- a/packages/trpc-interface/src/context/context.server.ts
+++ b/packages/trpc-interface/src/context/context.server.ts
@@ -15,11 +15,6 @@ type AuthorizationContext = {
   authToken: string | undefined;
 
   /**
-   * Projects approved for the marketplace are available to everyone.
-   */
-  marketplaceProjectIds: Array<string>;
-
-  /**
    * Allow service 2 service communications to skip authorization for view calls
    */
   isServiceCall: boolean;


### PR DESCRIPTION
## Description

- [x] - Todo cursor and other styles issues

ref #3446

We now display the marketplace project link only if it has a shared link with view permission. If there is no shared link, we show disabled buttons with a tooltip.

<img width="564" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/f1d98c9b-22a5-4706-b9f5-e2749c07f6e7">

<img width="732" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/02848dc7-ef99-4a4a-91a6-9e6d2d41ed7f">


## Steps for reproduction

Open marketplace, see one has link the other is not

<img width="300" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/90b2f352-305b-415a-86c5-056280e17000">

Check that link is working in incognito


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
