### PR TITLE
fix: Fix open state indication of the tabs in the left side bar

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Box, Tooltip, rawTheme } from "@webstudio-is/design-system";
+import { Box, rawTheme } from "@webstudio-is/design-system";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
 import { $dragAndDropState, $isPreviewMode } from "~/shared/nano-states";
 import { panels } from "./panels";
@@ -11,6 +11,7 @@ import { HelpPopover } from "./help-popover";
 import { useStore } from "@nanostores/react";
 import { $activeSidebarPanel } from "~/builder/shared/nano-states";
 import {
+  SidebarButton,
   SidebarTabs,
   SidebarTabsContent,
   SidebarTabsList,
@@ -46,22 +47,18 @@ const useHideActiveTabOnPreview = () => {
 const AiTabTrigger = () => {
   const [clientSettings, setClientSetting] = useClientSettings();
   return (
-    <Tooltip side="right" content="AI">
-      <SidebarTabsTrigger
-        aria-label="AI"
-        value={
-          "anyValueNotInTabName" /* !!! This button does not have active state, use impossible tab value  !!! */
-        }
-        onClick={() => {
-          setClientSetting(
-            "isAiCommandBarVisible",
-            clientSettings.isAiCommandBarVisible === true ? false : true
-          );
-        }}
-      >
-        <AiIcon size={rawTheme.spacing[10]} />
-      </SidebarTabsTrigger>
-    </Tooltip>
+    <SidebarButton
+      label="AI"
+      data-state={clientSettings.isAiCommandBarVisible ? "active" : undefined}
+      onClick={() => {
+        setClientSetting(
+          "isAiCommandBarVisible",
+          clientSettings.isAiCommandBarVisible === true ? false : true
+        );
+      }}
+    >
+      <AiIcon size={rawTheme.spacing[10]} />
+    </SidebarButton>
   );
 };
 
@@ -69,36 +66,30 @@ const HelpTabTrigger = () => {
   const [helpIsOpen, setHelpIsOpen] = useState(false);
   return (
     <HelpPopover onOpenChange={setHelpIsOpen}>
-      <Tooltip side="right" content="Learn Webstudio or ask for help">
-        <HelpPopover.Trigger asChild>
-          <SidebarTabsTrigger
-            as="button"
-            aria-label="Learn Webstudio or ask for help"
-            data-state={helpIsOpen ? "active" : undefined}
-          >
-            <HelpIcon size={rawTheme.spacing[10]} />
-          </SidebarTabsTrigger>
-        </HelpPopover.Trigger>
-      </Tooltip>
+      <HelpPopover.Trigger asChild>
+        <SidebarButton
+          label="Learn Webstudio or ask for help"
+          data-state={helpIsOpen ? "active" : undefined}
+        >
+          <HelpIcon size={rawTheme.spacing[10]} />
+        </SidebarButton>
+      </HelpPopover.Trigger>
     </HelpPopover>
   );
 };
 
 const GithubTabTrigger = () => {
   return (
-    <Tooltip side="right" content="Report a bug on Github">
-      <SidebarTabsTrigger
-        as="button"
-        aria-label="Report a bug on Github"
-        onClick={() => {
-          window.open(
-            "https://github.com/webstudio-is/webstudio-community/discussions/new?category=q-a&labels=bug&title=[Bug]"
-          );
-        }}
-      >
-        <BugIcon size={rawTheme.spacing[10]} />
-      </SidebarTabsTrigger>
-    </Tooltip>
+    <SidebarButton
+      label="Report a bug on Github"
+      onClick={() => {
+        window.open(
+          "https://github.com/webstudio-is/webstudio-community/discussions/new?category=q-a&labels=bug&title=[Bug]"
+        );
+      }}
+    >
+      <BugIcon size={rawTheme.spacing[10]} />
+    </SidebarButton>
   );
 };
 
@@ -134,25 +125,22 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
               {Array.from(panels.entries()).map(
                 ([tabName, { Icon, label }]) => {
                   return (
-                    <Tooltip side="right" content={label} key={tabName}>
-                      <SidebarTabsTrigger
-                        aria-label={label}
-                        value={tabName}
-                        onClick={() => {
-                          setActiveTab(
-                            activeTab === tabName ? "none" : tabName
-                          );
-                        }}
-                      >
-                        <Icon size={rawTheme.spacing[10]} />
-                      </SidebarTabsTrigger>
-                    </Tooltip>
+                    <SidebarTabsTrigger
+                      key={label}
+                      label={label}
+                      value={tabName}
+                      onClick={() => {
+                        setActiveTab(activeTab === tabName ? "none" : tabName);
+                      }}
+                    >
+                      <Icon size={rawTheme.spacing[10]} />
+                    </SidebarTabsTrigger>
                   );
                 }
               )}
-              <AiTabTrigger />
             </SidebarTabsList>
             <Box css={{ borderRight: `1px solid ${theme.colors.borderMain}` }}>
+              <AiTabTrigger />
               <HelpTabTrigger />
               <GithubTabTrigger />
             </Box>

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -53,7 +53,7 @@ const AiTabTrigger = () => {
       onClick={() => {
         setClientSetting(
           "isAiCommandBarVisible",
-          clientSettings.isAiCommandBarVisible === true ? false : true
+          clientSettings.isAiCommandBarVisible ? false : true
         );
       }}
     >

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-tabs.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-tabs.tsx
@@ -1,11 +1,15 @@
 import {
+  Box,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
+  Tooltip,
+  css,
   styled,
   theme,
 } from "@webstudio-is/design-system";
+import { forwardRef, type ComponentProps } from "react";
 
 export const SidebarTabs = styled(Tabs, {
   display: "flex",
@@ -27,7 +31,7 @@ const triggerFocusRing = {
   },
 };
 
-export const SidebarTabsTrigger = styled(TabsTrigger, {
+const buttonStyle = css({
   position: "relative",
   boxSizing: "border-box",
   flexShrink: 0,
@@ -53,6 +57,42 @@ export const SidebarTabsTrigger = styled(TabsTrigger, {
     color: theme.colors.foregroundMain,
     backgroundColor: theme.colors.backgroundHover,
   },
+});
+
+export const SidebarButton = forwardRef<
+  HTMLButtonElement,
+  ComponentProps<"button"> & { label: string }
+>(({ label, ...props }, ref) => {
+  return (
+    <Tooltip side="right" content={label}>
+      <button
+        {...props}
+        ref={ref}
+        aria-label={label}
+        className={buttonStyle()}
+      ></button>
+    </Tooltip>
+  );
+});
+
+export const SidebarTabsTrigger = forwardRef<
+  HTMLButtonElement,
+  ComponentProps<typeof TabsTrigger> & { label: string }
+>(({ label, children, ...props }, ref) => {
+  return (
+    <Tooltip side="right" content={label}>
+      <Box>
+        <TabsTrigger
+          {...props}
+          ref={ref}
+          aria-label={label}
+          className={buttonStyle()}
+        >
+          {children}
+        </TabsTrigger>
+      </Box>
+    </Tooltip>
+  );
 });
 
 export const SidebarTabsList = styled(TabsList, {


### PR DESCRIPTION
## Description

Additionally refactored the logic a bit and moved AI to the bottom. This way its more consistent with upper part all handling sidebar panels, being tabs

## Steps for reproduction

1. focus and hover should show a tooltip
2. open tab should have open state


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
