### PR TITLE
chore: Fix react key spread warning

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -522,11 +522,13 @@ export const StyleSourceInput = (
 
                   if (item.id === newItemId) {
                     hasNewTokenItem = true;
+                    const { key, ...itemProps } = getItemProps({ item, index });
                     return (
                       <Fragment key={index}>
                         <ComboboxLabel>New Token</ComboboxLabel>
                         <ComboboxListboxItem
-                          {...getItemProps({ item, index })}
+                          {...itemProps}
+                          key={key}
                           selectable={false}
                         >
                           <div>
@@ -565,11 +567,13 @@ export const StyleSourceInput = (
                       </>
                     );
                   }
+                  const { key, ...itemProps } = getItemProps({ item, index });
                   return (
                     <Fragment key={index}>
                       {label}
                       <ComboboxListboxItem
-                        {...getItemProps({ item, index })}
+                        {...itemProps}
+                        key={key}
                         selectable={false}
                       >
                         <StyleSourceBadge source={item.source}>

--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -103,12 +103,12 @@ const ListboxItemBase: ForwardRefRenderFunction<
 
   return (
     <ListboxItem
-      ref={ref}
       {...(disabled ? { "aria-disabled": true, disabled: true } : {})}
       {...(selected ? { "aria-current": true } : {})}
       {...(disabled ? {} : rest)}
       withIndicator={selectable}
       text={rest.text ?? "sentence"}
+      ref={ref}
     >
       {selectable && selected && <Indicator>{icon}</Indicator>}
       {children}


### PR DESCRIPTION
## Description

Key prop can't be spread

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
