### PR TITLE
refactor: move builder data loading to client side

### DIFF
--- a/apps/builder/app/builder/shared/sync/sync-server.ts
+++ b/apps/builder/app/builder/shared/sync/sync-server.ts
@@ -241,7 +241,7 @@ const syncServer = async function () {
   }
 };
 
-const useSyncProject = async ({
+export const startProjectSync = ({
   projectId,
   buildId,
   version,
@@ -254,19 +254,30 @@ const useSyncProject = async ({
   version: number;
   authPermit: AuthPermit;
 }) => {
+  if (authPermit === "view") {
+    return;
+  }
+  commandQueue.enqueue({
+    type: "setDetails",
+    projectId,
+    buildId,
+    version,
+    authToken,
+  });
+};
+
+const useSyncProject = async ({
+  projectId,
+  authPermit,
+}: {
+  projectId: Project["id"];
+  authPermit: AuthPermit;
+}) => {
   useEffect(() => {
     if (authPermit === "view") {
       return;
     }
     syncServer();
-
-    commandQueue.enqueue({
-      type: "setDetails",
-      projectId,
-      buildId,
-      version,
-      authToken,
-    });
 
     const updateProjectTransactions = () => {
       const transactions = serverSyncStore.popAll();
@@ -285,29 +296,17 @@ const useSyncProject = async ({
       updateProjectTransactions();
       clearInterval(intervalHandle);
     };
-  }, [authPermit, authToken, buildId, projectId, version]);
+  }, [authPermit]);
 };
 
 type SyncServerProps = {
-  buildId: Build["id"];
   projectId: Project["id"];
-  authToken: string | undefined;
   authPermit: AuthPermit;
-  version: number;
 };
 
-export const useSyncServer = ({
-  buildId,
-  projectId,
-  authToken,
-  authPermit,
-  version,
-}: SyncServerProps) => {
+export const useSyncServer = ({ projectId, authPermit }: SyncServerProps) => {
   useSyncProject({
-    buildId,
     projectId,
-    authToken,
-    version,
     authPermit,
   });
 

--- a/apps/builder/app/builder/shared/sync/sync-server.ts
+++ b/apps/builder/app/builder/shared/sync/sync-server.ts
@@ -296,7 +296,7 @@ const useSyncProject = async ({
       updateProjectTransactions();
       clearInterval(intervalHandle);
     };
-  }, [authPermit]);
+  }, [projectId, authPermit]);
 };
 
 type SyncServerProps = {

--- a/apps/builder/app/routes/builder.$projectId.tsx
+++ b/apps/builder/app/routes/builder.$projectId.tsx
@@ -19,13 +19,11 @@ import {
   AuthorizationError,
   authorizeProject,
 } from "@webstudio-is/trpc-interface/index.server";
-import { loadAssetsByProject } from "@webstudio-is/asset-uploader/index.server";
 import { createContext } from "~/shared/context.server";
 import { ErrorMessage } from "~/shared/error";
 import { loginPath } from "~/shared/router-utils";
 import type { BuilderProps } from "~/builder/index.client";
 import env from "~/env/env.server";
-import { staticEnv } from "~/env/env.static.server";
 
 import builderStyles from "~/builder/builder.css?url";
 import prismStyles from "prismjs/themes/prism-solarizedlight.min.css?url";
@@ -43,9 +41,6 @@ export const loader = async ({
   params,
   request,
 }: LoaderFunctionArgs): Promise<BuilderProps> => {
-  // TODO: remove after release 17 apr 2024
-  console.info({ staticEnv });
-
   const context = await createContext(request);
 
   try {
@@ -74,8 +69,6 @@ export const loader = async ({
     }
 
     const devBuild = await loadBuildByProjectId(project.id);
-
-    const assets = await loadAssetsByProject(project.id, context);
 
     const end = Date.now();
 
@@ -112,8 +105,10 @@ export const loader = async ({
       project,
       publisherHost,
       imageBaseUrl: env.IMAGE_BASE_URL,
-      build: devBuild,
-      assets: assets.map((asset) => [asset.id, asset]),
+      build: {
+        id: devBuild.id,
+        version: devBuild.version,
+      },
       authToken,
       authTokenPermissions,
       authPermit,

--- a/apps/builder/app/routes/rest.data.$projectId.ts
+++ b/apps/builder/app/routes/rest.data.$projectId.ts
@@ -1,0 +1,25 @@
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
+import { db } from "@webstudio-is/project/index.server";
+import { loadBuildByProjectId } from "@webstudio-is/project-build/index.server";
+import { loadAssetsByProject } from "@webstudio-is/asset-uploader/index.server";
+import { createContext } from "~/shared/context.server";
+
+export const loader = async ({ params, request }: LoaderFunctionArgs) => {
+  if (params.projectId === undefined) {
+    throw new Error("Project id undefined");
+  }
+  const context = await createContext(request);
+  const project = await db.project.loadById(params.projectId, context);
+  if (project === null) {
+    throw new Error(`Project "${params.projectId}" not found`);
+  }
+  if (project.userId === null) {
+    throw new Error("Project must have project userId defined");
+  }
+  const devBuild = await loadBuildByProjectId(project.id);
+  const assets = await loadAssetsByProject(project.id, context);
+  return {
+    build: devBuild,
+    assets,
+  };
+};

--- a/apps/builder/app/shared/builder-data.ts
+++ b/apps/builder/app/shared/builder-data.ts
@@ -1,0 +1,87 @@
+import type { Asset, WebstudioData } from "@webstudio-is/sdk";
+import type { Build, MarketplaceProduct } from "@webstudio-is/project-build";
+import {
+  $assets,
+  $breakpoints,
+  $dataSources,
+  $instances,
+  $marketplaceProduct,
+  $pages,
+  $props,
+  $resources,
+  $styleSourceSelections,
+  $styleSources,
+  $styles,
+} from "./nano-states";
+
+type BuilderData = WebstudioData & {
+  marketplaceProduct: undefined | MarketplaceProduct;
+};
+
+export const getBuilderData = (): BuilderData => {
+  const pages = $pages.get();
+  if (pages === undefined) {
+    throw Error(`Cannot get webstudio data with empty pages`);
+  }
+  return {
+    pages,
+    instances: $instances.get(),
+    props: $props.get(),
+    dataSources: $dataSources.get(),
+    resources: $resources.get(),
+    breakpoints: $breakpoints.get(),
+    styleSourceSelections: $styleSourceSelections.get(),
+    styleSources: $styleSources.get(),
+    styles: $styles.get(),
+    assets: $assets.get(),
+    marketplaceProduct: $marketplaceProduct.get(),
+  };
+};
+
+export const setBuilderData = (data: BuilderData) => {
+  $assets.set(data.assets);
+  $instances.set(data.instances);
+  $dataSources.set(data.dataSources);
+  $resources.set(data.resources);
+  // props should be after data sources to compute logic
+  $props.set(data.props);
+  $pages.set(data.pages);
+  $styleSources.set(data.styleSources);
+  $styleSourceSelections.set(data.styleSourceSelections);
+  $breakpoints.set(data.breakpoints);
+  $styles.set(data.styles);
+  $marketplaceProduct.set(data.marketplaceProduct);
+};
+
+export const loadBuilderData = async ({
+  projectId,
+  signal,
+}: {
+  projectId: string;
+  signal: AbortSignal;
+}) => {
+  const response = await fetch(`/rest/data/${projectId}`, { signal });
+  if (response.ok) {
+    const data = (await response.json()) as {
+      assets: Asset[];
+      build: Build;
+      marketplaceProduct: undefined | MarketplaceProduct;
+    };
+    const { assets, build } = data;
+    return {
+      version: build.version,
+      assets: new Map(assets.map((asset) => [asset.id, asset])),
+      instances: new Map(build.instances),
+      dataSources: new Map(build.dataSources),
+      resources: new Map(build.resources),
+      props: new Map(build.props),
+      pages: build.pages,
+      styleSources: new Map(build.styleSources),
+      styleSourceSelections: new Map(build.styleSourceSelections),
+      breakpoints: new Map(build.breakpoints),
+      styles: new Map(build.styles),
+      marketplaceProduct: build.marketplaceProduct,
+    } satisfies BuilderData & { version: number };
+  }
+  throw Error("Unable to load builder data");
+};

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { useStore } from "@nanostores/react";
 import { useNavigate } from "@remix-run/react";
 import { findPageByIdOrPath, type Page } from "@webstudio-is/sdk";
-import { useMount } from "~/shared/hook-utils/use-mount";
 import {
   $authToken,
   $pages,
@@ -30,9 +29,7 @@ export const switchPage = (pageId: Page["id"], pageHash: string = "") => {
 
   $selectedPageHash.set(pageHash);
   $selectedPageId.set(page.id);
-  $selectedInstanceSelector.set([
-    page.rootInstanceId ?? pages.homePage.rootInstanceId,
-  ]);
+  $selectedInstanceSelector.set([page.rootInstanceId]);
 };
 
 const setPageStateFromUrl = () => {
@@ -65,9 +62,16 @@ export const useSyncPageUrl = () => {
   const isPreviewMode = useStore($isPreviewMode);
 
   // Get pageId and pageHash from URL
-  useMount(() => {
-    setPageStateFromUrl();
-  });
+  // once pages are loaded
+  useEffect(() => {
+    const unsubscribe = $pages.subscribe((pages) => {
+      if (pages) {
+        unsubscribe();
+        setPageStateFromUrl();
+      }
+    });
+    return unsubscribe;
+  }, []);
 
   useEffect(() => {
     window.addEventListener("popstate", setPageStateFromUrl);

--- a/apps/builder/vite.config.ts
+++ b/apps/builder/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(({ mode }) => ({
     external: ["@webstudio-is/prisma-client"],
   },
   server: {
-    host: "0.0.0.0",
+    host: true,
   },
   envPrefix: "GITHUB_",
 }));


### PR DESCRIPTION
To synchronize data between tabs it should be consistent and be easily accessible. Loading from server creates huge latency and data can be changed by loading from another tab.

Here moved data loading to client side so it can be shared through IndexedDB.

Added new `/rest/data/:buildId` endpoint and defined global setter and getter for current state.