### PR TITLE
fix: Make env compatible across all envs

### DIFF
--- a/apps/builder/.env
+++ b/apps/builder/.env
@@ -1,7 +1,7 @@
 # To override environment variables, add a .env.development file in the same directory.
 # For more details, visit: https://vitejs.dev/guide/env-and-mode#env-files
-DATABASE_URL=postgresql://postgres:pass@db/webstudio?pgbouncer=true
-DIRECT_URL=postgresql://postgres:pass@db/webstudio
+DATABASE_URL=postgresql://postgres:pass@localhost/webstudio?pgbouncer=true
+DIRECT_URL=postgresql://postgres:pass@localhost/webstudio
 
 AUTH_SECRET="# Linux: $(openssl rand -hex 32) or go to https://generate-secret.now.sh/64"
 # GH_CLIENT_SECRET=

--- a/apps/builder/vite.config.ts
+++ b/apps/builder/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(({ mode }) => ({
     external: ["@webstudio-is/prisma-client"],
   },
   server: {
-    host: "0.0.0.0",
+    host: true,
   },
   envPrefix: "GITHUB_",
 }));


### PR DESCRIPTION
## Description

Having that we use network_mode: service:db
we can use localhost for the db connection string


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
