### PR TITLE
feat: insert a variable at the caret position from the list

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -87,6 +87,7 @@ const NameField = ({ defaultValue }: { defaultValue: string }) => {
           inputRef={ref}
           name="name"
           id={nameId}
+          autoComplete="off"
           color={error ? "error" : undefined}
           defaultValue={defaultValue}
           onChange={(event) => {

--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -5,6 +5,8 @@ import {
   useState,
   forwardRef,
   type ComponentProps,
+  type RefObject,
+  useImperativeHandle,
 } from "react";
 import {
   Annotation,
@@ -139,7 +141,12 @@ const highlightStyle = HighlightStyle.define([
   },
 ]);
 
+export type EditorApi = {
+  replaceSelection: (string: string) => void;
+};
+
 type EditorContentProps = {
+  editorApiRef?: RefObject<undefined | EditorApi>;
   extensions?: Extension[];
   readOnly?: boolean;
   autoFocus?: boolean;
@@ -150,6 +157,7 @@ type EditorContentProps = {
 };
 
 export const EditorContent = ({
+  editorApiRef,
   extensions = [],
   readOnly = false,
   autoFocus = false,
@@ -247,6 +255,17 @@ export const EditorContent = ({
       annotations: [ExternalChange.of(true)],
     });
   }, [value]);
+
+  useImperativeHandle(editorApiRef, () => ({
+    replaceSelection: (string) => {
+      const view = viewRef.current;
+      if (view === undefined) {
+        return;
+      }
+      view.dispatch(view.state.replaceSelection(string));
+      view.focus();
+    },
+  }));
 
   return (
     <div

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useRef, type ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+  type RefObject,
+} from "react";
 import { matchSorter } from "match-sorter";
 import type { SyntaxNode } from "@lezer/common";
 import { Facet } from "@codemirror/state";
@@ -36,7 +42,10 @@ import {
   CodeEditorBase,
   EditorContent,
   EditorDialog,
+  type EditorApi,
 } from "./code-editor-base";
+
+export type { EditorApi };
 
 export const formatValue = (value: unknown) => {
   if (Array.isArray(value)) {
@@ -343,6 +352,7 @@ const wrapperStyle = css({
 });
 
 export const ExpressionEditor = ({
+  editorApiRef,
   scope = emptyScope,
   aliases = emptyAliases,
   color,
@@ -352,6 +362,7 @@ export const ExpressionEditor = ({
   onChange,
   onBlur,
 }: {
+  editorApiRef?: RefObject<undefined | EditorApi>;
   /**
    * object with variables and their data to autocomplete
    */
@@ -417,6 +428,7 @@ export const ExpressionEditor = ({
   return (
     <div className={wrapperStyle.toString()}>
       <CodeEditorBase
+        editorApiRef={editorApiRef}
         extensions={extensions}
         invalid={color === "error"}
         readOnly={readOnly}

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -19,8 +19,8 @@
     "middleware:dev": "DOTENV_CONFIG_PATH=.env.preview tsx watch -r dotenv/config ./middleware.js"
   },
   "dependencies": {
-    "@codemirror/autocomplete": "^6.16.0",
-    "@codemirror/commands": "^6.3.3",
+    "@codemirror/autocomplete": "^6.16.2",
+    "@codemirror/commands": "^6.5.0",
     "@codemirror/lang-html": "^6.4.9",
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/language": "^6.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,11 +103,11 @@ importers:
   apps/builder:
     dependencies:
       '@codemirror/autocomplete':
-        specifier: ^6.16.0
-        version: 6.16.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
+        specifier: ^6.16.2
+        version: 6.16.2(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
       '@codemirror/commands':
-        specifier: ^6.3.3
-        version: 6.3.3
+        specifier: ^6.5.0
+        version: 6.5.0
       '@codemirror/lang-html':
         specifier: ^6.4.9
         version: 6.4.9
@@ -2898,16 +2898,16 @@ packages:
   '@cloudflare/workers-types@4.20240405.0':
     resolution: {integrity: sha512-sEVOhyOgXUwfLkgHqbLZa/sfkSYrh7/zLmI6EZNibPaVPvAnAcItbNNl3SAlLyLKuwf8m4wAIAgu9meKWCvXjg==}
 
-  '@codemirror/autocomplete@6.16.0':
-    resolution: {integrity: sha512-P/LeCTtZHRTCU4xQsa89vSKWecYv1ZqwzOd5topheGRf+qtacFgBeIMQi3eL8Kt/BUNvxUWkx+5qP2jlGoARrg==}
+  '@codemirror/autocomplete@6.16.2':
+    resolution: {integrity: sha512-MjfDrHy0gHKlPWsvSsikhO1+BOh+eBHNgfH1OXs1+DAf30IonQldgMM3kxLDTG9ktE7kDLaA1j/l7KMPA4KNfw==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
       '@lezer/common': ^1.0.0
 
-  '@codemirror/commands@6.3.3':
-    resolution: {integrity: sha512-dO4hcF0fGT9tu1Pj1D2PvGvxjeGkbC6RGcZw6Qs74TH+Ed1gw98jmUgd2axWvIZEqTeTuFrg1lEB1KV6cK9h1A==}
+  '@codemirror/commands@6.5.0':
+    resolution: {integrity: sha512-rK+sj4fCAN/QfcY9BEzYMgp4wwL/q5aj/VfNSoH1RWPF9XS/dUwBkvlL3hpWgEjOqlpdN1uLC9UkjJ4tmyjJYg==}
 
   '@codemirror/lang-css@6.2.1':
     resolution: {integrity: sha512-/UNWDNV5Viwi/1lpr/dIXJNWiwDxpw13I4pTUAsNxZdg6E0mI2kTQb0P2iHczg1Tu+H4EBgJR+hYhKiHKko7qg==}
@@ -10626,14 +10626,14 @@ snapshots:
 
   '@cloudflare/workers-types@4.20240405.0': {}
 
-  '@codemirror/autocomplete@6.16.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)':
+  '@codemirror/autocomplete@6.16.2(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)':
     dependencies:
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.26.3
       '@lezer/common': 1.2.1
 
-  '@codemirror/commands@6.3.3':
+  '@codemirror/commands@6.5.0':
     dependencies:
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.1
@@ -10642,7 +10642,7 @@ snapshots:
 
   '@codemirror/lang-css@6.2.1(@codemirror/view@6.26.3)':
     dependencies:
-      '@codemirror/autocomplete': 6.16.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.16.2(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.1
       '@lezer/common': 1.2.1
@@ -10652,7 +10652,7 @@ snapshots:
 
   '@codemirror/lang-html@6.4.9':
     dependencies:
-      '@codemirror/autocomplete': 6.16.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.16.2(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
       '@codemirror/lang-css': 6.2.1(@codemirror/view@6.26.3)
       '@codemirror/lang-javascript': 6.2.2
       '@codemirror/language': 6.10.1
@@ -10664,7 +10664,7 @@ snapshots:
 
   '@codemirror/lang-javascript@6.2.2':
     dependencies:
-      '@codemirror/autocomplete': 6.16.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.16.2(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.1
       '@codemirror/lint': 6.4.2
       '@codemirror/state': 6.4.1


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3080

Here improved variables list in bindings to insert variable at cursor instead of full expression override.

Also bumped codemirror and disabled autocomplete in variable "name".


https://github.com/webstudio-is/webstudio/assets/5635476/2a5482e2-b880-4bcd-abdf-10ce6db68d31

