### PR TITLE
feat: Make it easy for a self-hosted version to set the plan features

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,4 +24,4 @@
 - [ ] tested locally and on preview environment (preview dev login: 5de6)
 - [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
 - [ ] added tests
-- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
+- [ ] if any new env variables are added, added them to `.env` file

--- a/apps/builder/.env
+++ b/apps/builder/.env
@@ -46,6 +46,9 @@ ASSET_BASE_URL=/s/uploads/
 
 # Enable features behind a flag, * enables all.
 FEATURES=*
+# Current user plan features (default)
+USER_PLAN=pro
+
 
 # TRCP server url and API token. If empty local TRPC server is used
 # TRPC_SERVER_URL=

--- a/apps/builder/.env.production
+++ b/apps/builder/.env.production
@@ -1,0 +1,2 @@
+# Reset current user plan features (default)
+USER_PLAN=

--- a/apps/builder/app/env/env.server.ts
+++ b/apps/builder/app/env/env.server.ts
@@ -94,6 +94,9 @@ const env = {
   PUBLISHER_HOST: process.env.PUBLISHER_HOST || "wstd.work",
 
   FEATURES: process.env.FEATURES ?? "",
+
+  // current user plan features (default)
+  USER_PLAN: process.env.USER_PLAN ?? "",
 };
 
 export type ServerEnv = typeof env;

--- a/apps/builder/app/services/auth.server.ts
+++ b/apps/builder/app/services/auth.server.ts
@@ -68,11 +68,19 @@ if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
 if (env.DEV_LOGIN === "true") {
   authenticator.use(
     new FormStrategy(async ({ form }) => {
-      const secret = form.get("secret");
+      const secretValue = form.get("secret");
+
+      if (secretValue == null) {
+        throw new Error("Secret is required");
+      }
+
+      const [secret, email = "hello@webstudio.is"] = secretValue
+        .toString()
+        .split(":");
 
       if (secret === env.AUTH_SECRET?.slice(0, 4)) {
         try {
-          const user = await db.user.createOrLoginWithDev();
+          const user = await db.user.createOrLoginWithDev(email);
           return user;
         } catch (error) {
           if (error instanceof Error) {

--- a/apps/builder/app/shared/db/user-plan-features.server.ts
+++ b/apps/builder/app/shared/db/user-plan-features.server.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@webstudio-is/prisma-client";
 import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
+import env from "~/env/env.server";
 
 export type UserPlanFeatures = NonNullable<AppContext["userPlanFeatures"]>;
 
@@ -68,6 +69,18 @@ export const getUserPlanFeatures = async (
       hasSubscription,
       hasProPlan: true,
       planName: userProducts[0].product.name,
+    };
+  }
+
+  if (env.USER_PLAN === "pro") {
+    return {
+      allowShareAdminLinks: true,
+      allowDynamicData: true,
+      allowContactEmail: true,
+      maxDomainsAllowedPerUser: Number.MAX_SAFE_INTEGER,
+      hasSubscription: true,
+      hasProPlan: true,
+      planName: "env.USER_PLAN Pro",
     };
   }
 

--- a/apps/builder/app/shared/db/user.server.ts
+++ b/apps/builder/app/shared/db/user.server.ts
@@ -79,9 +79,9 @@ export const createOrLoginWithOAuth = async (
   return newUser;
 };
 
-export const createOrLoginWithDev = async (): Promise<User> => {
+export const createOrLoginWithDev = async (email: string): Promise<User> => {
   const userData = {
-    email: "hello@webstudio.is",
+    email,
     username: "admin",
     image: "",
     provider: "dev",


### PR DESCRIPTION
## Description

closes #3400 


`+` on dev login its now possible to add any email
like 
`{code}:hello@world.xx` to login as other user


## Steps for reproduction

Login on main with `{code}:ice@yandex.ru`
- See no plan
<img width="213" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/65f79295-63b3-4d4f-b5d2-ed854f8462e3">

---

Login on main as usual
- See user has plan
<img width="265" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/db9e1c3e-a8d7-4cde-bbd5-1f39ce7442b8">

---

Login locally
See user has plan

<img width="231" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/c1187bce-2c7e-49f3-a3ac-bfa15560ccce">




## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
