### PR TITLE
feat: support curl paste in graphql resource url

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -712,9 +712,8 @@ export const VariablePopoverTrigger = forwardRef<
             actions={
               variable?.type === "resource" && (
                 <>
-                  {/* allow to copy curl only for default resource control */}
-                  {resources.get(variable.resourceId)?.control ===
-                    undefined && (
+                  {/* allow to copy curl only for default and graphql resource controls */}
+                  {resources.get(variable.resourceId)?.control !== "system" && (
                     <Tooltip
                       content="Copy resource as cURL command"
                       side="bottom"


### PR DESCRIPTION
Looks like it would be useful to support curl in graphql resources as well.

<img width="283" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5635476/e4666f8f-2668-4c65-89be-14e84c981bbf">
