### PR TITLE
fix: treat link urls without pathname as self reference

### DIFF
--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -39,10 +39,11 @@ const switchPageAndUpdateSystem = (href: string, formData?: FormData) => {
   if (pages === undefined) {
     return;
   }
-  if (href === "") {
+  // preserve pathname when not specified in href/action
+  if (href === "" || href.startsWith("?") || href.startsWith("#")) {
     const pathname = getSelectedPagePathname();
     if (pathname) {
-      href = pathname;
+      href = pathname + href;
     }
   }
   const pageHref = new URL(href, "https://any-valid.url");

--- a/packages/sdk-components-react-remix/src/shared/remix-link.tsx
+++ b/packages/sdk-components-react-remix/src/shared/remix-link.tsx
@@ -20,10 +20,13 @@ export const wrapLinkComponent = (BaseLink: typeof Link) => {
     // cast to string when invalid value type is provided with binding
     const href = String(props.href ?? "");
 
-    // use remix link for home page and all relative urls
+    // use remix link for self reference and all relative urls
     // ignore asset paths which can be relative too
     if (
+      // remix appends ?index in runtime but not in ssr
       href === "" ||
+      href.startsWith("?") ||
+      href.startsWith("#") ||
       (href.startsWith("/") && href.startsWith(assetBaseUrl) === false)
     ) {
       // remix links behave in unexpected way when delete in content editable


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/3478

This fixes the issue with reloading pages when href="?" and href="#" are specified without any pathname.