### PR TITLE
feat: highlight Custom Code as html

### DIFF
--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -167,7 +167,11 @@ export const SectionGeneral = () => {
           Custom code and scripts will be added at the end of the &lt;head&gt;
           tag to every page across the published project.
         </Text>
-        <CodeEditor value={meta.code ?? ""} onChange={handleSave("code")} />
+        <CodeEditor
+          lang="html"
+          value={meta.code ?? ""}
+          onChange={handleSave("code")}
+        />
       </Grid>
 
       <Separator />


### PR DESCRIPTION
We missed to specify html language here.
Users in discord noticed this.


<img width="691" alt="Screenshot 2024-06-04 at 13 20 04" src="https://github.com/webstudio-is/webstudio/assets/5635476/69d388a4-b23e-499a-af8e-43d59a63156a">