### PR TITLE
build: automatically create release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       id: changelog
       with:
         commit-types: |
-          feat: New Features
-          fix: Bug Fixes
+          feat: Features
+          fix: Fixes
           docs: Documentation
-          experimental: Experimental features
+          experimental: Experimental
         semver: false
 
     - uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: ardalanamini/auto-changelog@v4
+      id: changelog
+      with:
+        commit-types: |
+          feat: New Features
+          fix: Bug Fixes
+          docs: Documentation
+          experimental: Experimental features
+        semver: false
+
+    - uses: ncipollo/release-action@v1
+      with:
+        body: |
+          ${{ steps.changelog.outputs.changelog }}


### PR DESCRIPTION
Here added workflow to automatically create release when tag is pushed to the repo.

All unconfigured types will go into "Other changes" section

Example of changelogs
https://github.com/TrySound/test-auto-release/releases