### PR TITLE
fix: close variable after creating

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -691,6 +691,11 @@ export const VariablePopoverTrigger = forwardRef<
                 if (event.currentTarget.checkValidity()) {
                   const formData = new FormData(event.currentTarget);
                   panelRef.current?.save(formData);
+                  // close popover whenever new variable is created
+                  // to prevent creating duplicated variable
+                  if (variable === undefined) {
+                    setOpen(false);
+                  }
                 }
               }}
             >


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/3480

Here always close popover when variable is created to avoid duplicating with a few "Enter" presses on "name" field.