### PR TITLE
fix: Sheet button padding for ios are now explicit

### DIFF
--- a/packages/sdk-components-react-radix/src/theme/styles.ts
+++ b/packages/sdk-components-react-radix/src/theme/styles.ts
@@ -49,7 +49,7 @@ export const getButtonStyles = (
   if (size === "icon") {
     // Set explicit paddings for IOS Safari to prevent the icon from collapsing
     // h-10 w-10
-    sizeStyles = [tc.h(10), tc.w(10), tc.px(6), tc.py(3)].flat();
+    sizeStyles = [tc.h(10), tc.w(10), tc.px(1.5), tc.py(0)].flat();
   }
   if (size === "sm") {
     // h-9 rounded-md px-3

--- a/packages/sdk-components-react-radix/src/theme/styles.ts
+++ b/packages/sdk-components-react-radix/src/theme/styles.ts
@@ -47,8 +47,9 @@ export const getButtonStyles = (
 
   let sizeStyles: EmbedTemplateStyleDecl[] = [];
   if (size === "icon") {
+    // Set explicit paddings for IOS Safari to prevent the icon from collapsing
     // h-10 w-10
-    sizeStyles = [tc.h(10), tc.w(10)].flat();
+    sizeStyles = [tc.h(10), tc.w(10), tc.px(6), tc.py(3)].flat();
   }
   if (size === "sm") {
     // h-9 rounded-md px-3

--- a/packages/sdk-components-react-radix/src/theme/styles.ts
+++ b/packages/sdk-components-react-radix/src/theme/styles.ts
@@ -19,6 +19,7 @@ export const getButtonStyles = (
     tc.rounded("md"),
     tc.text("sm"),
     tc.font("medium"),
+    tc.text("current"),
     tc.focusVisible(
       [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
     ),


### PR DESCRIPTION
## Description

Current fix does not fix existing Sheet components, but fixes new
Because of design tokens a little bit different size. (Can preserve if needed but will need some additional work)

<img width="97" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/372ae202-4238-49c8-8ff4-3ad450ae413c">


Example: 
https://btn-style.staging.webstudio.is/builder/ff5ca76c-dd27-44a9-8608-23e9b02e0427?authToken=e8a517f5-b699-4b73-9dc1-049fdadaa207&mode=preview

Result
https://sheettest-rpbvy.wstd.work/


The problem on IOS

<img width="406" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/c4d7c4a2-9ea5-4d7c-b068-9f4f20e9d896">

It's because Safari IOS default button paddings are
```
padding-left: 1em;
padding-right: 1em;
```

instead of defaults in other browsers. 

To solve safari IOS issue we need to set padding to explicit values

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
