### PR TITLE
build: replace dotenv with node env loader

### DIFF
--- a/apps/builder/middleware.js
+++ b/apps/builder/middleware.js
@@ -22,7 +22,7 @@
  * ```shell
  * pnpx vercel link
  * pnpx vercel env pull --environment=preview ./.env.preview
- * DOTENV_CONFIG_PATH=.env.preview pnpm tsx watch -r dotenv/config ./middleware.js
+ * pnpm tsx watch --env-file=.env.preview ./middleware.js
  * ```
  */
 import { Ratelimit } from "@upstash/ratelimit";

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -8,7 +8,6 @@
     "prebuild": "which remix",
     "build": "remix vite:build",
     "start": "remix-serve build/server/index.js",
-    "start-local": "NODE_OPTIONS='-r dotenv/config' remix-serve build/server/index.js",
     "dev": "remix vite:dev",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
@@ -16,7 +15,7 @@
     "ci:migrate": "migrations migrate",
     "middleware:link": "pnpx vercel link",
     "middleware:env": "pnpx vercel env pull --environment=preview ./.env.preview",
-    "middleware:dev": "DOTENV_CONFIG_PATH=.env.preview tsx watch -r dotenv/config ./middleware.js"
+    "middleware:dev": "tsx watch --env-file=.env.preview ./middleware.js"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.16.2",
@@ -132,7 +131,6 @@
     "@types/react-dom": "^18.2.25",
     "@webstudio-is/jest-config": "workspace:*",
     "@webstudio-is/tsconfig": "workspace:*",
-    "dotenv": "^16.3.1",
     "html-tags": "^3.3.1",
     "react-router-dom": "^6.23.1",
     "react-test-renderer": "18.3.0-canary-14898b6a9-20240318",

--- a/packages/prisma-client/migrations-cli/cli.ts
+++ b/packages/prisma-client/migrations-cli/cli.ts
@@ -1,12 +1,10 @@
 #!/usr/bin/env tsx
 
-import { cwd, loadEnvFile } from "node:process";
-import { resolve } from "node:path";
+import { loadEnvFile } from "node:process";
 import * as commands from "./commands";
 import * as logger from "./logger";
 import * as args from "./args";
 import { UserError } from "./errors";
-import { access } from "node:fs/promises";
 
 const USAGE = `Usage: migrations <command> [--dev]
 

--- a/packages/prisma-client/migrations-cli/cli.ts
+++ b/packages/prisma-client/migrations-cli/cli.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env tsx
 
-import * as dotenv from "dotenv";
+import { cwd, loadEnvFile } from "node:process";
+import { resolve } from "node:path";
 import * as commands from "./commands";
 import * as logger from "./logger";
 import * as args from "./args";
 import { UserError } from "./errors";
+import { access } from "node:fs/promises";
 
 const USAGE = `Usage: migrations <command> [--dev]
 
@@ -23,7 +25,16 @@ Arguments
 
 const main = async () => {
   if (args.values.dev) {
-    dotenv.config();
+    try {
+      loadEnvFile(".env.development");
+    } catch {
+      // empty block
+    }
+    try {
+      loadEnvFile(".env");
+    } catch {
+      // empty block
+    }
   }
 
   const command = args.positionals[0];

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -34,7 +34,6 @@
   "license": "AGPL-3.0-or-later",
   "private": true,
   "dependencies": {
-    "dotenv": "^16.3.1",
     "execa": "^7.2.0",
     "nanoid": "^5.0.1",
     "umzug": "^3.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,9 +435,6 @@ importers:
       '@webstudio-is/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
-      dotenv:
-        specifier: ^16.3.1
-        version: 16.3.1
       html-tags:
         specifier: ^3.3.1
         version: 3.3.1
@@ -1587,9 +1584,6 @@ importers:
 
   packages/prisma-client:
     dependencies:
-      dotenv:
-        specifier: ^16.3.1
-        version: 16.3.1
       execa:
         specifier: ^7.2.0
         version: 7.2.0


### PR DESCRIPTION
Refs
- https://nodejs.org/docs/latest/api/process.html#processloadenvfilepath
- https://nodejs.org/en/learn/command-line/how-to-read-environment-variables-from-nodejs

Here switched from dotenv to node env loader.
Solves both command line and runtime cases.
The only issue is inability to specify --env-file with NODE_OPTIONS.

Also fixed dev migrations by optionally loading .env.development