### PR TITLE
fix: Fix selecting text in places where it should be selectable

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -218,10 +218,10 @@ export const TooltipContent = ({
         <Text
           variant="monoBold"
           color="moreSubtle"
+          userSelect="text"
           css={{
             whiteSpace: "break-spaces",
             maxHeight: "3em",
-            userSelect: "text",
             cursor: "text",
           }}
         >

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -134,10 +134,10 @@ const EditableText = ({
       truncate
       ref={ref}
       spellCheck={false}
+      userSelect={isEditing ? "text" : "none"}
       css={{
         outline: "none",
         textOverflow: isEditing ? "clip" : "ellipsis",
-        userSelect: isEditing ? "auto" : "none",
         cursor: isEditing ? "auto" : "default",
       }}
       {...handlers}

--- a/apps/builder/app/builder/shared/tree/index.tsx
+++ b/apps/builder/app/builder/shared/tree/index.tsx
@@ -215,7 +215,7 @@ const EditableTreeItemLabel = styled(TreeItemLabel, {
         outline: "none",
         cursor: "auto",
         textOverflow: "clip",
-        userSelect: "auto",
+        userSelect: "text",
       },
     },
   },

--- a/apps/builder/app/dashboard/projects/project-card.tsx
+++ b/apps/builder/app/dashboard/projects/project-card.tsx
@@ -37,7 +37,7 @@ import { Card, CardContent, CardFooter } from "../shared/card";
 import { CloneProjectDialog } from "~/shared/clone-project";
 
 const titleStyle = css({
-  userSelect: "auto",
+  userSelect: "text",
   ...truncate(),
 });
 
@@ -313,7 +313,7 @@ export const ProjectTemplateCard = ({
       </CardContent>
       <CardFooter>
         <Flex direction="column" justify="around">
-          <Text variant="titles" truncate css={{ userSelect: "auto" }}>
+          <Text variant="titles" truncate userSelect="text">
             {title}
           </Text>
           {isPublished ? (

--- a/apps/builder/app/dashboard/projects/project-dialogs.tsx
+++ b/apps/builder/app/dashboard/projects/project-dialogs.tsx
@@ -328,13 +328,13 @@ export const DeleteProjectDialog = ({
         onChange={handleChange}
         errors={errors}
         label={
-          <Label css={{ userSelect: "auto" }}>
+          <Label css={{ userSelect: "text" }}>
             Confirm by typing
             <Text
               as="span"
               color="destructive"
               variant="labelsSentenceCase"
-              css={{ userSelect: "auto" }}
+              css={{ userSelect: "text" }}
             >
               {` ${title} `}
             </Text>

--- a/packages/design-system/src/components/text.ts
+++ b/packages/design-system/src/components/text.ts
@@ -56,8 +56,8 @@ export const textStyle = css({
       },
     },
     userSelect: {
-      auto: {
-        userSelect: "auto",
+      text: {
+        userSelect: "text",
       },
       none: {
         userSelect: "none",


### PR DESCRIPTION
## Description

Turns out userSelect auto doens't necessary mean it will fall back to. the default for the node, we need to be explicit.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
