### PR TITLE
fix: reset image url in inputs when users select a uploaded image after adding a remote url to the same.

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/image/image-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/image/image-control.tsx
@@ -36,6 +36,10 @@ export const ImageControl = ({
     if (styleValue?.type === "image" && styleValue.value.type === "url") {
       setRemoteImageURL({ type: "intermediate", value: styleValue.value.url });
     }
+
+    if (styleValue?.type === "image" && styleValue.value.type === "asset") {
+      setRemoteImageURL(undefined);
+    }
   }, [styleValue]);
 
   if (styleValue === undefined) {

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
@@ -5,14 +5,17 @@ import {
   Flex,
   theme,
   InputErrorsTooltip,
+  Label,
+  Tooltip,
+  Text,
 } from "@webstudio-is/design-system";
 import { useRef, useState, useEffect } from "react";
 import type { ControlProps } from "../../controls";
-import { NonResetablePropertyName } from "../../shared/property-name";
 import { useStore } from "@nanostores/react";
 import { $assets } from "~/shared/nano-states";
 import { parseCssValue } from "@webstudio-is/css-data";
 import type { StyleUpdateOptions } from "../../shared/use-style-data";
+import { InfoCircleIcon } from "@webstudio-is/icons";
 
 const property: StyleProperty = "backgroundImage";
 
@@ -161,11 +164,24 @@ export const BackgroundImage = (
         gap: theme.spacing[3],
       }}
     >
-      <NonResetablePropertyName
-        style={props.currentStyle}
-        properties={[property]}
-        label="Image"
-      />
+      <Label>
+        <Flex align="center" gap="1">
+          Code
+          <Tooltip
+            variant="wrapped"
+            content={
+              <Text>
+                Paste a background-image CSS property value here. You can use
+                the URL of an asset in your project or an external URL.
+                <br /> <br />
+                <Text variant="monoBold">url("image.jpg")</Text>
+              </Text>
+            }
+          >
+            <InfoCircleIcon />
+          </Tooltip>
+        </Flex>
+      </Label>
 
       <InputErrorsTooltip errors={errors}>
         <TextArea


### PR DESCRIPTION
## Description
fixes
- when choosing an image after having a url, url is normally being reset, so you don't have both, now I managed to have both
- Code area label should be Code

Regarding the 
- jump when switching between image and gradient.
This is a little tricky, to restrict from jumping. Thought about this while implementing itself. But there is too much negative spacing for gradients tab. We need to set `min-height`. Which is showing too much empty spacing for background gradients in my opinion. Let me know, if it's still fine and we can go ahead.
![Screen Recording 2024-06-07 at 10 32 08 AM](https://github.com/webstudio-is/webstudio/assets/11075561/8bb0f97a-e4c3-4495-822e-cb8b307b908b)

- shouldn't all properties land in the Code area? not just the url()?
This, i am not sure if its possible. Because, in every code-editing areas. We are showing only the property value and not the key. In this case, of we want to show multiple properties. Then we need to show multiple key-value pairs. Like, `background-image: url, background-cli: border-box` etc.  With some additional parsing of these values. 

## Steps for reproduction

1. Set a remote url for a background image, now use a uploaded image for the same. The input-box need to be refreshed.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
