### PR TITLE
build: run webstudio cli without rebuilding

### DIFF
--- a/fixtures/webstudio-cloudflare-template/package.json
+++ b/fixtures/webstudio-cloudflare-template/package.json
@@ -1,9 +1,10 @@
 {
   "type": "module",
   "scripts": {
-    "fixtures:link": "webstudio link --link \"https://main.development.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93&\"",
-    "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "webstudio build --template internal --template cloudflare --template saas-helpers  --preview && pnpm prettier --write ./app/ ./package.json",
+    "webstudio": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
+    "fixtures:link": "pnpm webstudio link --link \"https://main.development.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93&\"",
+    "fixtures:sync": "pnpm webstudio sync && pnpm prettier --write ./.webstudio/",
+    "fixtures:build": "pnpm webstudio build --template internal --template cloudflare --template saas-helpers  --preview && pnpm prettier --write ./app/ ./package.json",
     "build": "remix vite:build",
     "dev": "remix vite:dev",
     "typecheck": "tsc",

--- a/fixtures/webstudio-custom-template/package.json
+++ b/fixtures/webstudio-custom-template/package.json
@@ -6,9 +6,10 @@
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "size-test": "rm -rf ./public && remix build && size-limit",
-    "fixtures:link": "webstudio link --link \"https://main.development.webstudio.is/builder/0d856812-61d8-4014-a20a-82e01c0eb8ee?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f\"",
-    "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "webstudio build --template internal --template ./custom-template --template ./custom-template-stage --preview && pnpm prettier --write ./app/ ./package.json"
+    "webstudio": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
+    "fixtures:link": "pnpm webstudio link --link \"https://main.development.webstudio.is/builder/0d856812-61d8-4014-a20a-82e01c0eb8ee?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f\"",
+    "fixtures:sync": "pnpm webstudio sync && pnpm prettier --write ./.webstudio/",
+    "fixtures:build": "pnpm webstudio build --template internal --template ./custom-template --template ./custom-template-stage --preview && pnpm prettier --write ./app/ ./package.json"
   },
   "private": true,
   "sideEffects": false,

--- a/fixtures/webstudio-remix-netlify-edge-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/package.json
@@ -5,9 +5,10 @@
     "build": "remix vite:build",
     "dev": "remix vite:dev",
     "typecheck": "tsc",
-    "fixtures:link": "webstudio link --link \"https://main.development.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93&\"",
-    "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "webstudio build --template internal --template netlify-edge-functions --preview && pnpm prettier --write ./app/ ./package.json"
+    "webstudio": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
+    "fixtures:link": "pnpm webstudio link --link \"https://main.development.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93&\"",
+    "fixtures:sync": "pnpm webstudio sync && pnpm prettier --write ./.webstudio/",
+    "fixtures:build": "pnpm webstudio build --template internal --template netlify-edge-functions --preview && pnpm prettier --write ./app/ ./package.json"
   },
   "dependencies": {
     "@netlify/edge-functions": "^2.8.1",

--- a/fixtures/webstudio-remix-netlify-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-functions/package.json
@@ -4,9 +4,10 @@
     "dev": "remix vite:dev",
     "start": "netlify serve",
     "typecheck": "tsc",
-    "fixtures:link": "webstudio link --link \"https://main.development.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93\"",
-    "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "webstudio build --template internal --template netlify-functions --preview && pnpm prettier --write ./app/ ./package.json"
+    "webstudio": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
+    "fixtures:link": "pnpm webstudio link --link \"https://main.development.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93\"",
+    "fixtures:sync": "pnpm webstudio sync && pnpm prettier --write ./.webstudio/",
+    "fixtures:build": "pnpm webstudio build --template internal --template netlify-functions --preview && pnpm prettier --write ./app/ ./package.json"
   },
   "dependencies": {
     "@netlify/functions": "^2.7.0",

--- a/fixtures/webstudio-remix-vercel/package.json
+++ b/fixtures/webstudio-remix-vercel/package.json
@@ -4,9 +4,10 @@
     "build": "remix vite:build",
     "dev": "remix vite:dev",
     "typecheck": "tsc",
-    "fixtures:link": "webstudio link --link \"https://main.development.webstudio.is/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview\"",
-    "fixtures:sync": "webstudio sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "webstudio build --template internal --template vercel --preview && pnpm prettier --write ./app/ ./package.json"
+    "webstudio": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
+    "fixtures:link": "pnpm webstudio link --link \"https://main.development.webstudio.is/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview\"",
+    "fixtures:sync": "pnpm webstudio sync && pnpm prettier --write ./.webstudio/",
+    "fixtures:build": "pnpm webstudio build --template internal --template vercel --preview && pnpm prettier --write ./app/ ./package.json"
   },
   "private": true,
   "sideEffects": false,

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-import { main } from "./lib/cli.js";
+import { main } from "#cli";
 
 await main();

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,6 +9,12 @@
     "webstudio-cli": "./bin.js",
     "webstudio": "./bin.js"
   },
+  "imports": {
+    "#cli": {
+      "webstudio": "./src/cli.ts",
+      "default": "./lib/cli.js"
+    }
+  },
   "files": [
     "lib/*",
     "templates/*",
@@ -19,7 +25,6 @@
     "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "build": "rm -rf lib && esbuild src/cli.ts --outdir=lib --bundle --format=esm --packages=external",
-    "local-run": "tsx --no-warnings ./src/bin.ts",
     "dev": "esbuild src/cli.ts --watch --bundle --format=esm --packages=external --outdir=./lib",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,5 +1,0 @@
-#!/usr/bin/env node --experimental-specifier-resolution=node --no-warnings
-// pnpm tsx --no-warnings ./src/bin.ts
-import { main } from "./cli";
-
-await main();

--- a/packages/sdk-cli/src/bin.ts
+++ b/packages/sdk-cli/src/bin.ts
@@ -1,2 +1,2 @@
-#!/usr/bin/env tsx --conditions=webstudio --experimental-specifier-resolution=node --no-warnings
+#!/usr/bin/env tsx --conditions=webstudio
 import "./cli";


### PR DESCRIPTION
Finally figured out how to leverage node conditions to run webstudio cli in fixtures without rebuilding it on every change.

Import conditions is another thing which allows
to constrain not exposed modules but internal ones.

Now to run cli locally it should be have this env
which is basically same we do with vite.
Works for both import and export conditions.

```
NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio
```