### PR TITLE
fix: Image Manager. Ensure picture click and delete functionality work consistently

### DIFF
--- a/apps/builder/app/builder/builder.css
+++ b/apps/builder/app/builder/builder.css
@@ -7,3 +7,13 @@ body {
   overscroll-behavior: contain;
   -webkit-font-smoothing: antialiased;
 }
+
+[data-radix-scroll-area-viewport] {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+[data-radix-scroll-area-viewport]::-webkit-scrollbar {
+  display: none;
+}

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "patchedDependencies": {
       "@stitches/react@1.3.1-1": "patches/@stitches__react@1.3.1-1.patch",
       "css-tree@2.3.1": "patches/css-tree@2.3.1.patch",
-      "@types/css-tree@2.3.1": "patches/@types__css-tree@2.3.1.patch"
+      "@types/css-tree@2.3.1": "patches/@types__css-tree@2.3.1.patch",
+      "@radix-ui/react-scroll-area@1.0.5": "patches/@radix-ui__react-scroll-area@1.0.5.patch"
     }
   }
 }

--- a/patches/@radix-ui__react-scroll-area@1.0.5.patch
+++ b/patches/@radix-ui__react-scroll-area@1.0.5.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 275085e7140d855f7b2c6df3eba959f49cb5837d..e8f6263e261ede55f7fc0d2b6162f0c975f7d696 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -93,11 +93,8 @@ const $57acba87d6e25586$export$a21cbf9f11fca853 = /*#__PURE__*/ $fnFM9$forwardRe
+     const context = $57acba87d6e25586$var$useScrollAreaContext($57acba87d6e25586$var$VIEWPORT_NAME, __scopeScrollArea);
+     const ref = $fnFM9$useRef(null);
+     const composedRefs = $fnFM9$useComposedRefs(forwardedRef, ref, context.onViewportChange);
+-    return /*#__PURE__*/ $fnFM9$createElement($fnFM9$Fragment, null, /*#__PURE__*/ $fnFM9$createElement("style", {
+-        dangerouslySetInnerHTML: {
+-            __html: `[data-radix-scroll-area-viewport]{scrollbar-width:none;-ms-overflow-style:none;-webkit-overflow-scrolling:touch;}[data-radix-scroll-area-viewport]::-webkit-scrollbar{display:none}`
+-        }
+-    }), /*#__PURE__*/ $fnFM9$createElement($fnFM9$Primitive.div, $fnFM9$babelruntimehelpersesmextends({
++    return /*#__PURE__*/ $fnFM9$createElement($fnFM9$Fragment, null
++      , /*#__PURE__*/ $fnFM9$createElement($fnFM9$Primitive.div, $fnFM9$babelruntimehelpersesmextends({
+         "data-radix-scroll-area-viewport": ""
+     }, viewportProps, {
+         ref: composedRefs,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ overrides:
   react-dom: 18.3.0-canary-14898b6a9-20240318
 
 patchedDependencies:
+  '@radix-ui/react-scroll-area@1.0.5':
+    hash: 5y6bqj6dymxto7bikr5opyo7lm
+    path: patches/@radix-ui__react-scroll-area@1.0.5.patch
   '@stitches/react@1.3.1-1':
     hash: knml42mpr6mlzseo3d6gjljiq4
     path: patches/@stitches__react@1.3.1-1.patch
@@ -1226,7 +1229,7 @@ importers:
         version: 1.1.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       '@radix-ui/react-scroll-area':
         specifier: ^1.0.5
-        version: 1.0.5(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
+        version: 1.0.5(patch_hash=5y6bqj6dymxto7bikr5opyo7lm)(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       '@radix-ui/react-select':
         specifier: ^2.0.0
         version: 2.0.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
@@ -12642,7 +12645,7 @@ snapshots:
       '@types/react': 18.2.79
       '@types/react-dom': 18.2.25
 
-  '@radix-ui/react-scroll-area@1.0.5(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)':
+  '@radix-ui/react-scroll-area@1.0.5(patch_hash=5y6bqj6dymxto7bikr5opyo7lm)(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)':
     dependencies:
       '@babel/runtime': 7.22.3
       '@radix-ui/number': 1.0.1


### PR DESCRIPTION
## Description

closes #3504

Reflow caused by Style element rerender sometimes cause focus lose.
It can be or chrome issue or Mutattion observer used in radix focus scope.



## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
