### PR TITLE
feat: Enable URL drop functionality in Image Manager

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,8 @@
         "redhat.vscode-yaml",
         "me-dutour-mathieu.vscode-github-actions",
         "eamodio.gitlens",
-        "bradymholt.pgformatter"
+        "bradymholt.pgformatter",
+        "YoavBls.pretty-ts-errors"
       ]
     }
   }

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Box, rawTheme } from "@webstudio-is/design-system";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
 import { $dragAndDropState, $isPreviewMode } from "~/shared/nano-states";
@@ -17,6 +17,12 @@ import {
   SidebarTabsList,
   SidebarTabsTrigger,
 } from "./sidebar-tabs";
+import {
+  ExternalDragDropMonitor,
+  POTENTIAL,
+  isBlockedByBackdrop,
+  useExternalDragStateEffect,
+} from "~/builder/shared/assets/drag-monitor";
 
 const none = { TabContent: () => null };
 
@@ -103,9 +109,28 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
   const dragAndDropState = useStore($dragAndDropState);
   const { TabContent } = panels.get(activeTab) ?? none;
   const isPreviewMode = useStore($isPreviewMode);
+  const tabsWrapperRef = useRef<HTMLDivElement>(null);
 
   useSubscribe("dragEnd", () => {
     setActiveTab("none");
+  });
+
+  useExternalDragStateEffect((state) => {
+    if (state !== POTENTIAL) {
+      return;
+    }
+
+    const element = tabsWrapperRef.current;
+
+    if (element == null) {
+      return;
+    }
+
+    if (isBlockedByBackdrop(element)) {
+      return;
+    }
+
+    setActiveTab("assets");
   });
 
   return (
@@ -121,24 +146,30 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
         }
         {isPreviewMode === false && (
           <>
-            <SidebarTabsList>
-              {Array.from(panels.entries()).map(
-                ([tabName, { Icon, label }]) => {
-                  return (
-                    <SidebarTabsTrigger
-                      key={label}
-                      label={label}
-                      value={tabName}
-                      onClick={() => {
-                        setActiveTab(activeTab === tabName ? "none" : tabName);
-                      }}
-                    >
-                      <Icon size={rawTheme.spacing[10]} />
-                    </SidebarTabsTrigger>
-                  );
-                }
-              )}
-            </SidebarTabsList>
+            <ExternalDragDropMonitor />
+            <div ref={tabsWrapperRef} style={{ display: "contents" }}>
+              <SidebarTabsList>
+                {Array.from(panels.entries()).map(
+                  ([tabName, { Icon, label }]) => {
+                    return (
+                      <SidebarTabsTrigger
+                        key={label}
+                        label={label}
+                        value={tabName}
+                        onClick={() => {
+                          setActiveTab(
+                            activeTab === tabName ? "none" : tabName
+                          );
+                        }}
+                      >
+                        <Icon size={rawTheme.spacing[10]} />
+                      </SidebarTabsTrigger>
+                    );
+                  }
+                )}
+              </SidebarTabsList>
+            </div>
+
             <Box css={{ borderRight: `1px solid ${theme.colors.borderMain}` }}>
               <AiTabTrigger />
               <HelpTabTrigger />

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -21,8 +21,10 @@ import {
   ExternalDragDropMonitor,
   POTENTIAL,
   isBlockedByBackdrop,
+  useOnDropEffect,
   useExternalDragStateEffect,
 } from "~/builder/shared/assets/drag-monitor";
+import type { TabName } from "./types";
 
 const none = { TabContent: () => null };
 
@@ -111,12 +113,32 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
   const isPreviewMode = useStore($isPreviewMode);
   const tabsWrapperRef = useRef<HTMLDivElement>(null);
 
+  const returnTabRef = useRef<TabName | undefined>(undefined);
+
   useSubscribe("dragEnd", () => {
     setActiveTab("none");
   });
 
+  useOnDropEffect(() => {
+    const element = tabsWrapperRef.current;
+
+    if (element == null) {
+      return;
+    }
+
+    if (isBlockedByBackdrop(element)) {
+      return;
+    }
+
+    returnTabRef.current = undefined;
+  });
+
   useExternalDragStateEffect((state) => {
     if (state !== POTENTIAL) {
+      if (returnTabRef.current !== undefined) {
+        setActiveTab(returnTabRef.current);
+      }
+      returnTabRef.current = undefined;
       return;
     }
 
@@ -130,6 +152,8 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
       return;
     }
 
+    returnTabRef.current = activeTab;
+    // Save prevous state
     setActiveTab("assets");
   });
 

--- a/apps/builder/app/builder/shared/assets/asset-upload.tsx
+++ b/apps/builder/app/builder/shared/assets/asset-upload.tsx
@@ -10,6 +10,7 @@ import {
 import { FONT_MIME_TYPES } from "@webstudio-is/fonts";
 import { useUploadAsset } from "./use-assets";
 import { $authPermit } from "~/shared/nano-states";
+import { imageMimeTypes } from "./image-formats";
 
 const maxSize = toBytes(MAX_UPLOAD_SIZE);
 
@@ -45,24 +46,13 @@ const useUpload = (type: AssetType) => {
   return { inputRef, onChange };
 };
 
-// https://developers.cloudflare.com/images/image-resizing/format-limitations/
-const imageMimeTypes = [
-  "image/jpeg",
-  "image/png",
-  "image/gif",
-  "image/webp",
-  "image/svg+xml",
-  "image/x-icon",
-  "image/ico",
-];
-
 const acceptMap = {
   image: imageMimeTypes.join(", "),
   font: FONT_MIME_TYPES,
 };
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#unique_file_type_specifiers
-const acceptFileTypeSpecifier = (specifiers: string, file: File) => {
+export const acceptFileTypeSpecifier = (specifiers: string, file: File) => {
   const specifierArray = specifiers
     .split(",")
     .map((specifier) => specifier.trim());

--- a/apps/builder/app/builder/shared/assets/assets-shell.tsx
+++ b/apps/builder/app/builder/shared/assets/assets-shell.tsx
@@ -24,6 +24,7 @@ import { UploadIcon } from "@webstudio-is/icons";
 import {
   IDLE,
   isBlockedByBackdrop,
+  registerDrop,
   useExternalDragStateEffect,
   type ExternalMonitorDragState,
 } from "./drag-monitor";
@@ -114,6 +115,7 @@ export const AssetsShell = ({
         onDragEnter: () => setDropTargetState(OVER),
         onDragLeave: () => setDropTargetState(IDLE),
         onDrop: async ({ source }) => {
+          registerDrop();
           setMonitorState(IDLE);
           setDropTargetState(IDLE);
 

--- a/apps/builder/app/builder/shared/assets/assets-shell.tsx
+++ b/apps/builder/app/builder/shared/assets/assets-shell.tsx
@@ -18,7 +18,6 @@ import {
 import { dropTargetForExternal } from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
 import invariant from "tiny-invariant";
 import type { ContainsSource } from "@atlaskit/pragmatic-drag-and-drop/dist/types/public-utils/external/native-types";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { useUploadAsset } from "./use-assets";
 import { UploadIcon } from "@webstudio-is/icons";
 import {
@@ -38,10 +37,6 @@ type AssetsShellProps = {
 };
 
 const containsFilesOrUri = (parameter: ContainsSource) => {
-  if (false === isFeatureEnabled("assetDragSupport")) {
-    return false;
-  }
-
   return (
     containsFiles(parameter) || parameter.source.types.includes("text/uri-list")
   );

--- a/apps/builder/app/builder/shared/assets/drag-monitor.tsx
+++ b/apps/builder/app/builder/shared/assets/drag-monitor.tsx
@@ -1,0 +1,157 @@
+import { useStore } from "@nanostores/react";
+import { atom, computed } from "nanostores";
+import { useEffect, useState } from "react";
+import { monitorForExternal } from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
+import { preventUnhandled } from "@atlaskit/pragmatic-drag-and-drop/prevent-unhandled";
+import { containsFiles } from "@atlaskit/pragmatic-drag-and-drop/external/file";
+import type { ContainsSource } from "@atlaskit/pragmatic-drag-and-drop/dist/types/public-utils/external/native-types";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import { canvasApi } from "~/shared/canvas-api";
+import { useDebouncedCallback } from "use-debounce";
+
+import { $canvasIframeState } from "~/shared/nano-states";
+import invariant from "tiny-invariant";
+import { getAllElementsBoundingBox } from "~/shared/dom-utils";
+import { useEffectEvent } from "~/shared/hook-utils/effect-event";
+
+export const IDLE = 0;
+export const POTENTIAL = 1;
+
+export type ExternalMonitorDragState = typeof IDLE | typeof POTENTIAL;
+
+const monitorDragState = atom<ExternalMonitorDragState>(IDLE);
+const monitorCanvasDragState = atom<ExternalMonitorDragState>(IDLE);
+
+const externalDragState = computed(
+  [monitorDragState, monitorCanvasDragState],
+  (monitorDragState, monitorCanvasDragState) => {
+    return Math.max(
+      monitorDragState,
+      monitorCanvasDragState
+    ) as ExternalMonitorDragState;
+  }
+);
+
+const containsFilesOrUri = (parameter: ContainsSource) => {
+  return (
+    containsFiles(parameter) || parameter.source.types.includes("text/uri-list")
+  );
+};
+
+let usageCounter = 0;
+
+export const ExternalDragDropMonitor = () => {
+  const [refresh, setRefresh] = useState(0);
+
+  const handleBuilderOnDrop = useDebouncedCallback(() => {
+    monitorDragState.set(IDLE);
+  }, 300);
+
+  const handleCanvasOnDrop = useDebouncedCallback(() => {
+    monitorCanvasDragState.set(IDLE);
+  }, 300);
+
+  const preventUnhandledStop = useDebouncedCallback(() => {
+    preventUnhandled.stop();
+    canvasApi.preventUnhandled.stop();
+  }, 300);
+
+  useEffect(() => {
+    usageCounter += 1;
+
+    invariant(usageCounter === 1, "Monitor can be used only once per app");
+
+    return () => {
+      usageCounter -= 1;
+    };
+  }, []);
+
+  /**
+   * Allow URL drop for images only
+   */
+  // const containsByType = type === "image" ? containsFilesOrUri : containsFiles;
+
+  useEffect(() => {
+    if (false === canvasApi.isInitialized()) {
+      return $canvasIframeState.listen((state) => {
+        if (state === "ready") {
+          setRefresh((prev) => prev + 1);
+        }
+      });
+    }
+
+    const preventUnhandledStart = () => {
+      preventUnhandled.start();
+      canvasApi.preventUnhandled.start();
+    };
+
+    return combine(
+      monitorForExternal({
+        canMonitor: containsFilesOrUri,
+        onDragStart: () => {
+          preventUnhandledStart();
+          monitorDragState.set(POTENTIAL);
+          handleBuilderOnDrop.cancel();
+          preventUnhandledStop.cancel();
+        },
+        onDrop: () => {
+          handleBuilderOnDrop();
+          preventUnhandledStop();
+        },
+      }),
+      canvasApi.monitorForExternal({
+        canMonitor: containsFilesOrUri,
+        onDragStart: () => {
+          preventUnhandledStart();
+          monitorCanvasDragState.set(POTENTIAL);
+          handleCanvasOnDrop.cancel();
+          preventUnhandledStop.cancel();
+        },
+        onDrop: () => {
+          handleCanvasOnDrop();
+          preventUnhandledStop();
+        },
+      }),
+      () => {
+        return () => {
+          handleBuilderOnDrop.cancel();
+          preventUnhandledStop.cancel();
+
+          preventUnhandled.stop();
+          canvasApi.preventUnhandled.stop();
+          monitorDragState.set(IDLE);
+          monitorCanvasDragState.set(IDLE);
+        };
+      }
+    );
+  }, [handleBuilderOnDrop, handleCanvasOnDrop, preventUnhandledStop, refresh]);
+
+  return null;
+};
+
+export const useExternalDragState = () => {
+  const value = useStore(externalDragState);
+  return value;
+};
+
+export const useExternalDragStateEffect = (
+  callback: (state: ExternalMonitorDragState) => void
+) => {
+  const handleCallback = useEffectEvent(callback);
+
+  useEffect(() => {
+    return externalDragState.subscribe(handleCallback);
+  }, [handleCallback]);
+};
+
+export const isBlockedByBackdrop = (element: Element) => {
+  const elementRect = getAllElementsBoundingBox([element]);
+  const centerX = elementRect.left + elementRect.width / 2;
+  const centerY = elementRect.top + elementRect.height / 2;
+
+  // Get the element directly under the center of the target element
+  const topElement = document.elementFromPoint(centerX, centerY);
+  const isNotBlocked = element.contains(topElement) || topElement === element;
+
+  return false === isNotBlocked;
+};

--- a/apps/builder/app/builder/shared/assets/image-formats.ts
+++ b/apps/builder/app/builder/shared/assets/image-formats.ts
@@ -1,0 +1,49 @@
+import { nanoid } from "nanoid";
+
+const extensionToMime = new Map([
+  [".gif", "image/gif"],
+  [".ico", "image/x-icon"],
+  [".jpeg", "image/jpeg"],
+  [".jpg", "image/jpeg"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".webp", "image/webp"],
+] as const);
+
+const extensions = [...extensionToMime.keys()];
+
+export const imageMimeTypes = [...extensionToMime.values()];
+
+export const getImageNameAndType = (fileName: string) => {
+  const extension = extensions.find((ext) => fileName.endsWith(ext));
+
+  if (extension == null) {
+    return;
+  }
+
+  return [extensionToMime.get(extension)!, fileName] as const;
+};
+
+export const extractImageNameAndMimeTypeFromUrl = (url: URL) => {
+  const nameFromPath = url.pathname
+    .split("/")
+    .map(getImageNameAndType)
+    .filter(Boolean)[0];
+
+  if (nameFromPath != null) {
+    return nameFromPath;
+  }
+
+  const nameFromSearchParams = [...url.searchParams.values()]
+    .map(getImageNameAndType)
+    .filter(Boolean)[0];
+
+  if (nameFromSearchParams != null) {
+    return nameFromSearchParams;
+  }
+
+  // Any image format is suitable
+  const FALLBACK_URL_TYPE = "image/png";
+
+  return [FALLBACK_URL_TYPE, `${nanoid()}.png`] as const;
+};

--- a/apps/builder/app/builder/shared/image-manager/filename.tsx
+++ b/apps/builder/app/builder/shared/image-manager/filename.tsx
@@ -9,9 +9,10 @@ type FilenameProps = Omit<
 };
 
 export const Filename = ({ children, ...props }: FilenameProps) => {
-  const splitName = children.split(".");
-  const extension = splitName[splitName.length - 1];
-  const baseName = children.substr(0, children.length - extension.length - 1);
+  const parts = children.split(".");
+  const extension = parts.length > 1 ? parts.pop() : "";
+  const baseName = parts.join(".");
+
   return (
     <Flex>
       <DeprecatedText2 truncate {...props}>

--- a/apps/builder/app/builder/shared/image-manager/image.tsx
+++ b/apps/builder/app/builder/shared/image-manager/image.tsx
@@ -59,7 +59,7 @@ export const Image = ({ assetContainer, alt, width }: ImageProps) => {
         // when used inside an iframe.
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        webkitUserDrag: "none",
+        WebkitUserDrag: "none",
       }}
       key={asset.id}
       loader={imageLoader}

--- a/apps/builder/app/builder/shared/image-manager/image.tsx
+++ b/apps/builder/app/builder/shared/image-manager/image.tsx
@@ -53,6 +53,14 @@ export const Image = ({ assetContainer, alt, width }: ImageProps) => {
 
   return (
     <StyledWebstudioImage
+      style={{
+        // Prevent native image drag in Image Manager to avoid issues with monitorForExternal
+        // from @atlaskit/pragmatic-drag-and-drop, which incorrectly identifies it as an external drag operation
+        // when used inside an iframe.
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        webkitUserDrag: "none",
+      }}
       key={asset.id}
       loader={imageLoader}
       decoding={decoding}

--- a/apps/builder/app/routes/cgi.image.$name.ts
+++ b/apps/builder/app/routes/cgi.image.$name.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { createReadableStreamFromReadable } from "@remix-run/node";
 import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import env from "~/env/env.server";
+import { getImageNameAndType } from "~/builder/shared/assets/image-formats";
 
 // this route used as proxy for images to cloudflare endpoint
 // https://developers.cloudflare.com/fundamentals/get-started/reference/cdn-cgi-endpoint/
@@ -59,7 +60,14 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     });
   }
 
+  const [contentType] = getImageNameAndType(name) ?? ["image/png"];
+
   return new Response(
-    createReadableStreamFromReadable(createReadStream(filePath))
+    createReadableStreamFromReadable(createReadStream(filePath)),
+    {
+      headers: {
+        "content-type": contentType,
+      },
+    }
   );
 };

--- a/apps/builder/app/routes/rest.assets.$name.tsx
+++ b/apps/builder/app/routes/rest.assets.$name.tsx
@@ -3,6 +3,11 @@ import type { Asset } from "@webstudio-is/sdk";
 import { uploadFile } from "@webstudio-is/asset-uploader/index.server";
 import type { ActionData } from "~/builder/shared/assets";
 import { createAssetClient } from "~/shared/asset-client";
+import { z } from "zod";
+
+const UrlBody = z.object({
+  url: z.string(),
+});
 
 export const action = async (
   props: ActionFunctionArgs
@@ -15,11 +20,37 @@ export const action = async (
 
   try {
     if (request.method === "POST" && request.body !== null) {
-      const asset = await uploadFile(
-        params.name,
-        request.body,
-        createAssetClient()
-      );
+      let body = request.body;
+
+      const contentType = request.headers.get("Content-Type");
+
+      if (contentType?.includes("application/json")) {
+        const { url } = UrlBody.parse(await request.json());
+        const imageRequest = await fetch(url, {
+          method: "GET",
+          headers: {
+            // Image formats we support
+            Accept:
+              "image/jpeg,image/png,image/gif,image/webp,image/svg+xml,image/x-icon,image/ico",
+          },
+        });
+
+        if (false === imageRequest.ok) {
+          const error = await imageRequest.text();
+          const errors = `An error occurred while fetching the image at ${url}: ${error.slice(0, 500)}`;
+          throw new Error(errors);
+        }
+
+        if (imageRequest.body === null) {
+          throw new Error(
+            `An error occurred while fetching the image at ${url}: Image body is null`
+          );
+        }
+
+        body = imageRequest.body;
+      }
+
+      const asset = await uploadFile(params.name, body, createAssetClient());
       return {
         uploadedAssets: [asset],
       };

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -8,4 +8,3 @@ export const cssVars = false;
 export const filters = false;
 export const xmlElement = false;
 export const pasteFromWebflow = false;
-export const assetDragSupport = false;


### PR DESCRIPTION
## Description

https://github.com/webstudio-is/webstudio/assets/5077042/ea38835c-ec5c-4333-a982-f5bb9580d9e0

URLs can be dropped on Image Manager

+ small fixes.
- Files without extensions broke FileName control
- svg files were not shown on local builder after upload


## Steps for reproduction

Open Image Manager, drag urls


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
