### PR TITLE
experimental: add css shorthands utility

### DIFF
--- a/packages/css-data/src/shorthands.test.ts
+++ b/packages/css-data/src/shorthands.test.ts
@@ -1,0 +1,417 @@
+import { expect, test } from "@jest/globals";
+import { expandShorthands } from "./shorthands";
+
+test("expand border", () => {
+  expect(expandShorthands([["border", "1px solid red"]])).toEqual([
+    ["border-top-width", "1px"],
+    ["border-right-width", "1px"],
+    ["border-bottom-width", "1px"],
+    ["border-left-width", "1px"],
+    ["border-top-style", "solid"],
+    ["border-right-style", "solid"],
+    ["border-bottom-style", "solid"],
+    ["border-left-style", "solid"],
+    ["border-top-color", "red"],
+    ["border-right-color", "red"],
+    ["border-bottom-color", "red"],
+    ["border-left-color", "red"],
+  ]);
+  // logical
+  expect(expandShorthands([["border-inline", "1px solid red"]])).toEqual([
+    ["border-inline-start-width", "1px"],
+    ["border-inline-end-width", "1px"],
+    ["border-inline-start-style", "solid"],
+    ["border-inline-end-style", "solid"],
+    ["border-inline-start-color", "red"],
+    ["border-inline-end-color", "red"],
+  ]);
+  expect(expandShorthands([["border-block", "1px solid red"]])).toEqual([
+    ["border-block-start-width", "1px"],
+    ["border-block-end-width", "1px"],
+    ["border-block-start-style", "solid"],
+    ["border-block-end-style", "solid"],
+    ["border-block-start-color", "red"],
+    ["border-block-end-color", "red"],
+  ]);
+});
+
+test("expand border edges", () => {
+  expect(expandShorthands([["border-top", "1px solid red"]])).toEqual([
+    ["border-top-width", "1px"],
+    ["border-top-style", "solid"],
+    ["border-top-color", "red"],
+  ]);
+  expect(expandShorthands([["border-right", "1px solid red"]])).toEqual([
+    ["border-right-width", "1px"],
+    ["border-right-style", "solid"],
+    ["border-right-color", "red"],
+  ]);
+  expect(expandShorthands([["border-bottom", "1px solid red"]])).toEqual([
+    ["border-bottom-width", "1px"],
+    ["border-bottom-style", "solid"],
+    ["border-bottom-color", "red"],
+  ]);
+  expect(expandShorthands([["border-left", "1px solid red"]])).toEqual([
+    ["border-left-width", "1px"],
+    ["border-left-style", "solid"],
+    ["border-left-color", "red"],
+  ]);
+  // logical
+  expect(expandShorthands([["border-inline-start", "1px solid red"]])).toEqual([
+    ["border-inline-start-width", "1px"],
+    ["border-inline-start-style", "solid"],
+    ["border-inline-start-color", "red"],
+  ]);
+  expect(expandShorthands([["border-inline-end", "1px solid red"]])).toEqual([
+    ["border-inline-end-width", "1px"],
+    ["border-inline-end-style", "solid"],
+    ["border-inline-end-color", "red"],
+  ]);
+  expect(expandShorthands([["border-block-start", "1px solid red"]])).toEqual([
+    ["border-block-start-width", "1px"],
+    ["border-block-start-style", "solid"],
+    ["border-block-start-color", "red"],
+  ]);
+  expect(expandShorthands([["border-block-end", "1px solid red"]])).toEqual([
+    ["border-block-end-width", "1px"],
+    ["border-block-end-style", "solid"],
+    ["border-block-end-color", "red"],
+  ]);
+  // omit values
+  expect(expandShorthands([["border-top", "1px"]])).toEqual([
+    ["border-top-width", "1px"],
+    ["border-top-style", "initial"],
+    ["border-top-color", "initial"],
+  ]);
+  expect(expandShorthands([["border-top", "red"]])).toEqual([
+    ["border-top-width", "initial"],
+    ["border-top-style", "initial"],
+    ["border-top-color", "red"],
+  ]);
+});
+
+test("expand border types", () => {
+  expect(expandShorthands([["border-width", "1px"]])).toEqual([
+    ["border-top-width", "1px"],
+    ["border-right-width", "1px"],
+    ["border-bottom-width", "1px"],
+    ["border-left-width", "1px"],
+  ]);
+  expect(expandShorthands([["border-style", "solid"]])).toEqual([
+    ["border-top-style", "solid"],
+    ["border-right-style", "solid"],
+    ["border-bottom-style", "solid"],
+    ["border-left-style", "solid"],
+  ]);
+  expect(expandShorthands([["border-color", "red"]])).toEqual([
+    ["border-top-color", "red"],
+    ["border-right-color", "red"],
+    ["border-bottom-color", "red"],
+    ["border-left-color", "red"],
+  ]);
+  // logical
+  expect(expandShorthands([["border-inline-width", "1px"]])).toEqual([
+    ["border-inline-start-width", "1px"],
+    ["border-inline-end-width", "1px"],
+  ]);
+  expect(expandShorthands([["border-block-width", "1px"]])).toEqual([
+    ["border-block-start-width", "1px"],
+    ["border-block-end-width", "1px"],
+  ]);
+  expect(expandShorthands([["border-inline-style", "solid"]])).toEqual([
+    ["border-inline-start-style", "solid"],
+    ["border-inline-end-style", "solid"],
+  ]);
+  expect(expandShorthands([["border-block-style", "solid"]])).toEqual([
+    ["border-block-start-style", "solid"],
+    ["border-block-end-style", "solid"],
+  ]);
+  expect(expandShorthands([["border-inline-color", "red"]])).toEqual([
+    ["border-inline-start-color", "red"],
+    ["border-inline-end-color", "red"],
+  ]);
+  expect(expandShorthands([["border-block-color", "red"]])).toEqual([
+    ["border-block-start-color", "red"],
+    ["border-block-end-color", "red"],
+  ]);
+});
+
+test("expand border-radius", () => {
+  expect(expandShorthands([["border-radius", "5px"]])).toEqual([
+    ["border-top-left-radius", "5px"],
+    ["border-top-right-radius", "5px"],
+    ["border-bottom-right-radius", "5px"],
+    ["border-top-left-radius", "5px"],
+  ]);
+  expect(expandShorthands([["border-radius", "1px 2px 3px 4px"]])).toEqual([
+    ["border-top-left-radius", "1px"],
+    ["border-top-right-radius", "2px"],
+    ["border-bottom-right-radius", "3px"],
+    ["border-top-left-radius", "4px"],
+  ]);
+  expect(expandShorthands([["border-radius", "5px / 3px"]])).toEqual([
+    ["border-top-left-radius", "5px 3px"],
+    ["border-top-right-radius", "5px 3px"],
+    ["border-bottom-right-radius", "5px 3px"],
+    ["border-top-left-radius", "5px 3px"],
+  ]);
+  expect(expandShorthands([["border-radius", "5px 2px / 3px 4px"]])).toEqual([
+    ["border-top-left-radius", "5px 3px"],
+    ["border-top-right-radius", "2px 4px"],
+    ["border-bottom-right-radius", "5px 3px"],
+    ["border-top-left-radius", "2px 4px"],
+  ]);
+});
+
+test("expand outline", () => {
+  expect(expandShorthands([["outline", "1px solid red"]])).toEqual([
+    ["outline-width", "1px"],
+    ["outline-style", "solid"],
+    ["outline-color", "red"],
+  ]);
+});
+
+test("expand margin/padding", () => {
+  expect(expandShorthands([["margin", "5px"]])).toEqual([
+    ["margin-top", "5px"],
+    ["margin-right", "5px"],
+    ["margin-bottom", "5px"],
+    ["margin-left", "5px"],
+  ]);
+  expect(expandShorthands([["margin", "1px 2px"]])).toEqual([
+    ["margin-top", "1px"],
+    ["margin-right", "2px"],
+    ["margin-bottom", "1px"],
+    ["margin-left", "2px"],
+  ]);
+  expect(expandShorthands([["margin", "1px 2px 3px"]])).toEqual([
+    ["margin-top", "1px"],
+    ["margin-right", "2px"],
+    ["margin-bottom", "3px"],
+    ["margin-left", "2px"],
+  ]);
+  expect(expandShorthands([["margin", "1px 2px 3px 4px"]])).toEqual([
+    ["margin-top", "1px"],
+    ["margin-right", "2px"],
+    ["margin-bottom", "3px"],
+    ["margin-left", "4px"],
+  ]);
+  expect(expandShorthands([["padding", "5px"]])).toEqual([
+    ["padding-top", "5px"],
+    ["padding-right", "5px"],
+    ["padding-bottom", "5px"],
+    ["padding-left", "5px"],
+  ]);
+  // logical
+  expect(expandShorthands([["margin-inline", "5px"]])).toEqual([
+    ["margin-inline-start", "5px"],
+    ["margin-inline-end", "5px"],
+  ]);
+  expect(expandShorthands([["margin-inline", "1px 2px"]])).toEqual([
+    ["margin-inline-start", "1px"],
+    ["margin-inline-end", "2px"],
+  ]);
+  expect(expandShorthands([["margin-block", "5px"]])).toEqual([
+    ["margin-block-start", "5px"],
+    ["margin-block-end", "5px"],
+  ]);
+  expect(expandShorthands([["margin-block", "1px 2px"]])).toEqual([
+    ["margin-block-start", "1px"],
+    ["margin-block-end", "2px"],
+  ]);
+});
+
+test("expand inset", () => {
+  expect(expandShorthands([["inset", "5px"]])).toEqual([
+    ["top", "5px"],
+    ["right", "5px"],
+    ["bottom", "5px"],
+    ["left", "5px"],
+  ]);
+  expect(expandShorthands([["inset", "1px 2px"]])).toEqual([
+    ["top", "1px"],
+    ["right", "2px"],
+    ["bottom", "1px"],
+    ["left", "2px"],
+  ]);
+  expect(expandShorthands([["inset", "1px 2px 3px"]])).toEqual([
+    ["top", "1px"],
+    ["right", "2px"],
+    ["bottom", "3px"],
+    ["left", "2px"],
+  ]);
+  expect(expandShorthands([["inset", "1px 2px 3px 4px"]])).toEqual([
+    ["top", "1px"],
+    ["right", "2px"],
+    ["bottom", "3px"],
+    ["left", "4px"],
+  ]);
+  // logical
+  expect(expandShorthands([["inset-inline", "5px"]])).toEqual([
+    ["inset-inline-start", "5px"],
+    ["inset-inline-end", "5px"],
+  ]);
+  expect(expandShorthands([["inset-inline", "1px 2px"]])).toEqual([
+    ["inset-inline-start", "1px"],
+    ["inset-inline-end", "2px"],
+  ]);
+  expect(expandShorthands([["inset-block", "5px"]])).toEqual([
+    ["inset-block-start", "5px"],
+    ["inset-block-end", "5px"],
+  ]);
+  expect(expandShorthands([["inset-block", "1px 2px"]])).toEqual([
+    ["inset-block-start", "1px"],
+    ["inset-block-end", "2px"],
+  ]);
+});
+
+test("expand gap and grid-gap", () => {
+  expect(expandShorthands([["gap", "5px"]])).toEqual([
+    ["row-gap", "5px"],
+    ["column-gap", "5px"],
+  ]);
+  expect(expandShorthands([["gap", "1px 2px"]])).toEqual([
+    ["row-gap", "1px"],
+    ["column-gap", "2px"],
+  ]);
+  expect(expandShorthands([["grid-gap", "5px"]])).toEqual([
+    ["row-gap", "5px"],
+    ["column-gap", "5px"],
+  ]);
+  // remove grid- prefix
+  expect(expandShorthands([["grid-row-gap", "5px"]])).toEqual([
+    ["row-gap", "5px"],
+  ]);
+  expect(expandShorthands([["grid-column-gap", "5px"]])).toEqual([
+    ["column-gap", "5px"],
+  ]);
+});
+
+test("expand border-image", () => {
+  expect(
+    expandShorthands([
+      [
+        "border-image",
+        `url("/images/border.png") 27 23 / 50px 30px / 1rem round space`,
+      ],
+    ])
+  ).toEqual([
+    ["border-image-source", "url(/images/border.png)"],
+    ["border-image-slice", "27 23"],
+    ["border-image-width", "50px 30px"],
+    ["border-image-outset", "1rem"],
+    ["border-image-repeat", "round space"],
+  ]);
+  // shuffled
+  expect(
+    expandShorthands([
+      [
+        "border-image",
+        `round space url("/images/border.png") 27 23 / 50px 30px / 1rem`,
+      ],
+    ])
+  ).toEqual([
+    ["border-image-source", "url(/images/border.png)"],
+    ["border-image-slice", "27 23"],
+    ["border-image-width", "50px 30px"],
+    ["border-image-outset", "1rem"],
+    ["border-image-repeat", "round space"],
+  ]);
+  // invalid extra nodes and missing syntaxes
+  // can lead to infinite loop
+  expect(
+    expandShorthands([
+      [
+        "border-image",
+        `url("/images/border.png") 27 23 / 50px 30px / 1rem unknown keywords`,
+      ],
+    ])
+  ).toEqual([
+    ["border-image-source", "url(/images/border.png)"],
+    ["border-image-slice", "27 23"],
+    ["border-image-width", "50px 30px"],
+    ["border-image-outset", "1rem"],
+    ["border-image-repeat", "initial"],
+  ]);
+  // omitted types should be initial
+  expect(
+    expandShorthands([["border-image", `linear-gradient(red, blue) 27`]])
+  ).toEqual([
+    ["border-image-source", "linear-gradient(red,blue)"],
+    ["border-image-slice", "27"],
+    ["border-image-width", "initial"],
+    ["border-image-outset", "initial"],
+    ["border-image-repeat", "initial"],
+  ]);
+});
+
+test("expand place properties", () => {
+  expect(
+    expandShorthands([
+      ["place-content", "center"],
+      ["place-items", "center"],
+      ["place-self", "center"],
+    ])
+  ).toEqual([
+    ["align-content", "center"],
+    ["justify-content", "center"],
+    ["align-items", "center"],
+    ["justify-items", "center"],
+    ["align-self", "center"],
+    ["justify-self", "center"],
+  ]);
+  expect(
+    expandShorthands([
+      ["place-content", "start end"],
+      ["place-items", "start end"],
+      ["place-self", "start end"],
+    ])
+  ).toEqual([
+    ["align-content", "start"],
+    ["justify-content", "end"],
+    ["align-items", "start"],
+    ["justify-items", "end"],
+    ["align-self", "start"],
+    ["justify-self", "end"],
+  ]);
+});
+
+test.todo("animation");
+test.todo("container");
+test.todo("columns");
+test.todo("column-rule");
+test.todo("contain-intrinsic-size");
+test.todo("flex");
+test.todo("flex-flow");
+test.todo("font");
+test.todo("font-synthesis");
+test.todo("font-variant");
+test.todo("grid");
+test.todo("grid-area");
+test.todo("grid-column");
+test.todo("grid-row");
+test.todo("grid-template");
+test.todo("list-style");
+test.todo("mask");
+test.todo("mask-border");
+test.todo("offset");
+test.todo("scroll-margin");
+test.todo("scroll-padding");
+test.todo("scroll-timeline");
+test.todo("text-decoration");
+test.todo("text-emphasis");
+test.todo("transition");
+
+test.todo("all");
+test.todo("background - not used in webflow");
+test.todo("background-position-x - we use shorthand");
+test.todo("background-position-y - we use shorthand");
+test.todo("overflow - used in webflow");
+test.todo("overflow-x - we use shorthand");
+test.todo("overflow-y - we use shorthand");
+test.todo("text-wrap - webflow use shorthand");
+test.todo("white-space");
+test.todo("white-space-collapse");
+test.todo("translate - are these directly mappable to transform");
+test.todo("rotate");
+test.todo("scale");

--- a/packages/css-data/src/shorthands.ts
+++ b/packages/css-data/src/shorthands.ts
@@ -1,0 +1,360 @@
+import {
+  List,
+  parse,
+  lexer,
+  generate,
+  type CssNode,
+  type Value,
+} from "css-tree";
+
+const createValueNode = (data?: CssNode[]): Value => ({
+  type: "Value",
+  children: new List<CssNode>().fromArray(data ?? []),
+});
+
+const createInitialValueNode = (): Value => ({
+  type: "Value",
+  children: new List<CssNode>().appendData({
+    type: "Identifier",
+    name: "initial",
+  }),
+});
+
+const getValueList = (value: CssNode): CssNode[] => {
+  const children = "children" in value ? value.children?.toArray() : undefined;
+  return children ?? [value];
+};
+
+const splitBySlash = (list: List<CssNode>) => {
+  const lists: Array<undefined | CssNode[]> = [[]];
+  for (const node of list) {
+    if (node.type === "Operator" && node.value === "/") {
+      lists.push([]);
+    } else {
+      lists.at(-1)?.push(node);
+    }
+  }
+  return lists;
+};
+
+const parseUnordered = (syntaxes: string[], value: CssNode) => {
+  const matched = new Map<string, Value>();
+  const unprocessedSyntaxes = new Set(syntaxes);
+  let unprocessedNodes = getValueList(value);
+  let lastCursor = 0;
+  while (unprocessedSyntaxes.size > 0 && unprocessedNodes.length > 0) {
+    let nextCursor = lastCursor;
+    for (const syntax of unprocessedSyntaxes) {
+      const buffer = [];
+      let value: undefined | Value;
+      let cursor = 0;
+      for (const node of unprocessedNodes) {
+        buffer.push(node);
+        const newValue = createValueNode(buffer);
+        if (lexer.match(syntax, newValue).matched) {
+          value = newValue;
+          cursor = buffer.length;
+        }
+      }
+      if (value) {
+        matched.set(syntax, value);
+        unprocessedNodes = unprocessedNodes.slice(cursor);
+        unprocessedSyntaxes.delete(syntax);
+        nextCursor += cursor;
+      }
+    }
+    // last pass is the same as previous one
+    // which means infinite loop detected
+    if (lastCursor === nextCursor) {
+      break;
+    }
+    lastCursor = nextCursor;
+  }
+  return syntaxes.map((syntax) => matched.get(syntax));
+};
+
+/**
+ *
+ * border = <line-width> || <line-style> || <color>
+ *
+ */
+function* expandBorder(property: string, value: CssNode) {
+  switch (property) {
+    case "border":
+    case "border-inline":
+    case "border-inline-start":
+    case "border-inline-end":
+    case "border-block":
+    case "border-block-start":
+    case "border-block-end":
+    case "border-top":
+    case "border-right":
+    case "border-bottom":
+    case "border-left":
+    case "outline": {
+      const [width, style, color] = parseUnordered(
+        ["<line-width>", "<line-style>", "<color>"],
+        value
+      );
+      yield [`${property}-width`, width ?? createInitialValueNode()] as const;
+      yield [`${property}-style`, style ?? createInitialValueNode()] as const;
+      yield [`${property}-color`, color ?? createInitialValueNode()] as const;
+      break;
+    }
+    default:
+      yield [property, value] as const;
+  }
+}
+
+type GetProperty = (edge: string) => string;
+
+function* expandBox(getProperty: GetProperty, value: CssNode) {
+  const [top, right, bottom, left] = getValueList(value);
+  yield [getProperty("top"), top] as const;
+  yield [getProperty("right"), right ?? top] as const;
+  yield [getProperty("bottom"), bottom ?? top] as const;
+  yield [getProperty("left"), left ?? right ?? top] as const;
+}
+
+function* expandLogical(getProperty: GetProperty, value: CssNode) {
+  const [start, end] = getValueList(value);
+  yield [getProperty("start"), start] as const;
+  yield [getProperty("end"), end ?? start] as const;
+}
+
+function* expandEdges(property: string, value: CssNode) {
+  switch (property) {
+    case "margin":
+    case "padding":
+      yield* expandBox((edge) => `${property}-${edge}`, value);
+      break;
+    case "margin-inline":
+    case "padding-inline":
+    case "margin-block":
+    case "padding-block":
+      yield* expandLogical((edge) => `${property}-${edge}`, value);
+      break;
+    case "inset":
+      yield* expandBox((edge) => edge, value);
+      break;
+    case "inset-inline":
+    case "inset-block":
+      yield* expandLogical((edge) => `${property}-${edge}`, value);
+      break;
+    case "border-width":
+    case "border-style":
+    case "border-color": {
+      const type = property.split("-").pop() ?? ""; // width, style or color
+      yield* expandBox((edge) => `border-${edge}-${type}`, value);
+      break;
+    }
+    case "border-inline-width":
+    case "border-inline-style":
+    case "border-inline-color": {
+      const type = property.split("-").pop() ?? ""; // width, style or color
+      yield* expandLogical((edge) => `border-inline-${edge}-${type}`, value);
+      break;
+    }
+    case "border-block-width":
+    case "border-block-style":
+    case "border-block-color": {
+      const type = property.split("-").pop() ?? ""; // width, style or color
+      yield* expandLogical((edge) => `border-block-${edge}-${type}`, value);
+      break;
+    }
+    default:
+      yield [property, value] as const;
+  }
+}
+
+/**
+ *
+ * border-radius = <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
+ *
+ */
+function* expandBorderRadius(property: string, value: CssNode) {
+  if (property !== "border-radius") {
+    yield [property, value] as const;
+    return;
+  }
+  const firstRadius = [];
+  const secondRadius = [];
+  let hasSecondRadius = false;
+  for (const node of getValueList(value)) {
+    if (node.type === "Operator" && node.value === "/") {
+      hasSecondRadius = true;
+    } else if (hasSecondRadius) {
+      secondRadius.push(node);
+    } else {
+      firstRadius.push(node);
+    }
+  }
+  const topLeft = createValueNode();
+  const topRight = createValueNode();
+  const bottomRight = createValueNode();
+  const bottomLeft = createValueNode();
+  // add first radius
+  const [firstTopLeft, firstTopRight, firstBottomRight, firstBottomLeft] =
+    firstRadius;
+  topLeft.children.appendData(firstTopLeft);
+  topRight.children.appendData(firstTopRight ?? firstTopLeft);
+  bottomRight.children.appendData(firstBottomRight ?? firstTopLeft);
+  bottomLeft.children.appendData(
+    firstBottomLeft ?? firstTopRight ?? firstTopLeft
+  );
+  // add second radius if specified
+  const [secondTopLeft, secondTopRight, secondBottomRight, secondBottomLeft] =
+    secondRadius;
+  if (hasSecondRadius) {
+    topLeft.children.appendData(secondTopLeft);
+    topRight.children.appendData(secondTopRight ?? secondTopLeft);
+    bottomRight.children.appendData(secondBottomRight ?? secondTopLeft);
+    bottomLeft.children.appendData(
+      secondBottomLeft ?? secondTopRight ?? secondTopLeft
+    );
+  }
+  yield ["border-top-left-radius", topLeft] as const;
+  yield ["border-top-right-radius", topRight] as const;
+  yield ["border-bottom-right-radius", bottomRight] as const;
+  yield ["border-top-left-radius", bottomLeft] as const;
+}
+
+/**
+ *
+ * border-image =
+ *   <'border-image-source'>
+ *   || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]?
+ *   || <'border-image-repeat'>
+ * <border-image-source> = none | <image>
+ * <border-image-slice> = [ <number [0,∞]> | <percentage [0,∞]> ]{1,4} && fill?
+ * <border-image-width> = [ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4}
+ * <border-image-outset> = [ <length [0,∞]> | <number [0,∞]> ]{1,4}
+ * <border-image-repeat> = [ stretch | repeat | round | space ]{1,2}
+ *
+ */
+function* expandBorderImage(property: string, value: CssNode) {
+  if (property !== "border-image") {
+    yield [property, value] as const;
+    return;
+  }
+  const [source, config, repeat] = parseUnordered(
+    [
+      "<'border-image-source'>",
+      "<'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]?",
+      "<'border-image-repeat'>",
+    ],
+    value
+  );
+  let slice = createInitialValueNode();
+  let width = createInitialValueNode();
+  let outset = createInitialValueNode();
+  if (config) {
+    const [sliceNodes, widthNodes, outsetNodes] = splitBySlash(config.children);
+    if (sliceNodes && sliceNodes.length > 0) {
+      slice = createValueNode(sliceNodes);
+    }
+    if (widthNodes && widthNodes.length > 0) {
+      width = createValueNode(widthNodes);
+    }
+    if (outsetNodes && outsetNodes.length > 0) {
+      outset = createValueNode(outsetNodes);
+    }
+  }
+  yield ["border-image-source", source ?? createInitialValueNode()] as const;
+  yield ["border-image-slice", slice] as const;
+  yield ["border-image-width", width] as const;
+  yield ["border-image-outset", outset] as const;
+  yield ["border-image-repeat", repeat ?? createInitialValueNode()] as const;
+}
+
+function* expandGap(property: string, value: CssNode) {
+  switch (property) {
+    case "gap":
+    case "grid-gap": {
+      const [rowGap, columnGap] = getValueList(value);
+      yield ["row-gap", rowGap] as const;
+      yield ["column-gap", columnGap ?? rowGap] as const;
+      break;
+    }
+    case "grid-row-gap":
+      yield ["row-gap", value] as const;
+      break;
+    case "grid-column-gap":
+      yield ["column-gap", value] as const;
+      break;
+    default:
+      yield [property, value] as const;
+  }
+}
+
+function* expandPlace(property: string, value: CssNode) {
+  switch (property) {
+    case "place-content": {
+      const [align, justify] = getValueList(value);
+      yield ["align-content", align] as const;
+      yield ["justify-content", justify ?? align] as const;
+      break;
+    }
+    case "place-items": {
+      const [align, justify] = getValueList(value);
+      yield ["align-items", align] as const;
+      yield ["justify-items", justify ?? align] as const;
+      break;
+    }
+    case "place-self": {
+      const [align, justify] = getValueList(value);
+      yield ["align-self", align] as const;
+      yield ["justify-self", justify ?? align] as const;
+      break;
+    }
+    default:
+      yield [property, value] as const;
+  }
+}
+
+function* parseValue(property: string, value: string) {
+  try {
+    const ast = parse(value, { context: "value" });
+    yield [property, ast] as const;
+  } catch {
+    // empty block
+  }
+}
+
+export const expandShorthands = (
+  shorthands: [property: string, value: string][]
+) => {
+  const longhands: [property: string, value: string][] = [];
+  for (const [property, value] of shorthands) {
+    const generator = parseValue(property, value);
+
+    for (const [property, value] of generator) {
+      const generator = expandBorder(property, value);
+
+      for (const [property, value] of generator) {
+        const generator = expandEdges(property, value);
+
+        for (const [property, value] of generator) {
+          const generator = expandBorderRadius(property, value);
+
+          for (const [property, value] of generator) {
+            const generator = expandBorderImage(property, value);
+
+            for (const [property, value] of generator) {
+              const generator = expandGap(property, value);
+
+              for (const [property, value] of generator) {
+                const generator = expandPlace(property, value);
+
+                for (const [property, value] of generator) {
+                  longhands.push([property, generate(value)]);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return longhands;
+};

--- a/packages/css-data/src/shorthands.ts
+++ b/packages/css-data/src/shorthands.ts
@@ -37,6 +37,12 @@ const splitBySlash = (list: List<CssNode>) => {
   return lists;
 };
 
+/**
+ * Match the list of specified syntaxes with nodes
+ * Matches can be placed in different order than the list
+ * All specified matches are optional
+ * Value Definition Syntax use <Type> || <Type> operator for describe this
+ */
 const parseUnordered = (syntaxes: string[], value: CssNode) => {
   const matched = new Map<string, Value>();
   const unprocessedSyntaxes = new Set(syntaxes);

--- a/packages/css-data/src/shorthands.ts
+++ b/packages/css-data/src/shorthands.ts
@@ -78,7 +78,7 @@ const parseUnordered = (syntaxes: string[], value: CssNode) => {
  * border = <line-width> || <line-style> || <color>
  *
  */
-function* expandBorder(property: string, value: CssNode) {
+const expandBorder = function* (property: string, value: CssNode) {
   switch (property) {
     case "border":
     case "border-inline":
@@ -104,25 +104,25 @@ function* expandBorder(property: string, value: CssNode) {
     default:
       yield [property, value] as const;
   }
-}
+};
 
 type GetProperty = (edge: string) => string;
 
-function* expandBox(getProperty: GetProperty, value: CssNode) {
+const expandBox = function* (getProperty: GetProperty, value: CssNode) {
   const [top, right, bottom, left] = getValueList(value);
   yield [getProperty("top"), top] as const;
   yield [getProperty("right"), right ?? top] as const;
   yield [getProperty("bottom"), bottom ?? top] as const;
   yield [getProperty("left"), left ?? right ?? top] as const;
-}
+};
 
-function* expandLogical(getProperty: GetProperty, value: CssNode) {
+const expandLogical = function* (getProperty: GetProperty, value: CssNode) {
   const [start, end] = getValueList(value);
   yield [getProperty("start"), start] as const;
   yield [getProperty("end"), end ?? start] as const;
-}
+};
 
-function* expandEdges(property: string, value: CssNode) {
+const expandEdges = function* (property: string, value: CssNode) {
   switch (property) {
     case "margin":
     case "padding":
@@ -165,14 +165,14 @@ function* expandEdges(property: string, value: CssNode) {
     default:
       yield [property, value] as const;
   }
-}
+};
 
 /**
  *
  * border-radius = <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
  *
  */
-function* expandBorderRadius(property: string, value: CssNode) {
+const expandBorderRadius = function* (property: string, value: CssNode) {
   if (property !== "border-radius") {
     yield [property, value] as const;
     return;
@@ -217,7 +217,7 @@ function* expandBorderRadius(property: string, value: CssNode) {
   yield ["border-top-right-radius", topRight] as const;
   yield ["border-bottom-right-radius", bottomRight] as const;
   yield ["border-top-left-radius", bottomLeft] as const;
-}
+};
 
 /**
  *
@@ -232,7 +232,7 @@ function* expandBorderRadius(property: string, value: CssNode) {
  * <border-image-repeat> = [ stretch | repeat | round | space ]{1,2}
  *
  */
-function* expandBorderImage(property: string, value: CssNode) {
+const expandBorderImage = function* (property: string, value: CssNode) {
   if (property !== "border-image") {
     yield [property, value] as const;
     return;
@@ -265,9 +265,9 @@ function* expandBorderImage(property: string, value: CssNode) {
   yield ["border-image-width", width] as const;
   yield ["border-image-outset", outset] as const;
   yield ["border-image-repeat", repeat ?? createInitialValueNode()] as const;
-}
+};
 
-function* expandGap(property: string, value: CssNode) {
+const expandGap = function* (property: string, value: CssNode) {
   switch (property) {
     case "gap":
     case "grid-gap": {
@@ -285,9 +285,9 @@ function* expandGap(property: string, value: CssNode) {
     default:
       yield [property, value] as const;
   }
-}
+};
 
-function* expandPlace(property: string, value: CssNode) {
+const expandPlace = function* (property: string, value: CssNode) {
   switch (property) {
     case "place-content": {
       const [align, justify] = getValueList(value);
@@ -310,16 +310,16 @@ function* expandPlace(property: string, value: CssNode) {
     default:
       yield [property, value] as const;
   }
-}
+};
 
-function* parseValue(property: string, value: string) {
+const parseValue = function* (property: string, value: string) {
   try {
     const ast = parse(value, { context: "value" });
     yield [property, ast] as const;
   } catch {
     // empty block
   }
-}
+};
 
 export const expandShorthands = (
   shorthands: [property: string, value: string][]


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2647

Here added new utlity to expand css shorthand properties into longhands. Parsing is not trivial. csstree could help a lot with builtin lexer but it does not expose matched nodes on properties. Here we can leverage lexer to match big pieces and refined them into set of properties.

Supported following properties

- border
- border-radius
- border-image
- outline
- margin/padding
- inset
- gap
- place-content
- place-items
- place-self

Will do the rest in separate PRed them to `.env` file
