### PR TITLE
experimental: set collisionPadding for background panel to reduce panel jumps.

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -88,6 +88,12 @@ const Layer = (props: {
   return (
     <FloatingPanel
       title="Background"
+      // Background Panel is big, and the size differs when the tabs are changed.
+      // This results in the panel moving around when the tabs are changed.
+      // And sometimes, the tab moves away from the cursor, when the content change happens on the top.
+      // This is a workaround to prevent the panel from moving around too much when the tabs are changed from the popover trigger.
+      align="center"
+      collisionPadding={{ bottom: 200, top: 200 }}
       content={
         <BackgroundContent
           currentStyle={props.layerStyle}

--- a/apps/builder/app/builder/shared/floating-panel.tsx
+++ b/apps/builder/app/builder/shared/floating-panel.tsx
@@ -92,6 +92,11 @@ type FloatingPanelProps = {
   children: JSX.Element;
   open?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
+  // collisionPadding is the distance in pixels from the boundary edges where collision detection should occur.
+  collisionPadding?:
+    | number
+    | Partial<Record<"top" | "right" | "bottom" | "left", number>>;
+  align?: "start" | "center" | "end";
 };
 
 const contentStyle = css({
@@ -103,7 +108,9 @@ export const FloatingPanel = ({
   content,
   children,
   open,
+  align,
   onOpenChange,
+  collisionPadding,
 }: FloatingPanelProps) => {
   const { isOpen, handleOpenChange, triggerRef, sideOffset } = useLogic(
     open,
@@ -118,8 +125,9 @@ export const FloatingPanel = ({
       <FloatingPanelPopoverContent
         sideOffset={sideOffset}
         side="left"
-        align="start"
+        align={align ?? "start"}
         className={contentStyle()}
+        collisionPadding={collisionPadding}
       >
         {content}
         <FloatingPanelPopoverTitle>{title}</FloatingPanelPopoverTitle>


### PR DESCRIPTION
fixes #3511 

## Description

This is an experiment to see if setting `collisionPadding` can reduce the background panel jumps when switching tabs. `Popover` content always opens close to trigger, but there is no defined way to know when it repositions when the content is dynamically changed.
So, when the panel is opened close to the bottom of the screen, the panel moves away from arrows under the cursor. 

## Steps for reproduction

- Add a background
- Now, open the background panel and switch between the tabs.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
