### PR TITLE
experimental: Always finish up builder loading animation

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -61,7 +61,6 @@ import { canvasApi } from "~/shared/canvas-api";
 import { loadBuilderData, setBuilderData } from "~/shared/builder-data";
 import { WebstudioIcon } from "@webstudio-is/icons";
 import { computed } from "nanostores";
-import { useInterval } from "~/shared/hook-utils/use-interval";
 import { $dataLoadingState } from "~/shared/nano-states/builder";
 
 registerContainers();

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -283,47 +283,21 @@ const $loadingState = computed(
 const ProgressIndicator = ({ value }: { value: number }) => {
   const [isDone, setIsDone] = useState(false);
   const [fakeValue, setFakeValue] = useState(value);
-  // A maximum fake value we can grow to if the value is still 0, so that we don't get stuck at 0%.
-  const defaultFakeValueLimit = 50;
 
-  // This is an approximation of a real progress that should come from "value".
-  useInterval((timerId) => {
-    if (isDone) {
-      clearInterval(timerId);
-      return;
-    }
-    setFakeValue((fakeValue) => {
-      // - When real value is 0, we don't want to use it, because we don't want to get stuck at 0.
-      // - When real value is smaller than fake value, we don't want to use it because that would jump the progress back.
-      const minFakeValue =
-        value === 0 || value < fakeValue ? defaultFakeValueLimit : value;
-      fakeValue++;
-      return Math.min(fakeValue, minFakeValue);
-    });
-  }, 50);
-
-  // This will set the fake value to 100 so that the looading state can progress quickly.
-  // But then it will wait a bit until hiding the loading indicator entirely so that
-  // the user can see loading has finished.
-  // Otherwise when everything loaded to quickly, it will look like an aborted loading.
   useEffect(() => {
-    if (value < 100) {
-      return;
-    }
-    setFakeValue(100);
-
     const id = setTimeout(() => {
-      setIsDone(true);
-    }, 500);
-
-    return () => {
-      clearTimeout(id);
-    };
+      setFakeValue((fakeValue) => {
+        // Fetching data is the slowest part and we don't want to get stuck at 0% visually
+        return Math.max(value, 50);
+      });
+    }, 300);
+    return () => clearTimeout(id);
   }, [value]);
 
   if (isDone) {
     return;
   }
+
   return (
     <Flex
       direction="column"
@@ -343,9 +317,19 @@ const ProgressIndicator = ({ value }: { value: number }) => {
             drop-shadow(3px 3px 6px rgba(0, 0, 0, 0.7))
             brightness(${fakeValue}%)
           `,
+          transitionProperty: "filter",
+          transitionDuration: "500ms",
         }}
       />
-      <Progress value={fakeValue} />
+      <Progress
+        value={fakeValue}
+        transitionDuration="500ms"
+        onTransitionEnd={() => {
+          if (value === 100) {
+            setIsDone(true);
+          }
+        }}
+      />
     </Flex>
   );
 };

--- a/packages/design-system/src/components/progress.tsx
+++ b/packages/design-system/src/components/progress.tsx
@@ -1,5 +1,6 @@
 import { Root, Indicator } from "@radix-ui/react-progress";
 import { css, theme } from "../stitches.config";
+import type { TransitionEventHandler } from "react";
 
 const rootStyle = css({
   width: 200,
@@ -14,16 +15,18 @@ const indicatorStyle = css({
   width: "100%",
   height: "100%",
   background: theme.colors.brandBorderNavbar,
-  transitionDuration: "1000ms",
+  transitionDuration: "200ms",
   transitionProperty: "transform",
 });
 
 export const Progress = ({
   value,
   transitionDuration,
+  onTransitionEnd,
 }: {
   value: number;
   transitionDuration?: string;
+  onTransitionEnd?: TransitionEventHandler;
 }) => {
   return (
     <Root value={value} className={rootStyle()}>
@@ -33,6 +36,7 @@ export const Progress = ({
           transform: `translateX(-${100 - value}%)`,
           transitionDuration,
         }}
+        onTransitionEnd={onTransitionEnd}
       />
     </Root>
   );


### PR DESCRIPTION
## Description

When project loads very quickly, loading animation will end where it started at 0%. To make sure it always finishes at 100%, we need to let it do so.

Before
https://share.descript.com/view/TnNtRBlnxGq

After
https://share.descript.com/view/0WqOiBbVy8B

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
