### PR TITLE
fix: improve cli installing

### DIFF
--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -516,7 +516,7 @@ const Content = (props: {
 
 const deployTargets = {
   vercel: {
-    command: "npx@latest vercel",
+    command: "npx vercel@latest",
     docs: "https://vercel.com/docs/cli",
   },
   netlify: {

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -516,12 +516,12 @@ const Content = (props: {
 
 const deployTargets = {
   vercel: {
-    command: "npx vercel",
+    command: "npx@latest vercel",
     docs: "https://vercel.com/docs/cli",
   },
   netlify: {
     command: `
-npx netlify-cli login
+npx netlify-cli@latest login
 npx netlify-cli sites:create
 npx netlify-cli build
 npx netlify-cli deploy`,
@@ -535,7 +535,7 @@ const isDeployTargets = (value: string): value is DeployTargets =>
   Object.keys(deployTargets).includes(value);
 
 const ExportContent = () => {
-  const npxCommand = "npx webstudio";
+  const npxCommand = "npx webstudio@latest";
   const [deployTarget, setDeployTarget] = useState<DeployTargets>("vercel");
 
   return (

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -1,2 +1,0 @@
-# Explicitly include .npmrc https://docs.npmjs.com/cli/v9/using-npm/developers#keeping-files-out-of-your-package
-!.npmrc

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,7 +35,7 @@ To get started with the Webstudio CLI:
 1. Download and install the CLI using the following command:
 
    ```bash
-   npm install -g webstudio
+   npm install -g webstudio@latest
    ```
 
 1. Confirm the installation by checking the CLI version:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,9 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "license": "AGPL-3.0-or-later",
+  "engines": {
+    "node": ">=20.12"
+  },
   "dependencies": {
     "@clack/prompts": "^0.7.0",
     "@webstudio-is/http-client": "workspace:*",

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -251,6 +251,9 @@ export const prebuild = async (options: {
 
   await copyTemplates();
 
+  // force npm to install with not matching peer dependencies
+  await writeFile(join(cwd(), ".npmrc"), "force=true");
+
   for (const template of options.template) {
     // default template is already applied no need to copy twice
     if (template === "vanilla") {

--- a/packages/cli/templates/defaults/.npmrc
+++ b/packages/cli/templates/defaults/.npmrc
@@ -1,1 +1,0 @@
-force=true


### PR DESCRIPTION
- restrict node to >= 20.12 with "engines" field
- write .npmrc by code instead of copying from template because publish always cuts it from cli package
- use `npx webstudio@latest` to always install fresh cli if necessary