### PR TITLE
fix: Correct single-quoted attribute handling in Custom Code

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -92,9 +92,9 @@ const Style = ({ children, ...props }: Record<string, string | boolean>) => {
 export const CustomCode = () => {
   return (
     <>
-      <Script>{`console.log('HELLO')`}</Script>
-      {`\n`}
-      <meta property="saas:test" content="test"></meta>
+      <Script>{"console.log('HELLO')"}</Script>
+      {"\n"}
+      <meta property={"saas:test"} content={"test"}></meta>
     </>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -65,8 +65,8 @@ const Style = ({ children, ...props }: Record<string, string | boolean>) => {
 export const CustomCode = () => {
   return (
     <>
-      <Script>{`console.log('KittyGuardedZone')`}</Script>
-      {`\n`}
+      <Script>{"console.log('KittyGuardedZone')"}</Script>
+      {"\n"}
     </>
   );
 };

--- a/packages/cli/src/html-to-jsx.test.ts
+++ b/packages/cli/src/html-to-jsx.test.ts
@@ -176,7 +176,7 @@ test("Support styles", async () => {
 
 test("Supports symbols in attributes", async () => {
   const htmlCode = `
-  <script data-cf-beacon='{"token": "b4c645f1e8df4373a68a454a48673738"}'>
+  <script data-cf-beacon='{"token": "124"}'>
   </script>
 `;
   const result = await convertHtmlToJsxAndRenderToHtml(htmlCode);

--- a/packages/cli/src/html-to-jsx.test.ts
+++ b/packages/cli/src/html-to-jsx.test.ts
@@ -174,6 +174,16 @@ test("Support styles", async () => {
   expect(await formatHtml(htmlCode)).toBe(await formatHtml(result));
 });
 
+test("Supports symbols in attributes", async () => {
+  const htmlCode = `
+  <script data-cf-beacon='{"token": "b4c645f1e8df4373a68a454a48673738"}'>
+  </script>
+`;
+  const result = await convertHtmlToJsxAndRenderToHtml(htmlCode);
+
+  expect(await formatHtml(htmlCode)).toBe(await formatHtml(result));
+});
+
 test("Real User Script Works", async () => {
   const htmlCode = `
   <script type="text/javascript">

--- a/packages/cli/src/html-to-jsx.ts
+++ b/packages/cli/src/html-to-jsx.ts
@@ -96,7 +96,7 @@ const convertStyleString = (style: string) => {
   return JSON.stringify(res);
 };
 
-const escapeAttribute = (value: string) => JSON.stringify(value);
+const escape = (value: string) => JSON.stringify(value);
 
 const toAttrString = (name: string, value: string) => {
   const attName = name.toLowerCase();
@@ -110,7 +110,7 @@ const toAttrString = (name: string, value: string) => {
     return `${jsxName}={${convertStyleString(value)}}`;
   }
 
-  return `${jsxName}={${escapeAttribute(value)}}`;
+  return `${jsxName}={${escape(value)}}`;
 };
 
 const attributesToString = (attributes: [string, string][]) =>
@@ -131,14 +131,6 @@ const convertTagName = (tagName: string) => {
   return tag;
 };
 
-const escapeValue = (value: string) =>
-  value
-    .replace(/\\/g, "\\\\")
-    .replace(/`/g, "\\`")
-    .replace(/\$/g, "\\$")
-    .replace(/\r/g, "\\r")
-    .replace(/\n/g, "\\n");
-
 export const htmlToJsx = (html: string) => {
   const parsedHtml = parseFragment(html, { scriptingEnabled: false });
 
@@ -147,9 +139,9 @@ export const htmlToJsx = (html: string) => {
   for (const walkNode of walkChildNodes(parsedHtml)) {
     switch (walkNode.type) {
       case "text": {
-        const escapedValue = escapeValue(walkNode.value);
+        const escapedValue = escape(walkNode.value);
 
-        result += escapedValue ? "{`" + escapedValue + "`}" : "";
+        result += escapedValue ? "{" + escapedValue + "}" : "";
         break;
       }
 

--- a/packages/cli/src/html-to-jsx.ts
+++ b/packages/cli/src/html-to-jsx.ts
@@ -96,6 +96,8 @@ const convertStyleString = (style: string) => {
   return JSON.stringify(res);
 };
 
+const escapeAttribute = (value: string) => JSON.stringify(value);
+
 const toAttrString = (name: string, value: string) => {
   const attName = name.toLowerCase();
   const jsxName = attName === "class" ? "className" : attName;
@@ -108,7 +110,7 @@ const toAttrString = (name: string, value: string) => {
     return `${jsxName}={${convertStyleString(value)}}`;
   }
 
-  return `${jsxName}="${value}"`;
+  return `${jsxName}={${escapeAttribute(value)}}`;
 };
 
 const attributesToString = (attributes: [string, string][]) =>


### PR DESCRIPTION
## Description

Following code in Project Setting Custom Code 

```
<script data-cf-beacon='{"token": "123"}'>
```
failed on build

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
