### PR TITLE
fix: lint weird cases in expressions

### DIFF
--- a/packages/sdk/src/expression.test.ts
+++ b/packages/sdk/src/expression.test.ts
@@ -31,14 +31,26 @@ describe("lint expression", () => {
 
   test("output parse error as diagnostic", () => {
     expect(lintExpression({ expression: `a + ` })).toEqual([
-      error(4, 4, "Unexpected token (1:4)"),
+      error(4, 4, "Unexpected token"),
     ]);
   });
 
   test("restrict expression syntax", () => {
     expect(lintExpression({ expression: `var a = 1` })).toEqual([
-      error(0, 0, "Unexpected token (1:0)"),
+      error(0, 0, "Unexpected token"),
     ]);
+  });
+
+  test("lint whole expression instead of only first valid part", () => {
+    expect(
+      lintExpression({ expression: `a""`, availableVariables: new Set(["a"]) })
+    ).toEqual([error(1, 1, `Unexpected token`)]);
+    expect(
+      lintExpression({
+        expression: `/movie/{{CollectionItem['title']}}\n`,
+        availableVariables: new Set([""]),
+      })
+    ).toEqual([error(7, 7, `Unexpected token`)]);
   });
 
   test("supports accessing variable fields", () => {
@@ -76,7 +88,7 @@ describe("lint expression", () => {
       lintExpression({
         expression: "`my template",
       })
-    ).toEqual([error(1, 1, "Unterminated template (1:1)")]);
+    ).toEqual([error(1, 1, "Unterminated template")]);
   });
 
   test("supports parentheses", () => {
@@ -158,7 +170,7 @@ describe("lint expression", () => {
 
   test(`forbid "yield" keyword`, () => {
     expect(lintExpression({ expression: ` yield 1` })).toEqual([
-      error(1, 1, `The keyword 'yield' is reserved (1:1)`),
+      error(1, 1, `The keyword 'yield' is reserved`),
     ]);
   });
 

--- a/packages/sdk/src/expression.ts
+++ b/packages/sdk/src/expression.ts
@@ -27,8 +27,9 @@ export const lintExpression = ({
   const addError = (message: string) => {
     return (node: Expression) => {
       diagnostics.push({
-        from: node.start,
-        to: node.end,
+        // tune error position after wrapping expression with parentheses
+        from: node.start - 1,
+        to: node.end - 1,
         severity: "error",
         message: message,
       });
@@ -45,7 +46,10 @@ export const lintExpression = ({
     return diagnostics;
   }
   try {
-    const root = parseExpressionAt(expression, 0, {
+    // wrap expression with parentheses to force acorn parse whole expression
+    // instead of just first valid part
+    // https://github.com/acornjs/acorn/tree/master/acorn
+    const root = parseExpressionAt(`(${expression})`, 0, {
       ecmaVersion: "latest",
       // support parsing import to forbid explicitly
       sourceType: "module",
@@ -98,10 +102,13 @@ export const lintExpression = ({
   } catch (error) {
     const castedError = error as { message: string; pos: number };
     diagnostics.push({
-      from: castedError.pos,
-      to: castedError.pos,
+      // tune error position after wrapping expression with parentheses
+      from: castedError.pos - 1,
+      to: castedError.pos - 1,
       severity: "error",
-      message: castedError.message,
+      // trim auto generated error location
+      // to not conflict with tuned position
+      message: castedError.message.replaceAll(/\s+\(\d+:\d+\)$/g, ""),
     });
   }
   return diagnostics;


### PR DESCRIPTION
Looks like acorn skip thes rest of the input after successfully parsing expression. This resulted in weird syntax errors our linter allow user to enter.

The fix is simple, force acorn to consider whole input as expression by wrapping with parentheses. Though it also requires tuning diagnostics position.