### PR TITLE
fix: Properties like animation-name were receiving unneeded px suffix

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
@@ -3,9 +3,9 @@ import type {
   StyleValue,
   InvalidValue,
 } from "@webstudio-is/css-engine";
+import { units, properties, parseCssValue } from "@webstudio-is/css-data";
 import type { IntermediateStyleValue } from "./css-value-input";
 import { evaluateMath } from "./evaluate-math";
-import { units, parseCssValue } from "@webstudio-is/css-data";
 import { toKebabCase } from "../keyword-utils";
 
 const unitsList = Object.values(units).flat();
@@ -23,22 +23,32 @@ export const parseIntermediateOrInvalidValue = (
     };
   }
 
-  // Try value with existing or fallback unit
-  const unit = "unit" in styleValue ? styleValue.unit ?? "px" : "px";
-  let styleInput = parseCssValue(property, `${value}${unit}`);
+  const valueInfo = properties[property as keyof typeof properties];
 
-  if (styleInput.type !== "invalid") {
-    return styleInput;
+  // - When user enters a number, we don't know if its a valid unit value,
+  // so we are going to parse it with a unit and if its not invalid - we take it.
+  // - When value can be a custom-ident or a string - we can't do that test, because its going to be
+  // valid and we will end up adding unit to a user string.
+  if (
+    valueInfo.types.includes("string") === false &&
+    valueInfo.types.includes("custom-ident") === false
+  ) {
+    const testUnit = "unit" in styleValue ? styleValue.unit ?? "px" : "px";
+    const styleInput = parseCssValue(property, `${value}${testUnit}`);
+
+    if (styleInput.type !== "invalid") {
+      return styleInput;
+    }
   }
 
   // Probably value is already valid, use it
-  styleInput = parseCssValue(property, value);
+  let styleInput = parseCssValue(property, value);
 
   if (styleInput.type !== "invalid") {
     return styleInput;
   }
 
-  if (unit === "number") {
+  if ("unit" in styleValue && styleValue.unit === "number") {
     // Most css props supports 0 as unitless value, but not other numbers.
     // Its possible that we had { value: 0, unit: "number" } and value has changed
     // Lets try to parse it as px value

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
@@ -30,8 +30,8 @@ export const parseIntermediateOrInvalidValue = (
   // - When value can be a custom-ident or a string - we can't do that test, because its going to be
   // valid and we will end up adding unit to a user string.
   if (
-    valueInfo.types.includes("string") === false &&
-    valueInfo.types.includes("custom-ident") === false
+    valueInfo.types.flat().includes("string") === false &&
+    valueInfo.types.flat().includes("custom-ident") === false
   ) {
     const testUnit = "unit" in styleValue ? styleValue.unit ?? "px" : "px";
     const styleInput = parseCssValue(property, `${value}${testUnit}`);

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -310,17 +310,14 @@ for (property in filteredProperties) {
   const config = filteredProperties[property];
   // collect node types to improve parsing of css values
   const unitGroups = new Set<customData.UnitGroup>();
-  const types = new Set();
+  const types = new Set<customData.RawPropertyData["types"][number]>();
   walkSyntax(config.syntax, (node) => {
     if (node.type === "Type") {
-      if (
-        customData.valueTypes.includes(
-          node.name as customData.RawPropertyData["types"][number]
-        ) === false
-      ) {
+      const name = node.name as customData.RawPropertyData["types"][number];
+      if (customData.valueTypes.includes(name) === false) {
         throw Error(`Unknown value type "${node.name}"`);
       }
-      types.add(node.name);
+      types.add(name);
       if (node.name === "integer" || node.name === "number") {
         unitGroups.add("number");
         types.add("number");

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -300,7 +300,6 @@ for (property in filteredProperties) {
       types.add(name);
       if (node.name === "integer" || node.name === "number") {
         unitGroups.add("number");
-        types.add("number");
         return;
       }
 

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -310,12 +310,23 @@ for (property in filteredProperties) {
   const config = filteredProperties[property];
   // collect node types to improve parsing of css values
   const unitGroups = new Set<customData.UnitGroup>();
+  const types = new Set();
   walkSyntax(config.syntax, (node) => {
     if (node.type === "Type") {
+      if (
+        customData.valueTypes.includes(
+          node.name as customData.RawPropertyData["types"][number]
+        ) === false
+      ) {
+        throw Error(`Unknown value type "${node.name}"`);
+      }
+      types.add(node.name);
       if (node.name === "integer" || node.name === "number") {
         unitGroups.add("number");
+        types.add("number");
         return;
       }
+
       // type names match unit groups
       if (node.name in units) {
         unitGroups.add(node.name as customData.UnitGroup);
@@ -341,6 +352,7 @@ for (property in filteredProperties) {
         ?.dayPercentage || 0,
 
     appliesTo: patchAppliesTo(property, config),
+    types: Array.from(types),
   };
 }
 

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -14,7 +14,6 @@ import type {
   UnitValue,
   UnparsedValue,
 } from "@webstudio-is/css-engine";
-import { popularityIndex } from "../src/popularity-index";
 import * as customData from "../src/custom-data";
 
 const units: Record<customData.UnitGroup, Array<string>> = {
@@ -25,7 +24,7 @@ const units: Record<customData.UnitGroup, Array<string>> = {
 };
 
 type Property = keyof typeof properties;
-type Value = (typeof properties)[Property] & { alsoAppliesTo?: Array<string> };
+type Value = (typeof properties)[Property];
 
 const inheritValue = {
   type: "keyword",
@@ -286,25 +285,6 @@ const filteredProperties: FilteredProperties = (() => {
 
 const propertiesData = { ...customData.propertiesData };
 
-const patchAppliesTo = (property: Property, config: Value) => {
-  // see https://github.com/mdn/data/issues/585 alignItems and justifyItems have appliesTo = "allElements"
-  // this specification https://www.w3.org/TR/css-align-3/  - "block containers", "grid containers", "flex containers"
-  // chrome devtools check grid or flex here https://github.com/ChromeDevTools/devtools-frontend/blob/354fb0fd3fc0a4af43ef760450e7d644d0e04daf/front_end/panels/elements/CSSRuleValidator.ts#L374
-  // our opinion is that it must be "grid containers", "flex containers"
-  if (property === "align-items" || property === "justify-items") {
-    if (config.appliesto !== "allElements") {
-      throw new Error(
-        "Specification has changed, please check and update the code"
-      );
-    }
-
-    // flexContainersGridContainers not exists in mdn-data, it's our custom value
-    return "flexContainersGridContainers";
-  }
-
-  return config.appliesto;
-};
-
 let property: Property;
 for (property in filteredProperties) {
   const config = filteredProperties[property];
@@ -344,11 +324,6 @@ for (property in filteredProperties) {
     unitGroups: Array.from(unitGroups),
     inherited: config.inherited,
     initial: parseInitialValue(property, config.initial, unitGroups),
-    popularity:
-      popularityIndex.find((data) => data.property === property)
-        ?.dayPercentage || 0,
-
-    appliesTo: patchAppliesTo(property, config),
     types: Array.from(types),
   };
 }

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -7,8 +7,7 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.61281794,
-    appliesTo: "allElements",
+    types: [],
   },
   MozOsxFontSmoothing: {
     unitGroups: [],
@@ -17,8 +16,7 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "allElements",
+    types: [],
   },
   accentColor: {
     unitGroups: [],
@@ -27,8 +25,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00030097,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   alignContent: {
@@ -38,8 +34,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.2430101,
-    appliesTo: "multilineFlexContainers",
     types: [],
   },
   alignItems: {
@@ -49,8 +43,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.71654912,
-    appliesTo: "flexContainersGridContainers",
     types: [],
   },
   alignSelf: {
@@ -60,8 +52,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.43732689,
-    appliesTo: "flexItemsGridItemsAndAbsolutelyPositionedBoxes",
     types: [],
   },
   alignTracks: {
@@ -71,8 +61,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0,
-    appliesTo: "gridContainersWithMasonryLayoutInTheirBlockAxis",
     types: [],
   },
   animationComposition: {
@@ -82,8 +70,6 @@ export const properties = {
       type: "keyword",
       value: "replace",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["single-animation-composition"],
   },
   animationDelay: {
@@ -94,8 +80,6 @@ export const properties = {
       unit: "s",
       value: 0,
     },
-    popularity: 0.27086537,
-    appliesTo: "allElementsAndPseudos",
     types: ["time"],
   },
   animationDirection: {
@@ -105,8 +89,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.11739459,
-    appliesTo: "allElementsAndPseudos",
     types: [],
   },
   animationDuration: {
@@ -117,8 +99,6 @@ export const properties = {
       unit: "s",
       value: 0,
     },
-    popularity: 0.4062731,
-    appliesTo: "allElementsAndPseudos",
     types: ["time"],
   },
   animationFillMode: {
@@ -128,8 +108,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.2785038,
-    appliesTo: "allElementsAndPseudos",
     types: [],
   },
   animationIterationCount: {
@@ -140,8 +118,6 @@ export const properties = {
       unit: "number",
       value: 1,
     },
-    popularity: 0.21759716,
-    appliesTo: "allElementsAndPseudos",
     types: ["number"],
   },
   animationName: {
@@ -151,8 +127,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.40320939,
-    appliesTo: "allElementsAndPseudos",
     types: ["custom-ident", "string"],
   },
   animationPlayState: {
@@ -162,8 +136,6 @@ export const properties = {
       type: "keyword",
       value: "running",
     },
-    popularity: 0.07996997,
-    appliesTo: "allElementsAndPseudos",
     types: [],
   },
   animationTimingFunction: {
@@ -173,8 +145,6 @@ export const properties = {
       type: "keyword",
       value: "ease",
     },
-    popularity: 0.41317969,
-    appliesTo: "allElementsAndPseudos",
     types: [],
   },
   animationTimeline: {
@@ -184,8 +154,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 4e-8,
-    appliesTo: "allElements",
     types: ["custom-ident", "string"],
   },
   appearance: {
@@ -195,8 +163,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.24468974,
-    appliesTo: "allElements",
     types: [],
   },
   aspectRatio: {
@@ -206,8 +172,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.07243677,
-    appliesTo: "allElementsExceptInlineBoxesAndInternalRubyOrTableBoxes",
     types: ["number"],
   },
   backdropFilter: {
@@ -217,8 +181,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.0728427,
-    appliesTo: "allElementsSVGContainerElements",
     types: ["url"],
   },
   backfaceVisibility: {
@@ -228,8 +190,6 @@ export const properties = {
       type: "keyword",
       value: "visible",
     },
-    popularity: 0.19792557,
-    appliesTo: "transformableElements",
     types: [],
   },
   backgroundAttachment: {
@@ -239,8 +199,6 @@ export const properties = {
       type: "keyword",
       value: "scroll",
     },
-    popularity: 0.08164946,
-    appliesTo: "allElements",
     types: [],
   },
   backgroundBlendMode: {
@@ -250,8 +208,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.01578865,
-    appliesTo: "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
     types: [],
   },
   backgroundClip: {
@@ -261,8 +217,6 @@ export const properties = {
       type: "keyword",
       value: "border-box",
     },
-    popularity: 0.36203159,
-    appliesTo: "allElements",
     types: [],
   },
   backgroundColor: {
@@ -272,8 +226,6 @@ export const properties = {
       type: "keyword",
       value: "transparent",
     },
-    popularity: 0.89693959,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   backgroundImage: {
@@ -283,8 +235,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.78519153,
-    appliesTo: "allElements",
     types: ["url"],
   },
   backgroundOrigin: {
@@ -294,8 +244,6 @@ export const properties = {
       type: "keyword",
       value: "padding-box",
     },
-    popularity: 0.0847006,
-    appliesTo: "allElements",
     types: [],
   },
   backgroundPosition: {
@@ -316,8 +264,6 @@ export const properties = {
         },
       ],
     },
-    popularity: 0.76724967,
-    appliesTo: "allElements",
     types: ["length", "percentage"],
   },
   backgroundPositionX: {
@@ -328,8 +274,6 @@ export const properties = {
       unit: "%",
       value: 0,
     },
-    popularity: 0.08951679,
-    appliesTo: "allElements",
     types: ["length", "percentage"],
   },
   backgroundPositionY: {
@@ -340,8 +284,6 @@ export const properties = {
       unit: "%",
       value: 0,
     },
-    popularity: 0.06759137,
-    appliesTo: "allElements",
     types: ["length", "percentage"],
   },
   backgroundRepeat: {
@@ -351,8 +293,6 @@ export const properties = {
       type: "keyword",
       value: "repeat",
     },
-    popularity: 0.72870191,
-    appliesTo: "allElements",
     types: [],
   },
   backgroundSize: {
@@ -362,8 +302,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.73157126,
-    appliesTo: "allElements",
     types: ["length", "percentage"],
   },
   blockOverflow: {
@@ -373,8 +311,6 @@ export const properties = {
       type: "keyword",
       value: "clip",
     },
-    popularity: 0,
-    appliesTo: "blockContainers",
     types: ["string"],
   },
   blockSize: {
@@ -384,8 +320,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00226404,
-    appliesTo: "sameAsWidthAndHeight",
     types: ["length", "percentage"],
   },
   borderBlockColor: {
@@ -395,8 +329,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.00012849,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   borderBlockStyle: {
@@ -406,8 +338,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.0003145,
-    appliesTo: "allElements",
     types: [],
   },
   borderBlockWidth: {
@@ -417,8 +347,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.0003078,
-    appliesTo: "allElements",
     types: ["length"],
   },
   borderBlockEndColor: {
@@ -428,8 +356,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.00172099,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   borderBlockEndStyle: {
@@ -439,8 +365,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00169793,
-    appliesTo: "allElements",
     types: [],
   },
   borderBlockEndWidth: {
@@ -450,8 +374,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.00170225,
-    appliesTo: "allElements",
     types: ["length"],
   },
   borderBlockStartColor: {
@@ -461,8 +383,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.00170188,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   borderBlockStartStyle: {
@@ -472,8 +392,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00168772,
-    appliesTo: "allElements",
     types: [],
   },
   borderBlockStartWidth: {
@@ -483,8 +401,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.00169412,
-    appliesTo: "allElements",
     types: ["length"],
   },
   borderBottomColor: {
@@ -494,8 +410,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.42283564,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   borderBottomLeftRadius: {
@@ -506,8 +420,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.51220741,
-    appliesTo: "allElementsUAsNotRequiredWhenCollapse",
     types: ["length", "percentage"],
   },
   borderBottomRightRadius: {
@@ -518,8 +430,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.49744373,
-    appliesTo: "allElementsUAsNotRequiredWhenCollapse",
     types: ["length", "percentage"],
   },
   borderBottomStyle: {
@@ -529,8 +439,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.17956288,
-    appliesTo: "allElements",
     types: [],
   },
   borderBottomWidth: {
@@ -540,8 +448,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.24668981,
-    appliesTo: "allElements",
     types: ["length"],
   },
   borderCollapse: {
@@ -551,8 +457,6 @@ export const properties = {
       type: "keyword",
       value: "separate",
     },
-    popularity: 0.47856821,
-    appliesTo: "tableElements",
     types: [],
   },
   borderEndEndRadius: {
@@ -563,8 +467,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.00029065,
-    appliesTo: "allElementsUAsNotRequiredWhenCollapse",
     types: ["length", "percentage"],
   },
   borderEndStartRadius: {
@@ -575,8 +477,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.0003058,
-    appliesTo: "allElementsUAsNotRequiredWhenCollapse",
     types: ["length", "percentage"],
   },
   borderImageOutset: {
@@ -587,8 +487,6 @@ export const properties = {
       unit: "number",
       value: 0,
     },
-    popularity: 0.00458637,
-    appliesTo: "allElementsExceptTableElementsWhenCollapse",
     types: ["length", "number"],
   },
   borderImageRepeat: {
@@ -598,8 +496,6 @@ export const properties = {
       type: "keyword",
       value: "stretch",
     },
-    popularity: 0.00685817,
-    appliesTo: "allElementsExceptTableElementsWhenCollapse",
     types: [],
   },
   borderImageSlice: {
@@ -610,8 +506,6 @@ export const properties = {
       unit: "%",
       value: 100,
     },
-    popularity: 0.0093669,
-    appliesTo: "allElementsExceptTableElementsWhenCollapse",
     types: ["number", "percentage"],
   },
   borderImageSource: {
@@ -621,8 +515,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00991835,
-    appliesTo: "allElementsExceptTableElementsWhenCollapse",
     types: ["url"],
   },
   borderImageWidth: {
@@ -633,8 +525,6 @@ export const properties = {
       unit: "number",
       value: 1,
     },
-    popularity: 0.0072772,
-    appliesTo: "allElementsExceptTableElementsWhenCollapse",
     types: ["length", "percentage", "number"],
   },
   borderInlineColor: {
@@ -644,8 +534,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.00007844,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   borderInlineStyle: {
@@ -655,8 +543,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00031147,
-    appliesTo: "allElements",
     types: [],
   },
   borderInlineWidth: {
@@ -666,8 +552,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.0002956,
-    appliesTo: "allElements",
     types: ["length"],
   },
   borderInlineEndColor: {
@@ -677,8 +561,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.00196849,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   borderInlineEndStyle: {
@@ -688,8 +570,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00171907,
-    appliesTo: "allElements",
     types: [],
   },
   borderInlineEndWidth: {
@@ -699,8 +579,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.0051498,
-    appliesTo: "allElements",
     types: ["length"],
   },
   borderInlineStartColor: {
@@ -710,8 +588,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.00196928,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   borderInlineStartStyle: {
@@ -721,8 +597,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00177637,
-    appliesTo: "allElements",
     types: [],
   },
   borderInlineStartWidth: {
@@ -732,8 +606,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.00438625,
-    appliesTo: "allElements",
     types: ["length"],
   },
   borderLeftColor: {
@@ -743,8 +615,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.30754028,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   borderLeftStyle: {
@@ -754,8 +624,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.06120178,
-    appliesTo: "allElements",
     types: [],
   },
   borderLeftWidth: {
@@ -765,8 +633,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.17181793,
-    appliesTo: "allElements",
     types: ["length"],
   },
   borderRightColor: {
@@ -776,8 +642,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.29336595,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   borderRightStyle: {
@@ -787,8 +651,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.06714237,
-    appliesTo: "allElements",
     types: [],
   },
   borderRightWidth: {
@@ -798,8 +660,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.17940634,
-    appliesTo: "allElements",
     types: ["length"],
   },
   borderSpacing: {
@@ -810,8 +670,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.37217618,
-    appliesTo: "tableElements",
     types: ["length"],
   },
   borderStartEndRadius: {
@@ -822,8 +680,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.00029494,
-    appliesTo: "allElementsUAsNotRequiredWhenCollapse",
     types: ["length", "percentage"],
   },
   borderStartStartRadius: {
@@ -834,8 +690,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.00028405,
-    appliesTo: "allElementsUAsNotRequiredWhenCollapse",
     types: ["length", "percentage"],
   },
   borderTopColor: {
@@ -845,8 +699,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.43342948,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   borderTopLeftRadius: {
@@ -857,8 +709,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.50859807,
-    appliesTo: "allElementsUAsNotRequiredWhenCollapse",
     types: ["length", "percentage"],
   },
   borderTopRightRadius: {
@@ -869,8 +719,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.50073217,
-    appliesTo: "allElementsUAsNotRequiredWhenCollapse",
     types: ["length", "percentage"],
   },
   borderTopStyle: {
@@ -880,8 +728,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.16269446,
-    appliesTo: "allElements",
     types: [],
   },
   borderTopWidth: {
@@ -891,8 +737,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.21953437,
-    appliesTo: "allElements",
     types: ["length"],
   },
   bottom: {
@@ -902,8 +746,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.8243869,
-    appliesTo: "positionedElements",
     types: ["length", "percentage"],
   },
   boxDecorationBreak: {
@@ -913,8 +755,6 @@ export const properties = {
       type: "keyword",
       value: "slice",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: [],
   },
   boxShadow: {
@@ -924,8 +764,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.81259285,
-    appliesTo: "allElements",
     types: ["length", "hex-color"],
   },
   boxSizing: {
@@ -935,8 +773,6 @@ export const properties = {
       type: "keyword",
       value: "content-box",
     },
-    popularity: 0.86402206,
-    appliesTo: "allElementsAcceptingWidthOrHeight",
     types: [],
   },
   breakAfter: {
@@ -946,8 +782,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00365105,
-    appliesTo: "blockLevelElements",
     types: [],
   },
   breakBefore: {
@@ -957,8 +791,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00341796,
-    appliesTo: "blockLevelElements",
     types: [],
   },
   breakInside: {
@@ -968,8 +800,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.02782348,
-    appliesTo: "blockLevelElements",
     types: [],
   },
   captionSide: {
@@ -979,8 +809,6 @@ export const properties = {
       type: "keyword",
       value: "top",
     },
-    popularity: 0.04083929,
-    appliesTo: "tableCaptionElements",
     types: [],
   },
   caretColor: {
@@ -990,8 +818,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.05410129,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   caretShape: {
@@ -1001,8 +827,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "elementsThatAcceptInput",
     types: [],
   },
   clear: {
@@ -1012,8 +836,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.7016813,
-    appliesTo: "blockLevelElements",
     types: [],
   },
   clip: {
@@ -1023,8 +845,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.48810561,
-    appliesTo: "absolutelyPositionedElements",
     types: [],
   },
   clipPath: {
@@ -1034,8 +854,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.20754263,
-    appliesTo: "allElementsSVGContainerElements",
     types: ["url"],
   },
   color: {
@@ -1045,8 +863,6 @@ export const properties = {
       type: "keyword",
       value: "black",
     },
-    popularity: 0.90791486,
-    appliesTo: "allElementsAndText",
     types: ["hex-color"],
   },
   colorScheme: {
@@ -1056,8 +872,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.03358925,
-    appliesTo: "allElementsAndText",
     types: ["custom-ident"],
   },
   columnCount: {
@@ -1067,8 +881,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.07098549,
-    appliesTo: "blockContainersExceptTableWrappers",
     types: ["integer", "number"],
   },
   columnFill: {
@@ -1078,8 +890,6 @@ export const properties = {
       type: "keyword",
       value: "balance",
     },
-    popularity: 0.01738207,
-    appliesTo: "multicolElements",
     types: [],
   },
   columnGap: {
@@ -1090,8 +900,6 @@ export const properties = {
       value: 0,
       unit: "px",
     },
-    popularity: 0.09282422,
-    appliesTo: "multiColumnElementsFlexContainersGridContainers",
     types: ["length", "percentage"],
   },
   columnRuleColor: {
@@ -1101,8 +909,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.01356616,
-    appliesTo: "multicolElements",
     types: ["hex-color"],
   },
   columnRuleStyle: {
@@ -1112,8 +918,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.0131392,
-    appliesTo: "multicolElements",
     types: [],
   },
   columnRuleWidth: {
@@ -1123,8 +927,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.00328701,
-    appliesTo: "multicolElements",
     types: ["length"],
   },
   columnSpan: {
@@ -1134,8 +936,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00654278,
-    appliesTo: "inFlowBlockLevelElements",
     types: [],
   },
   columnWidth: {
@@ -1145,8 +945,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.03188644,
-    appliesTo: "blockContainersExceptTableWrappers",
     types: ["length"],
   },
   contain: {
@@ -1156,8 +954,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.17189203,
-    appliesTo: "allElements",
     types: [],
   },
   containIntrinsicBlockSize: {
@@ -1167,8 +963,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "elementsForWhichSizeContainmentCanApply",
     types: ["length"],
   },
   containIntrinsicHeight: {
@@ -1178,8 +972,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "elementsForWhichSizeContainmentCanApply",
     types: ["length"],
   },
   containIntrinsicInlineSize: {
@@ -1189,8 +981,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "elementsForWhichSizeContainmentCanApply",
     types: ["length"],
   },
   containIntrinsicWidth: {
@@ -1200,8 +990,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "elementsForWhichSizeContainmentCanApply",
     types: ["length"],
   },
   containerName: {
@@ -1211,8 +999,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["custom-ident"],
   },
   containerType: {
@@ -1222,8 +1008,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: [],
   },
   content: {
@@ -1233,8 +1017,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.81447258,
-    appliesTo: "allElementsTreeAbidingPseudoElementsPageMarginBoxes",
     types: ["url", "string"],
   },
   contentVisibility: {
@@ -1244,8 +1026,6 @@ export const properties = {
       type: "keyword",
       value: "visible",
     },
-    popularity: 0.04199404,
-    appliesTo: "elementsForWhichSizeContainmentCanApply",
     types: [],
   },
   counterIncrement: {
@@ -1255,8 +1035,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.07472144,
-    appliesTo: "allElements",
     types: ["custom-ident", "integer", "number"],
   },
   counterReset: {
@@ -1266,8 +1044,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.06641074,
-    appliesTo: "allElements",
     types: ["custom-ident", "integer", "number"],
   },
   counterSet: {
@@ -1277,8 +1053,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00016346,
-    appliesTo: "allElements",
     types: ["custom-ident", "integer", "number"],
   },
   cursor: {
@@ -1288,8 +1062,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.85037255,
-    appliesTo: "allElements",
     types: ["url", "x", "y"],
   },
   direction: {
@@ -1299,8 +1071,6 @@ export const properties = {
       type: "keyword",
       value: "ltr",
     },
-    popularity: 0.40017516,
-    appliesTo: "allElements",
     types: [],
   },
   display: {
@@ -1310,8 +1080,6 @@ export const properties = {
       type: "keyword",
       value: "inline",
     },
-    popularity: 0.93157435,
-    appliesTo: "allElements",
     types: [],
   },
   emptyCells: {
@@ -1321,8 +1089,6 @@ export const properties = {
       type: "keyword",
       value: "show",
     },
-    popularity: 0.03153899,
-    appliesTo: "tableCellElements",
     types: [],
   },
   filter: {
@@ -1332,8 +1098,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.32058162,
-    appliesTo: "allElementsSVGContainerElements",
     types: ["url"],
   },
   flexBasis: {
@@ -1343,8 +1107,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.3070072,
-    appliesTo: "flexItemsAndInFlowPseudos",
     types: ["length", "percentage"],
   },
   flexDirection: {
@@ -1354,8 +1116,6 @@ export const properties = {
       type: "keyword",
       value: "row",
     },
-    popularity: 0.65789154,
-    appliesTo: "flexContainers",
     types: [],
   },
   flexGrow: {
@@ -1366,8 +1126,6 @@ export const properties = {
       unit: "number",
       value: 0,
     },
-    popularity: 0.50511311,
-    appliesTo: "flexItemsAndInFlowPseudos",
     types: ["number"],
   },
   flexShrink: {
@@ -1378,8 +1136,6 @@ export const properties = {
       unit: "number",
       value: 1,
     },
-    popularity: 0.4809155,
-    appliesTo: "flexItemsAndInFlowPseudos",
     types: ["number"],
   },
   flexWrap: {
@@ -1389,8 +1145,6 @@ export const properties = {
       type: "keyword",
       value: "nowrap",
     },
-    popularity: 0.58959861,
-    appliesTo: "flexContainers",
     types: [],
   },
   float: {
@@ -1400,8 +1154,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.8383589,
-    appliesTo: "allElementsNoEffectIfDisplayNone",
     types: [],
   },
   fontFamily: {
@@ -1411,8 +1163,6 @@ export const properties = {
       type: "keyword",
       value: "inherit",
     },
-    popularity: 0.88101351,
-    appliesTo: "allElements",
     types: ["string", "custom-ident"],
   },
   fontFeatureSettings: {
@@ -1422,8 +1172,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.12538368,
-    appliesTo: "allElements",
     types: ["string", "integer", "number"],
   },
   fontKerning: {
@@ -1433,8 +1181,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.01160796,
-    appliesTo: "allElements",
     types: [],
   },
   fontLanguageOverride: {
@@ -1444,8 +1190,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["string"],
   },
   fontOpticalSizing: {
@@ -1455,8 +1199,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.0006232,
-    appliesTo: "allElements",
     types: [],
   },
   fontPalette: {
@@ -1466,8 +1208,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0,
-    appliesTo: "allElementsAndText",
     types: ["palette-identifier"],
   },
   fontVariationSettings: {
@@ -1477,8 +1217,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.00471835,
-    appliesTo: "allElements",
     types: ["string", "number"],
   },
   fontSize: {
@@ -1488,8 +1226,6 @@ export const properties = {
       type: "keyword",
       value: "inherit",
     },
-    popularity: 0.90325346,
-    appliesTo: "allElements",
     types: ["length", "percentage"],
   },
   fontSizeAdjust: {
@@ -1499,8 +1235,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.000003,
-    appliesTo: "allElements",
     types: ["number"],
   },
   fontStretch: {
@@ -1510,8 +1244,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.12741738,
-    appliesTo: "allElements",
     types: ["percentage"],
   },
   fontStyle: {
@@ -1521,8 +1253,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.7961795,
-    appliesTo: "allElements",
     types: ["angle"],
   },
   fontSynthesis: {
@@ -1541,8 +1271,6 @@ export const properties = {
         },
       ],
     },
-    popularity: 0.00686166,
-    appliesTo: "allElements",
     types: [],
   },
   fontVariant: {
@@ -1552,8 +1280,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.30968418,
-    appliesTo: "allElements",
     types: [],
   },
   fontVariantAlternates: {
@@ -1563,8 +1289,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: [],
   },
   fontVariantCaps: {
@@ -1574,8 +1298,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.00514777,
-    appliesTo: "allElements",
     types: [],
   },
   fontVariantEastAsian: {
@@ -1585,8 +1307,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.00328361,
-    appliesTo: "allElements",
     types: [],
   },
   fontVariantEmoji: {
@@ -1596,8 +1316,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0,
-    appliesTo: "allElementsAndText",
     types: [],
   },
   fontVariantLigatures: {
@@ -1607,8 +1325,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.05055055,
-    appliesTo: "allElements",
     types: [],
   },
   fontVariantNumeric: {
@@ -1618,8 +1334,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.01816086,
-    appliesTo: "allElements",
     types: [],
   },
   fontVariantPosition: {
@@ -1629,8 +1343,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: [],
   },
   fontWeight: {
@@ -1640,8 +1352,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.88598106,
-    appliesTo: "allElements",
     types: ["number"],
   },
   forcedColorAdjust: {
@@ -1651,8 +1361,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.02245871,
-    appliesTo: "allElementsAndText",
     types: [],
   },
   gridAutoColumns: {
@@ -1662,8 +1370,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.01226638,
-    appliesTo: "gridContainers",
     types: ["length", "percentage", "flex"],
   },
   gridAutoFlow: {
@@ -1673,8 +1379,6 @@ export const properties = {
       type: "keyword",
       value: "row",
     },
-    popularity: 0.03982344,
-    appliesTo: "gridContainers",
     types: [],
   },
   gridAutoRows: {
@@ -1684,8 +1388,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.02839547,
-    appliesTo: "gridContainers",
     types: ["length", "percentage", "flex"],
   },
   gridColumnEnd: {
@@ -1695,8 +1397,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.01848874,
-    appliesTo: "gridItemsAndBoxesWithinGridContainer",
     types: ["custom-ident", "integer", "number"],
   },
   gridColumnStart: {
@@ -1706,8 +1406,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.02019688,
-    appliesTo: "gridItemsAndBoxesWithinGridContainer",
     types: ["custom-ident", "integer", "number"],
   },
   gridRowEnd: {
@@ -1717,8 +1415,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00961681,
-    appliesTo: "gridItemsAndBoxesWithinGridContainer",
     types: ["custom-ident", "integer", "number"],
   },
   gridRowStart: {
@@ -1728,8 +1424,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.01281513,
-    appliesTo: "gridItemsAndBoxesWithinGridContainer",
     types: ["custom-ident", "integer", "number"],
   },
   gridTemplateAreas: {
@@ -1739,8 +1433,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.05496001,
-    appliesTo: "gridContainers",
     types: ["string"],
   },
   gridTemplateColumns: {
@@ -1750,8 +1442,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.17745181,
-    appliesTo: "gridContainers",
     types: ["custom-ident", "length", "percentage", "flex"],
   },
   gridTemplateRows: {
@@ -1761,8 +1451,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.07489386,
-    appliesTo: "gridContainers",
     types: ["custom-ident", "length", "percentage", "flex"],
   },
   hangingPunctuation: {
@@ -1772,8 +1460,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: [],
   },
   height: {
@@ -1783,8 +1469,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.93056784,
-    appliesTo: "allElementsButNonReplacedAndTableColumns",
     types: ["length", "percentage"],
   },
   hyphenateCharacter: {
@@ -1794,8 +1478,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["string"],
   },
   hyphenateLimitChars: {
@@ -1805,8 +1487,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["integer", "number"],
   },
   hyphens: {
@@ -1816,8 +1496,6 @@ export const properties = {
       type: "keyword",
       value: "manual",
     },
-    popularity: 0.10122444,
-    appliesTo: "allElements",
     types: [],
   },
   imageOrientation: {
@@ -1827,8 +1505,6 @@ export const properties = {
       type: "keyword",
       value: "from-image",
     },
-    popularity: 0.00207108,
-    appliesTo: "allElements",
     types: ["angle"],
   },
   imageRendering: {
@@ -1838,8 +1514,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.11112647,
-    appliesTo: "allElements",
     types: [],
   },
   imageResolution: {
@@ -1850,8 +1524,6 @@ export const properties = {
       unit: "dppx",
       value: 1,
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["resolution"],
   },
   initialLetter: {
@@ -1861,8 +1533,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0,
-    appliesTo: "firstLetterPseudoElementsAndInlineLevelFirstChildren",
     types: ["number", "integer"],
   },
   initialLetterAlign: {
@@ -1872,8 +1542,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "firstLetterPseudoElementsAndInlineLevelFirstChildren",
     types: [],
   },
   inlineSize: {
@@ -1883,8 +1551,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00381706,
-    appliesTo: "sameAsWidthAndHeight",
     types: ["length", "percentage"],
   },
   inputSecurity: {
@@ -1894,8 +1560,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "sensitiveTextInputs",
     types: [],
   },
   insetBlockEnd: {
@@ -1905,8 +1569,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00031067,
-    appliesTo: "positionedElements",
     types: ["length", "percentage"],
   },
   insetBlockStart: {
@@ -1916,8 +1578,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00036346,
-    appliesTo: "positionedElements",
     types: ["length", "percentage"],
   },
   insetInlineEnd: {
@@ -1927,8 +1587,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00419961,
-    appliesTo: "positionedElements",
     types: ["length", "percentage"],
   },
   insetInlineStart: {
@@ -1938,8 +1596,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00379395,
-    appliesTo: "positionedElements",
     types: ["length", "percentage"],
   },
   isolation: {
@@ -1949,8 +1605,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.01962288,
-    appliesTo: "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
     types: [],
   },
   justifyContent: {
@@ -1960,8 +1614,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.72371,
-    appliesTo: "flexContainers",
     types: [],
   },
   justifyItems: {
@@ -1971,8 +1623,6 @@ export const properties = {
       type: "keyword",
       value: "legacy",
     },
-    popularity: 0.05716411,
-    appliesTo: "flexContainersGridContainers",
     types: [],
   },
   justifySelf: {
@@ -1982,8 +1632,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.06147513,
-    appliesTo: "blockLevelBoxesAndAbsolutelyPositionedBoxesAndGridItems",
     types: [],
   },
   justifyTracks: {
@@ -1993,8 +1641,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0,
-    appliesTo: "gridContainersWithMasonryLayoutInTheirInlineAxis",
     types: [],
   },
   left: {
@@ -2004,8 +1650,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.90948372,
-    appliesTo: "positionedElements",
     types: ["length", "percentage"],
   },
   letterSpacing: {
@@ -2015,8 +1659,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.64325492,
-    appliesTo: "allElements",
     types: ["length"],
   },
   lineBreak: {
@@ -2026,8 +1668,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.03790035,
-    appliesTo: "allElements",
     types: [],
   },
   lineClamp: {
@@ -2037,8 +1677,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "blockContainersExceptMultiColumnContainers",
     types: ["integer", "number"],
   },
   lineHeight: {
@@ -2048,8 +1686,6 @@ export const properties = {
       type: "keyword",
       value: "inherit",
     },
-    popularity: 0.87354969,
-    appliesTo: "allElements",
     types: ["number", "length", "percentage"],
   },
   lineHeightStep: {
@@ -2060,8 +1696,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0,
-    appliesTo: "blockContainers",
     types: ["length"],
   },
   listStyleImage: {
@@ -2071,8 +1705,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.05896406,
-    appliesTo: "listItems",
     types: ["url"],
   },
   listStylePosition: {
@@ -2082,8 +1714,6 @@ export const properties = {
       type: "keyword",
       value: "outside",
     },
-    popularity: 0.10836703,
-    appliesTo: "listItems",
     types: [],
   },
   listStyleType: {
@@ -2093,8 +1723,6 @@ export const properties = {
       type: "keyword",
       value: "disc",
     },
-    popularity: 0.50305363,
-    appliesTo: "listItems",
     types: ["custom-ident", "string"],
   },
   marginBlockEnd: {
@@ -2105,8 +1733,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.06678285,
-    appliesTo: "sameAsMargin",
     types: ["length", "percentage"],
   },
   marginBlockStart: {
@@ -2117,8 +1743,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.06603158,
-    appliesTo: "sameAsMargin",
     types: ["length", "percentage"],
   },
   marginBottom: {
@@ -2129,8 +1753,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.84497162,
-    appliesTo: "allElementsExceptTableDisplayTypes",
     types: ["length", "percentage"],
   },
   marginInlineEnd: {
@@ -2141,8 +1763,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.02346878,
-    appliesTo: "sameAsMargin",
     types: ["length", "percentage"],
   },
   marginInlineStart: {
@@ -2153,8 +1773,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.03660688,
-    appliesTo: "sameAsMargin",
     types: ["length", "percentage"],
   },
   marginLeft: {
@@ -2165,8 +1783,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.84846503,
-    appliesTo: "allElementsExceptTableDisplayTypes",
     types: ["length", "percentage"],
   },
   marginRight: {
@@ -2177,8 +1793,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.83485199,
-    appliesTo: "allElementsExceptTableDisplayTypes",
     types: ["length", "percentage"],
   },
   marginTop: {
@@ -2189,8 +1803,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.90536837,
-    appliesTo: "allElementsExceptTableDisplayTypes",
     types: ["length", "percentage"],
   },
   marginTrim: {
@@ -2200,8 +1812,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "blockContainersAndMultiColumnContainers",
     types: [],
   },
   maskBorderMode: {
@@ -2211,8 +1821,6 @@ export const properties = {
       type: "keyword",
       value: "alpha",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: [],
   },
   maskBorderOutset: {
@@ -2223,8 +1831,6 @@ export const properties = {
       unit: "number",
       value: 0,
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: ["length", "number"],
   },
   maskBorderRepeat: {
@@ -2234,8 +1840,6 @@ export const properties = {
       type: "keyword",
       value: "stretch",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: [],
   },
   maskBorderSlice: {
@@ -2246,8 +1850,6 @@ export const properties = {
       unit: "number",
       value: 0,
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: ["number", "percentage"],
   },
   maskBorderSource: {
@@ -2257,8 +1859,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: ["url"],
   },
   maskBorderWidth: {
@@ -2268,8 +1868,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: ["length", "percentage", "number"],
   },
   maskClip: {
@@ -2279,8 +1877,6 @@ export const properties = {
       type: "keyword",
       value: "border-box",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: [],
   },
   maskComposite: {
@@ -2290,8 +1886,6 @@ export const properties = {
       type: "keyword",
       value: "add",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: [],
   },
   maskImage: {
@@ -2301,8 +1895,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: ["url"],
   },
   maskMode: {
@@ -2312,8 +1904,6 @@ export const properties = {
       type: "keyword",
       value: "match-source",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: [],
   },
   maskOrigin: {
@@ -2323,8 +1913,6 @@ export const properties = {
       type: "keyword",
       value: "border-box",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: [],
   },
   maskPosition: {
@@ -2334,8 +1922,6 @@ export const properties = {
       type: "keyword",
       value: "center",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: ["length", "percentage"],
   },
   maskRepeat: {
@@ -2345,8 +1931,6 @@ export const properties = {
       type: "keyword",
       value: "repeat",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: [],
   },
   maskSize: {
@@ -2356,8 +1940,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "allElementsSVGContainerElements",
     types: ["length", "percentage"],
   },
   maskType: {
@@ -2367,8 +1949,6 @@ export const properties = {
       type: "keyword",
       value: "luminance",
     },
-    popularity: 0.00355107,
-    appliesTo: "maskElements",
     types: [],
   },
   masonryAutoFlow: {
@@ -2378,8 +1958,6 @@ export const properties = {
       type: "keyword",
       value: "pack",
     },
-    popularity: 0,
-    appliesTo: "gridContainersWithMasonryLayout",
     types: [],
   },
   mathDepth: {
@@ -2390,8 +1968,6 @@ export const properties = {
       unit: "number",
       value: 0,
     },
-    popularity: 3e-8,
-    appliesTo: "allElements",
     types: ["integer", "number"],
   },
   mathShift: {
@@ -2401,8 +1977,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 3e-8,
-    appliesTo: "allElements",
     types: [],
   },
   mathStyle: {
@@ -2412,8 +1986,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 3e-8,
-    appliesTo: "allElements",
     types: [],
   },
   maxBlockSize: {
@@ -2423,8 +1995,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00064707,
-    appliesTo: "sameAsWidthAndHeight",
     types: ["length", "percentage"],
   },
   maxHeight: {
@@ -2434,8 +2004,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.72769912,
-    appliesTo: "allElementsButNonReplacedAndTableColumns",
     types: ["length", "percentage"],
   },
   maxInlineSize: {
@@ -2445,8 +2013,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00062504,
-    appliesTo: "sameAsWidthAndHeight",
     types: ["length", "percentage"],
   },
   maxLines: {
@@ -2456,8 +2022,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "blockContainersExceptMultiColumnContainers",
     types: ["integer", "number"],
   },
   maxWidth: {
@@ -2467,8 +2031,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.83290711,
-    appliesTo: "allElementsButNonReplacedAndTableRows",
     types: ["length", "percentage"],
   },
   minBlockSize: {
@@ -2479,8 +2041,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.00192722,
-    appliesTo: "sameAsWidthAndHeight",
     types: ["length", "percentage"],
   },
   minHeight: {
@@ -2490,8 +2050,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.80088013,
-    appliesTo: "allElementsButNonReplacedAndTableColumns",
     types: ["length", "percentage"],
   },
   minInlineSize: {
@@ -2502,8 +2060,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.00357429,
-    appliesTo: "sameAsWidthAndHeight",
     types: ["length", "percentage"],
   },
   minWidth: {
@@ -2513,8 +2069,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.77790217,
-    appliesTo: "allElementsButNonReplacedAndTableRows",
     types: ["length", "percentage"],
   },
   mixBlendMode: {
@@ -2524,8 +2078,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.05430564,
-    appliesTo: "allElements",
     types: [],
   },
   objectFit: {
@@ -2535,8 +2087,6 @@ export const properties = {
       type: "keyword",
       value: "fill",
     },
-    popularity: 0.38359477,
-    appliesTo: "replacedElements",
     types: [],
   },
   objectPosition: {
@@ -2557,8 +2107,6 @@ export const properties = {
         },
       ],
     },
-    popularity: 0.08374319,
-    appliesTo: "replacedElements",
     types: ["length", "percentage"],
   },
   offsetAnchor: {
@@ -2568,8 +2116,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 6e-8,
-    appliesTo: "transformableElements",
     types: ["length", "percentage"],
   },
   offsetDistance: {
@@ -2580,8 +2126,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.0007637,
-    appliesTo: "transformableElements",
     types: ["length", "percentage"],
   },
   offsetPath: {
@@ -2591,8 +2135,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.0008741,
-    appliesTo: "transformableElements",
     types: ["url"],
   },
   offsetPosition: {
@@ -2602,8 +2144,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 3e-8,
-    appliesTo: "transformableElements",
     types: ["length", "percentage"],
   },
   offsetRotate: {
@@ -2613,8 +2153,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00073039,
-    appliesTo: "transformableElements",
     types: ["angle"],
   },
   opacity: {
@@ -2625,8 +2163,6 @@ export const properties = {
       unit: "number",
       value: 1,
     },
-    popularity: 0.87714344,
-    appliesTo: "allElements",
     types: ["number", "percentage"],
   },
   order: {
@@ -2637,8 +2173,6 @@ export const properties = {
       unit: "number",
       value: 0,
     },
-    popularity: 0.28274872,
-    appliesTo: "flexItemsGridItemsAbsolutelyPositionedContainerChildren",
     types: ["integer", "number"],
   },
   orphans: {
@@ -2649,8 +2183,6 @@ export const properties = {
       unit: "number",
       value: 2,
     },
-    popularity: 0.03717837,
-    appliesTo: "blockContainerElements",
     types: ["integer", "number"],
   },
   outlineColor: {
@@ -2660,8 +2192,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.09538741,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   outlineOffset: {
@@ -2672,8 +2202,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.35495556,
-    appliesTo: "allElements",
     types: ["length"],
   },
   outlineStyle: {
@@ -2683,8 +2211,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.22264732,
-    appliesTo: "allElements",
     types: [],
   },
   outlineWidth: {
@@ -2694,8 +2220,6 @@ export const properties = {
       type: "keyword",
       value: "medium",
     },
-    popularity: 0.23008945,
-    appliesTo: "allElements",
     types: ["length"],
   },
   overflow: {
@@ -2705,8 +2229,6 @@ export const properties = {
       type: "keyword",
       value: "visible",
     },
-    popularity: 0.87464713,
-    appliesTo: "blockContainersFlexContainersGridContainers",
     types: [],
   },
   overflowAnchor: {
@@ -2716,8 +2238,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.05039229,
-    appliesTo: "allElements",
     types: [],
   },
   overflowBlock: {
@@ -2727,8 +2247,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "blockContainersFlexContainersGridContainers",
     types: [],
   },
   overflowClipMargin: {
@@ -2739,8 +2257,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.0001932,
-    appliesTo: "allElements",
     types: ["length"],
   },
   overflowInline: {
@@ -2750,8 +2266,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "blockContainersFlexContainersGridContainers",
     types: [],
   },
   overflowWrap: {
@@ -2761,8 +2275,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.2917187,
-    appliesTo: "nonReplacedInlineElements",
     types: [],
   },
   overflowX: {
@@ -2772,8 +2284,6 @@ export const properties = {
       type: "keyword",
       value: "visible",
     },
-    popularity: 0.6419296,
-    appliesTo: "blockContainersFlexContainersGridContainers",
     types: [],
   },
   overflowY: {
@@ -2783,8 +2293,6 @@ export const properties = {
       type: "keyword",
       value: "visible",
     },
-    popularity: 0.66040666,
-    appliesTo: "blockContainersFlexContainersGridContainers",
     types: [],
   },
   overscrollBehavior: {
@@ -2794,8 +2302,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "nonReplacedBlockAndInlineBlockElements",
     types: [],
   },
   overscrollBehaviorBlock: {
@@ -2805,8 +2311,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.0002038,
-    appliesTo: "nonReplacedBlockAndInlineBlockElements",
     types: [],
   },
   overscrollBehaviorInline: {
@@ -2816,8 +2320,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.0003654,
-    appliesTo: "nonReplacedBlockAndInlineBlockElements",
     types: [],
   },
   overscrollBehaviorX: {
@@ -2827,8 +2329,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "nonReplacedBlockAndInlineBlockElements",
     types: [],
   },
   overscrollBehaviorY: {
@@ -2838,8 +2338,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "nonReplacedBlockAndInlineBlockElements",
     types: [],
   },
   paddingBlockEnd: {
@@ -2850,8 +2348,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.00269343,
-    appliesTo: "allElementsExceptInternalTableDisplayTypes",
     types: ["length", "percentage"],
   },
   paddingBlockStart: {
@@ -2862,8 +2358,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.00281718,
-    appliesTo: "allElementsExceptInternalTableDisplayTypes",
     types: ["length", "percentage"],
   },
   paddingBottom: {
@@ -2874,8 +2368,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.80249482,
-    appliesTo: "allElementsExceptInternalTableDisplayTypes",
     types: ["length", "percentage"],
   },
   paddingInlineEnd: {
@@ -2886,8 +2378,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.02914235,
-    appliesTo: "allElementsExceptInternalTableDisplayTypes",
     types: ["length", "percentage"],
   },
   paddingInlineStart: {
@@ -2898,8 +2388,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.03734959,
-    appliesTo: "allElementsExceptInternalTableDisplayTypes",
     types: ["length", "percentage"],
   },
   paddingLeft: {
@@ -2910,8 +2398,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.81912414,
-    appliesTo: "allElementsExceptInternalTableDisplayTypes",
     types: ["length", "percentage"],
   },
   paddingRight: {
@@ -2922,8 +2408,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.80336339,
-    appliesTo: "allElementsExceptInternalTableDisplayTypes",
     types: ["length", "percentage"],
   },
   paddingTop: {
@@ -2934,8 +2418,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.82360295,
-    appliesTo: "allElementsExceptInternalTableDisplayTypes",
     types: ["length", "percentage"],
   },
   page: {
@@ -2945,8 +2427,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00131264,
-    appliesTo: "blockElementsInNormalFlow",
     types: ["custom-ident"],
   },
   pageBreakAfter: {
@@ -2956,8 +2436,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.04793594,
-    appliesTo: "blockElementsInNormalFlow",
     types: [],
   },
   pageBreakBefore: {
@@ -2967,8 +2445,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.0173306,
-    appliesTo: "blockElementsInNormalFlow",
     types: [],
   },
   pageBreakInside: {
@@ -2978,8 +2454,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.0636772,
-    appliesTo: "blockElementsInNormalFlow",
     types: [],
   },
   paintOrder: {
@@ -2989,8 +2463,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.0013931,
-    appliesTo: "textElements",
     types: [],
   },
   perspective: {
@@ -3000,8 +2472,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.11208199,
-    appliesTo: "transformableElements",
     types: ["length"],
   },
   perspectiveOrigin: {
@@ -3022,8 +2492,6 @@ export const properties = {
         },
       ],
     },
-    popularity: 0.03597136,
-    appliesTo: "transformableElements",
     types: ["length", "percentage"],
   },
   pointerEvents: {
@@ -3033,8 +2501,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.65656971,
-    appliesTo: "allElements",
     types: [],
   },
   position: {
@@ -3044,8 +2510,6 @@ export const properties = {
       type: "keyword",
       value: "static",
     },
-    popularity: 0.92435004,
-    appliesTo: "allElements",
     types: [],
   },
   printColorAdjust: {
@@ -3055,8 +2519,6 @@ export const properties = {
       type: "keyword",
       value: "economy",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: [],
   },
   quotes: {
@@ -3066,8 +2528,6 @@ export const properties = {
       type: "keyword",
       value: "dependsOnUserAgent",
     },
-    popularity: 0.08095164,
-    appliesTo: "allElements",
     types: ["string"],
   },
   resize: {
@@ -3077,8 +2537,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.20814477,
-    appliesTo: "elementsWithOverflowNotVisibleAndReplacedElements",
     types: [],
   },
   right: {
@@ -3088,8 +2546,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.83840245,
-    appliesTo: "positionedElements",
     types: ["length", "percentage"],
   },
   rotate: {
@@ -3099,8 +2555,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 4e-8,
-    appliesTo: "transformableElements",
     types: ["angle", "number"],
   },
   rowGap: {
@@ -3111,8 +2565,6 @@ export const properties = {
       value: 0,
       unit: "px",
     },
-    popularity: 0.01955862,
-    appliesTo: "multiColumnElementsFlexContainersGridContainers",
     types: ["length", "percentage"],
   },
   rubyAlign: {
@@ -3122,8 +2574,6 @@ export const properties = {
       type: "keyword",
       value: "space-around",
     },
-    popularity: 0,
-    appliesTo: "rubyBasesAnnotationsBaseAnnotationContainers",
     types: [],
   },
   rubyMerge: {
@@ -3133,8 +2583,6 @@ export const properties = {
       type: "keyword",
       value: "separate",
     },
-    popularity: 0,
-    appliesTo: "rubyAnnotationsContainers",
     types: [],
   },
   rubyPosition: {
@@ -3144,8 +2592,6 @@ export const properties = {
       type: "keyword",
       value: "alternate",
     },
-    popularity: 0.00156034,
-    appliesTo: "rubyAnnotationsContainers",
     types: [],
   },
   scale: {
@@ -3155,8 +2601,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 2e-7,
-    appliesTo: "transformableElements",
     types: ["number"],
   },
   scrollbarColor: {
@@ -3166,8 +2610,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0,
-    appliesTo: "scrollingBoxes",
     types: ["hex-color"],
   },
   scrollbarGutter: {
@@ -3177,8 +2619,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00128847,
-    appliesTo: "scrollingBoxes",
     types: [],
   },
   scrollbarWidth: {
@@ -3188,8 +2628,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.000001,
-    appliesTo: "scrollingBoxes",
     types: [],
   },
   scrollBehavior: {
@@ -3199,8 +2637,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.06855196,
-    appliesTo: "scrollingBoxes",
     types: [],
   },
   scrollMarginBlockStart: {
@@ -3211,8 +2647,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["length"],
   },
   scrollMarginBlockEnd: {
@@ -3223,8 +2657,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["length"],
   },
   scrollMarginBottom: {
@@ -3235,8 +2667,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["length"],
   },
   scrollMarginInlineStart: {
@@ -3247,8 +2677,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["length"],
   },
   scrollMarginInlineEnd: {
@@ -3259,8 +2687,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["length"],
   },
   scrollMarginLeft: {
@@ -3271,8 +2697,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["length"],
   },
   scrollMarginRight: {
@@ -3283,8 +2707,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["length"],
   },
   scrollMarginTop: {
@@ -3295,8 +2717,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["length"],
   },
   scrollPaddingBlockStart: {
@@ -3306,8 +2726,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.0003318,
-    appliesTo: "scrollContainers",
     types: ["length", "percentage"],
   },
   scrollPaddingBlockEnd: {
@@ -3317,8 +2735,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00033098,
-    appliesTo: "scrollContainers",
     types: ["length", "percentage"],
   },
   scrollPaddingBottom: {
@@ -3328,8 +2744,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00046042,
-    appliesTo: "scrollContainers",
     types: ["length", "percentage"],
   },
   scrollPaddingInlineStart: {
@@ -3339,8 +2753,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00034054,
-    appliesTo: "scrollContainers",
     types: ["length", "percentage"],
   },
   scrollPaddingInlineEnd: {
@@ -3350,8 +2762,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00033178,
-    appliesTo: "scrollContainers",
     types: ["length", "percentage"],
   },
   scrollPaddingLeft: {
@@ -3361,8 +2771,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00318274,
-    appliesTo: "scrollContainers",
     types: ["length", "percentage"],
   },
   scrollPaddingRight: {
@@ -3372,8 +2780,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00046376,
-    appliesTo: "scrollContainers",
     types: ["length", "percentage"],
   },
   scrollPaddingTop: {
@@ -3383,8 +2789,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.0199363,
-    appliesTo: "scrollContainers",
     types: ["length", "percentage"],
   },
   scrollSnapAlign: {
@@ -3394,8 +2798,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.05990673,
-    appliesTo: "allElements",
     types: [],
   },
   scrollSnapStop: {
@@ -3405,8 +2807,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.0074871,
-    appliesTo: "allElements",
     types: [],
   },
   scrollSnapType: {
@@ -3416,8 +2816,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.05778112,
-    appliesTo: "allElements",
     types: [],
   },
   scrollTimelineAxis: {
@@ -3427,8 +2825,6 @@ export const properties = {
       type: "keyword",
       value: "block",
     },
-    popularity: 0,
-    appliesTo: "scrollContainers",
     types: [],
   },
   scrollTimelineName: {
@@ -3438,8 +2834,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "scrollContainers",
     types: ["custom-ident"],
   },
   shapeImageThreshold: {
@@ -3450,8 +2844,6 @@ export const properties = {
       unit: "number",
       value: 0,
     },
-    popularity: 0.00579108,
-    appliesTo: "floats",
     types: ["number", "percentage"],
   },
   shapeMargin: {
@@ -3462,8 +2854,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.00212267,
-    appliesTo: "floats",
     types: ["length", "percentage"],
   },
   shapeOutside: {
@@ -3473,8 +2863,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00236383,
-    appliesTo: "floats",
     types: ["url"],
   },
   tabSize: {
@@ -3485,8 +2873,6 @@ export const properties = {
       unit: "number",
       value: 8,
     },
-    popularity: 0.03065152,
-    appliesTo: "blockContainers",
     types: ["integer", "number", "length"],
   },
   tableLayout: {
@@ -3496,8 +2882,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.20669832,
-    appliesTo: "tableElements",
     types: [],
   },
   textAlign: {
@@ -3507,8 +2891,6 @@ export const properties = {
       type: "keyword",
       value: "start",
     },
-    popularity: 0.89287477,
-    appliesTo: "blockContainers",
     types: [],
   },
   textAlignLast: {
@@ -3518,8 +2900,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.02339794,
-    appliesTo: "blockContainers",
     types: [],
   },
   textCombineUpright: {
@@ -3529,8 +2909,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.00187072,
-    appliesTo: "nonReplacedInlineElements",
     types: ["integer", "number"],
   },
   textDecorationColor: {
@@ -3540,8 +2918,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0.05079903,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   textDecorationLine: {
@@ -3551,8 +2927,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.03656271,
-    appliesTo: "allElements",
     types: [],
   },
   textDecorationSkip: {
@@ -3562,8 +2936,6 @@ export const properties = {
       type: "keyword",
       value: "objects",
     },
-    popularity: 0.054238,
-    appliesTo: "allElements",
     types: [],
   },
   textDecorationSkipInk: {
@@ -3573,8 +2945,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.01645826,
-    appliesTo: "allElements",
     types: [],
   },
   textDecorationStyle: {
@@ -3584,8 +2954,6 @@ export const properties = {
       type: "keyword",
       value: "solid",
     },
-    popularity: 0.02111189,
-    appliesTo: "allElements",
     types: [],
   },
   textDecorationThickness: {
@@ -3595,8 +2963,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00728976,
-    appliesTo: "allElements",
     types: ["length", "percentage"],
   },
   textEmphasisColor: {
@@ -3606,8 +2972,6 @@ export const properties = {
       type: "keyword",
       value: "currentColor",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["hex-color"],
   },
   textEmphasisPosition: {
@@ -3626,8 +2990,6 @@ export const properties = {
         },
       ],
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: [],
   },
   textEmphasisStyle: {
@@ -3637,8 +2999,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["string"],
   },
   textIndent: {
@@ -3649,8 +3009,6 @@ export const properties = {
       unit: "px",
       value: 0,
     },
-    popularity: 0.37633903,
-    appliesTo: "blockContainers",
     types: ["length", "percentage"],
   },
   textJustify: {
@@ -3660,8 +3018,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 8e-7,
-    appliesTo: "inlineLevelAndTableCellElements",
     types: [],
   },
   textOrientation: {
@@ -3671,8 +3027,6 @@ export const properties = {
       type: "keyword",
       value: "mixed",
     },
-    popularity: 0.00286298,
-    appliesTo: "allElementsExceptTableRowGroupsRowsColumnGroupsAndColumns",
     types: [],
   },
   textOverflow: {
@@ -3682,8 +3036,6 @@ export const properties = {
       type: "keyword",
       value: "clip",
     },
-    popularity: 0.65272517,
-    appliesTo: "blockContainerElements",
     types: ["string"],
   },
   textRendering: {
@@ -3693,8 +3045,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.3619822,
-    appliesTo: "textElements",
     types: [],
   },
   textShadow: {
@@ -3704,8 +3054,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.49899917,
-    appliesTo: "allElements",
     types: ["length", "hex-color"],
   },
   textSizeAdjust: {
@@ -3715,8 +3063,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.13611964,
-    appliesTo: "allElements",
     types: ["percentage"],
   },
   textTransform: {
@@ -3726,8 +3072,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.73056963,
-    appliesTo: "allElements",
     types: [],
   },
   textUnderlineOffset: {
@@ -3737,8 +3081,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.00558599,
-    appliesTo: "allElements",
     types: ["length", "percentage"],
   },
   textUnderlinePosition: {
@@ -3748,8 +3090,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.0070495,
-    appliesTo: "allElements",
     types: [],
   },
   top: {
@@ -3759,8 +3099,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.91426675,
-    appliesTo: "positionedElements",
     types: ["length", "percentage"],
   },
   touchAction: {
@@ -3770,9 +3108,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.37581741,
-    appliesTo:
-      "allElementsExceptNonReplacedInlineElementsTableRowsColumnsRowColumnGroups",
     types: [],
   },
   transform: {
@@ -3782,8 +3117,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0.82452786,
-    appliesTo: "transformableElements",
     types: [],
   },
   transformBox: {
@@ -3793,8 +3126,6 @@ export const properties = {
       type: "keyword",
       value: "view-box",
     },
-    popularity: 0.00167776,
-    appliesTo: "transformableElements",
     types: [],
   },
   transformOrigin: {
@@ -3820,8 +3151,6 @@ export const properties = {
         },
       ],
     },
-    popularity: 0.54179205,
-    appliesTo: "transformableElements",
     types: ["length", "percentage"],
   },
   transformStyle: {
@@ -3831,8 +3160,6 @@ export const properties = {
       type: "keyword",
       value: "flat",
     },
-    popularity: 0.11068509,
-    appliesTo: "transformableElements",
     types: [],
   },
   transition: {
@@ -3861,8 +3188,6 @@ export const properties = {
         },
       ],
     },
-    popularity: 0.78355592,
-    appliesTo: "allElementsAndPseudos",
     types: ["custom-ident", "time"],
   },
   transitionDelay: {
@@ -3873,8 +3198,6 @@ export const properties = {
       unit: "s",
       value: 0,
     },
-    popularity: 0.26633596,
-    appliesTo: "allElementsAndPseudos",
     types: ["time"],
   },
   transitionDuration: {
@@ -3885,8 +3208,6 @@ export const properties = {
       unit: "s",
       value: 0,
     },
-    popularity: 0.27645681,
-    appliesTo: "allElementsAndPseudos",
     types: ["time"],
   },
   transitionProperty: {
@@ -3896,8 +3217,6 @@ export const properties = {
       type: "keyword",
       value: "all",
     },
-    popularity: 0.28626935,
-    appliesTo: "allElementsAndPseudos",
     types: ["custom-ident"],
   },
   transitionTimingFunction: {
@@ -3907,8 +3226,6 @@ export const properties = {
       type: "keyword",
       value: "ease",
     },
-    popularity: 0.28535681,
-    appliesTo: "allElementsAndPseudos",
     types: [],
   },
   translate: {
@@ -3918,8 +3235,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 9e-8,
-    appliesTo: "transformableElements",
     types: ["length", "percentage"],
   },
   unicodeBidi: {
@@ -3929,8 +3244,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.13633243,
-    appliesTo: "allElementsSomeValuesNoEffectOnNonInlineElements",
     types: [],
   },
   userSelect: {
@@ -3940,8 +3253,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.55451382,
-    appliesTo: "allElements",
     types: [],
   },
   verticalAlign: {
@@ -3951,8 +3262,6 @@ export const properties = {
       type: "keyword",
       value: "baseline",
     },
-    popularity: 0.84531302,
-    appliesTo: "inlineLevelAndTableCellElements",
     types: ["percentage", "length"],
   },
   viewTransitionName: {
@@ -3962,8 +3271,6 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    popularity: 0,
-    appliesTo: "allElements",
     types: ["custom-ident"],
   },
   visibility: {
@@ -3973,8 +3280,6 @@ export const properties = {
       type: "keyword",
       value: "visible",
     },
-    popularity: 0.76715746,
-    appliesTo: "allElements",
     types: [],
   },
   whiteSpace: {
@@ -3984,8 +3289,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.80711821,
-    appliesTo: "allElements",
     types: [],
   },
   widows: {
@@ -3996,8 +3299,6 @@ export const properties = {
       unit: "number",
       value: 2,
     },
-    popularity: 0.03635817,
-    appliesTo: "blockContainerElements",
     types: ["integer", "number"],
   },
   width: {
@@ -4007,8 +3308,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.93671487,
-    appliesTo: "allElementsButNonReplacedAndTableRows",
     types: ["length", "percentage"],
   },
   willChange: {
@@ -4018,8 +3317,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.28251419,
-    appliesTo: "allElements",
     types: ["custom-ident"],
   },
   wordBreak: {
@@ -4029,8 +3326,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.51074263,
-    appliesTo: "allElements",
     types: [],
   },
   wordSpacing: {
@@ -4040,8 +3335,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.15650671,
-    appliesTo: "allElements",
     types: ["length"],
   },
   wordWrap: {
@@ -4051,8 +3344,6 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    popularity: 0.55291577,
-    appliesTo: "nonReplacedInlineElements",
     types: [],
   },
   writingMode: {
@@ -4062,8 +3353,6 @@ export const properties = {
       type: "keyword",
       value: "horizontal-tb",
     },
-    popularity: 0.00947773,
-    appliesTo: "allElementsExceptTableRowColumnGroupsTableRowsColumns",
     types: [],
   },
   zIndex: {
@@ -4073,8 +3362,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    popularity: 0.85875694,
-    appliesTo: "positionedElements",
     types: ["integer", "number"],
   },
 } as const;

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -881,7 +881,7 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    types: ["integer", "number"],
+    types: ["integer"],
   },
   columnFill: {
     unitGroups: [],
@@ -1035,7 +1035,7 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    types: ["custom-ident", "integer", "number"],
+    types: ["custom-ident", "integer"],
   },
   counterReset: {
     unitGroups: ["number"],
@@ -1044,7 +1044,7 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    types: ["custom-ident", "integer", "number"],
+    types: ["custom-ident", "integer"],
   },
   counterSet: {
     unitGroups: ["number"],
@@ -1053,7 +1053,7 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    types: ["custom-ident", "integer", "number"],
+    types: ["custom-ident", "integer"],
   },
   cursor: {
     unitGroups: [],
@@ -1172,7 +1172,7 @@ export const properties = {
       type: "keyword",
       value: "normal",
     },
-    types: ["string", "integer", "number"],
+    types: ["string", "integer"],
   },
   fontKerning: {
     unitGroups: [],
@@ -1397,7 +1397,7 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    types: ["custom-ident", "integer", "number"],
+    types: ["custom-ident", "integer"],
   },
   gridColumnStart: {
     unitGroups: ["number"],
@@ -1406,7 +1406,7 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    types: ["custom-ident", "integer", "number"],
+    types: ["custom-ident", "integer"],
   },
   gridRowEnd: {
     unitGroups: ["number"],
@@ -1415,7 +1415,7 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    types: ["custom-ident", "integer", "number"],
+    types: ["custom-ident", "integer"],
   },
   gridRowStart: {
     unitGroups: ["number"],
@@ -1424,7 +1424,7 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    types: ["custom-ident", "integer", "number"],
+    types: ["custom-ident", "integer"],
   },
   gridTemplateAreas: {
     unitGroups: [],
@@ -1487,7 +1487,7 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    types: ["integer", "number"],
+    types: ["integer"],
   },
   hyphens: {
     unitGroups: [],
@@ -1677,7 +1677,7 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    types: ["integer", "number"],
+    types: ["integer"],
   },
   lineHeight: {
     unitGroups: ["number", "length", "percentage"],
@@ -1968,7 +1968,7 @@ export const properties = {
       unit: "number",
       value: 0,
     },
-    types: ["integer", "number"],
+    types: ["integer"],
   },
   mathShift: {
     unitGroups: [],
@@ -2022,7 +2022,7 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    types: ["integer", "number"],
+    types: ["integer"],
   },
   maxWidth: {
     unitGroups: ["length", "percentage"],
@@ -2173,7 +2173,7 @@ export const properties = {
       unit: "number",
       value: 0,
     },
-    types: ["integer", "number"],
+    types: ["integer"],
   },
   orphans: {
     unitGroups: ["number"],
@@ -2183,7 +2183,7 @@ export const properties = {
       unit: "number",
       value: 2,
     },
-    types: ["integer", "number"],
+    types: ["integer"],
   },
   outlineColor: {
     unitGroups: [],
@@ -2873,7 +2873,7 @@ export const properties = {
       unit: "number",
       value: 8,
     },
-    types: ["integer", "number", "length"],
+    types: ["integer", "length"],
   },
   tableLayout: {
     unitGroups: [],
@@ -2909,7 +2909,7 @@ export const properties = {
       type: "keyword",
       value: "none",
     },
-    types: ["integer", "number"],
+    types: ["integer"],
   },
   textDecorationColor: {
     unitGroups: [],
@@ -3299,7 +3299,7 @@ export const properties = {
       unit: "number",
       value: 2,
     },
-    types: ["integer", "number"],
+    types: ["integer"],
   },
   width: {
     unitGroups: ["length", "percentage"],
@@ -3362,6 +3362,6 @@ export const properties = {
       type: "keyword",
       value: "auto",
     },
-    types: ["integer", "number"],
+    types: ["integer"],
   },
 } as const;

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -29,6 +29,7 @@ export const properties = {
     },
     popularity: 0.00030097,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   alignContent: {
     unitGroups: [],
@@ -39,6 +40,7 @@ export const properties = {
     },
     popularity: 0.2430101,
     appliesTo: "multilineFlexContainers",
+    types: [],
   },
   alignItems: {
     unitGroups: [],
@@ -49,6 +51,7 @@ export const properties = {
     },
     popularity: 0.71654912,
     appliesTo: "flexContainersGridContainers",
+    types: [],
   },
   alignSelf: {
     unitGroups: [],
@@ -59,6 +62,7 @@ export const properties = {
     },
     popularity: 0.43732689,
     appliesTo: "flexItemsGridItemsAndAbsolutelyPositionedBoxes",
+    types: [],
   },
   alignTracks: {
     unitGroups: [],
@@ -69,6 +73,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "gridContainersWithMasonryLayoutInTheirBlockAxis",
+    types: [],
   },
   animationComposition: {
     unitGroups: [],
@@ -79,6 +84,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["single-animation-composition"],
   },
   animationDelay: {
     unitGroups: ["time"],
@@ -90,6 +96,7 @@ export const properties = {
     },
     popularity: 0.27086537,
     appliesTo: "allElementsAndPseudos",
+    types: ["time"],
   },
   animationDirection: {
     unitGroups: [],
@@ -100,6 +107,7 @@ export const properties = {
     },
     popularity: 0.11739459,
     appliesTo: "allElementsAndPseudos",
+    types: [],
   },
   animationDuration: {
     unitGroups: ["time"],
@@ -111,6 +119,7 @@ export const properties = {
     },
     popularity: 0.4062731,
     appliesTo: "allElementsAndPseudos",
+    types: ["time"],
   },
   animationFillMode: {
     unitGroups: [],
@@ -121,6 +130,7 @@ export const properties = {
     },
     popularity: 0.2785038,
     appliesTo: "allElementsAndPseudos",
+    types: [],
   },
   animationIterationCount: {
     unitGroups: ["number"],
@@ -132,6 +142,7 @@ export const properties = {
     },
     popularity: 0.21759716,
     appliesTo: "allElementsAndPseudos",
+    types: ["number"],
   },
   animationName: {
     unitGroups: [],
@@ -142,6 +153,7 @@ export const properties = {
     },
     popularity: 0.40320939,
     appliesTo: "allElementsAndPseudos",
+    types: ["custom-ident", "string"],
   },
   animationPlayState: {
     unitGroups: [],
@@ -152,6 +164,7 @@ export const properties = {
     },
     popularity: 0.07996997,
     appliesTo: "allElementsAndPseudos",
+    types: [],
   },
   animationTimingFunction: {
     unitGroups: [],
@@ -162,6 +175,7 @@ export const properties = {
     },
     popularity: 0.41317969,
     appliesTo: "allElementsAndPseudos",
+    types: [],
   },
   animationTimeline: {
     unitGroups: [],
@@ -172,6 +186,7 @@ export const properties = {
     },
     popularity: 4e-8,
     appliesTo: "allElements",
+    types: ["custom-ident", "string"],
   },
   appearance: {
     unitGroups: [],
@@ -182,6 +197,7 @@ export const properties = {
     },
     popularity: 0.24468974,
     appliesTo: "allElements",
+    types: [],
   },
   aspectRatio: {
     unitGroups: ["number"],
@@ -192,6 +208,7 @@ export const properties = {
     },
     popularity: 0.07243677,
     appliesTo: "allElementsExceptInlineBoxesAndInternalRubyOrTableBoxes",
+    types: ["number"],
   },
   backdropFilter: {
     unitGroups: [],
@@ -202,6 +219,7 @@ export const properties = {
     },
     popularity: 0.0728427,
     appliesTo: "allElementsSVGContainerElements",
+    types: ["url"],
   },
   backfaceVisibility: {
     unitGroups: [],
@@ -212,6 +230,7 @@ export const properties = {
     },
     popularity: 0.19792557,
     appliesTo: "transformableElements",
+    types: [],
   },
   backgroundAttachment: {
     unitGroups: [],
@@ -222,6 +241,7 @@ export const properties = {
     },
     popularity: 0.08164946,
     appliesTo: "allElements",
+    types: [],
   },
   backgroundBlendMode: {
     unitGroups: [],
@@ -232,6 +252,7 @@ export const properties = {
     },
     popularity: 0.01578865,
     appliesTo: "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
+    types: [],
   },
   backgroundClip: {
     unitGroups: [],
@@ -242,6 +263,7 @@ export const properties = {
     },
     popularity: 0.36203159,
     appliesTo: "allElements",
+    types: [],
   },
   backgroundColor: {
     unitGroups: [],
@@ -252,6 +274,7 @@ export const properties = {
     },
     popularity: 0.89693959,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   backgroundImage: {
     unitGroups: [],
@@ -262,6 +285,7 @@ export const properties = {
     },
     popularity: 0.78519153,
     appliesTo: "allElements",
+    types: ["url"],
   },
   backgroundOrigin: {
     unitGroups: [],
@@ -272,6 +296,7 @@ export const properties = {
     },
     popularity: 0.0847006,
     appliesTo: "allElements",
+    types: [],
   },
   backgroundPosition: {
     unitGroups: ["length", "percentage"],
@@ -293,6 +318,7 @@ export const properties = {
     },
     popularity: 0.76724967,
     appliesTo: "allElements",
+    types: ["length", "percentage"],
   },
   backgroundPositionX: {
     unitGroups: ["length", "percentage"],
@@ -304,6 +330,7 @@ export const properties = {
     },
     popularity: 0.08951679,
     appliesTo: "allElements",
+    types: ["length", "percentage"],
   },
   backgroundPositionY: {
     unitGroups: ["length", "percentage"],
@@ -315,6 +342,7 @@ export const properties = {
     },
     popularity: 0.06759137,
     appliesTo: "allElements",
+    types: ["length", "percentage"],
   },
   backgroundRepeat: {
     unitGroups: [],
@@ -325,6 +353,7 @@ export const properties = {
     },
     popularity: 0.72870191,
     appliesTo: "allElements",
+    types: [],
   },
   backgroundSize: {
     unitGroups: ["length", "percentage"],
@@ -335,6 +364,7 @@ export const properties = {
     },
     popularity: 0.73157126,
     appliesTo: "allElements",
+    types: ["length", "percentage"],
   },
   blockOverflow: {
     unitGroups: [],
@@ -345,6 +375,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "blockContainers",
+    types: ["string"],
   },
   blockSize: {
     unitGroups: ["length", "percentage"],
@@ -355,6 +386,7 @@ export const properties = {
     },
     popularity: 0.00226404,
     appliesTo: "sameAsWidthAndHeight",
+    types: ["length", "percentage"],
   },
   borderBlockColor: {
     unitGroups: [],
@@ -365,6 +397,7 @@ export const properties = {
     },
     popularity: 0.00012849,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   borderBlockStyle: {
     unitGroups: [],
@@ -375,6 +408,7 @@ export const properties = {
     },
     popularity: 0.0003145,
     appliesTo: "allElements",
+    types: [],
   },
   borderBlockWidth: {
     unitGroups: ["length"],
@@ -385,6 +419,7 @@ export const properties = {
     },
     popularity: 0.0003078,
     appliesTo: "allElements",
+    types: ["length"],
   },
   borderBlockEndColor: {
     unitGroups: [],
@@ -395,6 +430,7 @@ export const properties = {
     },
     popularity: 0.00172099,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   borderBlockEndStyle: {
     unitGroups: [],
@@ -405,6 +441,7 @@ export const properties = {
     },
     popularity: 0.00169793,
     appliesTo: "allElements",
+    types: [],
   },
   borderBlockEndWidth: {
     unitGroups: ["length"],
@@ -415,6 +452,7 @@ export const properties = {
     },
     popularity: 0.00170225,
     appliesTo: "allElements",
+    types: ["length"],
   },
   borderBlockStartColor: {
     unitGroups: [],
@@ -425,6 +463,7 @@ export const properties = {
     },
     popularity: 0.00170188,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   borderBlockStartStyle: {
     unitGroups: [],
@@ -435,6 +474,7 @@ export const properties = {
     },
     popularity: 0.00168772,
     appliesTo: "allElements",
+    types: [],
   },
   borderBlockStartWidth: {
     unitGroups: ["length"],
@@ -445,6 +485,7 @@ export const properties = {
     },
     popularity: 0.00169412,
     appliesTo: "allElements",
+    types: ["length"],
   },
   borderBottomColor: {
     unitGroups: [],
@@ -455,6 +496,7 @@ export const properties = {
     },
     popularity: 0.42283564,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   borderBottomLeftRadius: {
     unitGroups: ["length", "percentage"],
@@ -466,6 +508,7 @@ export const properties = {
     },
     popularity: 0.51220741,
     appliesTo: "allElementsUAsNotRequiredWhenCollapse",
+    types: ["length", "percentage"],
   },
   borderBottomRightRadius: {
     unitGroups: ["length", "percentage"],
@@ -477,6 +520,7 @@ export const properties = {
     },
     popularity: 0.49744373,
     appliesTo: "allElementsUAsNotRequiredWhenCollapse",
+    types: ["length", "percentage"],
   },
   borderBottomStyle: {
     unitGroups: [],
@@ -487,6 +531,7 @@ export const properties = {
     },
     popularity: 0.17956288,
     appliesTo: "allElements",
+    types: [],
   },
   borderBottomWidth: {
     unitGroups: ["length"],
@@ -497,6 +542,7 @@ export const properties = {
     },
     popularity: 0.24668981,
     appliesTo: "allElements",
+    types: ["length"],
   },
   borderCollapse: {
     unitGroups: [],
@@ -507,6 +553,7 @@ export const properties = {
     },
     popularity: 0.47856821,
     appliesTo: "tableElements",
+    types: [],
   },
   borderEndEndRadius: {
     unitGroups: ["length", "percentage"],
@@ -518,6 +565,7 @@ export const properties = {
     },
     popularity: 0.00029065,
     appliesTo: "allElementsUAsNotRequiredWhenCollapse",
+    types: ["length", "percentage"],
   },
   borderEndStartRadius: {
     unitGroups: ["length", "percentage"],
@@ -529,6 +577,7 @@ export const properties = {
     },
     popularity: 0.0003058,
     appliesTo: "allElementsUAsNotRequiredWhenCollapse",
+    types: ["length", "percentage"],
   },
   borderImageOutset: {
     unitGroups: ["length", "number"],
@@ -540,6 +589,7 @@ export const properties = {
     },
     popularity: 0.00458637,
     appliesTo: "allElementsExceptTableElementsWhenCollapse",
+    types: ["length", "number"],
   },
   borderImageRepeat: {
     unitGroups: [],
@@ -550,6 +600,7 @@ export const properties = {
     },
     popularity: 0.00685817,
     appliesTo: "allElementsExceptTableElementsWhenCollapse",
+    types: [],
   },
   borderImageSlice: {
     unitGroups: ["number", "percentage"],
@@ -561,6 +612,7 @@ export const properties = {
     },
     popularity: 0.0093669,
     appliesTo: "allElementsExceptTableElementsWhenCollapse",
+    types: ["number", "percentage"],
   },
   borderImageSource: {
     unitGroups: [],
@@ -571,6 +623,7 @@ export const properties = {
     },
     popularity: 0.00991835,
     appliesTo: "allElementsExceptTableElementsWhenCollapse",
+    types: ["url"],
   },
   borderImageWidth: {
     unitGroups: ["length", "percentage", "number"],
@@ -582,6 +635,7 @@ export const properties = {
     },
     popularity: 0.0072772,
     appliesTo: "allElementsExceptTableElementsWhenCollapse",
+    types: ["length", "percentage", "number"],
   },
   borderInlineColor: {
     unitGroups: [],
@@ -592,6 +646,7 @@ export const properties = {
     },
     popularity: 0.00007844,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   borderInlineStyle: {
     unitGroups: [],
@@ -602,6 +657,7 @@ export const properties = {
     },
     popularity: 0.00031147,
     appliesTo: "allElements",
+    types: [],
   },
   borderInlineWidth: {
     unitGroups: ["length"],
@@ -612,6 +668,7 @@ export const properties = {
     },
     popularity: 0.0002956,
     appliesTo: "allElements",
+    types: ["length"],
   },
   borderInlineEndColor: {
     unitGroups: [],
@@ -622,6 +679,7 @@ export const properties = {
     },
     popularity: 0.00196849,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   borderInlineEndStyle: {
     unitGroups: [],
@@ -632,6 +690,7 @@ export const properties = {
     },
     popularity: 0.00171907,
     appliesTo: "allElements",
+    types: [],
   },
   borderInlineEndWidth: {
     unitGroups: ["length"],
@@ -642,6 +701,7 @@ export const properties = {
     },
     popularity: 0.0051498,
     appliesTo: "allElements",
+    types: ["length"],
   },
   borderInlineStartColor: {
     unitGroups: [],
@@ -652,6 +712,7 @@ export const properties = {
     },
     popularity: 0.00196928,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   borderInlineStartStyle: {
     unitGroups: [],
@@ -662,6 +723,7 @@ export const properties = {
     },
     popularity: 0.00177637,
     appliesTo: "allElements",
+    types: [],
   },
   borderInlineStartWidth: {
     unitGroups: ["length"],
@@ -672,6 +734,7 @@ export const properties = {
     },
     popularity: 0.00438625,
     appliesTo: "allElements",
+    types: ["length"],
   },
   borderLeftColor: {
     unitGroups: [],
@@ -682,6 +745,7 @@ export const properties = {
     },
     popularity: 0.30754028,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   borderLeftStyle: {
     unitGroups: [],
@@ -692,6 +756,7 @@ export const properties = {
     },
     popularity: 0.06120178,
     appliesTo: "allElements",
+    types: [],
   },
   borderLeftWidth: {
     unitGroups: ["length"],
@@ -702,6 +767,7 @@ export const properties = {
     },
     popularity: 0.17181793,
     appliesTo: "allElements",
+    types: ["length"],
   },
   borderRightColor: {
     unitGroups: [],
@@ -712,6 +778,7 @@ export const properties = {
     },
     popularity: 0.29336595,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   borderRightStyle: {
     unitGroups: [],
@@ -722,6 +789,7 @@ export const properties = {
     },
     popularity: 0.06714237,
     appliesTo: "allElements",
+    types: [],
   },
   borderRightWidth: {
     unitGroups: ["length"],
@@ -732,6 +800,7 @@ export const properties = {
     },
     popularity: 0.17940634,
     appliesTo: "allElements",
+    types: ["length"],
   },
   borderSpacing: {
     unitGroups: ["length"],
@@ -743,6 +812,7 @@ export const properties = {
     },
     popularity: 0.37217618,
     appliesTo: "tableElements",
+    types: ["length"],
   },
   borderStartEndRadius: {
     unitGroups: ["length", "percentage"],
@@ -754,6 +824,7 @@ export const properties = {
     },
     popularity: 0.00029494,
     appliesTo: "allElementsUAsNotRequiredWhenCollapse",
+    types: ["length", "percentage"],
   },
   borderStartStartRadius: {
     unitGroups: ["length", "percentage"],
@@ -765,6 +836,7 @@ export const properties = {
     },
     popularity: 0.00028405,
     appliesTo: "allElementsUAsNotRequiredWhenCollapse",
+    types: ["length", "percentage"],
   },
   borderTopColor: {
     unitGroups: [],
@@ -775,6 +847,7 @@ export const properties = {
     },
     popularity: 0.43342948,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   borderTopLeftRadius: {
     unitGroups: ["length", "percentage"],
@@ -786,6 +859,7 @@ export const properties = {
     },
     popularity: 0.50859807,
     appliesTo: "allElementsUAsNotRequiredWhenCollapse",
+    types: ["length", "percentage"],
   },
   borderTopRightRadius: {
     unitGroups: ["length", "percentage"],
@@ -797,6 +871,7 @@ export const properties = {
     },
     popularity: 0.50073217,
     appliesTo: "allElementsUAsNotRequiredWhenCollapse",
+    types: ["length", "percentage"],
   },
   borderTopStyle: {
     unitGroups: [],
@@ -807,6 +882,7 @@ export const properties = {
     },
     popularity: 0.16269446,
     appliesTo: "allElements",
+    types: [],
   },
   borderTopWidth: {
     unitGroups: ["length"],
@@ -817,6 +893,7 @@ export const properties = {
     },
     popularity: 0.21953437,
     appliesTo: "allElements",
+    types: ["length"],
   },
   bottom: {
     unitGroups: ["length", "percentage"],
@@ -827,6 +904,7 @@ export const properties = {
     },
     popularity: 0.8243869,
     appliesTo: "positionedElements",
+    types: ["length", "percentage"],
   },
   boxDecorationBreak: {
     unitGroups: [],
@@ -837,6 +915,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: [],
   },
   boxShadow: {
     unitGroups: ["length"],
@@ -847,6 +926,7 @@ export const properties = {
     },
     popularity: 0.81259285,
     appliesTo: "allElements",
+    types: ["length", "hex-color"],
   },
   boxSizing: {
     unitGroups: [],
@@ -857,6 +937,7 @@ export const properties = {
     },
     popularity: 0.86402206,
     appliesTo: "allElementsAcceptingWidthOrHeight",
+    types: [],
   },
   breakAfter: {
     unitGroups: [],
@@ -867,6 +948,7 @@ export const properties = {
     },
     popularity: 0.00365105,
     appliesTo: "blockLevelElements",
+    types: [],
   },
   breakBefore: {
     unitGroups: [],
@@ -877,6 +959,7 @@ export const properties = {
     },
     popularity: 0.00341796,
     appliesTo: "blockLevelElements",
+    types: [],
   },
   breakInside: {
     unitGroups: [],
@@ -887,6 +970,7 @@ export const properties = {
     },
     popularity: 0.02782348,
     appliesTo: "blockLevelElements",
+    types: [],
   },
   captionSide: {
     unitGroups: [],
@@ -897,6 +981,7 @@ export const properties = {
     },
     popularity: 0.04083929,
     appliesTo: "tableCaptionElements",
+    types: [],
   },
   caretColor: {
     unitGroups: [],
@@ -907,6 +992,7 @@ export const properties = {
     },
     popularity: 0.05410129,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   caretShape: {
     unitGroups: [],
@@ -917,6 +1003,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "elementsThatAcceptInput",
+    types: [],
   },
   clear: {
     unitGroups: [],
@@ -927,6 +1014,7 @@ export const properties = {
     },
     popularity: 0.7016813,
     appliesTo: "blockLevelElements",
+    types: [],
   },
   clip: {
     unitGroups: [],
@@ -937,6 +1025,7 @@ export const properties = {
     },
     popularity: 0.48810561,
     appliesTo: "absolutelyPositionedElements",
+    types: [],
   },
   clipPath: {
     unitGroups: [],
@@ -947,6 +1036,7 @@ export const properties = {
     },
     popularity: 0.20754263,
     appliesTo: "allElementsSVGContainerElements",
+    types: ["url"],
   },
   color: {
     unitGroups: [],
@@ -957,6 +1047,7 @@ export const properties = {
     },
     popularity: 0.90791486,
     appliesTo: "allElementsAndText",
+    types: ["hex-color"],
   },
   colorScheme: {
     unitGroups: [],
@@ -967,6 +1058,7 @@ export const properties = {
     },
     popularity: 0.03358925,
     appliesTo: "allElementsAndText",
+    types: ["custom-ident"],
   },
   columnCount: {
     unitGroups: ["number"],
@@ -977,6 +1069,7 @@ export const properties = {
     },
     popularity: 0.07098549,
     appliesTo: "blockContainersExceptTableWrappers",
+    types: ["integer", "number"],
   },
   columnFill: {
     unitGroups: [],
@@ -987,6 +1080,7 @@ export const properties = {
     },
     popularity: 0.01738207,
     appliesTo: "multicolElements",
+    types: [],
   },
   columnGap: {
     unitGroups: ["length", "percentage"],
@@ -998,6 +1092,7 @@ export const properties = {
     },
     popularity: 0.09282422,
     appliesTo: "multiColumnElementsFlexContainersGridContainers",
+    types: ["length", "percentage"],
   },
   columnRuleColor: {
     unitGroups: [],
@@ -1008,6 +1103,7 @@ export const properties = {
     },
     popularity: 0.01356616,
     appliesTo: "multicolElements",
+    types: ["hex-color"],
   },
   columnRuleStyle: {
     unitGroups: [],
@@ -1018,6 +1114,7 @@ export const properties = {
     },
     popularity: 0.0131392,
     appliesTo: "multicolElements",
+    types: [],
   },
   columnRuleWidth: {
     unitGroups: ["length"],
@@ -1028,6 +1125,7 @@ export const properties = {
     },
     popularity: 0.00328701,
     appliesTo: "multicolElements",
+    types: ["length"],
   },
   columnSpan: {
     unitGroups: [],
@@ -1038,6 +1136,7 @@ export const properties = {
     },
     popularity: 0.00654278,
     appliesTo: "inFlowBlockLevelElements",
+    types: [],
   },
   columnWidth: {
     unitGroups: ["length"],
@@ -1048,6 +1147,7 @@ export const properties = {
     },
     popularity: 0.03188644,
     appliesTo: "blockContainersExceptTableWrappers",
+    types: ["length"],
   },
   contain: {
     unitGroups: [],
@@ -1058,6 +1158,7 @@ export const properties = {
     },
     popularity: 0.17189203,
     appliesTo: "allElements",
+    types: [],
   },
   containIntrinsicBlockSize: {
     unitGroups: ["length"],
@@ -1068,6 +1169,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "elementsForWhichSizeContainmentCanApply",
+    types: ["length"],
   },
   containIntrinsicHeight: {
     unitGroups: ["length"],
@@ -1078,6 +1180,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "elementsForWhichSizeContainmentCanApply",
+    types: ["length"],
   },
   containIntrinsicInlineSize: {
     unitGroups: ["length"],
@@ -1088,6 +1191,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "elementsForWhichSizeContainmentCanApply",
+    types: ["length"],
   },
   containIntrinsicWidth: {
     unitGroups: ["length"],
@@ -1098,6 +1202,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "elementsForWhichSizeContainmentCanApply",
+    types: ["length"],
   },
   containerName: {
     unitGroups: [],
@@ -1108,6 +1213,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["custom-ident"],
   },
   containerType: {
     unitGroups: [],
@@ -1118,6 +1224,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: [],
   },
   content: {
     unitGroups: [],
@@ -1128,6 +1235,7 @@ export const properties = {
     },
     popularity: 0.81447258,
     appliesTo: "allElementsTreeAbidingPseudoElementsPageMarginBoxes",
+    types: ["url", "string"],
   },
   contentVisibility: {
     unitGroups: [],
@@ -1138,6 +1246,7 @@ export const properties = {
     },
     popularity: 0.04199404,
     appliesTo: "elementsForWhichSizeContainmentCanApply",
+    types: [],
   },
   counterIncrement: {
     unitGroups: ["number"],
@@ -1148,6 +1257,7 @@ export const properties = {
     },
     popularity: 0.07472144,
     appliesTo: "allElements",
+    types: ["custom-ident", "integer", "number"],
   },
   counterReset: {
     unitGroups: ["number"],
@@ -1158,6 +1268,7 @@ export const properties = {
     },
     popularity: 0.06641074,
     appliesTo: "allElements",
+    types: ["custom-ident", "integer", "number"],
   },
   counterSet: {
     unitGroups: ["number"],
@@ -1168,6 +1279,7 @@ export const properties = {
     },
     popularity: 0.00016346,
     appliesTo: "allElements",
+    types: ["custom-ident", "integer", "number"],
   },
   cursor: {
     unitGroups: [],
@@ -1178,6 +1290,7 @@ export const properties = {
     },
     popularity: 0.85037255,
     appliesTo: "allElements",
+    types: ["url", "x", "y"],
   },
   direction: {
     unitGroups: [],
@@ -1188,6 +1301,7 @@ export const properties = {
     },
     popularity: 0.40017516,
     appliesTo: "allElements",
+    types: [],
   },
   display: {
     unitGroups: [],
@@ -1198,6 +1312,7 @@ export const properties = {
     },
     popularity: 0.93157435,
     appliesTo: "allElements",
+    types: [],
   },
   emptyCells: {
     unitGroups: [],
@@ -1208,6 +1323,7 @@ export const properties = {
     },
     popularity: 0.03153899,
     appliesTo: "tableCellElements",
+    types: [],
   },
   filter: {
     unitGroups: [],
@@ -1218,6 +1334,7 @@ export const properties = {
     },
     popularity: 0.32058162,
     appliesTo: "allElementsSVGContainerElements",
+    types: ["url"],
   },
   flexBasis: {
     unitGroups: ["length", "percentage"],
@@ -1228,6 +1345,7 @@ export const properties = {
     },
     popularity: 0.3070072,
     appliesTo: "flexItemsAndInFlowPseudos",
+    types: ["length", "percentage"],
   },
   flexDirection: {
     unitGroups: [],
@@ -1238,6 +1356,7 @@ export const properties = {
     },
     popularity: 0.65789154,
     appliesTo: "flexContainers",
+    types: [],
   },
   flexGrow: {
     unitGroups: ["number"],
@@ -1249,6 +1368,7 @@ export const properties = {
     },
     popularity: 0.50511311,
     appliesTo: "flexItemsAndInFlowPseudos",
+    types: ["number"],
   },
   flexShrink: {
     unitGroups: ["number"],
@@ -1260,6 +1380,7 @@ export const properties = {
     },
     popularity: 0.4809155,
     appliesTo: "flexItemsAndInFlowPseudos",
+    types: ["number"],
   },
   flexWrap: {
     unitGroups: [],
@@ -1270,6 +1391,7 @@ export const properties = {
     },
     popularity: 0.58959861,
     appliesTo: "flexContainers",
+    types: [],
   },
   float: {
     unitGroups: [],
@@ -1280,6 +1402,7 @@ export const properties = {
     },
     popularity: 0.8383589,
     appliesTo: "allElementsNoEffectIfDisplayNone",
+    types: [],
   },
   fontFamily: {
     unitGroups: [],
@@ -1290,6 +1413,7 @@ export const properties = {
     },
     popularity: 0.88101351,
     appliesTo: "allElements",
+    types: ["string", "custom-ident"],
   },
   fontFeatureSettings: {
     unitGroups: ["number"],
@@ -1300,6 +1424,7 @@ export const properties = {
     },
     popularity: 0.12538368,
     appliesTo: "allElements",
+    types: ["string", "integer", "number"],
   },
   fontKerning: {
     unitGroups: [],
@@ -1310,6 +1435,7 @@ export const properties = {
     },
     popularity: 0.01160796,
     appliesTo: "allElements",
+    types: [],
   },
   fontLanguageOverride: {
     unitGroups: [],
@@ -1320,6 +1446,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["string"],
   },
   fontOpticalSizing: {
     unitGroups: [],
@@ -1330,6 +1457,7 @@ export const properties = {
     },
     popularity: 0.0006232,
     appliesTo: "allElements",
+    types: [],
   },
   fontPalette: {
     unitGroups: [],
@@ -1340,6 +1468,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsAndText",
+    types: ["palette-identifier"],
   },
   fontVariationSettings: {
     unitGroups: ["number"],
@@ -1350,6 +1479,7 @@ export const properties = {
     },
     popularity: 0.00471835,
     appliesTo: "allElements",
+    types: ["string", "number"],
   },
   fontSize: {
     unitGroups: ["length", "percentage"],
@@ -1360,6 +1490,7 @@ export const properties = {
     },
     popularity: 0.90325346,
     appliesTo: "allElements",
+    types: ["length", "percentage"],
   },
   fontSizeAdjust: {
     unitGroups: ["number"],
@@ -1370,6 +1501,7 @@ export const properties = {
     },
     popularity: 0.000003,
     appliesTo: "allElements",
+    types: ["number"],
   },
   fontStretch: {
     unitGroups: ["percentage"],
@@ -1380,6 +1512,7 @@ export const properties = {
     },
     popularity: 0.12741738,
     appliesTo: "allElements",
+    types: ["percentage"],
   },
   fontStyle: {
     unitGroups: ["angle"],
@@ -1390,6 +1523,7 @@ export const properties = {
     },
     popularity: 0.7961795,
     appliesTo: "allElements",
+    types: ["angle"],
   },
   fontSynthesis: {
     unitGroups: [],
@@ -1409,6 +1543,7 @@ export const properties = {
     },
     popularity: 0.00686166,
     appliesTo: "allElements",
+    types: [],
   },
   fontVariant: {
     unitGroups: [],
@@ -1419,6 +1554,7 @@ export const properties = {
     },
     popularity: 0.30968418,
     appliesTo: "allElements",
+    types: [],
   },
   fontVariantAlternates: {
     unitGroups: [],
@@ -1429,6 +1565,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: [],
   },
   fontVariantCaps: {
     unitGroups: [],
@@ -1439,6 +1576,7 @@ export const properties = {
     },
     popularity: 0.00514777,
     appliesTo: "allElements",
+    types: [],
   },
   fontVariantEastAsian: {
     unitGroups: [],
@@ -1449,6 +1587,7 @@ export const properties = {
     },
     popularity: 0.00328361,
     appliesTo: "allElements",
+    types: [],
   },
   fontVariantEmoji: {
     unitGroups: [],
@@ -1459,6 +1598,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsAndText",
+    types: [],
   },
   fontVariantLigatures: {
     unitGroups: [],
@@ -1469,6 +1609,7 @@ export const properties = {
     },
     popularity: 0.05055055,
     appliesTo: "allElements",
+    types: [],
   },
   fontVariantNumeric: {
     unitGroups: [],
@@ -1479,6 +1620,7 @@ export const properties = {
     },
     popularity: 0.01816086,
     appliesTo: "allElements",
+    types: [],
   },
   fontVariantPosition: {
     unitGroups: [],
@@ -1489,6 +1631,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: [],
   },
   fontWeight: {
     unitGroups: ["number"],
@@ -1499,6 +1642,7 @@ export const properties = {
     },
     popularity: 0.88598106,
     appliesTo: "allElements",
+    types: ["number"],
   },
   forcedColorAdjust: {
     unitGroups: [],
@@ -1509,6 +1653,7 @@ export const properties = {
     },
     popularity: 0.02245871,
     appliesTo: "allElementsAndText",
+    types: [],
   },
   gridAutoColumns: {
     unitGroups: ["length", "percentage", "flex"],
@@ -1519,6 +1664,7 @@ export const properties = {
     },
     popularity: 0.01226638,
     appliesTo: "gridContainers",
+    types: ["length", "percentage", "flex"],
   },
   gridAutoFlow: {
     unitGroups: [],
@@ -1529,6 +1675,7 @@ export const properties = {
     },
     popularity: 0.03982344,
     appliesTo: "gridContainers",
+    types: [],
   },
   gridAutoRows: {
     unitGroups: ["length", "percentage", "flex"],
@@ -1539,6 +1686,7 @@ export const properties = {
     },
     popularity: 0.02839547,
     appliesTo: "gridContainers",
+    types: ["length", "percentage", "flex"],
   },
   gridColumnEnd: {
     unitGroups: ["number"],
@@ -1549,6 +1697,7 @@ export const properties = {
     },
     popularity: 0.01848874,
     appliesTo: "gridItemsAndBoxesWithinGridContainer",
+    types: ["custom-ident", "integer", "number"],
   },
   gridColumnStart: {
     unitGroups: ["number"],
@@ -1559,6 +1708,7 @@ export const properties = {
     },
     popularity: 0.02019688,
     appliesTo: "gridItemsAndBoxesWithinGridContainer",
+    types: ["custom-ident", "integer", "number"],
   },
   gridRowEnd: {
     unitGroups: ["number"],
@@ -1569,6 +1719,7 @@ export const properties = {
     },
     popularity: 0.00961681,
     appliesTo: "gridItemsAndBoxesWithinGridContainer",
+    types: ["custom-ident", "integer", "number"],
   },
   gridRowStart: {
     unitGroups: ["number"],
@@ -1579,6 +1730,7 @@ export const properties = {
     },
     popularity: 0.01281513,
     appliesTo: "gridItemsAndBoxesWithinGridContainer",
+    types: ["custom-ident", "integer", "number"],
   },
   gridTemplateAreas: {
     unitGroups: [],
@@ -1589,6 +1741,7 @@ export const properties = {
     },
     popularity: 0.05496001,
     appliesTo: "gridContainers",
+    types: ["string"],
   },
   gridTemplateColumns: {
     unitGroups: ["length", "percentage", "flex"],
@@ -1599,6 +1752,7 @@ export const properties = {
     },
     popularity: 0.17745181,
     appliesTo: "gridContainers",
+    types: ["custom-ident", "length", "percentage", "flex"],
   },
   gridTemplateRows: {
     unitGroups: ["length", "percentage", "flex"],
@@ -1609,6 +1763,7 @@ export const properties = {
     },
     popularity: 0.07489386,
     appliesTo: "gridContainers",
+    types: ["custom-ident", "length", "percentage", "flex"],
   },
   hangingPunctuation: {
     unitGroups: [],
@@ -1619,6 +1774,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: [],
   },
   height: {
     unitGroups: ["length", "percentage"],
@@ -1629,6 +1785,7 @@ export const properties = {
     },
     popularity: 0.93056784,
     appliesTo: "allElementsButNonReplacedAndTableColumns",
+    types: ["length", "percentage"],
   },
   hyphenateCharacter: {
     unitGroups: [],
@@ -1639,6 +1796,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["string"],
   },
   hyphenateLimitChars: {
     unitGroups: ["number"],
@@ -1649,6 +1807,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["integer", "number"],
   },
   hyphens: {
     unitGroups: [],
@@ -1659,6 +1818,7 @@ export const properties = {
     },
     popularity: 0.10122444,
     appliesTo: "allElements",
+    types: [],
   },
   imageOrientation: {
     unitGroups: ["angle"],
@@ -1669,6 +1829,7 @@ export const properties = {
     },
     popularity: 0.00207108,
     appliesTo: "allElements",
+    types: ["angle"],
   },
   imageRendering: {
     unitGroups: [],
@@ -1679,6 +1840,7 @@ export const properties = {
     },
     popularity: 0.11112647,
     appliesTo: "allElements",
+    types: [],
   },
   imageResolution: {
     unitGroups: ["resolution"],
@@ -1690,6 +1852,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["resolution"],
   },
   initialLetter: {
     unitGroups: ["number"],
@@ -1700,6 +1863,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "firstLetterPseudoElementsAndInlineLevelFirstChildren",
+    types: ["number", "integer"],
   },
   initialLetterAlign: {
     unitGroups: [],
@@ -1710,6 +1874,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "firstLetterPseudoElementsAndInlineLevelFirstChildren",
+    types: [],
   },
   inlineSize: {
     unitGroups: ["length", "percentage"],
@@ -1720,6 +1885,7 @@ export const properties = {
     },
     popularity: 0.00381706,
     appliesTo: "sameAsWidthAndHeight",
+    types: ["length", "percentage"],
   },
   inputSecurity: {
     unitGroups: [],
@@ -1730,6 +1896,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "sensitiveTextInputs",
+    types: [],
   },
   insetBlockEnd: {
     unitGroups: ["length", "percentage"],
@@ -1740,6 +1907,7 @@ export const properties = {
     },
     popularity: 0.00031067,
     appliesTo: "positionedElements",
+    types: ["length", "percentage"],
   },
   insetBlockStart: {
     unitGroups: ["length", "percentage"],
@@ -1750,6 +1918,7 @@ export const properties = {
     },
     popularity: 0.00036346,
     appliesTo: "positionedElements",
+    types: ["length", "percentage"],
   },
   insetInlineEnd: {
     unitGroups: ["length", "percentage"],
@@ -1760,6 +1929,7 @@ export const properties = {
     },
     popularity: 0.00419961,
     appliesTo: "positionedElements",
+    types: ["length", "percentage"],
   },
   insetInlineStart: {
     unitGroups: ["length", "percentage"],
@@ -1770,6 +1940,7 @@ export const properties = {
     },
     popularity: 0.00379395,
     appliesTo: "positionedElements",
+    types: ["length", "percentage"],
   },
   isolation: {
     unitGroups: [],
@@ -1780,6 +1951,7 @@ export const properties = {
     },
     popularity: 0.01962288,
     appliesTo: "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
+    types: [],
   },
   justifyContent: {
     unitGroups: [],
@@ -1790,6 +1962,7 @@ export const properties = {
     },
     popularity: 0.72371,
     appliesTo: "flexContainers",
+    types: [],
   },
   justifyItems: {
     unitGroups: [],
@@ -1800,6 +1973,7 @@ export const properties = {
     },
     popularity: 0.05716411,
     appliesTo: "flexContainersGridContainers",
+    types: [],
   },
   justifySelf: {
     unitGroups: [],
@@ -1810,6 +1984,7 @@ export const properties = {
     },
     popularity: 0.06147513,
     appliesTo: "blockLevelBoxesAndAbsolutelyPositionedBoxesAndGridItems",
+    types: [],
   },
   justifyTracks: {
     unitGroups: [],
@@ -1820,6 +1995,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "gridContainersWithMasonryLayoutInTheirInlineAxis",
+    types: [],
   },
   left: {
     unitGroups: ["length", "percentage"],
@@ -1830,6 +2006,7 @@ export const properties = {
     },
     popularity: 0.90948372,
     appliesTo: "positionedElements",
+    types: ["length", "percentage"],
   },
   letterSpacing: {
     unitGroups: ["length"],
@@ -1840,6 +2017,7 @@ export const properties = {
     },
     popularity: 0.64325492,
     appliesTo: "allElements",
+    types: ["length"],
   },
   lineBreak: {
     unitGroups: [],
@@ -1850,6 +2028,7 @@ export const properties = {
     },
     popularity: 0.03790035,
     appliesTo: "allElements",
+    types: [],
   },
   lineClamp: {
     unitGroups: ["number"],
@@ -1860,6 +2039,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "blockContainersExceptMultiColumnContainers",
+    types: ["integer", "number"],
   },
   lineHeight: {
     unitGroups: ["number", "length", "percentage"],
@@ -1870,6 +2050,7 @@ export const properties = {
     },
     popularity: 0.87354969,
     appliesTo: "allElements",
+    types: ["number", "length", "percentage"],
   },
   lineHeightStep: {
     unitGroups: ["length"],
@@ -1881,6 +2062,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "blockContainers",
+    types: ["length"],
   },
   listStyleImage: {
     unitGroups: [],
@@ -1891,6 +2073,7 @@ export const properties = {
     },
     popularity: 0.05896406,
     appliesTo: "listItems",
+    types: ["url"],
   },
   listStylePosition: {
     unitGroups: [],
@@ -1901,6 +2084,7 @@ export const properties = {
     },
     popularity: 0.10836703,
     appliesTo: "listItems",
+    types: [],
   },
   listStyleType: {
     unitGroups: [],
@@ -1911,6 +2095,7 @@ export const properties = {
     },
     popularity: 0.50305363,
     appliesTo: "listItems",
+    types: ["custom-ident", "string"],
   },
   marginBlockEnd: {
     unitGroups: ["length", "percentage"],
@@ -1922,6 +2107,7 @@ export const properties = {
     },
     popularity: 0.06678285,
     appliesTo: "sameAsMargin",
+    types: ["length", "percentage"],
   },
   marginBlockStart: {
     unitGroups: ["length", "percentage"],
@@ -1933,6 +2119,7 @@ export const properties = {
     },
     popularity: 0.06603158,
     appliesTo: "sameAsMargin",
+    types: ["length", "percentage"],
   },
   marginBottom: {
     unitGroups: ["length", "percentage"],
@@ -1944,6 +2131,7 @@ export const properties = {
     },
     popularity: 0.84497162,
     appliesTo: "allElementsExceptTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   marginInlineEnd: {
     unitGroups: ["length", "percentage"],
@@ -1955,6 +2143,7 @@ export const properties = {
     },
     popularity: 0.02346878,
     appliesTo: "sameAsMargin",
+    types: ["length", "percentage"],
   },
   marginInlineStart: {
     unitGroups: ["length", "percentage"],
@@ -1966,6 +2155,7 @@ export const properties = {
     },
     popularity: 0.03660688,
     appliesTo: "sameAsMargin",
+    types: ["length", "percentage"],
   },
   marginLeft: {
     unitGroups: ["length", "percentage"],
@@ -1977,6 +2167,7 @@ export const properties = {
     },
     popularity: 0.84846503,
     appliesTo: "allElementsExceptTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   marginRight: {
     unitGroups: ["length", "percentage"],
@@ -1988,6 +2179,7 @@ export const properties = {
     },
     popularity: 0.83485199,
     appliesTo: "allElementsExceptTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   marginTop: {
     unitGroups: ["length", "percentage"],
@@ -1999,6 +2191,7 @@ export const properties = {
     },
     popularity: 0.90536837,
     appliesTo: "allElementsExceptTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   marginTrim: {
     unitGroups: [],
@@ -2009,6 +2202,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "blockContainersAndMultiColumnContainers",
+    types: [],
   },
   maskBorderMode: {
     unitGroups: [],
@@ -2019,6 +2213,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: [],
   },
   maskBorderOutset: {
     unitGroups: ["length", "number"],
@@ -2030,6 +2225,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: ["length", "number"],
   },
   maskBorderRepeat: {
     unitGroups: [],
@@ -2040,6 +2236,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: [],
   },
   maskBorderSlice: {
     unitGroups: ["number", "percentage"],
@@ -2051,6 +2248,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: ["number", "percentage"],
   },
   maskBorderSource: {
     unitGroups: [],
@@ -2061,6 +2259,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: ["url"],
   },
   maskBorderWidth: {
     unitGroups: ["length", "percentage", "number"],
@@ -2071,6 +2270,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: ["length", "percentage", "number"],
   },
   maskClip: {
     unitGroups: [],
@@ -2081,6 +2281,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: [],
   },
   maskComposite: {
     unitGroups: [],
@@ -2091,6 +2292,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: [],
   },
   maskImage: {
     unitGroups: [],
@@ -2101,6 +2303,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: ["url"],
   },
   maskMode: {
     unitGroups: [],
@@ -2111,6 +2314,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: [],
   },
   maskOrigin: {
     unitGroups: [],
@@ -2121,6 +2325,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: [],
   },
   maskPosition: {
     unitGroups: ["length", "percentage"],
@@ -2131,6 +2336,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: ["length", "percentage"],
   },
   maskRepeat: {
     unitGroups: [],
@@ -2141,6 +2347,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: [],
   },
   maskSize: {
     unitGroups: ["length", "percentage"],
@@ -2151,6 +2358,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElementsSVGContainerElements",
+    types: ["length", "percentage"],
   },
   maskType: {
     unitGroups: [],
@@ -2161,6 +2369,7 @@ export const properties = {
     },
     popularity: 0.00355107,
     appliesTo: "maskElements",
+    types: [],
   },
   masonryAutoFlow: {
     unitGroups: [],
@@ -2171,6 +2380,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "gridContainersWithMasonryLayout",
+    types: [],
   },
   mathDepth: {
     unitGroups: ["number"],
@@ -2182,6 +2392,7 @@ export const properties = {
     },
     popularity: 3e-8,
     appliesTo: "allElements",
+    types: ["integer", "number"],
   },
   mathShift: {
     unitGroups: [],
@@ -2192,6 +2403,7 @@ export const properties = {
     },
     popularity: 3e-8,
     appliesTo: "allElements",
+    types: [],
   },
   mathStyle: {
     unitGroups: [],
@@ -2202,6 +2414,7 @@ export const properties = {
     },
     popularity: 3e-8,
     appliesTo: "allElements",
+    types: [],
   },
   maxBlockSize: {
     unitGroups: ["length", "percentage"],
@@ -2212,6 +2425,7 @@ export const properties = {
     },
     popularity: 0.00064707,
     appliesTo: "sameAsWidthAndHeight",
+    types: ["length", "percentage"],
   },
   maxHeight: {
     unitGroups: ["length", "percentage"],
@@ -2222,6 +2436,7 @@ export const properties = {
     },
     popularity: 0.72769912,
     appliesTo: "allElementsButNonReplacedAndTableColumns",
+    types: ["length", "percentage"],
   },
   maxInlineSize: {
     unitGroups: ["length", "percentage"],
@@ -2232,6 +2447,7 @@ export const properties = {
     },
     popularity: 0.00062504,
     appliesTo: "sameAsWidthAndHeight",
+    types: ["length", "percentage"],
   },
   maxLines: {
     unitGroups: ["number"],
@@ -2242,6 +2458,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "blockContainersExceptMultiColumnContainers",
+    types: ["integer", "number"],
   },
   maxWidth: {
     unitGroups: ["length", "percentage"],
@@ -2252,6 +2469,7 @@ export const properties = {
     },
     popularity: 0.83290711,
     appliesTo: "allElementsButNonReplacedAndTableRows",
+    types: ["length", "percentage"],
   },
   minBlockSize: {
     unitGroups: ["length", "percentage"],
@@ -2263,6 +2481,7 @@ export const properties = {
     },
     popularity: 0.00192722,
     appliesTo: "sameAsWidthAndHeight",
+    types: ["length", "percentage"],
   },
   minHeight: {
     unitGroups: ["length", "percentage"],
@@ -2273,6 +2492,7 @@ export const properties = {
     },
     popularity: 0.80088013,
     appliesTo: "allElementsButNonReplacedAndTableColumns",
+    types: ["length", "percentage"],
   },
   minInlineSize: {
     unitGroups: ["length", "percentage"],
@@ -2284,6 +2504,7 @@ export const properties = {
     },
     popularity: 0.00357429,
     appliesTo: "sameAsWidthAndHeight",
+    types: ["length", "percentage"],
   },
   minWidth: {
     unitGroups: ["length", "percentage"],
@@ -2294,6 +2515,7 @@ export const properties = {
     },
     popularity: 0.77790217,
     appliesTo: "allElementsButNonReplacedAndTableRows",
+    types: ["length", "percentage"],
   },
   mixBlendMode: {
     unitGroups: [],
@@ -2304,6 +2526,7 @@ export const properties = {
     },
     popularity: 0.05430564,
     appliesTo: "allElements",
+    types: [],
   },
   objectFit: {
     unitGroups: [],
@@ -2314,6 +2537,7 @@ export const properties = {
     },
     popularity: 0.38359477,
     appliesTo: "replacedElements",
+    types: [],
   },
   objectPosition: {
     unitGroups: ["length", "percentage"],
@@ -2335,6 +2559,7 @@ export const properties = {
     },
     popularity: 0.08374319,
     appliesTo: "replacedElements",
+    types: ["length", "percentage"],
   },
   offsetAnchor: {
     unitGroups: ["length", "percentage"],
@@ -2345,6 +2570,7 @@ export const properties = {
     },
     popularity: 6e-8,
     appliesTo: "transformableElements",
+    types: ["length", "percentage"],
   },
   offsetDistance: {
     unitGroups: ["length", "percentage"],
@@ -2356,6 +2582,7 @@ export const properties = {
     },
     popularity: 0.0007637,
     appliesTo: "transformableElements",
+    types: ["length", "percentage"],
   },
   offsetPath: {
     unitGroups: [],
@@ -2366,6 +2593,7 @@ export const properties = {
     },
     popularity: 0.0008741,
     appliesTo: "transformableElements",
+    types: ["url"],
   },
   offsetPosition: {
     unitGroups: ["length", "percentage"],
@@ -2376,6 +2604,7 @@ export const properties = {
     },
     popularity: 3e-8,
     appliesTo: "transformableElements",
+    types: ["length", "percentage"],
   },
   offsetRotate: {
     unitGroups: ["angle"],
@@ -2386,6 +2615,7 @@ export const properties = {
     },
     popularity: 0.00073039,
     appliesTo: "transformableElements",
+    types: ["angle"],
   },
   opacity: {
     unitGroups: ["number", "percentage"],
@@ -2397,6 +2627,7 @@ export const properties = {
     },
     popularity: 0.87714344,
     appliesTo: "allElements",
+    types: ["number", "percentage"],
   },
   order: {
     unitGroups: ["number"],
@@ -2408,6 +2639,7 @@ export const properties = {
     },
     popularity: 0.28274872,
     appliesTo: "flexItemsGridItemsAbsolutelyPositionedContainerChildren",
+    types: ["integer", "number"],
   },
   orphans: {
     unitGroups: ["number"],
@@ -2419,6 +2651,7 @@ export const properties = {
     },
     popularity: 0.03717837,
     appliesTo: "blockContainerElements",
+    types: ["integer", "number"],
   },
   outlineColor: {
     unitGroups: [],
@@ -2429,6 +2662,7 @@ export const properties = {
     },
     popularity: 0.09538741,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   outlineOffset: {
     unitGroups: ["length"],
@@ -2440,6 +2674,7 @@ export const properties = {
     },
     popularity: 0.35495556,
     appliesTo: "allElements",
+    types: ["length"],
   },
   outlineStyle: {
     unitGroups: [],
@@ -2450,6 +2685,7 @@ export const properties = {
     },
     popularity: 0.22264732,
     appliesTo: "allElements",
+    types: [],
   },
   outlineWidth: {
     unitGroups: ["length"],
@@ -2460,6 +2696,7 @@ export const properties = {
     },
     popularity: 0.23008945,
     appliesTo: "allElements",
+    types: ["length"],
   },
   overflow: {
     unitGroups: [],
@@ -2470,6 +2707,7 @@ export const properties = {
     },
     popularity: 0.87464713,
     appliesTo: "blockContainersFlexContainersGridContainers",
+    types: [],
   },
   overflowAnchor: {
     unitGroups: [],
@@ -2480,6 +2718,7 @@ export const properties = {
     },
     popularity: 0.05039229,
     appliesTo: "allElements",
+    types: [],
   },
   overflowBlock: {
     unitGroups: [],
@@ -2490,6 +2729,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "blockContainersFlexContainersGridContainers",
+    types: [],
   },
   overflowClipMargin: {
     unitGroups: ["length"],
@@ -2501,6 +2741,7 @@ export const properties = {
     },
     popularity: 0.0001932,
     appliesTo: "allElements",
+    types: ["length"],
   },
   overflowInline: {
     unitGroups: [],
@@ -2511,6 +2752,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "blockContainersFlexContainersGridContainers",
+    types: [],
   },
   overflowWrap: {
     unitGroups: [],
@@ -2521,6 +2763,7 @@ export const properties = {
     },
     popularity: 0.2917187,
     appliesTo: "nonReplacedInlineElements",
+    types: [],
   },
   overflowX: {
     unitGroups: [],
@@ -2531,6 +2774,7 @@ export const properties = {
     },
     popularity: 0.6419296,
     appliesTo: "blockContainersFlexContainersGridContainers",
+    types: [],
   },
   overflowY: {
     unitGroups: [],
@@ -2541,6 +2785,7 @@ export const properties = {
     },
     popularity: 0.66040666,
     appliesTo: "blockContainersFlexContainersGridContainers",
+    types: [],
   },
   overscrollBehavior: {
     unitGroups: [],
@@ -2551,6 +2796,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "nonReplacedBlockAndInlineBlockElements",
+    types: [],
   },
   overscrollBehaviorBlock: {
     unitGroups: [],
@@ -2561,6 +2807,7 @@ export const properties = {
     },
     popularity: 0.0002038,
     appliesTo: "nonReplacedBlockAndInlineBlockElements",
+    types: [],
   },
   overscrollBehaviorInline: {
     unitGroups: [],
@@ -2571,6 +2818,7 @@ export const properties = {
     },
     popularity: 0.0003654,
     appliesTo: "nonReplacedBlockAndInlineBlockElements",
+    types: [],
   },
   overscrollBehaviorX: {
     unitGroups: [],
@@ -2581,6 +2829,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "nonReplacedBlockAndInlineBlockElements",
+    types: [],
   },
   overscrollBehaviorY: {
     unitGroups: [],
@@ -2591,6 +2840,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "nonReplacedBlockAndInlineBlockElements",
+    types: [],
   },
   paddingBlockEnd: {
     unitGroups: ["length", "percentage"],
@@ -2602,6 +2852,7 @@ export const properties = {
     },
     popularity: 0.00269343,
     appliesTo: "allElementsExceptInternalTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   paddingBlockStart: {
     unitGroups: ["length", "percentage"],
@@ -2613,6 +2864,7 @@ export const properties = {
     },
     popularity: 0.00281718,
     appliesTo: "allElementsExceptInternalTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   paddingBottom: {
     unitGroups: ["length", "percentage"],
@@ -2624,6 +2876,7 @@ export const properties = {
     },
     popularity: 0.80249482,
     appliesTo: "allElementsExceptInternalTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   paddingInlineEnd: {
     unitGroups: ["length", "percentage"],
@@ -2635,6 +2888,7 @@ export const properties = {
     },
     popularity: 0.02914235,
     appliesTo: "allElementsExceptInternalTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   paddingInlineStart: {
     unitGroups: ["length", "percentage"],
@@ -2646,6 +2900,7 @@ export const properties = {
     },
     popularity: 0.03734959,
     appliesTo: "allElementsExceptInternalTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   paddingLeft: {
     unitGroups: ["length", "percentage"],
@@ -2657,6 +2912,7 @@ export const properties = {
     },
     popularity: 0.81912414,
     appliesTo: "allElementsExceptInternalTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   paddingRight: {
     unitGroups: ["length", "percentage"],
@@ -2668,6 +2924,7 @@ export const properties = {
     },
     popularity: 0.80336339,
     appliesTo: "allElementsExceptInternalTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   paddingTop: {
     unitGroups: ["length", "percentage"],
@@ -2679,6 +2936,7 @@ export const properties = {
     },
     popularity: 0.82360295,
     appliesTo: "allElementsExceptInternalTableDisplayTypes",
+    types: ["length", "percentage"],
   },
   page: {
     unitGroups: [],
@@ -2689,6 +2947,7 @@ export const properties = {
     },
     popularity: 0.00131264,
     appliesTo: "blockElementsInNormalFlow",
+    types: ["custom-ident"],
   },
   pageBreakAfter: {
     unitGroups: [],
@@ -2699,6 +2958,7 @@ export const properties = {
     },
     popularity: 0.04793594,
     appliesTo: "blockElementsInNormalFlow",
+    types: [],
   },
   pageBreakBefore: {
     unitGroups: [],
@@ -2709,6 +2969,7 @@ export const properties = {
     },
     popularity: 0.0173306,
     appliesTo: "blockElementsInNormalFlow",
+    types: [],
   },
   pageBreakInside: {
     unitGroups: [],
@@ -2719,6 +2980,7 @@ export const properties = {
     },
     popularity: 0.0636772,
     appliesTo: "blockElementsInNormalFlow",
+    types: [],
   },
   paintOrder: {
     unitGroups: [],
@@ -2729,6 +2991,7 @@ export const properties = {
     },
     popularity: 0.0013931,
     appliesTo: "textElements",
+    types: [],
   },
   perspective: {
     unitGroups: ["length"],
@@ -2739,6 +3002,7 @@ export const properties = {
     },
     popularity: 0.11208199,
     appliesTo: "transformableElements",
+    types: ["length"],
   },
   perspectiveOrigin: {
     unitGroups: ["length", "percentage"],
@@ -2760,6 +3024,7 @@ export const properties = {
     },
     popularity: 0.03597136,
     appliesTo: "transformableElements",
+    types: ["length", "percentage"],
   },
   pointerEvents: {
     unitGroups: [],
@@ -2770,6 +3035,7 @@ export const properties = {
     },
     popularity: 0.65656971,
     appliesTo: "allElements",
+    types: [],
   },
   position: {
     unitGroups: [],
@@ -2780,6 +3046,7 @@ export const properties = {
     },
     popularity: 0.92435004,
     appliesTo: "allElements",
+    types: [],
   },
   printColorAdjust: {
     unitGroups: [],
@@ -2790,6 +3057,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: [],
   },
   quotes: {
     unitGroups: [],
@@ -2800,6 +3068,7 @@ export const properties = {
     },
     popularity: 0.08095164,
     appliesTo: "allElements",
+    types: ["string"],
   },
   resize: {
     unitGroups: [],
@@ -2810,6 +3079,7 @@ export const properties = {
     },
     popularity: 0.20814477,
     appliesTo: "elementsWithOverflowNotVisibleAndReplacedElements",
+    types: [],
   },
   right: {
     unitGroups: ["length", "percentage"],
@@ -2820,6 +3090,7 @@ export const properties = {
     },
     popularity: 0.83840245,
     appliesTo: "positionedElements",
+    types: ["length", "percentage"],
   },
   rotate: {
     unitGroups: ["angle", "number"],
@@ -2830,6 +3101,7 @@ export const properties = {
     },
     popularity: 4e-8,
     appliesTo: "transformableElements",
+    types: ["angle", "number"],
   },
   rowGap: {
     unitGroups: ["length", "percentage"],
@@ -2841,6 +3113,7 @@ export const properties = {
     },
     popularity: 0.01955862,
     appliesTo: "multiColumnElementsFlexContainersGridContainers",
+    types: ["length", "percentage"],
   },
   rubyAlign: {
     unitGroups: [],
@@ -2851,6 +3124,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "rubyBasesAnnotationsBaseAnnotationContainers",
+    types: [],
   },
   rubyMerge: {
     unitGroups: [],
@@ -2861,6 +3135,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "rubyAnnotationsContainers",
+    types: [],
   },
   rubyPosition: {
     unitGroups: [],
@@ -2871,6 +3146,7 @@ export const properties = {
     },
     popularity: 0.00156034,
     appliesTo: "rubyAnnotationsContainers",
+    types: [],
   },
   scale: {
     unitGroups: ["number"],
@@ -2881,6 +3157,7 @@ export const properties = {
     },
     popularity: 2e-7,
     appliesTo: "transformableElements",
+    types: ["number"],
   },
   scrollbarColor: {
     unitGroups: [],
@@ -2891,6 +3168,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "scrollingBoxes",
+    types: ["hex-color"],
   },
   scrollbarGutter: {
     unitGroups: [],
@@ -2901,6 +3179,7 @@ export const properties = {
     },
     popularity: 0.00128847,
     appliesTo: "scrollingBoxes",
+    types: [],
   },
   scrollbarWidth: {
     unitGroups: [],
@@ -2911,6 +3190,7 @@ export const properties = {
     },
     popularity: 0.000001,
     appliesTo: "scrollingBoxes",
+    types: [],
   },
   scrollBehavior: {
     unitGroups: [],
@@ -2921,6 +3201,7 @@ export const properties = {
     },
     popularity: 0.06855196,
     appliesTo: "scrollingBoxes",
+    types: [],
   },
   scrollMarginBlockStart: {
     unitGroups: ["length"],
@@ -2932,6 +3213,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["length"],
   },
   scrollMarginBlockEnd: {
     unitGroups: ["length"],
@@ -2943,6 +3225,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["length"],
   },
   scrollMarginBottom: {
     unitGroups: ["length"],
@@ -2954,6 +3237,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["length"],
   },
   scrollMarginInlineStart: {
     unitGroups: ["length"],
@@ -2965,6 +3249,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["length"],
   },
   scrollMarginInlineEnd: {
     unitGroups: ["length"],
@@ -2976,6 +3261,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["length"],
   },
   scrollMarginLeft: {
     unitGroups: ["length"],
@@ -2987,6 +3273,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["length"],
   },
   scrollMarginRight: {
     unitGroups: ["length"],
@@ -2998,6 +3285,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["length"],
   },
   scrollMarginTop: {
     unitGroups: ["length"],
@@ -3009,6 +3297,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["length"],
   },
   scrollPaddingBlockStart: {
     unitGroups: ["length", "percentage"],
@@ -3019,6 +3308,7 @@ export const properties = {
     },
     popularity: 0.0003318,
     appliesTo: "scrollContainers",
+    types: ["length", "percentage"],
   },
   scrollPaddingBlockEnd: {
     unitGroups: ["length", "percentage"],
@@ -3029,6 +3319,7 @@ export const properties = {
     },
     popularity: 0.00033098,
     appliesTo: "scrollContainers",
+    types: ["length", "percentage"],
   },
   scrollPaddingBottom: {
     unitGroups: ["length", "percentage"],
@@ -3039,6 +3330,7 @@ export const properties = {
     },
     popularity: 0.00046042,
     appliesTo: "scrollContainers",
+    types: ["length", "percentage"],
   },
   scrollPaddingInlineStart: {
     unitGroups: ["length", "percentage"],
@@ -3049,6 +3341,7 @@ export const properties = {
     },
     popularity: 0.00034054,
     appliesTo: "scrollContainers",
+    types: ["length", "percentage"],
   },
   scrollPaddingInlineEnd: {
     unitGroups: ["length", "percentage"],
@@ -3059,6 +3352,7 @@ export const properties = {
     },
     popularity: 0.00033178,
     appliesTo: "scrollContainers",
+    types: ["length", "percentage"],
   },
   scrollPaddingLeft: {
     unitGroups: ["length", "percentage"],
@@ -3069,6 +3363,7 @@ export const properties = {
     },
     popularity: 0.00318274,
     appliesTo: "scrollContainers",
+    types: ["length", "percentage"],
   },
   scrollPaddingRight: {
     unitGroups: ["length", "percentage"],
@@ -3079,6 +3374,7 @@ export const properties = {
     },
     popularity: 0.00046376,
     appliesTo: "scrollContainers",
+    types: ["length", "percentage"],
   },
   scrollPaddingTop: {
     unitGroups: ["length", "percentage"],
@@ -3089,6 +3385,7 @@ export const properties = {
     },
     popularity: 0.0199363,
     appliesTo: "scrollContainers",
+    types: ["length", "percentage"],
   },
   scrollSnapAlign: {
     unitGroups: [],
@@ -3099,6 +3396,7 @@ export const properties = {
     },
     popularity: 0.05990673,
     appliesTo: "allElements",
+    types: [],
   },
   scrollSnapStop: {
     unitGroups: [],
@@ -3109,6 +3407,7 @@ export const properties = {
     },
     popularity: 0.0074871,
     appliesTo: "allElements",
+    types: [],
   },
   scrollSnapType: {
     unitGroups: [],
@@ -3119,6 +3418,7 @@ export const properties = {
     },
     popularity: 0.05778112,
     appliesTo: "allElements",
+    types: [],
   },
   scrollTimelineAxis: {
     unitGroups: [],
@@ -3129,6 +3429,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "scrollContainers",
+    types: [],
   },
   scrollTimelineName: {
     unitGroups: [],
@@ -3139,6 +3440,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "scrollContainers",
+    types: ["custom-ident"],
   },
   shapeImageThreshold: {
     unitGroups: ["number", "percentage"],
@@ -3150,6 +3452,7 @@ export const properties = {
     },
     popularity: 0.00579108,
     appliesTo: "floats",
+    types: ["number", "percentage"],
   },
   shapeMargin: {
     unitGroups: ["length", "percentage"],
@@ -3161,6 +3464,7 @@ export const properties = {
     },
     popularity: 0.00212267,
     appliesTo: "floats",
+    types: ["length", "percentage"],
   },
   shapeOutside: {
     unitGroups: [],
@@ -3171,6 +3475,7 @@ export const properties = {
     },
     popularity: 0.00236383,
     appliesTo: "floats",
+    types: ["url"],
   },
   tabSize: {
     unitGroups: ["number", "length"],
@@ -3182,6 +3487,7 @@ export const properties = {
     },
     popularity: 0.03065152,
     appliesTo: "blockContainers",
+    types: ["integer", "number", "length"],
   },
   tableLayout: {
     unitGroups: [],
@@ -3192,6 +3498,7 @@ export const properties = {
     },
     popularity: 0.20669832,
     appliesTo: "tableElements",
+    types: [],
   },
   textAlign: {
     unitGroups: [],
@@ -3202,6 +3509,7 @@ export const properties = {
     },
     popularity: 0.89287477,
     appliesTo: "blockContainers",
+    types: [],
   },
   textAlignLast: {
     unitGroups: [],
@@ -3212,6 +3520,7 @@ export const properties = {
     },
     popularity: 0.02339794,
     appliesTo: "blockContainers",
+    types: [],
   },
   textCombineUpright: {
     unitGroups: ["number"],
@@ -3222,6 +3531,7 @@ export const properties = {
     },
     popularity: 0.00187072,
     appliesTo: "nonReplacedInlineElements",
+    types: ["integer", "number"],
   },
   textDecorationColor: {
     unitGroups: [],
@@ -3232,6 +3542,7 @@ export const properties = {
     },
     popularity: 0.05079903,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   textDecorationLine: {
     unitGroups: [],
@@ -3242,6 +3553,7 @@ export const properties = {
     },
     popularity: 0.03656271,
     appliesTo: "allElements",
+    types: [],
   },
   textDecorationSkip: {
     unitGroups: [],
@@ -3252,6 +3564,7 @@ export const properties = {
     },
     popularity: 0.054238,
     appliesTo: "allElements",
+    types: [],
   },
   textDecorationSkipInk: {
     unitGroups: [],
@@ -3262,6 +3575,7 @@ export const properties = {
     },
     popularity: 0.01645826,
     appliesTo: "allElements",
+    types: [],
   },
   textDecorationStyle: {
     unitGroups: [],
@@ -3272,6 +3586,7 @@ export const properties = {
     },
     popularity: 0.02111189,
     appliesTo: "allElements",
+    types: [],
   },
   textDecorationThickness: {
     unitGroups: ["length", "percentage"],
@@ -3282,6 +3597,7 @@ export const properties = {
     },
     popularity: 0.00728976,
     appliesTo: "allElements",
+    types: ["length", "percentage"],
   },
   textEmphasisColor: {
     unitGroups: [],
@@ -3292,6 +3608,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["hex-color"],
   },
   textEmphasisPosition: {
     unitGroups: [],
@@ -3311,6 +3628,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: [],
   },
   textEmphasisStyle: {
     unitGroups: [],
@@ -3321,6 +3639,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["string"],
   },
   textIndent: {
     unitGroups: ["length", "percentage"],
@@ -3332,6 +3651,7 @@ export const properties = {
     },
     popularity: 0.37633903,
     appliesTo: "blockContainers",
+    types: ["length", "percentage"],
   },
   textJustify: {
     unitGroups: [],
@@ -3342,6 +3662,7 @@ export const properties = {
     },
     popularity: 8e-7,
     appliesTo: "inlineLevelAndTableCellElements",
+    types: [],
   },
   textOrientation: {
     unitGroups: [],
@@ -3352,6 +3673,7 @@ export const properties = {
     },
     popularity: 0.00286298,
     appliesTo: "allElementsExceptTableRowGroupsRowsColumnGroupsAndColumns",
+    types: [],
   },
   textOverflow: {
     unitGroups: [],
@@ -3362,6 +3684,7 @@ export const properties = {
     },
     popularity: 0.65272517,
     appliesTo: "blockContainerElements",
+    types: ["string"],
   },
   textRendering: {
     unitGroups: [],
@@ -3372,6 +3695,7 @@ export const properties = {
     },
     popularity: 0.3619822,
     appliesTo: "textElements",
+    types: [],
   },
   textShadow: {
     unitGroups: ["length"],
@@ -3382,6 +3706,7 @@ export const properties = {
     },
     popularity: 0.49899917,
     appliesTo: "allElements",
+    types: ["length", "hex-color"],
   },
   textSizeAdjust: {
     unitGroups: ["percentage"],
@@ -3392,6 +3717,7 @@ export const properties = {
     },
     popularity: 0.13611964,
     appliesTo: "allElements",
+    types: ["percentage"],
   },
   textTransform: {
     unitGroups: [],
@@ -3402,6 +3728,7 @@ export const properties = {
     },
     popularity: 0.73056963,
     appliesTo: "allElements",
+    types: [],
   },
   textUnderlineOffset: {
     unitGroups: ["length", "percentage"],
@@ -3412,6 +3739,7 @@ export const properties = {
     },
     popularity: 0.00558599,
     appliesTo: "allElements",
+    types: ["length", "percentage"],
   },
   textUnderlinePosition: {
     unitGroups: [],
@@ -3422,6 +3750,7 @@ export const properties = {
     },
     popularity: 0.0070495,
     appliesTo: "allElements",
+    types: [],
   },
   top: {
     unitGroups: ["length", "percentage"],
@@ -3432,6 +3761,7 @@ export const properties = {
     },
     popularity: 0.91426675,
     appliesTo: "positionedElements",
+    types: ["length", "percentage"],
   },
   touchAction: {
     unitGroups: [],
@@ -3443,6 +3773,7 @@ export const properties = {
     popularity: 0.37581741,
     appliesTo:
       "allElementsExceptNonReplacedInlineElementsTableRowsColumnsRowColumnGroups",
+    types: [],
   },
   transform: {
     unitGroups: [],
@@ -3453,6 +3784,7 @@ export const properties = {
     },
     popularity: 0.82452786,
     appliesTo: "transformableElements",
+    types: [],
   },
   transformBox: {
     unitGroups: [],
@@ -3463,6 +3795,7 @@ export const properties = {
     },
     popularity: 0.00167776,
     appliesTo: "transformableElements",
+    types: [],
   },
   transformOrigin: {
     unitGroups: ["length", "percentage"],
@@ -3489,6 +3822,7 @@ export const properties = {
     },
     popularity: 0.54179205,
     appliesTo: "transformableElements",
+    types: ["length", "percentage"],
   },
   transformStyle: {
     unitGroups: [],
@@ -3499,6 +3833,7 @@ export const properties = {
     },
     popularity: 0.11068509,
     appliesTo: "transformableElements",
+    types: [],
   },
   transition: {
     unitGroups: ["time"],
@@ -3528,6 +3863,7 @@ export const properties = {
     },
     popularity: 0.78355592,
     appliesTo: "allElementsAndPseudos",
+    types: ["custom-ident", "time"],
   },
   transitionDelay: {
     unitGroups: ["time"],
@@ -3539,6 +3875,7 @@ export const properties = {
     },
     popularity: 0.26633596,
     appliesTo: "allElementsAndPseudos",
+    types: ["time"],
   },
   transitionDuration: {
     unitGroups: ["time"],
@@ -3550,6 +3887,7 @@ export const properties = {
     },
     popularity: 0.27645681,
     appliesTo: "allElementsAndPseudos",
+    types: ["time"],
   },
   transitionProperty: {
     unitGroups: [],
@@ -3560,6 +3898,7 @@ export const properties = {
     },
     popularity: 0.28626935,
     appliesTo: "allElementsAndPseudos",
+    types: ["custom-ident"],
   },
   transitionTimingFunction: {
     unitGroups: [],
@@ -3570,6 +3909,7 @@ export const properties = {
     },
     popularity: 0.28535681,
     appliesTo: "allElementsAndPseudos",
+    types: [],
   },
   translate: {
     unitGroups: ["length", "percentage"],
@@ -3580,6 +3920,7 @@ export const properties = {
     },
     popularity: 9e-8,
     appliesTo: "transformableElements",
+    types: ["length", "percentage"],
   },
   unicodeBidi: {
     unitGroups: [],
@@ -3590,6 +3931,7 @@ export const properties = {
     },
     popularity: 0.13633243,
     appliesTo: "allElementsSomeValuesNoEffectOnNonInlineElements",
+    types: [],
   },
   userSelect: {
     unitGroups: [],
@@ -3600,6 +3942,7 @@ export const properties = {
     },
     popularity: 0.55451382,
     appliesTo: "allElements",
+    types: [],
   },
   verticalAlign: {
     unitGroups: ["percentage", "length"],
@@ -3610,6 +3953,7 @@ export const properties = {
     },
     popularity: 0.84531302,
     appliesTo: "inlineLevelAndTableCellElements",
+    types: ["percentage", "length"],
   },
   viewTransitionName: {
     unitGroups: [],
@@ -3620,6 +3964,7 @@ export const properties = {
     },
     popularity: 0,
     appliesTo: "allElements",
+    types: ["custom-ident"],
   },
   visibility: {
     unitGroups: [],
@@ -3630,6 +3975,7 @@ export const properties = {
     },
     popularity: 0.76715746,
     appliesTo: "allElements",
+    types: [],
   },
   whiteSpace: {
     unitGroups: [],
@@ -3640,6 +3986,7 @@ export const properties = {
     },
     popularity: 0.80711821,
     appliesTo: "allElements",
+    types: [],
   },
   widows: {
     unitGroups: ["number"],
@@ -3651,6 +3998,7 @@ export const properties = {
     },
     popularity: 0.03635817,
     appliesTo: "blockContainerElements",
+    types: ["integer", "number"],
   },
   width: {
     unitGroups: ["length", "percentage"],
@@ -3661,6 +4009,7 @@ export const properties = {
     },
     popularity: 0.93671487,
     appliesTo: "allElementsButNonReplacedAndTableRows",
+    types: ["length", "percentage"],
   },
   willChange: {
     unitGroups: [],
@@ -3671,6 +4020,7 @@ export const properties = {
     },
     popularity: 0.28251419,
     appliesTo: "allElements",
+    types: ["custom-ident"],
   },
   wordBreak: {
     unitGroups: [],
@@ -3681,6 +4031,7 @@ export const properties = {
     },
     popularity: 0.51074263,
     appliesTo: "allElements",
+    types: [],
   },
   wordSpacing: {
     unitGroups: ["length"],
@@ -3691,6 +4042,7 @@ export const properties = {
     },
     popularity: 0.15650671,
     appliesTo: "allElements",
+    types: ["length"],
   },
   wordWrap: {
     unitGroups: [],
@@ -3701,6 +4053,7 @@ export const properties = {
     },
     popularity: 0.55291577,
     appliesTo: "nonReplacedInlineElements",
+    types: [],
   },
   writingMode: {
     unitGroups: [],
@@ -3711,6 +4064,7 @@ export const properties = {
     },
     popularity: 0.00947773,
     appliesTo: "allElementsExceptTableRowColumnGroupsTableRowsColumns",
+    types: [],
   },
   zIndex: {
     unitGroups: ["number"],
@@ -3721,5 +4075,6 @@ export const properties = {
     },
     popularity: 0.85875694,
     appliesTo: "positionedElements",
+    types: ["integer", "number"],
   },
 } as const;

--- a/packages/css-data/src/custom-data.ts
+++ b/packages/css-data/src/custom-data.ts
@@ -1,5 +1,4 @@
 import type { StyleValue } from "@webstudio-is/css-engine";
-import { popularityIndex } from "./popularity-index";
 
 const numericTypes = [
   "number",
@@ -31,17 +30,11 @@ export type RawPropertyData = {
   unitGroups: Array<UnitGroup>;
   inherited: boolean;
   initial: StyleValue;
-  popularity: number;
-  appliesTo: string;
   types: Array<(typeof valueTypes)[number]>;
 };
 
 export const propertiesData: { [property: string]: RawPropertyData } = {};
 export const keywordValues: { [property: string]: Array<string> } = {};
-
-const getPopularityIndex = (property: string) =>
-  popularityIndex.find((data) => data.property === property)?.dayPercentage ??
-  0;
 
 propertiesData.WebkitFontSmoothing = {
   unitGroups: [],
@@ -50,8 +43,6 @@ propertiesData.WebkitFontSmoothing = {
     type: "keyword",
     value: "auto",
   },
-  popularity: getPopularityIndex("webkit-font-smoothing"),
-  appliesTo: "allElements",
   types: [],
 };
 keywordValues.WebkitFontSmoothing = [
@@ -68,8 +59,6 @@ propertiesData.MozOsxFontSmoothing = {
     type: "keyword",
     value: "auto",
   },
-  popularity: getPopularityIndex("moz-osx-font-smoothing"),
-  appliesTo: "allElements",
   types: [],
 };
 keywordValues.MozOsxFontSmoothing = ["auto", "grayscale"];

--- a/packages/css-data/src/custom-data.ts
+++ b/packages/css-data/src/custom-data.ts
@@ -1,13 +1,30 @@
 import type { StyleValue } from "@webstudio-is/css-engine";
 import { popularityIndex } from "./popularity-index";
 
-export type UnitGroup =
-  | "number"
-  | "percentage"
-  | "length"
-  | "time"
-  | "angle"
-  | "resolution";
+const numericTypes = [
+  "number",
+  "percentage",
+  "length",
+  "time",
+  "angle",
+  "resolution",
+  "integer",
+  "x",
+  "y",
+] as const;
+
+export const valueTypes = [
+  ...numericTypes,
+  "hex-color",
+  "url",
+  "string",
+  "custom-ident",
+  "single-animation-composition",
+  "palette-identifier",
+  "flex",
+] as const;
+
+export type UnitGroup = (typeof numericTypes)[number];
 
 // Data type used before we generate a the constants.
 export type RawPropertyData = {
@@ -16,6 +33,7 @@ export type RawPropertyData = {
   initial: StyleValue;
   popularity: number;
   appliesTo: string;
+  types: Array<(typeof valueTypes)[number]>;
 };
 
 export const propertiesData: { [property: string]: RawPropertyData } = {};
@@ -34,6 +52,7 @@ propertiesData.WebkitFontSmoothing = {
   },
   popularity: getPopularityIndex("webkit-font-smoothing"),
   appliesTo: "allElements",
+  types: [],
 };
 keywordValues.WebkitFontSmoothing = [
   "auto",
@@ -51,6 +70,7 @@ propertiesData.MozOsxFontSmoothing = {
   },
   popularity: getPopularityIndex("moz-osx-font-smoothing"),
   appliesTo: "allElements",
+  types: [],
 };
 keywordValues.MozOsxFontSmoothing = ["auto", "grayscale"];
 


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3529

## Description

Values that can have custom identifiers (user defined string) were tested to accept a unit value and they did, because anything is valid.

Now they are not tested with units any more

## Steps for reproduction

1. add animation-name in advanced panel
2. use any name it should stay as-is
3. previously we would add a "px"

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
