### PR TITLE
refactor: Save content when content box is closed/blur

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/filter-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/filter-content.tsx
@@ -267,6 +267,11 @@ export const FilterSectionContent = ({
           onChange={(value) =>
             setIntermediateValue({ type: "intermediate", value })
           }
+          onBlur={() => {
+            if (intermediateValue !== undefined) {
+              handleComplete(intermediateValue.value);
+            }
+          }}
           onKeyDown={(event) => {
             if (event.key === "Enter" && intermediateValue !== undefined) {
               handleComplete(intermediateValue.value);

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -419,6 +419,7 @@ export const ShadowContent = ({
                 intermediateValue?.type === "invalid" ? "error" : undefined
               }
               onChange={handleChange}
+              onBlur={handleComplete}
               onKeyDown={(event) => {
                 if (event.key === "Enter") {
                   handleComplete();


### PR DESCRIPTION
## Description

fixes #2967 
This will save the content when the content box is blur. This will wrap up all the things that we need to handle under the #2967 issue.

## Steps for reproduction

- Add a layer to any of the `shadow` or `filter` properties.
- Now, edit the values using the content box and click somewhere else on the panel.
- This should save the values once the box looses focus.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
