### PR TITLE
build: enable semver check in changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
           fix: Fixes
           docs: Documentation
           experimental: Experimental
-        semver: false
 
     - uses: ncipollo/release-action@v1
       with:


### PR DESCRIPTION
Main reason is github sends tags in alphabetical order so changelog generated from very old accidental tag like `diff` from mistyped `gt diff` command.

I dropped all such tags. Though semver is another thing which can guarantee correct tag lookup. Let's try this for next release.