### PR TITLE
chore: Add buider API

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -62,6 +62,7 @@ import { loadBuilderData, setBuilderData } from "~/shared/builder-data";
 import { WebstudioIcon } from "@webstudio-is/icons";
 import { computed } from "nanostores";
 import { $dataLoadingState } from "~/shared/nano-states/builder";
+import { initBuilderApi } from "~/shared/builder-api";
 
 registerContainers();
 
@@ -354,6 +355,8 @@ export const Builder = ({
   userPlanFeatures,
   authTokenPermissions,
 }: BuilderProps) => {
+  useMount(initBuilderApi);
+
   useMount(() => {
     // additional data stores
     $project.set(project);

--- a/apps/builder/app/shared/builder-api.ts
+++ b/apps/builder/app/shared/builder-api.ts
@@ -1,0 +1,93 @@
+import { createRecursiveProxy } from "@trpc/server/shared";
+import invariant from "tiny-invariant";
+import { toast } from "@webstudio-is/design-system";
+
+const apiWindowNamespace = "__webstudio__$__builderApi";
+
+const _builderApi = {
+  isInitialized: () => true,
+  toast,
+};
+
+declare global {
+  interface Window {
+    [apiWindowNamespace]: typeof _builderApi;
+  }
+}
+
+const isInTop = () => {
+  try {
+    return window.self === window.top;
+  } catch (e) {
+    return true;
+  }
+};
+
+const getTopApi = () => {
+  if (isInTop()) {
+    // Inside the iframe, use the local window.api
+    return _builderApi;
+  } else {
+    // Find first iframe with the API
+    invariant(window.top);
+    return window.top[apiWindowNamespace];
+  }
+};
+
+const isKeyOf = <T>(key: unknown, obj: T): key is keyof T => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return key in obj;
+};
+
+/**
+ * Forwards the call from the builder to the iframe, invoking the original API in the iframe.
+ */
+export const builderApi = createRecursiveProxy((options) => {
+  const api = getTopApi();
+
+  if (api == null) {
+    if (
+      options.path.join(".") ===
+      ("isInitialized" satisfies keyof typeof _builderApi)
+    ) {
+      return false;
+    }
+
+    // eslint-disable-next-line no-console
+    console.warn(
+      `API not found in the iframe, skipping ${options.path.join(".")} call, iframe probably not loaded yet`
+    );
+    return null;
+  }
+
+  let currentMethod = api as unknown;
+
+  for (const key of options.path) {
+    invariant(
+      isKeyOf(key, currentMethod),
+      `API method ${options.path.join(".")} not found`
+    );
+    invariant(typeof currentMethod === "object");
+    invariant(currentMethod != null);
+
+    currentMethod = currentMethod[key];
+  }
+
+  invariant(
+    typeof currentMethod === "function",
+    `API method ${options.path.join(".")} is not a function`
+  );
+
+  return currentMethod.call(null, ...options.args);
+}) as typeof _builderApi;
+
+/**
+ * Initializes the builder API in the window. Must be called in the builder context.
+ */
+export const initBuilderApi = () => {
+  if (isInTop()) {
+    window[apiWindowNamespace] = _builderApi;
+  }
+  return () => {};
+};

--- a/apps/builder/app/shared/builder-api.ts
+++ b/apps/builder/app/shared/builder-api.ts
@@ -18,7 +18,7 @@ declare global {
 const isInTop = () => {
   try {
     return window.self === window.top;
-  } catch (e) {
+  } catch {
     return true;
   }
 };


### PR DESCRIPTION
## Description

Add ability to make direct calls to builder API, like toast.

## Steps for reproduction

usage.

```
import { builderApi } from 'blaba';
builderApi.toast('ANYTHING')
```

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
