### PR TITLE
fix: validate using long-hand property for transition while saving

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
@@ -101,13 +101,20 @@ export const TransitionContent = ({
       (item): item is UnitValue | KeywordValue => item != null
     );
     const newLayer: TupleValue = { type: "tuple", value };
+    const layers = parseTransition(toValue(newLayer));
+    if (layers.type === "invalid") {
+      setIntermediateValue({
+        type: "invalid",
+        value: toValue(newLayer),
+      });
+      return;
+    }
 
     setIntermediateValue({
       type: "intermediate",
       value: toValue(newLayer),
     });
-
-    onEditLayer(index, { type: "layers", value: [newLayer] }, options);
+    onEditLayer(index, layers, options);
   };
 
   return (


### PR DESCRIPTION
## Description

fixes #3069 
The properties `transition-delay` and `transition-duration` are being saved directly considering they are being valued using the `CSSValueItemProperty`. But not all values in long hand are valid in `short-hand` property. So, we need to validate the property value before saving them

## Steps for reproduction

- Add a transition layer.
- Now change the values in the transition-delay and transition-duration and try to save them.


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
