### PR TITLE
refactor: use jsx in component generator tests

### DIFF
--- a/packages/sdk/src/jsx.test.tsx
+++ b/packages/sdk/src/jsx.test.tsx
@@ -1,5 +1,12 @@
 import { expect, test } from "@jest/globals";
-import { $, renderJsx } from "./jsx";
+import {
+  $,
+  AssetValue,
+  ExpressionValue,
+  PageValue,
+  ParameterValue,
+  renderJsx,
+} from "./jsx";
 
 test("render jsx into instances with generated id", () => {
   const { instances } = renderJsx(
@@ -79,6 +86,144 @@ test("override generated ids with ws:id prop", () => {
           id: "custom3",
           component: "Span",
           children: [],
+        },
+      ],
+    ])
+  );
+});
+
+test("render text children", () => {
+  const { instances } = renderJsx(<$.Body>children</$.Body>);
+  expect(instances).toEqual(
+    new Map([
+      [
+        "0",
+        {
+          type: "instance",
+          id: "0",
+          component: "Body",
+          children: [{ type: "text", value: "children" }],
+        },
+      ],
+    ])
+  );
+});
+
+test("render literal props", () => {
+  const { props } = renderJsx(
+    <$.Body data-string="string" data-number={0}>
+      <$.Box data-bool={true} data-json={{ param: "value" }}></$.Box>
+    </$.Body>
+  );
+  expect(props).toEqual(
+    new Map([
+      [
+        "0:data-number",
+        {
+          id: "0:data-number",
+          instanceId: "0",
+          name: "data-number",
+          type: "number",
+          value: 0,
+        },
+      ],
+      [
+        "0:data-string",
+        {
+          id: "0:data-string",
+          instanceId: "0",
+          name: "data-string",
+          type: "string",
+          value: "string",
+        },
+      ],
+      [
+        "1:data-bool",
+        {
+          id: "1:data-bool",
+          instanceId: "1",
+          name: "data-bool",
+          type: "boolean",
+          value: true,
+        },
+      ],
+      [
+        "1:data-json",
+        {
+          id: "1:data-json",
+          instanceId: "1",
+          name: "data-json",
+          type: "json",
+          value: { param: "value" },
+        },
+      ],
+    ])
+  );
+});
+
+test("render defined props", () => {
+  const { props } = renderJsx(
+    <$.Body
+      data-expression={new ExpressionValue("1 + 1")}
+      data-parameter={new ParameterValue("parameterId")}
+    >
+      <$.Box
+        data-asset={new AssetValue("assetId")}
+        data-page={new PageValue("pageId")}
+        data-instance={new PageValue("pageId", "instanceId")}
+      ></$.Box>
+    </$.Body>
+  );
+  expect(props).toEqual(
+    new Map([
+      [
+        "0:data-expression",
+        {
+          id: "0:data-expression",
+          instanceId: "0",
+          name: "data-expression",
+          type: "expression",
+          value: "1 + 1",
+        },
+      ],
+      [
+        "0:data-parameter",
+        {
+          id: "0:data-parameter",
+          instanceId: "0",
+          name: "data-parameter",
+          type: "parameter",
+          value: "parameterId",
+        },
+      ],
+      [
+        "1:data-asset",
+        {
+          id: "1:data-asset",
+          instanceId: "1",
+          name: "data-asset",
+          type: "asset",
+          value: "assetId",
+        },
+      ],
+      [
+        "1:data-page",
+        {
+          id: "1:data-page",
+          instanceId: "1",
+          name: "data-page",
+          type: "page",
+          value: "pageId",
+        },
+      ],
+      [
+        "1:data-instance",
+        {
+          id: "1:data-instance",
+          instanceId: "1",
+          name: "data-instance",
+          type: "page",
+          value: { pageId: "pageId", instanceId: "instanceId" },
         },
       ],
     ])

--- a/packages/sdk/src/jsx.ts
+++ b/packages/sdk/src/jsx.ts
@@ -75,7 +75,7 @@ export const renderJsx = (root: JSX.Element) => {
   };
   traverseJsx(root, (element, children) => {
     const instanceId = element.props?.["ws:id"] ?? getId(element);
-    for (let [name, value] of Object.entries({ ...element.props })) {
+    for (const [name, value] of Object.entries({ ...element.props })) {
       if (name === "ws:id" || name === "children") {
         continue;
       }

--- a/packages/sdk/src/jsx.ts
+++ b/packages/sdk/src/jsx.ts
@@ -1,5 +1,45 @@
 import type { ReactNode } from "react";
 import type { Instances } from "./schema/instances";
+import type { Props } from "./schema/props";
+
+export class ExpressionValue {
+  value;
+  constructor(expression: string) {
+    this.value = expression;
+  }
+}
+
+export class ParameterValue {
+  value;
+  constructor(dataSourceID: string) {
+    this.value = dataSourceID;
+  }
+}
+
+export class ActionValue {
+  value;
+  constructor(args: string[], code: string) {
+    this.value = { type: "execute" as const, args, code };
+  }
+}
+
+export class AssetValue {
+  value;
+  constructor(assetId: string) {
+    this.value = assetId;
+  }
+}
+
+export class PageValue {
+  value;
+  constructor(pageId: string, instanceId?: string) {
+    if (instanceId) {
+      this.value = { pageId, instanceId };
+    } else {
+      this.value = pageId;
+    }
+  }
+}
 
 const traverseJsx = (
   element: JSX.Element,
@@ -12,6 +52,9 @@ const traverseJsx = (
       : [];
   callback(element, children);
   for (const child of children) {
+    if (typeof child === "string") {
+      continue;
+    }
     traverseJsx(child, callback);
   }
 };
@@ -19,6 +62,7 @@ const traverseJsx = (
 export const renderJsx = (root: JSX.Element) => {
   let lastId = -1;
   const instances: Instances = new Map();
+  const props: Props = new Map();
   const ids = new Map<unknown, string>();
   const getId = (key: unknown) => {
     let id = ids.get(key);
@@ -30,37 +74,88 @@ export const renderJsx = (root: JSX.Element) => {
     return id;
   };
   traverseJsx(root, (element, children) => {
-    const id = element.props?.["ws:id"] ?? getId(element);
+    const instanceId = element.props?.["ws:id"] ?? getId(element);
+    for (let [name, value] of Object.entries({ ...element.props })) {
+      if (name === "ws:id" || name === "children") {
+        continue;
+      }
+      const propId = `${instanceId}:${name}`;
+      const base = { id: propId, instanceId, name };
+      if (value instanceof ExpressionValue) {
+        props.set(propId, { ...base, type: "expression", value: value.value });
+        continue;
+      }
+      if (value instanceof ParameterValue) {
+        props.set(propId, { ...base, type: "parameter", value: value.value });
+        continue;
+      }
+      if (value instanceof ActionValue) {
+        props.set(propId, { ...base, type: "action", value: [value.value] });
+        continue;
+      }
+      if (value instanceof AssetValue) {
+        props.set(propId, { ...base, type: "asset", value: value.value });
+        continue;
+      }
+      if (value instanceof PageValue) {
+        props.set(propId, { ...base, type: "page", value: value.value });
+        continue;
+      }
+      if (typeof value === "string") {
+        props.set(propId, { ...base, type: "string", value });
+        continue;
+      }
+      if (typeof value === "number") {
+        props.set(propId, { ...base, type: "number", value });
+        continue;
+      }
+      if (typeof value === "boolean") {
+        props.set(propId, { ...base, type: "boolean", value });
+        continue;
+      }
+      props.set(propId, { ...base, type: "json", value });
+    }
     const component = element.type.displayName;
-    instances.set(id, {
+    instances.set(instanceId, {
       type: "instance",
-      id,
+      id: instanceId,
       component,
-      children: children.map((child) => ({
-        type: "id",
-        value: child.props?.["ws:id"] ?? getId(child),
-      })),
+      children: children.map((child) =>
+        typeof child === "string"
+          ? { type: "text", value: child }
+          : { type: "id", value: child.props?.["ws:id"] ?? getId(child) }
+      ),
     });
   });
   return {
     instances,
+    props,
   };
 };
 
-type Props = {
-  "ws:id"?: string;
-  children?: ReactNode;
+type ComponentProps = Record<string, unknown> &
+  Record<`${string}:expression`, string> & {
+    "ws:id"?: string;
+    children?: ReactNode;
+  };
+
+type Component = { displayName: string } & ((
+  props: ComponentProps
+) => ReactNode);
+
+export const createProxy = (prefix: string): Record<string, Component> => {
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        const component: Component = () => undefined;
+        component.displayName = `${prefix}${prop as string}`;
+        return component;
+      },
+    }
+  );
 };
 
-type Component = { displayName: string } & ((props: Props) => ReactNode);
+export const $ = createProxy("");
 
-export const $: Record<string, Component> = new Proxy(
-  {},
-  {
-    get(_target, prop) {
-      const component: Component = () => undefined;
-      component.displayName = prop as string;
-      return component;
-    },
-  }
-);
+export const ws = createProxy("ws:");


### PR DESCRIPTION
Here enahnced our jsx with props support and rewrote component generator tests with it as an example.

Props are solved in straightforward way, type of value described prop type. Though in case of expression, parameter, asset, page, action used classes as opaque types.