### PR TITLE
refactor: insert fragments with multiple roots

### DIFF
--- a/apps/builder/app/shared/instance-utils.test.ts
+++ b/apps/builder/app/shared/instance-utils.test.ts
@@ -3085,4 +3085,31 @@ describe("insert webstudio fragment copy", () => {
       },
     ]);
   });
+
+  test("insert instances with multiple roots", () => {
+    const data = getWebstudioDataStub();
+    const { newInstanceIds } = insertWebstudioFragmentCopy({
+      data,
+      fragment: {
+        ...emptyFragment,
+        // body1
+        //   box1
+        // body2
+        //   box2
+        // explicily define box first and then body
+        // to check first instance is not used as root
+        instances: [
+          createInstance("box1", "Box", []),
+          createInstance("body1", "Body", [{ type: "id", value: "box1" }]),
+          createInstance("body2", "Body", [{ type: "id", value: "box2" }]),
+          createInstance("box2", "Box", []),
+        ],
+        resources: [],
+        dataSources: [],
+      },
+      availableDataSources: new Set(),
+    });
+    expect(data.instances.size).toEqual(4);
+    expect(newInstanceIds.size).toEqual(4);
+  });
 });

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -61,6 +61,7 @@ import { removeByMutable } from "./array-utils";
 import { isBaseBreakpoint } from "./breakpoints";
 import { humanizeString } from "./string-utils";
 import { serverSyncStore } from "./sync";
+import { setDifference, setUnion } from "./shim";
 
 export const updateWebstudioData = (mutate: (data: WebstudioData) => void) => {
   serverSyncStore.createTransaction(
@@ -1031,13 +1032,13 @@ export const insertWebstudioFragmentCopy = ({
   }
 
   const fragmentInstances: Instances = new Map();
-  const portalContentIds = new Set<Instance["id"]>();
+  const portalContentRootIds = new Set<Instance["id"]>();
   for (const instance of fragment.instances) {
     fragmentInstances.set(instance.id, instance);
     if (instance.component === portalComponent) {
       for (const child of instance.children) {
         if (child.type === "id") {
-          portalContentIds.add(child.value);
+          portalContentRootIds.add(child.value);
         }
       }
     }
@@ -1122,21 +1123,24 @@ export const insertWebstudioFragmentCopy = ({
     }
   }
 
+  let portalContentIds = new Set<Instance["id"]>();
+
   // insert portal contents
   // - instances
   // - data sources
   // - props
   // - local styles
-  for (const rootInstanceId of portalContentIds) {
-    // prevent reinserting portals which could be already changed by user
-    if (instances.has(rootInstanceId)) {
-      continue;
-    }
-
+  for (const rootInstanceId of portalContentRootIds) {
     const instanceIds = findTreeInstanceIdsExcludingSlotDescendants(
       fragmentInstances,
       rootInstanceId
     );
+    portalContentIds = setUnion(portalContentIds, instanceIds);
+
+    // prevent reinserting portals which could be already changed by user
+    if (instances.has(rootInstanceId)) {
+      continue;
+    }
 
     const availablePortalDataSources = new Set(availableDataSources);
     const usedResourceIds = new Set<Resource["id"]>();
@@ -1289,9 +1293,9 @@ export const insertWebstudioFragmentCopy = ({
    */
 
   // generate new ids only instances outside of portals
-  const fragmentInstanceIds = findTreeInstanceIdsExcludingSlotDescendants(
-    fragmentInstances,
-    fragment.instances[0].id
+  const fragmentInstanceIds = setDifference(
+    new Set(fragmentInstances.keys()),
+    portalContentIds
   );
   for (const instanceId of fragmentInstanceIds) {
     newInstanceIds.set(instanceId, nanoid());


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2647

Here fixed the issue with detecting root as first instance in the fragment. The idea of this utility is to not rely on any root but instead insert with new ids all instances outside of portals/components. Roots semantics is left for outer utilities.