### PR TITLE
fix: Skip inaccessible iframes added by extensions to prevent cross-origin errors

### DIFF
--- a/apps/builder/app/shared/canvas-api.ts
+++ b/apps/builder/app/shared/canvas-api.ts
@@ -36,9 +36,15 @@ const getIframeApi = () => {
   } else {
     // Find first iframe with the API
     for (let i = 0; i < window.frames.length; ++i) {
-      const frame = window.frames[i];
-      if (frame && frame[apiWindowNamespace]) {
-        return frame[apiWindowNamespace];
+      try {
+        const frame = window.frames[i];
+        if (frame && frame[apiWindowNamespace]) {
+          return frame[apiWindowNamespace];
+        }
+      } catch {
+        // Certain extensions, such as Zotero, inject iframes into the page
+        // These iframes can be inaccessible and may cause access errors
+        // Therefore, we should skip processing them
       }
     }
 


### PR DESCRIPTION
## Description

Already released as hotfix

https://cdn.discordapp.com/attachments/1252596836729094184/1252596837056118834/image.png?ex=6672cb36&is=667179b6&hm=fc5718dfac9bd0e5a430b22a09cf0889831a767f5c60e2ca1731e6f3fd43a779&

## Steps for reproduction
Install Zotero extension

Then open 
https://main.development.webstudio.is/builder/a1371dce-752c-4ccf-8ea4-88bab577fe50
See error
`Failed to read a named property '__webstudio__$__canvasApi' from 'Window': Blocked a frame with origin "https://main.development.webstudio.is" from accessing a cross-origin frame.`

Now open
https://fix-zotero.development.webstudio.is/builder/a1371dce-752c-4ccf-8ea4-88bab577fe50
See no Error

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
