### PR TITLE
fix: Reload scripts in HTML Embed on dynamic pages

### DIFF
--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -316,7 +316,7 @@ export const action = async ({
 };
 
 const Outlet = () => {
-  const { system, resources } = useLoaderData<typeof loader>();
+  const { system, resources, url } = useLoaderData<typeof loader>();
   return (
     <ReactSdkContext.Provider
       value={{
@@ -326,7 +326,8 @@ const Outlet = () => {
         resources,
       }}
     >
-      <Page system={system} />
+      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
+      <Page key={url} system={system} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/sdk-components-react/src/html-embed-patchers.ts
+++ b/packages/sdk-components-react/src/html-embed-patchers.ts
@@ -25,8 +25,6 @@ export const patchDomEvents = () => {
 
   domContentLoadedPatched = true;
 
-  console.info("Patching DOMContentLoaded event listener");
-
   const originalAddEventListener = document.addEventListener;
   const originalWindowAddEventListener = window.addEventListener;
 

--- a/packages/sdk-components-react/src/html-embed.tsx
+++ b/packages/sdk-components-react/src/html-embed.tsx
@@ -70,7 +70,6 @@ const processSyncTasks = async (syncTasks: ScriptTask[]) => {
 
   patchDomEvents();
 
-  console.info("Start processing sync tasks");
   processing = true;
 
   while (syncTasksQueue.length > 0) {
@@ -81,7 +80,6 @@ const processSyncTasks = async (syncTasks: ScriptTask[]) => {
   executeDomEvents();
 
   processing = false;
-  console.info("Stop processing sync tasks");
 };
 
 // Inspiration https://ghinda.net/article/script-tags


### PR DESCRIPTION
## Description

Reload scripts in HTML Embed on dynamic pages
Closes #3581


## Steps for reproduction

Open
https://scripts-reload-saas-2-pgmkm.wstd.work/test/1

dynamic link clicks should cause `console.log` from IFrame

Anchor link should not.


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
