### PR TITLE
feat: switch to overflow longhands

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -63,6 +63,8 @@ import { WebstudioIcon } from "@webstudio-is/icons";
 import { computed } from "nanostores";
 import { $dataLoadingState } from "~/shared/nano-states/builder";
 import { initBuilderApi } from "~/shared/builder-api";
+import { updateWebstudioData } from "~/shared/instance-utils";
+import { migrateWebstudioDataMutable } from "~/shared/webstudio-data-migrator";
 
 registerContainers();
 
@@ -380,6 +382,10 @@ export const Builder = ({
           authPermit,
           authToken,
         });
+        updateWebstudioData((data) => {
+          migrateWebstudioDataMutable(data);
+        });
+
         // render canvas only after all data is loaded
         // so builder is started listening for connect event
         // when canvas is rendered

--- a/apps/builder/app/builder/features/style-panel/sections/size/size.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/size/size.tsx
@@ -104,7 +104,8 @@ export const properties = [
   "minHeight",
   "maxWidth",
   "maxHeight",
-  "overflow",
+  "overflowX",
+  "overflowY",
   "objectFit",
   "objectPosition",
   "aspectRatio",
@@ -120,6 +121,7 @@ export const Section = ({
   currentStyle,
   setProperty,
   deleteProperty,
+  createBatchUpdate,
 }: SectionProps) => {
   return (
     <CollapsibleSection
@@ -181,16 +183,31 @@ export const Section = ({
       <Separator />
       <SectionLayout columns={2}>
         <PropertyName
-          label={styleConfigByName("overflow").label}
-          properties={["overflow"]}
+          label="Overflow"
+          properties={["overflowX", "overflowY"]}
           style={currentStyle}
-          onReset={() => deleteProperty("overflow")}
+          onReset={() => {
+            const batch = createBatchUpdate();
+            deleteProperty("overflowX");
+            deleteProperty("overflowY");
+            batch.publish();
+          }}
         />
         <ToggleGroupControl
-          property="overflow"
+          property="overflowX"
           currentStyle={currentStyle}
-          setProperty={setProperty}
-          deleteProperty={deleteProperty}
+          setProperty={() => (value) => {
+            const batch = createBatchUpdate();
+            batch.setProperty("overflowX")(value);
+            batch.setProperty("overflowY")(value);
+            batch.publish();
+          }}
+          deleteProperty={() => {
+            const batch = createBatchUpdate();
+            batch.deleteProperty("overflowX");
+            batch.deleteProperty("overflowY");
+            batch.publish();
+          }}
           items={[
             {
               child: <EyeconOpenIcon />,
@@ -198,7 +215,7 @@ export const Section = ({
               description:
                 "Content is fully visible and extends beyond the container if it exceeds its size.",
               value: "visible",
-              propertyValues: "overflow: visible;",
+              propertyValues: "overflow-x: visible;\noverflow-y: visible;",
             },
             {
               child: <EyeconClosedIcon />,
@@ -206,7 +223,7 @@ export const Section = ({
               description:
                 "Content that exceeds the container's size is clipped and hidden without scrollbars.",
               value: "hidden",
-              propertyValues: "overflow: hidden;",
+              propertyValues: "overflow-x: hidden;\noverflow-y: hidden;",
             },
             {
               child: <ScrollIcon />,
@@ -214,7 +231,7 @@ export const Section = ({
               description:
                 "Scrollbars are added to the container, allowing users to scroll and view the exceeding content.",
               value: "scroll",
-              propertyValues: "overflow: scroll;",
+              propertyValues: "overflow-x: scroll;\noverflow-y: scroll;",
             },
 
             {
@@ -223,7 +240,7 @@ export const Section = ({
               description:
                 "Scrollbars are added to the container only when necessary, based on the content size.",
               value: "auto",
-              propertyValues: "overflow: auto;",
+              propertyValues: "overflow-x: auto;\noverflow-y: auto;",
             },
           ]}
         />

--- a/apps/builder/app/shared/builder-data.ts
+++ b/apps/builder/app/shared/builder-data.ts
@@ -14,7 +14,7 @@ import {
   $styles,
 } from "./nano-states";
 
-type BuilderData = WebstudioData & {
+export type BuilderData = WebstudioData & {
   marketplaceProduct: undefined | MarketplaceProduct;
 };
 

--- a/apps/builder/app/shared/webstudio-data-migrator.test.ts
+++ b/apps/builder/app/shared/webstudio-data-migrator.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@jest/globals";
+import type { WebstudioData } from "@webstudio-is/sdk";
+import { createDefaultPages } from "@webstudio-is/project-build";
+import type { StyleProperty } from "@webstudio-is/css-engine";
+import { migrateWebstudioDataMutable } from "./webstudio-data-migrator";
+
+const emptyData: WebstudioData = {
+  pages: createDefaultPages({
+    rootInstanceId: "rootInstanceId",
+    systemDataSourceId: "systemDataSourceId",
+  }),
+  assets: new Map(),
+  dataSources: new Map(),
+  resources: new Map(),
+  instances: new Map(),
+  props: new Map(),
+  breakpoints: new Map(),
+  styleSources: new Map(),
+  styleSourceSelections: new Map(),
+  styles: new Map(),
+};
+
+test("expand overflow shorthand", () => {
+  const data = structuredClone(emptyData);
+  data.styles.set("base:local:overflow::hover", {
+    breakpointId: "base",
+    styleSourceId: "local",
+    state: ":hover",
+    property: "overflow" as StyleProperty,
+    value: {
+      type: "tuple",
+      value: [
+        { type: "keyword", value: "auto" },
+        { type: "keyword", value: "hidden" },
+      ],
+    },
+  });
+  migrateWebstudioDataMutable(data);
+  expect(Array.from(data.styles.values())).toEqual([
+    {
+      breakpointId: "base",
+      property: "overflowX",
+      state: ":hover",
+      styleSourceId: "local",
+      value: { type: "keyword", value: "auto" },
+    },
+    {
+      breakpointId: "base",
+      property: "overflowY",
+      state: ":hover",
+      styleSourceId: "local",
+      value: { type: "keyword", value: "hidden" },
+    },
+  ]);
+});

--- a/apps/builder/app/shared/webstudio-data-migrator.ts
+++ b/apps/builder/app/shared/webstudio-data-migrator.ts
@@ -1,0 +1,43 @@
+import { camelCase } from "change-case";
+import {
+  getStyleDeclKey,
+  type StyleDecl,
+  type WebstudioData,
+} from "@webstudio-is/sdk";
+import { toValue, type StyleProperty } from "@webstudio-is/css-engine";
+import { expandShorthands, parseCssValue } from "@webstudio-is/css-data";
+
+/**
+ *
+ * Transform loaded data and sync into server
+ * before passing into application
+ * should be idempotent because can be executed multiple times
+ *
+ * Very basic version of client migrations
+ * Should be versioned eventually to avoid running every time
+ *
+ * For now patch is prevented by excluding empty transactions from sync queue
+ *
+ */
+export const migrateWebstudioDataMutable = (data: WebstudioData) => {
+  for (const [styleDeclKey, styleDecl] of data.styles) {
+    const property = styleDecl.property as string;
+
+    // expand overflow shorthand into overflow-x and overflow-y longhands
+    if (property === "overflow") {
+      data.styles.delete(styleDeclKey);
+      const longhands = expandShorthands([
+        [property, toValue(styleDecl.value)],
+      ]);
+      for (const [hyphenedProperty, value] of longhands) {
+        const longhandProperty = camelCase(hyphenedProperty) as StyleProperty;
+        const longhandStyleDecl: StyleDecl = {
+          ...styleDecl,
+          property: longhandProperty,
+          value: parseCssValue(longhandProperty, value),
+        };
+        data.styles.set(getStyleDeclKey(longhandStyleDecl), longhandStyleDecl);
+      }
+    }
+  }
+};

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -241,6 +241,7 @@ const unsupportedProperties = [
   "all",
   "font-synthesis",
   "font-variant",
+  "overflow",
   // @todo for now webstudio supports only white-space
   // need to figure out how to make it future proof
   "white-space-collapse",

--- a/packages/css-data/src/__generated__/keyword-values.ts
+++ b/packages/css-data/src/__generated__/keyword-values.ts
@@ -3874,16 +3874,6 @@ export const keywordValues = {
     "unset",
   ],
   outlineWidth: ["thin", "medium", "thick", "initial", "inherit", "unset"],
-  overflow: [
-    "visible",
-    "hidden",
-    "clip",
-    "scroll",
-    "auto",
-    "initial",
-    "inherit",
-    "unset",
-  ],
   overflowWrap: [
     "normal",
     "break-word",

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -2049,15 +2049,6 @@ export const properties = {
     },
     types: ["length"],
   },
-  overflow: {
-    unitGroups: [],
-    inherited: false,
-    initial: {
-      type: "keyword",
-      value: "visible",
-    },
-    types: [],
-  },
   overflowWrap: {
     unitGroups: [],
     inherited: true,

--- a/packages/css-data/src/html.ts
+++ b/packages/css-data/src/html.ts
@@ -158,6 +158,17 @@ const borderColor = (value: string): Styles => [
   },
 ];
 
+const overflow = (value: string): Styles => [
+  {
+    property: "overflowX",
+    value: { type: "keyword", value },
+  },
+  {
+    property: "overflowY",
+    value: { type: "keyword", value },
+  },
+];
+
 const appearance = (value: string): Styles[number] => ({
   property: "appearance",
   value: { type: "keyword", value },
@@ -459,10 +470,7 @@ export const hr: Styles = [
     value: { type: "keyword", value: "auto" },
   },
   // firefox only
-  {
-    property: "overflow",
-    value: { type: "keyword", value: "hidden" },
-  },
+  ...overflow("hidden"),
   /* This is not really per spec but all browsers define it */
   display("block"),
 ];
@@ -569,10 +577,7 @@ export const select: Styles = [
   cursor("default"),
   boxSizing("border-box"),
   userSelect("none"),
-  {
-    property: "overflow",
-    value: { type: "keyword", value: "clip" },
-  },
+  ...overflow("clip"),
   verticalAlign("baseline"),
   appearance("auto"),
 ];

--- a/packages/css-data/src/shorthands.test.ts
+++ b/packages/css-data/src/shorthands.test.ts
@@ -778,6 +778,17 @@ test("expand grid-row and grid-column", () => {
   ]);
 });
 
+test("expand overflow", () => {
+  expect(expandShorthands([["overflow", "hidden"]])).toEqual([
+    ["overflow-x", "hidden"],
+    ["overflow-y", "hidden"],
+  ]);
+  expect(expandShorthands([["overflow", "hidden auto"]])).toEqual([
+    ["overflow-x", "hidden"],
+    ["overflow-y", "auto"],
+  ]);
+});
+
 test.todo("container");
 test.todo("contain-intrinsic-size");
 test.todo("grid");
@@ -794,9 +805,6 @@ test.todo("all - can negatively affect build size");
 test.todo("background - not used in webflow");
 test.todo("background-position-x - we use shorthand");
 test.todo("background-position-y - we use shorthand");
-test.todo("overflow - used in webflow");
-test.todo("overflow-x - we use shorthand");
-test.todo("overflow-y - we use shorthand");
 test.todo("translate - are these directly mappable to transform");
 test.todo("rotate");
 test.todo("scale");

--- a/packages/css-data/src/shorthands.ts
+++ b/packages/css-data/src/shorthands.ts
@@ -892,6 +892,13 @@ const expandShorthand = function* (property: string, value: CssNode) {
       yield* expandTransition(value);
       break;
 
+    case "overflow": {
+      const [x, y] = getValueList(value);
+      yield ["overflow-x", x] as const;
+      yield ["overflow-y", y ?? x] as const;
+      break;
+    }
+
     default:
       yield [property, value] as const;
   }

--- a/packages/css-engine/src/__generated__/types.ts
+++ b/packages/css-engine/src/__generated__/types.ts
@@ -219,7 +219,6 @@ export type Property =
   | "outlineOffset"
   | "outlineStyle"
   | "outlineWidth"
-  | "overflow"
   | "overflowWrap"
   | "overflowX"
   | "overflowY"

--- a/packages/sdk-components-react-radix/src/theme/tailwind-classes.ts
+++ b/packages/sdk-components-react-radix/src/theme/tailwind-classes.ts
@@ -82,7 +82,11 @@ export const overflow = (
   value: "hidden" | "visible" | "scroll" | "auto"
 ): EmbedTemplateStyleDecl[] => [
   {
-    property: "overflow",
+    property: "overflowX",
+    value: { type: "keyword", value },
+  },
+  {
+    property: "overflowY",
     value: { type: "keyword", value },
   },
 ];
@@ -603,13 +607,7 @@ export const lineClamp = (
   lineClampValue: StringEnumToNumeric<keyof typeof theme.lineClamp>
 ): EmbedTemplateStyleDecl[] => {
   return [
-    {
-      property: "overflow",
-      value: {
-        type: "keyword",
-        value: "hidden",
-      },
-    },
+    ...overflow("hidden"),
     {
       property: "display",
 


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2647

Here refactored overflow UI to update "overflow-x" and "overflow-y" longhands instead of "overflow" shorthand.

Removed "overflow" from advanced panel suggestions.

Added support for expanding overflow shorthand for webflow copy paste.

And implemented very basic migrations utility
which always run after data is loaded from server
and sends patch for expanding overflow longhands.
Patch is not sent when no properties are modified. Though eventually we will need to support versioning to avoid executing old migrations.

<img width="279" alt="Screenshot 2024-06-18 at 19 33 21" src="https://github.com/webstudio-is/webstudio/assets/5635476/ce44385e-3316-4e34-bc9c-5f790cbdcd4f">
