### PR TITLE
refactor: switch preset styles to nesting rules

### DIFF
--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -11,8 +11,8 @@ import {
   collapsedAttribute,
   idAttribute,
   addGlobalRules,
+  addPresetRules,
   createImageValueTransformer,
-  getPresetStyleRules,
   descendantComponent,
   type Params,
 } from "@webstudio-is/react-sdk";
@@ -319,16 +319,7 @@ export const GlobalStyles = ({ params }: { params: Params }) => {
 
   useLayoutEffect(() => {
     presetSheet.clear();
-    for (const [component, meta] of metas) {
-      const presetStyle = meta.presetStyle;
-      if (presetStyle === undefined) {
-        continue;
-      }
-      const rules = getPresetStyleRules(component, presetStyle);
-      for (const [selector, style] of rules) {
-        presetSheet.addStyleRule({ style }, selector);
-      }
-    }
+    addPresetRules(presetSheet, metas);
     presetSheet.render();
   }, [metas]);
 

--- a/packages/react-sdk/src/css/css.test.tsx
+++ b/packages/react-sdk/src/css/css.test.tsx
@@ -176,3 +176,63 @@ Map {
 }
 `);
 });
+
+test("generate component presets", () => {
+  const { cssText, atomicCssText, classesMap } = generateAllCss({
+    assets: new Map(),
+    instances: new Map(),
+    props: new Map(),
+    breakpoints: new Map(),
+    styleSourceSelections: new Map([]),
+    styles: new Map(),
+    componentMetas: new Map([
+      [
+        "Box",
+        {
+          type: "container",
+          icon: "",
+          presetStyle: {
+            div: [
+              {
+                property: "display",
+                value: { type: "keyword", value: "block" },
+              },
+            ],
+            a: [
+              {
+                property: "userSelect",
+                value: { type: "keyword", value: "none" },
+              },
+            ],
+          },
+        },
+      ],
+    ]),
+    assetBaseUrl: "",
+  });
+  expect(cssText).toMatchInlineSnapshot(`
+"html {margin: 0; display: grid; min-height: 100%}
+@media all {
+  div:where([data-ws-component="Box"]) {
+    display: block
+  }
+  a:where([data-ws-component="Box"]) {
+    user-select: none
+  }
+}
+"
+`);
+  expect(atomicCssText).toMatchInlineSnapshot(`
+"html {margin: 0; display: grid; min-height: 100%}
+@media all {
+  div:where([data-ws-component="Box"]) {
+    display: block
+  }
+  a:where([data-ws-component="Box"]) {
+    user-select: none
+  }
+}
+"
+`);
+  expect(classesMap).toMatchInlineSnapshot(`Map {}`);
+});

--- a/packages/react-sdk/src/css/global-rules.ts
+++ b/packages/react-sdk/src/css/global-rules.ts
@@ -1,6 +1,7 @@
 import type { StyleSheetRegular } from "@webstudio-is/css-engine";
 import type { Assets, FontAsset } from "@webstudio-is/sdk";
 import { getFontFaces } from "@webstudio-is/fonts";
+import type { WsComponentMeta } from "../components/component-meta";
 
 export const addGlobalRules = (
   sheet: StyleSheetRegular,
@@ -22,5 +23,27 @@ export const addGlobalRules = (
   const fontFaces = getFontFaces(fontAssets, { assetBaseUrl });
   for (const fontFace of fontFaces) {
     sheet.addFontFaceRule(fontFace);
+  }
+};
+
+export const addPresetRules = (
+  sheet: StyleSheetRegular,
+  metas: Map<string, WsComponentMeta>
+) => {
+  sheet.addMediaRule("presets");
+  for (const [component, meta] of metas) {
+    for (const [tag, styles] of Object.entries(meta.presetStyle ?? {})) {
+      const rule = sheet.addNestingRule(
+        `${tag}:where([data-ws-component="${component}"])`
+      );
+      for (const declaration of styles) {
+        rule.setDeclaration({
+          breakpoint: "presets",
+          selector: declaration.state ?? "",
+          property: declaration.property,
+          value: declaration.value,
+        });
+      }
+    }
   }
 };

--- a/packages/react-sdk/src/css/style-rules.ts
+++ b/packages/react-sdk/src/css/style-rules.ts
@@ -6,8 +6,6 @@ import type {
   StyleSource,
   StyleSourceSelections,
 } from "@webstudio-is/sdk";
-import type { PresetStyle } from "../components/component-meta";
-import { componentAttribute } from "../props";
 
 type StyleRule = {
   instanceId: string;
@@ -78,26 +76,4 @@ export const getStyleRules = (
   }
 
   return styleRules;
-};
-
-export const getPresetStyleRules = (
-  component: string,
-  presetStyle: PresetStyle
-) => {
-  // group style declarations by selector to render as separate rules
-  const presetStyleRules = new Map<string, Style>();
-  for (const [tag, styles] of Object.entries(presetStyle)) {
-    for (const styleDecl of styles) {
-      const selector = `${tag}:where([${componentAttribute}="${component}"])${
-        styleDecl.state ?? ""
-      }`;
-      let rule = presetStyleRules.get(selector);
-      if (rule === undefined) {
-        rule = {};
-        presetStyleRules.set(selector, rule);
-      }
-      rule[styleDecl.property] = styleDecl.value;
-    }
-  }
-  return presetStyleRules;
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2647

Moved preset styles to new nesting rules in css engine. Will simplify future prefixer solution.
