### PR TITLE
refactor: drop legacy style rule

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/navigator/css-preview.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/navigator/css-preview.tsx
@@ -7,13 +7,12 @@ import {
 import {
   type StyleInfo,
   useStyleInfo,
-  type StyleValueInfo,
 } from "../../../style-panel/shared/style-info";
-import { createRegularStyleSheet } from "@webstudio-is/css-engine";
+import { generateStyleMap } from "@webstudio-is/css-engine";
+import type { StyleMap, StyleProperty } from "@webstudio-is/css-engine";
 import { CollapsibleSection } from "~/builder/shared/collapsible-section";
 import { useMemo } from "react";
 import Prism from "prismjs";
-import type { Style, StyleProperty } from "@webstudio-is/css-engine";
 import { captureError } from "@webstudio-is/error-utils";
 
 const preStyle = css(textVariants.mono, {
@@ -26,15 +25,10 @@ const preStyle = css(textVariants.mono, {
 // - Compiles a CSS string from the style info
 // - Groups by category and separates categories with comments
 const getCssText = (currentStyle: StyleInfo) => {
-  const sheet = createRegularStyleSheet();
-  type StyleValueInfoMap = Map<
-    StyleProperty,
-    StyleValueInfo[keyof StyleValueInfo]
-  >;
-  const sourceStyles: StyleValueInfoMap = new Map();
-  const inheritedStyles: StyleValueInfoMap = new Map();
-  const cascadedStyles: StyleValueInfoMap = new Map();
-  const presetStyles: StyleValueInfoMap = new Map();
+  const sourceStyles: StyleMap = new Map();
+  const inheritedStyles: StyleMap = new Map();
+  const cascadedStyles: StyleMap = new Map();
+  const presetStyles: StyleMap = new Map();
 
   // Aggregate styles by category so we can group them when rendering.
   let property: StyleProperty;
@@ -68,16 +62,12 @@ const getCssText = (currentStyle: StyleInfo) => {
 
   const result: Array<string> = [];
 
-  const add = (comment: string, styles: StyleValueInfoMap) => {
-    if (styles.size === 0) {
+  const add = (comment: string, style: StyleMap) => {
+    if (style.size === 0) {
       return;
     }
-    const rule = sheet.addStyleRule(
-      { style: Object.fromEntries(styles) as Style },
-      comment
-    );
     result.push(`/* ${comment} */`);
-    result.push(rule.styleMap.toString());
+    result.push(generateStyleMap({ style }));
   };
 
   add("Style Sources", sourceStyles);

--- a/packages/css-engine/src/core/css-engine.stories.tsx
+++ b/packages/css-engine/src/core/css-engine.stories.tsx
@@ -4,24 +4,31 @@ export default {
   component: "CssEngine",
 };
 
-const style0 = {
-  color: { type: "keyword", value: "red" },
-} as const;
-
 const mediaRuleOptions0 = { minWidth: 0 } as const;
 const mediaId = "0";
 
 export const Basic = () => {
   const sheet = createRegularStyleSheet();
   sheet.addMediaRule(mediaId, mediaRuleOptions0);
-  const rule = sheet.addStyleRule({ style: style0, breakpoint: "0" }, ".test");
+  const rule = sheet.addNestingRule(".test");
+  rule.setDeclaration({
+    breakpoint: "0",
+    selector: "",
+    property: "color",
+    value: { type: "keyword", value: "red" },
+  });
   sheet.render();
   return (
     <>
       <div className="test">Should be red</div>
       <button
         onClick={() => {
-          rule.styleMap.set("color", { type: "keyword", value: "green" });
+          rule.setDeclaration({
+            breakpoint: "0",
+            selector: "",
+            property: "color",
+            value: { type: "keyword", value: "green" },
+          });
           sheet.render();
         }}
       >
@@ -29,13 +36,13 @@ export const Basic = () => {
       </button>
       <button
         onClick={() => {
-          sheet.addStyleRule(
-            {
-              style: { backgroundColor: { type: "keyword", value: "yellow" } },
-              breakpoint: "0",
-            },
-            ".test"
-          );
+          const rule = sheet.addNestingRule(".test");
+          rule.setDeclaration({
+            breakpoint: "0",
+            selector: "",
+            property: "backgroundColor",
+            value: { type: "keyword", value: "yellow" },
+          });
           sheet.render();
         }}
       >

--- a/packages/css-engine/src/core/index.ts
+++ b/packages/css-engine/src/core/index.ts
@@ -1,10 +1,11 @@
 export type {
+  StyleMap,
   NestingRule,
-  StyleRule,
   MediaRule,
   PlaintextRule,
   FontFaceRule,
 } from "./rules";
+export { generateStyleMap } from "./rules";
 export type { StyleSheetRegular } from "./style-sheet-regular";
 export * from "./create-style-sheet";
 export * from "./to-value";

--- a/packages/css-engine/src/core/style-sheet-regular.test.ts
+++ b/packages/css-engine/src/core/style-sheet-regular.test.ts
@@ -1,23 +1,9 @@
-import { describe, beforeEach, test, expect } from "@jest/globals";
-import type { StyleSheetRegular } from "./style-sheet-regular";
+import { describe, test, expect } from "@jest/globals";
 import { createRegularStyleSheet } from "./create-style-sheet";
 import type { TransformValue } from "./to-value";
 
-const style0 = {
-  display: { type: "keyword", value: "block" },
-} as const;
-
 const mediaRuleOptions0 = { minWidth: 0 } as const;
 const mediaId0 = "0";
-
-const style1 = {
-  display: { type: "keyword", value: "flex" },
-} as const;
-
-const style2 = {
-  display: { type: "keyword", value: "block" },
-  color: { type: "keyword", value: "black" },
-} as const;
 
 const mediaRuleOptions1 = { minWidth: 300 } as const;
 const mediaId1 = "1";
@@ -317,23 +303,15 @@ describe("mixin rule", () => {
 });
 
 describe("Style Sheet Regular", () => {
-  let sheet: StyleSheetRegular;
-
-  const reset = () => {
-    sheet = createRegularStyleSheet();
-  };
-
-  beforeEach(reset);
-
   test("minWidth media rule", () => {
+    const sheet = createRegularStyleSheet();
     sheet.addMediaRule("0", { minWidth: 0 });
-    sheet.addStyleRule(
-      {
-        style: { color: { type: "keyword", value: "red" } },
-        breakpoint: "0",
-      },
-      ".c1"
-    );
+    sheet.addNestingRule(".c1").setDeclaration({
+      breakpoint: "0",
+      selector: "",
+      property: "color",
+      value: { type: "keyword", value: "red" },
+    });
     expect(sheet.cssText).toMatchInlineSnapshot(`
       "@media all and (min-width: 0px) {
         .c1 {
@@ -344,14 +322,14 @@ describe("Style Sheet Regular", () => {
   });
 
   test("maxWidth media rule", () => {
+    const sheet = createRegularStyleSheet();
     sheet.addMediaRule("0", { maxWidth: 1000 });
-    sheet.addStyleRule(
-      {
-        style: { color: { type: "keyword", value: "red" } },
-        breakpoint: "0",
-      },
-      ".c1"
-    );
+    sheet.addNestingRule(".c1").setDeclaration({
+      breakpoint: "0",
+      selector: "",
+      property: "color",
+      value: { type: "keyword", value: "red" },
+    });
     expect(sheet.cssText).toMatchInlineSnapshot(`
       "@media all and (max-width: 1000px) {
         .c1 {
@@ -362,14 +340,14 @@ describe("Style Sheet Regular", () => {
   });
 
   test("maxWidth and maxWith media rule", () => {
+    const sheet = createRegularStyleSheet();
     sheet.addMediaRule("0", { maxWidth: 1000, minWidth: 360 });
-    sheet.addStyleRule(
-      {
-        style: { color: { type: "keyword", value: "red" } },
-        breakpoint: "0",
-      },
-      ".c1"
-    );
+    sheet.addNestingRule(".c1").setDeclaration({
+      breakpoint: "0",
+      selector: "",
+      property: "color",
+      value: { type: "keyword", value: "red" },
+    });
     expect(sheet.cssText).toMatchInlineSnapshot(`
       "@media all and (min-width: 360px) and (max-width: 1000px) {
         .c1 {
@@ -379,91 +357,31 @@ describe("Style Sheet Regular", () => {
     `);
   });
 
-  test("use default media rule when there is no matching one registered", () => {
-    sheet.addStyleRule(
-      {
-        style: style0,
-        breakpoint: "x",
-      },
-      ".c"
-    );
-    expect(sheet.cssText).toMatchInlineSnapshot(`
-      "@media all {
-        .c {
-          display: block
-        }
-      }"
-    `);
-    sheet.addStyleRule(
-      {
-        style: { color: { type: "keyword", value: "red" } },
-        breakpoint: "x",
-      },
-      ".c1"
-    );
-    expect(sheet.cssText).toMatchInlineSnapshot(`
-      "@media all {
-        .c {
-          display: block
-        }
-        .c1 {
-          color: red
-        }
-      }"
-    `);
-
-    sheet.addMediaRule(mediaId0, mediaRuleOptions0);
-    sheet.addStyleRule(
-      {
-        style: { color: { type: "keyword", value: "blue" } },
-        breakpoint: mediaId0,
-      },
-      ".c1"
-    );
-    // Default media query should allways be the first to have the lowest source order specificity
-    expect(sheet.cssText).toMatchInlineSnapshot(`
-      "@media all {
-        .c {
-          display: block
-        }
-        .c1 {
-          color: red
-        }
-      }
-      @media all and (min-width: 0px) {
-        .c1 {
-          color: blue
-        }
-      }"
-    `);
-  });
-
   test("sort media queries based on lower min-width", () => {
+    const sheet = createRegularStyleSheet();
     sheet.addMediaRule(mediaId1, mediaRuleOptions1);
-    sheet.addStyleRule(
-      {
-        style: style1,
-        breakpoint: mediaId1,
-      },
-      ".c2"
-    );
+    sheet.addNestingRule(".c2").setDeclaration({
+      breakpoint: mediaId1,
+      selector: "",
+      property: "display",
+      value: { type: "keyword", value: "flex" },
+    });
 
     sheet.addMediaRule(mediaId0, mediaRuleOptions0);
-    sheet.addStyleRule(
-      {
-        style: style0,
-        breakpoint: mediaId0,
-      },
-      ".c1"
-    );
+    sheet.addNestingRule(".c1").setDeclaration({
+      breakpoint: mediaId0,
+      selector: "",
+      property: "display",
+      value: { type: "keyword", value: "block" },
+    });
 
-    sheet.addStyleRule(
-      {
-        style: style0,
-        breakpoint: "x",
-      },
-      ".c3"
-    );
+    sheet.addMediaRule("x");
+    sheet.addNestingRule(".c3").setDeclaration({
+      breakpoint: "x",
+      selector: "",
+      property: "display",
+      value: { type: "keyword", value: "block" },
+    });
 
     // Default media query should allways be the first to have the lowest source order specificity
     expect(sheet.cssText).toMatchInlineSnapshot(`
@@ -486,20 +404,20 @@ describe("Style Sheet Regular", () => {
   });
 
   test("keep the sort order when minWidth is not defined", () => {
-    sheet.addStyleRule(
-      {
-        style: style0,
-        breakpoint: "x",
-      },
-      ".c0"
-    );
-    sheet.addStyleRule(
-      {
-        style: style1,
-        breakpoint: "x",
-      },
-      ".c1"
-    );
+    let sheet = createRegularStyleSheet();
+    sheet.addMediaRule("x");
+    sheet.addNestingRule(".c0").setDeclaration({
+      breakpoint: "x",
+      selector: "",
+      property: "display",
+      value: { type: "keyword", value: "block" },
+    });
+    sheet.addNestingRule(".c1").setDeclaration({
+      breakpoint: "x",
+      selector: "",
+      property: "display",
+      value: { type: "keyword", value: "flex" },
+    });
     expect(sheet.cssText).toMatchInlineSnapshot(`
       "@media all {
         .c0 {
@@ -511,22 +429,20 @@ describe("Style Sheet Regular", () => {
       }"
     `);
 
-    reset();
-
-    sheet.addStyleRule(
-      {
-        style: style1,
-        breakpoint: "x",
-      },
-      ".c1"
-    );
-    sheet.addStyleRule(
-      {
-        style: style0,
-        breakpoint: "x",
-      },
-      ".c0"
-    );
+    sheet = createRegularStyleSheet();
+    sheet.addMediaRule("x");
+    sheet.addNestingRule(".c1").setDeclaration({
+      breakpoint: "x",
+      selector: "",
+      property: "display",
+      value: { type: "keyword", value: "flex" },
+    });
+    sheet.addNestingRule(".c0").setDeclaration({
+      breakpoint: "x",
+      selector: "",
+      property: "display",
+      value: { type: "keyword", value: "block" },
+    });
     expect(sheet.cssText).toMatchInlineSnapshot(`
       "@media all {
         .c1 {
@@ -534,44 +450,20 @@ describe("Style Sheet Regular", () => {
         }
         .c0 {
           display: block
-        }
-      }"
-    `);
-  });
-
-  test("rule with multiple properties", () => {
-    sheet.addMediaRule(mediaId0, mediaRuleOptions0);
-    sheet.addStyleRule(
-      {
-        style: {
-          ...style0,
-          color: { type: "keyword", value: "red" },
-        },
-        breakpoint: "0",
-      },
-      ".c"
-    );
-    expect(sheet.cssText).toMatchInlineSnapshot(`
-      "@media all and (min-width: 0px) {
-        .c {
-          display: block;
-          color: red
         }
       }"
     `);
   });
 
   test("hyphenate property", () => {
+    const sheet = createRegularStyleSheet();
     sheet.addMediaRule(mediaId0, mediaRuleOptions0);
-    sheet.addStyleRule(
-      {
-        style: {
-          backgroundColor: { type: "keyword", value: "red" },
-        },
-        breakpoint: "0",
-      },
-      ".c"
-    );
+    sheet.addNestingRule(".c").setDeclaration({
+      breakpoint: "0",
+      selector: "",
+      property: "backgroundColor",
+      value: { type: "keyword", value: "red" },
+    });
     expect(sheet.cssText).toMatchInlineSnapshot(`
       "@media all and (min-width: 0px) {
         .c {
@@ -581,113 +473,15 @@ describe("Style Sheet Regular", () => {
     `);
   });
 
-  test("add rule", () => {
-    sheet.addMediaRule(mediaId0, mediaRuleOptions0);
-    const rule1 = sheet.addStyleRule(
-      {
-        style: {
-          ...style0,
-          color: { type: "keyword", value: "red" },
-        },
-        breakpoint: "0",
-      },
-      ".c"
-    );
-    expect(sheet.cssText).toMatchInlineSnapshot(`
-      "@media all and (min-width: 0px) {
-        .c {
-          display: block;
-          color: red
-        }
-      }"
-    `);
-    expect(rule1.cssText).toMatchInlineSnapshot(`
-      ".c {
-        display: block;
-        color: red
-      }"
-    `);
-    sheet.addStyleRule(
-      {
-        style: {
-          ...style0,
-          color: { type: "keyword", value: "green" },
-        },
-        breakpoint: "0",
-      },
-      ".c2"
-    );
-    expect(sheet.cssText).toMatchInlineSnapshot(`
-      "@media all and (min-width: 0px) {
-        .c {
-          display: block;
-          color: red
-        }
-        .c2 {
-          display: block;
-          color: green
-        }
-      }"
-    `);
-  });
-
-  test("update rule", () => {
-    sheet.addMediaRule(mediaId0, mediaRuleOptions0);
-    const rule = sheet.addStyleRule(
-      {
-        style: {
-          ...style0,
-          color: { type: "keyword", value: "red" },
-        },
-        breakpoint: "0",
-      },
-      ".c"
-    );
-    expect(sheet.cssText).toMatchInlineSnapshot(`
-      "@media all and (min-width: 0px) {
-        .c {
-          display: block;
-          color: red
-        }
-      }"
-    `);
-    expect(rule.cssText).toMatchInlineSnapshot(`
-      ".c {
-        display: block;
-        color: red
-      }"
-    `);
-
-    rule.styleMap.set("color", { type: "keyword", value: "green" });
-
-    expect(rule.cssText).toMatchInlineSnapshot(`
-      ".c {
-        display: block;
-        color: green
-      }"
-    `);
-
-    expect(sheet.cssText).toMatchInlineSnapshot(`
-      "@media all and (min-width: 0px) {
-        .c {
-          display: block;
-          color: green
-        }
-      }"
-    `);
-  });
-
   test("update media rule options", () => {
+    const sheet = createRegularStyleSheet();
     sheet.addMediaRule(mediaId0, mediaRuleOptions0);
-    sheet.addStyleRule(
-      {
-        style: {
-          color: { type: "keyword", value: "red" },
-        },
-        breakpoint: "0",
-      },
-      ".c"
-    );
+    sheet.addNestingRule(".c").setDeclaration({
+      breakpoint: "0",
+      selector: "",
+      property: "color",
+      value: { type: "keyword", value: "red" },
+    });
     expect(sheet.cssText).toMatchInlineSnapshot(`
       "@media all and (min-width: 0px) {
         .c {
@@ -706,14 +500,14 @@ describe("Style Sheet Regular", () => {
   });
 
   test("don't override media queries", () => {
+    const sheet = createRegularStyleSheet();
     sheet.addMediaRule(mediaId0, mediaRuleOptions0);
-    sheet.addStyleRule(
-      {
-        style: style0,
-        breakpoint: "0",
-      },
-      ".c"
-    );
+    sheet.addNestingRule(".c").setDeclaration({
+      breakpoint: "0",
+      selector: "",
+      property: "display",
+      value: { type: "keyword", value: "block" },
+    });
     expect(sheet.cssText).toMatchInlineSnapshot(`
       "@media all and (min-width: 0px) {
         .c {
@@ -732,11 +526,13 @@ describe("Style Sheet Regular", () => {
   });
 
   test("plaintext rule", () => {
+    const sheet = createRegularStyleSheet();
     sheet.addPlaintextRule(".c { color: red }");
     expect(sheet.cssText).toMatchInlineSnapshot(`".c { color: red }"`);
   });
 
   test("plaintext - no duplicates", () => {
+    const sheet = createRegularStyleSheet();
     sheet.addPlaintextRule(".c { color: red }");
     sheet.addPlaintextRule(".c { color: red }");
     sheet.addPlaintextRule(".c { color: green }");
@@ -747,6 +543,7 @@ describe("Style Sheet Regular", () => {
   });
 
   test("font family rule with space in the name", () => {
+    const sheet = createRegularStyleSheet();
     sheet.addFontFaceRule({
       fontFamily: "Some Font",
       fontStyle: "normal",
@@ -761,53 +558,8 @@ describe("Style Sheet Regular", () => {
 `);
   });
 
-  test("clear", () => {
-    sheet.addStyleRule(
-      {
-        style: style0,
-        breakpoint: "0",
-      },
-      ".c"
-    );
-    sheet.clear();
-    expect(sheet.cssText).toMatchInlineSnapshot(`""`);
-  });
-
-  test("get all rule style keys", () => {
-    const rule = sheet.addStyleRule(
-      {
-        style: style2,
-        breakpoint: "0",
-      },
-      ".c"
-    );
-    expect(Array.from(rule.styleMap.keys())).toMatchInlineSnapshot(`
-      [
-        "display",
-        "color",
-      ]
-    `);
-  });
-
-  test("delete style from rule", () => {
-    const rule = sheet.addStyleRule(
-      {
-        style: style2,
-        breakpoint: "0",
-      },
-      ".c"
-    );
-    rule.styleMap.delete("display");
-    expect(sheet.cssText).toMatchInlineSnapshot(`
-      "@media all {
-        .c {
-          color: black
-        }
-      }"
-    `);
-  });
-
   test("render images with injected asset url", () => {
+    const sheet = createRegularStyleSheet();
     const assets = new Map<string, { path: string }>([
       ["1234", { path: "foo.png" }],
     ]);
@@ -826,22 +578,19 @@ describe("Style Sheet Regular", () => {
         };
       }
     });
-    const rule = sheet.addStyleRule(
-      {
-        style: {
-          backgroundImage: {
-            type: "image",
-            value: {
-              type: "asset",
-              value: "1234",
-            },
-          },
+    sheet.addMediaRule("0");
+    sheet.addNestingRule(".c").setDeclaration({
+      breakpoint: "0",
+      selector: "",
+      property: "backgroundImage",
+      value: {
+        type: "image",
+        value: {
+          type: "asset",
+          value: "1234",
         },
-        breakpoint: "0",
       },
-      ".c"
-    );
-    rule.styleMap.delete("display");
+    });
     expect(sheet.cssText).toMatchInlineSnapshot(`
       "@media all {
         .c {

--- a/packages/css-engine/src/core/style-sheet-regular.ts
+++ b/packages/css-engine/src/core/style-sheet-regular.ts
@@ -1,14 +1,3 @@
-import { StyleRule } from "./rules";
-import { StyleSheet, type CssRule } from "./style-sheet";
+import { StyleSheet } from "./style-sheet";
 
-const defaultMediaRuleId = "__default-media-rule__";
-
-export class StyleSheetRegular extends StyleSheet {
-  addStyleRule(rule: CssRule, selectorText: string) {
-    const mediaRule = this.addMediaRule(rule.breakpoint || defaultMediaRuleId);
-
-    const styleRule = new StyleRule(selectorText, rule.style);
-    mediaRule.insertRule(styleRule);
-    return styleRule;
-  }
-}
+export class StyleSheetRegular extends StyleSheet {}

--- a/packages/css-engine/src/core/style-sheet.ts
+++ b/packages/css-engine/src/core/style-sheet.ts
@@ -1,4 +1,3 @@
-import type { Style } from "../schema";
 import {
   FontFaceRule,
   MediaRule,
@@ -11,11 +10,6 @@ import {
 import { compareMedia } from "./compare-media";
 import { StyleElement } from "./style-element";
 import type { TransformValue } from "./to-value";
-
-export type CssRule = {
-  style: Style;
-  breakpoint?: string;
-};
 
 export class StyleSheet {
   #cssText = "";


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2647

Switched to nesting rule and style map generator
everywhere in builder.

Now will be much easier to implement properties prefixing and merging utilities.