### PR TITLE
fix: prefix more css properties

### DIFF
--- a/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
@@ -30,7 +30,7 @@ const Page = ({}: { system: any }) => {
     <Body
       data-ws-id="MMimeobf_zi4ZkRGXapju"
       data-ws-component="Body"
-      className="c1jaw2zx c1bn74oy c1vwwfi7 c1xn7xpo"
+      className="c1jaw2zx cbipm55 ctniqj4 ctgx88l"
     >
       <Heading data-ws-id="MYDt0guk1-vzc7yzqyN6A" data-ws-component="Heading">
         {"Simple Project to test CLI"}

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/index.css
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/index.css
@@ -82,13 +82,13 @@ html {
   .c1jaw2zx {
     display: flex;
   }
-  .c1bn74oy {
+  .cbipm55 {
     align-items: center;
   }
-  .c1vwwfi7 {
+  .ctniqj4 {
     justify-content: center;
   }
-  .c1xn7xpo {
+  .ctgx88l {
     flex-direction: column;
   }
 }

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -39,7 +39,7 @@ const Page = ({}: { system: any }) => {
     <Body
       data-ws-id="LW98_-srDnnagkR10lsk4"
       data-ws-component="Body"
-      className="crro89i ca0mhw9 c1ldy0s3 c1t3ec4y"
+      className="c306nq8 cp7h9on ciostvv c12dzlms"
     >
       <Heading data-ws-id="SHXddDLFWST_sy44UfGQO" data-ws-component="Heading">
         {"Script Test"}

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -104,19 +104,19 @@ const Page = ({}: { system: any }) => {
     <Body
       data-ws-id="ibXgMoi9_ipHx1gVrvii0"
       data-ws-component="Body"
-      className="crro89i c1ldy0s3 ca0mhw9 c1t3ec4y"
+      className="c306nq8 ciostvv cp7h9on c12dzlms"
     >
       <Heading
         data-ws-id="7pwqBSgrfuuOfk1JblWcL"
         data-ws-component="Heading"
-        className="c12poxag c13p4xw cpwo0o8 cjtvnga c1dgu1f0 c1mko7pq c1ryjtry c1yhbwj4 cm4n0xq c1weo8li"
+        className="ce7mxws cd0g70b c1ku1ozg c1kbs9xq c1m6kmmg crjoqt7 c1n5sjmn c1hqh3e6 cwdggon c4o64du"
       >
         {"DO NOT TOUCH THIS PROJECT, IT'S USED FOR FIXTURES"}
       </Heading>
       <Box
         data-ws-id="GMg3Wi9tJBFMtKcwbIK6z"
         data-ws-component="Box"
-        className="cxb89wn czqi13r ct7y0ym cy9si0i c1zln9k"
+        className="cxb89wn c12qr5j7 c111rqf8 cp8i2p0 cwfevk3"
       >
         <Image
           data-ws-id="Mfd_mI-VJtT4r7gICAvXi"
@@ -126,12 +126,12 @@ const Page = ({}: { system: any }) => {
           }
           width={1024}
           height={1024}
-          className="c9mecv c1xeb6ie c1cpdzfi cub4hpc"
+          className="ccgiojm cv4f3rn cer5re4 c9lz7ss"
         />
         <Box
           data-ws-id="COafOppxs73Ne4O0Geik0"
           data-ws-component="Box"
-          className="c9mecv c1xeb6ie c1cpdzfi cub4hpc"
+          className="ccgiojm cv4f3rn cer5re4 c9lz7ss"
         />
       </Box>
       <Heading data-ws-id="jWb8SRMYG_XPWqCYvGZjo" data-ws-component="Heading">
@@ -164,7 +164,7 @@ const Page = ({}: { system: any }) => {
         data-ws-component="Vimeo"
         url={"https://player.vimeo.com/video/831343124"}
         showPreview={true}
-        className="c17osjft c53gbe c8mrdqb"
+        className="c17osjft c5kxibo c8mrdqb"
       >
         <VimeoPreviewImage
           data-ws-id="wxd8Wul8dl2yPRFFedNn6"
@@ -172,12 +172,12 @@ const Page = ({}: { system: any }) => {
           alt={"Vimeo video preview image"}
           sizes={"100vw"}
           src={"/custom-folder/home_wsKvRSqvkajPPBeycZ-C8.svg"}
-          className="c13adha2 c3sa779 c8mrdqb chv0hit c14mu2ti c1dsdrfn c1id445d cf36655 c1dfx0rt"
+          className="c13adha2 c19kjzjn c8mrdqb chv0hit c1vw7ut7 c64vnj4 cow7xo6 cddunt6 cqjhyu2"
         />
         <VimeoSpinner
           data-ws-id="o8sAMUoaOraWYZClEfRgl"
           data-ws-component="VimeoSpinner"
-          className="c13adha2 c1ifzo79 c1ljqvnn c10zke2u cplzsl2 c1h30nuz czav9qc"
+          className="c13adha2 c1ifzo79 c1ljqvnn c10zke2u cplzsl2 c1ardg8l ces5mo3"
         >
           <HtmlEmbed
             data-ws-id="BeQ7sgDlUizFvf4aHqOsh"
@@ -192,7 +192,7 @@ const Page = ({}: { system: any }) => {
           data-ws-id="9hBBPGSf7hB30ZkSHKjNd"
           data-ws-component="VimeoPlayButton"
           aria-label={"Play button"}
-          className="c13adha2 c1t88ri8 ca7kf99 c1ifzo79 c1ljqvnn cguufcz c1an2y3u cxb89wn c1h8v1ng c19cfw6s cv7bbk3 c1tly7k c8mtcs c7jk6jf c17y59v6 c1d4fd4d c1yj9i1y c1xqoqjh cil01r8 crmtz4w coba2o7 c11eux2f"
+          className="c13adha2 c1t88ri8 ca7kf99 c1ifzo79 c1ljqvnn c1bld9op ctly9e6 cxb89wn cwcnvqs cvchf4 c1y7dyx c1bnrgjg c1joowif c120xed6 c2eug5n cvwgylz c1f0qcby c1syyj1x cil01r8 c11087u4 coba2o7 c82nx6d"
         >
           <Box
             data-ws-id="D__QElBIIQtamhJN3a4FI"

--- a/fixtures/webstudio-custom-template/app/__generated__/index.css
+++ b/fixtures/webstudio-custom-template/app/__generated__/index.css
@@ -225,22 +225,23 @@ html {
   }
 }
 @media all {
-  .c12poxag {
+  .ce7mxws {
     font-size: 4em;
   }
-  .c13p4xw {
+  .cd0g70b {
     font-family: "Cormorant Garamond", sans-serif;
   }
-  .cpwo0o8 {
+  .c1ku1ozg {
     background-attachment: scroll, scroll, scroll;
   }
-  .cjtvnga {
+  .c1kbs9xq {
     -webkit-background-clip: border-box, border-box, border-box;
+    background-clip: border-box, border-box, border-box;
   }
-  .c1dgu1f0 {
+  .c1m6kmmg {
     background-blend-mode: normal, normal, normal;
   }
-  .c1mko7pq {
+  .crjoqt7 {
     background-image: linear-gradient(
         rgba(255, 0, 0, 0.2),
         rgba(0, 255, 255, 0.2)
@@ -248,34 +249,34 @@ html {
       url("/custom-folder/home_wsKvRSqvkajPPBeycZ-C8.svg"),
       linear-gradient(to right, rgba(255, 0, 255, 0.2), rgba(0, 255, 0, 0.2));
   }
-  .c1ryjtry {
+  .c1n5sjmn {
     background-origin: padding-box, padding-box, padding-box;
   }
-  .c1yhbwj4 {
+  .c1hqh3e6 {
     background-position: 0%, 0%, 0%;
   }
-  .cm4n0xq {
+  .cwdggon {
     background-repeat: repeat, repeat, repeat;
   }
-  .c1weo8li {
+  .c4o64du {
     background-size: auto, auto, auto;
   }
-  .crro89i {
+  .c306nq8 {
     margin-top: 15px;
   }
-  .ca0mhw9 {
+  .cp7h9on {
     margin-bottom: 15px;
   }
-  .c1ldy0s3 {
+  .ciostvv {
     margin-right: 15px;
   }
-  .c1t3ec4y {
+  .c12dzlms {
     margin-left: 15px;
   }
   .c17osjft {
     position: relative;
   }
-  .c53gbe {
+  .c5kxibo {
     aspect-ratio: 640/360;
   }
   .c8mrdqb {
@@ -284,25 +285,25 @@ html {
   .c13adha2 {
     position: absolute;
   }
-  .c3sa779 {
+  .c19kjzjn {
     object-fit: cover;
   }
   .chv0hit {
     height: 100%;
   }
-  .c14mu2ti {
+  .c1vw7ut7 {
     border-top-left-radius: 20px;
   }
-  .c1dsdrfn {
+  .c64vnj4 {
     border-top-right-radius: 20px;
   }
-  .c1id445d {
+  .cow7xo6 {
     border-bottom-left-radius: 20px;
   }
-  .cf36655 {
+  .cddunt6 {
     border-bottom-right-radius: 20px;
   }
-  .c1dfx0rt {
+  .cqjhyu2 {
     object-position: cover;
   }
   .c1t88ri8 {
@@ -317,55 +318,55 @@ html {
   .c1ljqvnn {
     left: 50%;
   }
-  .cguufcz {
+  .c1bld9op {
     margin-top: -40px;
   }
-  .c1an2y3u {
+  .ctly9e6 {
     margin-left: -70px;
   }
   .cxb89wn {
     display: flex;
   }
-  .c1h8v1ng {
+  .cwcnvqs {
     align-items: center;
   }
-  .c19cfw6s {
+  .cvchf4 {
     justify-content: center;
   }
-  .cv7bbk3 {
+  .c1y7dyx {
     border-top-style: none;
   }
-  .c1tly7k {
+  .c1bnrgjg {
     border-right-style: none;
   }
-  .c8mtcs {
+  .c1joowif {
     border-bottom-style: none;
   }
-  .c7jk6jf {
+  .c120xed6 {
     border-left-style: none;
   }
-  .c17y59v6 {
+  .c2eug5n {
     border-top-left-radius: 5px;
   }
-  .c1d4fd4d {
+  .cvwgylz {
     border-top-right-radius: 5px;
   }
-  .c1yj9i1y {
+  .c1f0qcby {
     border-bottom-left-radius: 5px;
   }
-  .c1xqoqjh {
+  .c1syyj1x {
     border-bottom-right-radius: 5px;
   }
   .cil01r8 {
     cursor: pointer;
   }
-  .crmtz4w {
+  .c11087u4 {
     background-color: rgba(18, 18, 18, 1);
   }
   .coba2o7 {
     color: rgba(255, 255, 255, 1);
   }
-  .c11eux2f:hover {
+  .c82nx6d:hover {
     background-color: rgba(0, 173, 239, 1);
   }
   .c1cccshn {
@@ -380,34 +381,34 @@ html {
   .cplzsl2 {
     height: 70px;
   }
-  .c1h30nuz {
+  .c1ardg8l {
     margin-top: -35px;
   }
-  .czav9qc {
+  .ces5mo3 {
     margin-left: -35px;
   }
-  .czqi13r {
+  .c12qr5j7 {
     flex-direction: row;
   }
-  .ct7y0ym {
+  .c111rqf8 {
     flex-wrap: nowrap;
   }
-  .cy9si0i {
+  .cp8i2p0 {
     align-items: stretch;
   }
-  .c1zln9k {
+  .cwfevk3 {
     justify-content: space-between;
   }
-  .c9mecv {
+  .ccgiojm {
     flex-grow: 1;
   }
-  .c1xeb6ie {
+  .cv4f3rn {
     flex-shrink: 0;
   }
-  .c1cpdzfi {
+  .cer5re4 {
     min-width: 0px;
   }
-  .cub4hpc {
+  .c9lz7ss {
     flex-basis: 0px;
   }
 }

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -30,7 +30,7 @@ const Page = ({}: { system: any }) => {
     <Body
       data-ws-id="MMimeobf_zi4ZkRGXapju"
       data-ws-component="Body"
-      className="c1jaw2zx c1bn74oy c1vwwfi7 c1xn7xpo"
+      className="c1jaw2zx cbipm55 ctniqj4 ctgx88l"
     >
       <Heading data-ws-id="MYDt0guk1-vzc7yzqyN6A" data-ws-component="Heading">
         {"Simple Project to test CLI"}

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/index.css
@@ -82,13 +82,13 @@ html {
   .c1jaw2zx {
     display: flex;
   }
-  .c1bn74oy {
+  .cbipm55 {
     align-items: center;
   }
-  .c1vwwfi7 {
+  .ctniqj4 {
     justify-content: center;
   }
-  .c1xn7xpo {
+  .ctgx88l {
     flex-direction: column;
   }
 }

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -30,7 +30,7 @@ const Page = ({}: { system: any }) => {
     <Body
       data-ws-id="MMimeobf_zi4ZkRGXapju"
       data-ws-component="Body"
-      className="c1jaw2zx c1bn74oy c1vwwfi7 c1xn7xpo"
+      className="c1jaw2zx cbipm55 ctniqj4 ctgx88l"
     >
       <Heading data-ws-id="MYDt0guk1-vzc7yzqyN6A" data-ws-component="Heading">
         {"Simple Project to test CLI"}

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/index.css
@@ -82,13 +82,13 @@ html {
   .c1jaw2zx {
     display: flex;
   }
-  .c1bn74oy {
+  .cbipm55 {
     align-items: center;
   }
-  .c1vwwfi7 {
+  .ctniqj4 {
     justify-content: center;
   }
-  .c1xn7xpo {
+  .ctgx88l {
     flex-direction: column;
   }
 }

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -35,7 +35,7 @@ const Page = ({}: { system: any }) => {
         data-ws-id="AdXSAYCx4QDo5QN6nLoGs"
         data-ws-component="Image"
         src={"/assets/small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp"}
-        className="czgliev"
+        className="c1czoo99"
       />
     </Body>
   );

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -67,7 +67,7 @@ const Page = ({}: { system: any }) => {
           data-ws-id="zJ927zk9txwUbYycKB7QA"
           data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionItem"
           data-ws-index="0"
-          className="c1jm23u4 c17v6wg4 c14ypr85"
+          className="c11jd1pp cpr1920 czj7fc1"
         >
           <AccordionHeader
             data-ws-id="sMxg7xT1hwYt05hbOvoPL"
@@ -77,7 +77,7 @@ const Page = ({}: { system: any }) => {
             <AccordionTrigger
               data-ws-id="qQSA4NoyKC88O68mBiQe2"
               data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionTrigger"
-              className="c13v7j50 c1njwnl4 cr59mug cuiulls c1aj1vjn cxqmhs5 cmt2mhu c1f88uyp coehty2 c1bsiosv cg783j6 c1s4llbc"
+              className="c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax c1ad236a cg783j6 c1s4llbc"
             >
               <Text data-ws-id="q-DVI4YTNrQ1LizmEyJHI" data-ws-component="Text">
                 {"Is it accessible?"}
@@ -85,7 +85,7 @@ const Page = ({}: { system: any }) => {
               <Box
                 data-ws-id="RSk81lLj2IGXgchTuXF7V"
                 data-ws-component="Box"
-                className="c14hansb c6d2sb5 cwwiftc c9oe4mg cum13td clcagvf cszwd2x"
+                className="c14hansb c6d2sb5 cwwiftc c16vb2zi c1hl6g8z c1xm49r0 c1vri55v"
               >
                 <HtmlEmbed
                   data-ws-id="d0sd_G-kHirxgjq6s6Uq1"
@@ -100,7 +100,7 @@ const Page = ({}: { system: any }) => {
           <AccordionContent
             data-ws-id="IUftdfjK-ilSzfOTdIx1u"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionContent"
-            className="c1mxwmum c11q6wf c11rm5bv c1f88uyp"
+            className="c1mxwmum c1j0j9ep c1gl2i2 c44srea"
           >
             {"Yes. It adheres to the WAI-ARIA design pattern."}
           </AccordionContent>
@@ -109,7 +109,7 @@ const Page = ({}: { system: any }) => {
           data-ws-id="C838wkvIcA1BQu30Xu2G8"
           data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionItem"
           data-ws-index="1"
-          className="c1jm23u4 c17v6wg4 c14ypr85"
+          className="c11jd1pp cpr1920 czj7fc1"
         >
           <AccordionHeader
             data-ws-id="fYUOB_brm6s0Ky68lzMfU"
@@ -119,7 +119,7 @@ const Page = ({}: { system: any }) => {
             <AccordionTrigger
               data-ws-id="dfd4gonev_AX6BpuCsxjb"
               data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionTrigger"
-              className="c13v7j50 c1njwnl4 cr59mug cuiulls c1aj1vjn cxqmhs5 cmt2mhu c1f88uyp coehty2 c1bsiosv cg783j6 c1s4llbc"
+              className="c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax c1ad236a cg783j6 c1s4llbc"
             >
               <Text data-ws-id="lZ7sI6Kw_0VZkURriKscB" data-ws-component="Text">
                 {"Is it styled?"}
@@ -127,7 +127,7 @@ const Page = ({}: { system: any }) => {
               <Box
                 data-ws-id="wRw75kuvFzl5NWD8IGJoI"
                 data-ws-component="Box"
-                className="c14hansb c6d2sb5 cwwiftc c9oe4mg cum13td clcagvf cszwd2x"
+                className="c14hansb c6d2sb5 cwwiftc c16vb2zi c1hl6g8z c1xm49r0 c1vri55v"
               >
                 <HtmlEmbed
                   data-ws-id="StPslEr81nfBISqBE2R-Y"
@@ -142,7 +142,7 @@ const Page = ({}: { system: any }) => {
           <AccordionContent
             data-ws-id="wNRVuu0L5E8TVufKdswp1"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionContent"
-            className="c1mxwmum c11q6wf c11rm5bv c1f88uyp"
+            className="c1mxwmum c1j0j9ep c1gl2i2 c44srea"
           >
             {
               "Yes. It comes with default styles that matches the other components' aesthetic."
@@ -153,7 +153,7 @@ const Page = ({}: { system: any }) => {
           data-ws-id="65djoTmSBGemZ2L5izQ5M"
           data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionItem"
           data-ws-index="2"
-          className="c1jm23u4 c17v6wg4 c14ypr85"
+          className="c11jd1pp cpr1920 czj7fc1"
         >
           <AccordionHeader
             data-ws-id="UJYfe6kH7HqhH0YYeJwe7"
@@ -163,7 +163,7 @@ const Page = ({}: { system: any }) => {
             <AccordionTrigger
               data-ws-id="600nGddaNxGGdsuGgpxJR"
               data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionTrigger"
-              className="c13v7j50 c1njwnl4 cr59mug cuiulls c1aj1vjn cxqmhs5 cmt2mhu c1f88uyp coehty2 c1bsiosv cg783j6 c1s4llbc"
+              className="c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax c1ad236a cg783j6 c1s4llbc"
             >
               <Text data-ws-id="1iNKIMG91n83PzJnEdxq9" data-ws-component="Text">
                 {"Is it animated?"}
@@ -171,7 +171,7 @@ const Page = ({}: { system: any }) => {
               <Box
                 data-ws-id="Ta70VqUb_fGJXBT_zsnxQ"
                 data-ws-component="Box"
-                className="c14hansb c6d2sb5 cwwiftc c9oe4mg cum13td clcagvf cszwd2x"
+                className="c14hansb c6d2sb5 cwwiftc c16vb2zi c1hl6g8z c1xm49r0 c1vri55v"
               >
                 <HtmlEmbed
                   data-ws-id="sO80m5u4f87jVGG91t6u8"
@@ -186,7 +186,7 @@ const Page = ({}: { system: any }) => {
           <AccordionContent
             data-ws-id="mOVPnIrlt6IwVAzI_i2Fc"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionContent"
-            className="c1mxwmum c11q6wf c11rm5bv c1f88uyp"
+            className="c1mxwmum c1j0j9ep c1gl2i2 c44srea"
           >
             {
               "Yes. It's animated by default, but you can disable it if you prefer."

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -76,24 +76,24 @@ const Page = ({}: { system: any }) => {
     <Body
       data-ws-id="On9cvWCxr5rdZtY9O1Bv0"
       data-ws-component="Body"
-      className="c198lioj cr65sqc c1ucc9vx c1dhla2v"
+      className="c1rv17ff ceuqm0z c1dj16g6 c11ai4np"
     >
       <Heading
         data-ws-id="nVMWvMsaLCcb0o1wuNQgg"
         data-ws-component="Heading"
-        className="c1knjlal"
+        className="ceva767"
       >
         {"DO NOT TOUCH THIS PROJECT, IT'S USED FOR FIXTURES"}
       </Heading>
       <Box
         data-ws-id="f0kF-WmL7DQg7MSyRvqY1"
         data-ws-component="Box"
-        className="c13v7j50 c1ubj2iz clu0378"
+        className="c13v7j50 cqkqnmd cv6wa71"
       >
         <Box
           data-ws-id="5XDbqPrZDeCwq4YJ3CHsc"
           data-ws-component="Box"
-          className="c15heboa c1njwnl4 cxq4cho cn5joda"
+          className="c1t3ybra c1qxdkbn c1ogzcge cv3kvac"
         >
           <Heading
             data-ws-id="oLXYe1UQiVMhVnZGvJSMr"
@@ -151,7 +151,7 @@ const Page = ({}: { system: any }) => {
         <Box
           data-ws-id="qPnkiFGDj8dITWb1kmpGl"
           data-ws-component="Box"
-          className="c15heboa c1njwnl4 cxq4cho cn5joda"
+          className="c1t3ybra c1qxdkbn c1ogzcge cv3kvac"
         >
           <Image
             data-ws-id="pX1ovPI7NdC0HRjkw6Kpw"
@@ -159,7 +159,7 @@ const Page = ({}: { system: any }) => {
             src={
               "/assets/_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg"
             }
-            className="czgliev"
+            className="c1czoo99"
           />
         </Box>
       </Box>

--- a/fixtures/webstudio-remix-vercel/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/index.css
@@ -317,76 +317,76 @@ html {
   }
 }
 @media all {
-  .c1knjlal {
+  .ceva767 {
     font-size: 4em;
   }
   .c13v7j50 {
     display: flex;
   }
-  .c1ubj2iz {
+  .cqkqnmd {
     justify-content: center;
   }
-  .clu0378 {
+  .cv6wa71 {
     align-items: start;
   }
-  .c15heboa {
+  .c1t3ybra {
     min-width: 0px;
   }
-  .c1njwnl4 {
+  .c1qxdkbn {
     flex-grow: 1;
   }
-  .cxq4cho {
+  .c1ogzcge {
     flex-shrink: 0;
   }
-  .cn5joda {
+  .cv3kvac {
     flex-basis: 0px;
   }
-  .czgliev {
+  .c1czoo99 {
     aspect-ratio: 1;
   }
-  .c198lioj {
+  .c1rv17ff {
     padding-top: 16px;
   }
-  .cr65sqc {
+  .ceuqm0z {
     padding-right: 16px;
   }
-  .c1ucc9vx {
+  .c1dj16g6 {
     padding-left: 16px;
   }
-  .c1dhla2v {
+  .c11ai4np {
     padding-bottom: 16px;
   }
-  .c1jm23u4 {
+  .c11jd1pp {
     border-bottom-width: 1px;
   }
-  .c17v6wg4 {
+  .cpr1920 {
     border-bottom-style: solid;
   }
-  .c14ypr85 {
+  .czj7fc1 {
     border-bottom-color: rgba(226, 232, 240, 1);
   }
-  .cr59mug {
+  .chhejm9 {
     flex-shrink: 1;
   }
-  .cuiulls {
+  .c13bviim {
     flex-basis: 0%;
   }
-  .c1aj1vjn {
+  .cpjvam0 {
     align-items: center;
   }
-  .cxqmhs5 {
+  .c1tw5o2 {
     justify-content: space-between;
   }
-  .cmt2mhu {
+  .cqw88jp {
     padding-top: 1rem;
   }
-  .c1f88uyp {
+  .c44srea {
     padding-bottom: 1rem;
   }
-  .coehty2 {
+  .c14kxsax {
     font-weight: 500;
   }
-  .c1bsiosv:hover {
+  .c1ad236a:hover {
     text-decoration-line: underline;
   }
   .cg783j6 {
@@ -404,25 +404,25 @@ html {
   .cwwiftc {
     width: 1rem;
   }
-  .c9oe4mg {
+  .c16vb2zi {
     flex-grow: 0;
   }
-  .cum13td {
+  .c1hl6g8z {
     transition-property: all;
   }
-  .clcagvf {
+  .c1xm49r0 {
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   }
-  .cszwd2x {
+  .c1vri55v {
     transition-duration: 200ms;
   }
   .c1mxwmum {
     overflow: hidden;
   }
-  .c11q6wf {
+  .c1j0j9ep {
     font-size: 0.875rem;
   }
-  .c11rm5bv {
+  .c1gl2i2 {
     line-height: 1.25rem;
   }
   .ch2exr5 {

--- a/packages/css-engine/src/core/atomic.test.ts
+++ b/packages/css-engine/src/core/atomic.test.ts
@@ -12,8 +12,8 @@ test("use matching media rule", () => {
   rule.setDeclaration({
     breakpoint: "x",
     selector: "",
-    property: "display",
-    value: { type: "keyword", value: "block" },
+    property: "marginTop",
+    value: { type: "keyword", value: "auto" },
   });
   rule.setDeclaration({
     breakpoint: "x",
@@ -24,8 +24,8 @@ test("use matching media rule", () => {
   expect(generateAtomic(sheet, { getKey: () => "" }).cssText)
     .toMatchInlineSnapshot(`
 "@media all {
-  .ccqp4le {
-    display: block
+  .chcgnqf {
+    margin-top: auto
   }
   .cen0ymu {
     color: red
@@ -201,6 +201,27 @@ test("support descendant suffix", () => {
   }
   .cpdl2lp img:hover {
     display: block
+  }
+}"
+`);
+});
+
+test("generated prefixed and unprefixed in the same rule", () => {
+  const sheet = createRegularStyleSheet();
+  sheet.addMediaRule("x");
+  const rule1 = sheet.addNestingRule("instance");
+  rule1.setDeclaration({
+    breakpoint: "x",
+    selector: "",
+    property: "textSizeAdjust",
+    value: { type: "keyword", value: "auto" },
+  });
+  expect(generateAtomic(sheet, { getKey: () => "" }).cssText)
+    .toMatchInlineSnapshot(`
+"@media all {
+  .c1h1gugw {
+    -webkit-text-size-adjust: auto;
+    text-size-adjust: auto
   }
 }"
 `);

--- a/packages/css-engine/src/core/prefixer.test.ts
+++ b/packages/css-engine/src/core/prefixer.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@jest/globals";
+import { prefixStyles } from "./prefixer";
+
+test("prefix background-clip", () => {
+  expect(
+    prefixStyles(
+      new Map([["background-clip", { type: "keyword", value: "text" }]])
+    )
+  ).toEqual(
+    new Map([
+      ["-webkit-background-clip", { type: "keyword", value: "text" }],
+      ["background-clip", { type: "keyword", value: "text" }],
+    ])
+  );
+});
+
+test("prefix user-select", () => {
+  expect(
+    prefixStyles(new Map([["user-select", { type: "keyword", value: "none" }]]))
+  ).toEqual(
+    new Map([
+      ["-webkit-user-select", { type: "keyword", value: "none" }],
+      ["user-select", { type: "keyword", value: "none" }],
+    ])
+  );
+});
+
+test("prefix text-size-adjust", () => {
+  expect(
+    prefixStyles(
+      new Map([["text-size-adjust", { type: "keyword", value: "auto" }]])
+    )
+  ).toEqual(
+    new Map([
+      ["-webkit-text-size-adjust", { type: "keyword", value: "auto" }],
+      ["text-size-adjust", { type: "keyword", value: "auto" }],
+    ])
+  );
+});

--- a/packages/css-engine/src/core/prefixer.ts
+++ b/packages/css-engine/src/core/prefixer.ts
@@ -1,0 +1,25 @@
+import type { StyleMap } from "./rules";
+
+export const prefixStyles = (styleMap: StyleMap) => {
+  const newStyleMap: StyleMap = new Map();
+  for (const [property, value] of styleMap) {
+    // chrome started to support unprefixed background-clip in December 2023
+    // https://caniuse.com/background-clip-text
+    // @todo stop prerfixed maybe one year later
+    if (property === "background-clip") {
+      newStyleMap.set("-webkit-background-clip", value);
+    }
+    // safari still supports only prefixed version
+    // https://caniuse.com/?search=user-select
+    if (property === "user-select") {
+      newStyleMap.set("-webkit-user-select", value);
+    }
+    // ios safari and firefox android supports only -webkit- prefix
+    // https://caniuse.com/text-size-adjust
+    if (property === "text-size-adjust") {
+      newStyleMap.set("-webkit-text-size-adjust", value);
+    }
+    newStyleMap.set(property, value);
+  }
+  return newStyleMap;
+};

--- a/packages/css-engine/src/core/to-property.test.ts
+++ b/packages/css-engine/src/core/to-property.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "@jest/globals";
-import { hyphenateProperty, toProperty } from "./to-property";
+import { hyphenateProperty } from "./to-property";
 
 describe("hyphenateProperty", () => {
   test("hyphenates regular css", () => {
@@ -15,13 +15,10 @@ describe("hyphenateProperty", () => {
     expect(hyphenateProperty("MozTransition")).toEqual("-moz-transition");
     expect(hyphenateProperty("WebkitTransition")).toEqual("-webkit-transition");
   });
-});
 
-describe("toProperty", () => {
-  test("boxSizing", () => {
-    expect(toProperty("boxSizing")).toBe("box-sizing");
-  });
-  test("backgroundClip", () => {
-    expect(toProperty("backgroundClip")).toBe("-webkit-background-clip");
+  test("hyphenating is idempotent", () => {
+    expect(hyphenateProperty(hyphenateProperty("-moz-transition"))).toEqual(
+      "-moz-transition"
+    );
   });
 });

--- a/packages/css-engine/src/core/to-property.ts
+++ b/packages/css-engine/src/core/to-property.ts
@@ -1,17 +1,5 @@
-import type { StyleProperty } from "../schema";
-
 /**
  * Hyphenates a camelcased CSS property name
  */
 export const hyphenateProperty = (property: string) =>
   property.replace(/[A-Z]/g, (match) => "-" + match.toLowerCase());
-
-export const toProperty = (property: StyleProperty) => {
-  // chrome started to support unprefixed background-clip in December 2023
-  // https://caniuse.com/background-clip-text
-  // @todo stop prerfixed maybe one year later
-  if (property === "backgroundClip") {
-    return "-webkit-background-clip";
-  }
-  return hyphenateProperty(property);
-};

--- a/packages/react-sdk/src/css/css.test.tsx
+++ b/packages/react-sdk/src/css/css.test.tsx
@@ -217,6 +217,7 @@ test("generate component presets", () => {
     display: block
   }
   a:where([data-ws-component="Box"]) {
+    -webkit-user-select: none;
     user-select: none
   }
 }
@@ -229,6 +230,7 @@ test("generate component presets", () => {
     display: block
   }
   a:where([data-ws-component="Box"]) {
+    -webkit-user-select: none;
     user-select: none
   }
 }


### PR DESCRIPTION
These fields should have -webkit- prefix additionally to unprefixed version to support more browsers.

- background-clip
- user-select
- text-size-adjust