### PR TITLE
feat: Add native select control

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -12,6 +12,7 @@ import {
 import * as baseComponents from "@webstudio-is/sdk-components-react";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
 import * as baseComponentPropsMetas from "@webstudio-is/sdk-components-react/props";
+import { hooks as baseComponentHooks } from "@webstudio-is/sdk-components-react/hooks";
 import * as remixComponents from "@webstudio-is/sdk-components-react-remix";
 import * as remixComponentMetas from "@webstudio-is/sdk-components-react-remix/metas";
 import * as remixComponentPropsMetas from "@webstudio-is/sdk-components-react-remix/props";
@@ -159,6 +160,7 @@ export const Canvas = ({ params, imageLoader }: CanvasProps) => {
       components: baseComponents,
       metas: baseComponentMetas,
       propsMetas: baseComponentPropsMetas,
+      hooks: baseComponentHooks,
     });
     registerComponentLibrary({
       components: remixComponents,

--- a/apps/builder/app/canvas/collapsed.ts
+++ b/apps/builder/app/canvas/collapsed.ts
@@ -168,7 +168,11 @@ const recalculate = () => {
     const elementPosition = window.getComputedStyle(element).position;
 
     if (element.parentElement) {
-      if (elementPosition === "absolute" || elementPosition === "fixed") {
+      if (
+        elementPosition === "absolute" ||
+        elementPosition === "fixed" ||
+        element.offsetParent == null
+      ) {
         parentsWithAbsoluteChildren.set(
           element.parentElement,
           parentsWithAbsoluteChildren.get(element.parentElement) ?? 0

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -31,7 +31,7 @@ import {
 } from "@webstudio-is/react-sdk";
 import { rawTheme } from "@webstudio-is/design-system";
 import {
-  $propValuesByInstanceSelector,
+  $propValuesByInstanceSelectorWithMemoryProps,
   getIndexedInstanceId,
   $instances,
   $registeredComponentMetas,
@@ -216,7 +216,7 @@ const useInstanceProps = (instanceSelector: InstanceSelector) => {
   const [instanceId] = instanceSelector;
   const $instancePropsObject = useMemo(() => {
     return computed(
-      [$propValuesByInstanceSelector, $indexesWithinAncestors],
+      [$propValuesByInstanceSelectorWithMemoryProps, $indexesWithinAncestors],
       (propValuesByInstanceSelector, indexesWithinAncestors) => {
         const instancePropsObject: Record<Prop["name"], unknown> = {};
         const index = indexesWithinAncestors.get(instanceId);

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -407,9 +407,14 @@ export const WebstudioComponentCanvas = forwardRef<
     [idAttribute]: instance.id,
   };
 
+  // React ignores defaultValue changes after first render.
+  // Key prop forces re-creation to reflect updates on canvas.
+  const key =
+    props.defaultValue != null ? props.defaultValue.toString() : undefined;
+
   const instanceElement = (
     <>
-      <Component {...props} ref={ref}>
+      <Component key={key} {...props} ref={ref}>
         {children}
       </Component>
     </>

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -10,7 +10,7 @@ import {
   $stylesIndex,
   $instances,
   $selectedInstanceSelector,
-  $propValuesByInstanceSelector,
+  $propValuesByInstanceSelectorWithMemoryProps,
   $styles,
   $selectedInstanceStates,
   $styleSourceSelections,
@@ -250,7 +250,7 @@ const subscribeSelectedInstance = (
   const unsubscribe$stylesIndex = $stylesIndex.subscribe(update);
   const unsubscribe$instances = $instances.subscribe(update);
   const unsubscribePropValuesStore =
-    $propValuesByInstanceSelector.subscribe(update);
+    $propValuesByInstanceSelectorWithMemoryProps.subscribe(update);
 
   const unsubscribeIsResizingCanvas = $isResizingCanvas.subscribe(
     (isResizing) => {

--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -93,6 +93,16 @@ export const subscribeInterceptedEvents = () => {
     }
   };
 
+  const handlePointerDown = (event: PointerEvent) => {
+    if (false === event.target instanceof HTMLElement) {
+      return;
+    }
+
+    if (event.target.closest("select") && $isPreviewMode.get() === false) {
+      event.preventDefault();
+    }
+  };
+
   const handleSubmit = (event: SubmitEvent) => {
     if ($isPreviewMode.get()) {
       const form =
@@ -138,7 +148,14 @@ export const subscribeInterceptedEvents = () => {
   });
 
   document.documentElement.addEventListener("keydown", handleKeydown);
+
+  document.documentElement.addEventListener("pointerdown", handlePointerDown);
+
   return () => {
+    document.documentElement.removeEventListener(
+      "pointerdown",
+      handlePointerDown
+    );
     document.documentElement.removeEventListener("click", handleClick, {
       capture: true,
     });

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -67,7 +67,21 @@ export const getElementsByInstanceSelector = (
     rootSelectorSet.has(element.getAttribute(selectorIdAttribute) ?? "")
   );
 
-  return rootElements;
+  return rootElements.map((element) => {
+    if (getComputedStyle(element).position === "fixed") {
+      // Can be edge case when fixed element has display: none
+      return element;
+    }
+
+    // We are not interested in display:none or option elements (they have offsetParent === null)
+    let findElt: HTMLElement = element;
+
+    while (findElt.offsetParent === null && findElt.parentElement !== null) {
+      findElt = findElt.parentElement;
+    }
+
+    return findElt;
+  });
 };
 
 type Rect = {

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -68,19 +68,21 @@ export const getElementsByInstanceSelector = (
   );
 
   return rootElements.map((element) => {
-    if (getComputedStyle(element).position === "fixed") {
-      // Can be edge case when fixed element has display: none
-      return element;
-    }
-
     // We are not interested in display:none or option elements (they have offsetParent === null)
-    let findElt: HTMLElement = element;
+    let elementResult: HTMLElement = element;
 
-    while (findElt.offsetParent === null && findElt.parentElement !== null) {
-      findElt = findElt.parentElement;
+    while (
+      elementResult.offsetParent === null &&
+      elementResult.parentElement !== null
+    ) {
+      if (getComputedStyle(element).position === "fixed") {
+        return element;
+      }
+
+      elementResult = elementResult.parentElement;
     }
 
-    return findElt;
+    return elementResult;
   });
 };
 

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -394,7 +394,7 @@ export const $propValuesByInstanceSelectorWithMemoryProps = computed(
       const result = new Map(propValuesByInstanceSelector);
 
       for (const [memoryKey, memoryValue] of memoryProps) {
-        const propsBySelector = result.get(memoryKey) ?? new Map();
+        const propsBySelector = new Map(result.get(memoryKey));
 
         for (const [memoryProp, memoryPropValue] of memoryValue) {
           propsBySelector.set(memoryProp, memoryPropValue.value);

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -246,8 +246,6 @@ export const $propValuesByInstanceSelector = computed(
     $pages,
     $assets,
     $uploadingFilesDataStore,
-    $memoryProps,
-    $isPreviewMode,
   ],
   (
     instances,
@@ -257,9 +255,7 @@ export const $propValuesByInstanceSelector = computed(
     params,
     pages,
     assets,
-    uploadingFilesDataStore,
-    memoryProps,
-    isPreviewMode
+    uploadingFilesDataStore
   ) => {
     const variableValues = new Map<string, unknown>(unscopedVariableValues);
 
@@ -387,19 +383,27 @@ export const $propValuesByInstanceSelector = computed(
 
     traverseInstances([page.rootInstanceId]);
 
+    return propValuesByInstanceSelector;
+  }
+);
+
+export const $propValuesByInstanceSelectorWithMemoryProps = computed(
+  [$propValuesByInstanceSelector, $memoryProps, $isPreviewMode],
+  (propValuesByInstanceSelector, memoryProps, isPreviewMode) => {
     if (false === isPreviewMode) {
+      const result = new Map(propValuesByInstanceSelector);
+
       for (const [memoryKey, memoryValue] of memoryProps) {
-        const propsBySelector =
-          propValuesByInstanceSelector.get(memoryKey) ?? new Map();
+        const propsBySelector = result.get(memoryKey) ?? new Map();
 
         for (const [memoryProp, memoryPropValue] of memoryValue) {
           propsBySelector.set(memoryProp, memoryPropValue.value);
         }
 
-        propValuesByInstanceSelector.set(memoryKey, propsBySelector);
+        result.set(memoryKey, propsBySelector);
       }
+      return result;
     }
-
     return propValuesByInstanceSelector;
   }
 );

--- a/packages/generate-arg-types/src/arg-types.ts
+++ b/packages/generate-arg-types/src/arg-types.ts
@@ -88,6 +88,8 @@ export const getArgType = (propItem: PropItem): PropMeta | undefined => {
         return makePropMeta("number", "number");
       case "string":
         return makePropMeta("string", "text");
+      case "string | number | readonly string[]":
+        return makePropMeta("string", "text");
       case "string | number":
       case "number | string":
         if (defaultValue?.value === "") {

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -27,6 +27,11 @@
       "webstudio": "./src/props.ts",
       "types": "./lib/types/props.d.ts",
       "import": "./lib/props.js"
+    },
+    "./hooks": {
+      "webstudio": "./src/hooks.ts",
+      "types": "./lib/types/hooks.d.ts",
+      "import": "./lib/hooks.js"
     }
   },
   "scripts": {

--- a/packages/sdk-components-react/src/__generated__/blockquote.props.ts
+++ b/packages/sdk-components-react/src/__generated__/blockquote.props.ts
@@ -429,6 +429,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/body.props.ts
+++ b/packages/sdk-components-react/src/__generated__/body.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/bold.props.ts
+++ b/packages/sdk-components-react/src/__generated__/bold.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/box.props.ts
+++ b/packages/sdk-components-react/src/__generated__/box.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/button.props.ts
+++ b/packages/sdk-components-react/src/__generated__/button.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",
@@ -619,6 +620,13 @@ export const props: Record<string, PropMeta> = {
     control: "radio",
     type: "string",
     options: ["on", "off"],
+  },
+  value: {
+    required: false,
+    control: "text",
+    type: "string",
+    description:
+      "Defines a default value which will be displayed in the element on pageload.",
   },
   vocab: { required: false, control: "text", type: "string" },
 };

--- a/packages/sdk-components-react/src/__generated__/code-text.props.ts
+++ b/packages/sdk-components-react/src/__generated__/code-text.props.ts
@@ -423,6 +423,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/form.props.ts
+++ b/packages/sdk-components-react/src/__generated__/form.props.ts
@@ -442,6 +442,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/heading.props.ts
+++ b/packages/sdk-components-react/src/__generated__/heading.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/image.props.ts
+++ b/packages/sdk-components-react/src/__generated__/image.props.ts
@@ -443,6 +443,7 @@ export const props: Record<string, PropMeta> = {
     description: "Indicates the preferred method to decode the image.",
   },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/input.props.ts
+++ b/packages/sdk-components-react/src/__generated__/input.props.ts
@@ -442,6 +442,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",
@@ -750,6 +751,13 @@ export const props: Record<string, PropMeta> = {
     control: "radio",
     type: "string",
     options: ["off", "on"],
+  },
+  value: {
+    required: false,
+    control: "text",
+    type: "string",
+    description:
+      "Defines a default value which will be displayed in the element on pageload.",
   },
   vocab: { required: false, control: "text", type: "string" },
   width: {

--- a/packages/sdk-components-react/src/__generated__/italic.props.ts
+++ b/packages/sdk-components-react/src/__generated__/italic.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/label.props.ts
+++ b/packages/sdk-components-react/src/__generated__/label.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/link.props.ts
+++ b/packages/sdk-components-react/src/__generated__/link.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/list-item.props.ts
+++ b/packages/sdk-components-react/src/__generated__/list-item.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",
@@ -556,6 +557,13 @@ export const props: Record<string, PropMeta> = {
     control: "radio",
     type: "string",
     options: ["on", "off"],
+  },
+  value: {
+    required: false,
+    control: "text",
+    type: "string",
+    description:
+      "Defines a default value which will be displayed in the element on pageload.",
   },
   vocab: { required: false, control: "text", type: "string" },
 };

--- a/packages/sdk-components-react/src/__generated__/list.props.ts
+++ b/packages/sdk-components-react/src/__generated__/list.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/option.props.ts
+++ b/packages/sdk-components-react/src/__generated__/option.props.ts
@@ -2,24 +2,11 @@ import type { PropMeta } from "@webstudio-is/react-sdk";
 
 export const props: Record<string, PropMeta> = {
   about: { required: false, control: "text", type: "string" },
-  accept: {
-    required: false,
-    control: "text",
-    type: "string",
-    description: "List of types the server accepts, typically a file type.",
-  },
   accessKey: {
     required: false,
     control: "text",
     type: "string",
     description: "Keyboard shortcut to activate or add focus to the element.",
-  },
-  alt: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Text description of the image, which is very important for accessibility and search engine optimization. Screen readers read this description to users so they know what the image means. Alt text is also displayed on the page if the image can't be loaded for some reason.",
   },
   "aria-activedescendant": {
     description:
@@ -411,13 +398,6 @@ export const props: Record<string, PropMeta> = {
       "Indicates that an element should be focused on page load, or when its parent dialog is displayed.",
   },
   autoSave: { required: false, control: "text", type: "string" },
-  checked: {
-    required: false,
-    control: "boolean",
-    type: "boolean",
-    description:
-      "Indicates whether the element should be checked on page load.",
-  },
   className: { required: false, control: "text", type: "string" },
   color: {
     required: false,
@@ -462,61 +442,6 @@ export const props: Record<string, PropMeta> = {
     type: "boolean",
     description: "Defines whether the element can be dragged.",
   },
-  enterKeyHint: {
-    required: false,
-    control: "select",
-    type: "string",
-    options: ["search", "enter", "done", "go", "next", "previous", "send"],
-    description:
-      "The enterkeyhint specifies what action label (or icon) to present for the enter key onvirtual keyboards. The attribute can be used with form controls (such asthe value of textarea elements), or in elements in anediting host (e.g., using contenteditable attribute).",
-  },
-  form: {
-    required: false,
-    control: "text",
-    type: "string",
-    description: "Indicates the form that is the owner of the element.",
-  },
-  formAction: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Indicates the action of the element, overriding the action defined inthe form.",
-  },
-  formEncType: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      'If the button/input is a submit button (e.g. type="submit"), this attribute sets the encoding type to use during form submission. If this attribute is specified, it overrides theenctype attribute of the button\'s form owner.',
-  },
-  formMethod: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      'If the button/input is a submit button (e.g. type="submit"), this attribute sets the submission method to use during form submission (GET, POST, etc.). If this attribute is specified, it overrides the method attribute of the button\'s form owner.',
-  },
-  formNoValidate: {
-    required: false,
-    control: "boolean",
-    type: "boolean",
-    description:
-      'If the button/input is a submit button (e.g. type="submit"), this boolean attribute specifies that the form is not to be validatedwhen it is submitted. If this attribute is specified, it overrides thenovalidate attribute of the button\'s form owner.',
-  },
-  formTarget: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      'If the button/input is a submit button (e.g. type="submit"), this attribute specifies the browsing context (for example, tab, window, or inline frame) in which to display the response that is received aftersubmitting the form. If this attribute is specified, it overrides thetarget attribute of the button\'s form owner.',
-  },
-  height: {
-    required: false,
-    control: "number",
-    type: "number",
-    description: "Defines the image’s height in pixels.",
-  },
   hidden: {
     required: false,
     control: "boolean",
@@ -540,10 +465,10 @@ export const props: Record<string, PropMeta> = {
     options: [
       "search",
       "text",
-      "email",
-      "tel",
       "none",
+      "tel",
       "url",
+      "email",
       "numeric",
       "decimal",
     ],
@@ -560,96 +485,28 @@ export const props: Record<string, PropMeta> = {
   itemRef: { required: false, control: "text", type: "string" },
   itemScope: { required: false, control: "boolean", type: "boolean" },
   itemType: { required: false, control: "text", type: "string" },
+  label: {
+    required: false,
+    control: "text",
+    type: "string",
+    description: "Specifies a user-readable title of the element.",
+  },
   lang: {
     required: false,
     control: "text",
     type: "string",
     description: "Defines the language used in the element.",
   },
-  list: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Identifies a list of pre-defined options to suggest to the user.",
-  },
-  max: {
-    required: false,
-    control: "number",
-    type: "number",
-    description: "Indicates the maximum value allowed.",
-  },
-  maxLength: {
-    required: false,
-    control: "number",
-    type: "number",
-    description:
-      "Defines the maximum number of characters allowed in the element.",
-  },
-  min: {
-    required: false,
-    control: "number",
-    type: "number",
-    description: "Indicates the minimum value allowed.",
-  },
-  minLength: {
-    required: false,
-    control: "number",
-    type: "number",
-    description:
-      "Defines the minimum number of characters allowed in the element.",
-  },
-  multiple: {
-    required: false,
-    control: "boolean",
-    type: "boolean",
-    description:
-      "Indicates whether multiple values can be entered in an input of the type email or file.",
-  },
-  name: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "This name is important when submitting form data to the server, as it identifies the data associated with the input. When multiple inputs share the same name attribute, they are treated as part of the same group (e.g., radio buttons or checkboxes).",
-  },
   nonce: { required: false, control: "text", type: "string" },
-  pattern: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Defines a regular expression which the element's value will be validated against.",
-  },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
-  readOnly: {
-    required: false,
-    control: "boolean",
-    type: "boolean",
-    description: "Indicates whether the element can be edited.",
-  },
   rel: {
     required: false,
     control: "text",
     type: "string",
     description:
       "Specifies the relationship of the target object to the link object.",
-  },
-  required: {
-    required: false,
-    control: "boolean",
-    type: "boolean",
-    description:
-      "Indicates whether this form element must be filled before the form can be submitted.",
   },
   resource: { required: false, control: "text", type: "string" },
   results: { required: false, control: "number", type: "number" },
@@ -662,12 +519,11 @@ export const props: Record<string, PropMeta> = {
       "Defines an explicit role for an element for use by assistive technologies.",
   },
   security: { required: false, control: "text", type: "string" },
-  size: {
+  selected: {
     required: false,
-    control: "number",
-    type: "number",
-    description:
-      "Defines the width of the element (in pixels). If the element'stype attribute is text or password then it's the number of characters.",
+    control: "boolean",
+    type: "boolean",
+    description: "Defines a value which will be selected on page load.",
   },
   slot: {
     required: false,
@@ -681,13 +537,6 @@ export const props: Record<string, PropMeta> = {
     type: "boolean",
     description: "Indicates whether spell checking is allowed for the element.",
   },
-  src: {
-    required: false,
-    control: "text",
-    type: "string",
-    description: "The URL of the embeddable content.",
-  },
-  step: { required: false, control: "number", type: "number" },
   suppressContentEditableWarning: {
     required: false,
     control: "boolean",
@@ -725,7 +574,7 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "radio",
     type: "string",
-    options: ["off", "on"],
+    options: ["on", "off"],
   },
   value: {
     required: false,
@@ -735,10 +584,4 @@ export const props: Record<string, PropMeta> = {
       "Defines a default value which will be displayed in the element on pageload.",
   },
   vocab: { required: false, control: "text", type: "string" },
-  width: {
-    required: false,
-    control: "number",
-    type: "number",
-    description: "Defines the image’s width in pixels.",
-  },
 };

--- a/packages/sdk-components-react/src/__generated__/paragraph.props.ts
+++ b/packages/sdk-components-react/src/__generated__/paragraph.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/radio-button.props.ts
+++ b/packages/sdk-components-react/src/__generated__/radio-button.props.ts
@@ -442,6 +442,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/rich-text-link.props.ts
+++ b/packages/sdk-components-react/src/__generated__/rich-text-link.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/select.props.ts
+++ b/packages/sdk-components-react/src/__generated__/select.props.ts
@@ -2,24 +2,11 @@ import type { PropMeta } from "@webstudio-is/react-sdk";
 
 export const props: Record<string, PropMeta> = {
   about: { required: false, control: "text", type: "string" },
-  accept: {
-    required: false,
-    control: "text",
-    type: "string",
-    description: "List of types the server accepts, typically a file type.",
-  },
   accessKey: {
     required: false,
     control: "text",
     type: "string",
     description: "Keyboard shortcut to activate or add focus to the element.",
-  },
-  alt: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Text description of the image, which is very important for accessibility and search engine optimization. Screen readers read this description to users so they know what the image means. Alt text is also displayed on the page if the image can't be loaded for some reason.",
   },
   "aria-activedescendant": {
     description:
@@ -402,6 +389,13 @@ export const props: Record<string, PropMeta> = {
     description:
       "Sets whether input is automatically capitalized when entered by user.",
   },
+  autoComplete: {
+    required: false,
+    control: "text",
+    type: "string",
+    description:
+      "Indicates whether controls in this form can by default have their valuesautomatically completed by the browser.",
+  },
   autoCorrect: { required: false, control: "text", type: "string" },
   autoFocus: {
     required: false,
@@ -411,13 +405,6 @@ export const props: Record<string, PropMeta> = {
       "Indicates that an element should be focused on page load, or when its parent dialog is displayed.",
   },
   autoSave: { required: false, control: "text", type: "string" },
-  checked: {
-    required: false,
-    control: "boolean",
-    type: "boolean",
-    description:
-      "Indicates whether the element should be checked on page load.",
-  },
   className: { required: false, control: "text", type: "string" },
   color: {
     required: false,
@@ -462,60 +449,11 @@ export const props: Record<string, PropMeta> = {
     type: "boolean",
     description: "Defines whether the element can be dragged.",
   },
-  enterKeyHint: {
-    required: false,
-    control: "select",
-    type: "string",
-    options: ["search", "enter", "done", "go", "next", "previous", "send"],
-    description:
-      "The enterkeyhint specifies what action label (or icon) to present for the enter key onvirtual keyboards. The attribute can be used with form controls (such asthe value of textarea elements), or in elements in anediting host (e.g., using contenteditable attribute).",
-  },
   form: {
     required: false,
     control: "text",
     type: "string",
     description: "Indicates the form that is the owner of the element.",
-  },
-  formAction: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Indicates the action of the element, overriding the action defined inthe form.",
-  },
-  formEncType: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      'If the button/input is a submit button (e.g. type="submit"), this attribute sets the encoding type to use during form submission. If this attribute is specified, it overrides theenctype attribute of the button\'s form owner.',
-  },
-  formMethod: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      'If the button/input is a submit button (e.g. type="submit"), this attribute sets the submission method to use during form submission (GET, POST, etc.). If this attribute is specified, it overrides the method attribute of the button\'s form owner.',
-  },
-  formNoValidate: {
-    required: false,
-    control: "boolean",
-    type: "boolean",
-    description:
-      'If the button/input is a submit button (e.g. type="submit"), this boolean attribute specifies that the form is not to be validatedwhen it is submitted. If this attribute is specified, it overrides thenovalidate attribute of the button\'s form owner.',
-  },
-  formTarget: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      'If the button/input is a submit button (e.g. type="submit"), this attribute specifies the browsing context (for example, tab, window, or inline frame) in which to display the response that is received aftersubmitting the form. If this attribute is specified, it overrides thetarget attribute of the button\'s form owner.',
-  },
-  height: {
-    required: false,
-    control: "number",
-    type: "number",
-    description: "Defines the image’s height in pixels.",
   },
   hidden: {
     required: false,
@@ -540,10 +478,10 @@ export const props: Record<string, PropMeta> = {
     options: [
       "search",
       "text",
-      "email",
-      "tel",
       "none",
+      "tel",
       "url",
+      "email",
       "numeric",
       "decimal",
     ],
@@ -566,39 +504,6 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     description: "Defines the language used in the element.",
   },
-  list: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Identifies a list of pre-defined options to suggest to the user.",
-  },
-  max: {
-    required: false,
-    control: "number",
-    type: "number",
-    description: "Indicates the maximum value allowed.",
-  },
-  maxLength: {
-    required: false,
-    control: "number",
-    type: "number",
-    description:
-      "Defines the maximum number of characters allowed in the element.",
-  },
-  min: {
-    required: false,
-    control: "number",
-    type: "number",
-    description: "Indicates the minimum value allowed.",
-  },
-  minLength: {
-    required: false,
-    control: "number",
-    type: "number",
-    description:
-      "Defines the minimum number of characters allowed in the element.",
-  },
   multiple: {
     required: false,
     control: "boolean",
@@ -614,29 +519,9 @@ export const props: Record<string, PropMeta> = {
       "This name is important when submitting form data to the server, as it identifies the data associated with the input. When multiple inputs share the same name attribute, they are treated as part of the same group (e.g., radio buttons or checkboxes).",
   },
   nonce: { required: false, control: "text", type: "string" },
-  pattern: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Defines a regular expression which the element's value will be validated against.",
-  },
-  placeholder: {
-    required: false,
-    control: "text",
-    type: "string",
-    description:
-      "Provides a hint to the user of what can be entered in the field.",
-  },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },
-  readOnly: {
-    required: false,
-    control: "boolean",
-    type: "boolean",
-    description: "Indicates whether the element can be edited.",
-  },
   rel: {
     required: false,
     control: "text",
@@ -681,13 +566,6 @@ export const props: Record<string, PropMeta> = {
     type: "boolean",
     description: "Indicates whether spell checking is allowed for the element.",
   },
-  src: {
-    required: false,
-    control: "text",
-    type: "string",
-    description: "The URL of the embeddable content.",
-  },
-  step: { required: false, control: "number", type: "number" },
   suppressContentEditableWarning: {
     required: false,
     control: "boolean",
@@ -725,7 +603,7 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "radio",
     type: "string",
-    options: ["off", "on"],
+    options: ["on", "off"],
   },
   value: {
     required: false,
@@ -735,10 +613,4 @@ export const props: Record<string, PropMeta> = {
       "Defines a default value which will be displayed in the element on pageload.",
   },
   vocab: { required: false, control: "text", type: "string" },
-  width: {
-    required: false,
-    control: "number",
-    type: "number",
-    description: "Defines the image’s width in pixels.",
-  },
 };

--- a/packages/sdk-components-react/src/__generated__/separator.props.ts
+++ b/packages/sdk-components-react/src/__generated__/separator.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/span.props.ts
+++ b/packages/sdk-components-react/src/__generated__/span.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/subscript.props.ts
+++ b/packages/sdk-components-react/src/__generated__/subscript.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/superscript.props.ts
+++ b/packages/sdk-components-react/src/__generated__/superscript.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/text.props.ts
+++ b/packages/sdk-components-react/src/__generated__/text.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/textarea.props.ts
+++ b/packages/sdk-components-react/src/__generated__/textarea.props.ts
@@ -435,6 +435,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",
@@ -629,6 +630,13 @@ export const props: Record<string, PropMeta> = {
     control: "radio",
     type: "string",
     options: ["on", "off"],
+  },
+  value: {
+    required: false,
+    control: "text",
+    type: "string",
+    description:
+      "Defines a default value which will be displayed in the element on pageload.",
   },
   vocab: { required: false, control: "text", type: "string" },
   wrap: {

--- a/packages/sdk-components-react/src/__generated__/vimeo-play-button.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo-play-button.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",
@@ -617,6 +618,13 @@ export const props: Record<string, PropMeta> = {
     control: "radio",
     type: "string",
     options: ["on", "off"],
+  },
+  value: {
+    required: false,
+    control: "text",
+    type: "string",
+    description:
+      "Defines a default value which will be displayed in the element on pageload.",
   },
   vocab: { required: false, control: "text", type: "string" },
 };

--- a/packages/sdk-components-react/src/__generated__/vimeo-preview-image.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo-preview-image.props.ts
@@ -443,6 +443,7 @@ export const props: Record<string, PropMeta> = {
     description: "Indicates the preferred method to decode the image.",
   },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/vimeo-spinner.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo-spinner.props.ts
@@ -422,6 +422,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/__generated__/vimeo.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo.props.ts
@@ -460,6 +460,7 @@ export const props: Record<string, PropMeta> = {
   },
   datatype: { required: false, control: "text", type: "string" },
   defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
   dir: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/components.ts
+++ b/packages/sdk-components-react/src/components.ts
@@ -32,3 +32,5 @@ export { VimeoPlayButton } from "./vimeo-play-button";
 export { VimeoSpinner } from "./vimeo-spinner";
 export { XmlNode } from "./xml-node";
 export { Time } from "./time";
+export { Select } from "./select";
+export { Option } from "./option";

--- a/packages/sdk-components-react/src/hooks.ts
+++ b/packages/sdk-components-react/src/hooks.ts
@@ -1,0 +1,4 @@
+import type { Hook } from "@webstudio-is/react-sdk";
+import { hooksSelect } from "./select";
+
+export const hooks: Hook[] = [hooksSelect];

--- a/packages/sdk-components-react/src/metas.ts
+++ b/packages/sdk-components-react/src/metas.ts
@@ -33,3 +33,5 @@ export { meta as VimeoPlayButton } from "./vimeo-play-button.ws";
 export { meta as VimeoSpinner } from "./vimeo-spinner.ws";
 export { meta as XmlNode } from "./xml-node.ws";
 export { meta as Time } from "./time.ws";
+export { meta as Select } from "./select.ws";
+export { meta as Option } from "./option.ws";

--- a/packages/sdk-components-react/src/option.tsx
+++ b/packages/sdk-components-react/src/option.tsx
@@ -1,0 +1,10 @@
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
+
+export const defaultTag = "option";
+
+export const Option = forwardRef<
+  ElementRef<typeof defaultTag>,
+  ComponentProps<typeof defaultTag>
+>((props, ref) => <option {...props} ref={ref} />);
+
+Option.displayName = "Option";

--- a/packages/sdk-components-react/src/option.ws.ts
+++ b/packages/sdk-components-react/src/option.ws.ts
@@ -22,9 +22,19 @@ export const meta: WsComponentMeta = {
     "An item within a drop-down menu that users can select as their chosen value.",
   icon: ItemIcon,
   presetStyle,
+  states: [
+    // Applies when option is being activated (clicked)
+    { selector: ":active", label: "Active" },
+    // Applies to the currently selected option
+    { selector: ":checked", label: "Checked" },
+    // For <option> elements: The :default pseudo-class selects the <option> that has the selected attribute when the page loads. This is true even if the user later selects a different option.
+    { selector: ":default", label: "Default" },
+    { selector: ":hover", label: "Hover" },
+    { selector: ":disabled", label: "Disabled" },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["label", "selected", "value", "label"],
+  initialProps: ["label", "selected", "value", "label", "disabled"],
 };

--- a/packages/sdk-components-react/src/option.ws.ts
+++ b/packages/sdk-components-react/src/option.ws.ts
@@ -9,7 +9,19 @@ import type { defaultTag } from "./option";
 import { props } from "./__generated__/option.props";
 
 const presetStyle = {
-  option: [],
+  option: [
+    {
+      property: "backgroundColor",
+      state: ":checked",
+      value: {
+        type: "rgb",
+        alpha: 1,
+        r: 209,
+        g: 209,
+        b: 209,
+      },
+    },
+  ],
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {

--- a/packages/sdk-components-react/src/option.ws.ts
+++ b/packages/sdk-components-react/src/option.ws.ts
@@ -1,0 +1,30 @@
+import { ItemIcon } from "@webstudio-is/icons/svg";
+import {
+  type PresetStyle,
+  type WsComponentMeta,
+  type WsComponentPropsMeta,
+} from "@webstudio-is/react-sdk";
+
+import type { defaultTag } from "./option";
+import { props } from "./__generated__/option.props";
+
+const presetStyle = {
+  option: [],
+} satisfies PresetStyle<typeof defaultTag>;
+
+export const meta: WsComponentMeta = {
+  category: "hidden",
+  // @todo: requiredAncestors should be ["Select", "Optgroup", "Datalist"] but that gives unreadable error when adding Select onto Canvas
+  requiredAncestors: ["Select"],
+  type: "control",
+  label: "Option",
+  description:
+    "An item within a drop-down menu that users can select as their chosen value.",
+  icon: ItemIcon,
+  presetStyle,
+};
+
+export const propsMeta: WsComponentPropsMeta = {
+  props,
+  initialProps: ["label", "selected", "value", "label"],
+};

--- a/packages/sdk-components-react/src/props.ts
+++ b/packages/sdk-components-react/src/props.ts
@@ -32,3 +32,5 @@ export { propsMeta as VimeoPlayButton } from "./vimeo-play-button.ws";
 export { propsMeta as VimeoSpinner } from "./vimeo-spinner.ws";
 export { propsMeta as XmlNode } from "./xml-node.ws";
 export { propsMeta as Time } from "./time.ws";
+export { propsMeta as Select } from "./select.ws";
+export { propsMeta as Option } from "./option.ws";

--- a/packages/sdk-components-react/src/select.tsx
+++ b/packages/sdk-components-react/src/select.tsx
@@ -1,3 +1,8 @@
+import {
+  getClosestInstance,
+  getInstanceSelectorById,
+  type Hook,
+} from "@webstudio-is/react-sdk";
 import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 export const defaultTag = "select";
@@ -8,3 +13,45 @@ export const Select = forwardRef<
 >((props, ref) => <select {...props} ref={ref} />);
 
 Select.displayName = "Select";
+
+// For each CollapsibleContent component within the selection,
+// we identify its closest parent Collapsible component
+// and update its open prop bound to variable.
+export const hooksSelect: Hook = {
+  onNavigatorUnselect: (context, event) => {
+    for (const instance of event.instancePath) {
+      if (instance.component === `Option`) {
+        const option = getClosestInstance(
+          event.instancePath,
+          instance,
+          `Option`
+        );
+        if (option) {
+          const instanceSelector = getInstanceSelectorById(
+            event.instanceSelector,
+            option.id
+          );
+          context.setMemoryProp(instanceSelector, "selected", undefined);
+        }
+      }
+    }
+  },
+  onNavigatorSelect: (context, event) => {
+    for (const instance of event.instancePath) {
+      if (instance.component === `Option`) {
+        const option = getClosestInstance(
+          event.instancePath,
+          instance,
+          `Option`
+        );
+        if (option) {
+          const instanceSelector = getInstanceSelectorById(
+            event.instanceSelector,
+            option.id
+          );
+          context.setMemoryProp(instanceSelector, "selected", true);
+        }
+      }
+    }
+  },
+};

--- a/packages/sdk-components-react/src/select.tsx
+++ b/packages/sdk-components-react/src/select.tsx
@@ -1,0 +1,10 @@
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
+
+export const defaultTag = "select";
+
+export const Select = forwardRef<
+  ElementRef<typeof defaultTag>,
+  ComponentProps<typeof defaultTag>
+>((props, ref) => <select {...props} ref={ref} />);
+
+Select.displayName = "Select";

--- a/packages/sdk-components-react/src/select.ws.ts
+++ b/packages/sdk-components-react/src/select.ws.ts
@@ -94,6 +94,7 @@ export const propsMeta: WsComponentPropsMeta = {
     "id",
     "className",
     "name",
+    "multiple",
     "defaultValue",
     "required",
     "autoFocus",

--- a/packages/sdk-components-react/src/select.ws.ts
+++ b/packages/sdk-components-react/src/select.ws.ts
@@ -22,7 +22,7 @@ const presetStyle = {
 export const meta: WsComponentMeta = {
   category: "forms",
   invalidAncestors: ["Button", "Link"],
-  type: "control",
+  type: "container",
   label: "Select",
   description:
     "A drop-down menu for users to select a single option from a predefined list.",
@@ -90,5 +90,5 @@ export const meta: WsComponentMeta = {
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["id", "className", "name", "required", "autoFocus"],
+  initialProps: ["id", "className", "name", "value", "required", "autoFocus"],
 };

--- a/packages/sdk-components-react/src/select.ws.ts
+++ b/packages/sdk-components-react/src/select.ws.ts
@@ -1,0 +1,94 @@
+import { SelectIcon } from "@webstudio-is/icons/svg";
+import {
+  defaultStates,
+  type PresetStyle,
+  type WsComponentMeta,
+  type WsComponentPropsMeta,
+} from "@webstudio-is/react-sdk";
+import { select } from "@webstudio-is/react-sdk/css-normalize";
+import type { defaultTag } from "./select";
+import { props } from "./__generated__/select.props";
+
+const presetStyle = {
+  select: [
+    ...select,
+    {
+      property: "display",
+      value: { type: "keyword", value: "block" },
+    },
+  ],
+} satisfies PresetStyle<typeof defaultTag>;
+
+export const meta: WsComponentMeta = {
+  category: "forms",
+  invalidAncestors: ["Button", "Link"],
+  type: "control",
+  label: "Select",
+  description:
+    "A drop-down menu for users to select a single option from a predefined list.",
+  icon: SelectIcon,
+  presetStyle,
+  order: 4,
+  states: [
+    ...defaultStates,
+    { selector: "::placeholder", label: "Placeholder" },
+    { selector: ":valid", label: "Valid" },
+    { selector: ":invalid", label: "Invalid" },
+    { selector: ":required", label: "Required" },
+    { selector: ":optional", label: "Optional" },
+  ],
+  template: [
+    {
+      type: "instance",
+      component: "Select",
+      label: "Select",
+      children: [
+        {
+          type: "instance",
+          component: "Option",
+          label: "Option",
+          props: [
+            { type: "string", name: "label", value: "Please choose an option" },
+            { type: "string", name: "value", value: "" },
+          ],
+          children: [],
+        },
+        {
+          type: "instance",
+          component: "Option",
+          label: "Option",
+          props: [
+            { type: "string", name: "label", value: "Option A" },
+            { type: "string", name: "value", value: "a" },
+          ],
+          children: [],
+        },
+        {
+          type: "instance",
+          component: "Option",
+          label: "Option",
+          props: [
+            { type: "string", name: "label", value: "Option B" },
+            { type: "string", name: "value", value: "b" },
+          ],
+          children: [],
+        },
+        {
+          type: "instance",
+          component: "Option",
+          label: "Option",
+          props: [
+            { type: "string", name: "label", value: "Option C" },
+            { type: "string", name: "value", value: "c" },
+          ],
+          children: [],
+        },
+      ],
+    },
+  ],
+};
+
+export const propsMeta: WsComponentPropsMeta = {
+  props,
+  initialProps: ["id", "className", "name", "required", "autoFocus"],
+};

--- a/packages/sdk-components-react/src/select.ws.ts
+++ b/packages/sdk-components-react/src/select.ws.ts
@@ -90,5 +90,12 @@ export const meta: WsComponentMeta = {
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["id", "className", "name", "value", "required", "autoFocus"],
+  initialProps: [
+    "id",
+    "className",
+    "name",
+    "defaultValue",
+    "required",
+    "autoFocus",
+  ],
 };


### PR DESCRIPTION
## Description

rename of #3609

## New

- Native Select

## Changes

- Improved detection algorithm to include invisible elements (like `option` or `display:none`).
- Added interceptor to handle pointer down events, preventing select from opening.
- Enhanced element selection on canvas to support `display:none` and option selection.
- Fixed prop types generation (previously, the value property was broken).
- Memory props has effect on canvas only
- Recreate component on Canvas in case of defaultValue has changed


## Steps for reproduction

Add `Select` see it works

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
