### PR TITLE
fix: Deduplicate styles on data paste from Webflow

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -12,7 +12,11 @@ import {
 import { $, renderJsx } from "@webstudio-is/sdk/testing";
 import * as defaultMetas from "@webstudio-is/sdk-components-react-remix/metas";
 import { __testing__ } from "./plugin-webflow";
-import { $breakpoints, $registeredComponentMetas } from "../../nano-states";
+import {
+  $breakpoints,
+  $project,
+  $registeredComponentMetas,
+} from "../../nano-states";
 
 const { toWebstudioFragment } = __testing__;
 
@@ -83,6 +87,16 @@ const toCss = (fragment: WebstudioFragment) => {
 beforeEach(() => {
   const defaultMetasMap = new Map(Object.entries(defaultMetas));
   $registeredComponentMetas.set(defaultMetasMap);
+  $project.set({
+    id: "test",
+    createdAt: "",
+    domain: "",
+    title: "",
+    userId: "",
+    isDeleted: false,
+    previewImageAsset: null,
+    marketplaceApprovalStatus: "PENDING",
+  });
 
   $breakpoints.set(
     new Map(

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
@@ -58,7 +58,7 @@ const toWebstudioFragment = async (wfData: WfData) => {
    * Generates deterministic style IDs based on sourceId or unique data.
    * This simplifies merging and deduplicating styles from different sources.
    */
-  const generateId = async (sourceData: string) => {
+  const generateStyleSourceId = async (sourceData: string) => {
     // We are using projectId here to avoid id collisions between different projects.
     const projectId = $project.get()?.id;
     if (projectId === undefined) {
@@ -67,7 +67,13 @@ const toWebstudioFragment = async (wfData: WfData) => {
     return nanoHash(`${projectId}-${sourceData}`);
   };
 
-  await addStyles(wfNodes, wfStyles, doneNodes, fragment, generateId);
+  await addStyles(
+    wfNodes,
+    wfStyles,
+    doneNodes,
+    fragment,
+    generateStyleSourceId
+  );
   // First node should be always the root node in theory, if not
   // we need to find a node that is not a child of any other node.
   const rootWfNode = wfData.payload.nodes[0];

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
@@ -60,7 +60,10 @@ const toWebstudioFragment = async (wfData: WfData) => {
    */
   const generateId = async (sourceData: string) => {
     // We are using projectId here to avoid id collisions between different projects.
-    const projectId = $project.get()!.id;
+    const projectId = $project.get()?.id;
+    if (projectId === undefined) {
+      throw new Error("Project id is not set");
+    }
     return nanoHash(`${projectId}-${sourceData}`);
   };
 

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
@@ -139,12 +139,14 @@ const addBreakpoints = (
 };
 
 const addNodeStyles = ({
+  styleSourceId,
   name,
   variants,
   instanceId,
   fragment,
   breakpointsByName,
 }: {
+  styleSourceId: string;
   name: string;
   variants: UnparsedVariants;
   instanceId: Instance["id"];
@@ -153,7 +155,6 @@ const addNodeStyles = ({
 }) => {
   const parsedVariants = toParsedVariants(variants);
 
-  const styleSourceId = nanoid();
   fragment.styleSources.push({
     type: "token",
     id: styleSourceId,
@@ -277,7 +278,8 @@ export const addStyles = async (
   wfNodes: Map<WfNode["_id"], WfNode>,
   wfStyles: Map<WfStyle["_id"], WfStyle>,
   doneNodes: Map<WfNode["_id"], Instance["id"] | false>,
-  fragment: WebstudioFragment
+  fragment: WebstudioFragment,
+  generateId: (sourceData: string) => Promise<string>
 ) => {
   const { styles: stylePresets } = await import(
     "./__generated__/style-presets"
@@ -298,8 +300,9 @@ export const addStyles = async (
 
     const breakpointsByName = addBreakpoints($breakpoints.get(), fragment);
 
-    mapComponentAndPresetStyles(wfNode, stylePresets).forEach((name) => {
+    for (const name of mapComponentAndPresetStyles(wfNode, stylePresets)) {
       addNodeStyles({
+        styleSourceId: await generateId(name),
         name,
         variants: new Map([
           ["base", stylePresets[name] as Array<EmbedTemplateStyleDecl>],
@@ -308,7 +311,7 @@ export const addStyles = async (
         fragment,
         breakpointsByName,
       });
-    });
+    }
 
     const instance = fragment.instances.find(
       (instance) => instance.id === instanceId
@@ -336,7 +339,9 @@ export const addStyles = async (
           variants.set(breakpointName, variant.styleLess);
         }
       });
+
       addNodeStyles({
+        styleSourceId: await generateId(classId),
         name: style.name,
         variants,
         instanceId,

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
@@ -279,7 +279,7 @@ export const addStyles = async (
   wfStyles: Map<WfStyle["_id"], WfStyle>,
   doneNodes: Map<WfNode["_id"], Instance["id"] | false>,
   fragment: WebstudioFragment,
-  generateId: (sourceData: string) => Promise<string>
+  generateStyleSourceId: (sourceData: string) => Promise<string>
 ) => {
   const { styles: stylePresets } = await import(
     "./__generated__/style-presets"
@@ -302,7 +302,7 @@ export const addStyles = async (
 
     for (const name of mapComponentAndPresetStyles(wfNode, stylePresets)) {
       addNodeStyles({
-        styleSourceId: await generateId(name),
+        styleSourceId: await generateStyleSourceId(name),
         name,
         variants: new Map([
           ["base", stylePresets[name] as Array<EmbedTemplateStyleDecl>],
@@ -341,7 +341,7 @@ export const addStyles = async (
       });
 
       addNodeStyles({
-        styleSourceId: await generateId(classId),
+        styleSourceId: await generateStyleSourceId(classId),
         name: style.name,
         variants,
         instanceId,


### PR DESCRIPTION
## Description

ref #2647

We already had logic to handle style sources on paste: if the destination has the same styleSource.id as the source, we do nothing.

Now, we add deterministic ID generation for Webflow classes. This, combined with the existing logic, achieves the desired behavior.


## Steps for reproduction

Paste anything from single webflow project multiple times. See no duplicated.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
