### PR TITLE
fix: Fallback to file name when family name is not defined in the meta

### DIFF
--- a/packages/asset-uploader/src/clients/fs/upload.ts
+++ b/packages/asset-uploader/src/clients/fs/upload.ts
@@ -30,6 +30,7 @@ export const uploadToFs = async ({
     type: type.startsWith("image") ? "image" : "font",
     size: data.byteLength,
     data,
+    name,
   });
 
   return assetData;

--- a/packages/asset-uploader/src/clients/s3/upload.ts
+++ b/packages/asset-uploader/src/clients/s3/upload.ts
@@ -69,6 +69,7 @@ export const uploadToS3 = async ({
     type: type.startsWith("image") ? "image" : "font",
     size: data.byteLength,
     data: new Uint8Array(data),
+    name,
   });
 
   return assetData;

--- a/packages/asset-uploader/src/utils/font-data.test.ts
+++ b/packages/asset-uploader/src/utils/font-data.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from "@jest/globals";
-import { parseSubfamily, normalizeFamily } from "./font-data";
+import { parseSubfamily, __testing__ } from "./font-data";
+
+const { normalizeFamily } = __testing__;
 
 describe("font-data", () => {
   describe("parseSubfamily()", () => {
@@ -55,16 +57,31 @@ describe("font-data", () => {
 
   describe("normalizeFamily()", () => {
     test("basic", () => {
-      expect(normalizeFamily("Roboto Black", "Black")).toBe("Roboto");
-      expect(normalizeFamily("Roboto Light", "Light Italic")).toBe("Roboto");
-      expect(normalizeFamily("Robolder Bold", "Bold")).toBe("Robolder");
-      expect(normalizeFamily(" Roboto X Bold ", "Bold")).toBe("Roboto X");
-      expect(normalizeFamily(" 'Roboto X' Bold ", "Bold")).toBe("'Roboto X'");
-      expect(normalizeFamily(` "Roboto X" Bold `, "Bold")).toBe(`"Roboto X"`);
-      expect(normalizeFamily(`"Roboto Bold"`, "Bold")).toBe(`"Roboto Bold"`);
-      expect(normalizeFamily(`"Roboto Bold" Bold`, "Bold")).toBe(
+      expect(normalizeFamily("Roboto Black", "Black", "font.woff")).toBe(
+        "Roboto"
+      );
+      expect(normalizeFamily("Roboto Light", "Light Italic", "font.woff")).toBe(
+        "Roboto"
+      );
+      expect(normalizeFamily("Robolder Bold", "Bold", "font.woff")).toBe(
+        "Robolder"
+      );
+      expect(normalizeFamily(" Roboto X Bold ", "Bold", "font.woff")).toBe(
+        "Roboto X"
+      );
+      expect(normalizeFamily(" 'Roboto X' Bold ", "Bold", "font.woff")).toBe(
+        "'Roboto X'"
+      );
+      expect(normalizeFamily(` "Roboto X" Bold `, "Bold", "font.woff")).toBe(
+        `"Roboto X"`
+      );
+      expect(normalizeFamily(`"Roboto Bold"`, "Bold", "font.woff")).toBe(
         `"Roboto Bold"`
       );
+      expect(normalizeFamily(`"Roboto Bold" Bold`, "Bold", "font.woff")).toBe(
+        `"Roboto Bold"`
+      );
+      expect(normalizeFamily("", "", "font.woff")).toBe(`font`);
     });
   });
 });

--- a/packages/asset-uploader/src/utils/font-data.ts
+++ b/packages/asset-uploader/src/utils/font-data.ts
@@ -45,13 +45,22 @@ const splitAndTrim = (string: string) =>
 
 // Family name can contain additional information like "Roboto Black" or "Roboto Bold", though we need pure family name "Roboto", because the rest is already encoded in weight and style.
 // We need a name we can reference in CSS font-family property, while CSS matches it with the right font-face considering the weight and style.
-export const normalizeFamily = (family: string, subfamily: string) => {
+const normalizeFamily = (
+  family: string,
+  subfamily: string,
+  fileName: string
+) => {
   const familyParts = splitAndTrim(family);
   const subfamilyParts = splitAndTrim(subfamily.toLowerCase());
   const familyPartsNormalized = familyParts.filter(
     (familyPart) => subfamilyParts.includes(familyPart.toLowerCase()) === false
   );
-  return familyPartsNormalized.join(" ");
+  if (familyPartsNormalized.length !== 0) {
+    return familyPartsNormalized.join(" ");
+  }
+  // Broken fonts may lack any family information, so last resort is to use the file name
+  const extensionIndex = fileName.lastIndexOf(".");
+  return extensionIndex === -1 ? fileName : fileName.slice(0, extensionIndex);
 };
 
 type FontDataStatic = {
@@ -67,7 +76,7 @@ type FontDataVariable = {
 };
 type FontData = FontDataStatic | FontDataVariable;
 
-export const getFontData = (data: Uint8Array): FontData => {
+export const getFontData = (data: Uint8Array, fileName: string): FontData => {
   const font = createFontKit(data as Buffer);
   if (font.type !== "TTF" && font.type !== "WOFF" && font.type !== "WOFF2") {
     throw Error(`Unsupported font type ${font.type}`);
@@ -78,7 +87,7 @@ export const getFontData = (data: Uint8Array): FontData => {
     font.getName("preferredSubfamily", defaultLanguage) ??
     font.getName("fontSubfamily", defaultLanguage) ??
     "";
-  const family = normalizeFamily(originalFamily, subfamily);
+  const family = normalizeFamily(originalFamily, subfamily, fileName);
   const isVariable = Object.keys(font.variationAxes).length !== 0;
 
   if (isVariable) {
@@ -95,3 +104,5 @@ export const getFontData = (data: Uint8Array): FontData => {
     ...parseSubfamily(subfamily),
   };
 };
+
+export const __testing__ = { normalizeFamily };

--- a/packages/asset-uploader/src/utils/get-asset-data.ts
+++ b/packages/asset-uploader/src/utils/get-asset-data.ts
@@ -15,6 +15,7 @@ export type AssetData = z.infer<typeof AssetData>;
 type BaseAssetOptions = {
   size: number;
   data: Uint8Array;
+  name: string;
 };
 
 type AssetOptions =
@@ -51,8 +52,7 @@ export const getAssetData = async (
       meta: { width, height },
     };
   }
-
-  const { format, ...meta } = getFontData(options.data);
+  const { format, ...meta } = getFontData(options.data, options.name);
 
   return {
     size: options.size,


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3626

## Description

Some fonts lack any family information in the meta data. For such fonts we will fall back to their file name.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
