### PR TITLE
chore: Parse css backgorund support

### DIFF
--- a/apps/builder/app/routes/$.tsx
+++ b/apps/builder/app/routes/$.tsx
@@ -26,10 +26,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   // This is because immutable caching rules apply to redirects, causing these files
   // to become permanently inaccessible. Ensure asset files are served correctly
   // without redirects to maintain availability and proper caching behavior.
-  const publicPath = "/assets/";
+  const publicPaths = ["/cgi/", "/assets/"];
 
   // In case of 404 on static assets, this route will be executed
-  if (url.pathname.startsWith(publicPath)) {
+  if (publicPaths.some((publicPath) => url.pathname.startsWith(publicPath))) {
     throw new Response("Not found", {
       status: 404,
       headers: {

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -1968,3 +1968,124 @@ test("Breakpoints", async () => {
     }"
   `);
 });
+
+test("background images", async () => {
+  const fragment = await toWebstudioFragment({
+    type: "@webflow/XscpData",
+    payload: {
+      nodes: [
+        {
+          _id: "2e9842a4-ac18-9d21-894b-026c6eb20441",
+          type: "Block",
+          tag: "div",
+          classes: ["98133834-439c-9a8c-7e9f-c3186f2fa45f"],
+          children: [],
+          data: {
+            text: false,
+          },
+        },
+      ],
+      styles: [
+        {
+          _id: "98133834-439c-9a8c-7e9f-c3186f2fa45f",
+          fake: false,
+          type: "class",
+          name: "Div Block",
+          namespace: "",
+          comb: "",
+          styleLess:
+            "height: 400px; background-image: linear-gradient(180deg, hsla(0, 0.00%, 0.00%, 0.11), white), @img_667d0b7769e0cc3754b584f6, @img_667d0fe180995eadc1534a26; background-position: 0px 0px, 550px 0px, 0px 0px; background-size: auto, contain, auto; background-repeat: repeat, no-repeat, repeat; background-attachment: scroll, fixed, scroll;",
+          variants: {},
+          children: [],
+          createdBy: "5b7c48038bdf56493c54eae4",
+          origin: null,
+          selector: null,
+        },
+      ],
+      assets: [
+        {
+          cdnUrl:
+            "https://uploads-ssl.webflow.com/667c32290bd6159c18dca9a0/667d0b7769e0cc3754b584f6_IMG_2882%20(1).png",
+          siteId: "667c32290bd6159c18dca9a0",
+          width: 800,
+          height: 600,
+          fileName: "IMG_2882 (1).png",
+          createdOn: "2024-06-27T06:49:27.100Z",
+          origFileName: "IMG_2882 (1).png",
+          fileHash: "36f49907757795f0a4ecfcfdfc483115",
+          variants: [
+            {
+              origFileName: "IMG_2882%20(1)-p-500.png",
+              fileName: "667d0b7769e0cc3754b584f6_IMG_2882%20(1)-p-500.png",
+              format: "png",
+              size: 192728,
+              width: 500,
+              quality: 100,
+              cdnUrl:
+                "https://daks2k3a4ib2z.cloudfront.net/667c32290bd6159c18dca9a0/667d0b7769e0cc3754b584f6_IMG_2882%20(1)-p-500.png",
+              s3Url:
+                "https://s3.amazonaws.com/webflow-prod-assets/667c32290bd6159c18dca9a0/667d0b7769e0cc3754b584f6_IMG_2882%20(1)-p-500.png",
+            },
+          ],
+          mimeType: "image/png",
+          s3Url:
+            "https://s3.amazonaws.com/webflow-prod-assets/667c32290bd6159c18dca9a0/667d0b7769e0cc3754b584f6_IMG_2882%20(1).png",
+          thumbUrl: "",
+          _id: "667d0b7769e0cc3754b584f6",
+          markedAsDeleted: false,
+          fileSize: 862053,
+        },
+        {
+          cdnUrl:
+            "https://uploads-ssl.webflow.com/667c32290bd6159c18dca9a0/667d0fe180995eadc1534a26_%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%9C%D0%B8%D1%80%20%3A%20%252F%20.webp",
+          siteId: "667c32290bd6159c18dca9a0",
+          width: 1024,
+          height: 1024,
+          fileName: "Привет Мир : %2F .webp",
+          createdOn: "2024-06-27T07:08:17.010Z",
+          origFileName: "Привет Мир : %2F .webp",
+          fileHash: "d86e52a94c04120f455b276effa59046",
+          variants: [
+            {
+              origFileName:
+                "%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%9C%D0%B8%D1%80%20%3A%20%252F%20-p-500.webp",
+              fileName:
+                "667d0fe180995eadc1534a26_%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%9C%D0%B8%D1%80%20%3A%20%252F%20-p-500.webp",
+              format: "webp",
+              size: 26992,
+              width: 500,
+              quality: 100,
+              cdnUrl:
+                "https://daks2k3a4ib2z.cloudfront.net/667c32290bd6159c18dca9a0/667d0fe180995eadc1534a26_%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%9C%D0%B8%D1%80%20%3A%20%252F%20-p-500.webp",
+              s3Url:
+                "https://s3.amazonaws.com/webflow-prod-assets/667c32290bd6159c18dca9a0/667d0fe180995eadc1534a26_%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%9C%D0%B8%D1%80%20%3A%20%252F%20-p-500.webp",
+            },
+            {
+              origFileName:
+                "%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%9C%D0%B8%D1%80%20%3A%20%252F%20-p-800.webp",
+              fileName:
+                "667d0fe180995eadc1534a26_%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%9C%D0%B8%D1%80%20%3A%20%252F%20-p-800.webp",
+              format: "webp",
+              size: 45964,
+              width: 800,
+              quality: 100,
+              cdnUrl:
+                "https://daks2k3a4ib2z.cloudfront.net/667c32290bd6159c18dca9a0/667d0fe180995eadc1534a26_%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%9C%D0%B8%D1%80%20%3A%20%252F%20-p-800.webp",
+              s3Url:
+                "https://s3.amazonaws.com/webflow-prod-assets/667c32290bd6159c18dca9a0/667d0fe180995eadc1534a26_%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%9C%D0%B8%D1%80%20%3A%20%252F%20-p-800.webp",
+            },
+          ],
+          mimeType: "image/webp",
+          s3Url:
+            "https://s3.amazonaws.com/webflow-prod-assets/667c32290bd6159c18dca9a0/667d0fe180995eadc1534a26_%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%9C%D0%B8%D1%80%20%3A%20%252F%20.webp",
+          thumbUrl: "",
+          _id: "667d0fe180995eadc1534a26",
+          markedAsDeleted: false,
+          fileSize: 191270,
+        },
+      ],
+    },
+  });
+
+  console.log(fragment.styles);
+});

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -2087,5 +2087,6 @@ test("background images", async () => {
     },
   });
 
-  console.log(fragment.styles);
+  // @todo finish in the following PR
+  fragment;
 });

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
@@ -14,7 +14,7 @@ import {
   $selectedPage,
   $project,
 } from "../../nano-states";
-import { WfData, WfNode, WfStyle, wfNodeTypes } from "./schema";
+import { WfData, WfNode, WfStyle, wfNodeTypes, type WfAsset } from "./schema";
 import { addInstanceAndProperties } from "./instances-properties";
 import { addStyles } from "./styles";
 import { builderApi } from "~/shared/builder-api";
@@ -48,6 +48,11 @@ const toWebstudioFragment = async (wfData: WfData) => {
   const wfStyles = new Map<WfStyle["_id"], WfStyle>(
     wfData.payload.styles.map((style: WfStyle) => [style._id, style])
   );
+
+  const wfAssets = new Map<WfAsset["_id"], WfAsset>(
+    wfData.payload.assets.map((asset: WfAsset) => [asset._id, asset])
+  );
+
   // False value used to skip a node.
   const doneNodes = new Map<WfNode["_id"], Instance["id"] | false>();
   for (const wfNode of wfNodes.values()) {
@@ -70,6 +75,7 @@ const toWebstudioFragment = async (wfData: WfData) => {
   await addStyles(
     wfNodes,
     wfStyles,
+    wfAssets,
     doneNodes,
     fragment,
     generateStyleSourceId

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/schema.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/schema.ts
@@ -261,7 +261,7 @@ export const WfStyle = z.object({
 });
 export type WfStyle = z.infer<typeof WfStyle>;
 
-const AssetVariantSchema = z.object({
+const WfAssetVariant = z.object({
   origFileName: z.string(),
   fileName: z.string(),
   format: z.string(),
@@ -273,7 +273,7 @@ const AssetVariantSchema = z.object({
   s3Url: z.string().url(),
 });
 
-export const WfAssetSchema = z.object({
+const WfAsset = z.object({
   cdnUrl: z.string().url(),
   siteId: z.string(),
   width: z.number(),
@@ -282,7 +282,7 @@ export const WfAssetSchema = z.object({
   createdOn: z.string(),
   origFileName: z.string(),
   fileHash: z.string(),
-  variants: z.array(AssetVariantSchema),
+  variants: z.array(WfAssetVariant),
   mimeType: z.string(),
   s3Url: z.string().url(),
   thumbUrl: z.string(),
@@ -291,13 +291,15 @@ export const WfAssetSchema = z.object({
   fileSize: z.number(),
 });
 
+export type WfAsset = z.infer<typeof WfAsset>;
+
 export const WfData = z.object({
   type: z.literal("@webflow/XscpData"),
   payload: z.object({
     // Using WfBaseNode here just so we can skip a node with unknown node.type.
     nodes: z.array(z.union([WfNode, WfBaseNode])),
     styles: z.array(WfStyle),
-    assets: z.array(WfAssetSchema),
+    assets: z.array(WfAsset),
   }),
 });
 export type WfData = z.infer<typeof WfData>;

--- a/packages/css-data/src/parse-css.test.ts
+++ b/packages/css-data/src/parse-css.test.ts
@@ -39,9 +39,9 @@ describe("Parse CSS", () => {
 
   test("parses supported shorthand values", () => {
     const css = `
-      .test { 
-        background: #ff0000 linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), #EBFFFC; 
-      }    
+      .test {
+        background: #ff0000 linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), #EBFFFC;
+      }
     `;
     expect(parseCss(css)).toMatchInlineSnapshot(`
       {
@@ -71,6 +71,19 @@ describe("Parse CSS", () => {
         ],
       }
     `);
+  });
+
+  test.only("parses supported shorthand values 2", () => {
+    const css = `
+      .test {
+          background-image: linear-gradient(180deg, hsla(0, 0.00%, 0.00%, 0.11), white), url("https://667d0b7769e0cc3754b584f6"), url("https://667d0fe180995eadc1534a26");
+          background-position: 0px 0px, 550px 0px, 0px 0px;
+          background-size: auto, contain, auto;
+          background-repeat: repeat, no-repeat, repeat;
+          background-attachment: scroll, fixed, scroll;
+      }
+    `;
+    console.log(JSON.stringify(parseCss(css), null, " "));
   });
 
   test("parse state", () => {
@@ -214,7 +227,7 @@ describe("Parse CSS", () => {
         margin-bottom: 10px;
         font-weight: bold;
       }
-      
+
       h1 {
         margin-top: 20px;
         font-size: 38px;

--- a/packages/css-data/src/parse-css.test.ts
+++ b/packages/css-data/src/parse-css.test.ts
@@ -73,7 +73,7 @@ describe("Parse CSS", () => {
     `);
   });
 
-  test.only("parses supported shorthand values 2", () => {
+  test("parses supported shorthand values 2", () => {
     const css = `
       .test {
           background-image: linear-gradient(180deg, hsla(0, 0.00%, 0.00%, 0.11), white), url("https://667d0b7769e0cc3754b584f6"), url("https://667d0fe180995eadc1534a26");

--- a/packages/css-data/src/parse-css.test.ts
+++ b/packages/css-data/src/parse-css.test.ts
@@ -83,7 +83,151 @@ describe("Parse CSS", () => {
           background-attachment: scroll, fixed, scroll;
       }
     `;
-    console.log(JSON.stringify(parseCss(css), null, " "));
+    expect(parseCss(css)).toMatchInlineSnapshot(`
+{
+  "test": [
+    {
+      "property": "backgroundImage",
+      "value": {
+        "type": "layers",
+        "value": [
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(180deg,hsla(0,0.00%,0.00%,0.11),white)",
+          },
+          {
+            "type": "image",
+            "value": {
+              "type": "url",
+              "url": "https://667d0b7769e0cc3754b584f6",
+            },
+          },
+          {
+            "type": "image",
+            "value": {
+              "type": "url",
+              "url": "https://667d0fe180995eadc1534a26",
+            },
+          },
+        ],
+      },
+    },
+    {
+      "property": "backgroundPosition",
+      "value": {
+        "type": "layers",
+        "value": [
+          {
+            "type": "tuple",
+            "value": [
+              {
+                "type": "unit",
+                "unit": "px",
+                "value": 0,
+              },
+              {
+                "type": "unit",
+                "unit": "px",
+                "value": 0,
+              },
+            ],
+          },
+          {
+            "type": "tuple",
+            "value": [
+              {
+                "type": "unit",
+                "unit": "px",
+                "value": 550,
+              },
+              {
+                "type": "unit",
+                "unit": "px",
+                "value": 0,
+              },
+            ],
+          },
+          {
+            "type": "tuple",
+            "value": [
+              {
+                "type": "unit",
+                "unit": "px",
+                "value": 0,
+              },
+              {
+                "type": "unit",
+                "unit": "px",
+                "value": 0,
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "property": "backgroundSize",
+      "value": {
+        "type": "layers",
+        "value": [
+          {
+            "type": "keyword",
+            "value": "auto",
+          },
+          {
+            "type": "keyword",
+            "value": "contain",
+          },
+          {
+            "type": "keyword",
+            "value": "auto",
+          },
+        ],
+      },
+    },
+    {
+      "property": "backgroundRepeat",
+      "value": {
+        "type": "layers",
+        "value": [
+          {
+            "type": "keyword",
+            "value": "repeat",
+          },
+          {
+            "type": "keyword",
+            "value": "no-repeat",
+          },
+          {
+            "type": "keyword",
+            "value": "repeat",
+          },
+        ],
+      },
+    },
+    {
+      "property": "backgroundAttachment",
+      "value": {
+        "type": "layers",
+        "value": [
+          {
+            "type": "keyword",
+            "value": "scroll",
+          },
+          {
+            "type": "keyword",
+            "value": "fixed",
+          },
+          {
+            "type": "keyword",
+            "value": "scroll",
+          },
+        ],
+      },
+    },
+  ],
+}
+`);
   });
 
   test("parse state", () => {

--- a/packages/css-data/src/property-parsers/background.test.ts
+++ b/packages/css-data/src/property-parsers/background.test.ts
@@ -91,41 +91,48 @@ describe("parseBackground", () => {
     `);
   });
 
-  test("parse background and skips url background", () => {
+  test.only("parse background and skips url background", () => {
     expect(
       parseBackground(
         "url(https://hello.world/some-image), linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%), radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */"
       )
     ).toMatchInlineSnapshot(`
+{
+  "backgroundColor": undefined,
+  "backgroundImage": {
+    "type": "layers",
+    "value": [
       {
-        "backgroundColor": undefined,
-        "backgroundImage": {
-          "type": "layers",
-          "value": [
-            {
-              "type": "unparsed",
-              "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
-            },
-          ],
+        "type": "image",
+        "value": {
+          "type": "url",
+          "url": "https://hello.world/some-image",
         },
-      }
-    `);
+      },
+      {
+        "type": "unparsed",
+        "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
+      },
+      {
+        "type": "unparsed",
+        "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
+      },
+      {
+        "type": "unparsed",
+        "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
+      },
+      {
+        "type": "unparsed",
+        "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
+      },
+      {
+        "type": "unparsed",
+        "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
+      },
+    ],
+  },
+}
+`);
   });
 
   test("parse background partially copied background", () => {

--- a/packages/css-data/src/property-parsers/background.test.ts
+++ b/packages/css-data/src/property-parsers/background.test.ts
@@ -91,7 +91,7 @@ describe("parseBackground", () => {
     `);
   });
 
-  test.only("parse background and skips url background", () => {
+  test("parse background and skips url background", () => {
     expect(
       parseBackground(
         "url(https://hello.world/some-image), linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%), radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */"


### PR DESCRIPTION
## Description

Add support for background parsing into webstudio layers.
With partial support of webflow copy-pasting.
Main support will be in the next PR.
https `id`s are temporary used instead of real URLs to avoid various encoding/decoding issues, will be changed in next PR or PRs


## Steps for reproduction

Copy-Paste something like this
<img width="1069" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/caf827db-a6f7-43d6-b19c-4467fa1e3968">

Get this

<img width="286" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/6a59beee-4eea-4f6b-840a-20684e0c0be8">



## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
