### PR TITLE
experimental: Upload Webflow background-image assets on copy-paste

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
@@ -16,18 +16,13 @@ import { $assets } from "~/shared/nano-states";
 import { parseCssValue } from "@webstudio-is/css-data";
 import type { StyleUpdateOptions } from "../../shared/use-style-data";
 import { InfoCircleIcon } from "@webstudio-is/icons";
+import { url } from "css-tree";
 
 const property: StyleProperty = "backgroundImage";
 
 type IntermediateValue = {
   type: "intermediate";
   value: string;
-};
-
-const extractUrlFromValue = (cssValue: string) => {
-  const regex = /url\(["']?(.*?)["']?\)/;
-  const match = cssValue.match(regex);
-  return match ? match[1] : undefined;
 };
 
 const isAbsoluteURL = (value: string) => {
@@ -104,7 +99,7 @@ export const BackgroundImage = (
     }
 
     if (newValue.type === "unparsed") {
-      const urlFromProperty = extractUrlFromValue(value);
+      const urlFromProperty = url.decode(value);
       if (urlFromProperty === undefined) {
         setIntermediateValue({
           type: "invalid",

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -223,6 +223,10 @@ export const subscribeStyles = () => {
     renderUserSheetInTheNextFrame();
   });
 
+  const unsubscribeTransformValue = $transformValue.subscribe(() => {
+    renderUserSheetInTheNextFrame();
+  });
+
   // add/delete declarations in mixins
   let prevStylesSet = new Set<StyleDecl>();
   const unsubscribeStyles = $styles.subscribe((styles) => {
@@ -292,6 +296,7 @@ export const subscribeStyles = () => {
     unsubscribeStyles();
     unsubscribeStyleSourceSelections();
     unsubscribeDescendantSelectors();
+    unsubscribeTransformValue();
     if (animationFrameId) {
       cancelAnimationFrame(animationFrameId);
     }

--- a/apps/builder/app/shared/copy-paste/asset-upload.test.tsx
+++ b/apps/builder/app/shared/copy-paste/asset-upload.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from "@jest/globals";
 import { $, renderJsx, AssetValue } from "@webstudio-is/sdk/testing";
 import { denormalizeSrcProps } from "./asset-upload";
-import type { WebstudioFragment } from "@webstudio-is/sdk";
+import type { StyleDecl, WebstudioFragment } from "@webstudio-is/sdk";
 
 test("extractSrcProps works well", async () => {
   const inputData = renderJsx(
@@ -65,4 +65,81 @@ test("extractSrcProps works well", async () => {
   ]);
 
   expect(denormalizedData.props).toEqual([...desiredOutcome.props.values()]);
+});
+
+test("it works well with no background-images", async () => {
+  const style: StyleDecl = {
+    styleSourceId: "uulh2yW_VLZUgzjQ1bUt4",
+    breakpointId: "oQzjv7ZBzTiajBs6H03St",
+    property: "backgroundImage",
+    value: {
+      type: "layers",
+      value: [
+        {
+          type: "unparsed",
+          value: "linear-gradient(180deg,hsla(0,0.00%,0.00%,0.11),white)",
+        },
+        {
+          type: "image",
+          value: {
+            type: "url",
+            url: "https://s3.amazonaws.com/webflow-prod-assets/667c32290bd6159c18dca9a0/667d0b7769e0cc3754b584f6_IMG_2882%20(1).png",
+          },
+        },
+        {
+          type: "image",
+          value: {
+            type: "url",
+            url: "https://s3.amazonaws.com/webflow-prod-assets/667c32290bd6159c18dca9a0/667d0fe180995eadc1534a26_%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%9C%D0%B8%D1%80%20%3A%20%252F%20.webp",
+          },
+        },
+      ],
+    },
+  };
+
+  const data: WebstudioFragment = {
+    assets: [],
+    breakpoints: [],
+    children: [],
+    dataSources: [],
+    instances: [],
+    props: [],
+    resources: [],
+    styles: [style],
+    styleSources: [],
+    styleSourceSelections: [],
+  };
+
+  const src2AssetId = (src: string) => `asset-id::::${src}::::asset-id`;
+
+  const uploadImages = async (srcs: string[]) => {
+    return new Map(srcs.map((src) => [src, `${src2AssetId(src)}`]));
+  };
+
+  const denormalizedData = await denormalizeSrcProps(
+    data,
+    uploadImages,
+    (instanceId, propName) => `${instanceId}:${propName}`
+  );
+  const inputUrls = data.styles
+    .filter((style) => style.property === "backgroundImage")
+    .map((style) => style.value)
+    .filter((value) => value.type === "layers")
+    .flatMap((layer) => layer.value)
+    .filter((value) => value.type === "image")
+    .map((value) => value.value)
+    .filter((value) => value.type === "url")
+    .map((value) => value.url);
+
+  const denormalizedAssetIds = denormalizedData.styles
+    .filter((style) => style.property === "backgroundImage")
+    .map((style) => style.value)
+    .filter((value) => value.type === "layers")
+    .flatMap((layer) => layer.value)
+    .filter((value) => value.type === "image")
+    .map((value) => value.value)
+    .filter((value) => value.type === "asset")
+    .map((value) => value.value);
+
+  expect(denormalizedAssetIds).toEqual(inputUrls.map(src2AssetId));
 });

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -2137,5 +2137,5 @@ test("background images", async () => {
   });
 
   // @todo finish in the following PR
-  fragment;
+  console.log(JSON.stringify(fragment.styles));
 });

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -2045,7 +2045,7 @@ test("background images", async () => {
           namespace: "",
           comb: "",
           styleLess:
-            "height: 400px; background-image: linear-gradient(180deg, hsla(0, 0.00%, 0.00%, 0.11), white), @img_667d0b7769e0cc3754b584f6, @img_667d0fe180995eadc1534a26; background-position: 0px 0px, 550px 0px, 0px 0px; background-size: auto, contain, auto; background-repeat: repeat, no-repeat, repeat; background-attachment: scroll, fixed, scroll;",
+            "height: 400px; background-image: linear-gradient(180deg, hsla(0, 0.00%, 0.00%, 0.11), white), @img_667d0b7769e0cc3754b584f6, @img_667d0fe180995eadc1534a26, @img_example_bg; background-position: 0px 0px, 550px 0px, 0px 0px,0px 0px; background-size: auto, contain, auto, auto; background-repeat: repeat, no-repeat, repeat,repeat; background-attachment: scroll, fixed, scroll, fixed;",
           variants: {},
           children: [],
           createdBy: "5b7c48038bdf56493c54eae4",
@@ -2143,6 +2143,7 @@ test("background images", async () => {
   const bgStyle = fragment.styles.find(
     (style) => style.property === "backgroundImage"
   );
+  //
 
   expect(bgStyle).not.toBeNull();
   expect(bgStyle?.value.type).toEqual("layers");
@@ -2153,6 +2154,7 @@ test("background images", async () => {
 
   const imgA = layers.value[1];
   const imgB = layers.value[2];
+  const noneLayer = layers.value[3];
 
   invariant(imgA.type === "image");
   invariant(imgA.value.type === "url");
@@ -2161,4 +2163,8 @@ test("background images", async () => {
 
   expect(imgA.value.url).toEqual(input.payload.assets[0].s3Url);
   expect(imgB.value.url).toEqual(input.payload.assets[1].s3Url);
+
+  expect(noneLayer.type).toEqual("keyword");
+  invariant(noneLayer.type === "keyword");
+  expect(noneLayer.value).toEqual("none");
 });

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/schema.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/schema.ts
@@ -299,7 +299,7 @@ const WfAsset = z.object({
   createdOn: z.string(),
   origFileName: z.string(),
   fileHash: z.string(),
-  variants: z.array(z.union([WfAssetVariant, WfErrorAssetVariant])),
+  variants: z.array(z.union([WfAssetVariant, WfErrorAssetVariant])).optional(),
   mimeType: z.string(),
   s3Url: z.string().url(),
   thumbUrl: z.string(),

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
@@ -89,8 +89,10 @@ const replaceAtImages = (
     const asset = wfAssets.get(assetId);
 
     if (asset === undefined) {
-      console.error(`Asset not found: ${assetId}`);
-      return `url("https://asset-not-found")`;
+      if (assetId !== "example_bg") {
+        console.error(`Asset not found: ${assetId}`);
+      }
+      return `none`;
     }
 
     return url.encode(asset.s3Url);

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
@@ -15,6 +15,7 @@ import { equalMedia } from "@webstudio-is/css-engine";
 import { isBaseBreakpoint } from "~/shared/breakpoints";
 import type { Styles as WfStylePresets } from "./__generated__/style-presets";
 import { builderApi } from "~/shared/builder-api";
+import { url } from "css-tree";
 
 const { toast } = builderApi;
 
@@ -79,10 +80,20 @@ const replaceAtVariables = (styles: string) => {
 
 // Converts webflow asset references like `@img_667d0b7769e0cc3754b584f6` to valid urls like
 // url("https://667d0b7769e0cc3754b584f6") to not break csstree parser
-const replaceAtImages = (styles: string) => {
+const replaceAtImages = (
+  styles: string,
+  wfAssets: Map<WfAsset["_id"], WfAsset>
+) => {
   return styles.replace(/@img_[\w-]+/g, (match) => {
     const assetId = match.slice(5);
-    return `url("https://${assetId}")`;
+    const asset = wfAssets.get(assetId);
+
+    if (asset === undefined) {
+      console.error(`Asset not found: ${assetId}`);
+      return `url("https://asset-not-found")`;
+    }
+
+    return url.encode(asset.s3Url);
   });
 };
 
@@ -362,7 +373,7 @@ export const addStyles = async (
       const variants = new Map();
       variants.set(
         "base",
-        replaceAtImages(replaceAtVariables(style.styleLess))
+        replaceAtImages(replaceAtVariables(style.styleLess), wfAssets)
       );
       const wfVariants = style.variants ?? {};
       Object.keys(wfVariants).forEach((breakpointName) => {
@@ -370,7 +381,7 @@ export const addStyles = async (
         if (variant && "styleLess" in variant) {
           variants.set(
             breakpointName,
-            replaceAtImages(replaceAtVariables(variant.styleLess))
+            replaceAtImages(replaceAtVariables(variant.styleLess), wfAssets)
           );
         }
       });

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -82,6 +82,7 @@
     "change-case": "^5.4.4",
     "colord": "^2.9.3",
     "cookie": "^0.6.0",
+    "css-tree": "^2.3.1",
     "date-fns": "^3.6.0",
     "detect-font": "^0.1.5",
     "downshift": "^6.1.7",

--- a/packages/css-data/src/parse-css.test.ts
+++ b/packages/css-data/src/parse-css.test.ts
@@ -76,11 +76,11 @@ describe("Parse CSS", () => {
   test("parses supported shorthand values 2", () => {
     const css = `
       .test {
-          background-image: linear-gradient(180deg, hsla(0, 0.00%, 0.00%, 0.11), white), url("https://667d0b7769e0cc3754b584f6"), url("https://667d0fe180995eadc1534a26");
-          background-position: 0px 0px, 550px 0px, 0px 0px;
-          background-size: auto, contain, auto;
-          background-repeat: repeat, no-repeat, repeat;
-          background-attachment: scroll, fixed, scroll;
+          background-image: linear-gradient(180deg, hsla(0, 0.00%, 0.00%, 0.11), white), url("https://667d0b7769e0cc3754b584f6"), none, url("https://667d0fe180995eadc1534a26");
+          background-position: 0px 0px, 550px 0px, 0px 0px, 0px 0px;
+          background-size: auto, contain, auto, auto;
+          background-repeat: repeat, no-repeat, repeat, repeat;
+          background-attachment: scroll, fixed, scroll, scroll;
       }
     `;
     expect(parseCss(css)).toMatchInlineSnapshot(`
@@ -101,6 +101,10 @@ describe("Parse CSS", () => {
               "type": "url",
               "url": "https://667d0b7769e0cc3754b584f6",
             },
+          },
+          {
+            "type": "keyword",
+            "value": "none",
           },
           {
             "type": "image",
@@ -162,6 +166,21 @@ describe("Parse CSS", () => {
               },
             ],
           },
+          {
+            "type": "tuple",
+            "value": [
+              {
+                "type": "unit",
+                "unit": "px",
+                "value": 0,
+              },
+              {
+                "type": "unit",
+                "unit": "px",
+                "value": 0,
+              },
+            ],
+          },
         ],
       },
     },
@@ -177,6 +196,10 @@ describe("Parse CSS", () => {
           {
             "type": "keyword",
             "value": "contain",
+          },
+          {
+            "type": "keyword",
+            "value": "auto",
           },
           {
             "type": "keyword",
@@ -202,6 +225,10 @@ describe("Parse CSS", () => {
             "type": "keyword",
             "value": "repeat",
           },
+          {
+            "type": "keyword",
+            "value": "repeat",
+          },
         ],
       },
     },
@@ -217,6 +244,10 @@ describe("Parse CSS", () => {
           {
             "type": "keyword",
             "value": "fixed",
+          },
+          {
+            "type": "keyword",
+            "value": "scroll",
           },
           {
             "type": "keyword",

--- a/packages/css-data/src/parse-css.test.ts
+++ b/packages/css-data/src/parse-css.test.ts
@@ -261,6 +261,67 @@ describe("Parse CSS", () => {
 `);
   });
 
+  test("parses single layer", () => {
+    const css = `
+      .test {
+          background-image: none; background-position: 0px 0px; background-size: auto;
+      }
+    `;
+    expect(parseCss(css)).toMatchInlineSnapshot(`
+{
+  "test": [
+    {
+      "property": "backgroundImage",
+      "value": {
+        "type": "layers",
+        "value": [
+          {
+            "type": "keyword",
+            "value": "none",
+          },
+        ],
+      },
+    },
+    {
+      "property": "backgroundPosition",
+      "value": {
+        "type": "layers",
+        "value": [
+          {
+            "type": "tuple",
+            "value": [
+              {
+                "type": "unit",
+                "unit": "px",
+                "value": 0,
+              },
+              {
+                "type": "unit",
+                "unit": "px",
+                "value": 0,
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "property": "backgroundSize",
+      "value": {
+        "type": "layers",
+        "value": [
+          {
+            "type": "keyword",
+            "value": "auto",
+          },
+        ],
+      },
+    },
+  ],
+}
+`);
+  });
+
   test("parse state", () => {
     expect(parseCss(`a:hover { color: #ff0000 }`)).toMatchInlineSnapshot(`
       {

--- a/packages/css-data/src/parse-css.ts
+++ b/packages/css-data/src/parse-css.ts
@@ -133,6 +133,16 @@ const convertBackgroundProps = (styles: EmbedTemplateStyleDecl[]) => {
     .map((style) => {
       if (backgroundProps.includes(style.property)) {
         if (style.value.type !== "unparsed") {
+          const safeStyle = LayersValue.safeParse({
+            type: "layers",
+            value: [style.value],
+          });
+          if (safeStyle.success) {
+            return {
+              property: style.property,
+              value: safeStyle.data,
+            };
+          }
           return style;
         }
 
@@ -161,6 +171,16 @@ const convertBackgroundProps = (styles: EmbedTemplateStyleDecl[]) => {
     .map((style) => {
       if (style.property === "backgroundImage") {
         if (style.value.type !== "unparsed") {
+          const safeStyle = LayersValue.safeParse({
+            type: "layers",
+            value: [style.value],
+          });
+          if (safeStyle.success) {
+            return {
+              property: style.property,
+              value: safeStyle.data,
+            };
+          }
           return style;
         }
 

--- a/packages/css-data/src/property-parsers/background.test.ts
+++ b/packages/css-data/src/property-parsers/background.test.ts
@@ -9,45 +9,49 @@ describe("parseBackground", () => {
         "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), none, linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%), radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, #EBFFFC;"
       )
     ).toMatchInlineSnapshot(`
+{
+  "backgroundColor": {
+    "alpha": 1,
+    "b": 252,
+    "g": 255,
+    "r": 235,
+    "type": "rgb",
+  },
+  "backgroundImage": {
+    "type": "layers",
+    "value": [
       {
-        "backgroundColor": {
-          "alpha": 1,
-          "b": 252,
-          "g": 255,
-          "r": 235,
-          "type": "rgb",
-        },
-        "backgroundImage": {
-          "type": "layers",
-          "value": [
-            {
-              "type": "unparsed",
-              "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
-            },
-          ],
-        },
-      }
-    `);
+        "type": "unparsed",
+        "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
+      },
+      {
+        "type": "keyword",
+        "value": "none",
+      },
+      {
+        "type": "unparsed",
+        "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
+      },
+      {
+        "type": "unparsed",
+        "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
+      },
+      {
+        "type": "unparsed",
+        "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
+      },
+      {
+        "type": "unparsed",
+        "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
+      },
+      {
+        "type": "unparsed",
+        "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
+      },
+    ],
+  },
+}
+`);
   });
 
   test("parse background from figma without backgroundColor", () => {

--- a/packages/css-data/src/property-parsers/background.ts
+++ b/packages/css-data/src/property-parsers/background.ts
@@ -2,6 +2,7 @@ import * as csstree from "css-tree";
 import type {
   ImageValue,
   InvalidValue,
+  KeywordValue,
   LayersValue,
   RgbValue,
   UnparsedValue,
@@ -103,6 +104,10 @@ export const backgroundToLonghand = (
       if (node.type === "Url") {
         layers.push(csstree.generate(node));
       }
+
+      if (node.type === "Identifier" && node.name === "none") {
+        layers.push(csstree.generate(node));
+      }
     },
     leave: (node, item, list) => {
       if (node.type === "Function") {
@@ -120,9 +125,17 @@ export const backgroundToLonghand = (
 export const parseBackgroundImage = (
   layers: string[]
 ): LayersValue | InvalidValue => {
-  const backgroundImages: (UnparsedValue | ImageValue)[] = [];
+  const backgroundImages: (UnparsedValue | ImageValue | KeywordValue)[] = [];
 
   for (const layer of layers) {
+    if (layer === "none") {
+      backgroundImages.push({
+        type: "keyword",
+        value: "none",
+      });
+      continue;
+    }
+
     if (
       gradientNames.some((gradientName) => layer.startsWith(gradientName)) ===
         false &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,9 @@ importers:
       cookie:
         specifier: ^0.6.0
         version: 0.6.0
+      css-tree:
+        specifier: ^2.3.1
+        version: 2.3.1(patch_hash=epgcmebti7rfrc2ej4odb3t4jy)
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
@@ -15358,12 +15361,12 @@ snapshots:
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
 
   css-tree@2.3.1(patch_hash=epgcmebti7rfrc2ej4odb3t4jy):
     dependencies:
       mdn-data: 2.0.30
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
 
   css-what@6.1.0: {}
 


### PR DESCRIPTION
## Description

Upload backgrounds on webflow paste.

## Steps for reproduction

Create backgrounds with images at webflow
paste into the new project.

Example (everything is pasted from webflow in a single copy-paste)
https://upload-style-assets.development.webstudio.is/builder/dc6eae9d-dae6-4ba8-ade2-abd86f733d6a

Layers use assets
<img width="495" alt="image" src="https://github.com/webstudio-is/webstudio/assets/5077042/aed96a08-f369-48b4-84ec-3e935c293510">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
