### PR TITLE
feat: support -webkit-line-clamp

### DIFF
--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -17,6 +17,18 @@ import type {
 } from "@webstudio-is/css-engine";
 import * as customData from "../src/custom-data";
 
+/**
+ * Store prefixed properties without change
+ * and convert to camel case only unprefixed properties
+ * @todo stop converting to camel case and use hyphenated format
+ */
+const normalizePropertyName = (property: string) => {
+  if (property.startsWith("-")) {
+    return property;
+  }
+  return camelCase(property);
+};
+
 const units: Record<customData.UnitGroup, Array<string>> = {
   number: [],
   // consider % as unit
@@ -228,15 +240,11 @@ type FilteredProperties = { [property in Property]: Value };
 const experimentalProperties = [
   "appearance",
   "aspect-ratio",
-  // not standard and not implemented without prefix
-  // @todo get rid once the issue with types in radix sdk is resolved
-  "line-clamp",
-  // used in normalize
   "text-size-adjust",
+  "-webkit-line-clamp",
 ];
 
 const unsupportedProperties = [
-  "-webkit-line-clamp",
   "--*",
   // shorthand properties
   "all",
@@ -278,7 +286,9 @@ const filteredProperties: FilteredProperties = (() => {
   return result;
 })();
 
-const propertiesData = { ...customData.propertiesData };
+const propertiesData = {
+  ...customData.propertiesData,
+};
 
 let property: Property;
 for (property in filteredProperties) {
@@ -314,7 +324,7 @@ for (property in filteredProperties) {
     );
   }
 
-  propertiesData[camelCase(property)] = {
+  propertiesData[normalizePropertyName(property)] = {
     unitGroups: Array.from(unitGroups),
     inherited: config.inherited,
     initial: parseInitialValue(property, config.initial, unitGroups),
@@ -379,7 +389,7 @@ const keywordValues = (() => {
     }
 
     if (keywords.size !== 0) {
-      const key = camelCase(property);
+      const key = normalizePropertyName(property);
       result[key] = [...(result[key] ?? []), ...keywords];
     }
   }

--- a/packages/css-data/src/__generated__/animatable-properties.ts
+++ b/packages/css-data/src/__generated__/animatable-properties.ts
@@ -84,7 +84,6 @@ export const animatableProperties = [
   "inset-inline-start",
   "left",
   "letter-spacing",
-  "line-clamp",
   "line-height",
   "margin-block-end",
   "margin-block-start",

--- a/packages/css-data/src/__generated__/keyword-values.ts
+++ b/packages/css-data/src/__generated__/keyword-values.ts
@@ -2,6 +2,7 @@
 export const keywordValues = {
   WebkitFontSmoothing: ["auto", "none", "antialiased", "subpixel-antialiased"],
   MozOsxFontSmoothing: ["auto", "grayscale"],
+  "-webkit-box-orient": ["horizontal", "vertical"],
   listStyleType: [
     "disc",
     "circle",
@@ -15,6 +16,7 @@ export const keywordValues = {
     "inherit",
     "unset",
   ],
+  "-webkit-line-clamp": ["none", "initial", "inherit", "unset"],
   accentColor: [
     "auto",
     "transparent",
@@ -3485,7 +3487,6 @@ export const keywordValues = {
     "inherit",
     "unset",
   ],
-  lineClamp: ["none", "initial", "inherit", "unset"],
   lineHeight: ["normal", "initial", "inherit", "unset"],
   listStyleImage: ["none", "initial", "inherit", "unset"],
   listStylePosition: ["inside", "outside", "initial", "inherit", "unset"],

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -18,6 +18,24 @@ export const properties = {
     },
     types: [],
   },
+  "-webkit-box-orient": {
+    unitGroups: [],
+    inherited: false,
+    initial: {
+      type: "keyword",
+      value: "horizontal",
+    },
+    types: [],
+  },
+  "-webkit-line-clamp": {
+    unitGroups: ["number"],
+    inherited: false,
+    initial: {
+      type: "keyword",
+      value: "none",
+    },
+    types: ["integer"],
+  },
   accentColor: {
     unitGroups: [],
     inherited: true,
@@ -1540,15 +1558,6 @@ export const properties = {
       value: "auto",
     },
     types: [],
-  },
-  lineClamp: {
-    unitGroups: ["number"],
-    inherited: false,
-    initial: {
-      type: "keyword",
-      value: "none",
-    },
-    types: ["integer"],
   },
   lineHeight: {
     unitGroups: ["number", "length", "percentage"],

--- a/packages/css-data/src/custom-data.ts
+++ b/packages/css-data/src/custom-data.ts
@@ -70,6 +70,14 @@ propertiesData.MozOsxFontSmoothing = {
 };
 keywordValues.MozOsxFontSmoothing = ["auto", "grayscale"];
 
+propertiesData["-webkit-box-orient"] = {
+  unitGroups: [],
+  inherited: false,
+  initial: { type: "keyword", value: "horizontal" },
+  types: [],
+};
+keywordValues["-webkit-box-orient"] = ["horizontal", "vertical"];
+
 keywordValues.listStyleType = [
   "disc",
   "circle",

--- a/packages/css-data/src/parse-css-value.ts
+++ b/packages/css-data/src/parse-css-value.ts
@@ -16,7 +16,6 @@ import {
   parseShadow,
   parseTransitionLonghandProperty,
 } from "./property-parsers";
-import { camelCase } from "change-case";
 
 export const cssTryParseValue = (input: string) => {
   try {
@@ -156,8 +155,7 @@ export const parseCssValue = (
     }
 
     if (first?.type === "Identifier") {
-      const values =
-        keywordValues[camelCase(property) as keyof typeof keywordValues];
+      const values = keywordValues[property as keyof typeof keywordValues];
       if (values === undefined) {
         return {
           type: "invalid",

--- a/packages/css-data/src/parse-css.test.ts
+++ b/packages/css-data/src/parse-css.test.ts
@@ -583,18 +583,18 @@ describe("Parse CSS", () => {
     // @todo parser is wrong here, it should be keyword horizontal
     expect(parseCss(`a { -webkit-box-orient: horizontal; }`))
       .toMatchInlineSnapshot(`
-      {
-        "a": [
-          {
-            "property": "WebkitBoxOrient",
-            "value": {
-              "type": "invalid",
-              "value": "",
-            },
-          },
-        ],
-      }
-    `);
+{
+  "a": [
+    {
+      "property": "-webkit-box-orient",
+      "value": {
+        "type": "keyword",
+        "value": "horizontal",
+      },
+    },
+  ],
+}
+`);
   });
 
   test("parse child combinator", () => {

--- a/packages/css-data/src/parse-css.ts
+++ b/packages/css-data/src/parse-css.ts
@@ -98,24 +98,24 @@ const parseCssValue = (
 
   const expanded = new Map(expandShorthands([[property, value]]));
   const final = new Map();
-  for (let [property, value] of expanded) {
-    property = normalizePropertyName(property);
+  for (const [property, value] of expanded) {
+    const normalizedProperty = normalizePropertyName(property);
     if (value === "") {
       // Keep the browser behavior when property is defined with an empty value e.g. `color:;`
       // It may override some existing value and effectively set it to "unset";
-      final.set(property, { type: "keyword", value: "unset" });
+      final.set(normalizedProperty, { type: "keyword", value: "unset" });
       continue;
     }
 
     // @todo https://github.com/webstudio-is/webstudio/issues/3399
     if (value.startsWith("var(")) {
-      final.set(property, { type: "keyword", value: "unset" });
+      final.set(normalizedProperty, { type: "keyword", value: "unset" });
       continue;
     }
 
     final.set(
-      property,
-      parseCssValueLonghand(property as StyleProperty, value)
+      normalizedProperty,
+      parseCssValueLonghand(normalizedProperty as StyleProperty, value)
     );
   }
   return final;

--- a/packages/css-engine/src/__generated__/types.ts
+++ b/packages/css-engine/src/__generated__/types.ts
@@ -1,6 +1,8 @@
 export type Property =
   | "WebkitFontSmoothing"
   | "MozOsxFontSmoothing"
+  | "-webkit-box-orient"
+  | "-webkit-line-clamp"
   | "accentColor"
   | "alignContent"
   | "alignItems"
@@ -167,7 +169,6 @@ export type Property =
   | "left"
   | "letterSpacing"
   | "lineBreak"
-  | "lineClamp"
   | "lineHeight"
   | "listStyleImage"
   | "listStylePosition"

--- a/packages/sdk-components-react-radix/scripts/generate-tailwind-theme.ts
+++ b/packages/sdk-components-react-radix/scripts/generate-tailwind-theme.ts
@@ -135,7 +135,7 @@ const generatedThemeData: GeneratedThemeItem[] = [
   },
   {
     name: "lineClamp",
-    values: parsePropertyValues("lineClamp", theme.lineClamp),
+    values: parsePropertyValues("-webkit-line-clamp", theme.lineClamp),
   },
   {
     name: "textUnderlineOffset",


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2647 Closes https://github.com/webstudio-is/webstudio/issues/3427

Here added -webkit-line-clamp and -webkit-box-orient properties support which is the only way to add multiline truncation at the moment.

All properties with prefixes are stored without camel casing. With font smoothing as the only exception because added very early.

<img width="911" alt="Screenshot 2024-06-28 at 17 48 08" src="https://github.com/webstudio-is/webstudio/assets/5635476/ca773cf0-81f0-47d7-97c8-5f78751332d4">

