### PR TITLE
refactor: reuse css parser in tailwind parser

### DIFF
--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -38,8 +38,8 @@
   "private": true,
   "sideEffects": false,
   "dependencies": {
-    "@unocss/core": "^0.56.4",
-    "@unocss/preset-uno": "^0.56.4",
+    "@unocss/core": "^0.61.0",
+    "@unocss/preset-uno": "^0.61.0",
     "@webstudio-is/css-engine": "workspace:*",
     "change-case": "^5.4.4",
     "colord": "^2.9.3",

--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -112,6 +112,16 @@ describe("Parse CSS value", () => {
       });
     });
 
+    test("modern format", () => {
+      expect(parseCssValue("backgroundColor", "rgb(99 102 241/0.5)")).toEqual({
+        type: "rgb",
+        r: 99,
+        g: 102,
+        b: 241,
+        alpha: 0.5,
+      });
+    });
+
     test("Color rgba values", () => {
       expect(parseCssValue("backgroundColor", "#00220011")).toEqual({
         type: "rgb",

--- a/packages/css-data/src/tailwind-parser/parse.test.ts
+++ b/packages/css-data/src/tailwind-parser/parse.test.ts
@@ -22,7 +22,7 @@ Quick Validation of Generated CSS in WebStudio:
             "type": "layers",
             "value": [{
               type: "unparsed",
-              value: "linear-gradient(to right,rgba(99,102,241,1) 0%,rgba(99,102,241,0) 100%)"
+              value: "linear-gradient(to right,rgb(99 102 241/1) 0%,rgb(99 102 241/0) 100%)"
             }]
           }
         }
@@ -107,7 +107,7 @@ describe("parseTailwindToWebstudio", () => {
       "value": [
         {
           "type": "unparsed",
-          "value": "linear-gradient(to right,rgba(99,102,241,1) 10%,rgba(14,165,233,1) 30%,rgba(16,185,129,1) 90%)",
+          "value": "linear-gradient(to right,rgb(99 102 241/1) 10%,rgb(14 165 233/1) 30%,rgb(16 185 129/1) 90%)",
         },
       ],
     },
@@ -387,7 +387,7 @@ describe("parseTailwindToCss", () => {
     const tailwindClasses = `bg-gradient-to-r from-indigo-500`;
 
     expect(await parseTailwindToCss(tailwindClasses)).toMatchInlineSnapshot(
-      `".bg-gradient-to-r{background-image:linear-gradient(to right,rgba(99,102,241,1) 0%,rgba(99,102,241,0) 100%)}"`
+      `".bg-gradient-to-r{background-image:linear-gradient(to right,rgb(99 102 241/1) 0%,rgb(99 102 241/0) 100%)}"`
     );
   });
 
@@ -403,7 +403,7 @@ describe("parseTailwindToCss", () => {
     const tailwindClasses = `shadow`;
 
     expect(await parseTailwindToCss(tailwindClasses)).toMatchInlineSnapshot(
-      `".shadow{box-shadow:0 0 rgba(0,0,0,0),0 0 rgba(0,0,0,0),0 1px 3px 0 rgba(0,0,0,0.1),0 1px 2px -1px rgba(0,0,0,0.1)}"`
+      `".shadow{box-shadow:0 0 rgb(0 0 0/0),0 0 rgb(0 0 0/0),0 1px 3px 0 rgb(0 0 0/0.1),0 1px 2px -1px rgb(0 0 0/0.1)}"`
     );
   });
 

--- a/packages/css-data/src/tailwind-parser/shorthand.ts
+++ b/packages/css-data/src/tailwind-parser/shorthand.ts
@@ -1,5 +1,3 @@
-export const expandShorthand = (property: string) => {};
-
 /**
  * Expands shorthand CSS properties into their long-form equivalents.
  * For example, 'mx' is expanded to 'mr' (margin-right) and 'ml' (margin-left).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,11 +1068,11 @@ importers:
   packages/css-data:
     dependencies:
       '@unocss/core':
-        specifier: ^0.56.4
-        version: 0.56.4
+        specifier: ^0.61.0
+        version: 0.61.0
       '@unocss/preset-uno':
-        specifier: ^0.56.4
-        version: 0.56.4
+        specifier: ^0.61.0
+        version: 0.61.0
       '@webstudio-is/css-engine':
         specifier: workspace:*
         version: link:../css-engine
@@ -5557,23 +5557,23 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  '@unocss/core@0.56.4':
-    resolution: {integrity: sha512-9DL+2adfjWWnFWp2QOJTq2OcfKKo++agaXnCX7CzeD8KgfWCBqxs2RDoxP3HrDbTflhDHdbjz23B+vJoVykhZw==}
+  '@unocss/core@0.61.0':
+    resolution: {integrity: sha512-Y/Ly3LPIAzOBlWCdKBVzVzIaaWDsf+oWPIUZlaW7DL++WWypVBCghmxXIT5dyuMGXE560Hj92st4AkXfuVdxGQ==}
 
-  '@unocss/extractor-arbitrary-variants@0.56.4':
-    resolution: {integrity: sha512-Q93Bu3wZld+Vj5dqfJYH6phcmjm7fy6mEul64RexLWF00As9WrRzWEXbLVYmmVwUm9e5xcxZO6s98gKq1nTH6Q==}
+  '@unocss/extractor-arbitrary-variants@0.61.0':
+    resolution: {integrity: sha512-9ru/UR4kZ1+jGXpMawV9T8kpL54FrJBmWKMuFlDTEDIwtzDyyfLbt/buoXdzKDLmil9hOXH3IH8+dah/OiiDoA==}
 
-  '@unocss/preset-mini@0.56.4':
-    resolution: {integrity: sha512-FCKs3sUUiHLXQ/ON/ZCQc2JZQox4tv0W8Du+8Y1mRZ6w1yazqqBhR2yDPaEZ51yKcHmDf6ndiTvcJ2tPIz/o8g==}
+  '@unocss/preset-mini@0.61.0':
+    resolution: {integrity: sha512-P+DdMtPtzAQ2aQ1/WWPoO3X/qvky+Fqq4eKXIvbqXOQ9c2oem7/dnsPeT08zzLIqxVJnuykymPwRT85EumS0gg==}
 
-  '@unocss/preset-uno@0.56.4':
-    resolution: {integrity: sha512-E4VbUe1nIeJ7D1en84osGzwP79IBJ1P9v37Pcx2PvaRAQTKf6WRF7EXzmzEm6HPF+skyGOX9RWuXs9QFODsW8A==}
+  '@unocss/preset-uno@0.61.0':
+    resolution: {integrity: sha512-mkKOra3dQEc3uI7aPIqa3t8MJXlmpLSgGaPfEJK52xkFe991ex6CiUunYMMWbh6ZSzmdxkO31IwQIH9lcmj/Uw==}
 
-  '@unocss/preset-wind@0.56.4':
-    resolution: {integrity: sha512-llQYQxrA531kl1juYMyaDEEl/IVdHoIPXaaJTdNHbGkSbMqrpZSRzLPsGE+CpaOBKTNqa93UyU1qlUGSr9ZB+A==}
+  '@unocss/preset-wind@0.61.0':
+    resolution: {integrity: sha512-PooyLVAF4wH9KvW4OKfDxYFuM4qmnlU+Ci6O6RGgVsKyQMq76crRqqK76lbnehg7jOoZJVxmWfQ6k5gT3aQeXQ==}
 
-  '@unocss/rule-utils@0.56.4':
-    resolution: {integrity: sha512-pZmTPqi/Tb+vbwjNXu9+PwxEh7PVe+FwP+pzUbfNSUpE5Hg9CCbl8hpsXRE/r8kdaoKhmw2ryxvjocOgKXG/ag==}
+  '@unocss/rule-utils@0.61.0':
+    resolution: {integrity: sha512-MCdmfhE6Q9HSWjWqi2sx5/nnKyOEhfhoo+pVumHIqkHQICQ/LuKioFf7Y7e5ycqjFE/7dC2hKGZJ8WTMGIOMwA==}
     engines: {node: '>=14'}
 
   '@upstash/core-analytics@0.0.6':
@@ -7833,6 +7833,9 @@ packages:
   magic-string@0.30.1:
     resolution: {integrity: sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==}
     engines: {node: '>=12'}
+
+  magic-string@0.30.10:
+    resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -14508,34 +14511,35 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@unocss/core@0.56.4': {}
+  '@unocss/core@0.61.0': {}
 
-  '@unocss/extractor-arbitrary-variants@0.56.4':
+  '@unocss/extractor-arbitrary-variants@0.61.0':
     dependencies:
-      '@unocss/core': 0.56.4
+      '@unocss/core': 0.61.0
 
-  '@unocss/preset-mini@0.56.4':
+  '@unocss/preset-mini@0.61.0':
     dependencies:
-      '@unocss/core': 0.56.4
-      '@unocss/extractor-arbitrary-variants': 0.56.4
-      '@unocss/rule-utils': 0.56.4
+      '@unocss/core': 0.61.0
+      '@unocss/extractor-arbitrary-variants': 0.61.0
+      '@unocss/rule-utils': 0.61.0
 
-  '@unocss/preset-uno@0.56.4':
+  '@unocss/preset-uno@0.61.0':
     dependencies:
-      '@unocss/core': 0.56.4
-      '@unocss/preset-mini': 0.56.4
-      '@unocss/preset-wind': 0.56.4
-      '@unocss/rule-utils': 0.56.4
+      '@unocss/core': 0.61.0
+      '@unocss/preset-mini': 0.61.0
+      '@unocss/preset-wind': 0.61.0
+      '@unocss/rule-utils': 0.61.0
 
-  '@unocss/preset-wind@0.56.4':
+  '@unocss/preset-wind@0.61.0':
     dependencies:
-      '@unocss/core': 0.56.4
-      '@unocss/preset-mini': 0.56.4
-      '@unocss/rule-utils': 0.56.4
+      '@unocss/core': 0.61.0
+      '@unocss/preset-mini': 0.61.0
+      '@unocss/rule-utils': 0.61.0
 
-  '@unocss/rule-utils@0.56.4':
+  '@unocss/rule-utils@0.61.0':
     dependencies:
-      '@unocss/core': 0.56.4
+      '@unocss/core': 0.61.0
+      magic-string: 0.30.10
 
   '@upstash/core-analytics@0.0.6':
     dependencies:
@@ -17312,6 +17316,10 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.4.15
 
   magic-string@0.30.1:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+
+  magic-string@0.30.10:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 


### PR DESCRIPTION
We duplicate the logic for parsing css for ai and webflow. Here a bit of cleanup to simplify further work on shorthands.

Also upgraded unocss and got rid of bug workaround (fixed in unocss)