### PR TITLE
experimental: expand background shorthand

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
@@ -3,7 +3,7 @@
  * as of now just implement feature parity with old backgrounds section
  **/
 
-import type { RgbValue, StyleValue } from "@webstudio-is/css-engine";
+import type { StyleValue } from "@webstudio-is/css-engine";
 import {
   theme,
   Flex,
@@ -48,7 +48,7 @@ type BackgroundContentProps = {
   currentStyle: StyleInfo;
   setProperty: SetBackgroundProperty;
   deleteProperty: DeleteBackgroundProperty;
-  setBackgroundColor: (color: RgbValue) => void;
+  setBackgroundColor: (color: StyleValue) => void;
 };
 
 const safeDeleteProperty = (

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -1,4 +1,4 @@
-import type { InvalidValue, RgbValue } from "@webstudio-is/css-engine";
+import type { InvalidValue, StyleValue } from "@webstudio-is/css-engine";
 import { parseCssValue, parseBackground } from "@webstudio-is/css-data";
 import {
   Flex,
@@ -17,7 +17,7 @@ type IntermediateValue = {
 
 export const BackgroundGradient = (
   props: Omit<ControlProps, "property" | "items"> & {
-    setBackgroundColor: (color: RgbValue) => void;
+    setBackgroundColor: (color: StyleValue) => void;
   }
 ) => {
   const property = "backgroundImage";

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -65,20 +65,25 @@ export const BackgroundGradient = (
     const { backgroundImage, backgroundColor } = parseBackground(
       intermediateValue.value
     );
+    const [layer] =
+      backgroundImage?.type === "layers"
+        ? backgroundImage.value
+        : [backgroundImage];
 
-    if (backgroundColor !== undefined) {
-      props.setBackgroundColor(backgroundColor);
-    }
-
-    if (backgroundImage.type !== "invalid") {
-      setIntermediateValue(undefined);
-      props.setProperty(property)(backgroundImage);
+    // set invalid state
+    if (
+      backgroundColor === undefined ||
+      backgroundColor.type === "invalid" ||
+      layer === undefined ||
+      layer.type === "invalid"
+    ) {
+      setIntermediateValue({ type: "invalid", value: intermediateValue.value });
+      props.deleteProperty(property, { isEphemeral: true });
       return;
     }
-
-    // Set invalid state
-    setIntermediateValue({ type: "invalid", value: intermediateValue.value });
-    props.deleteProperty(property, { isEphemeral: true });
+    props.setBackgroundColor(backgroundColor);
+    setIntermediateValue(undefined);
+    props.setProperty(property)(layer);
   };
 
   const handleOnCompleteRef = useRef(handleOnComplete);

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
@@ -97,8 +97,7 @@ export const BackgroundImage = (
       return;
     }
 
-    const [layer] =
-      newValue.type === "layers" ? newValue.value : [newValue.value];
+    const [layer] = newValue.type === "layers" ? newValue.value : [newValue];
     if (layer?.type !== "image" || layer.value.type !== "url") {
       setIntermediateValue({
         type: "invalid",

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
@@ -98,6 +98,10 @@ export const BackgroundImage = (
     }
 
     const [layer] = newValue.type === "layers" ? newValue.value : [newValue];
+    if (layer?.type === "keyword") {
+      setIntermediateValue(undefined);
+      props.setProperty(property)(layer, options);
+    }
     if (layer?.type !== "image" || layer.value.type !== "url") {
       setIntermediateValue({
         type: "invalid",

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
@@ -16,7 +16,6 @@ import { $assets } from "~/shared/nano-states";
 import { parseCssValue } from "@webstudio-is/css-data";
 import type { StyleUpdateOptions } from "../../shared/use-style-data";
 import { InfoCircleIcon } from "@webstudio-is/icons";
-import { url } from "css-tree";
 
 const property: StyleProperty = "backgroundImage";
 
@@ -98,9 +97,26 @@ export const BackgroundImage = (
       return;
     }
 
-    if (newValue.type === "unparsed") {
-      const urlFromProperty = url.decode(value);
-      if (urlFromProperty === undefined) {
+    const [layer] =
+      newValue.type === "layers" ? newValue.value : [newValue.value];
+    if (layer?.type !== "image" || layer.value.type !== "url") {
+      setIntermediateValue({
+        type: "invalid",
+        value: value,
+      });
+      return;
+    }
+    const url = layer.value.url;
+
+    if (isAbsoluteURL(url) === true) {
+      props.setProperty(property)(layer, options);
+    } else {
+      const usedAsset = Array.from($assets.get().values()).find(
+        (asset) => asset.type === "image" && asset.name === url
+      );
+
+      if (usedAsset === undefined) {
+        setErrors([`Asset ${url} is not found in project `]);
         setIntermediateValue({
           type: "invalid",
           value: value,
@@ -108,43 +124,17 @@ export const BackgroundImage = (
         return;
       }
 
-      if (isAbsoluteURL(urlFromProperty) === true) {
-        props.setProperty(property)(
-          {
-            type: "image",
-            value: {
-              type: "url",
-              url: urlFromProperty,
-            },
+      setErrors([]);
+      props.setProperty(property)(
+        {
+          type: "image",
+          value: {
+            type: "asset",
+            value: usedAsset.id,
           },
-          options
-        );
-      } else {
-        const usedAsset = Array.from($assets.get().values()).find(
-          (asset) => asset.type === "image" && asset.name === urlFromProperty
-        );
-
-        if (usedAsset === undefined) {
-          setErrors([`Asset ${urlFromProperty} is not found in project `]);
-          setIntermediateValue({
-            type: "invalid",
-            value: value,
-          });
-          return;
-        }
-
-        setErrors([]);
-        props.setProperty(property)(
-          {
-            type: "image",
-            value: {
-              type: "asset",
-              value: usedAsset.id,
-            },
-          },
-          options
-        );
-      }
+        },
+        options
+      );
     }
   };
 

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -43,7 +43,7 @@ import {
 import { BackgroundContent } from "./background-content";
 import { getLayerName, LayerThumbnail } from "./background-thumbnail";
 import { useMemo } from "react";
-import type { RgbValue, StyleProperty } from "@webstudio-is/css-engine";
+import type { StyleProperty, StyleValue } from "@webstudio-is/css-engine";
 import {
   CollapsibleSectionRoot,
   useOpenState,
@@ -58,7 +58,7 @@ const Layer = (props: {
   setProperty: SetBackgroundProperty;
   deleteProperty: DeleteBackgroundProperty;
   deleteLayer: () => void;
-  setBackgroundColor: (color: RgbValue) => void;
+  setBackgroundColor: (color: StyleValue) => void;
 }) => {
   const assets = useStore($assets);
 

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts
@@ -557,8 +557,103 @@ export const styles = {
         type: "layers",
         value: [
           {
-            type: "invalid",
-            value: "",
+            type: "keyword",
+            value: "none",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionX",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundSize",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "tuple",
+            value: [
+              {
+                type: "keyword",
+                value: "auto",
+              },
+              {
+                type: "keyword",
+                value: "auto",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundRepeat",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "repeat",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundAttachment",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "scroll",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundOrigin",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "padding-box",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundClip",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "border-box",
           },
         ],
       },
@@ -2979,6 +3074,101 @@ export const styles = {
           {
             type: "keyword",
             value: "none",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionX",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundSize",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "tuple",
+            value: [
+              {
+                type: "keyword",
+                value: "auto",
+              },
+              {
+                type: "keyword",
+                value: "auto",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundRepeat",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "repeat",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundAttachment",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "scroll",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundOrigin",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "padding-box",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundClip",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "border-box",
           },
         ],
       },
@@ -7137,8 +7327,103 @@ export const styles = {
         type: "layers",
         value: [
           {
-            type: "invalid",
-            value: "",
+            type: "keyword",
+            value: "none",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionX",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundSize",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "tuple",
+            value: [
+              {
+                type: "keyword",
+                value: "auto",
+              },
+              {
+                type: "keyword",
+                value: "auto",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundRepeat",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "repeat",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundAttachment",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "scroll",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundOrigin",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "padding-box",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundClip",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "border-box",
           },
         ],
       },
@@ -7937,8 +8222,103 @@ export const styles = {
         type: "layers",
         value: [
           {
-            type: "invalid",
-            value: "",
+            type: "keyword",
+            value: "none",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionX",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundSize",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "tuple",
+            value: [
+              {
+                type: "keyword",
+                value: "auto",
+              },
+              {
+                type: "keyword",
+                value: "auto",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundRepeat",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "repeat",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundAttachment",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "scroll",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundOrigin",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "padding-box",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundClip",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "border-box",
           },
         ],
       },
@@ -9583,8 +9963,103 @@ export const styles = {
         type: "layers",
         value: [
           {
-            type: "invalid",
-            value: "",
+            type: "keyword",
+            value: "none",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionX",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundSize",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "tuple",
+            value: [
+              {
+                type: "keyword",
+                value: "auto",
+              },
+              {
+                type: "keyword",
+                value: "auto",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundRepeat",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "repeat",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundAttachment",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "scroll",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundOrigin",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "padding-box",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundClip",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "border-box",
           },
         ],
       },
@@ -9870,8 +10345,103 @@ export const styles = {
         type: "layers",
         value: [
           {
-            type: "invalid",
-            value: "",
+            type: "keyword",
+            value: "none",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionX",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundSize",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "tuple",
+            value: [
+              {
+                type: "keyword",
+                value: "auto",
+              },
+              {
+                type: "keyword",
+                value: "auto",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundRepeat",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "repeat",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundAttachment",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "scroll",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundOrigin",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "padding-box",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundClip",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "border-box",
           },
         ],
       },
@@ -10334,8 +10904,103 @@ export const styles = {
         type: "layers",
         value: [
           {
-            type: "invalid",
-            value: "",
+            type: "keyword",
+            value: "none",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionX",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundSize",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "tuple",
+            value: [
+              {
+                type: "keyword",
+                value: "auto",
+              },
+              {
+                type: "keyword",
+                value: "auto",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundRepeat",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "repeat",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundAttachment",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "scroll",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundOrigin",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "padding-box",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundClip",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "border-box",
           },
         ],
       },
@@ -10494,7 +11159,19 @@ export const styles = {
       },
     },
     {
-      property: "backgroundPosition",
+      property: "backgroundPositionX",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "center",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
       value: {
         type: "layers",
         value: [
@@ -10958,8 +11635,103 @@ export const styles = {
         type: "layers",
         value: [
           {
-            type: "invalid",
-            value: "",
+            type: "keyword",
+            value: "none",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionX",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundSize",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "tuple",
+            value: [
+              {
+                type: "keyword",
+                value: "auto",
+              },
+              {
+                type: "keyword",
+                value: "auto",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundRepeat",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "repeat",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundAttachment",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "scroll",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundOrigin",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "padding-box",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundClip",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "border-box",
           },
         ],
       },
@@ -11844,8 +12616,103 @@ export const styles = {
         type: "layers",
         value: [
           {
-            type: "invalid",
-            value: "",
+            type: "keyword",
+            value: "none",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionX",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            unit: "%",
+            value: 0,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundSize",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "tuple",
+            value: [
+              {
+                type: "keyword",
+                value: "auto",
+              },
+              {
+                type: "keyword",
+                value: "auto",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundRepeat",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "repeat",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundAttachment",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "scroll",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundOrigin",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "padding-box",
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundClip",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "border-box",
           },
         ],
       },
@@ -12989,7 +13856,7 @@ export const styles = {
       },
     },
     {
-      property: "backgroundPosition",
+      property: "backgroundPositionX",
       value: {
         type: "layers",
         value: [
@@ -12997,6 +13864,18 @@ export const styles = {
             type: "unit",
             unit: "%",
             value: 50,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "center",
           },
         ],
       },
@@ -13383,7 +14262,7 @@ export const styles = {
       },
     },
     {
-      property: "backgroundPosition",
+      property: "backgroundPositionX",
       value: {
         type: "layers",
         value: [
@@ -13391,6 +14270,18 @@ export const styles = {
             type: "unit",
             unit: "%",
             value: 50,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "center",
           },
         ],
       },
@@ -13527,7 +14418,7 @@ export const styles = {
       },
     },
     {
-      property: "backgroundPosition",
+      property: "backgroundPositionX",
       value: {
         type: "layers",
         value: [
@@ -13535,6 +14426,18 @@ export const styles = {
             type: "unit",
             unit: "%",
             value: 50,
+          },
+        ],
+      },
+    },
+    {
+      property: "backgroundPositionY",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "center",
           },
         ],
       },

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "prebuild": "which remix",
     "build": "remix vite:build",
-    "build:webflow-presets": "css-to-ws ./app/shared/copy-paste/plugin-webflow/style-presets.css ./app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts",
+    "css-to-ws": "NODE_OPTIONS='--conditions=webstudio --import=tsx' css-to-ws",
+    "build:webflow-presets": "pnpm css-to-ws ./app/shared/copy-paste/plugin-webflow/style-presets.css ./app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts",
     "start": "remix-serve build/server/index.js",
     "dev": "remix vite:dev",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",

--- a/packages/css-data/src/parse-css.test.ts
+++ b/packages/css-data/src/parse-css.test.ts
@@ -55,6 +55,144 @@ describe("Parse CSS", () => {
                   "type": "unparsed",
                   "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
                 },
+                {
+                  "type": "keyword",
+                  "value": "none",
+                },
+              ],
+            },
+          },
+          {
+            "property": "backgroundPositionX",
+            "value": {
+              "type": "layers",
+              "value": [
+                {
+                  "type": "unit",
+                  "unit": "%",
+                  "value": 0,
+                },
+                {
+                  "type": "unit",
+                  "unit": "%",
+                  "value": 0,
+                },
+              ],
+            },
+          },
+          {
+            "property": "backgroundPositionY",
+            "value": {
+              "type": "layers",
+              "value": [
+                {
+                  "type": "unit",
+                  "unit": "%",
+                  "value": 0,
+                },
+                {
+                  "type": "unit",
+                  "unit": "%",
+                  "value": 0,
+                },
+              ],
+            },
+          },
+          {
+            "property": "backgroundSize",
+            "value": {
+              "type": "layers",
+              "value": [
+                {
+                  "type": "tuple",
+                  "value": [
+                    {
+                      "type": "keyword",
+                      "value": "auto",
+                    },
+                    {
+                      "type": "keyword",
+                      "value": "auto",
+                    },
+                  ],
+                },
+                {
+                  "type": "tuple",
+                  "value": [
+                    {
+                      "type": "keyword",
+                      "value": "auto",
+                    },
+                    {
+                      "type": "keyword",
+                      "value": "auto",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            "property": "backgroundRepeat",
+            "value": {
+              "type": "layers",
+              "value": [
+                {
+                  "type": "keyword",
+                  "value": "repeat",
+                },
+                {
+                  "type": "keyword",
+                  "value": "repeat",
+                },
+              ],
+            },
+          },
+          {
+            "property": "backgroundAttachment",
+            "value": {
+              "type": "layers",
+              "value": [
+                {
+                  "type": "keyword",
+                  "value": "scroll",
+                },
+                {
+                  "type": "keyword",
+                  "value": "scroll",
+                },
+              ],
+            },
+          },
+          {
+            "property": "backgroundOrigin",
+            "value": {
+              "type": "layers",
+              "value": [
+                {
+                  "type": "keyword",
+                  "value": "padding-box",
+                },
+                {
+                  "type": "keyword",
+                  "value": "padding-box",
+                },
+              ],
+            },
+          },
+          {
+            "property": "backgroundClip",
+            "value": {
+              "type": "layers",
+              "value": [
+                {
+                  "type": "keyword",
+                  "value": "border-box",
+                },
+                {
+                  "type": "keyword",
+                  "value": "border-box",
+                },
               ],
             },
           },

--- a/packages/css-data/src/parse-css.ts
+++ b/packages/css-data/src/parse-css.ts
@@ -1,10 +1,8 @@
+import { camelCase } from "change-case";
 import * as csstree from "css-tree";
 import { StyleValue, type StyleProperty } from "@webstudio-is/css-engine";
 import type { EmbedTemplateStyleDecl } from "@webstudio-is/react-sdk";
 import { parseCssValue as parseCssValueLonghand } from "./parse-css-value";
-import * as parsers from "./property-parsers/parsers";
-import * as toLonghand from "./property-parsers/to-longhand";
-import { camelCase } from "change-case";
 import { expandShorthands } from "./shorthands";
 
 /**
@@ -49,48 +47,10 @@ type Selector = string;
 
 export type Styles = Record<Selector, Array<EmbedTemplateStyleDecl>>;
 
-type Longhand = keyof typeof toLonghand;
-
 const parseCssValue = (
   property: string,
   value: string
 ): Map<StyleProperty, StyleValue> => {
-  const unwrap = toLonghand[property as Longhand];
-
-  if (typeof unwrap === "function") {
-    const longhands = unwrap(value);
-
-    return new Map(
-      Object.entries(longhands).map(([property, value]) => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore @todo remove this ignore: property is a `keyof typeof longhands` which is a key in parsers but TS can't infer the link
-        const valueParser = parsers[property];
-
-        if (typeof valueParser === "function") {
-          return [property, valueParser(value)];
-        }
-        if (Array.isArray(value)) {
-          return [
-            property,
-            {
-              type: "invalid",
-              value: value.join(""),
-            },
-          ];
-        }
-
-        if (value === undefined || value === "") {
-          return [property, { type: "invalid", value: "" }];
-        }
-
-        return [
-          property,
-          parseCssValueLonghand(property as StyleProperty, value),
-        ];
-      })
-    ) as Map<StyleProperty, StyleValue>;
-  }
-
   const expanded = new Map(expandShorthands([[property, value]]));
   const final = new Map();
   for (const [property, value] of expanded) {

--- a/packages/css-data/src/property-parsers/background.test.ts
+++ b/packages/css-data/src/property-parsers/background.test.ts
@@ -8,50 +8,51 @@ describe("parseBackground", () => {
       parseBackground(
         "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), none, linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%), radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, #EBFFFC;"
       )
-    ).toMatchInlineSnapshot(`
-{
-  "backgroundColor": {
-    "alpha": 1,
-    "b": 252,
-    "g": 255,
-    "r": 235,
-    "type": "rgb",
-  },
-  "backgroundImage": {
-    "type": "layers",
-    "value": [
-      {
-        "type": "unparsed",
-        "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
+    ).toEqual({
+      backgroundColor: { alpha: 1, b: 252, g: 255, r: 235, type: "rgb" },
+      backgroundImage: {
+        type: "layers",
+        value: [
+          {
+            type: "unparsed",
+            value: "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
+          },
+          {
+            type: "keyword",
+            value: "none",
+          },
+          {
+            type: "unparsed",
+            value:
+              "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
+          },
+          {
+            type: "keyword",
+            value: "none",
+          },
+        ],
       },
-      {
-        "type": "keyword",
-        "value": "none",
-      },
-      {
-        "type": "unparsed",
-        "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
-      },
-      {
-        "type": "unparsed",
-        "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
-      },
-      {
-        "type": "unparsed",
-        "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
-      },
-      {
-        "type": "unparsed",
-        "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
-      },
-      {
-        "type": "unparsed",
-        "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
-      },
-    ],
-  },
-}
-`);
+    });
   });
 
   test("parse background from figma without backgroundColor", () => {
@@ -59,40 +60,43 @@ describe("parseBackground", () => {
       parseBackground(
         "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%), radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */"
       )
-    ).toMatchInlineSnapshot(`
-      {
-        "backgroundColor": undefined,
-        "backgroundImage": {
-          "type": "layers",
-          "value": [
-            {
-              "type": "unparsed",
-              "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
-            },
-            {
-              "type": "unparsed",
-              "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
-            },
-          ],
-        },
-      }
-    `);
+    ).toEqual({
+      backgroundColor: { type: "keyword", value: "transparent" },
+      backgroundImage: {
+        type: "layers",
+        value: [
+          {
+            type: "unparsed",
+            value: "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
+          },
+        ],
+      },
+    });
   });
 
   test("parse background and skips url background", () => {
@@ -100,43 +104,43 @@ describe("parseBackground", () => {
       parseBackground(
         "url(https://hello.world/some-image), linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%), radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */"
       )
-    ).toMatchInlineSnapshot(`
-{
-  "backgroundColor": undefined,
-  "backgroundImage": {
-    "type": "layers",
-    "value": [
-      {
-        "type": "image",
-        "value": {
-          "type": "url",
-          "url": "https://hello.world/some-image",
-        },
+    ).toEqual({
+      backgroundColor: { type: "keyword", value: "transparent" },
+      backgroundImage: {
+        type: "layers",
+        value: [
+          {
+            type: "image",
+            value: { type: "url", url: "https://hello.world/some-image" },
+          },
+          {
+            type: "unparsed",
+            value:
+              "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
+          },
+          {
+            type: "unparsed",
+            value:
+              "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
+          },
+        ],
       },
-      {
-        "type": "unparsed",
-        "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
-      },
-      {
-        "type": "unparsed",
-        "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
-      },
-      {
-        "type": "unparsed",
-        "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
-      },
-      {
-        "type": "unparsed",
-        "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
-      },
-      {
-        "type": "unparsed",
-        "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
-      },
-    ],
-  },
-}
-`);
+    });
   });
 
   test("parse background partially copied background", () => {
@@ -144,20 +148,19 @@ describe("parseBackground", () => {
       parseBackground(
         "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), linear-gradient(180deg, "
       )
-    ).toMatchInlineSnapshot(`
-      {
-        "backgroundColor": undefined,
-        "backgroundImage": {
-          "type": "layers",
-          "value": [
-            {
-              "type": "unparsed",
-              "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
-            },
-          ],
-        },
-      }
-    `);
+    ).toEqual({
+      backgroundColor: { type: "keyword", value: "transparent" },
+      backgroundImage: {
+        type: "layers",
+        value: [
+          {
+            type: "unparsed",
+            value: "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
+          },
+          { type: "keyword", value: "none" },
+        ],
+      },
+    });
   });
 
   test("parse background partially commented", () => {
@@ -165,31 +168,28 @@ describe("parseBackground", () => {
       parseBackground(
         "linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), /* radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%) */"
       )
-    ).toMatchInlineSnapshot(`
-      {
-        "backgroundColor": undefined,
-        "backgroundImage": {
-          "type": "layers",
-          "value": [
-            {
-              "type": "unparsed",
-              "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
-            },
-          ],
-        },
-      }
-    `);
+    ).toEqual({
+      backgroundColor: { type: "keyword", value: "transparent" },
+      backgroundImage: {
+        type: "layers",
+        value: [
+          {
+            type: "unparsed",
+            value:
+              "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
+          },
+        ],
+      },
+    });
   });
 
   test("parse bad background", () => {
-    expect(parseBackground("linear-gradient(180deg,")).toMatchInlineSnapshot(`
-      {
-        "backgroundColor": undefined,
-        "backgroundImage": {
-          "type": "invalid",
-          "value": "linear-gradient(180deg,)",
-        },
-      }
-    `);
+    expect(parseBackground("linear-gradient(180deg,")).toEqual({
+      backgroundColor: { type: "keyword", value: "transparent" },
+      backgroundImage: {
+        type: "layers",
+        value: [{ type: "keyword", value: "none" }],
+      },
+    });
   });
 });

--- a/packages/css-data/src/property-parsers/background.ts
+++ b/packages/css-data/src/property-parsers/background.ts
@@ -6,8 +6,8 @@ import { parseCssValue } from "../parse-css-value";
 export const parseBackground = (
   background: string
 ): {
-  backgroundColor: StyleValue;
-  backgroundImage: StyleValue;
+  backgroundColor?: StyleValue;
+  backgroundImage?: StyleValue;
 } => {
   let tokenStream = background.trim();
 

--- a/packages/css-data/src/property-parsers/background.ts
+++ b/packages/css-data/src/property-parsers/background.ts
@@ -1,52 +1,14 @@
-import * as csstree from "css-tree";
-import type {
-  ImageValue,
-  InvalidValue,
-  KeywordValue,
-  LayersValue,
-  RgbValue,
-  UnparsedValue,
-} from "@webstudio-is/css-engine";
-import { parseCssValue, cssTryParseValue } from "../parse-css-value";
+import type { StyleProperty, StyleValue } from "@webstudio-is/css-engine";
+import { expandShorthands } from "../shorthands";
+import { normalizePropertyName } from "../parse-css";
+import { parseCssValue } from "../parse-css-value";
 
-export const gradientNames = [
-  "conic-gradient",
-  "linear-gradient",
-  "radial-gradient",
-  "repeating-conic-gradient",
-  "repeating-linear-gradient",
-  "repeating-radial-gradient",
-];
-// @todo rewrite to return a Map
 export const parseBackground = (
   background: string
 ): {
-  backgroundImage: LayersValue | InvalidValue;
-  backgroundColor: RgbValue | undefined;
+  backgroundColor: StyleValue;
+  backgroundImage: StyleValue;
 } => {
-  const { backgroundImage, backgroundColor: backgroundColorRaw } =
-    backgroundToLonghand(background);
-
-  const backgroundColor = backgroundColorRaw
-    ? (parseCssValue("backgroundColor", backgroundColorRaw, false) as RgbValue)
-    : undefined;
-
-  return {
-    backgroundImage: parseBackgroundImage(backgroundImage),
-    backgroundColor:
-      backgroundColor && backgroundColor.type === "rgb"
-        ? backgroundColor
-        : undefined,
-  };
-};
-
-export const backgroundToLonghand = (
-  background: string
-): {
-  backgroundImage: string[];
-  backgroundColor: string | undefined;
-} => {
-  const layers: string[] = [];
   let tokenStream = background.trim();
 
   tokenStream = tokenStream.endsWith(";")
@@ -63,111 +25,20 @@ export const backgroundToLonghand = (
       : tokenStream;
   }
 
-  const cssAst = cssTryParseValue(tokenStream);
-
-  if (cssAst === undefined) {
-    return {
-      backgroundImage: [],
-      backgroundColor: undefined,
-    };
-  }
-
-  let backgroundColorRaw: string | undefined;
-
-  let nestingLevel = 0;
-
-  csstree.walk(cssAst, {
-    enter: (node, item, list) => {
-      if (node.type === "Function") {
-        if (gradientNames.includes(node.name)) {
-          layers.push(csstree.generate(node));
-        }
-
-        // If the depth is at level 0 and the next item is null, it's likely that the backgroundColor
-        // is written as rgba(x,y,z,a) or similar format.
-        // nestingLevel is used as a fast way to check existance of parent Function node
-        if (item.next === null && nestingLevel === 0) {
-          backgroundColorRaw = csstree.generate(node);
-        }
-
-        nestingLevel++;
-        return;
-      }
-
-      if (node.type === "Hash" && item.next === null && nestingLevel === 0) {
-        // If the depth is at level 0 and the next item is null, it's likely that the backgroundColor
-        // is written as hex #XYZFGH
-        backgroundColorRaw = csstree.generate(node);
-        return;
-      }
-
-      if (node.type === "Url") {
-        layers.push(csstree.generate(node));
-      }
-
-      if (node.type === "Identifier" && node.name === "none") {
-        layers.push(csstree.generate(node));
-      }
-    },
-    leave: (node, item, list) => {
-      if (node.type === "Function") {
-        nestingLevel--;
-      }
-    },
-  });
-
-  return {
-    backgroundImage: layers,
-    backgroundColor: backgroundColorRaw,
+  return Object.fromEntries(
+    expandShorthands([["background", tokenStream]])
+      .filter(
+        ([property]) =>
+          property === "background-image" || property === "background-color"
+      )
+      .map(([property, value]) => {
+        const normalizedProperty = normalizePropertyName(
+          property
+        ) as StyleProperty;
+        return [normalizedProperty, parseCssValue(normalizedProperty, value)];
+      })
+  ) as {
+    backgroundColor: StyleValue;
+    backgroundImage: StyleValue;
   };
-};
-
-export const parseBackgroundImage = (
-  layers: string[]
-): LayersValue | InvalidValue => {
-  const backgroundImages: (UnparsedValue | ImageValue | KeywordValue)[] = [];
-
-  for (const layer of layers) {
-    if (layer === "none") {
-      backgroundImages.push({
-        type: "keyword",
-        value: "none",
-      });
-      continue;
-    }
-
-    if (
-      gradientNames.some((gradientName) => layer.startsWith(gradientName)) ===
-        false &&
-      layer.startsWith("url(") === false
-    ) {
-      break;
-    }
-
-    if (layer.startsWith("url(")) {
-      backgroundImages.push({
-        type: "image",
-        value: {
-          type: "url",
-          url: layer
-            .replace(/^url\(/, "")
-            .replace(/\)$/, "")
-            .replaceAll(/\\(.)/g, "$1"),
-        },
-      });
-      continue;
-    }
-
-    const layerStyle = parseCssValue("backgroundImage", layer, false);
-
-    if (layerStyle.type !== "unparsed") {
-      break;
-    }
-
-    backgroundImages.push(layerStyle);
-  }
-
-  return backgroundImages.length > 0
-    ? { type: "layers", value: backgroundImages }
-    : { type: "invalid", value: layers.join(",") };
 };

--- a/packages/css-data/src/property-parsers/parsers.ts
+++ b/packages/css-data/src/property-parsers/parsers.ts
@@ -1,5 +1,0 @@
-/*
-  Longhand properties parsers. Each named export should match a property name.
-*/
-export { parseBackgroundImage as backgroundImage } from "./background";
-export { parseShadow } from "./shadows";

--- a/packages/css-data/src/property-parsers/to-longhand.ts
+++ b/packages/css-data/src/property-parsers/to-longhand.ts
@@ -1,4 +1,0 @@
-/*
-  Shorthand properties unwrappers. Each named export should match a property name.
-*/
-export { backgroundToLonghand as background } from "./background";

--- a/packages/css-data/src/shorthands.test.ts
+++ b/packages/css-data/src/shorthands.test.ts
@@ -1112,8 +1112,100 @@ test("expand background-position", () => {
   );
 });
 
+test("expand background", () => {
+  expect(expandShorthands([["background", `none`]])).toEqual([
+    ["background-image", "none"],
+    ["background-position-x", "0%"],
+    ["background-position-y", "0%"],
+    ["background-size", "auto auto"],
+    ["background-repeat", "repeat"],
+    ["background-attachment", "scroll"],
+    ["background-origin", "padding-box"],
+    ["background-clip", "border-box"],
+    ["background-color", "transparent"],
+  ]);
+  expect(expandShorthands([["background", `green`]])).toEqual([
+    ["background-image", "none"],
+    ["background-position-x", "0%"],
+    ["background-position-y", "0%"],
+    ["background-size", "auto auto"],
+    ["background-repeat", "repeat"],
+    ["background-attachment", "scroll"],
+    ["background-origin", "padding-box"],
+    ["background-clip", "border-box"],
+    ["background-color", "green"],
+  ]);
+  expect(expandShorthands([["background", `transparent`]])).toEqual([
+    ["background-image", "none"],
+    ["background-position-x", "0%"],
+    ["background-position-y", "0%"],
+    ["background-size", "auto auto"],
+    ["background-repeat", "repeat"],
+    ["background-attachment", "scroll"],
+    ["background-origin", "padding-box"],
+    ["background-clip", "border-box"],
+    ["background-color", "transparent"],
+  ]);
+  expect(
+    expandShorthands([["background", `url("test.jpg") repeat-y`]])
+  ).toEqual([
+    ["background-image", "url(test.jpg)"],
+    ["background-position-x", "0%"],
+    ["background-position-y", "0%"],
+    ["background-size", "auto auto"],
+    ["background-repeat", "repeat-y"],
+    ["background-attachment", "scroll"],
+    ["background-origin", "padding-box"],
+    ["background-clip", "border-box"],
+    ["background-color", "transparent"],
+  ]);
+  expect(expandShorthands([["background", `border-box red`]])).toEqual([
+    ["background-image", "none"],
+    ["background-position-x", "0%"],
+    ["background-position-y", "0%"],
+    ["background-size", "auto auto"],
+    ["background-repeat", "repeat"],
+    ["background-attachment", "scroll"],
+    ["background-origin", "border-box"],
+    ["background-clip", "border-box"],
+    ["background-color", "red"],
+  ]);
+  expect(
+    expandShorthands([
+      ["background", `no-repeat center/80% url("../img/image.png")`],
+    ])
+  ).toEqual([
+    ["background-image", "url(../img/image.png)"],
+    ["background-position-x", "center"],
+    ["background-position-y", "center"],
+    ["background-size", "80%"],
+    ["background-repeat", "no-repeat"],
+    ["background-attachment", "scroll"],
+    ["background-origin", "padding-box"],
+    ["background-clip", "border-box"],
+    ["background-color", "transparent"],
+  ]);
+  expect(
+    expandShorthands([
+      [
+        "background",
+        `repeat scroll 0% 0% / auto padding-box border-box none transparent`,
+      ],
+    ])
+  ).toEqual([
+    ["background-image", "none"],
+    ["background-position-x", "0%"],
+    ["background-position-y", "0%"],
+    ["background-size", "auto"],
+    ["background-repeat", "repeat"],
+    ["background-attachment", "scroll"],
+    ["background-origin", "padding-box"],
+    ["background-clip", "border-box"],
+    ["background-color", "transparent"],
+  ]);
+});
+
 test.todo("all - can negatively affect build size");
-test.todo("background - not used in webflow");
 // https://developer.mozilla.org/en-US/docs/Web/CSS/animation-range
 test.todo("animation-range");
 // https://developer.mozilla.org/en-US/docs/Web/CSS/view-timeline


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2647

Here added support for background shorthand in css parser. Refactored background image parser and simplified figma paste parser.