### PR TITLE
experimental: parse css wide keywords correctly

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts
@@ -921,8 +921,8 @@ export const styles = {
     {
       property: "all",
       value: {
-        type: "invalid",
-        value: "",
+        type: "keyword",
+        value: "inherit",
       },
     },
   ],

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "prebuild": "which remix",
     "build": "remix vite:build",
-    "build:webflow-presets": "css-to-ws ./app/shared/copy-paste/plugin-webflow/style-presets.css ./app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts",
+    "css-to-ws": "NODE_OPTIONS=--conditions=webstudio css-to-ws",
+    "build:webflow-presets": "pnpm css-to-ws ./app/shared/copy-paste/plugin-webflow/style-presets.css ./app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts",
     "start": "remix-serve build/server/index.js",
     "dev": "remix vite:dev",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",

--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -228,6 +228,29 @@ test("parse background-attachment property as layers", () => {
   });
 });
 
+test("parse repeated value with css wide keywords", () => {
+  expect(parseCssValue("backgroundAttachment", "initial")).toEqual({
+    type: "keyword",
+    value: "initial",
+  });
+  expect(parseCssValue("backgroundAttachment", "INHERIT")).toEqual({
+    type: "keyword",
+    value: "inherit",
+  });
+  expect(parseCssValue("backgroundAttachment", "unset")).toEqual({
+    type: "keyword",
+    value: "unset",
+  });
+  expect(parseCssValue("backgroundAttachment", "revert")).toEqual({
+    type: "keyword",
+    value: "revert",
+  });
+  expect(parseCssValue("backgroundAttachment", "revert-layer")).toEqual({
+    type: "keyword",
+    value: "revert-layer",
+  });
+});
+
 test("parse transition-behavior property as layers", () => {
   expect(parseCssValue("transitionBehavior", `normal`)).toEqual({
     type: "layers",

--- a/packages/css-data/src/parse-css-value.ts
+++ b/packages/css-data/src/parse-css-value.ts
@@ -4,6 +4,7 @@ import type { CssNode } from "css-tree";
 import warnOnce from "warn-once";
 import {
   TupleValue,
+  cssWideKeywords,
   hyphenateProperty,
   type LayerValueItem,
   type StyleProperty,
@@ -112,6 +113,11 @@ export const parseCssValue = (
   input: string,
   topLevel = true
 ): StyleValue => {
+  const potentialKeyword = input.toLowerCase();
+  if (cssWideKeywords.has(potentialKeyword)) {
+    return { type: "keyword", value: potentialKeyword };
+  }
+
   const invalidValue = {
     type: "invalid",
     value: input,

--- a/packages/css-engine/src/core/merger.ts
+++ b/packages/css-engine/src/core/merger.ts
@@ -1,8 +1,7 @@
 import { StyleValue, TupleValue, TupleValueItem } from "../schema";
+import { cssWideKeywords } from "../css";
 import type { StyleMap } from "./rules";
 import { toValue } from "./to-value";
-
-const cssWideKeywords = new Set(["initial", "inherit", "unset", "revert"]);
 
 /**
  * Css wide keywords cannot be used in shorthand parts

--- a/packages/css-engine/src/css.ts
+++ b/packages/css-engine/src/css.ts
@@ -1,0 +1,7 @@
+export const cssWideKeywords = new Set([
+  "initial",
+  "inherit",
+  "unset",
+  "revert",
+  "revert-layer",
+]);

--- a/packages/css-engine/src/index.ts
+++ b/packages/css-engine/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./core/index";
 export * from "./schema";
+export * from "./css";
 
 // necessary for sdk dts generation
 export type {


### PR DESCRIPTION
Here added universal support for css wide keywords. initial, inherit and unset will be parsed the same way for layered properties and singular properties.

It will never be part of layers and always be represented as root keyword.