### PR TITLE
fix: Correct transition timing function for Webflow paste

### DIFF
--- a/packages/css-data/src/property-parsers/transition-property-extractor.ts
+++ b/packages/css-data/src/property-parsers/transition-property-extractor.ts
@@ -8,10 +8,17 @@ import {
 } from "@webstudio-is/css-engine";
 import { isAnimatableProperty } from "..";
 
-export const isTimingFunction = (timing: string) => {
-  const regex =
-    /^(ease(-in-out|-in|-out)?|linear|cubic-bezier\((-?\d+(\.\d+)?(, ?)?){3}-?\d+(\.\d+)?\)|steps\(\d+(,(start|end|jump-start|jump-end|jump-none|jump-both))?\))$/gm;
-  return regex.test(timing);
+export const isTimingFunction = (name: string) => {
+  const allowedNames = [
+    "ease-in",
+    "ease-out",
+    "ease-in-out",
+    "linear",
+    "cubic-bezier",
+    "steps",
+  ];
+
+  return allowedNames.includes(name);
 };
 
 export type ExtractedTransitionProperties = {

--- a/packages/css-data/src/property-parsers/transition.test.ts
+++ b/packages/css-data/src/property-parsers/transition.test.ts
@@ -34,6 +34,105 @@ test("parses an in-valid transitionDuration longhand property", () => {
 `);
 });
 
+test("parses a vaild transitionProeprty longhand property", () => {
+  expect(
+    parseTransitionLonghandProperty("transitionProperty", "opacity, width, all")
+  ).toMatchInlineSnapshot(`
+{
+  "type": "layers",
+  "value": [
+    {
+      "type": "keyword",
+      "value": "opacity",
+    },
+    {
+      "type": "keyword",
+      "value": "width",
+    },
+    {
+      "type": "keyword",
+      "value": "all",
+    },
+  ],
+}
+`);
+});
+
+test("parses only valid transitionProperty longhand property", () => {
+  expect(
+    parseTransitionLonghandProperty("transitionProperty", "opacity, width, foo")
+  ).toMatchInlineSnapshot(`
+{
+  "type": "invalid",
+  "value": "opacity, width, foo",
+}
+`);
+});
+
+test("parses a vaild transitionTimingFunction longhand property with 0 omitted", () => {
+  const parsedValue = parseTransitionLonghandProperty(
+    "transitionTimingFunction",
+    "ease, ease-in, cubic-bezier(.68,-0.6,0.32,1.6), steps(4, jump-start)"
+  );
+  expect(parsedValue).toMatchInlineSnapshot(`
+{
+  "type": "layers",
+  "value": [
+    {
+      "type": "keyword",
+      "value": "ease",
+    },
+    {
+      "type": "keyword",
+      "value": "ease-in",
+    },
+    {
+      "args": {
+        "type": "layers",
+        "value": [
+          {
+            "type": "keyword",
+            "value": ".68",
+          },
+          {
+            "type": "keyword",
+            "value": "-0.6",
+          },
+          {
+            "type": "keyword",
+            "value": "0.32",
+          },
+          {
+            "type": "keyword",
+            "value": "1.6",
+          },
+        ],
+      },
+      "name": "cubic-bezier",
+      "type": "function",
+    },
+    {
+      "args": {
+        "type": "layers",
+        "value": [
+          {
+            "type": "keyword",
+            "value": "4",
+          },
+          {
+            "type": "keyword",
+            "value": "jump-start",
+          },
+        ],
+      },
+      "name": "steps",
+      "type": "function",
+    },
+  ],
+}
+`);
+});
+
 test("parses a vaild transitionTimingFunction longhand property", () => {
   const parsedValue = parseTransitionLonghandProperty(
     "transitionTimingFunction",

--- a/packages/css-data/src/property-parsers/transition.test.ts
+++ b/packages/css-data/src/property-parsers/transition.test.ts
@@ -34,41 +34,6 @@ test("parses an in-valid transitionDuration longhand property", () => {
 `);
 });
 
-test("parses a vaild transitionProeprty longhand property", () => {
-  expect(
-    parseTransitionLonghandProperty("transitionProperty", "opacity, width, all")
-  ).toMatchInlineSnapshot(`
-{
-  "type": "layers",
-  "value": [
-    {
-      "type": "keyword",
-      "value": "opacity",
-    },
-    {
-      "type": "keyword",
-      "value": "width",
-    },
-    {
-      "type": "keyword",
-      "value": "all",
-    },
-  ],
-}
-`);
-});
-
-test("parses only valid transitionProperty longhand property", () => {
-  expect(
-    parseTransitionLonghandProperty("transitionProperty", "opacity, width, foo")
-  ).toMatchInlineSnapshot(`
-{
-  "type": "invalid",
-  "value": "opacity, width, foo",
-}
-`);
-});
-
 test("parses a vaild transitionTimingFunction longhand property with 0 omitted", () => {
   const parsedValue = parseTransitionLonghandProperty(
     "transitionTimingFunction",

--- a/packages/css-data/src/property-parsers/transition.ts
+++ b/packages/css-data/src/property-parsers/transition.ts
@@ -95,17 +95,11 @@ export const parseTransitionLonghandProperty = (
           switch (property) {
             case "transitionTimingFunction": {
               if (child.type === "Identifier") {
-                if (isTimingFunction(csstree.generate(child)) === false) {
-                  throw new Error(
-                    `Invalid timing function, received ${csstree.generate(child)}`
-                  );
-                }
-
                 layers.value.push({ type: "keyword", value: child.name });
               }
 
               if (child.type === "Function") {
-                if (isTimingFunction(csstree.generate(child)) === false) {
+                if (isTimingFunction(child.name) === false) {
                   throw new Error(
                     `Invalid timing function, received ${csstree.generate(child)}`
                   );


### PR DESCRIPTION
## Description

Numbers like `.65` were not parsed as valid.
Also I don't think we need to use regexps to check functions validity. There can be vars calc and anything inside

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
