### PR TITLE
experimental: improve parsing transition-property

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -21,15 +21,17 @@ import {
   Flex,
   ComboboxScrollArea,
 } from "@webstudio-is/design-system";
-import type { KeywordValue } from "@webstudio-is/css-engine";
+import type { KeywordValue, UnparsedValue } from "@webstudio-is/css-engine";
 import { matchSorter } from "match-sorter";
 import { setUnion } from "~/shared/shim";
 
 type AnimatableProperties = (typeof animatableProperties)[number];
 type NameAndLabel = { name: string; label?: string };
 type TransitionPropertyProps = {
-  property: KeywordValue;
-  onPropertySelection: (params: { property: KeywordValue }) => void;
+  property: KeywordValue | UnparsedValue;
+  onPropertySelection: (params: {
+    property: KeywordValue | UnparsedValue;
+  }) => void;
 };
 
 const commonPropertiesSet = new Set(commonTransitionProperties);
@@ -66,7 +68,7 @@ export const TransitionProperty = ({
         return;
       }
       setInputValue(prop.name);
-      onPropertySelection({ property: { type: "keyword", value: prop.name } });
+      onPropertySelection({ property: { type: "unparsed", value: prop.name } });
     },
     onInputChange: (value) => setInputValue(value ?? ""),
     /*

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-utils.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-utils.ts
@@ -1,5 +1,6 @@
 import {
   FunctionValue,
+  UnparsedValue,
   type KeywordValue,
   type LayersValue,
   type StyleProperty,
@@ -21,8 +22,8 @@ import {
 } from "@webstudio-is/css-data";
 import { camelCase } from "change-case";
 
-export const defaultTransitionProperty: KeywordValue = {
-  type: "keyword",
+export const defaultTransitionProperty: UnparsedValue = {
+  type: "unparsed",
   value: "opacity",
 };
 export const defaultTransitionDuration: UnitValue = {
@@ -277,7 +278,7 @@ export const editTransitionLayer = (props: {
   const { index, layers, createBatchUpdate, options, currentStyle } = props;
   const batch = createBatchUpdate();
 
-  const newTransitionProperties: KeywordValue[] = [];
+  const newTransitionProperties: Array<KeywordValue | UnparsedValue> = [];
   const newTransitionDurations: UnitValue[] = [];
   const newTransitionDelays: UnitValue[] = [];
   const newTransitionTimingFunctions: Array<KeywordValue | FunctionValue> = [];
@@ -390,7 +391,11 @@ export const hideTransitionLayer = (props: {
     batch.setProperty(property)({
       type: "layers",
       value: propertyLayer.value.map((layer, i) => {
-        if (layer.type !== "keyword" && layer.type !== "unit") {
+        if (
+          layer.type !== "keyword" &&
+          layer.type !== "unit" &&
+          layer.type !== "unparsed"
+        ) {
           return layer;
         }
 

--- a/apps/builder/app/builder/features/style-panel/style-layers-list.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-layers-list.tsx
@@ -90,6 +90,11 @@ const extractPropertiesFromLayer = (layer: TupleValue | FunctionValue) => {
       shadow.push(item.value);
     }
 
+    if (item.type === "unparsed") {
+      name.push(item.value);
+      shadow.push(item.value);
+    }
+
     if (item.type === "function") {
       const value = `${item.name}(${toValue(item.args)})`;
       name.push(value);

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts
@@ -3313,7 +3313,7 @@ export const styles = {
     {
       property: "transitionProperty",
       value: {
-        type: "invalid",
+        type: "keyword",
         value: "none",
       },
     },
@@ -8798,11 +8798,11 @@ export const styles = {
         type: "layers",
         value: [
           {
-            type: "keyword",
+            type: "unparsed",
             value: "background-color",
           },
           {
-            type: "keyword",
+            type: "unparsed",
             value: "color",
           },
         ],

--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -251,6 +251,31 @@ test("parse repeated value with css wide keywords", () => {
   });
 });
 
+test("parse transition-property property", () => {
+  expect(parseCssValue("transitionProperty", "none")).toEqual({
+    type: "keyword",
+    value: "none",
+  });
+  expect(parseCssValue("transitionProperty", "opacity, width, all")).toEqual({
+    type: "layers",
+    value: [
+      { type: "unparsed", value: "opacity" },
+      { type: "unparsed", value: "width" },
+      { type: "keyword", value: "all" },
+    ],
+  });
+  expect(parseCssValue("transitionProperty", "opacity, none, unknown")).toEqual(
+    {
+      type: "layers",
+      value: [
+        { type: "unparsed", value: "opacity" },
+        { type: "unparsed", value: "none" },
+        { type: "unparsed", value: "unknown" },
+      ],
+    }
+  );
+});
+
 test("parse transition-behavior property as layers", () => {
   expect(parseCssValue("transitionBehavior", `normal`)).toEqual({
     type: "layers",

--- a/packages/css-data/src/parse-css-value.ts
+++ b/packages/css-data/src/parse-css-value.ts
@@ -105,6 +105,7 @@ const repeatedProps = new Set<StyleProperty>([
   "backgroundRepeat",
   "backgroundSize",
   "backgroundImage",
+  "transitionProperty",
   "transitionBehavior",
 ]);
 
@@ -113,9 +114,18 @@ export const parseCssValue = (
   input: string,
   topLevel = true
 ): StyleValue => {
-  const potentialKeyword = input.toLowerCase();
+  const potentialKeyword = input.toLowerCase().trim();
   if (cssWideKeywords.has(potentialKeyword)) {
     return { type: "keyword", value: potentialKeyword };
+  }
+
+  if (property === "transitionProperty" && potentialKeyword === "none") {
+    if (topLevel) {
+      return { type: "keyword", value: potentialKeyword };
+    } else {
+      // none is not valid layer keyword
+      return { type: "unparsed", value: potentialKeyword };
+    }
   }
 
   const invalidValue = {
@@ -151,7 +161,8 @@ export const parseCssValue = (
 
   if (
     isTransitionLongHandProperty(property) &&
-    property !== "transitionBehavior"
+    property !== "transitionBehavior" &&
+    property !== "transitionProperty"
   ) {
     return parseTransitionLonghandProperty(property, input);
   }

--- a/packages/css-data/src/property-parsers/transition-property-extractor.ts
+++ b/packages/css-data/src/property-parsers/transition-property-extractor.ts
@@ -1,6 +1,7 @@
 import {
   FunctionValue,
   toValue,
+  UnparsedValue,
   type KeywordValue,
   type TupleValue,
   type UnitValue,
@@ -14,7 +15,7 @@ export const isTimingFunction = (timing: string) => {
 };
 
 export type ExtractedTransitionProperties = {
-  property?: KeywordValue;
+  property?: KeywordValue | UnparsedValue;
   timing?: KeywordValue | FunctionValue;
   delay?: UnitValue;
   duration?: UnitValue;
@@ -23,14 +24,14 @@ export type ExtractedTransitionProperties = {
 export const extractTransitionProperties = (
   transition: TupleValue
 ): ExtractedTransitionProperties => {
-  let property: KeywordValue | undefined;
+  let property: KeywordValue | UnparsedValue | undefined;
   let timing: KeywordValue | FunctionValue | undefined;
 
   const unitValues: UnitValue[] = [];
 
   for (const item of transition.value) {
     if (
-      item.type === "keyword" &&
+      (item.type === "keyword" || item.type === "unparsed") &&
       isAnimatableProperty(toValue(item)) === true
     ) {
       property = item;

--- a/packages/css-data/src/property-parsers/transition.test.ts
+++ b/packages/css-data/src/property-parsers/transition.test.ts
@@ -34,41 +34,6 @@ test("parses an in-valid transitionDuration longhand property", () => {
 `);
 });
 
-test("parses a vaild transitionProeprty longhand property", () => {
-  expect(
-    parseTransitionLonghandProperty("transitionProperty", "opacity, width, all")
-  ).toMatchInlineSnapshot(`
-{
-  "type": "layers",
-  "value": [
-    {
-      "type": "keyword",
-      "value": "opacity",
-    },
-    {
-      "type": "keyword",
-      "value": "width",
-    },
-    {
-      "type": "keyword",
-      "value": "all",
-    },
-  ],
-}
-`);
-});
-
-test("parses only valid transitionProperty longhand property", () => {
-  expect(
-    parseTransitionLonghandProperty("transitionProperty", "opacity, width, foo")
-  ).toMatchInlineSnapshot(`
-{
-  "type": "invalid",
-  "value": "opacity, width, foo",
-}
-`);
-});
-
 test("parses a vaild transitionTimingFunction longhand property", () => {
   const parsedValue = parseTransitionLonghandProperty(
     "transitionTimingFunction",

--- a/packages/css-data/src/property-parsers/transition.ts
+++ b/packages/css-data/src/property-parsers/transition.ts
@@ -60,7 +60,8 @@ export const isValidTransitionValue = (
   return (
     value.type === "keyword" ||
     value.type === "unit" ||
-    value.type === "function"
+    value.type === "function" ||
+    value.type === "unparsed"
   );
 };
 
@@ -92,19 +93,6 @@ export const parseTransitionLonghandProperty = (
 
         for (const child of children) {
           switch (property) {
-            case "transitionProperty": {
-              if (child.type === "Identifier") {
-                if (isAnimatableProperty(child.name) === false) {
-                  throw new Error(
-                    `Invalid animatable property, received ${csstree.generate(child)}`
-                  );
-                }
-
-                layers.value.push({ type: "keyword", value: child.name });
-              }
-              break;
-            }
-
             case "transitionTimingFunction": {
               if (child.type === "Identifier") {
                 if (isTimingFunction(csstree.generate(child)) === false) {


### PR DESCRIPTION
Fixed parsing "none" in transition-property.
Switched to unparsed as property type to semantically distinct from keyword.