### PR TITLE
experimental: parse unknown properties as unparsed value

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/__generated__/style-presets.ts
@@ -12017,21 +12017,21 @@ export const styles = {
     {
       property: "animationTimeline",
       value: {
-        type: "invalid",
-        value: "",
+        type: "unparsed",
+        value: "auto",
       },
     },
     {
       property: "animationRangeStart",
       value: {
-        type: "invalid",
+        type: "unparsed",
         value: "normal",
       },
     },
     {
       property: "animationRangeEnd",
       value: {
-        type: "invalid",
+        type: "unparsed",
         value: "normal",
       },
     },

--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "@jest/globals";
 import { parseCssValue } from "./parse-css-value";
+import type { StyleProperty } from "@webstudio-is/css-engine";
 
 describe("Parse CSS value", () => {
   describe("number value", () => {
@@ -294,4 +295,23 @@ test("parse transition-behavior property as layers", () => {
     type: "invalid",
     value: "normal, invalid",
   });
+});
+
+test("parse unknown properties as unparsed", () => {
+  expect(parseCssValue("animationTimeline" as StyleProperty, "auto")).toEqual({
+    type: "unparsed",
+    value: "auto",
+  });
+  expect(
+    parseCssValue("animationRangeStart" as StyleProperty, "normal")
+  ).toEqual({
+    type: "unparsed",
+    value: "normal",
+  });
+  expect(parseCssValue("animationRangeEnd" as StyleProperty, "normal")).toEqual(
+    {
+      type: "unparsed",
+      value: "normal",
+    }
+  );
 });

--- a/packages/css-data/src/parse-css-value.ts
+++ b/packages/css-data/src/parse-css-value.ts
@@ -92,6 +92,11 @@ export const isValidDeclaration = (
 
   const matchResult = csstree.lexer.matchProperty(cssPropertyName, ast);
 
+  // allow to parse unknown properties as unparsed
+  if (matchResult.error?.message.includes("Unknown property")) {
+    return true;
+  }
+
   return matchResult.matched != null;
 };
 
@@ -239,8 +244,8 @@ export const parseCssValue = (
       const values = keywordValues[property as keyof typeof keywordValues];
       if (values === undefined) {
         return {
-          type: "invalid",
-          value: "",
+          type: "unparsed",
+          value: input,
         };
       }
       const lettersRegex = /[^a-zA-Z]+/g;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/2647

Here improved our value parser to not output invalid type every now and then and just represent unknown properties as unparsed. This will let us parse it in the future without loosing anything on paste.