### PR TITLE
refactor: move redirect into template

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/[hello]._index.ts
+++ b/fixtures/webstudio-custom-template/app/__generated__/[hello]._index.ts
@@ -1,0 +1,2 @@
+export const url = "/world";
+export const status = 301;

--- a/packages/cli/templates/defaults/app/route-templates/redirect.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/redirect.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "@remix-run/server-runtime";
-import { url, status } from "../__generated__/[hello]._index";
+import { url, status } from "__REDIRECT__";
 
 export const loader = () => {
   return redirect(url, status);

--- a/packages/react-sdk/placeholder.d.ts
+++ b/packages/react-sdk/placeholder.d.ts
@@ -48,3 +48,8 @@ declare module "__SITEMAP__" {
     lastModified: string;
   }>;
 }
+
+declare module "__REDIRECT__" {
+  export const url: string;
+  export const status: number;
+}


### PR DESCRIPTION
Here decoupled redirect generation from cli.
Moved remix related code to template and
generated only module with url and status.