### PR TITLE
fix:  dropdown menu position on list ittems (variables list)

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -194,12 +194,14 @@ const VariablesItem = ({
       ? variable.name
       : `${variable.name}: ${formatValuePreview(value)}`;
   const [inspectDialogOpen, setInspectDialogOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   return (
     <VariablePopoverTrigger key={variable.id} variable={variable}>
       <CssValueListItem
         id={variable.id}
         index={index}
         label={<Label truncate>{label}</Label>}
+        state={isMenuOpen ? "open" : undefined}
         buttons={
           <>
             <ValuePreviewDialog
@@ -210,7 +212,7 @@ const VariablesItem = ({
             >
               {undefined}
             </ValuePreviewDialog>
-            <DropdownMenu modal>
+            <DropdownMenu modal onOpenChange={setIsMenuOpen}>
               <DropdownMenuTrigger asChild>
                 {/* a11y is completely broken here
                   focus is not restored to button invoker

--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -201,7 +201,7 @@ const VariablesItem = ({
         id={variable.id}
         index={index}
         label={<Label truncate>{label}</Label>}
-        state={isMenuOpen ? "open" : undefined}
+        data-state={isMenuOpen ? "open" : undefined}
         buttons={
           <>
             <ValuePreviewDialog

--- a/packages/design-system/src/components/css-value-list-item.stories.tsx
+++ b/packages/design-system/src/components/css-value-list-item.stories.tsx
@@ -34,8 +34,6 @@ export default {
   title: "Library/CSS Value List Item",
 };
 
-const listItemAttributes = { [__testing__.listItemAttribute]: true };
-
 const Thumbnail = styled("div", {
   width: theme.spacing[10],
   height: theme.spacing[10],
@@ -89,7 +87,7 @@ const ListItem = (props: {
           />
         </>
       }
-      {...listItemAttributes}
+      {...__testing__.listItemAttributes}
     />
   );
 };

--- a/packages/design-system/src/components/css-value-list-item.stories.tsx
+++ b/packages/design-system/src/components/css-value-list-item.stories.tsx
@@ -3,6 +3,7 @@ import { css, styled, theme } from "../stitches.config";
 import {
   CssValueListArrowFocus,
   CssValueListItem,
+  __testing__,
 } from "./css-value-list-item";
 import { Label, labelColors } from "./label";
 import { SmallToggleButton } from "./small-toggle-button";
@@ -33,9 +34,7 @@ export default {
   title: "Library/CSS Value List Item",
 };
 
-const LIST_ITEM_ATTRIBUTE = "data-list-item";
-
-const listItemAttributes = { [LIST_ITEM_ATTRIBUTE]: true };
+const listItemAttributes = { [__testing__.listItemAttribute]: true };
 
 const Thumbnail = styled("div", {
   width: theme.spacing[10],

--- a/packages/design-system/src/components/css-value-list-item.tsx
+++ b/packages/design-system/src/components/css-value-list-item.tsx
@@ -2,8 +2,6 @@ import {
   type ComponentProps,
   type Ref,
   forwardRef,
-  Children,
-  useMemo,
   type ReactNode,
 } from "react";
 import { styled } from "../stitches.config";
@@ -13,8 +11,8 @@ import { theme } from "../stitches.config";
 import { DragHandleIcon } from "@webstudio-is/icons";
 import { ArrowFocus } from "./primitives/arrow-focus";
 
-const LIST_ITEM_ATTRIBUTE = "data-list-item";
-const listItemAttributes = { [LIST_ITEM_ATTRIBUTE]: true };
+const listItemAttribute = "data-list-item";
+const listItemAttributes = { [listItemAttribute]: true };
 
 const DragHandleIconStyled = styled(DragHandleIcon, {
   visibility: "hidden",
@@ -67,7 +65,7 @@ const ItemButton = styled("button", {
       visibility: "visible",
     },
 
-    "&:after": {
+    "&::after": {
       borderRadius: theme.borderRadius[3],
       outline: `2px solid ${theme.colors.borderFocus}`,
       outlineOffset: "-2px",
@@ -209,7 +207,7 @@ export const CssValueListArrowFocus = ({
             if (event.key === "ArrowUp" || event.key === "ArrowDown") {
               handleKeyDown(event, {
                 accept: (element) =>
-                  element.getAttribute(LIST_ITEM_ATTRIBUTE) === "true",
+                  element.getAttribute(listItemAttribute) === "true",
               });
             }
           }}

--- a/packages/design-system/src/components/css-value-list-item.tsx
+++ b/packages/design-system/src/components/css-value-list-item.tsx
@@ -215,3 +215,7 @@ export const CssValueListArrowFocus = ({
     />
   );
 };
+
+export const __testing__ = {
+  listItemAttribute,
+};

--- a/packages/design-system/src/components/css-value-list-item.tsx
+++ b/packages/design-system/src/components/css-value-list-item.tsx
@@ -217,5 +217,5 @@ export const CssValueListArrowFocus = ({
 };
 
 export const __testing__ = {
-  listItemAttribute,
+  listItemAttributes,
 };

--- a/packages/design-system/src/components/css-value-list-item.tsx
+++ b/packages/design-system/src/components/css-value-list-item.tsx
@@ -40,12 +40,7 @@ const IconButtonsWrapper = styled(Flex, {
   top: 0,
   bottom: 0,
   paddingRight: sharedPaddingRight,
-  display: "none",
-});
-
-const FakeIconButtonsWrapper = styled(Flex, {
-  paddingLeft: theme.spacing[5],
-  display: "none",
+  visibility: "hidden",
 });
 
 /**
@@ -68,11 +63,8 @@ const ItemButton = styled("button", {
   position: "relative",
 
   "&:focus-visible, &[data-focused=true], &[data-state=open]": {
-    [`& ${FakeIconButtonsWrapper}`]: {
-      display: "flex",
-    },
     [`~ ${IconButtonsWrapper}`]: {
-      display: "flex",
+      visibility: "visible",
     },
 
     "&:after": {
@@ -127,17 +119,9 @@ const ItemWrapper = styled("div", {
       },
     },
     [`& ${IconButtonsWrapper}`]: {
-      display: "flex",
-    },
-    [`& ${FakeIconButtonsWrapper}`]: {
-      display: "flex",
+      display: "block",
     },
   },
-});
-
-const FakeSmallButton = styled("div", {
-  width: theme.spacing[9],
-  height: theme.spacing[9],
 });
 
 export const CssValueListItem = forwardRef(
@@ -158,18 +142,6 @@ export const CssValueListItem = forwardRef(
     }: Props,
     ref: Ref<HTMLButtonElement>
   ) => {
-    const buttonsCount = Children.count(buttons?.props.children);
-    const fakeButtons = useMemo(
-      () => (
-        <>
-          {Array.from(new Array(buttonsCount), (_v, index) => (
-            <FakeSmallButton key={index} />
-          ))}
-        </>
-      ),
-      [buttonsCount]
-    );
-
     return (
       <ArrowFocus
         render={({ handleKeyDown }) => (
@@ -202,20 +174,8 @@ export const CssValueListItem = forwardRef(
               </Flex>
 
               <Flex grow={true} />
-
-              {/*
-            We place fake divs with same dimensions as small buttons here to avoid following warning:
-            Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>
-            Real buttons will be placed on top of fake buttons
-          */}
-              <FakeIconButtonsWrapper shrink={false} gap={2}>
-                {fakeButtons}
-              </FakeIconButtonsWrapper>
             </ItemButton>
 
-            {/*
-          Real buttons are placed above ItemButton to avoid <button> cannot appear as a descendant of <button> warning
-        */}
             <IconButtonsWrapper gap={2} align="center">
               {buttons}
             </IconButtonsWrapper>

--- a/packages/design-system/src/components/css-value-list-item.tsx
+++ b/packages/design-system/src/components/css-value-list-item.tsx
@@ -116,9 +116,6 @@ const ItemWrapper = styled("div", {
         visibility: "visible",
       },
     },
-    [`& ${IconButtonsWrapper}`]: {
-      display: "block",
-    },
   },
 });
 


### PR DESCRIPTION
closes https://github.com/webstudio-is/webstudio/issues/3668

Ensure trigger stays open when menu is opened, otherwise radix will loose anchor for positioning

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. hover variable item in the settings
2. click inspect
3. see menu position is correct

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
