### PR TITLE
fix: Set initial canvas width once selected breakpoint is known

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
@@ -38,7 +38,7 @@ import {
   minCanvasWidth,
 } from "~/shared/breakpoints";
 import { $scale } from "~/builder/shared/nano-states";
-import { setInitialCanvasWidth } from "./use-set-initial-canvas-width";
+import { setCanvasWidth } from "./use-set-initial-canvas-width";
 import { serverSyncStore } from "~/shared/sync";
 
 export const BreakpointsPopover = () => {
@@ -76,7 +76,7 @@ export const BreakpointsPopover = () => {
       const base =
         breakpointsArray.find(isBaseBreakpoint) ?? breakpointsArray[0];
       $selectedBreakpointId.set(base.id);
-      setInitialCanvasWidth(base.id);
+      setCanvasWidth(base.id);
     }
     setBreakpointToDelete(undefined);
     $breakpointsMenuView.set("editor");
@@ -147,7 +147,7 @@ export const BreakpointsPopover = () => {
                           asChild
                           onSelect={() => {
                             $selectedBreakpointId.set(breakpoint.id);
-                            setInitialCanvasWidth(breakpoint.id);
+                            setCanvasWidth(breakpoint.id);
                           }}
                           index={index}
                           key={breakpoint.id}

--- a/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
@@ -17,7 +17,7 @@ import {
   $selectedBreakpointId,
 } from "~/shared/nano-states";
 import { groupBreakpoints, isBaseBreakpoint } from "~/shared/breakpoints";
-import { setInitialCanvasWidth } from "./use-set-initial-canvas-width";
+import { setCanvasWidth } from "./use-set-initial-canvas-width";
 import { $canvasWidth } from "~/builder/shared/nano-states";
 import { useDebouncedCallback } from "use-debounce";
 
@@ -149,7 +149,7 @@ export const BreakpointsSelector = ({
             return;
           }
           $selectedBreakpointId.set(breakpointId);
-          setInitialCanvasWidth(breakpointId);
+          setCanvasWidth(breakpointId);
         }}
         css={{ position: "relative" }}
       >

--- a/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
@@ -8,12 +8,11 @@ import {
 } from "~/shared/nano-states";
 import { calcCanvasWidth } from "./calc-canvas-width";
 
-// Fixes initial canvas width jump on wide screens.
-// Calculate canvas width during SSR based on known initial width for wide screens.
-export const setInitialCanvasWidth = (breakpointId: Breakpoint["id"]) => {
+export const setCanvasWidth = (breakpointId: Breakpoint["id"]) => {
   const workspaceRect = $workspaceRect.get();
   const breakpoints = $breakpoints.get();
   const selectedBreakpoint = breakpoints.get(breakpointId);
+
   if (workspaceRect === undefined || selectedBreakpoint === undefined) {
     return false;
   }
@@ -34,45 +33,38 @@ export const setInitialCanvasWidth = (breakpointId: Breakpoint["id"]) => {
 export const useSetCanvasWidth = () => {
   useEffect(() => {
     const update = () => {
-      const breakpoints = $breakpoints.get();
-      const workspaceRect = $workspaceRect.get();
-      if (workspaceRect === undefined || breakpoints.size === 0) {
-        return;
-      }
       const selectedBreakpoint = $selectedBreakpoint.get();
-
-      // When there is selected breakpoint, we want to find the smallest possible size
-      // that is bigger than any max-width breakpoints and smaller than any min-width breakpoints.
-      // When on base breakpoint it will be the biggest possible but smaller than the workspace.
       if (selectedBreakpoint) {
-        const canvasWidth = $canvasWidth.get();
-        const nextWidth = calcCanvasWidth({
-          breakpoints: Array.from(breakpoints.values()),
-          selectedBreakpoint,
-          workspaceWidth: workspaceRect.width,
-          canvasWidth,
-        });
-        $canvasWidth.set(nextWidth);
+        // When there is selected breakpoint, we want to find the smallest possible size
+        // that is bigger than any max-width breakpoints and smaller than any min-width breakpoints.
+        // When on base breakpoint it will be the biggest possible but smaller than the workspace.
+        setCanvasWidth(selectedBreakpoint.id);
       }
     };
 
-    const unsubscribeBreakpointStore = $breakpoints.subscribe(update);
-    const unsubscribeRectStore = $workspaceRect.listen((workspaceRect) => {
-      if (workspaceRect === undefined) {
-        return;
-      }
-      update();
-    });
+    const unsubscribeBreakpoints = $breakpoints.subscribe(update);
+    const unsubscribeRect = $workspaceRect.listen(update);
     const unsubscribeIsPreviewMode = $isPreviewMode.listen((isPreviewMode) => {
       if (isPreviewMode) {
         update();
       }
     });
+    const unsubscribeSelectedBreakpoint = $selectedBreakpoint.subscribe(
+      (selectedBreakpoint) => {
+        // This will set initial width of the canvas once the initial selected breakpoint is known.
+        if (selectedBreakpoint) {
+          update();
+          // We can unsubscribe right away as we only need this once.
+          unsubscribeSelectedBreakpoint();
+        }
+      }
+    );
 
     return () => {
-      unsubscribeBreakpointStore();
-      unsubscribeRectStore();
+      unsubscribeBreakpoints();
+      unsubscribeRect();
       unsubscribeIsPreviewMode();
+      unsubscribeSelectedBreakpoint();
     };
   }, []);
 };

--- a/apps/builder/app/shared/breakpoints/select-breakpoint-by-order.ts
+++ b/apps/builder/app/shared/breakpoints/select-breakpoint-by-order.ts
@@ -1,6 +1,6 @@
 import { groupBreakpoints } from "./group-breakpoints";
 import { $selectedBreakpointId, $breakpoints } from "../nano-states";
-import { setInitialCanvasWidth } from "~/builder/features/breakpoints";
+import { setCanvasWidth } from "~/builder/features/breakpoints";
 
 /**
  * Order number starts with 1 and covers all existing breakpoints
@@ -13,6 +13,6 @@ export const selectBreakpointByOrder = (orderNumber: number) => {
   );
   if (breakpoint) {
     $selectedBreakpointId.set(breakpoint.id);
-    setInitialCanvasWidth(breakpoint.id);
+    setCanvasWidth(breakpoint.id);
   }
 };


### PR DESCRIPTION
Close https://github.com/webstudio-is/webstudio/issues/3682

## Description

1. on initial load resize handes were not visible because initial width was not set

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
