### PR TITLE
experimental: Relax asset schema for wf data

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-webflow/schema.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/schema.ts
@@ -292,15 +292,15 @@ const WfErrorAssetVariant = z.object({
   origFileName: z.string(),
   fileName: z.string(),
   format: z.string(),
-  size: z.number(),
-  width: z.number(),
-  quality: z.number(),
+  size: z.number().optional(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  quality: z.number().optional(),
   error: z.string(),
   _id: z.string(),
 });
 
 const WfAssetVariant = z.object({
-  _id: z.string(),
   origFileName: z.string(),
   fileName: z.string(),
   format: z.string(),
@@ -315,8 +315,8 @@ const WfAssetVariant = z.object({
 const WfAsset = z.object({
   cdnUrl: z.string().url(),
   siteId: z.string(),
-  width: z.number(),
-  height: z.number(),
+  width: z.number().optional(),
+  height: z.number().optional(),
   fileName: z.string(),
   createdOn: z.string(),
   origFileName: z.string(),

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/schema.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/schema.ts
@@ -300,13 +300,14 @@ const WfErrorAssetVariant = z.object({
 });
 
 const WfAssetVariant = z.object({
+  _id: z.string(),
   origFileName: z.string(),
   fileName: z.string(),
   format: z.string(),
-  size: z.number(),
-  width: z.number(),
+  size: z.number().optional(),
+  width: z.number().optional(),
   height: z.number().optional(),
-  quality: z.number(),
+  quality: z.number().optional(),
   cdnUrl: z.string().url(),
   s3Url: z.string().url(),
 });


### PR DESCRIPTION
## Description

That schema is currently too string, and throws an error

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
