### PR TITLE
fix: Fix nsubscribe logic when entering builder second time

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
@@ -49,7 +49,7 @@ export const useSetCanvasWidth = () => {
         update();
       }
     });
-    const unsubscribeSelectedBreakpoint = $selectedBreakpoint.subscribe(
+    const unsubscribeSelectedBreakpoint = $selectedBreakpoint.listen(
       (selectedBreakpoint) => {
         // This will set initial width of the canvas once the initial selected breakpoint is known.
         if (selectedBreakpoint) {


### PR DESCRIPTION
## Description

Canvas crash.

When store.subscribe callback can be called sync and unsubscribe function isn't yet defined, it will crash

## Steps for reproduction

1. open project
2. go back to dashboard
3. open project again
4. should not crash

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
