### PR TITLE
experimental: Only add a breakpoint when there are styles on that breakpoint

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -72,7 +72,7 @@ const toCss = (fragment: WebstudioFragment) => {
   }
   const ruleByStyleSourceId = new Map<string, NestingRule>();
   for (const styleDecl of fragment.styleSources) {
-    const name = styleDecl.type === "token" ? styleDecl.name : "Local";
+    const name = "name" in styleDecl ? styleDecl.name : "Local";
     const rule = sheet.addNestingRule(name);
     ruleByStyleSourceId.set(styleDecl.id, rule);
   }
@@ -2798,10 +2798,7 @@ describe("Styles", () => {
                   "background-color: hsla(150, 100.00%, 50.00%, 1.00);",
               },
               xl: {
-                styleLess: "background-color: hsla(69, 100.00%, 50.00%, 1.00);",
-              },
-              xxl: {
-                styleLess: "background-color: hsla(14, 100.00%, 50.00%, 1.00);",
+                styleLess: "",
               },
               medium: {
                 styleLess:
@@ -2821,6 +2818,14 @@ describe("Styles", () => {
         assets: [],
       },
     });
+
+    expect(fragment.breakpoints).toEqual([
+      { id: expect.any(String), label: "base" },
+      { id: expect.any(String), label: "large", minWidth: 1280 },
+      { id: expect.any(String), label: "medium", maxWidth: 991 },
+      { id: expect.any(String), label: "small", maxWidth: 767 },
+      { id: expect.any(String), label: "tiny", maxWidth: 479 },
+    ]);
 
     expect(toCss(fragment)).toMatchInlineSnapshot(`
       "@media all {
@@ -2846,16 +2851,6 @@ describe("Styles", () => {
       @media all and (min-width: 1280px) {
         Div Block 2 {
           background-color: rgba(0, 255, 128, 1)
-        }
-      }
-      @media all and (min-width: 1440px) {
-        Div Block 2 {
-          background-color: rgba(217, 255, 0, 1)
-        }
-      }
-      @media all and (min-width: 1920px) {
-        Div Block 2 {
-          background-color: rgba(255, 60, 0, 1)
         }
       }"
     `);

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -72,7 +72,7 @@ const toCss = (fragment: WebstudioFragment) => {
   }
   const ruleByStyleSourceId = new Map<string, NestingRule>();
   for (const styleDecl of fragment.styleSources) {
-    const name = "name" in styleDecl ? styleDecl.name : "Local";
+    const name = styleDecl.type === "token" ? styleDecl.name : "Local";
     const rule = sheet.addNestingRule(name);
     ruleByStyleSourceId.set(styleDecl.id, rule);
   }


### PR DESCRIPTION
## Description

Instead of adding all wf breakpoints at once, we now will add them incrementally if there are styles on a particular breakpoint

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
