### PR TITLE
refactor: allow any style value to be hidden

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-layer-utils.test.ts
+++ b/apps/builder/app/builder/features/style-panel/style-layer-utils.test.ts
@@ -203,7 +203,7 @@ describe("boxShadowUtils", () => {
     expect(published).toBe(true);
     expect(boxShadowValue).toBeDefined();
     expect(deletedProperties.has("boxShadow")).toBe(false);
-    expect((boxShadowValue.value[0] as TupleValue).hidden).toBe(true);
+    expect(boxShadowValue.value[0].hidden).toBe(true);
   });
 
   test("adds layer to box-shadow proeprty", () => {

--- a/apps/builder/app/builder/features/style-panel/style-layers-list.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-layers-list.tsx
@@ -171,10 +171,7 @@ export const LayersList = (props: LayerListProps) => {
                 active={dragItemId === id}
                 index={index}
                 label={<Label truncate>{properties.name}</Label>}
-                hidden={
-                  (layer.type === "tuple" || layer.type === "function") &&
-                  layer?.hidden
-                }
+                hidden={layer.hidden}
                 thumbnail={
                   property === "textShadow" || property === "boxShadow" ? (
                     <ColorThumb color={properties.color} />
@@ -185,12 +182,12 @@ export const LayersList = (props: LayerListProps) => {
                     {layer.type === "tuple" || layer.type === "function" ? (
                       <SmallToggleButton
                         variant="normal"
-                        pressed={layer?.hidden}
+                        pressed={layer.hidden}
                         disabled={false}
                         tabIndex={-1}
                         onPressedChange={() => handleHideLayer(index)}
                         icon={
-                          layer?.hidden ? (
+                          layer.hidden ? (
                             <EyeconClosedIcon />
                           ) : (
                             <EyeconOpenIcon />
@@ -201,10 +198,7 @@ export const LayersList = (props: LayerListProps) => {
                     <SmallIconButton
                       variant="destructive"
                       tabIndex={-1}
-                      disabled={
-                        (layer.type === "tuple" || layer.type === "function") &&
-                        layer.hidden
-                      }
+                      disabled={layer.hidden}
                       icon={<SubtractIcon />}
                       onClick={() => handleDeleteLayer(index)}
                     />

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -96,20 +96,17 @@ export const toValue = (
 
   if (value.type === "layers") {
     const valueString = value.value
-      .filter(
-        (layer) =>
-          "hidden" in layer === false ||
-          ("hidden" in layer && layer.hidden === false)
-      )
-      .map((layer) => {
-        return toValue(layer, transformValue);
-      })
+      .filter((layer) => layer.hidden !== true)
+      .map((layer) => toValue(layer, transformValue))
       .join(", ");
     return valueString === "" ? "none" : valueString;
   }
 
   if (value.type === "tuple") {
-    return value.value.map((value) => toValue(value, transformValue)).join(" ");
+    return value.value
+      .filter((value) => value.hidden !== true)
+      .map((value) => toValue(value, transformValue))
+      .join(" ");
   }
 
   if (value.type === "function") {

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -44,6 +44,7 @@ export type UnparsedValue = z.infer<typeof UnparsedValue>;
 const FontFamilyValue = z.object({
   type: z.literal("fontFamily"),
   value: z.array(z.string()),
+  hidden: z.boolean().optional(),
 });
 export type FontFamilyValue = z.infer<typeof FontFamilyValue>;
 
@@ -53,6 +54,7 @@ const RgbValue = z.object({
   g: z.number(),
   b: z.number(),
   alpha: z.number(),
+  hidden: z.boolean().optional(),
 });
 export type RgbValue = z.infer<typeof RgbValue>;
 
@@ -88,6 +90,7 @@ export type ImageValue = z.infer<typeof ImageValue>;
 // https://www.w3.org/TR/css-variables-1/#guaranteed-invalid
 export const GuaranteedInvalidValue = z.object({
   type: z.literal("guaranteedInvalid"),
+  hidden: z.boolean().optional(),
 });
 export type GuaranteedInvalidValue = z.infer<typeof GuaranteedInvalidValue>;
 
@@ -96,12 +99,14 @@ export type GuaranteedInvalidValue = z.infer<typeof GuaranteedInvalidValue>;
 export const InvalidValue = z.object({
   type: z.literal("invalid"),
   value: z.string(),
+  hidden: z.boolean().optional(),
 });
 export type InvalidValue = z.infer<typeof InvalidValue>;
 
 const UnsetValue = z.object({
   type: z.literal("unset"),
   value: z.literal(""),
+  hidden: z.boolean().optional(),
 });
 export type UnsetValue = z.infer<typeof UnsetValue>;
 
@@ -139,6 +144,7 @@ export type LayerValueItem = z.infer<typeof LayerValueItem>;
 export const LayersValue = z.object({
   type: z.literal("layers"),
   value: z.array(LayerValueItem),
+  hidden: z.boolean().optional(),
 });
 
 export type LayersValue = z.infer<typeof LayersValue>;
@@ -186,6 +192,7 @@ const VarValue = z.object({
   type: z.literal("var"),
   value: z.string(),
   fallbacks: z.array(ValidStaticStyleValue),
+  hidden: z.boolean().optional(),
 });
 export type VarValue = z.infer<typeof VarValue>;
 


### PR DESCRIPTION
This simplifies maintaining style values.
No more checked for hidden possibility. Just check the flag for true.