### PR TITLE
experimental: support webflow custom properties

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -3016,4 +3016,50 @@ describe("Styles", () => {
       }"
   `);
   });
+
+  test("@raw webflow custom properties", async () => {
+    const input = WfData.parse({
+      type: "@webflow/XscpData",
+      payload: {
+        nodes: [
+          {
+            _id: "89ed49d8-2d32-5bab-22e1-264acb8d2d84",
+            type: "Block",
+            tag: "div",
+            classes: ["393ac121-a395-7678-e598-994e30fb7880"],
+            children: [],
+            data: { text: false, tag: "div" },
+          },
+        ],
+        styles: [
+          {
+            _id: "393ac121-a395-7678-e598-994e30fb7880",
+            fake: false,
+            type: "class",
+            name: "Div Block",
+            namespace: "",
+            comb: "",
+            styleLess: "color: @raw<|black|>; background-color: @raw<|red|>;",
+            variants: {},
+            children: [],
+            createdBy: "635e72dd77408d16b581b4bc",
+            origin: null,
+            selector: null,
+          },
+        ],
+        assets: [],
+      },
+    });
+
+    const fragment = await toWebstudioFragment(input);
+
+    expect(toCss(fragment)).toMatchInlineSnapshot(`
+"@media all {
+  Div Block {
+    color: black;
+    background-color: red
+  }
+}"
+`);
+  });
 });

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
@@ -113,7 +113,8 @@ const toParsedVariants = (variants: UnparsedVariants) => {
     const { breakpointName, state } = parseVariantName(variant);
     if (typeof styles === "string") {
       try {
-        const parsed = parseCss(`.styles${state} {${styles}}`) ?? [];
+        const sanitizedStyles = styles.replaceAll(/@raw<\|([^@]+)\|>/g, "$1");
+        const parsed = parseCss(`.styles${state} {${sanitizedStyles}}`) ?? [];
         const allBreakpointStyles = parsedVariants.get(breakpointName) ?? [];
         allBreakpointStyles.push(...parsed);
         parsedVariants.set(breakpointName, allBreakpointStyles);


### PR DESCRIPTION
Webflow wraps its custom properties (which are not actually custom properties) with `@raw<|value|>` which our parser just skips because unable to parse.

Here simply stripped with regex all such wrappers.