### PR TITLE
refactor: split css literal parser

### DIFF
--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -307,10 +307,10 @@ test("parse transition-timing-function property", () => {
         args: {
           type: "layers",
           value: [
-            { type: "keyword", value: "0.68" },
-            { type: "keyword", value: "-0.6" },
-            { type: "keyword", value: ".32" },
-            { type: "keyword", value: "1.6" },
+            { type: "unit", value: 0.68, unit: "number" },
+            { type: "unit", value: -0.6, unit: "number" },
+            { type: "unit", value: 0.32, unit: "number" },
+            { type: "unit", value: 1.6, unit: "number" },
           ],
         },
       },
@@ -320,7 +320,7 @@ test("parse transition-timing-function property", () => {
         args: {
           type: "layers",
           value: [
-            { type: "keyword", value: "4" },
+            { type: "unit", value: 4, unit: "number" },
             { type: "keyword", value: "jump-start" },
           ],
         },
@@ -328,7 +328,7 @@ test("parse transition-timing-function property", () => {
     ],
   });
   expect(toValue(parsedValue)).toMatchInlineSnapshot(
-    `"ease, ease-in, cubic-bezier(0.68, -0.6, .32, 1.6), steps(4, jump-start)"`
+    `"ease, ease-in, cubic-bezier(0.68, -0.6, 0.32, 1.6), steps(4, jump-start)"`
   );
   expect(parseCssValue("transitionTimingFunction", "ease, testing")).toEqual({
     type: "invalid",

--- a/packages/css-data/src/tailwind-parser/parse.test.ts
+++ b/packages/css-data/src/tailwind-parser/parse.test.ts
@@ -49,7 +49,7 @@ describe("parseTailwindToWebstudio", () => {
       },
       {
         property: "textDecorationColor",
-        value: { type: "keyword", value: "currentColor" },
+        value: { type: "keyword", value: "currentcolor" },
       },
     ]);
   });

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -114,6 +114,7 @@ export const TupleValueItem = z.union([
   UnitValue,
   KeywordValue,
   UnparsedValue,
+  ImageValue,
   RgbValue,
   FunctionValue,
 ]);
@@ -133,6 +134,7 @@ const LayerValueItem = z.union([
   UnparsedValue,
   ImageValue,
   TupleValue,
+  RgbValue,
   InvalidValue,
   FunctionValue,
 ]);


### PR DESCRIPTION
Here refactored value parser with literal parser
which can be reused in all functions, tuples and layers.

Color parser now relies on specific ast types.

Tuples are generated for all values with multiple nodes.

This all will let us build more universal parsers with less effort.