### PR TITLE
experimental: optionally support parsing custom properties

### DIFF
--- a/apps/builder/app/shared/style-object-model.ts
+++ b/apps/builder/app/shared/style-object-model.ts
@@ -336,7 +336,7 @@ export const getComputedStyleDecl = ({
     computedValue = specifiedValue;
 
     if (computedValue.type === "var") {
-      const customProperty = computedValue.value;
+      const customProperty = `--${computedValue.value}`;
       // https://www.w3.org/TR/css-variables-1/#cycles
       if (usedCustomProperties.has(customProperty)) {
         computedValue = invalidValue;

--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -582,3 +582,40 @@ test("throws error for invalid scale proeprty values", () => {
     value: "5px",
   });
 });
+
+test("support custom properties as unparsed values", () => {
+  expect(parseCssValue("--my-property", "blue")).toEqual({
+    type: "unparsed",
+    value: "blue",
+  });
+  expect(parseCssValue("--my-property", "1px")).toEqual({
+    type: "unparsed",
+    value: "1px",
+  });
+});
+
+test("support custom properties var reference", () => {
+  expect(parseCssValue("color", "var(--color)")).toEqual({
+    type: "var",
+    value: "color",
+    fallbacks: [],
+  });
+  expect(parseCssValue("color", "var(--color, red)")).toEqual({
+    type: "var",
+    value: "color",
+    fallbacks: [{ type: "unparsed", value: "red" }],
+  });
+});
+
+test("support custom properties var reference in custom property", () => {
+  expect(parseCssValue("--bg", "var(--color)")).toEqual({
+    type: "var",
+    value: "color",
+    fallbacks: [],
+  });
+  expect(parseCssValue("--bg", "var(--color, red)")).toEqual({
+    type: "var",
+    value: "color",
+    fallbacks: [{ type: "unparsed", value: "red" }],
+  });
+});

--- a/packages/css-data/src/parse-css.test.ts
+++ b/packages/css-data/src/parse-css.test.ts
@@ -374,13 +374,52 @@ describe("Parse CSS", () => {
     ]);
   });
 
+  test("parse custom property", () => {
+    expect(parseCss(`a { --my-property: red; }`)).toEqual([
+      {
+        selector: "a",
+        property: "--my-property",
+        value: { type: "unparsed", value: "red" },
+      },
+    ]);
+  });
+
   // @todo https://github.com/webstudio-is/webstudio/issues/3399
-  test("parse variable", () => {
+  test("parse variable as unset default", () => {
     expect(parseCss(`a { color: var(--color) }`)).toEqual([
       {
         selector: "a",
         property: "color",
         value: { type: "keyword", value: "unset" },
+      },
+    ]);
+  });
+
+  test("optionally parse variable as var value", () => {
+    expect(
+      parseCss(
+        `
+        a {
+          color: var(--color);
+          background-color: var(--color, red);
+        }
+        `,
+        { customProperties: true }
+      )
+    ).toEqual([
+      {
+        selector: "a",
+        property: "color",
+        value: { type: "var", value: "color", fallbacks: [] },
+      },
+      {
+        selector: "a",
+        property: "backgroundColor",
+        value: {
+          type: "var",
+          value: "color",
+          fallbacks: [{ type: "unparsed", value: "red" }],
+        },
       },
     ]);
   });

--- a/packages/css-data/src/parse-css.ts
+++ b/packages/css-data/src/parse-css.ts
@@ -57,7 +57,8 @@ const unprefixProperty = (property: string) => {
 
 const parseCssValue = (
   property: string,
-  value: string
+  value: string,
+  { customProperties }: { customProperties: boolean }
 ): Map<StyleProperty, StyleValue> => {
   const expanded = new Map(expandShorthands([[property, value]]));
   const final = new Map();
@@ -70,7 +71,7 @@ const parseCssValue = (
     }
 
     // @todo https://github.com/webstudio-is/webstudio/issues/3399
-    if (value.startsWith("var(")) {
+    if (customProperties === false && value.startsWith("var(")) {
       final.set(property, { type: "keyword", value: "unset" });
       continue;
     }
@@ -100,7 +101,12 @@ type Selector = {
   state?: string;
 };
 
-export const parseCss = (css: string) => {
+type ParserOptions = {
+  customProperties?: boolean;
+};
+
+export const parseCss = (css: string, options: ParserOptions = {}) => {
+  const customProperties = options.customProperties ?? false;
   const ast = cssTreeTryParse(css);
   const styles = new Map<string, ParsedStyleDecl>();
 
@@ -200,7 +206,8 @@ export const parseCss = (css: string) => {
 
     const parsedCss = parseCssValue(
       unprefixProperty(node.property),
-      stringValue
+      stringValue,
+      { customProperties }
     );
 
     for (const { name: selector, state } of selectors) {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399 https://github.com/webstudio-is/webstudio/issues/1536

Here added optional support for custom properties in css parser. Also refactored basic style object model tests with css/jsx fixtures.