### PR TITLE
fix: DOMContentLoaded is not firing for inline module scripts

### DIFF
--- a/packages/sdk-components-react/src/html-embed.tsx
+++ b/packages/sdk-components-react/src/html-embed.tsx
@@ -22,6 +22,8 @@ const insertScript = (sourceScript: HTMLScriptElement): Promise<void> => {
     const script = document.createElement("script");
     const hasSrc = sourceScript.hasAttribute("src");
 
+    const isTypeModule = sourceScript.type === "module";
+
     // Copy all attributes from the source script to the new script, because we are going to replace the source script with the new one
     // and the user might rely on some attributes.
     for (const { name, value } of sourceScript.attributes) {
@@ -39,6 +41,19 @@ const insertScript = (sourceScript: HTMLScriptElement): Promise<void> => {
       });
       script.addEventListener("error", reject);
     } else {
+      // Module scripts are deferred by default, and there's no direct 'load' event for inline scripts.
+      // By creating a Blob and using dynamic import(), we can detect when the script has been
+      // loaded, parsed, and executed. This approach allows us to handle inline module scripts
+      // in a way that preserves execution order and provides a mechanism to know when execution is complete.
+      if (isTypeModule) {
+        const blob = new Blob([sourceScript.innerText], {
+          type: "text/javascript",
+        });
+        const url = URL.createObjectURL(blob);
+        import(/* @vite-ignore */ url).then(resolve).catch(reject);
+        return;
+      }
+
       script.textContent = sourceScript.innerText;
     }
 

--- a/packages/sdk-components-react/src/html-embed.tsx
+++ b/packages/sdk-components-react/src/html-embed.tsx
@@ -50,7 +50,12 @@ const insertScript = (sourceScript: HTMLScriptElement): Promise<void> => {
           type: "text/javascript",
         });
         const url = URL.createObjectURL(blob);
-        import(/* @vite-ignore */ url).then(resolve).catch(reject);
+        import(/* @vite-ignore */ url)
+          .then(resolve)
+          .catch(reject)
+          .finally(() => {
+            URL.revokeObjectURL(url);
+          });
         return;
       }
 


### PR DESCRIPTION
## Description

closes #3724

## Steps for reproduction

https://embed.staging.webstudio.is/builder/f3843f61-c4dd-4fc6-9463-bb88e8cc5f9b

2 "Client Only" Embeds

```html
<!--Embed 1 -->
<script type="module">
  import _ from 'https://cdn.jsdelivr.net/npm/lodash-es/lodash.js';

  console.log(_.join(['Hello', 'World', '1'], ' '));

  document.addEventListener('DOMContentLoaded', (event) => {
    console.log('DOM fully loaded 1');
  });
</script>

<!--Embed 2 -->
<script type="module">
  console.log('Hello 2');
  document.addEventListener('DOMContentLoaded', (event) => {
    console.log('DOM fully loaded 2');
  });
</script>
```

Before this PR gave output with following errors:
- Broken order
- Broken `DOMContentLoaded`

```log
Hello 2
Hello World 1
```

Now no issues

```log
Hello World 1
Hello 2
DOM fully loaded 1
DOM fully loaded 2
```




## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
