### PR TITLE
experimental: fix webflow validation error

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -685,6 +685,7 @@ test("QuickStack with instance styles", async () => {
                   noPseudo: {
                     gridTemplateColumns: "1fr 1fr",
                     gridTemplateRows: "auto",
+                    order: 1,
                   },
                 },
               },
@@ -731,7 +732,8 @@ test("QuickStack with instance styles", async () => {
       }
       Local {
         grid-template-columns: 1fr 1fr;
-        grid-template-rows: auto
+        grid-template-rows: auto;
+        order: 1
       }
       w-layout-cell {
         flex-direction: column;

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/schema.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/schema.ts
@@ -10,7 +10,7 @@ const stylePseudo = z.string();
 
 const styleProperty = z.string();
 
-const styleValue = z.string();
+const styleValue = z.unknown();
 
 const WfNodeData = z.object({
   attr: Attr.optional(),


### PR DESCRIPTION
This error happened because we assumed local styles to be strings but for example order can be number. Relaxed validation to unknown. Value is used only in template literal.
