### PR TITLE
fix: support backdrop-filter in safari

### DIFF
--- a/packages/css-engine/src/core/prefixer.test.ts
+++ b/packages/css-engine/src/core/prefixer.test.ts
@@ -37,3 +37,16 @@ test("prefix text-size-adjust", () => {
     ])
   );
 });
+
+test("prefix backdrop-filter", () => {
+  expect(
+    prefixStyles(
+      new Map([["backdrop-filter", { type: "unparsed", value: "blur(4px)" }]])
+    )
+  ).toEqual(
+    new Map([
+      ["-webkit-backdrop-filter", { type: "unparsed", value: "blur(4px)" }],
+      ["backdrop-filter", { type: "unparsed", value: "blur(4px)" }],
+    ])
+  );
+});

--- a/packages/css-engine/src/core/prefixer.ts
+++ b/packages/css-engine/src/core/prefixer.ts
@@ -19,6 +19,12 @@ export const prefixStyles = (styleMap: StyleMap) => {
     if (property === "text-size-adjust") {
       newStyleMap.set("-webkit-text-size-adjust", value);
     }
+    // safari supports with -webkit- prefix in stable version
+    // and without prefix in technology preview
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter
+    if (property === "backdrop-filter") {
+      newStyleMap.set("-webkit-backdrop-filter", value);
+    }
     newStyleMap.set(property, value);
   }
   return newStyleMap;


### PR DESCRIPTION
Safari was the first to build this feature but still supports only prefixed version. Might land unprefixed in safari 18.