### PR TITLE
fix: Prevent accidental clicks on label with boolean control

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
@@ -1,5 +1,5 @@
 import { useStore } from "@nanostores/react";
-import { Grid, Switch, theme, useId } from "@webstudio-is/design-system";
+import { Grid, Switch, theme } from "@webstudio-is/design-system";
 import {
   BindingControl,
   BindingPopover,
@@ -23,7 +23,6 @@ export const BooleanControl = ({
   onChange,
   onDelete,
 }: ControlProps<"boolean">) => {
-  const id = useId();
   const label = humanizeString(meta.label || propName);
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression =
@@ -44,16 +43,11 @@ export const BooleanControl = ({
       align="center"
       gap="2"
     >
-      <Label
-        htmlFor={id}
-        description={meta.description}
-        readOnly={overwritable === false}
-      >
+      <Label description={meta.description} readOnly={overwritable === false}>
         {label}
       </Label>
       <BindingControl>
         <Switch
-          id={id}
           disabled={overwritable === false}
           checked={Boolean(computedValue ?? false)}
           onCheckedChange={(value) => {


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/3751

## Description

Clicking on a label that toggles the switch is not necessary and leads to accidental changes.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
