### PR TITLE
fix: Do not load full Build data at builder loader

### DIFF
--- a/apps/builder/app/routes/builder.$projectId.tsx
+++ b/apps/builder/app/routes/builder.$projectId.tsx
@@ -11,7 +11,7 @@ import {
   json,
 } from "@remix-run/server-runtime";
 
-import { loadBuildByProjectId } from "@webstudio-is/project-build/index.server";
+import { loadBuildIdAndVersionByProjectId } from "@webstudio-is/project-build/index.server";
 import { db } from "@webstudio-is/project/index.server";
 import { db as authDb } from "@webstudio-is/authorization-token/index.server";
 
@@ -68,7 +68,7 @@ export const loader = async ({
       throw new Error(`Project "${params.projectId}" not found`);
     }
 
-    const devBuild = await loadBuildByProjectId(project.id);
+    const devBuild = await loadBuildIdAndVersionByProjectId(project.id);
 
     const end = Date.now();
 

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -105,6 +105,24 @@ export const loadBuildById = async (
   return parseBuild(build);
 };
 
+export const loadBuildIdAndVersionByProjectId = async (
+  projectId: Build["projectId"]
+): Promise<{ id: string; version: number }> => {
+  const build = await prisma.build.findFirst({
+    select: {
+      id: true,
+      version: true,
+    },
+    where: { projectId, deployment: null },
+  });
+
+  if (build === null) {
+    throw new Error("Dev build not found");
+  }
+
+  return build;
+};
+
 export const loadBuildByProjectId = async (
   projectId: Build["projectId"]
 ): Promise<Build> => {


### PR DESCRIPTION
## Description

Loading of html (first request)

https://project-load-perf.development.webstudio.is/builder/be939bf2-9095-4e17-b175-69de2bbf9597
700ms

Same on main 8sec
https://main.development.webstudio.is/builder/be939bf2-9095-4e17-b175-69de2bbf9597

10x difference

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
