### PR TITLE
feat: Display navigator item show state

### DIFF
--- a/apps/builder/app/builder/shared/tree/index.tsx
+++ b/apps/builder/app/builder/shared/tree/index.tsx
@@ -12,7 +12,7 @@ import {
   rawTheme,
 } from "@webstudio-is/design-system";
 import type { Instance } from "@webstudio-is/sdk";
-import { collectionComponent } from "@webstudio-is/react-sdk";
+import { collectionComponent, showAttribute } from "@webstudio-is/react-sdk";
 import {
   $propValuesByInstanceSelector,
   $editingItemSelector,
@@ -151,12 +151,16 @@ export const InstanceTree = (
       {...props}
       canLeaveParent={canLeaveParent}
       getItemChildren={getItemChildren}
-      getItemProps={(itemData) => {
-        if (itemData.component === "Slot") {
-          return {
-            style: getNodeVars({ color: rawTheme.colors.foregroundReusable }),
-          };
-        }
+      getItemProps={({ itemData, itemSelector }) => {
+        const props = propValues.get(JSON.stringify(itemSelector));
+        const opacity = props?.get(showAttribute) === false ? 0.4 : undefined;
+        const color =
+          itemData.component === "Slot"
+            ? rawTheme.colors.foregroundReusable
+            : undefined;
+        return {
+          style: getNodeVars({ color, opacity }),
+        };
       }}
       renderItem={renderItem}
       editingItemId={editingItemSelector?.[0]}

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -174,13 +174,26 @@ const hoverStyle: CSS = {
 };
 
 const itemContainerColor: string = "--ws-tree-node-item-container-color";
+const itemContainerOpacity: string = "--ws-tree-node-item-container-opacity";
 
-export const getNodeVars = ({ color }: { color: string }) => ({
-  [itemContainerColor]: color,
-});
+export const getNodeVars = ({
+  color,
+  opacity,
+}: {
+  color?: string;
+  opacity?: number;
+}) => {
+  return {
+    ...(color ? { [itemContainerColor]: color } : undefined),
+    ...(opacity !== undefined
+      ? { [itemContainerOpacity]: opacity }
+      : undefined),
+  };
+};
 
 const ItemContainer = styled(Flex, {
   color: `var(${itemContainerColor}, ${theme.colors.foregroundMain})`,
+  opacity: `var(${itemContainerOpacity}, 1)`,
   alignItems: "center",
   position: "relative",
   ...getItemButtonCssVars({ suffixVisible: false }),
@@ -424,7 +437,10 @@ export const TreeItemLabel = forwardRef(TreeItemLabelBase);
 export type TreeNodeProps<Data extends { id: ItemId }> = {
   itemData: Data;
   getItemChildren: (itemSelector: ItemSelector) => Data[];
-  getItemProps?: (itemData: Data) => ComponentProps<"div"> | undefined;
+  getItemProps?: (options: {
+    itemData: Data;
+    itemSelector: ItemSelector;
+  }) => ComponentProps<"div"> | undefined;
   isItemHidden: (itemSelector: ItemSelector) => boolean;
   renderItem: (props: TreeItemRenderProps<Data>) => React.ReactNode;
 
@@ -481,7 +497,10 @@ export const TreeNode = <Data extends { id: string }>({
   const shouldRenderExpandButton = isExpandable && isAlwaysExpanded === false;
 
   return (
-    <div data-drop-target-id={itemData.id} {...getItemProps?.(itemData)}>
+    <div
+      data-drop-target-id={itemData.id}
+      {...getItemProps?.({ itemData, itemSelector })}
+    >
       {/* optionally prevent rendering root item */}
       {itemIsHidden === false &&
         renderItem({


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/3750

## Description

Indicate show=false in the navigator

## Steps for reproduction

1. toggle show switch
2. see item in the navigator opacity changed including it's children

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
