### PR TITLE
fix: Set correct tag when pasting a Block from webflow

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-webflow/instances-properties.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/instances-properties.ts
@@ -110,6 +110,9 @@ const toFragment = (
     }
     case "Block": {
       const component = wfNode.data?.text ? "Text" : "Box";
+      if (wfNode.tag !== "div") {
+        addProp("tag", wfNode.tag);
+      }
       addInstance(component);
       return fragment;
     }

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -530,6 +530,38 @@ test("Section", async () => {
   `);
 });
 
+test("Figure", async () => {
+  const fragment = await toWebstudioFragment({
+    type: "@webflow/XscpData",
+    payload: {
+      nodes: [
+        {
+          _id: "7c6bc1fd-128d-514b-167b-605a910e435c",
+          type: "Block",
+          tag: "figure",
+          classes: [],
+          children: [],
+        },
+      ],
+      styles: [],
+      assets: [],
+    },
+  });
+
+  equalFragment(fragment, <$.Box tag="figure" />);
+  expect(toCss(fragment)).toMatchInlineSnapshot(`
+    "@media all {
+      figure {
+        display: block;
+        margin-top: 0;
+        margin-right: 0;
+        margin-bottom: 10px;
+        margin-left: 0
+      }
+    }"
+  `);
+});
+
 test("BlockContainer", async () => {
   const fragment = await toWebstudioFragment({
     type: "@webflow/XscpData",


### PR DESCRIPTION
## Description

We were currently not setting the tag that comes from webflow properties

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
