### PR TITLE
refactor: move social asset into page meta

### DIFF
--- a/fixtures/webstudio-cloudflare-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/_index.server.tsx
@@ -19,7 +19,7 @@ export const getPageMeta = ({
     description: undefined,
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
@@ -14,8 +14,6 @@ export const siteName = "";
 
 export const favIconAsset: ImageAsset | undefined = undefined;
 
-export const socialImageAsset: ImageAsset | undefined = undefined;
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.server.tsx
@@ -19,7 +19,7 @@ export const getPageMeta = ({
     description: "",
     excludePageFromSearch: false,
     language: undefined,
-    socialImageAssetId: "",
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -27,8 +27,6 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 16, height: 16 },
 };
 
-export const socialImageAsset: ImageAsset | undefined = undefined;
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml]._index.server.tsx
@@ -45,7 +45,7 @@ export const getPageMeta = ({
     description: "",
     excludePageFromSearch: false,
     language: "",
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: "",
     status: 200,
     redirect: "",

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml]._index.tsx
@@ -20,8 +20,6 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 16, height: 16 },
 };
 
-export const socialImageAsset: ImageAsset | undefined = undefined;
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.server.tsx
@@ -19,7 +19,7 @@ export const getPageMeta = ({
     description: "",
     excludePageFromSearch: false,
     language: "ru",
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: "",
     status: 200,
     redirect: "",

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
@@ -21,8 +21,6 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 16, height: 16 },
 };
 
-export const socialImageAsset: ImageAsset | undefined = undefined;
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.server.tsx
@@ -19,7 +19,8 @@ export const getPageMeta = ({
     description: "Page description f511c297-b44f-4e4b-96bd-d013da06bada",
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: "ff546bd2-9bb1-4717-a180-1a1fc05565dd",
+    socialImageAssetName:
+      "_937084ed-a798-49fe-8664-df93a2af605e_1JqSy_0Wy9fY5mXNZSLJ0.jpeg",
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -33,18 +33,6 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 16, height: 16 },
 };
 
-export const socialImageAsset: ImageAsset | undefined = {
-  id: "ff546bd2-9bb1-4717-a180-1a1fc05565dd",
-  name: "_937084ed-a798-49fe-8664-df93a2af605e_1JqSy_0Wy9fY5mXNZSLJ0.jpeg",
-  description: null,
-  projectId: "0d856812-61d8-4014-a20a-82e01c0eb8ee",
-  size: 210614,
-  type: "image",
-  format: "jpg",
-  createdAt: "2024-03-26T18:31:04.086Z",
-  meta: { width: 1024, height: 1024 },
-};
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [
   {

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[script-test]._index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[world]._index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.server.tsx
@@ -19,7 +19,7 @@ export const getPageMeta = ({
     description: undefined,
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -14,8 +14,6 @@ export const siteName = "";
 
 export const favIconAsset: ImageAsset | undefined = undefined;
 
-export const socialImageAsset: ImageAsset | undefined = undefined;
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.server.tsx
@@ -19,7 +19,7 @@ export const getPageMeta = ({
     description: undefined,
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -14,8 +14,6 @@ export const siteName = "";
 
 export const favIconAsset: ImageAsset | undefined = undefined;
 
-export const socialImageAsset: ImageAsset | undefined = undefined;
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.server.tsx
@@ -19,7 +19,7 @@ export const getPageMeta = ({
     description: "",
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -21,8 +21,6 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
-export const socialImageAsset: ImageAsset | undefined = undefined;
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.server.tsx
@@ -19,7 +19,7 @@ export const getPageMeta = ({
     description: "",
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -30,8 +30,6 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
-export const socialImageAsset: ImageAsset | undefined = undefined;
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.server.tsx
@@ -19,7 +19,7 @@ export const getPageMeta = ({
     description: "",
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -21,8 +21,6 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
-export const socialImageAsset: ImageAsset | undefined = undefined;
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.server.tsx
@@ -19,7 +19,7 @@ export const getPageMeta = ({
     description: "",
     excludePageFromSearch: false,
     language: undefined,
-    socialImageAssetId: "",
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -21,8 +21,6 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
-export const socialImageAsset: ImageAsset | undefined = undefined;
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.server.tsx
@@ -20,7 +20,8 @@ export const getPageMeta = ({
       "Delve deep into the radix roots of feline behaviors. At KittyNoTouchy, we dissect the core essence, or 'radix', of what makes cats the enigmatic creatures they are. Join us as we explore the radix of their instincts, habits, and quirks.",
     excludePageFromSearch: true,
     language: undefined,
-    socialImageAssetId: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
+    socialImageAssetName:
+      "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -32,18 +32,6 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
-export const socialImageAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416Z",
-  meta: { width: 790, height: 786 },
-};
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.server.tsx
@@ -45,7 +45,7 @@ export const getPageMeta = ({
     description: "",
     excludePageFromSearch: false,
     language: undefined,
-    socialImageAssetId: "",
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -24,8 +24,6 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
-export const socialImageAsset: ImageAsset | undefined = undefined;
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.server.tsx
@@ -20,7 +20,8 @@ export const getPageMeta = ({
       "Dive into the world of felines and discover why some whiskers are best left untouched. From intriguing cat behaviors to protective measures, \nKittyGuardedZone is your go-to hub for all things 'hands-off' in the cat realm.",
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
+    socialImageAssetName:
+      "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -30,18 +30,6 @@ export const favIconAsset: ImageAsset | undefined = {
   meta: { width: 790, height: 786 },
 };
 
-export const socialImageAsset: ImageAsset | undefined = {
-  id: "cd939c56-bcdd-4e64-bd9c-567a9bccd3da",
-  name: "_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 210614,
-  type: "image",
-  format: "jpeg",
-  createdAt: "2023-09-06T11:28:43.031Z",
-  meta: { width: 1024, height: 1024 },
-};
-
 // Font assets on current page (can be preloaded)
 export const pageFontAssets: FontAsset[] = [];
 

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[_route_with_symbols_]._index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[form]._index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[heading-with-id]._index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[nested].[nested-page]._index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[radix]._index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/[resources]._index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "../__generated__/_index";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -590,9 +590,7 @@ export const prebuild = async (options: {
     const contactEmail: undefined | string =
       // fallback to user email when contact email is empty string
       projectMeta?.contactEmail || siteData.user?.email || undefined;
-    const pageMeta = pageData.page.meta;
     const favIconAsset = assets.get(projectMeta?.faviconAssetId ?? "");
-    const socialImageAsset = assets.get(pageMeta.socialImageAssetId ?? "");
 
     const pagePath = getPagePath(pageData.page.id, siteData.build.pages);
 
@@ -609,9 +607,6 @@ export const prebuild = async (options: {
 
       export const favIconAsset: ImageAsset | undefined =
         ${JSON.stringify(favIconAsset)};
-
-      export const socialImageAsset: ImageAsset | undefined =
-        ${JSON.stringify(socialImageAsset)};
 
       // Font assets on current page (can be preloaded)
       export const pageFontAssets: FontAsset[] =
@@ -673,6 +668,7 @@ export const prebuild = async (options: {
         globalScope: scope,
         page: pageData.page,
         dataSources,
+        assets,
       })}
 
       ${generateFormsProperties(props)}

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -20,7 +20,6 @@ import {
   Page,
   siteName,
   favIconAsset,
-  socialImageAsset,
   pageFontAssets,
   pageBackgroundImageAssets,
 } from "__CLIENT__";
@@ -152,11 +151,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
 
-  if (socialImageAsset) {
+  if (pageMeta.socialImageAssetName) {
     metas.push({
       property: "og:image",
       content: `https://${data.host}${imageLoader({
-        src: socialImageAsset.name,
+        src: pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,

--- a/packages/react-sdk/placeholder.d.ts
+++ b/packages/react-sdk/placeholder.d.ts
@@ -5,8 +5,6 @@ declare module "__CLIENT__" {
 
   export const favIconAsset: ImageAsset | undefined;
 
-  export const socialImageAsset: ImageAsset | undefined;
-
   // Font assets on current page (can be preloaded)
   export const pageFontAssets: FontAsset[];
 

--- a/packages/sdk/src/page-meta-generator.test.ts
+++ b/packages/sdk/src/page-meta-generator.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@jest/globals";
 import { createScope } from "./scope";
 import { generatePageMeta } from "./page-meta-generator";
+import type { Asset } from "./schema/assets";
 
 const toMap = <T extends { id: string }>(list: T[]) =>
   new Map(list.map((item) => [item.id, item] as const));
@@ -19,6 +20,7 @@ test("generate minimal static page meta factory", () => {
         meta: {},
       },
       dataSources: new Map(),
+      assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
 "export const getPageMeta = ({
@@ -33,7 +35,7 @@ test("generate minimal static page meta factory", () => {
     description: undefined,
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,
@@ -60,7 +62,7 @@ test("generate complete static page meta factory", () => {
           description: `"Page description"`,
           excludePageFromSearch: "true",
           language: `"en-US"`,
-          socialImageAssetId: "social-image-name",
+          socialImageAssetId: "social-image-id",
           status: `302`,
           redirect: `"/new-path"`,
           custom: [
@@ -70,6 +72,22 @@ test("generate complete static page meta factory", () => {
         },
       },
       dataSources: new Map(),
+      assets: new Map([
+        [
+          "social-image-id",
+          {
+            id: "social-image-id",
+            type: "image",
+            format: "",
+            projectId: "",
+            size: 0,
+            name: "social-image-name",
+            description: null,
+            createdAt: "",
+            meta: { width: 0, height: 0 },
+          } satisfies Asset,
+        ],
+      ]),
     })
   ).toMatchInlineSnapshot(`
 "export const getPageMeta = ({
@@ -84,7 +102,7 @@ test("generate complete static page meta factory", () => {
     description: "Page description",
     excludePageFromSearch: true,
     language: "en-US",
-    socialImageAssetId: "social-image-name",
+    socialImageAssetName: "social-image-name",
     socialImageUrl: undefined,
     status: 302,
     redirect: "/new-path",
@@ -120,6 +138,7 @@ test("generate asset url instead of id", () => {
         },
       },
       dataSources: new Map(),
+      assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
 "export const getPageMeta = ({
@@ -134,7 +153,7 @@ test("generate asset url instead of id", () => {
     description: undefined,
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: "https://my-image",
     status: undefined,
     redirect: undefined,
@@ -165,6 +184,7 @@ test("generate custom meta ignoring empty property name", () => {
         },
       },
       dataSources: new Map(),
+      assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
 "export const getPageMeta = ({
@@ -179,7 +199,7 @@ test("generate custom meta ignoring empty property name", () => {
     description: undefined,
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,
@@ -217,6 +237,7 @@ test("generate page meta factory with variables", () => {
           value: { type: "string", value: "" },
         },
       ]),
+      assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
 "export const getPageMeta = ({
@@ -232,7 +253,7 @@ test("generate page meta factory with variables", () => {
     description: undefined,
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,
@@ -265,6 +286,7 @@ test("generate page meta factory with system", () => {
           type: "parameter",
         },
       ]),
+      assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
 "export const getPageMeta = ({
@@ -280,7 +302,7 @@ test("generate page meta factory with system", () => {
     description: undefined,
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,
@@ -314,6 +336,7 @@ test("generate page meta factory with resources", () => {
           resourceId: "resourceId",
         },
       ]),
+      assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
 "export const getPageMeta = ({
@@ -329,7 +352,7 @@ test("generate page meta factory with resources", () => {
     description: undefined,
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,
@@ -383,6 +406,7 @@ test("generate page meta factory without unused variables", () => {
           resourceId: "resourceId",
         },
       ]),
+      assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
 "export const getPageMeta = ({
@@ -398,7 +422,7 @@ test("generate page meta factory without unused variables", () => {
     description: undefined,
     excludePageFromSearch: undefined,
     language: undefined,
-    socialImageAssetId: undefined,
+    socialImageAssetName: undefined,
     socialImageUrl: undefined,
     status: undefined,
     redirect: undefined,

--- a/packages/sdk/src/page-meta-generator.ts
+++ b/packages/sdk/src/page-meta-generator.ts
@@ -1,4 +1,4 @@
-import type { Asset } from "./schema/assets";
+import type { Asset, Assets } from "./schema/assets";
 import type { DataSources } from "./schema/data-sources";
 import type { Page } from "./schema/pages";
 import { type Scope, createScope } from "./scope";
@@ -9,7 +9,7 @@ export type PageMeta = {
   description?: string;
   excludePageFromSearch?: boolean;
   language?: string;
-  socialImageAssetId?: Asset["id"];
+  socialImageAssetName?: Asset["name"];
   socialImageUrl?: string;
   status?: number;
   redirect?: string;
@@ -20,10 +20,12 @@ export const generatePageMeta = ({
   globalScope,
   page,
   dataSources,
+  assets,
 }: {
   globalScope: Scope;
   page: Page;
   dataSources: DataSources;
+  assets: Assets;
 }) => {
   // reserve parameter names passed to generated function
   const localScope = createScope(["system", "resources"]);
@@ -52,8 +54,10 @@ export const generatePageMeta = ({
     usedDataSources,
     scope: localScope,
   });
-  const socialImageAssetIdExpression = JSON.stringify(
+  const socialImageAssetNameExpression = JSON.stringify(
     page.meta.socialImageAssetId
+      ? assets.get(page.meta.socialImageAssetId)?.name
+      : undefined
   );
   const socialImageUrlExpression = generateExpression({
     expression: page.meta.socialImageUrl ?? "undefined",
@@ -130,7 +134,7 @@ export const generatePageMeta = ({
   generated += `    description: ${descriptionExpression},\n`;
   generated += `    excludePageFromSearch: ${excludePageFromSearchExpression},\n`;
   generated += `    language: ${languageExpression},\n`;
-  generated += `    socialImageAssetId: ${socialImageAssetIdExpression},\n`;
+  generated += `    socialImageAssetName: ${socialImageAssetNameExpression},\n`;
   generated += `    socialImageUrl: ${socialImageUrlExpression},\n`;
   generated += `    status: ${statusExpression},\n`;
   generated += `    redirect: ${redirectExpression},\n`;


### PR DESCRIPTION
Removed social asset form top level and moved into generated page meta.
Will be less generated data and simple page head.