### PR TITLE
refactor: replace constants in templates

### DIFF
--- a/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[another-page]._index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/_index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[script-test]._index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap.xml]._index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { renderToString } from "react-dom/server";
 import { type LoaderFunctionArgs, redirect } from "@remix-run/server-runtime";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { Page } from "../__generated__/[sitemap.xml]._index";
@@ -8,7 +9,6 @@ import {
   getRemixParams,
 } from "../__generated__/[sitemap.xml]._index.server";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
-import { renderToString } from "react-dom/server";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[world]._index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/_index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[another-page]._index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[another-page]._index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/_index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[another-page]._index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[another-page]._index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/_index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[_route_with_symbols_]._index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[form]._index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[heading-with-id]._index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[nested].[nested-page]._index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[radix]._index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[resources]._index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/_index.server";
-
-import css from "../__generated__/index.css?url";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import css from "../__generated__/index.css?url";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -31,9 +31,8 @@ import {
   projectId,
   contactEmail,
 } from "__SERVER__";
-
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "__CONSTANTS__";
 import css from "__CSS__?url";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/packages/cli/templates/defaults/app/route-templates/xml.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/xml.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable camelcase */
+import { renderToString } from "react-dom/server";
 import { type LoaderFunctionArgs, redirect } from "@remix-run/server-runtime";
 import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { Page } from "__CLIENT__";
 import { loadResources, getPageMeta, getRemixParams } from "__SERVER__";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
-import { renderToString } from "react-dom/server";
+import { assetBaseUrl, imageBaseUrl, imageLoader } from "__CONSTANTS__";
 
 export const loader = async (arg: LoaderFunctionArgs) => {
   const url = new URL(arg.request.url);

--- a/packages/react-sdk/placeholder.d.ts
+++ b/packages/react-sdk/placeholder.d.ts
@@ -1,3 +1,10 @@
+declare module "__CONSTANTS__" {
+  import type { ImageLoader } from "@webstudio-is/image";
+  export const assetBaseUrl: string;
+  export const imageBaseUrl: string;
+  export const imageLoader: ImageLoader;
+}
+
 declare module "__CLIENT__" {
   import type { FontAsset, ImageAsset, System } from "@webstudio-is/sdk";
 


### PR DESCRIPTION
Here made constants path easier to access from dynamic paths by automatically replacing __CONSTANTS__ with actual relative path.

This is necessary for vike support which has folder based routes.