### PR TITLE
fix: Fix show property handling from navigation

### DIFF
--- a/apps/builder/app/builder/shared/tree/index.tsx
+++ b/apps/builder/app/builder/shared/tree/index.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
   SmallIconButton,
 } from "@webstudio-is/design-system";
-import type { Instance } from "@webstudio-is/sdk";
+import { Prop, type Instance } from "@webstudio-is/sdk";
 import { collectionComponent, showAttribute } from "@webstudio-is/react-sdk";
 import {
   $propValuesByInstanceSelector,
@@ -31,6 +31,7 @@ import { serverSyncStore } from "~/shared/sync";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { shallowEqual } from "shallow-equal";
 import { EyeconClosedIcon, EyeconOpenIcon } from "@webstudio-is/icons";
+import { nanoid } from "nanoid";
 
 const ShowToggle = ({
   show,
@@ -48,7 +49,6 @@ const ShowToggle = ({
     >
       <SmallIconButton
         aria-label="Show"
-        state={show ? "open" : undefined}
         onClick={() => onChange(show ? false : true)}
         icon={show ? <EyeconOpenIcon /> : <EyeconClosedIcon />}
       />
@@ -56,15 +56,25 @@ const ShowToggle = ({
   );
 };
 
-const updateShowProp = (instanceId: Instance["id"], show: boolean) => {
+const updateShowProp = (instanceId: Instance["id"], value: boolean) => {
   serverSyncStore.createTransaction([$props], (props) => {
     const { propsByInstanceId } = $propsIndex.get();
-    const propsArr = propsByInstanceId.get(instanceId);
-    const prop = propsArr?.find((prop) => prop.name === showAttribute);
-    if (prop?.type === "boolean") {
-      props.set(prop.id, {
-        ...prop,
-        value: show,
+    const instanceProps = propsByInstanceId.get(instanceId);
+    let showProp = instanceProps?.find((prop) => prop.name === showAttribute);
+
+    if (showProp === undefined) {
+      showProp = {
+        id: nanoid(),
+        instanceId,
+        name: showAttribute,
+        type: "boolean",
+        value,
+      };
+    }
+    if (showProp.type === "boolean") {
+      props.set(showProp.id, {
+        ...showProp,
+        value,
       });
     }
   });
@@ -161,7 +171,8 @@ export const InstanceTree = (
       const label = getInstanceLabel(itemData, meta);
       const isEditing = shallowEqual(itemSelector, editingItemSelector);
       const instanceProps = propValues.get(JSON.stringify(itemSelector));
-      const show = instanceProps?.get(showAttribute) as boolean;
+      const show = Boolean(instanceProps?.get(showAttribute) ?? true);
+
       return (
         <TreeItemBody
           {...props}

--- a/apps/builder/app/builder/shared/tree/index.tsx
+++ b/apps/builder/app/builder/shared/tree/index.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
   SmallIconButton,
 } from "@webstudio-is/design-system";
-import { Prop, type Instance } from "@webstudio-is/sdk";
+import { type Instance } from "@webstudio-is/sdk";
 import { collectionComponent, showAttribute } from "@webstudio-is/react-sdk";
 import {
   $propValuesByInstanceSelector,


### PR DESCRIPTION
## Description

1. when show was not set before, its undefined and needs to be treated as false
2. when instance has no properties at all, show prop needs to be created

## Steps for reproduction

1. test with a new instance that has no properties e.g. body
2. test with an instance that had never set show to true or false, so its undefined

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
