### PR TITLE
refactor: merge tsconfig from CLI templates

### DIFF
--- a/fixtures/webstudio-cloudflare-template/package.json
+++ b/fixtures/webstudio-cloudflare-template/package.json
@@ -4,7 +4,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link \"https://main.development.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93&\"",
     "fixtures:sync": "pnpm cli sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "pnpm cli build --template internal --template cloudflare --template saas-helpers  --preview && pnpm prettier --write ./app/ ./package.json",
+    "fixtures:build": "pnpm cli build --template internal --template cloudflare --template saas-helpers  --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json",
     "build": "remix vite:build",
     "dev": "remix vite:dev",
     "typecheck": "tsc",

--- a/fixtures/webstudio-cloudflare-template/tsconfig.json
+++ b/fixtures/webstudio-cloudflare-template/tsconfig.json
@@ -8,7 +8,7 @@
     "**/.client/**/*.tsx"
   ],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2023"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "types": [
       "@remix-run/cloudflare",
       "vite/client",
@@ -19,17 +19,13 @@
     "esModuleInterop": true,
     "jsx": "react-jsx",
     "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
     "target": "ES2022",
     "strict": true,
     "allowJs": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
-    "customConditions": ["webstudio"],
-
-    // Vite takes care of building everything, not tsc.
-    "noEmit": true
+    "noEmit": true,
+    "skipLibCheck": true,
+    "customConditions": ["webstudio"]
   }
 }

--- a/fixtures/webstudio-custom-template/package.json
+++ b/fixtures/webstudio-custom-template/package.json
@@ -8,7 +8,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link \"https://main.development.webstudio.is/builder/0d856812-61d8-4014-a20a-82e01c0eb8ee?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f\"",
     "fixtures:sync": "pnpm cli sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "pnpm cli build --template internal --template ./custom-template --template ./custom-template-stage --preview && pnpm prettier --write ./app/ ./package.json"
+    "fixtures:build": "pnpm cli build --template internal --template ./custom-template --template ./custom-template-stage --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },
   "private": true,
   "sideEffects": false,

--- a/fixtures/webstudio-custom-template/tsconfig.json
+++ b/fixtures/webstudio-custom-template/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2023"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "types": [
       "@remix-run/node",
       "vite/client",
@@ -12,18 +12,12 @@
     "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "resolveJsonModule": true,
     "target": "ES2022",
     "strict": true,
     "allowJs": true,
-    "checkJs": true,
     "forceConsistentCasingInFileNames": true,
-    "allowImportingTsExtensions": true,
-    "baseUrl": ".",
-    "customConditions": ["webstudio"],
-
-    // Remix takes care of building everything in `remix build`.
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "customConditions": ["webstudio"]
   }
 }

--- a/fixtures/webstudio-remix-netlify-edge-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/package.json
@@ -8,7 +8,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link \"https://main.development.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93&\"",
     "fixtures:sync": "pnpm cli sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "pnpm cli build --template internal --template netlify-edge-functions --preview && pnpm prettier --write ./app/ ./package.json"
+    "fixtures:build": "pnpm cli build --template internal --template netlify-edge-functions --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },
   "dependencies": {
     "@netlify/edge-functions": "^2.10.0",

--- a/fixtures/webstudio-remix-netlify-edge-functions/tsconfig.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2023"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "types": [
       "@remix-run/node",
       "vite/client",
@@ -12,18 +12,12 @@
     "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "resolveJsonModule": true,
     "target": "ES2022",
     "strict": true,
     "allowJs": true,
-    "checkJs": true,
     "forceConsistentCasingInFileNames": true,
-    "allowImportingTsExtensions": true,
-    "baseUrl": ".",
-    "customConditions": ["webstudio"],
-
-    // Remix takes care of building everything in `remix build`.
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "customConditions": ["webstudio"]
   }
 }

--- a/fixtures/webstudio-remix-netlify-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-functions/package.json
@@ -7,7 +7,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link \"https://main.development.webstudio.is/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93\"",
     "fixtures:sync": "pnpm cli sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "pnpm cli build --template internal --template netlify-functions --preview && pnpm prettier --write ./app/ ./package.json"
+    "fixtures:build": "pnpm cli build --template internal --template netlify-functions --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },
   "dependencies": {
     "@netlify/functions": "^2.8.1",

--- a/fixtures/webstudio-remix-netlify-functions/tsconfig.json
+++ b/fixtures/webstudio-remix-netlify-functions/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2023"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "types": [
       "@remix-run/node",
       "vite/client",
@@ -12,18 +12,12 @@
     "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "resolveJsonModule": true,
     "target": "ES2022",
     "strict": true,
     "allowJs": true,
-    "checkJs": true,
     "forceConsistentCasingInFileNames": true,
-    "allowImportingTsExtensions": true,
-    "baseUrl": ".",
-    "customConditions": ["webstudio"],
-
-    // Remix takes care of building everything in `remix build`.
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "customConditions": ["webstudio"]
   }
 }

--- a/fixtures/webstudio-remix-vercel/package.json
+++ b/fixtures/webstudio-remix-vercel/package.json
@@ -7,7 +7,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link \"https://main.development.webstudio.is/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d&mode=preview\"",
     "fixtures:sync": "pnpm cli sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "pnpm cli build --template internal --template vercel --preview && pnpm prettier --write ./app/ ./package.json"
+    "fixtures:build": "pnpm cli build --template internal --template vercel --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },
   "private": true,
   "sideEffects": false,

--- a/fixtures/webstudio-remix-vercel/tsconfig.json
+++ b/fixtures/webstudio-remix-vercel/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2023"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "types": [
       "@remix-run/node",
       "vite/client",
@@ -12,18 +12,12 @@
     "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "resolveJsonModule": true,
     "target": "ES2022",
     "strict": true,
     "allowJs": true,
-    "checkJs": true,
     "forceConsistentCasingInFileNames": true,
-    "allowImportingTsExtensions": true,
-    "baseUrl": ".",
-    "customConditions": ["webstudio"],
-
-    // Remix takes care of building everything in `remix build`.
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "customConditions": ["webstudio"]
   }
 }

--- a/packages/cli/templates/cloudflare/tsconfig.json
+++ b/packages/cli/templates/cloudflare/tsconfig.json
@@ -8,27 +8,11 @@
     "**/.client/**/*.tsx"
   ],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "types": [
       "@remix-run/cloudflare",
       "vite/client",
       "@cloudflare/workers-types/2023-07-01",
       "@webstudio-is/react-sdk/placeholder"
-    ],
-    "isolatedModules": true,
-    "esModuleInterop": true,
-    "jsx": "react-jsx",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "resolveJsonModule": true,
-    "target": "ES2022",
-    "strict": true,
-    "allowJs": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
-
-    // Vite takes care of building everything, not tsc.
-    "noEmit": true
+    ]
   }
 }

--- a/packages/cli/templates/defaults/tsconfig.json
+++ b/packages/cli/templates/defaults/tsconfig.json
@@ -12,15 +12,10 @@
     "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "resolveJsonModule": true,
     "target": "ES2022",
     "strict": true,
     "allowJs": true,
-    "checkJs": true,
     "forceConsistentCasingInFileNames": true,
-    "allowImportingTsExtensions": true,
-    "baseUrl": ".",
-    // Remix takes care of building everything in `remix build`.
     "noEmit": true,
     "skipLibCheck": true
   }

--- a/packages/cli/templates/internal/tsconfig.json
+++ b/packages/cli/templates/internal/tsconfig.json
@@ -1,29 +1,5 @@
 {
-  "include": ["**/*.ts", "**/*.tsx", "**/*.mjs"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2023"],
-    "types": [
-      "@remix-run/node",
-      "vite/client",
-      "@webstudio-is/react-sdk/placeholder"
-    ],
-    "isolatedModules": true,
-    "esModuleInterop": true,
-    "jsx": "react-jsx",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "target": "ES2022",
-    "strict": true,
-    "allowJs": true,
-    "checkJs": true,
-    "forceConsistentCasingInFileNames": true,
-    "allowImportingTsExtensions": true,
-    "baseUrl": ".",
-    "customConditions": ["webstudio"],
-
-    // Remix takes care of building everything in `remix build`.
-    "noEmit": true,
-    "skipLibCheck": true
+    "customConditions": ["webstudio"]
   }
 }

--- a/packages/cli/templates/saas-helpers/tsconfig.json
+++ b/packages/cli/templates/saas-helpers/tsconfig.json
@@ -8,28 +8,11 @@
     "**/.client/**/*.tsx"
   ],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "types": [
       "@remix-run/cloudflare",
       "vite/client",
       "@cloudflare/workers-types/2023-07-01",
       "@webstudio-is/react-sdk/placeholder"
-    ],
-    "isolatedModules": true,
-    "esModuleInterop": true,
-    "jsx": "react-jsx",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "resolveJsonModule": true,
-    "target": "ES2022",
-    "strict": true,
-    "allowJs": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
-    "customConditions": ["webstudio"],
-
-    // Vite takes care of building everything, not tsc.
-    "noEmit": true
+    ]
   }
 }


### PR DESCRIPTION
Here changed tsconfig copying logic to merge instead of override. This simplifies alternative frameworks support.