### PR TITLE
docs: change dashboard intro video to use new 101 playlist

### DIFF
--- a/apps/builder/app/dashboard/resources/intro-video.tsx
+++ b/apps/builder/app/dashboard/resources/intro-video.tsx
@@ -31,7 +31,7 @@ export const IntroVideoDialog = ({
       >
         <iframe
           className={iframeStyle()}
-          src="https://www.youtube-nocookie.com/embed/aL2sBSb3ghg?si=siExeIRt-YI_ypuA&autoplay=true"
+          src="https://www.youtube-nocookie.com/embed/videoseries?si=fk5L11IcnVErQRRS&list=PL4vVqpngzeT4Bfs_D25xNi_qNMY99R928&autoplay=true"
           allowFullScreen
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         />


### PR DESCRIPTION
## Description

Recorded a new video series and added them to a playlist. Changed intro vid in dashboard to open the playlist.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
