### PR TITLE
fix: style panel layers list rendering

### DIFF
--- a/packages/design-system/src/components/css-value-list-item.tsx
+++ b/packages/design-system/src/components/css-value-list-item.tsx
@@ -40,12 +40,12 @@ const IconButtonsWrapper = styled(Flex, {
   top: 0,
   bottom: 0,
   paddingRight: sharedPaddingRight,
-  visibility: "hidden",
+  display: "none",
 });
 
 const FakeIconButtonsWrapper = styled(Flex, {
   paddingLeft: theme.spacing[5],
-  visibility: "hidden",
+  display: "none",
 });
 
 /**
@@ -69,10 +69,10 @@ const ItemButton = styled("button", {
 
   "&:focus-visible, &[data-focused=true], &[data-state=open]": {
     [`& ${FakeIconButtonsWrapper}`]: {
-      visibility: "visible",
+      display: "flex",
     },
     [`~ ${IconButtonsWrapper}`]: {
-      visibility: "visible",
+      display: "flex",
     },
 
     "&:after": {
@@ -127,10 +127,10 @@ const ItemWrapper = styled("div", {
       },
     },
     [`& ${IconButtonsWrapper}`]: {
-      visibility: "visible",
+      display: "flex",
     },
     [`& ${FakeIconButtonsWrapper}`]: {
-      visibility: "hidden",
+      display: "flex",
     },
   },
 });


### PR DESCRIPTION
## Description

Currently it reserves space for the menu when it shouldn't

before
<img width="245" alt="image" src="https://github.com/user-attachments/assets/f5afaa7c-be33-405c-9b23-97b8c32f40a7">
after
<img width="248" alt="image" src="https://github.com/user-attachments/assets/c63bcf18-6556-40eb-93cd-3bb14dee5a7f">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
