### PR TITLE
feat: move bug report into help menu

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/help-popover.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/help-popover.tsx
@@ -9,10 +9,10 @@ import {
   theme,
 } from "@webstudio-is/design-system";
 import {
+  BugIcon,
   DiscordIcon,
   GithubIcon,
   Webstudio1cIcon,
-  XIcon,
   Youtube1cIcon,
 } from "@webstudio-is/icons";
 import { type ComponentProps } from "react";
@@ -74,11 +74,15 @@ export const HelpPopover = ({
               Discuss on GitHub
             </Button>
             <Button
-              formAction="https://x.com/getwebstudio"
-              prefix={<XIcon />}
+              prefix={<BugIcon />}
               color="dark"
+              onClick={() => {
+                window.open(
+                  "https://github.com/webstudio-is/webstudio-community/discussions/new?category=q-a&labels=bug&title=[Bug]"
+                );
+              }}
             >
-              Follow us on X
+              Report a bug
             </Button>
           </Flex>
         </PopoverContent>

--- a/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/sidebar-left.tsx
@@ -6,7 +6,7 @@ import { panels } from "./panels";
 import { useClientSettings } from "~/builder/shared/client-settings";
 import { Flex } from "@webstudio-is/design-system";
 import { theme } from "@webstudio-is/design-system";
-import { AiIcon, BugIcon, HelpIcon } from "@webstudio-is/icons";
+import { AiIcon, HelpIcon } from "@webstudio-is/icons";
 import { HelpPopover } from "./help-popover";
 import { useStore } from "@nanostores/react";
 import { $activeSidebarPanel } from "~/builder/shared/nano-states";
@@ -83,21 +83,6 @@ const HelpTabTrigger = () => {
         </SidebarButton>
       </HelpPopover.Trigger>
     </HelpPopover>
-  );
-};
-
-const GithubTabTrigger = () => {
-  return (
-    <SidebarButton
-      label="Report a bug on Github"
-      onClick={() => {
-        window.open(
-          "https://github.com/webstudio-is/webstudio-community/discussions/new?category=q-a&labels=bug&title=[Bug]"
-        );
-      }}
-    >
-      <BugIcon size={rawTheme.spacing[10]} />
-    </SidebarButton>
   );
 };
 
@@ -197,7 +182,6 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
             <Box css={{ borderRight: `1px solid ${theme.colors.borderMain}` }}>
               <AiTabTrigger />
               <HelpTabTrigger />
-              <GithubTabTrigger />
             </Box>
           </>
         )}


### PR DESCRIPTION
## Description

Decided to move bug report into the help menu, because that's the most likely place people will go anyways

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
