### PR TITLE
fix: Wrong user is used when counting available custom domains on a free plan

### DIFF
--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -360,6 +360,11 @@ const useCanAddDomain = () => {
   useEffect(() => {
     load();
   }, [load]);
+
+  if (data?.success === false) {
+    return { canAddDomain: false, maxDomainsAllowedPerUser };
+  }
+
   const withinFreeLimit = data
     ? data.success && data.data < maxDomainsAllowedPerUser
     : true;

--- a/apps/builder/app/shared/context.server.ts
+++ b/apps/builder/app/shared/context.server.ts
@@ -75,13 +75,14 @@ const createEntriContext = () => {
   };
 };
 
-const createUserPlanContext = async (request: Request) => {
-  const url = new URL(request.url);
-
-  const authToken = url.searchParams.get("authToken");
+const createUserPlanContext = async (
+  request: Request,
+  authorization: AppContext["authorization"]
+) => {
+  const { authToken } = authorization;
   // When a shared link is accessed, identified by the presence of an authToken,
   // the system retrieves the plan features associated with the project owner's account.
-  if (authToken !== null) {
+  if (authToken != null) {
     const planFeatures = await getTokenPlanFeatures(authToken);
     return planFeatures;
   }
@@ -119,10 +120,11 @@ const createPostrestContext = () => {
  */
 export const createContext = async (request: Request): Promise<AppContext> => {
   const authorization = await createAuthorizationContext(request);
+
   const domain = createDomainContext(request);
   const deployment = createDeploymentContext(request);
   const entri = createEntriContext();
-  const userPlanFeatures = await createUserPlanContext(request);
+  const userPlanFeatures = await createUserPlanContext(request, authorization);
   const trpcCache = createTrpcCache();
   const postgrest = createPostrestContext();
 

--- a/apps/builder/app/shared/context.server.ts
+++ b/apps/builder/app/shared/context.server.ts
@@ -4,12 +4,10 @@ import { authenticator } from "~/services/auth.server";
 import { trpcSharedClient } from "~/services/trpc.server";
 import { entryApi } from "./entri/entri-api.server";
 
-import {
-  getTokenPlanFeatures,
-  getUserPlanFeatures,
-} from "./db/user-plan-features.server";
+import { getUserPlanFeatures } from "./db/user-plan-features.server";
 import { staticEnv } from "~/env/env.static.server";
 import { createClient } from "@webstudio-is/postrest/index.server";
+import { prisma } from "@webstudio-is/prisma-client";
 
 const createAuthorizationContext = async (
   request: Request
@@ -19,7 +17,7 @@ const createAuthorizationContext = async (
   const authToken =
     url.searchParams.get("authToken") ??
     request.headers.get("x-auth-token") ??
-    url.hostname;
+    undefined;
 
   const user = await authenticator.isAuthenticated(request);
 
@@ -27,10 +25,41 @@ const createAuthorizationContext = async (
     request.headers.has("Authorization") &&
     request.headers.get("Authorization") === env.TRPC_SERVER_API_TOKEN;
 
+  let ownerId = user?.id;
+
+  if (authToken != null) {
+    const projectOwnerIdByToken = await prisma.authorizationToken.findUnique({
+      where: {
+        token: authToken,
+      },
+      select: {
+        project: {
+          select: {
+            id: true,
+            userId: true,
+          },
+        },
+      },
+    });
+
+    if (projectOwnerIdByToken === null) {
+      throw new Error(`Project owner can't be found for token ${authToken}`);
+    }
+
+    const projectOwnerId = projectOwnerIdByToken.project.userId;
+    if (projectOwnerId === null) {
+      throw new Error(
+        `Project ${projectOwnerIdByToken.project.id} has null userId`
+      );
+    }
+    ownerId = projectOwnerId;
+  }
+
   const context: AppContext["authorization"] = {
     userId: user?.id,
     authToken,
     isServiceCall,
+    ownerId,
   };
 
   return context;
@@ -76,20 +105,10 @@ const createEntriContext = () => {
 };
 
 const createUserPlanContext = async (
-  request: Request,
   authorization: AppContext["authorization"]
 ) => {
-  const { authToken } = authorization;
-  // When a shared link is accessed, identified by the presence of an authToken,
-  // the system retrieves the plan features associated with the project owner's account.
-  if (authToken != null) {
-    const planFeatures = await getTokenPlanFeatures(authToken);
-    return planFeatures;
-  }
-
-  const user = await authenticator.isAuthenticated(request);
-  const planFeatures = user?.id
-    ? await getUserPlanFeatures(user.id)
+  const planFeatures = authorization.ownerId
+    ? await getUserPlanFeatures(authorization.ownerId)
     : undefined;
   return planFeatures;
 };
@@ -124,7 +143,7 @@ export const createContext = async (request: Request): Promise<AppContext> => {
   const domain = createDomainContext(request);
   const deployment = createDeploymentContext(request);
   const entri = createEntriContext();
-  const userPlanFeatures = await createUserPlanContext(request, authorization);
+  const userPlanFeatures = await createUserPlanContext(authorization);
   const trpcCache = createTrpcCache();
   const postgrest = createPostrestContext();
 

--- a/apps/builder/app/shared/db/user-plan-features.server.ts
+++ b/apps/builder/app/shared/db/user-plan-features.server.ts
@@ -4,35 +4,6 @@ import env from "~/env/env.server";
 
 export type UserPlanFeatures = NonNullable<AppContext["userPlanFeatures"]>;
 
-export const getTokenPlanFeatures = async (token: string) => {
-  const projectOwnerIdByToken = await prisma.authorizationToken.findUnique({
-    where: {
-      token,
-    },
-    select: {
-      project: {
-        select: {
-          id: true,
-          userId: true,
-        },
-      },
-    },
-  });
-
-  if (projectOwnerIdByToken === null) {
-    throw new Error(`Project owner can't be found for token ${token}`);
-  }
-
-  const userId = projectOwnerIdByToken.project.userId;
-  if (userId === null) {
-    throw new Error(
-      `Project ${projectOwnerIdByToken.project.id} has null instead of userId`
-    );
-  }
-
-  return await getUserPlanFeatures(userId);
-};
-
 export const getUserPlanFeatures = async (
   userId: string
 ): Promise<UserPlanFeatures> => {

--- a/apps/builder/app/shared/trpc/trpc-client.ts
+++ b/apps/builder/app/shared/trpc/trpc-client.ts
@@ -19,6 +19,9 @@ const client = createTRPCProxyClient<AppRouter>({
       async headers(_opts) {
         const authToken = $authToken.get();
 
+        if (authToken == null) {
+          return {};
+        }
         // Pass token to api call
         return {
           "x-auth-token": authToken,

--- a/packages/domain/src/trpc/domain.ts
+++ b/packages/domain/src/trpc/domain.ts
@@ -206,10 +206,10 @@ export const domainRouter = router({
 
   countTotalDomains: procedure.query(async ({ ctx }) => {
     try {
-      if (ctx.authorization.userId === undefined) {
+      if (ctx.authorization.ownerId === undefined) {
         throw new Error("Not authorized");
       }
-      const data = await db.countTotalDomains(ctx.authorization.userId);
+      const data = await db.countTotalDomains(ctx.authorization.ownerId);
       return { success: true, data } as const;
     } catch (error) {
       return {

--- a/packages/trpc-interface/src/context/context.server.ts
+++ b/packages/trpc-interface/src/context/context.server.ts
@@ -16,6 +16,11 @@ type AuthorizationContext = {
   authToken: string | undefined;
 
   /**
+   * In case of authToken, this is the ownerId of the project
+   */
+  ownerId: string | undefined;
+
+  /**
    * Allow service 2 service communications to skip authorization for view calls
    */
   isServiceCall: boolean;


### PR DESCRIPTION
## Description




AuthorisationToken didn't used in case of trpc call for context creation
Closes #3786

## Steps for reproduction

Open in incognito

https://fix-plan.development.webstudio.is/builder/d68d6dd1-bc0a-4b21-b5e5-08b7f99336f7?authToken=9d196f63-4256-4e74-98d4-ea678f9f94f1&mode=edit

Add domain, owner plan settings will be used 



## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
