### PR TITLE
feat: use classes for regular styles

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -167,12 +167,12 @@ const Page = ({}: { system: any }) => {
           alt={"Vimeo video preview image"}
           sizes={"100vw"}
           src={"/custom-folder/home_wsKvRSqvkajPPBeycZ-C8.svg"}
-          className="w-vimeo-preview-image c13adha2 c19kjzjn c8mrdqb chv0hit c1vw7ut7 c64vnj4 cow7xo6 cddunt6 cqjhyu2"
+          className="w-preview-image c13adha2 c19kjzjn c8mrdqb chv0hit c1vw7ut7 c64vnj4 cow7xo6 cddunt6 cqjhyu2"
         />
         <VimeoSpinner
           data-ws-id="o8sAMUoaOraWYZClEfRgl"
           data-ws-component="VimeoSpinner"
-          className="w-vimeo-spinner c13adha2 c1ifzo79 c1ljqvnn c10zke2u cplzsl2 c1ardg8l ces5mo3"
+          className="w-spinner c13adha2 c1ifzo79 c1ljqvnn c10zke2u cplzsl2 c1ardg8l ces5mo3"
         >
           <HtmlEmbed
             data-ws-id="BeQ7sgDlUizFvf4aHqOsh"
@@ -188,7 +188,7 @@ const Page = ({}: { system: any }) => {
           data-ws-id="9hBBPGSf7hB30ZkSHKjNd"
           data-ws-component="VimeoPlayButton"
           aria-label={"Play button"}
-          className="w-vimeo-play-button c13adha2 c1t88ri8 ca7kf99 c1ifzo79 c1ljqvnn c1bld9op ctly9e6 cxb89wn cwcnvqs cvchf4 c1y7dyx c1bnrgjg c1joowif c120xed6 c2eug5n cvwgylz c1f0qcby c1syyj1x cil01r8 c11087u4 coba2o7 c82nx6d"
+          className="w-play-button c13adha2 c1t88ri8 ca7kf99 c1ifzo79 c1ljqvnn c1bld9op ctly9e6 cxb89wn cwcnvqs cvchf4 c1y7dyx c1bnrgjg c1joowif c120xed6 c2eug5n cvwgylz c1f0qcby c1syyj1x cil01r8 c11087u4 coba2o7 c82nx6d"
         >
           <Box
             data-ws-id="D__QElBIIQtamhJN3a4FI"

--- a/fixtures/webstudio-custom-template/app/__generated__/index.css
+++ b/fixtures/webstudio-custom-template/app/__generated__/index.css
@@ -91,7 +91,7 @@ html {
     border-left-width: 1px;
     outline-width: 1px;
   }
-  :where(img.w-vimeo-preview-image) {
+  :where(img.w-preview-image) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -102,7 +102,7 @@ html {
     display: block;
     height: auto;
   }
-  :where(button.w-vimeo-play-button) {
+  :where(button.w-play-button) {
     font-family: inherit;
     font-size: 100%;
     line-height: 1.15;
@@ -201,7 +201,7 @@ html {
   :where(div.w-html-embed) {
     display: contents;
   }
-  :where(div.w-vimeo-spinner) {
+  :where(div.w-spinner) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -52,7 +52,7 @@ const Page = ({}: { system: any }) => {
           formState = state;
           set$formState(formState);
         }}
-        className="w-form"
+        className="w-webhook-form"
       >
         {(formState === "initial" || formState === "error") && (
           <Box
@@ -71,7 +71,7 @@ const Page = ({}: { system: any }) => {
             <Label
               data-ws-id="A0RNI1WVwOGGDbwYnoZia"
               data-ws-component="Label"
-              className="w-label"
+              className="w-input-label"
             >
               {"Name"}
             </Label>
@@ -79,12 +79,12 @@ const Page = ({}: { system: any }) => {
               data-ws-id="e035xi9fcwYtrn9La49Eh"
               data-ws-component="Input"
               name={"name"}
-              className="w-input"
+              className="w-text-input"
             />
             <Label
               data-ws-id="LImtuVzw5R9yQsG4faiGV"
               data-ws-component="Label"
-              className="w-label"
+              className="w-input-label"
             >
               {"Email"}
             </Label>
@@ -92,7 +92,7 @@ const Page = ({}: { system: any }) => {
               data-ws-id="dcHjdeW_HXPkyQlx3ZiL7"
               data-ws-component="Input"
               name={"email"}
-              className="w-input"
+              className="w-text-input"
             />
             <Button
               data-ws-id="ZAtG6JgK4sbTnOAZlp2rU"
@@ -132,7 +132,7 @@ const Page = ({}: { system: any }) => {
         }}
         method={"get"}
         action={"/custom"}
-        className="w-form"
+        className="w-webhook-form"
       >
         {(formState_1 === "initial" || formState_1 === "error") && (
           <Box
@@ -151,7 +151,7 @@ const Page = ({}: { system: any }) => {
             <Label
               data-ws-id="_gLjS0enBOV8KW9Ykz_es"
               data-ws-component="Label"
-              className="w-label"
+              className="w-input-label"
             >
               {"Name"}
             </Label>
@@ -159,12 +159,12 @@ const Page = ({}: { system: any }) => {
               data-ws-id="ydR5B_9uMS4PXFS76TmBh"
               data-ws-component="Input"
               name={"name"}
-              className="w-input"
+              className="w-text-input"
             />
             <Label
               data-ws-id="8RU1FyL2QRyqhNUKELGrb"
               data-ws-component="Label"
-              className="w-label"
+              className="w-input-label"
             >
               {"Email"}
             </Label>
@@ -172,7 +172,7 @@ const Page = ({}: { system: any }) => {
               data-ws-id="TsqGP49hjgEW41ReCwrpZ"
               data-ws-component="Input"
               name={"email"}
-              className="w-input"
+              className="w-text-input"
             />
             <Button
               data-ws-id="5GWjwVdapuGdn443GIKDW"

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -60,17 +60,17 @@ const Page = ({}: { system: any }) => {
           data-ws-id="zJ927zk9txwUbYycKB7QA"
           data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionItem"
           data-ws-index="0"
-          className="w-accordion-item c2onvcp"
+          className="w-item c2onvcp"
         >
           <AccordionHeader
             data-ws-id="sMxg7xT1hwYt05hbOvoPL"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionHeader"
-            className="w-accordion-header c13v7j50"
+            className="w-item-header c13v7j50"
           >
             <AccordionTrigger
               data-ws-id="qQSA4NoyKC88O68mBiQe2"
               data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionTrigger"
-              className="w-accordion-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc"
+              className="w-item-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc"
             >
               <Text
                 data-ws-id="q-DVI4YTNrQ1LizmEyJHI"
@@ -98,7 +98,7 @@ const Page = ({}: { system: any }) => {
           <AccordionContent
             data-ws-id="IUftdfjK-ilSzfOTdIx1u"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionContent"
-            className="w-accordion-content c1mxwmum c1j0j9ep c1gl2i2 c44srea"
+            className="w-item-content c1mxwmum c1j0j9ep c1gl2i2 c44srea"
           >
             {"Yes. It adheres to the WAI-ARIA design pattern."}
           </AccordionContent>
@@ -107,17 +107,17 @@ const Page = ({}: { system: any }) => {
           data-ws-id="C838wkvIcA1BQu30Xu2G8"
           data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionItem"
           data-ws-index="1"
-          className="w-accordion-item c2onvcp"
+          className="w-item c2onvcp"
         >
           <AccordionHeader
             data-ws-id="fYUOB_brm6s0Ky68lzMfU"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionHeader"
-            className="w-accordion-header c13v7j50"
+            className="w-item-header c13v7j50"
           >
             <AccordionTrigger
               data-ws-id="dfd4gonev_AX6BpuCsxjb"
               data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionTrigger"
-              className="w-accordion-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc"
+              className="w-item-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc"
             >
               <Text
                 data-ws-id="lZ7sI6Kw_0VZkURriKscB"
@@ -145,7 +145,7 @@ const Page = ({}: { system: any }) => {
           <AccordionContent
             data-ws-id="wNRVuu0L5E8TVufKdswp1"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionContent"
-            className="w-accordion-content c1mxwmum c1j0j9ep c1gl2i2 c44srea"
+            className="w-item-content c1mxwmum c1j0j9ep c1gl2i2 c44srea"
           >
             {
               "Yes. It comes with default styles that matches the other components' aesthetic."
@@ -156,17 +156,17 @@ const Page = ({}: { system: any }) => {
           data-ws-id="65djoTmSBGemZ2L5izQ5M"
           data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionItem"
           data-ws-index="2"
-          className="w-accordion-item c2onvcp"
+          className="w-item c2onvcp"
         >
           <AccordionHeader
             data-ws-id="UJYfe6kH7HqhH0YYeJwe7"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionHeader"
-            className="w-accordion-header c13v7j50"
+            className="w-item-header c13v7j50"
           >
             <AccordionTrigger
               data-ws-id="600nGddaNxGGdsuGgpxJR"
               data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionTrigger"
-              className="w-accordion-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc"
+              className="w-item-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc"
             >
               <Text
                 data-ws-id="1iNKIMG91n83PzJnEdxq9"
@@ -194,7 +194,7 @@ const Page = ({}: { system: any }) => {
           <AccordionContent
             data-ws-id="mOVPnIrlt6IwVAzI_i2Fc"
             data-ws-component="@webstudio-is/sdk-components-react-radix:AccordionContent"
-            className="w-accordion-content c1mxwmum c1j0j9ep c1gl2i2 c44srea"
+            className="w-item-content c1mxwmum c1j0j9ep c1gl2i2 c44srea"
           >
             {
               "Yes. It's animated by default, but you can disable it if you prefer."

--- a/fixtures/webstudio-remix-vercel/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/index.css
@@ -191,7 +191,7 @@ html {
     border-left-width: 1px;
     outline-width: 1px;
   }
-  :where(div.w-accordion-item) {
+  :where(div.w-item) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -199,7 +199,7 @@ html {
     border-left-width: 1px;
     outline-width: 1px;
   }
-  :where(h3.w-accordion-header) {
+  :where(h3.w-item-header) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -209,7 +209,7 @@ html {
     margin-top: 0px;
     margin-bottom: 0px;
   }
-  :where(button.w-accordion-trigger) {
+  :where(button.w-item-trigger) {
     font-family: inherit;
     font-size: 100%;
     line-height: 1.15;
@@ -224,7 +224,7 @@ html {
   :where(div.w-html-embed) {
     display: contents;
   }
-  :where(div.w-accordion-content) {
+  :where(div.w-item-content) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -232,7 +232,7 @@ html {
     border-left-width: 1px;
     outline-width: 1px;
   }
-  :where(form.w-form) {
+  :where(form.w-webhook-form) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -241,7 +241,7 @@ html {
     outline-width: 1px;
     min-height: 20px;
   }
-  :where(label.w-label) {
+  :where(label.w-input-label) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -250,7 +250,7 @@ html {
     outline-width: 1px;
     display: block;
   }
-  :where(input.w-input) {
+  :where(input.w-text-input) {
     font-family: inherit;
     font-size: 100%;
     line-height: 1.15;

--- a/packages/react-sdk/src/css/css.test.tsx
+++ b/packages/react-sdk/src/css/css.test.tsx
@@ -55,7 +55,7 @@ test("generate css for one instance with two tokens", () => {
   expect(cssText).toMatchInlineSnapshot(`
 "html {margin: 0; display: grid; min-height: 100%}
 @media all {
-  [data-ws-id="box"] {
+  .w-box {
     color: red
   }
 }"
@@ -135,16 +135,16 @@ test("generate descendant selector", () => {
   expect(cssText).toMatchInlineSnapshot(`
 "html {margin: 0; display: grid; min-height: 100%}
 @media all {
-  [data-ws-id="root"] {
+  .w-body {
     color: blue
   }
-  [data-ws-id="root"]:hover {
+  .w-body:hover {
     color: red
   }
-  [data-ws-id="root"] a {
+  .w-body a {
     color: blue
   }
-  [data-ws-id="root"] a:hover {
+  .w-body a:hover {
     color: red
   }
 }"
@@ -314,7 +314,7 @@ test("expose preset classes to instances", () => {
         <$.Box ws:id="box"></$.Box>
       </$.Body>
     ),
-    breakpoints: new Map(),
+    breakpoints: toMap([{ id: "base", label: "" }]),
     styleSourceSelections: new Map([
       ["body", { instanceId: "body", values: ["localBody"] }],
       ["box", { instanceId: "box", values: ["localBox"] }],
@@ -383,15 +383,24 @@ test("expose preset classes to instances", () => {
     display: flex
   }
 }
-"
+@media all {
+  .c17hlgoh {
+    color: blue
+  }
+  .cawkhls {
+    color: red
+  }
+}"
 `);
   expect(classes).toMatchInlineSnapshot(`
 Map {
   "body" => [
     "w-body",
+    "w-body-1",
   ],
   "box" => [
     "w-box",
+    "w-box-1",
   ],
 }
 `);
@@ -404,6 +413,108 @@ Map {
   "box" => [
     "w-box",
     "cawkhls",
+  ],
+}
+`);
+});
+
+test("generate classes with instance and meta label", () => {
+  const { cssText, classes } = generateAllCss({
+    assets: new Map(),
+    ...renderJsx(
+      <$.Body ws:id="body">
+        <$.Box ws:id="box" ws:label="box%instance#label"></$.Box>
+      </$.Body>
+    ),
+    breakpoints: toMap([{ id: "base", label: "" }]),
+    styleSourceSelections: new Map([
+      ["body", { instanceId: "body", values: ["localBody"] }],
+      ["box", { instanceId: "box", values: ["localBox"] }],
+    ]),
+    styles: new Map([
+      [
+        "localBody:base:color",
+        {
+          styleSourceId: "localBody",
+          breakpointId: "base",
+          property: "color",
+          value: { type: "keyword", value: "blue" },
+        },
+      ],
+      [
+        "localBox:base:color::hover",
+        {
+          styleSourceId: "localBox",
+          breakpointId: "base",
+          property: "color",
+          value: { type: "keyword", value: "red" },
+        },
+      ],
+    ]),
+    componentMetas: new Map([
+      [
+        "Body",
+        {
+          type: "container",
+          icon: "",
+          label: "body meta label",
+          presetStyle: {
+            div: [
+              {
+                property: "display",
+                value: { type: "keyword", value: "block" },
+              },
+            ],
+          },
+        },
+      ],
+      [
+        "Box",
+        {
+          type: "container",
+          icon: "",
+          label: "box meta label",
+          presetStyle: {
+            div: [
+              {
+                property: "display",
+                value: { type: "keyword", value: "flex" },
+              },
+            ],
+          },
+        },
+      ],
+    ]),
+    assetBaseUrl: "",
+  });
+  expect(cssText).toMatchInlineSnapshot(`
+"html {margin: 0; display: grid; min-height: 100%}
+@media all {
+  :where(div.w-body-meta-label) {
+    display: block
+  }
+  :where(div.w-box-meta-label) {
+    display: flex
+  }
+}
+@media all {
+  .w-body-meta-label-1 {
+    color: blue
+  }
+  .w-box-instance-label {
+    color: red
+  }
+}"
+`);
+  expect(classes).toMatchInlineSnapshot(`
+Map {
+  "body" => [
+    "w-body-meta-label",
+    "w-body-meta-label-1",
+  ],
+  "box" => [
+    "w-box-meta-label",
+    "w-box-instance-label",
   ],
 }
 `);

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -81,7 +81,7 @@ export const generateCss = ({
   const scope = createScope([], normalizeClassName, "-");
   for (const [component, meta] of componentMetas) {
     const [_namespace, componentName] = parseComponentName(component);
-    const className = `w-${scope.getName(component, componentName)}`;
+    const className = `w-${scope.getName(component, meta.label ?? componentName)}`;
     const presetStyle = Object.entries(meta.presetStyle ?? {});
     if (presetStyle.length > 0) {
       // add preset class only when at least one style is defined
@@ -158,10 +158,19 @@ export const generateCss = ({
         instanceId = parentId;
       }
     }
-    const rule = sheet.addNestingRule(
-      `[${idAttribute}="${instanceId}"]`,
-      descendantSuffix
-    );
+    const meta = instance ? componentMetas.get(instance.component) : undefined;
+    const baseName =
+      instance?.label ?? meta?.label ?? instance?.component ?? instanceId;
+    const className = `w-${scope.getName(instanceId, baseName)}`;
+    if (atomic === false) {
+      let classList = classes.get(instanceId);
+      if (classList === undefined) {
+        classList = [];
+        classes.set(instanceId, classList);
+      }
+      classList.push(className);
+    }
+    const rule = sheet.addNestingRule(`.${className}`, descendantSuffix);
     rule.applyMixins(values);
     instanceByRule.set(rule, instanceId);
   }

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -16,7 +16,6 @@ import {
   type Styles,
 } from "@webstudio-is/sdk";
 import type { WsComponentMeta } from "../components/component-meta";
-import { idAttribute } from "../props";
 import { descendantComponent } from "../core-components";
 import { addGlobalRules } from "./global-rules";
 import { kebabCase } from "change-case";

--- a/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/accordion.stories.tsx
@@ -25,22 +25,26 @@ const Component = () => {
           data-ws-id="4"
           data-ws-component="AccordionItem"
           data-ws-index="0"
-          className="w-accordion-item"
+          className="w-item w-item-1"
         >
           <AccordionHeader
             data-ws-id="6"
             data-ws-component="AccordionHeader"
-            className="w-accordion-header"
+            className="w-item-header w-item-header-1"
           >
             <AccordionTrigger
               data-ws-id="8"
               data-ws-component="AccordionTrigger"
-              className="w-accordion-trigger"
+              className="w-item-trigger w-item-trigger-1"
             >
               <Text data-ws-id="10" data-ws-component="Text" className="w-text">
                 {"Is it accessible?"}
               </Text>
-              <Box data-ws-id="11" data-ws-component="Box" className="w-box">
+              <Box
+                data-ws-id="11"
+                data-ws-component="Box"
+                className="w-box w-icon-container"
+              >
                 <HtmlEmbed
                   data-ws-id="13"
                   data-ws-component="HtmlEmbed"
@@ -55,7 +59,7 @@ const Component = () => {
           <AccordionContent
             data-ws-id="15"
             data-ws-component="AccordionContent"
-            className="w-accordion-content"
+            className="w-item-content w-item-content-1"
           >
             {"Yes. It adheres to the WAI-ARIA design pattern."}
           </AccordionContent>
@@ -64,22 +68,26 @@ const Component = () => {
           data-ws-id="17"
           data-ws-component="AccordionItem"
           data-ws-index="1"
-          className="w-accordion-item"
+          className="w-item w-item-2"
         >
           <AccordionHeader
             data-ws-id="19"
             data-ws-component="AccordionHeader"
-            className="w-accordion-header"
+            className="w-item-header w-item-header-2"
           >
             <AccordionTrigger
               data-ws-id="21"
               data-ws-component="AccordionTrigger"
-              className="w-accordion-trigger"
+              className="w-item-trigger w-item-trigger-2"
             >
               <Text data-ws-id="23" data-ws-component="Text" className="w-text">
                 {"Is it styled?"}
               </Text>
-              <Box data-ws-id="24" data-ws-component="Box" className="w-box">
+              <Box
+                data-ws-id="24"
+                data-ws-component="Box"
+                className="w-box w-icon-container-1"
+              >
                 <HtmlEmbed
                   data-ws-id="26"
                   data-ws-component="HtmlEmbed"
@@ -94,7 +102,7 @@ const Component = () => {
           <AccordionContent
             data-ws-id="28"
             data-ws-component="AccordionContent"
-            className="w-accordion-content"
+            className="w-item-content w-item-content-2"
           >
             {
               "Yes. It comes with default styles that matches the other components' aesthetic."
@@ -105,22 +113,26 @@ const Component = () => {
           data-ws-id="30"
           data-ws-component="AccordionItem"
           data-ws-index="2"
-          className="w-accordion-item"
+          className="w-item w-item-3"
         >
           <AccordionHeader
             data-ws-id="32"
             data-ws-component="AccordionHeader"
-            className="w-accordion-header"
+            className="w-item-header w-item-header-3"
           >
             <AccordionTrigger
               data-ws-id="34"
               data-ws-component="AccordionTrigger"
-              className="w-accordion-trigger"
+              className="w-item-trigger w-item-trigger-3"
             >
               <Text data-ws-id="36" data-ws-component="Text" className="w-text">
                 {"Is it animated?"}
               </Text>
-              <Box data-ws-id="37" data-ws-component="Box" className="w-box">
+              <Box
+                data-ws-id="37"
+                data-ws-component="Box"
+                className="w-box w-icon-container-2"
+              >
                 <HtmlEmbed
                   data-ws-id="39"
                   data-ws-component="HtmlEmbed"
@@ -135,7 +147,7 @@ const Component = () => {
           <AccordionContent
             data-ws-id="41"
             data-ws-component="AccordionContent"
-            className="w-accordion-content"
+            className="w-item-content w-item-content-3"
           >
             {
               "Yes. It's animated by default, but you can disable it if you prefer."
@@ -260,7 +272,7 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     outline-width: 1px
   }
-  :where(div.w-accordion-item) {
+  :where(div.w-item) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -268,7 +280,7 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     outline-width: 1px
   }
-  :where(h3.w-accordion-header) {
+  :where(h3.w-item-header) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -278,7 +290,7 @@ html {margin: 0; display: grid; min-height: 100%}
     margin-top: 0px;
     margin-bottom: 0px
   }
-  :where(button.w-accordion-trigger) {
+  :where(button.w-item-trigger) {
     font-family: inherit;
     font-size: 100%;
     line-height: 1.15;
@@ -302,7 +314,7 @@ html {margin: 0; display: grid; min-height: 100%}
   :where(div.w-html-embed) {
     display: contents
   }
-  :where(div.w-accordion-content) {
+  :where(div.w-item-content) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -312,13 +324,13 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="4"] {
+  .w-item-1 {
     border-bottom: 1px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="6"] {
+  .w-item-header-1 {
     display: flex
   }
-  [data-ws-id="8"] {
+  .w-item-trigger-1 {
     display: flex;
     flex-grow: 1;
     flex-shrink: 1;
@@ -330,13 +342,13 @@ html {margin: 0; display: grid; min-height: 100%}
     font-weight: 500;
     --accordion-trigger-icon-transform: 0deg
   }
-  [data-ws-id="8"]:hover {
+  .w-item-trigger-1:hover {
     text-decoration-line: underline
   }
-  [data-ws-id="8"][data-state=open] {
+  .w-item-trigger-1[data-state=open] {
     --accordion-trigger-icon-transform: 180deg
   }
-  [data-ws-id="11"] {
+  .w-icon-container {
     rotate: var(--accordion-trigger-icon-transform);
     height: 1rem;
     width: 1rem;
@@ -345,20 +357,20 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="15"] {
+  .w-item-content-1 {
     overflow-x: hidden;
     overflow-y: hidden;
     font-size: 0.875rem;
     line-height: 1.25rem;
     padding-bottom: 1rem
   }
-  [data-ws-id="17"] {
+  .w-item-2 {
     border-bottom: 1px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="19"] {
+  .w-item-header-2 {
     display: flex
   }
-  [data-ws-id="21"] {
+  .w-item-trigger-2 {
     display: flex;
     flex-grow: 1;
     flex-shrink: 1;
@@ -370,13 +382,13 @@ html {margin: 0; display: grid; min-height: 100%}
     font-weight: 500;
     --accordion-trigger-icon-transform: 0deg
   }
-  [data-ws-id="21"]:hover {
+  .w-item-trigger-2:hover {
     text-decoration-line: underline
   }
-  [data-ws-id="21"][data-state=open] {
+  .w-item-trigger-2[data-state=open] {
     --accordion-trigger-icon-transform: 180deg
   }
-  [data-ws-id="24"] {
+  .w-icon-container-1 {
     rotate: var(--accordion-trigger-icon-transform);
     height: 1rem;
     width: 1rem;
@@ -385,20 +397,20 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="28"] {
+  .w-item-content-2 {
     overflow-x: hidden;
     overflow-y: hidden;
     font-size: 0.875rem;
     line-height: 1.25rem;
     padding-bottom: 1rem
   }
-  [data-ws-id="30"] {
+  .w-item-3 {
     border-bottom: 1px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="32"] {
+  .w-item-header-3 {
     display: flex
   }
-  [data-ws-id="34"] {
+  .w-item-trigger-3 {
     display: flex;
     flex-grow: 1;
     flex-shrink: 1;
@@ -410,13 +422,13 @@ html {margin: 0; display: grid; min-height: 100%}
     font-weight: 500;
     --accordion-trigger-icon-transform: 0deg
   }
-  [data-ws-id="34"]:hover {
+  .w-item-trigger-3:hover {
     text-decoration-line: underline
   }
-  [data-ws-id="34"][data-state=open] {
+  .w-item-trigger-3[data-state=open] {
     --accordion-trigger-icon-transform: 180deg
   }
-  [data-ws-id="37"] {
+  .w-icon-container-2 {
     rotate: var(--accordion-trigger-icon-transform);
     height: 1rem;
     width: 1rem;
@@ -425,7 +437,7 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="41"] {
+  .w-item-content-3 {
     overflow-x: hidden;
     overflow-y: hidden;
     font-size: 0.875rem;

--- a/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/checkbox.stories.tsx
@@ -14,7 +14,11 @@ const Component = () => {
   let [checkboxChecked, set$checkboxChecked] = useState<any>(false);
   return (
     <Box data-ws-id="root" data-ws-component="Box" className="w-box">
-      <Label data-ws-id="1" data-ws-component="Label" className="w-label">
+      <Label
+        data-ws-id="1"
+        data-ws-component="Label"
+        className="w-label w-checkbox-field"
+      >
         <Checkbox
           data-ws-id="3"
           data-ws-component="Checkbox"
@@ -23,12 +27,12 @@ const Component = () => {
             checkboxChecked = checked;
             set$checkboxChecked(checkboxChecked);
           }}
-          className="w-checkbox"
+          className="w-checkbox w-checkbox-1"
         >
           <CheckboxIndicator
             data-ws-id="8"
             data-ws-component="CheckboxIndicator"
-            className="w-checkbox-indicator"
+            className="w-checkbox-indicator w-checkbox-indicator-1"
           >
             <HtmlEmbed
               data-ws-id="10"
@@ -200,13 +204,13 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="1"] {
+  .w-checkbox-field {
     display: flex;
     row-gap: 0.5rem;
     column-gap: 0.5rem;
     align-items: center
   }
-  [data-ws-id="3"] {
+  .w-checkbox-1 {
     height: 1rem;
     width: 1rem;
     flex-grow: 0;
@@ -216,20 +220,20 @@ html {margin: 0; display: grid; min-height: 100%}
     border-bottom-left-radius: 0.125rem;
     border: 1px solid rgba(15, 23, 42, 1)
   }
-  [data-ws-id="3"]:disabled {
+  .w-checkbox-1:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="3"]:focus-visible {
+  .w-checkbox-1:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="3"][data-state=checked] {
+  .w-checkbox-1[data-state=checked] {
     background-color: rgba(15, 23, 42, 1);
     color: rgba(248, 250, 252, 1)
   }
-  [data-ws-id="8"] {
+  .w-checkbox-indicator-1 {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/collapsible.stories.tsx
@@ -24,7 +24,7 @@ const Component = () => {
           <Button
             data-ws-id="3"
             data-ws-component="Button"
-            className="w-button"
+            className="w-button w-button-1"
           >
             {"Click to toggle content"}
           </Button>
@@ -191,7 +191,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="3"] {
+  .w-button-1 {
     background-color: rgba(255, 255, 255, 0.8);
     display: inline-flex;
     align-items: center;
@@ -211,16 +211,16 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-bottom: 0.5rem;
     border: 1px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="3"]:disabled {
+  .w-button-1:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="3"]:focus-visible {
+  .w-button-1:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="3"]:hover {
+  .w-button-1:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.stories.tsx
@@ -22,7 +22,7 @@ const Component = () => {
           <Button
             data-ws-id="3"
             data-ws-component="Button"
-            className="w-button"
+            className="w-button w-button-1"
           >
             {"Button"}
           </Button>
@@ -30,25 +30,29 @@ const Component = () => {
         <DialogOverlay
           data-ws-id="5"
           data-ws-component="DialogOverlay"
-          className="w-dialog-overlay"
+          className="w-dialog-overlay w-dialog-overlay-1"
         >
           <DialogContent
             data-ws-id="7"
             data-ws-component="DialogContent"
-            className="w-dialog-content"
+            className="w-dialog-content w-dialog-content-1"
           >
-            <Box data-ws-id="9" data-ws-component="Box" className="w-box">
+            <Box
+              data-ws-id="9"
+              data-ws-component="Box"
+              className="w-box w-dialog-header"
+            >
               <DialogTitle
                 data-ws-id="11"
                 data-ws-component="DialogTitle"
-                className="w-dialog-title"
+                className="w-dialog-title w-dialog-title-1"
               >
                 {"Dialog Title you can edit"}
               </DialogTitle>
               <DialogDescription
                 data-ws-id="13"
                 data-ws-component="DialogDescription"
-                className="w-dialog-description"
+                className="w-dialog-description w-dialog-description-1"
               >
                 {"Dialog description text you can edit"}
               </DialogDescription>
@@ -59,7 +63,7 @@ const Component = () => {
             <DialogClose
               data-ws-id="16"
               data-ws-component="DialogClose"
-              className="w-dialog-close"
+              className="w-close-button w-close-button-1"
             >
               <HtmlEmbed
                 data-ws-id="18"
@@ -239,7 +243,7 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-width: 1px;
     min-height: 1em
   }
-  :where(button.w-dialog-close) {
+  :where(button.w-close-button) {
     background-color: transparent;
     background-image: none;
     font-family: inherit;
@@ -256,7 +260,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="3"] {
+  .w-button-1 {
     background-color: rgba(255, 255, 255, 0.8);
     display: inline-flex;
     align-items: center;
@@ -276,20 +280,20 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-bottom: 0.5rem;
     border: 1px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="3"]:disabled {
+  .w-button-1:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="3"]:focus-visible {
+  .w-button-1:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="3"]:hover {
+  .w-button-1:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="5"] {
+  .w-dialog-overlay-1 {
     position: fixed;
     left: 0px;
     right: 0px;
@@ -303,7 +307,7 @@ html {margin: 0; display: grid; min-height: 100%}
     overflow-x: auto;
     overflow-y: auto
   }
-  [data-ws-id="7"] {
+  .w-dialog-content-1 {
     width: 100%;
     z-index: 50;
     display: flex;
@@ -318,27 +322,27 @@ html {margin: 0; display: grid; min-height: 100%}
     margin: auto;
     padding: 1.5rem
   }
-  [data-ws-id="9"] {
+  .w-dialog-header {
     display: flex;
     flex-direction: column;
     row-gap: 0.25rem;
     column-gap: 0.25rem
   }
-  [data-ws-id="11"] {
+  .w-dialog-title-1 {
     margin-top: 0px;
     margin-bottom: 0px;
     line-height: 1.75rem;
     font-size: 1.125rem;
     letter-spacing: -0.025em
   }
-  [data-ws-id="13"] {
+  .w-dialog-description-1 {
     margin-top: 0px;
     margin-bottom: 0px;
     font-size: 0.875rem;
     line-height: 1.25rem;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="16"] {
+  .w-close-button-1 {
     position: absolute;
     right: 1rem;
     top: 1rem;
@@ -357,10 +361,10 @@ html {margin: 0; display: grid; min-height: 100%}
     outline: 2px solid transparent;
     border: 0px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="16"]:focus {
+  .w-close-button-1:focus {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="16"]:hover {
+  .w-close-button-1:hover {
     opacity: 1
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/label.stories.tsx
@@ -4,7 +4,11 @@ import { Label as Label } from "../components";
 const Component = () => {
   return (
     <Box data-ws-id="root" data-ws-component="Box" className="w-box">
-      <Label data-ws-id="1" data-ws-component="Label" className="w-label">
+      <Label
+        data-ws-id="1"
+        data-ws-component="Label"
+        className="w-label w-label-1"
+      >
         {"Form Label"}
       </Label>
     </Box>
@@ -126,7 +130,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="1"] {
+  .w-label-1 {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500

--- a/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/navigation-menu.stories.tsx
@@ -22,28 +22,28 @@ const Component = () => {
       <NavigationMenu
         data-ws-id="1"
         data-ws-component="NavigationMenu"
-        className="w-navigation-menu"
+        className="w-navigation-menu w-navigation-menu-1"
       >
         <NavigationMenuList
           data-ws-id="3"
           data-ws-component="NavigationMenuList"
-          className="w-navigation-menu-list"
+          className="w-menu-list w-menu-list-1"
         >
           <NavigationMenuItem
             data-ws-id="5"
             data-ws-component="NavigationMenuItem"
             data-ws-index="0"
-            className="w-navigation-menu-item"
+            className="w-menu-item"
           >
             <NavigationMenuTrigger
               data-ws-id="6"
               data-ws-component="NavigationMenuTrigger"
-              className="w-navigation-menu-trigger"
+              className="w-menu-trigger"
             >
               <Button
                 data-ws-id="7"
                 data-ws-component="Button"
-                className="w-button"
+                className="w-button w-button-1"
               >
                 <Text
                   data-ws-id="9"
@@ -52,7 +52,11 @@ const Component = () => {
                 >
                   {"About"}
                 </Text>
-                <Box data-ws-id="10" data-ws-component="Box" className="w-box">
+                <Box
+                  data-ws-id="10"
+                  data-ws-component="Box"
+                  className="w-box w-icon-container"
+                >
                   <HtmlEmbed
                     data-ws-id="12"
                     data-ws-component="HtmlEmbed"
@@ -68,35 +72,47 @@ const Component = () => {
               data-ws-id="14"
               data-ws-component="NavigationMenuContent"
               data-ws-index="0"
-              className="w-navigation-menu-content"
+              className="w-menu-content w-menu-content-1"
             >
-              <Box data-ws-id="16" data-ws-component="Box" className="w-box">
-                <Box data-ws-id="18" data-ws-component="Box" className="w-box">
+              <Box
+                data-ws-id="16"
+                data-ws-component="Box"
+                className="w-box w-content"
+              >
+                <Box
+                  data-ws-id="18"
+                  data-ws-component="Box"
+                  className="w-box w-box-1"
+                >
                   {""}
                 </Box>
-                <Box data-ws-id="20" data-ws-component="Box" className="w-box">
+                <Box
+                  data-ws-id="20"
+                  data-ws-component="Box"
+                  className="w-box w-flex-column"
+                >
                   <NavigationMenuLink
                     data-ws-id="22"
                     data-ws-component="NavigationMenuLink"
-                    className="w-navigation-menu-link"
+                    className="w-accessible-link-wrapper"
                   >
                     <Link
                       data-ws-id="23"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/sheet"}
-                      className="w-link"
+                      className="w-link w-link-1"
                     >
                       <Text
                         data-ws-id="26"
                         data-ws-component="Text"
-                        className="w-text"
+                        className="w-text w-text-1"
                       >
                         {"Sheet"}
                       </Text>
                       <Paragraph
                         data-ws-id="28"
                         data-ws-component="Paragraph"
-                        className="w-paragraph"
+                        className="w-paragraph w-paragraph-1"
                       >
                         {
                           "Extends the Dialog component to display content that complements the main content of the screen."
@@ -107,7 +123,7 @@ const Component = () => {
                   <NavigationMenuLink
                     data-ws-id="30"
                     data-ws-component="NavigationMenuLink"
-                    className="w-navigation-menu-link"
+                    className="w-accessible-link-wrapper"
                   >
                     <Link
                       data-ws-id="31"
@@ -115,19 +131,19 @@ const Component = () => {
                       href={
                         "https://ui.shadcn.com/docs/components/navigation-menu"
                       }
-                      className="w-link"
+                      className="w-link w-link-2"
                     >
                       <Text
                         data-ws-id="34"
                         data-ws-component="Text"
-                        className="w-text"
+                        className="w-text w-text-2"
                       >
                         {"Navigation Menu"}
                       </Text>
                       <Paragraph
                         data-ws-id="36"
                         data-ws-component="Paragraph"
-                        className="w-paragraph"
+                        className="w-paragraph w-paragraph-2"
                       >
                         {"A collection of links for navigating websites."}
                       </Paragraph>
@@ -136,25 +152,25 @@ const Component = () => {
                   <NavigationMenuLink
                     data-ws-id="38"
                     data-ws-component="NavigationMenuLink"
-                    className="w-navigation-menu-link"
+                    className="w-accessible-link-wrapper"
                   >
                     <Link
                       data-ws-id="39"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/tabs"}
-                      className="w-link"
+                      className="w-link w-link-3"
                     >
                       <Text
                         data-ws-id="42"
                         data-ws-component="Text"
-                        className="w-text"
+                        className="w-text w-text-3"
                       >
                         {"Tabs"}
                       </Text>
                       <Paragraph
                         data-ws-id="44"
                         data-ws-component="Paragraph"
-                        className="w-paragraph"
+                        className="w-paragraph w-paragraph-3"
                       >
                         {
                           "A set of layered sections of content—known as tab panels—that are displayed one at a time."
@@ -170,17 +186,17 @@ const Component = () => {
             data-ws-id="46"
             data-ws-component="NavigationMenuItem"
             data-ws-index="1"
-            className="w-navigation-menu-item"
+            className="w-menu-item"
           >
             <NavigationMenuTrigger
               data-ws-id="47"
               data-ws-component="NavigationMenuTrigger"
-              className="w-navigation-menu-trigger"
+              className="w-menu-trigger"
             >
               <Button
                 data-ws-id="48"
                 data-ws-component="Button"
-                className="w-button"
+                className="w-button w-button-2"
               >
                 <Text
                   data-ws-id="50"
@@ -189,7 +205,11 @@ const Component = () => {
                 >
                   {"Components"}
                 </Text>
-                <Box data-ws-id="51" data-ws-component="Box" className="w-box">
+                <Box
+                  data-ws-id="51"
+                  data-ws-component="Box"
+                  className="w-box w-icon-container-1"
+                >
                   <HtmlEmbed
                     data-ws-id="53"
                     data-ws-component="HtmlEmbed"
@@ -205,32 +225,40 @@ const Component = () => {
               data-ws-id="55"
               data-ws-component="NavigationMenuContent"
               data-ws-index="1"
-              className="w-navigation-menu-content"
+              className="w-menu-content w-menu-content-2"
             >
-              <Box data-ws-id="57" data-ws-component="Box" className="w-box">
-                <Box data-ws-id="59" data-ws-component="Box" className="w-box">
+              <Box
+                data-ws-id="57"
+                data-ws-component="Box"
+                className="w-box w-content-1"
+              >
+                <Box
+                  data-ws-id="59"
+                  data-ws-component="Box"
+                  className="w-box w-flex-column-1"
+                >
                   <NavigationMenuLink
                     data-ws-id="61"
                     data-ws-component="NavigationMenuLink"
-                    className="w-navigation-menu-link"
+                    className="w-accessible-link-wrapper"
                   >
                     <Link
                       data-ws-id="62"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/accordion"}
-                      className="w-link"
+                      className="w-link w-link-4"
                     >
                       <Text
                         data-ws-id="65"
                         data-ws-component="Text"
-                        className="w-text"
+                        className="w-text w-text-4"
                       >
                         {"Accordion"}
                       </Text>
                       <Paragraph
                         data-ws-id="67"
                         data-ws-component="Paragraph"
-                        className="w-paragraph"
+                        className="w-paragraph w-paragraph-4"
                       >
                         {
                           "A vertically stacked set of interactive headings that each reveal a section of content."
@@ -241,25 +269,25 @@ const Component = () => {
                   <NavigationMenuLink
                     data-ws-id="69"
                     data-ws-component="NavigationMenuLink"
-                    className="w-navigation-menu-link"
+                    className="w-accessible-link-wrapper"
                   >
                     <Link
                       data-ws-id="70"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/dialog"}
-                      className="w-link"
+                      className="w-link w-link-5"
                     >
                       <Text
                         data-ws-id="73"
                         data-ws-component="Text"
-                        className="w-text"
+                        className="w-text w-text-5"
                       >
                         {"Dialog"}
                       </Text>
                       <Paragraph
                         data-ws-id="75"
                         data-ws-component="Paragraph"
-                        className="w-paragraph"
+                        className="w-paragraph w-paragraph-5"
                       >
                         {
                           "A window overlaid on either the primary window or another dialog window, rendering the content underneath inert."
@@ -270,25 +298,25 @@ const Component = () => {
                   <NavigationMenuLink
                     data-ws-id="77"
                     data-ws-component="NavigationMenuLink"
-                    className="w-navigation-menu-link"
+                    className="w-accessible-link-wrapper"
                   >
                     <Link
                       data-ws-id="78"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/collapsible"}
-                      className="w-link"
+                      className="w-link w-link-6"
                     >
                       <Text
                         data-ws-id="81"
                         data-ws-component="Text"
-                        className="w-text"
+                        className="w-text w-text-6"
                       >
                         {"Collapsible"}
                       </Text>
                       <Paragraph
                         data-ws-id="83"
                         data-ws-component="Paragraph"
-                        className="w-paragraph"
+                        className="w-paragraph w-paragraph-6"
                       >
                         {
                           "An interactive component which expands/collapses a panel."
@@ -297,29 +325,33 @@ const Component = () => {
                     </Link>
                   </NavigationMenuLink>
                 </Box>
-                <Box data-ws-id="85" data-ws-component="Box" className="w-box">
+                <Box
+                  data-ws-id="85"
+                  data-ws-component="Box"
+                  className="w-box w-flex-column-2"
+                >
                   <NavigationMenuLink
                     data-ws-id="87"
                     data-ws-component="NavigationMenuLink"
-                    className="w-navigation-menu-link"
+                    className="w-accessible-link-wrapper"
                   >
                     <Link
                       data-ws-id="88"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/popover"}
-                      className="w-link"
+                      className="w-link w-link-7"
                     >
                       <Text
                         data-ws-id="91"
                         data-ws-component="Text"
-                        className="w-text"
+                        className="w-text w-text-7"
                       >
                         {"Popover"}
                       </Text>
                       <Paragraph
                         data-ws-id="93"
                         data-ws-component="Paragraph"
-                        className="w-paragraph"
+                        className="w-paragraph w-paragraph-7"
                       >
                         {
                           "Displays rich content in a portal, triggered by a button."
@@ -330,25 +362,25 @@ const Component = () => {
                   <NavigationMenuLink
                     data-ws-id="95"
                     data-ws-component="NavigationMenuLink"
-                    className="w-navigation-menu-link"
+                    className="w-accessible-link-wrapper"
                   >
                     <Link
                       data-ws-id="96"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/tooltip"}
-                      className="w-link"
+                      className="w-link w-link-8"
                     >
                       <Text
                         data-ws-id="99"
                         data-ws-component="Text"
-                        className="w-text"
+                        className="w-text w-text-8"
                       >
                         {"Tooltip"}
                       </Text>
                       <Paragraph
                         data-ws-id="101"
                         data-ws-component="Paragraph"
-                        className="w-paragraph"
+                        className="w-paragraph w-paragraph-8"
                       >
                         {
                           "A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it."
@@ -359,25 +391,25 @@ const Component = () => {
                   <NavigationMenuLink
                     data-ws-id="103"
                     data-ws-component="NavigationMenuLink"
-                    className="w-navigation-menu-link"
+                    className="w-accessible-link-wrapper"
                   >
                     <Link
                       data-ws-id="104"
                       data-ws-component="Link"
                       href={"https://ui.shadcn.com/docs/components/button"}
-                      className="w-link"
+                      className="w-link w-link-9"
                     >
                       <Text
                         data-ws-id="107"
                         data-ws-component="Text"
-                        className="w-text"
+                        className="w-text w-text-9"
                       >
                         {"Button"}
                       </Text>
                       <Paragraph
                         data-ws-id="109"
                         data-ws-component="Paragraph"
-                        className="w-paragraph"
+                        className="w-paragraph w-paragraph-9"
                       >
                         {
                           "Displays a button or a component that looks like a button."
@@ -393,28 +425,32 @@ const Component = () => {
             data-ws-id="111"
             data-ws-component="NavigationMenuItem"
             data-ws-index="2"
-            className="w-navigation-menu-item"
+            className="w-menu-item"
           >
             <NavigationMenuLink
               data-ws-id="112"
               data-ws-component="NavigationMenuLink"
-              className="w-navigation-menu-link"
+              className="w-accessible-link-wrapper"
             >
               <Link
                 data-ws-id="113"
                 data-ws-component="Link"
-                className="w-link"
+                className="w-link w-link-10"
               >
                 {"Standalone"}
               </Link>
             </NavigationMenuLink>
           </NavigationMenuItem>
         </NavigationMenuList>
-        <Box data-ws-id="115" data-ws-component="Box" className="w-box">
+        <Box
+          data-ws-id="115"
+          data-ws-component="Box"
+          className="w-box w-viewport-container"
+        >
           <NavigationMenuViewport
             data-ws-id="117"
             data-ws-component="NavigationMenuViewport"
-            className="w-navigation-menu-viewport"
+            className="w-menu-viewport w-menu-viewport-1"
           />
         </Box>
       </NavigationMenu>
@@ -535,7 +571,7 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     outline-width: 1px
   }
-  :where(div.w-navigation-menu-list) {
+  :where(div.w-menu-list) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -543,7 +579,7 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     outline-width: 1px
   }
-  :where(div.w-navigation-menu-item) {
+  :where(div.w-menu-item) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -551,7 +587,7 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     outline-width: 1px
   }
-  :where(div.w-navigation-menu-trigger) {
+  :where(div.w-menu-trigger) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -587,7 +623,7 @@ html {margin: 0; display: grid; min-height: 100%}
   :where(div.w-html-embed) {
     display: contents
   }
-  :where(div.w-navigation-menu-content) {
+  :where(div.w-menu-content) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -595,7 +631,7 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     outline-width: 1px
   }
-  :where(div.w-navigation-menu-link) {
+  :where(div.w-accessible-link-wrapper) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -621,7 +657,7 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     outline-width: 1px
   }
-  :where(div.w-navigation-menu-viewport) {
+  :where(div.w-menu-viewport) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -631,11 +667,11 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="1"] {
+  .w-navigation-menu-1 {
     position: relative;
     max-width: max-content
   }
-  [data-ws-id="3"] {
+  .w-menu-list-1 {
     display: flex;
     flex-grow: 1;
     flex-shrink: 1;
@@ -648,7 +684,7 @@ html {margin: 0; display: grid; min-height: 100%}
     margin: 0px;
     padding: 0px
   }
-  [data-ws-id="7"] {
+  .w-button-1 {
     background-color: transparent;
     display: inline-flex;
     align-items: center;
@@ -667,23 +703,23 @@ html {margin: 0; display: grid; min-height: 100%}
     --navigation-menu-trigger-icon-transform: 0deg;
     border: 0px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="7"]:disabled {
+  .w-button-1:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="7"]:focus-visible {
+  .w-button-1:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="7"]:hover {
+  .w-button-1:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="7"][data-state=open] {
+  .w-button-1[data-state=open] {
     --navigation-menu-trigger-icon-transform: 180deg
   }
-  [data-ws-id="10"] {
+  .w-icon-container {
     margin-left: 0.25rem;
     rotate: var(--navigation-menu-trigger-icon-transform);
     height: 1rem;
@@ -693,20 +729,20 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="14"] {
+  .w-menu-content-1 {
     left: 0px;
     top: 0px;
     position: absolute;
     width: max-content;
     padding: 1rem
   }
-  [data-ws-id="16"] {
+  .w-content {
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
     padding: 0.5rem
   }
-  [data-ws-id="18"] {
+  .w-box-1 {
     background-color: rgba(226, 232, 240, 1);
     width: 12rem;
     border-top-left-radius: 0.375rem;
@@ -715,14 +751,14 @@ html {margin: 0; display: grid; min-height: 100%}
     border-bottom-left-radius: 0.375rem;
     padding: 1rem
   }
-  [data-ws-id="20"] {
+  .w-flex-column {
     width: 16rem;
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
     flex-direction: column
   }
-  [data-ws-id="23"] {
+  .w-link-1 {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -740,20 +776,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline: 2px solid transparent;
     padding: 0.75rem
   }
-  [data-ws-id="23"]:focus {
+  .w-link-1:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="23"]:hover {
+  .w-link-1:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="26"] {
+  .w-text-1 {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="28"] {
+  .w-paragraph-1 {
     overflow-x: hidden;
     overflow-y: hidden;
     display: -webkit-box;
@@ -764,7 +800,7 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(100, 116, 139, 1);
     margin: 0px
   }
-  [data-ws-id="31"] {
+  .w-link-2 {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -782,20 +818,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline: 2px solid transparent;
     padding: 0.75rem
   }
-  [data-ws-id="31"]:focus {
+  .w-link-2:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="31"]:hover {
+  .w-link-2:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="34"] {
+  .w-text-2 {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="36"] {
+  .w-paragraph-2 {
     overflow-x: hidden;
     overflow-y: hidden;
     display: -webkit-box;
@@ -806,7 +842,7 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(100, 116, 139, 1);
     margin: 0px
   }
-  [data-ws-id="39"] {
+  .w-link-3 {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -824,20 +860,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline: 2px solid transparent;
     padding: 0.75rem
   }
-  [data-ws-id="39"]:focus {
+  .w-link-3:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="39"]:hover {
+  .w-link-3:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="42"] {
+  .w-text-3 {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="44"] {
+  .w-paragraph-3 {
     overflow-x: hidden;
     overflow-y: hidden;
     display: -webkit-box;
@@ -848,7 +884,7 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(100, 116, 139, 1);
     margin: 0px
   }
-  [data-ws-id="48"] {
+  .w-button-2 {
     background-color: transparent;
     display: inline-flex;
     align-items: center;
@@ -867,23 +903,23 @@ html {margin: 0; display: grid; min-height: 100%}
     --navigation-menu-trigger-icon-transform: 0deg;
     border: 0px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="48"]:disabled {
+  .w-button-2:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="48"]:focus-visible {
+  .w-button-2:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="48"]:hover {
+  .w-button-2:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="48"][data-state=open] {
+  .w-button-2[data-state=open] {
     --navigation-menu-trigger-icon-transform: 180deg
   }
-  [data-ws-id="51"] {
+  .w-icon-container-1 {
     margin-left: 0.25rem;
     rotate: var(--navigation-menu-trigger-icon-transform);
     height: 1rem;
@@ -893,27 +929,27 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms
   }
-  [data-ws-id="55"] {
+  .w-menu-content-2 {
     left: 0px;
     top: 0px;
     position: absolute;
     width: max-content;
     padding: 1rem
   }
-  [data-ws-id="57"] {
+  .w-content-1 {
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
     padding: 0px
   }
-  [data-ws-id="59"] {
+  .w-flex-column-1 {
     width: 16rem;
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
     flex-direction: column
   }
-  [data-ws-id="62"] {
+  .w-link-4 {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -931,20 +967,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline: 2px solid transparent;
     padding: 0.75rem
   }
-  [data-ws-id="62"]:focus {
+  .w-link-4:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="62"]:hover {
+  .w-link-4:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="65"] {
+  .w-text-4 {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="67"] {
+  .w-paragraph-4 {
     overflow-x: hidden;
     overflow-y: hidden;
     display: -webkit-box;
@@ -955,7 +991,7 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(100, 116, 139, 1);
     margin: 0px
   }
-  [data-ws-id="70"] {
+  .w-link-5 {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -973,20 +1009,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline: 2px solid transparent;
     padding: 0.75rem
   }
-  [data-ws-id="70"]:focus {
+  .w-link-5:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="70"]:hover {
+  .w-link-5:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="73"] {
+  .w-text-5 {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="75"] {
+  .w-paragraph-5 {
     overflow-x: hidden;
     overflow-y: hidden;
     display: -webkit-box;
@@ -997,7 +1033,7 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(100, 116, 139, 1);
     margin: 0px
   }
-  [data-ws-id="78"] {
+  .w-link-6 {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -1015,20 +1051,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline: 2px solid transparent;
     padding: 0.75rem
   }
-  [data-ws-id="78"]:focus {
+  .w-link-6:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="78"]:hover {
+  .w-link-6:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="81"] {
+  .w-text-6 {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="83"] {
+  .w-paragraph-6 {
     overflow-x: hidden;
     overflow-y: hidden;
     display: -webkit-box;
@@ -1039,14 +1075,14 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(100, 116, 139, 1);
     margin: 0px
   }
-  [data-ws-id="85"] {
+  .w-flex-column-2 {
     width: 16rem;
     display: flex;
     row-gap: 1rem;
     column-gap: 1rem;
     flex-direction: column
   }
-  [data-ws-id="88"] {
+  .w-link-7 {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -1064,20 +1100,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline: 2px solid transparent;
     padding: 0.75rem
   }
-  [data-ws-id="88"]:focus {
+  .w-link-7:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="88"]:hover {
+  .w-link-7:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="91"] {
+  .w-text-7 {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="93"] {
+  .w-paragraph-7 {
     overflow-x: hidden;
     overflow-y: hidden;
     display: -webkit-box;
@@ -1088,7 +1124,7 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(100, 116, 139, 1);
     margin: 0px
   }
-  [data-ws-id="96"] {
+  .w-link-8 {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -1106,20 +1142,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline: 2px solid transparent;
     padding: 0.75rem
   }
-  [data-ws-id="96"]:focus {
+  .w-link-8:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="96"]:hover {
+  .w-link-8:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="99"] {
+  .w-text-8 {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="101"] {
+  .w-paragraph-8 {
     overflow-x: hidden;
     overflow-y: hidden;
     display: -webkit-box;
@@ -1130,7 +1166,7 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(100, 116, 139, 1);
     margin: 0px
   }
-  [data-ws-id="104"] {
+  .w-link-9 {
     color: inherit;
     display: flex;
     flex-direction: column;
@@ -1148,20 +1184,20 @@ html {margin: 0; display: grid; min-height: 100%}
     outline: 2px solid transparent;
     padding: 0.75rem
   }
-  [data-ws-id="104"]:focus {
+  .w-link-9:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="104"]:hover {
+  .w-link-9:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="107"] {
+  .w-text-9 {
     font-size: 0.875rem;
     line-height: 1;
     font-weight: 500
   }
-  [data-ws-id="109"] {
+  .w-paragraph-9 {
     overflow-x: hidden;
     overflow-y: hidden;
     display: -webkit-box;
@@ -1172,7 +1208,7 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(100, 116, 139, 1);
     margin: 0px
   }
-  [data-ws-id="113"] {
+  .w-link-10 {
     background-color: transparent;
     display: inline-flex;
     align-items: center;
@@ -1191,27 +1227,27 @@ html {margin: 0; display: grid; min-height: 100%}
     text-decoration-line: none;
     border: 0px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="113"]:disabled {
+  .w-link-10:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="113"]:focus-visible {
+  .w-link-10:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="113"]:hover {
+  .w-link-10:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="115"] {
+  .w-viewport-container {
     position: absolute;
     left: 0px;
     top: 100%;
     display: flex;
     justify-content: center
   }
-  [data-ws-id="117"] {
+  .w-menu-viewport-1 {
     position: relative;
     margin-top: 0.375rem;
     overflow-x: hidden;

--- a/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.stories.tsx
@@ -17,7 +17,7 @@ const Component = () => {
           <Button
             data-ws-id="3"
             data-ws-component="Button"
-            className="w-button"
+            className="w-button w-button-1"
           >
             {"Button"}
           </Button>
@@ -25,7 +25,7 @@ const Component = () => {
         <PopoverContent
           data-ws-id="5"
           data-ws-component="PopoverContent"
-          className="w-popover-content"
+          className="w-popover-content w-popover-content-1"
         >
           <Text data-ws-id="7" data-ws-component="Text" className="w-text">
             {"The text you can edit"}
@@ -176,7 +176,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="3"] {
+  .w-button-1 {
     background-color: rgba(255, 255, 255, 0.8);
     display: inline-flex;
     align-items: center;
@@ -196,20 +196,20 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-bottom: 0.5rem;
     border: 1px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="3"]:disabled {
+  .w-button-1:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="3"]:focus-visible {
+  .w-button-1:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="3"]:hover {
+  .w-button-1:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="5"] {
+  .w-popover-content-1 {
     z-index: 50;
     width: 18rem;
     border-top-left-radius: 0.375rem;

--- a/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/radio-group.stories.tsx
@@ -23,14 +23,18 @@ const Component = () => {
           radioGroupValue = value;
           set$radioGroupValue(radioGroupValue);
         }}
-        className="w-radio-group"
+        className="w-radio-group w-radio-group-1"
       >
-        <Label data-ws-id="6" data-ws-component="Label" className="w-label">
+        <Label
+          data-ws-id="6"
+          data-ws-component="Label"
+          className="w-label w-label-1"
+        >
           <RadioGroupItem
             data-ws-id="8"
             data-ws-component="RadioGroupItem"
             value={"default"}
-            className="w-radio-group-item"
+            className="w-radio-group-item w-radio-group-item-1"
           >
             <RadioGroupIndicator
               data-ws-id="11"
@@ -51,12 +55,16 @@ const Component = () => {
             {"Default"}
           </Text>
         </Label>
-        <Label data-ws-id="15" data-ws-component="Label" className="w-label">
+        <Label
+          data-ws-id="15"
+          data-ws-component="Label"
+          className="w-label w-label-2"
+        >
           <RadioGroupItem
             data-ws-id="17"
             data-ws-component="RadioGroupItem"
             value={"comfortable"}
-            className="w-radio-group-item"
+            className="w-radio-group-item w-radio-group-item-2"
           >
             <RadioGroupIndicator
               data-ws-id="20"
@@ -77,12 +85,16 @@ const Component = () => {
             {"Comfortable"}
           </Text>
         </Label>
-        <Label data-ws-id="24" data-ws-component="Label" className="w-label">
+        <Label
+          data-ws-id="24"
+          data-ws-component="Label"
+          className="w-label w-label-3"
+        >
           <RadioGroupItem
             data-ws-id="26"
             data-ws-component="RadioGroupItem"
             value={"compact"}
-            className="w-radio-group-item"
+            className="w-radio-group-item w-radio-group-item-3"
           >
             <RadioGroupIndicator
               data-ws-id="29"
@@ -263,19 +275,19 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="1"] {
+  .w-radio-group-1 {
     display: flex;
     flex-direction: column;
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="6"] {
+  .w-label-1 {
     display: flex;
     align-items: center;
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="8"] {
+  .w-radio-group-item-1 {
     aspect-ratio: 1 / 1;
     height: 1rem;
     width: 1rem;
@@ -286,22 +298,22 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(15, 23, 42, 1);
     border: 1px solid rgba(15, 23, 42, 1)
   }
-  [data-ws-id="8"]:disabled {
+  .w-radio-group-item-1:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="8"]:focus-visible {
+  .w-radio-group-item-1:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="15"] {
+  .w-label-2 {
     display: flex;
     align-items: center;
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="17"] {
+  .w-radio-group-item-2 {
     aspect-ratio: 1 / 1;
     height: 1rem;
     width: 1rem;
@@ -312,22 +324,22 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(15, 23, 42, 1);
     border: 1px solid rgba(15, 23, 42, 1)
   }
-  [data-ws-id="17"]:disabled {
+  .w-radio-group-item-2:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="17"]:focus-visible {
+  .w-radio-group-item-2:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="24"] {
+  .w-label-3 {
     display: flex;
     align-items: center;
     row-gap: 0.5rem;
     column-gap: 0.5rem
   }
-  [data-ws-id="26"] {
+  .w-radio-group-item-3 {
     aspect-ratio: 1 / 1;
     height: 1rem;
     width: 1rem;
@@ -338,11 +350,11 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(15, 23, 42, 1);
     border: 1px solid rgba(15, 23, 42, 1)
   }
-  [data-ws-id="26"]:disabled {
+  .w-radio-group-item-3:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="26"]:focus-visible {
+  .w-radio-group-item-3:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent

--- a/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/select.stories.tsx
@@ -30,35 +30,35 @@ const Component = () => {
         <SelectTrigger
           data-ws-id="5"
           data-ws-component="SelectTrigger"
-          className="w-select-trigger"
+          className="w-select-trigger w-select-trigger-1"
         >
           <SelectValue
             data-ws-id="7"
             data-ws-component="SelectValue"
             placeholder={"Theme"}
-            className="w-select-value"
+            className="w-value"
           />
         </SelectTrigger>
         <SelectContent
           data-ws-id="9"
           data-ws-component="SelectContent"
-          className="w-select-content"
+          className="w-select-content w-select-content-1"
         >
           <SelectViewport
             data-ws-id="11"
             data-ws-component="SelectViewport"
-            className="w-select-viewport"
+            className="w-select-viewport w-select-viewport-1"
           >
             <SelectItem
               data-ws-id="13"
               data-ws-component="SelectItem"
               value={"light"}
-              className="w-select-item"
+              className="w-select-item w-select-item-1"
             >
               <SelectItemIndicator
                 data-ws-id="16"
                 data-ws-component="SelectItemIndicator"
-                className="w-select-item-indicator"
+                className="w-indicator w-indicator-1"
               >
                 <HtmlEmbed
                   data-ws-id="18"
@@ -72,7 +72,7 @@ const Component = () => {
               <SelectItemText
                 data-ws-id="20"
                 data-ws-component="SelectItemText"
-                className="w-select-item-text"
+                className="w-item-text"
               >
                 {"Light"}
               </SelectItemText>
@@ -81,12 +81,12 @@ const Component = () => {
               data-ws-id="21"
               data-ws-component="SelectItem"
               value={"dark"}
-              className="w-select-item"
+              className="w-select-item w-select-item-2"
             >
               <SelectItemIndicator
                 data-ws-id="24"
                 data-ws-component="SelectItemIndicator"
-                className="w-select-item-indicator"
+                className="w-indicator w-indicator-2"
               >
                 <HtmlEmbed
                   data-ws-id="26"
@@ -100,7 +100,7 @@ const Component = () => {
               <SelectItemText
                 data-ws-id="28"
                 data-ws-component="SelectItemText"
-                className="w-select-item-text"
+                className="w-item-text"
               >
                 {"Dark"}
               </SelectItemText>
@@ -109,12 +109,12 @@ const Component = () => {
               data-ws-id="29"
               data-ws-component="SelectItem"
               value={"system"}
-              className="w-select-item"
+              className="w-select-item w-select-item-3"
             >
               <SelectItemIndicator
                 data-ws-id="32"
                 data-ws-component="SelectItemIndicator"
-                className="w-select-item-indicator"
+                className="w-indicator w-indicator-3"
               >
                 <HtmlEmbed
                   data-ws-id="34"
@@ -128,7 +128,7 @@ const Component = () => {
               <SelectItemText
                 data-ws-id="36"
                 data-ws-component="SelectItemText"
-                className="w-select-item-text"
+                className="w-item-text"
               >
                 {"System"}
               </SelectItemText>
@@ -261,7 +261,7 @@ html {margin: 0; display: grid; min-height: 100%}
     text-transform: none;
     margin: 0
   }
-  :where(span.w-select-value) {
+  :where(span.w-value) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -293,7 +293,7 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     outline-width: 1px
   }
-  :where(span.w-select-item-indicator) {
+  :where(span.w-indicator) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -304,7 +304,7 @@ html {margin: 0; display: grid; min-height: 100%}
   :where(div.w-html-embed) {
     display: contents
   }
-  :where(span.w-select-item-text) {
+  :where(span.w-item-text) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -314,7 +314,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="5"] {
+  .w-select-trigger-1 {
     display: flex;
     height: 2.5rem;
     width: 100%;
@@ -333,19 +333,19 @@ html {margin: 0; display: grid; min-height: 100%}
     line-height: 1.25rem;
     border: 1px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="5"]::placeholder {
+  .w-select-trigger-1::placeholder {
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="5"]:disabled {
+  .w-select-trigger-1:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="5"]:focus {
+  .w-select-trigger-1:focus {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="9"] {
+  .w-select-content-1 {
     position: relative;
     z-index: 50;
     min-width: 8rem;
@@ -360,13 +360,13 @@ html {margin: 0; display: grid; min-height: 100%}
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
     border: 1px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="11"] {
+  .w-select-viewport-1 {
     height: var(--radix-select-trigger-height);
     width: 100%;
     min-width: var(--radix-select-trigger-width);
     padding: 0.25rem
   }
-  [data-ws-id="13"] {
+  .w-select-item-1 {
     position: relative;
     display: flex;
     width: 100%;
@@ -387,15 +387,15 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-offset: 2px;
     outline: 2px solid transparent
   }
-  [data-ws-id="13"]:focus {
+  .w-select-item-1:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="13"][data-disabled] {
+  .w-select-item-1[data-disabled] {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="16"] {
+  .w-indicator-1 {
     position: absolute;
     left: 0.5rem;
     display: flex;
@@ -404,7 +404,7 @@ html {margin: 0; display: grid; min-height: 100%}
     align-items: center;
     justify-content: center
   }
-  [data-ws-id="21"] {
+  .w-select-item-2 {
     position: relative;
     display: flex;
     width: 100%;
@@ -425,15 +425,15 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-offset: 2px;
     outline: 2px solid transparent
   }
-  [data-ws-id="21"]:focus {
+  .w-select-item-2:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="21"][data-disabled] {
+  .w-select-item-2[data-disabled] {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="24"] {
+  .w-indicator-2 {
     position: absolute;
     left: 0.5rem;
     display: flex;
@@ -442,7 +442,7 @@ html {margin: 0; display: grid; min-height: 100%}
     align-items: center;
     justify-content: center
   }
-  [data-ws-id="29"] {
+  .w-select-item-3 {
     position: relative;
     display: flex;
     width: 100%;
@@ -463,15 +463,15 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-offset: 2px;
     outline: 2px solid transparent
   }
-  [data-ws-id="29"]:focus {
+  .w-select-item-3:focus {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="29"][data-disabled] {
+  .w-select-item-3[data-disabled] {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="32"] {
+  .w-indicator-3 {
     position: absolute;
     left: 0.5rem;
     display: flex;

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.stories.tsx
@@ -22,7 +22,7 @@ const Component = () => {
           <Button
             data-ws-id="3"
             data-ws-component="Button"
-            className="w-button"
+            className="w-button w-button-1"
           >
             <HtmlEmbed
               data-ws-id="5"
@@ -37,12 +37,12 @@ const Component = () => {
         <DialogOverlay
           data-ws-id="7"
           data-ws-component="DialogOverlay"
-          className="w-dialog-overlay"
+          className="w-dialog-overlay w-sheet-overlay"
         >
           <DialogContent
             data-ws-id="9"
             data-ws-component="DialogContent"
-            className="w-dialog-content"
+            className="w-dialog-content w-sheet-content"
           >
             <Box
               data-ws-id="11"
@@ -51,18 +51,22 @@ const Component = () => {
               role={"navigation"}
               className="w-box"
             >
-              <Box data-ws-id="14" data-ws-component="Box" className="w-box">
+              <Box
+                data-ws-id="14"
+                data-ws-component="Box"
+                className="w-box w-sheet-header"
+              >
                 <DialogTitle
                   data-ws-id="16"
                   data-ws-component="DialogTitle"
-                  className="w-dialog-title"
+                  className="w-dialog-title w-sheet-title"
                 >
                   {"Sheet Title"}
                 </DialogTitle>
                 <DialogDescription
                   data-ws-id="18"
                   data-ws-component="DialogDescription"
-                  className="w-dialog-description"
+                  className="w-dialog-description w-sheet-description"
                 >
                   {"Sheet description text you can edit"}
                 </DialogDescription>
@@ -74,7 +78,7 @@ const Component = () => {
             <DialogClose
               data-ws-id="21"
               data-ws-component="DialogClose"
-              className="w-dialog-close"
+              className="w-close-button w-close-button-1"
             >
               <HtmlEmbed
                 data-ws-id="23"
@@ -257,7 +261,7 @@ html {margin: 0; display: grid; min-height: 100%}
     outline-width: 1px;
     min-height: 1em
   }
-  :where(button.w-dialog-close) {
+  :where(button.w-close-button) {
     background-color: transparent;
     background-image: none;
     font-family: inherit;
@@ -271,7 +275,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="3"] {
+  .w-button-1 {
     background-color: transparent;
     display: inline-flex;
     align-items: center;
@@ -292,20 +296,20 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-bottom: 0px;
     border: 0px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="3"]:disabled {
+  .w-button-1:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="3"]:focus-visible {
+  .w-button-1:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="3"]:hover {
+  .w-button-1:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="7"] {
+  .w-sheet-overlay {
     position: fixed;
     left: 0px;
     right: 0px;
@@ -320,7 +324,7 @@ html {margin: 0; display: grid; min-height: 100%}
     overflow-x: auto;
     overflow-y: auto
   }
-  [data-ws-id="9"] {
+  .w-sheet-content {
     width: 100%;
     z-index: 50;
     display: flex;
@@ -336,27 +340,27 @@ html {margin: 0; display: grid; min-height: 100%}
     border: 1px solid rgba(226, 232, 240, 1);
     padding: 1.5rem
   }
-  [data-ws-id="14"] {
+  .w-sheet-header {
     display: flex;
     flex-direction: column;
     row-gap: 0.25rem;
     column-gap: 0.25rem
   }
-  [data-ws-id="16"] {
+  .w-sheet-title {
     margin-top: 0px;
     margin-bottom: 0px;
     line-height: 1.75rem;
     font-size: 1.125rem;
     letter-spacing: -0.025em
   }
-  [data-ws-id="18"] {
+  .w-sheet-description {
     margin-top: 0px;
     margin-bottom: 0px;
     font-size: 0.875rem;
     line-height: 1.25rem;
     color: rgba(100, 116, 139, 1)
   }
-  [data-ws-id="21"] {
+  .w-close-button-1 {
     position: absolute;
     right: 1rem;
     top: 1rem;
@@ -375,10 +379,10 @@ html {margin: 0; display: grid; min-height: 100%}
     outline: 2px solid transparent;
     border: 0px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="21"]:focus {
+  .w-close-button-1:focus {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1)
   }
-  [data-ws-id="21"]:hover {
+  .w-close-button-1:hover {
     opacity: 1
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/switch.stories.tsx
@@ -14,12 +14,12 @@ const Component = () => {
           switchChecked = checked;
           set$switchChecked(switchChecked);
         }}
-        className="w-switch"
+        className="w-switch w-switch-1"
       >
         <SwitchThumb
           data-ws-id="6"
           data-ws-component="SwitchThumb"
-          className="w-switch-thumb"
+          className="w-switch-thumb w-switch-thumb-1"
         />
       </Switch>
     </Box>
@@ -153,7 +153,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="1"] {
+  .w-switch-1 {
     display: inline-flex;
     height: 24px;
     width: 44px;
@@ -169,22 +169,22 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-duration: 150ms;
     border: 2px solid transparent
   }
-  [data-ws-id="1"]:disabled {
+  .w-switch-1:disabled {
     cursor: not-allowed;
     opacity: 0.5
   }
-  [data-ws-id="1"]:focus-visible {
+  .w-switch-1:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="1"][data-state=checked] {
+  .w-switch-1[data-state=checked] {
     background-color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="1"][data-state=unchecked] {
+  .w-switch-1[data-state=unchecked] {
     background-color: rgba(226, 232, 240, 1)
   }
-  [data-ws-id="6"] {
+  .w-switch-thumb-1 {
     pointer-events: none;
     display: block;
     height: 1.25rem;
@@ -199,10 +199,10 @@ html {margin: 0; display: grid; min-height: 100%}
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 150ms
   }
-  [data-ws-id="6"][data-state=checked] {
+  .w-switch-thumb-1[data-state=checked] {
     transform: translateX(20px)
   }
-  [data-ws-id="6"][data-state=unchecked] {
+  .w-switch-thumb-1[data-state=unchecked] {
     transform: translateX(0px)
   }
 }

--- a/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tabs.stories.tsx
@@ -18,13 +18,13 @@ const Component = () => {
         <TabsList
           data-ws-id="3"
           data-ws-component="TabsList"
-          className="w-tabs-list"
+          className="w-tabs-list w-tabs-list-1"
         >
           <TabsTrigger
             data-ws-id="5"
             data-ws-component="TabsTrigger"
             data-ws-index="0"
-            className="w-tabs-trigger"
+            className="w-tab-trigger w-tab-trigger-1"
           >
             {"Account"}
           </TabsTrigger>
@@ -32,7 +32,7 @@ const Component = () => {
             data-ws-id="7"
             data-ws-component="TabsTrigger"
             data-ws-index="1"
-            className="w-tabs-trigger"
+            className="w-tab-trigger w-tab-trigger-2"
           >
             {"Password"}
           </TabsTrigger>
@@ -41,7 +41,7 @@ const Component = () => {
           data-ws-id="9"
           data-ws-component="TabsContent"
           data-ws-index="0"
-          className="w-tabs-content"
+          className="w-tab-content w-tab-content-1"
         >
           {"Make changes to your account here."}
         </TabsContent>
@@ -49,7 +49,7 @@ const Component = () => {
           data-ws-id="11"
           data-ws-component="TabsContent"
           data-ws-index="1"
-          className="w-tabs-content"
+          className="w-tab-content w-tab-content-2"
         >
           {"Change your password here."}
         </TabsContent>
@@ -179,7 +179,7 @@ html {margin: 0; display: grid; min-height: 100%}
     border-left-width: 1px;
     outline-width: 1px
   }
-  :where(button.w-tabs-trigger) {
+  :where(button.w-tab-trigger) {
     font-family: inherit;
     font-size: 100%;
     line-height: 1.15;
@@ -191,7 +191,7 @@ html {margin: 0; display: grid; min-height: 100%}
     margin: 0;
     padding: 0px
   }
-  :where(div.w-tabs-content) {
+  :where(div.w-tab-content) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;
@@ -201,7 +201,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="3"] {
+  .w-tabs-list-1 {
     display: inline-flex;
     height: 2.5rem;
     align-items: center;
@@ -214,7 +214,7 @@ html {margin: 0; display: grid; min-height: 100%}
     color: rgba(100, 116, 139, 1);
     padding: 0.25rem
   }
-  [data-ws-id="5"] {
+  .w-tab-trigger-1 {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -235,21 +235,21 @@ html {margin: 0; display: grid; min-height: 100%}
     white-space: normal;
     white-space-collapse: collapse
   }
-  [data-ws-id="5"]:disabled {
+  .w-tab-trigger-1:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="5"]:focus-visible {
+  .w-tab-trigger-1:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="5"][data-state=active] {
+  .w-tab-trigger-1[data-state=active] {
     background-color: rgba(255, 255, 255, 0.8);
     color: rgba(2, 8, 23, 1);
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05)
   }
-  [data-ws-id="7"] {
+  .w-tab-trigger-2 {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -270,32 +270,32 @@ html {margin: 0; display: grid; min-height: 100%}
     white-space: normal;
     white-space-collapse: collapse
   }
-  [data-ws-id="7"]:disabled {
+  .w-tab-trigger-2:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="7"]:focus-visible {
+  .w-tab-trigger-2:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="7"][data-state=active] {
+  .w-tab-trigger-2[data-state=active] {
     background-color: rgba(255, 255, 255, 0.8);
     color: rgba(2, 8, 23, 1);
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05)
   }
-  [data-ws-id="9"] {
+  .w-tab-content-1 {
     margin-top: 0.5rem
   }
-  [data-ws-id="9"]:focus-visible {
+  .w-tab-content-1:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="11"] {
+  .w-tab-content-2 {
     margin-top: 0.5rem
   }
-  [data-ws-id="11"]:focus-visible {
+  .w-tab-content-2:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.stories.tsx
@@ -17,7 +17,7 @@ const Component = () => {
           <Button
             data-ws-id="3"
             data-ws-component="Button"
-            className="w-button"
+            className="w-button w-button-1"
           >
             {"Button"}
           </Button>
@@ -25,7 +25,7 @@ const Component = () => {
         <TooltipContent
           data-ws-id="5"
           data-ws-component="TooltipContent"
-          className="w-tooltip-content"
+          className="w-tooltip-content w-tooltip-content-1"
         >
           <Text data-ws-id="7" data-ws-component="Text" className="w-text">
             {"The text you can edit"}
@@ -176,7 +176,7 @@ html {margin: 0; display: grid; min-height: 100%}
   }
 }
 @media all {
-  [data-ws-id="3"] {
+  .w-button-1 {
     background-color: rgba(255, 255, 255, 0.8);
     display: inline-flex;
     align-items: center;
@@ -196,20 +196,20 @@ html {margin: 0; display: grid; min-height: 100%}
     padding-bottom: 0.5rem;
     border: 1px solid rgba(226, 232, 240, 1)
   }
-  [data-ws-id="3"]:disabled {
+  .w-button-1:disabled {
     pointer-events: none;
     opacity: 0.5
   }
-  [data-ws-id="3"]:focus-visible {
+  .w-button-1:focus-visible {
     outline-offset: 2px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 0 0 4px rgba(148, 163, 184, 1);
     outline: 2px solid transparent
   }
-  [data-ws-id="3"]:hover {
+  .w-button-1:hover {
     background-color: rgba(241, 245, 249, 0.9);
     color: rgba(15, 23, 42, 1)
   }
-  [data-ws-id="5"] {
+  .w-tooltip-content-1 {
     z-index: 50;
     overflow-x: hidden;
     overflow-y: hidden;

--- a/packages/sdk/src/jsx.ts
+++ b/packages/sdk/src/jsx.ts
@@ -139,6 +139,7 @@ export const renderJsx = (root: JSX.Element) => {
 type ComponentProps = Record<string, unknown> &
   Record<`${string}:expression`, string> & {
     "ws:id"?: string;
+    "ws:label"?: string;
     children?: ReactNode;
   };
 


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3788

Here switched from attribute selector to classes when atomic styles are disabled. This will let us get rid from data-ws-* attributes in generated html.