### PR TITLE
fix: Ensure AI doesn't return json markdown

### DIFF
--- a/packages/ai/src/chains/command-detect/__generated__/command-detect.system.prompt.ts
+++ b/packages/ai/src/chains/command-detect/__generated__/command-detect.system.prompt.ts
@@ -9,4 +9,6 @@ Avaliable tasks are provided below as an object with task_name:task_description 
 The task description can help you infer the task name to pick. For example if the user is asking to translate you should respond with ["copywrite"]
 
 Respond with a valid JSON array of task names that are relevant for the user request. Start with [
+
+Do not start your response with \`\`\`json
 `;

--- a/packages/ai/src/chains/command-detect/command-detect.system.prompt.md
+++ b/packages/ai/src/chains/command-detect/command-detect.system.prompt.md
@@ -9,3 +9,5 @@ Avaliable tasks are provided below as an object with task_name:task_description 
 The task description can help you infer the task name to pick. For example if the user is asking to translate you should respond with ["copywrite"]
 
 Respond with a valid JSON array of task names that are relevant for the user request. Start with [
+
+Do not start your response with ```json


### PR DESCRIPTION
## Description

Detect route started returning json in markdown instead of pure json `json\n[\"generate-template-prompt\"]\n` 

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
