### PR TITLE
chore: move transforms section behind a flag

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transforms.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transforms.tsx
@@ -42,6 +42,7 @@ import { humanizeString } from "~/shared/string-utils";
 import { getStyleSource } from "../../shared/style-info";
 import { PropertyName } from "../../shared/property-name";
 import { getDots } from "../../shared/collapsible-section";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 export const transformPanels = [
   "translate",
@@ -60,8 +61,13 @@ export const properties = [
 ] satisfies Array<StyleProperty>;
 
 export const Section = (props: SectionProps) => {
-  const { currentStyle, createBatchUpdate } = props;
   const [isOpen, setIsOpen] = useState(true);
+
+  if (isFeatureEnabled("transforms") === false) {
+    return;
+  }
+
+  const { currentStyle, createBatchUpdate } = props;
   const translateStyleSource = getStyleSource(currentStyle["translate"]);
   const scaleStyleSource = getStyleSource(currentStyle["scale"]);
   const rotateAndSkewStyleSrouce = getStyleSource(currentStyle["transform"]);

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -7,3 +7,4 @@ export const cms = false;
 export const cssVars = false;
 export const filters = false;
 export const xmlElement = false;
+export const transforms = false;


### PR DESCRIPTION
## Description

This PR moves the `transforms` section behind a feature flag. The section needs to add tooltips for all properties and scale need to have a `lock` behaviour between the `scaleX` and `scaleY` properties.


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
