### PR TITLE
feat: submit webhook form without n8n

### DIFF
--- a/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[another-page]._index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[another-page]._index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -244,19 +244,6 @@ export const links: LinksFunction = () => {
 const getRequestHost = (request: Request): string =>
   request.headers.get("x-forwarded-host") || request.headers.get("host") || "";
 
-const getMethod = (value: string | undefined) => {
-  if (value === undefined) {
-    return "post";
-  }
-
-  switch (value.toLowerCase()) {
-    case "get":
-      return "get";
-    default:
-      return "post";
-  }
-};
-
 export const action = async ({
   request,
   context,

--- a/packages/form-handlers/src/n8n.ts
+++ b/packages/form-handlers/src/n8n.ts
@@ -2,10 +2,8 @@ import {
   type FormInfo,
   type Result,
   formToEmail,
-  getFormEntries,
   getErrors,
   getResponseBody,
-  formIdFieldName,
 } from "./shared";
 
 const getAuth = (hookUrl: string) => {
@@ -40,19 +38,13 @@ export const n8nHandler = async ({
     headers["Authorization"] = `Basic ${btoa([username, password].join(":"))}`;
   }
 
-  const formId = formInfo.formData.get(formIdFieldName);
-
-  if (formId === undefined) {
-    return { success: false, errors: ["No form id in FormData"] };
-  }
-
   const payload = {
     email: formToEmail(formInfo),
     // globally unique form id (can be used for unsubscribing)
-    formId: [formInfo.projectId, formId].join("--"),
-    action: formInfo.action,
-    method: formInfo.method,
-    formData: Object.fromEntries(getFormEntries(formInfo.formData)),
+    formId: formInfo.formId,
+    action: null,
+    method: "post",
+    formData: formInfo.formData,
   };
 
   let response: Response;

--- a/packages/form-handlers/src/shared.ts
+++ b/packages/form-handlers/src/shared.ts
@@ -5,14 +5,11 @@ export const formBotFieldName = `${formHiddenFieldPrefix}-bot`;
 
 // Input data common for all handlers
 export type FormInfo = {
-  projectId: string;
+  formId: string;
   pageUrl: string;
   formData: FormData;
   toEmail: string;
   fromEmail: string;
-  // null as serializable
-  action: string | null;
-  method: "get" | "post";
 };
 
 export type EmailInfo = {
@@ -25,14 +22,6 @@ export type EmailInfo = {
 };
 
 export type Result = { success: true } | { success: false; errors: string[] };
-
-/** Returns form entries that should be send in email: removes `File` entries and `formId` */
-export const getFormEntries = (formData: FormData): [string, string][] =>
-  [...formData.entries()].flatMap(([key, value]) =>
-    key.startsWith(formHiddenFieldPrefix) === false && typeof value === "string"
-      ? [[key, value]]
-      : []
-  );
 
 const getDomain = (url: string) => {
   try {
@@ -53,7 +42,7 @@ export const formToEmail = ({
 
   html += "<table><tbody>";
 
-  for (const [key, value] of getFormEntries(formData)) {
+  for (const [key, value] of formData) {
     html += `<tr><td><strong>${key}:</strong></td><td>${value}</td></tr>`;
     txt += `${key}: ${value}\n`;
   }

--- a/packages/form-handlers/src/shared.ts
+++ b/packages/form-handlers/src/shared.ts
@@ -43,6 +43,9 @@ export const formToEmail = ({
   html += "<table><tbody>";
 
   for (const [key, value] of formData) {
+    if (typeof value !== "string") {
+      continue;
+    }
     html += `<tr><td><strong>${key}:</strong></td><td>${value}</td></tr>`;
     txt += `${key}: ${value}\n`;
   }

--- a/packages/sdk/src/resource-loader.ts
+++ b/packages/sdk/src/resource-loader.ts
@@ -28,14 +28,15 @@ export const loadResource = async (
     if (
       response.ok &&
       // accept json by default and when specified explicitly
-      (requestHeaders.has("accept") === false ||
-        requestHeaders.get("accept") === "application/json")
+      (response.headers.has("content-type") === false ||
+        response.headers.get("content-type")?.includes("application/json"))
     ) {
       data = await response.json();
     } else {
       data = await response.text();
     }
     return {
+      ok: response.ok,
       data,
       status: response.status,
       statusText: response.statusText,
@@ -43,6 +44,7 @@ export const loadResource = async (
   } catch (error) {
     const message = (error as unknown as Error).message;
     return {
+      ok: false,
       data: undefined,
       status: 500,
       statusText: message,


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3789

Here stopped submitting webhook form with custom action to n8n and requested directly from generated code. This has a few benefits

- self-hosted websites (vercel, netlify) no longer have to setup n8n to support forms
- we can pay n8n for these executions no more
- user no longer have to unsubscribe from emails when setup custom webhook