### PR TITLE
fix: clone projects with preview images properly

### DIFF
--- a/packages/prisma-client/prisma/migrations/20240730131207_clone_project_preview_imagea/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20240730131207_clone_project_preview_imagea/migration.sql
@@ -1,0 +1,71 @@
+DROP FUNCTION IF EXISTS clone_project;
+CREATE FUNCTION clone_project(
+  project_id text,
+  user_id text,
+  title text,
+  domain text
+) RETURNS "Project" AS $$
+DECLARE
+  old_project "Project";
+  new_project "Project";
+BEGIN
+  SELECT * FROM "Project" WHERE id=project_id INTO old_project;
+
+  INSERT INTO "Project" (
+    id,
+    "userId",
+    title,
+    domain
+  )
+  VALUES (
+    extensions.uuid_generate_v4(),
+    user_id,
+    title,
+    domain
+  )
+  RETURNING * INTO new_project;
+
+  INSERT INTO "Asset" (id, name, "projectId")
+  SELECT asset.id, asset.name, new_project.id AS "projectId"
+  FROM "Asset" AS asset, "File" AS file
+  WHERE
+    asset.name = file.name AND
+    file.status = 'UPLOADED' AND
+    asset."projectId" = old_project.id;
+
+  -- set preview image asset after copying assets to the project
+  UPDATE "Project"
+  SET "previewImageAssetId"= old_project."previewImageAssetId"
+  WHERE id=new_project.id;
+
+  INSERT INTO "Build" (
+    id,
+    "projectId",
+    pages,
+    "styleSources",
+    "styleSourceSelections",
+    styles,
+    breakpoints,
+    props,
+    instances,
+    "dataSources",
+    resources
+  )
+  SELECT
+    extensions.uuid_generate_v4() AS id,
+    new_project.id AS "projectId",
+    pages,
+    "styleSources",
+    "styleSourceSelections",
+    styles,
+    breakpoints,
+    props,
+    instances,
+    "dataSources",
+    resources
+  FROM "Build"
+  WHERE "projectId" = old_project.id AND deployment IS NULL;
+
+  RETURN new_project;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/3823

This fixes the issue with preview images set before assets are copied to the new project.