### PR TITLE
build: upgrade actions

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -7,7 +7,7 @@ runs:
   using: "composite"
 
   steps:
-    - uses: pnpm/action-setup@v3
+    - uses: pnpm/action-setup@v4
     - uses: actions/setup-node@v4
       with:
         node-version: 20

--- a/.github/workflows/cli-r2-static.yaml
+++ b/.github/workflows/cli-r2-static.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           ref: ${{ github.sha }} # HEAD commit instead of merge commit
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -81,7 +81,7 @@ jobs:
     needs: build
 
     steps:
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
           version: "9"
 

--- a/.github/workflows/cli-r2.yaml
+++ b/.github/workflows/cli-r2.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           ref: ${{ github.sha }} # HEAD commit instead of merge commit
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -81,7 +81,7 @@ jobs:
     needs: build
 
     steps:
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
           version: "9"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: ./.github/actions/ci-setup
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ./node_modules/.cache/prettier/.prettier-cache

--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           ref: ${{ github.sha }} # HEAD commit instead of merge commit
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -73,7 +73,7 @@ jobs:
         with:
           ref: ${{ github.sha }} # HEAD commit instead of merge commit
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/vercel-deploy-staging.yml
+++ b/.github/workflows/vercel-deploy-staging.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
New actions/cache should have proper exit handling to not hang for 2 minutes.