### PR TITLE
fix: scrub and arrow strokes are not working for transition content and delay

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
@@ -205,15 +205,18 @@ export const TransitionContent = ({
           keywords={[]}
           deleteProperty={() => {}}
           setValue={(value, options) => {
-            if (
-              value === undefined ||
-              value.type !== "layers" ||
-              value.value[0].type !== "unit"
-            ) {
+            if (value === undefined) {
               return;
             }
 
-            handlePropertyUpdate({ duration: value.value[0] }, options);
+            if (value.type === "unit") {
+              handlePropertyUpdate({ duration: value }, options);
+              return;
+            }
+
+            if (value.type === "layers" && value.value[0].type === "unit") {
+              handlePropertyUpdate({ duration: value.value[0] }, options);
+            }
           }}
         />
 
@@ -243,15 +246,18 @@ export const TransitionContent = ({
           keywords={[]}
           deleteProperty={() => {}}
           setValue={(value, options) => {
-            if (
-              value === undefined ||
-              value.type !== "layers" ||
-              value.value[0].type !== "unit"
-            ) {
+            if (value === undefined) {
               return;
             }
 
-            handlePropertyUpdate({ delay: value.value[0] }, options);
+            if (value.type === "unit") {
+              handlePropertyUpdate({ delay: value }, options);
+              return;
+            }
+
+            if (value.type === "layers" && value.value[0].type === "unit") {
+              handlePropertyUpdate({ delay: value.value[0] }, options);
+            }
           }}
         />
 


### PR DESCRIPTION
## Description

fixes #3821 
Fixes the bug related to updating values for `scrub` and `key strokes`. 

@TrySound @kof was there anything changed in the `CSSValueInputContainer` or something recently. Because, i see the values are `unit` values when it is scrub and key down. But it's sending the whole parsed value when it is just a `onChange` update. Faced a similar issue in #3812 too.

Steps to reproduce
- Add a transition layer.
- Change the values inside the delay and duration using scrub
- Now, try to repeat the same using key up and down arrows.
- The values will reset back to the original values.


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)