### PR TITLE
refactor: move reserved form fields to sdk

### DIFF
--- a/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[another-page]._index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[another-page]._index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -14,13 +14,11 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
-} from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
-import {
-  n8nHandler,
   formIdFieldName,
   formBotFieldName,
-} from "@webstudio-is/form-handlers";
+} from "@webstudio-is/sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { n8nHandler } from "@webstudio-is/form-handlers";
 import {
   Page,
   siteName,

--- a/packages/form-handlers/src/index.ts
+++ b/packages/form-handlers/src/index.ts
@@ -1,2 +1,1 @@
-export { formIdFieldName, formBotFieldName } from "./shared";
 export { n8nHandler } from "./n8n";

--- a/packages/form-handlers/src/shared.ts
+++ b/packages/form-handlers/src/shared.ts
@@ -1,8 +1,3 @@
-const formHiddenFieldPrefix = "ws--form";
-export const formIdFieldName = `${formHiddenFieldPrefix}-id`;
-// Used for simlpe protection against non js bots
-export const formBotFieldName = `${formHiddenFieldPrefix}-bot`;
-
 // Input data common for all handlers
 export type FormInfo = {
   formId: string;

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -41,9 +41,9 @@
     "react-dom": "18.3.0-canary-14898b6a9-20240318"
   },
   "dependencies": {
-    "@webstudio-is/form-handlers": "workspace:*",
     "@webstudio-is/icons": "workspace:*",
     "@webstudio-is/react-sdk": "workspace:*",
+    "@webstudio-is/sdk": "workspace:*",
     "@webstudio-is/sdk-components-react": "workspace:*"
   },
   "devDependencies": {

--- a/packages/sdk-components-react-remix/src/webhook-form.tsx
+++ b/packages/sdk-components-react-remix/src/webhook-form.tsx
@@ -6,8 +6,7 @@ import {
   useEffect,
 } from "react";
 import { useFetcher, type Fetcher, type FormProps } from "@remix-run/react";
-import { formIdFieldName } from "@webstudio-is/form-handlers";
-import { formBotFieldName } from "../../form-handlers/src/shared";
+import { formIdFieldName, formBotFieldName } from "@webstudio-is/sdk";
 
 export const defaultTag = "form";
 

--- a/packages/sdk/src/form-fields.ts
+++ b/packages/sdk/src/form-fields.ts
@@ -1,0 +1,8 @@
+/**
+ * Used to identify form inside server handler
+ */
+export const formIdFieldName = `ws--form-id`;
+/**
+ * Used for simlpe protection against non js bots
+ */
+export const formBotFieldName = `ws--form-bot`;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -19,3 +19,4 @@ export * from "./expression";
 export * from "./resources-generator";
 export * from "./page-meta-generator";
 export * from "./url-pattern";
+export * from "./form-fields";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2016,15 +2016,15 @@ importers:
 
   packages/sdk-components-react-remix:
     dependencies:
-      '@webstudio-is/form-handlers':
-        specifier: workspace:*
-        version: link:../form-handlers
       '@webstudio-is/icons':
         specifier: workspace:*
         version: link:../icons
       '@webstudio-is/react-sdk':
         specifier: workspace:*
         version: link:../react-sdk
+      '@webstudio-is/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       '@webstudio-is/sdk-components-react':
         specifier: workspace:*
         version: link:../sdk-components-react


### PR DESCRIPTION
Form handlers no longer rely on reserved form fields. They are excluded before passing form data to n8n handler.