### PR TITLE
fix: fix placeholder images

### DIFF
--- a/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
@@ -14,7 +14,6 @@ import {
   InputErrorsTooltip,
   PanelBanner,
   Select,
-  rawTheme,
   Box,
 } from "@webstudio-is/design-system";
 import { ImageControl } from "./image-control";
@@ -41,7 +40,14 @@ const thumbnailStyle = css({
   borderWidth: 1,
   borderStyle: "solid",
   borderColor: theme.colors.borderMain,
+  width: theme.spacing[28],
   aspectRatio: "1.91",
+  background: "#DFE3E6",
+});
+
+const thumbnailImageStyle = css({
+  width: "100%",
+  height: "100%",
   variants: {
     hasAsset: {
       true: {
@@ -208,12 +214,15 @@ export const SectionMarketplace = () => {
         <Label>Thumbnail</Label>
         <Grid flow="column" gap={3}>
           <InputErrorsTooltip errors={errors?.thumbnailAssetId}>
-            <Image
-              width={rawTheme.spacing[28]}
-              className={thumbnailStyle({ hasAsset: asset !== undefined })}
-              src={asset ? `${asset.name}` : undefined}
-              loader={imageLoader}
-            />
+            <Box className={thumbnailStyle()}>
+              <Image
+                className={thumbnailImageStyle({
+                  hasAsset: asset !== undefined,
+                })}
+                src={asset ? `${asset.name}` : undefined}
+                loader={imageLoader}
+              />
+            </Box>
           </InputErrorsTooltip>
 
           <Grid gap={2}>

--- a/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-marketplace.tsx
@@ -37,15 +37,16 @@ import { rightPanelWidth, sectionSpacing } from "./utils";
 
 const thumbnailStyle = css({
   borderRadius: theme.borderRadius[4],
-  borderWidth: 1,
-  borderStyle: "solid",
-  borderColor: theme.colors.borderMain,
+  outlineWidth: 1,
+  outlineStyle: "solid",
+  outlineColor: theme.colors.borderMain,
   width: theme.spacing[28],
   aspectRatio: "1.91",
   background: "#DFE3E6",
 });
 
 const thumbnailImageStyle = css({
+  display: "block",
   width: "100%",
   height: "100%",
   variants: {

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/social-preview.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/social-preview.tsx
@@ -15,7 +15,7 @@ const imgStyle = css({
   borderTopLeftRadius: theme.borderRadius[4],
   borderTopRightRadius: theme.borderRadius[4],
   width: "100%",
-  aspectRatio: "1.91 / 1",
+  aspectRatio: "1.91",
   background: "#DFE3E6",
   borderBottom: `1px solid ${theme.colors.borderMain}`,
   variants: {
@@ -51,7 +51,8 @@ export const SocialPreview = ({
           src={ogImageUrl}
           loader={imageLoader}
           className={imgStyle({
-            hasImage: ogImageUrl !== undefined ? true : undefined,
+            hasImage:
+              ogImageUrl === undefined || ogImageUrl === "" ? false : true,
           })}
         />
 

--- a/packages/image/src/image.tsx
+++ b/packages/image/src/image.tsx
@@ -53,7 +53,7 @@ const imagePlaceholderSvg = `data:image/svg+xml;base64,${btoa(`<svg
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
   >
-  <rect width="600" height="600" fill="hsla(0, 0%, 80%, 0.2)" />
+  <rect width="600" height="600" fill="#DFE3E6" />
   <path
     fill-rule="evenodd"
     clip-rule="evenodd"


### PR DESCRIPTION
## Description

Placeholders in page settings and project settings marketplace got wrong size, new version:

<img width="480" alt="image" src="https://github.com/user-attachments/assets/a1f1ab83-6b20-4ddb-b3b2-a38e6d9ddd70">
<img width="391" alt="image" src="https://github.com/user-attachments/assets/260ef9a5-c79a-4001-859d-98209f12443a">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
