### PR TITLE
fix: resolve conflicts in variabld and class names

### DIFF
--- a/packages/sdk/src/scope.test.ts
+++ b/packages/sdk/src/scope.test.ts
@@ -30,3 +30,14 @@ test("prefix name starting with digit", () => {
   const scope = createScope(["_"]);
   expect(scope.getName("1", "123")).toEqual("_123");
 });
+
+test("resolve conflict between name with number and name with index", () => {
+  const scope = createScope();
+  expect([
+    scope.getName("1", "image"),
+    scope.getName("2", "image"),
+    scope.getName("3", "image"),
+    scope.getName("4", "image"),
+    scope.getName("5", "image_3"),
+  ]).toEqual(["image", "image_1", "image_2", "image_3", "image_3_1"]);
+});

--- a/packages/sdk/src/scope.ts
+++ b/packages/sdk/src/scope.ts
@@ -35,25 +35,26 @@ export const createScope = (
   normalizeName = normalizeJsName,
   separator = "_"
 ): Scope => {
-  const freeIndexByPreferredName = new Map<string, number>();
-  const scopedNameByIdMap = new Map<string, string>();
+  const nameById = new Map<string, string>();
+  const usedNames = new Set<string>();
   for (const identifier of occupiedIdentifiers) {
-    freeIndexByPreferredName.set(identifier, 1);
+    usedNames.add(identifier);
   }
 
   const getName = (id: string, preferredName: string) => {
-    const cachedName = scopedNameByIdMap.get(id);
+    const cachedName = nameById.get(id);
     if (cachedName !== undefined) {
       return cachedName;
     }
     preferredName = normalizeName(preferredName);
-    const index = freeIndexByPreferredName.get(preferredName);
-    freeIndexByPreferredName.set(preferredName, (index ?? 0) + 1);
+    let index = 0;
     let scopedName = preferredName;
-    if (index !== undefined) {
+    while (usedNames.has(scopedName)) {
+      index += 1;
       scopedName = `${preferredName}${separator}${index}`;
     }
-    scopedNameByIdMap.set(id, scopedName);
+    nameById.set(id, scopedName);
+    usedNames.add(scopedName);
     return scopedName;
   };
 


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/3837

This fixes the issue with duplicating classes for different instances. Affected both atomic and non-atomic styles because non-atomic class is used as identifier internally.