### PR TITLE
refactor: create production build with sql function

### DIFF
--- a/packages/domain/src/trpc/domain.ts
+++ b/packages/domain/src/trpc/domain.ts
@@ -129,6 +129,7 @@ export const domainRouter = router({
 
         return result;
       } catch (error) {
+        console.error(error);
         return {
           success: false,
           error: error instanceof Error ? error.message : "Unknown error",

--- a/packages/postgrest/src/__generated__/db-types.ts
+++ b/packages/postgrest/src/__generated__/db-types.ts
@@ -781,6 +781,13 @@ export type Database = {
           userId: string | null;
         };
       };
+      create_production_build: {
+        Args: {
+          project_id: string;
+          deployment: string;
+        };
+        Returns: string;
+      };
     };
     Enums: {
       AuthorizationRelation:

--- a/packages/prisma-client/prisma/migrations/20240731170412_create_production_build/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20240731170412_create_production_build/migration.sql
@@ -1,0 +1,50 @@
+DROP FUNCTION IF EXISTS create_production_build;
+CREATE FUNCTION create_production_build(
+  project_id text,
+  deployment text
+) RETURNS text AS $$
+DECLARE
+  new_build_id text;
+BEGIN
+  INSERT INTO "Build" (
+    version,
+    "lastTransactionId",
+    pages,
+    breakpoints,
+    styles,
+    "styleSources",
+    "styleSourceSelections",
+    props,
+    "dataSources",
+    resources,
+    instances,
+    "marketplaceProduct",
+    "publishStatus",
+    "projectId",
+    id,
+    deployment
+  )
+  SELECT
+    version,
+    "lastTransactionId",
+    pages,
+    breakpoints,
+    styles,
+    "styleSources",
+    "styleSourceSelections",
+    props,
+    "dataSources",
+    resources,
+    instances,
+    "marketplaceProduct",
+    "publishStatus",
+    "projectId",
+    uuid_generate_v4() as id,
+    create_production_build.deployment as deployment
+  FROM "Build"
+  WHERE "projectId" = project_id AND "Build"."deployment" IS NULL
+  RETURNING "id" INTO new_build_id;
+
+  RETURN new_build_id;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/project-build/src/db/deployment.ts
+++ b/packages/project-build/src/db/deployment.ts
@@ -7,7 +7,3 @@ export const parseDeployment = (deployment: string | null) => {
 
   return JSON.parse(deployment) as Deployment;
 };
-
-export const serializeDeployment = (deployment: Deployment) => {
-  return JSON.stringify(deployment);
-};


### PR DESCRIPTION
Moved sql for cloning build with production deployment into sql function. Now all clone build logic is removed from codebase.