### PR TITLE
experimental: Set vanilla export as default and add static site help link

### DIFF
--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -751,7 +751,7 @@ const isDeployTargets = (value: string): value is DeployTargets =>
 
 const ExportContent = (props: { projectId: Project["id"] }) => {
   const npxCommand = "npx webstudio@latest";
-  const [deployTarget, setDeployTarget] = useState<DeployTargets>("vercel");
+  const [deployTarget, setDeployTarget] = useState<DeployTargets>("vanilla");
 
   return (
     <Grid

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -792,7 +792,7 @@ const ExportContent = (props: { projectId: Project["id"] }) => {
             />
             <div />
             <Text color="subtle">
-              Read the detailed documentation{" "}
+              Learn about deploying static sites{" "}
               <Link
                 variant="inherit"
                 color="inherit"

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -791,6 +791,20 @@ const ExportContent = (props: { projectId: Project["id"] }) => {
               templates={deployTargets[deployTarget].ssgTemplates}
             />
             <div />
+            <Text color="subtle">
+              Read the detailed documentation{" "}
+              <Link
+                variant="inherit"
+                color="inherit"
+                href="https://wstd.us/ssg"
+                target="_blank"
+                rel="noreferrer"
+              >
+                here
+              </Link>
+            </Text>
+
+            <div />
             <div />
             <Grid
               gap={2}


### PR DESCRIPTION
## Description

Set vanilla export as default and add static site help link

<img width="356" alt="image" src="https://github.com/user-attachments/assets/87af7283-da72-46b2-ab51-c04483dd2c73">


- [ ] - Doc must be created here https://wstd.us/ssg cc @kof @johnsicili 

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
