### PR TITLE
refactor: migrate project build to postgrest

### DIFF
--- a/apps/builder/app/shared/marketplace/db.server.ts
+++ b/apps/builder/app/shared/marketplace/db.server.ts
@@ -13,7 +13,7 @@ export const getBuildProdData = async (
   { projectId }: { projectId: Project["id"] },
   context: AppContext
 ): Promise<BuildData> => {
-  const build = await loadApprovedProdBuildByProjectId(projectId);
+  const build = await loadApprovedProdBuildByProjectId(context, projectId);
 
   const assets = await loadAssetsByProject(projectId, context, {
     skipPermissionsCheck: true,

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -21,7 +21,6 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
-    "@webstudio-is/prisma-client": "workspace:*",
     "@webstudio-is/sdk": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
     "@webstudio-is/postrest": "workspace:*",

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -1,7 +1,6 @@
 /* eslint no-console: ["error", { allow: ["time", "timeEnd"] }] */
 
 import { nanoid } from "nanoid";
-import { prisma, Prisma } from "@webstudio-is/prisma-client";
 import type { Database } from "@webstudio-is/postrest/index.server";
 import {
   AuthorizationError,
@@ -27,6 +26,7 @@ import { parseDeployment } from "./deployment";
 import { parsePages, serializePages } from "./pages";
 import { createDefaultPages } from "../shared/pages-utils";
 import type { MarketplaceProduct } from "../shared//marketplace";
+import { randomUUID } from "crypto";
 
 export const parseData = <Type extends { id: string }>(
   string: string
@@ -151,32 +151,36 @@ export const loadBuildByProjectId = async (
 };
 
 export const loadApprovedProdBuildByProjectId = async (
+  context: AppContext,
   projectId: Build["projectId"]
 ): Promise<Build> => {
-  const projectData = await prisma.project.findUnique({
-    where: {
-      marketplaceApprovalStatus: "APPROVED",
-      id_isDeleted: { id: projectId, isDeleted: false },
-    },
-    select: {
-      latestBuild: {
-        select: {
-          build: true,
-        },
-      },
-    },
-  });
-
-  const build = projectData?.latestBuild?.build;
-  if (build === undefined) {
-    throw new Error("Prod build not found");
+  const latestBuild = await context.postgrest.client
+    .from("LatestBuildPerProject")
+    .select(
+      `
+        buildId,
+        project:Project!inner (id)
+      `
+    )
+    .eq("projectId", projectId)
+    .eq("project.isDeleted", false)
+    .eq("project.marketplaceApprovalStatus", "APPROVED")
+    .single();
+  if (latestBuild.error) {
+    throw latestBuild.error;
   }
-
-  return parseBuild({
-    ...build,
-    createdAt: build.createdAt.toISOString(),
-    updatedAt: build.updatedAt.toISOString(),
-  });
+  if (latestBuild.data.buildId === null) {
+    throw Error("Build not found");
+  }
+  const build = await context.postgrest.client
+    .from("Build")
+    .select()
+    .eq("id", latestBuild.data.buildId)
+    .single();
+  if (build.error) {
+    throw build.error;
+  }
+  return parseBuild(build.data);
 };
 
 const createNewPageInstances = (): Build["instances"] => {
@@ -217,17 +221,8 @@ export const createBuild = async (
   props: {
     projectId: Build["projectId"];
   },
-  _context: AppContext,
-  client: Prisma.TransactionClient
+  context: AppContext
 ): Promise<void> => {
-  const count = await client.build.count({
-    where: { projectId: props.projectId, deployment: null },
-  });
-
-  if (count > 0) {
-    throw new Error("Dev build already exists");
-  }
-
   const newInstances = createNewPageInstances();
   const [rootInstanceId] = newInstances[0];
   const systemDataSource: DataSource = {
@@ -244,19 +239,19 @@ export const createBuild = async (
     })
   );
 
-  await client.build.create({
-    data: {
-      projectId: props.projectId,
-      pages: serializePages(defaultPages),
-      breakpoints: serializeData<Breakpoint>(
-        new Map(createInitialBreakpoints())
-      ),
-      instances: serializeData<Instance>(new Map(newInstances)),
-      dataSources: serializeData<DataSource>(
-        new Map([[systemDataSource.id, systemDataSource]])
-      ),
-    },
+  const newBuild = await context.postgrest.client.from("Build").insert({
+    id: randomUUID(),
+    projectId: props.projectId,
+    pages: serializePages(defaultPages),
+    breakpoints: serializeData<Breakpoint>(new Map(createInitialBreakpoints())),
+    instances: serializeData<Instance>(new Map(newInstances)),
+    dataSources: serializeData<DataSource>(
+      new Map([[systemDataSource.id, systemDataSource]])
+    ),
   });
+  if (newBuild.error) {
+    throw newBuild.error;
+  }
 };
 
 export const createProductionBuild = async (

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -26,7 +26,6 @@ import { parseDeployment } from "./deployment";
 import { parsePages, serializePages } from "./pages";
 import { createDefaultPages } from "../shared/pages-utils";
 import type { MarketplaceProduct } from "../shared//marketplace";
-import { randomUUID } from "crypto";
 
 export const parseData = <Type extends { id: string }>(
   string: string
@@ -240,7 +239,7 @@ export const createBuild = async (
   );
 
   const newBuild = await context.postgrest.client.from("Build").insert({
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     projectId: props.projectId,
     pages: serializePages(defaultPages),
     breakpoints: serializeData<Breakpoint>(new Map(createInitialBreakpoints())),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1716,9 +1716,6 @@ importers:
       '@webstudio-is/postrest':
         specifier: workspace:*
         version: link:../postgrest
-      '@webstudio-is/prisma-client':
-        specifier: workspace:*
-        version: link:../prisma-client
       '@webstudio-is/sdk':
         specifier: workspace:*
         version: link:../sdk


### PR DESCRIPTION
Migrated prisma with postgrest in project build.
Got two cases

- in many cases it is ok to use a couple of select queries since round trip is low
- transactions can be avoided with late binding to user