### PR TITLE
build: set tag as release name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,5 +55,6 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             tag_name,
+            name: tag_name,
             body: changelog,
           })


### PR DESCRIPTION
Github started defaulting to tag + commit instead of just tag as release name. So set it here explicitly for future releases.