### PR TITLE
refactor: split react-sdk/runtime

### DIFF
--- a/fixtures/ssg/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/ssg/app/__generated__/[another-page]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Heading as Heading,

--- a/fixtures/ssg/app/__generated__/_index.tsx
+++ b/fixtures/ssg/app/__generated__/_index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Heading as Heading,

--- a/fixtures/ssg/pages/another-page/+Page.tsx
+++ b/fixtures/ssg/pages/another-page/+Page.tsx
@@ -1,5 +1,5 @@
 import type { PageContext } from "vike/types";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   assetBaseUrl,
   imageBaseUrl,

--- a/fixtures/ssg/pages/index/+Page.tsx
+++ b/fixtures/ssg/pages/index/+Page.tsx
@@ -1,5 +1,5 @@
 import type { PageContext } from "vike/types";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   assetBaseUrl,
   imageBaseUrl,

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/[another-page]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import { XmlNode } from "@webstudio-is/sdk-components-react";
 
 export const siteName = "Fixture Site";

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap.xml]._index.tsx
@@ -2,7 +2,7 @@
 import { renderToString } from "react-dom/server";
 import { type LoaderFunctionArgs, redirect } from "@remix-run/server-runtime";
 import { isLocalResource, loadResources } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import { Page } from "../__generated__/[sitemap.xml]._index";
 import {
   getPageMeta,

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/[another-page]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[another-page]._index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/[another-page]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[another-page]._index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Image as Image } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Form as Form,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Accordion as Accordion,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import {
   Box as Box,

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, useState } from "react";
 import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-import { useResource } from "@webstudio-is/react-sdk";
+import { useResource } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -615,7 +615,7 @@ export const prebuild = async (options: {
 
       import { Fragment, useState } from "react";
       import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
-      import { useResource } from "@webstudio-is/react-sdk";
+      import { useResource } from "@webstudio-is/react-sdk/runtime";
       ${componentImports}
 
       export const siteName = ${JSON.stringify(projectMeta?.siteName)};

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -17,7 +17,7 @@ import {
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Page,
   siteName,

--- a/packages/cli/templates/defaults/app/route-templates/xml.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/xml.tsx
@@ -2,7 +2,7 @@
 import { renderToString } from "react-dom/server";
 import { type LoaderFunctionArgs, redirect } from "@remix-run/server-runtime";
 import { isLocalResource, loadResources } from "@webstudio-is/sdk";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import { Page } from "__CLIENT__";
 import { getPageMeta, getRemixParams, getResources } from "__SERVER__";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "__CONSTANTS__";

--- a/packages/cli/templates/ssg/app/route-templates/html/+Page.tsx
+++ b/packages/cli/templates/ssg/app/route-templates/html/+Page.tsx
@@ -1,5 +1,5 @@
 import type { PageContext } from "vike/types";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import { assetBaseUrl, imageBaseUrl, imageLoader } from "__CONSTANTS__";
 import { Page } from "__CLIENT__";
 

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "build": "rm -rf lib && esbuild src/index.ts ./src/css/normalize.ts --outdir=lib --bundle --format=esm --packages=external",
+    "build": "rm -rf lib && esbuild src/index.ts src/runtime.ts ./src/css/normalize.ts --outdir=lib --bundle --format=esm --packages=external",
     "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests"
@@ -45,6 +45,11 @@
       "webstudio": "./src/index.ts",
       "types": "./lib/types/index.d.ts",
       "import": "./lib/index.js"
+    },
+    "./runtime": {
+      "webstudio": "./src/runtime.ts",
+      "types": "./lib/types/runtime.d.ts",
+      "import": "./lib/runtime.js"
     },
     "./css-normalize": {
       "webstudio": "./src/css/normalize.ts",

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -15,9 +15,9 @@ export {
 } from "./components/component-meta";
 export * from "./embed-template";
 export * from "./props";
-export * from "./context";
+export type * from "./context";
 export { getIndexesWithinAncestors } from "./instance-utils";
-export * from "./hook";
+export type * from "./hook";
 export {
   generateWebstudioComponent,
   generateJsxElement,

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -129,9 +129,3 @@ export const showAttribute = "data-ws-show" as const;
 export const indexAttribute = "data-ws-index" as const;
 export const collapsedAttribute = "data-ws-collapsed" as const;
 export const textContentAttribute = "data-ws-text-content" as const;
-
-export const getIndexWithinAncestorFromComponentProps = (
-  props: Record<string, unknown>
-) => {
-  return props[indexAttribute] as string | undefined;
-};

--- a/packages/react-sdk/src/runtime.ts
+++ b/packages/react-sdk/src/runtime.ts
@@ -1,0 +1,8 @@
+export * from "./context";
+export * from "./hook";
+
+export const getIndexWithinAncestorFromComponentProps = (
+  props: Record<string, unknown>
+) => {
+  return props["data-ws-index"] as string | undefined;
+};

--- a/packages/sdk-components-react-radix/src/accordion.tsx
+++ b/packages/sdk-components-react-radix/src/accordion.tsx
@@ -17,7 +17,7 @@ import {
   getIndexWithinAncestorFromComponentProps,
   getInstanceSelectorById,
   type Hook,
-} from "@webstudio-is/react-sdk";
+} from "@webstudio-is/react-sdk/runtime";
 
 export const Accordion = forwardRef<
   HTMLDivElement,

--- a/packages/sdk-components-react-radix/src/collapsible.tsx
+++ b/packages/sdk-components-react-radix/src/collapsible.tsx
@@ -11,7 +11,7 @@ import {
   type Hook,
   getClosestInstance,
   getInstanceSelectorById,
-} from "@webstudio-is/react-sdk";
+} from "@webstudio-is/react-sdk/runtime";
 
 export const Collapsible: ForwardRefExoticComponent<
   Omit<ComponentProps<typeof Root>, "defaultOpen" | "asChild"> &

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -14,7 +14,7 @@ import {
   getClosestInstance,
   getInstanceSelectorById,
   type Hook,
-} from "@webstudio-is/react-sdk";
+} from "@webstudio-is/react-sdk/runtime";
 
 /**
  * Naive heuristic to determine if a click event will cause navigate

--- a/packages/sdk-components-react-radix/src/navigation-menu.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-menu.tsx
@@ -5,7 +5,7 @@ import {
   getInstanceSelectorById,
   ReactSdkContext,
   type Hook,
-} from "@webstudio-is/react-sdk";
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Children,
   forwardRef,

--- a/packages/sdk-components-react-radix/src/popover.tsx
+++ b/packages/sdk-components-react-radix/src/popover.tsx
@@ -9,7 +9,7 @@ import {
   getClosestInstance,
   getInstanceSelectorById,
   type Hook,
-} from "@webstudio-is/react-sdk";
+} from "@webstudio-is/react-sdk/runtime";
 
 // wrap in forwardRef because Root is functional component without ref
 export const Popover = forwardRef<

--- a/packages/sdk-components-react-radix/src/select.tsx
+++ b/packages/sdk-components-react-radix/src/select.tsx
@@ -22,7 +22,7 @@ import {
   getClosestInstance,
   getInstanceSelectorById,
   ReactSdkContext,
-} from "@webstudio-is/react-sdk";
+} from "@webstudio-is/react-sdk/runtime";
 
 // wrap in forwardRef because Root is functional component without ref
 export const Select = forwardRef<

--- a/packages/sdk-components-react-radix/src/sheet.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.tsx
@@ -7,7 +7,7 @@ import {
   getClosestInstance,
   getInstanceSelectorById,
   type Hook,
-} from "@webstudio-is/react-sdk";
+} from "@webstudio-is/react-sdk/runtime";
 import * as Dialog from "./dialog";
 
 export const Sheet = Dialog.Dialog;

--- a/packages/sdk-components-react-radix/src/tabs.tsx
+++ b/packages/sdk-components-react-radix/src/tabs.tsx
@@ -11,7 +11,7 @@ import {
   getIndexWithinAncestorFromComponentProps,
   getInstanceSelectorById,
   type Hook,
-} from "@webstudio-is/react-sdk";
+} from "@webstudio-is/react-sdk/runtime";
 
 export const Tabs: ForwardRefExoticComponent<
   Omit<ComponentProps<typeof Root>, "asChild"> & RefAttributes<HTMLDivElement>

--- a/packages/sdk-components-react-radix/src/tooltip.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.tsx
@@ -3,7 +3,7 @@ import {
   getClosestInstance,
   getInstanceSelectorById,
   type Hook,
-} from "@webstudio-is/react-sdk";
+} from "@webstudio-is/react-sdk/runtime";
 
 import {
   forwardRef,

--- a/packages/sdk-components-react-remix/src/remix-form.tsx
+++ b/packages/sdk-components-react-remix/src/remix-form.tsx
@@ -5,7 +5,7 @@ import {
   useContext,
 } from "react";
 import { Form, type FormProps } from "@remix-run/react";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 
 export const defaultTag = "form";
 

--- a/packages/sdk-components-react-remix/src/shared/remix-link.tsx
+++ b/packages/sdk-components-react-remix/src/shared/remix-link.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, type ComponentPropsWithoutRef, useContext } from "react";
 import { NavLink as RemixLink } from "@remix-run/react";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import type { Link } from "@webstudio-is/sdk-components-react";
 
 type Props = Omit<ComponentPropsWithoutRef<typeof Link>, "target"> & {

--- a/packages/sdk-components-react/src/html-embed.test.tsx
+++ b/packages/sdk-components-react/src/html-embed.test.tsx
@@ -5,8 +5,8 @@ import * as React from "react";
 import ReactDOMServer from "react-dom/server";
 import { test, expect, describe } from "@jest/globals";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import { __testing__, HtmlEmbed } from "./html-embed";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
 import { cartesian } from "./test-utils/cartesian";
 
 const scriptTestIdPrefix = __testing__.scriptTestIdPrefix;

--- a/packages/sdk-components-react/src/html-embed.tsx
+++ b/packages/sdk-components-react/src/html-embed.tsx
@@ -10,7 +10,7 @@ import {
   useMemo,
 } from "react";
 import { mergeRefs } from "@react-aria/utils";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import { executeDomEvents, patchDomEvents } from "./html-embed-patchers";
 
 export const __testing__ = {

--- a/packages/sdk-components-react/src/image.tsx
+++ b/packages/sdk-components-react/src/image.tsx
@@ -5,7 +5,7 @@ import {
   useContext,
 } from "react";
 import { Image as WebstudioImage } from "@webstudio-is/image";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 
 export const defaultTag = "img";
 

--- a/packages/sdk-components-react/src/select.tsx
+++ b/packages/sdk-components-react/src/select.tsx
@@ -2,7 +2,7 @@ import {
   getClosestInstance,
   getInstanceSelectorById,
   type Hook,
-} from "@webstudio-is/react-sdk";
+} from "@webstudio-is/react-sdk/runtime";
 import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 export const defaultTag = "select";

--- a/packages/sdk-components-react/src/vimeo.tsx
+++ b/packages/sdk-components-react/src/vimeo.tsx
@@ -15,7 +15,7 @@ import {
   createContext,
   type ContextType,
 } from "react";
-import { ReactSdkContext } from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 
 // https://developer.vimeo.com/player/sdk/embed
 type VimeoPlayerOptions = {

--- a/packages/sdk-components-react/src/xml-node.tsx
+++ b/packages/sdk-components-react/src/xml-node.tsx
@@ -1,8 +1,4 @@
-import {
-  idAttribute,
-  componentAttribute,
-  ReactSdkContext,
-} from "@webstudio-is/react-sdk";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import {
   Children,
   createElement,
@@ -19,9 +15,6 @@ type Props = {
   tag: string;
   xmlns?: string;
   children: ReactNode;
-  // xxxAttribute is used for typings only
-  [idAttribute]?: string;
-  [componentAttribute]?: string;
 };
 
 export const XmlNode = forwardRef<ElementRef<"div">, Props>(


### PR DESCRIPTION
Here split everything imported from react-sdk by published sites into separate entry point react-sdk/runtime.

The result in ssg fixture is the following

```diff
-  429788 chunk-CuG10VAj.js
+  370366 chunk-D4NWbWis.js
```