### PR TITLE
build: stop formatting minified ssg scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
               }
             }
             const results = [
-              await assertSize('./fixtures/ssg/dist/client', 480),
+              await assertSize('./fixtures/ssg/dist/client', 308),
               await assertSize('./fixtures/webstudio-remix-netlify-functions/build/client', 560),
             ]
             for (const result of results) {

--- a/fixtures/ssg/package.json
+++ b/fixtures/ssg/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "vite build",
-    "postbuild": "prettier --write . || true",
+    "postbuild": "prettier --write \"dist/**/*.html\" || true",
     "dev": "vite dev",
     "typecheck": "tsc",
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",


### PR DESCRIPTION
Prettier makes minified scripts huge.
Need to format only html.
