### PR TITLE
experimental: return empty values for hidden keyword properties

### DIFF
--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -55,6 +55,15 @@ export const toValue = (
   }
 
   if (value.type === "keyword") {
+    // The hidden property is used to hide values in the builder
+    // But we can't use none here like its done for image.
+    // As none is not valid in all cases.
+    // Eg: backface-visibility
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/backface-visibility#syntax
+    if (value.hidden === true) {
+      return "";
+    }
+
     return value.value;
   }
 


### PR DESCRIPTION
## Description

This PR helps in returning empty strings for keyword values which are hidden from the UI. This support is needed in #3802 backface-visibility in transforms

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")