### PR TITLE
fix: parse transform-origin property values as tuples

### DIFF
--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "@jest/globals";
 import { parseCssValue } from "./parse-css-value";
 import { toValue, type StyleProperty } from "@webstudio-is/css-engine";
+import { parseCss } from "./parse-css";
 
 describe("Parse CSS value", () => {
   describe("number value", () => {
@@ -918,5 +919,47 @@ describe("font-family", () => {
       type: "fontFamily",
       value: ["Song Ti", "Hei Ti"],
     });
+  });
+});
+
+test("parse transform-origin", () => {
+  expect(parseCssValue("transformOrigin", "bottom")).toEqual({
+    type: "tuple",
+    value: [
+      {
+        type: "keyword",
+        value: "bottom",
+      },
+    ],
+  });
+
+  expect(parseCssValue("transformOrigin", "left 2px")).toEqual({
+    type: "tuple",
+    value: [
+      { type: "keyword", value: "left" },
+      { type: "unit", value: 2, unit: "px" },
+    ],
+  });
+
+  expect(parseCssValue("transformOrigin", "right top")).toEqual({
+    type: "tuple",
+    value: [
+      { type: "keyword", value: "right" },
+      { type: "keyword", value: "top" },
+    ],
+  });
+
+  expect(parseCssValue("transformOrigin", "2px 30% 10px")).toEqual({
+    type: "tuple",
+    value: [
+      { type: "unit", value: 2, unit: "px" },
+      { type: "unit", value: 30, unit: "%" },
+      { type: "unit", value: 10, unit: "px" },
+    ],
+  });
+
+  expect(parseCssValue("transformOrigin", "top left right")).toEqual({
+    type: "invalid",
+    value: "top left right",
   });
 });

--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -1,7 +1,6 @@
 import { describe, test, expect } from "@jest/globals";
 import { parseCssValue } from "./parse-css-value";
 import { toValue, type StyleProperty } from "@webstudio-is/css-engine";
-import { parseCss } from "./parse-css";
 
 describe("Parse CSS value", () => {
   describe("number value", () => {
@@ -925,12 +924,7 @@ describe("font-family", () => {
 test("parse transform-origin", () => {
   expect(parseCssValue("transformOrigin", "bottom")).toEqual({
     type: "tuple",
-    value: [
-      {
-        type: "keyword",
-        value: "bottom",
-      },
-    ],
+    value: [{ type: "keyword", value: "bottom" }],
   });
 
   expect(parseCssValue("transformOrigin", "left 2px")).toEqual({

--- a/packages/css-data/src/parse-css-value.ts
+++ b/packages/css-data/src/parse-css-value.ts
@@ -143,6 +143,7 @@ const tupleProps = new Set<StyleProperty>([
   "transform",
   "filter",
   "backdropFilter",
+  "transformOrigin",
 ]);
 
 const availableUnits = new Set<string>(Object.values(units).flat());


### PR DESCRIPTION
## Description

The current parser is not able to parse all the possible values for `transform-origin` property. The property takes `single`, `double` and `triple` values. So these need to be parsed as `tuples` to support `triple` values now.

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [x] added tests

