### PR TITLE
fix: broken copy paste when inputs or text selection were used before

### DIFF
--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -34,7 +34,11 @@ const isTextEditing = (event: ClipboardEvent) => {
 };
 
 const validateClipboardEvent = (event: ClipboardEvent) => {
-  if (event.clipboardData === null || isTextEditing(event)) {
+  if (isTextEditing(event)) {
+    return false;
+  }
+
+  if (event.clipboardData === null) {
     return false;
   }
   if ($authTokenPermissions.get().canCopy === false) {
@@ -58,6 +62,15 @@ export const initCopyPaste = (plugins: Plugin[]) => {
     if (validateClipboardEvent(event) === false) {
       return;
     }
+
+    const isInBuilderContext = window.self === window.top;
+
+    if (isInBuilderContext) {
+      if (event.target !== window.document.body) {
+        return;
+      }
+    }
+
     for (const { mimeType = defaultMimeType, onCopy } of plugins) {
       const data = await onCopy?.();
       if (data) {

--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -1,10 +1,11 @@
 import { toastError } from "../error/toast-error";
-import { $authTokenPermissions } from "../nano-states";
+import {
+  $authTokenPermissions,
+  $textEditingInstanceSelector,
+} from "../nano-states";
 
 const isTextEditing = (event: ClipboardEvent) => {
-  const selection = document.getSelection();
-
-  if (selection?.type === "Range" || selection?.type === "Caret") {
+  if ($textEditingInstanceSelector.get() !== null) {
     return true;
   }
 

--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -5,7 +5,7 @@ import {
 } from "../nano-states";
 
 const isTextEditing = (event: ClipboardEvent) => {
-  if ($textEditingInstanceSelector.get() !== null) {
+  if ($textEditingInstanceSelector.get() != null) {
     return true;
   }
 

--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -5,22 +5,12 @@ import {
 } from "../nano-states";
 
 const isTextEditing = (event: ClipboardEvent) => {
+  // Text is edited on the Canvas using the default Canvas text editor settings.
   if ($textEditingInstanceSelector.get() != null) {
     return true;
   }
 
-  // Note on event.target:
-  //
-  //   The spec (https://w3c.github.io/clipboard-apis/#to-fire-a-clipboard-event)
-  //   says that if the context is not editable, the target should be the focused node.
-  //
-  //   But in practice it seems that the target is based
-  //   on where the cursor is, rather than which element has focus.
-  //   For example, if a <button> has focus, the target is the <body> element
-  //   (at least in Chrome).
-
-  // If cursor is in input,
-  // don't copy (we may want to add more exceptions here in the future)
+  // Text is edited inside an input, textarea, or contenteditable (i.e. codemirror editor) field.
   if (
     event.target instanceof HTMLInputElement ||
     event.target instanceof HTMLTextAreaElement ||
@@ -33,14 +23,47 @@ const isTextEditing = (event: ClipboardEvent) => {
   return false;
 };
 
+/**
+ *
+ * # Note:
+ * validateClipboardEvent determines when to use default copy/paste behavior or if a WebStudio instance will be copied, pasted, or cut.
+ * # How to test:
+ * 1. Focus on an input in the style panel (width, style source) or name input in settings. Select the text, then copy and paste any instance in the Navigator tree or on the Canvas.
+ * 2. Edit text in a paragraph on the Canvas. Select text (single or multiple lines), then press Cmd+X. The paragraph should not be deleted.
+ * 3. Select CSS preview text, then select an instance in the Navigator. Press Cmd+C, then Cmd+V.
+ **/
 const validateClipboardEvent = (event: ClipboardEvent) => {
+  if (event.clipboardData === null) {
+    return false;
+  }
+
   if (isTextEditing(event)) {
     return false;
   }
 
-  if (event.clipboardData === null) {
-    return false;
+  // Allows native selection of text in the Builder panels, such as CSS Preview.
+  if (event.type === "copy") {
+    const isInBuilderContext = window.self === window.top;
+
+    if (isInBuilderContext) {
+      // Note on event.target:
+      //
+      //   The spec (https://w3c.github.io/clipboard-apis/#to-fire-a-clipboard-event)
+      //   says that if the context is not editable, the target should be the focused node.
+      //
+      //   But in practice it seems that the target is based
+      //   on where the cursor is, rather than which element has focus.
+      //   For example, if a <button> has focus, the target is the <body> element.
+      //   If some text is selected, the target is a wrapping element of the text.
+      //   (at least in Chrome).
+
+      // We are using the behavior described above: if some text is selected, the target is usually (at least in the cases we need) not the body.
+      if (event.target !== window.document.body) {
+        return false;
+      }
+    }
   }
+
   if ($authTokenPermissions.get().canCopy === false) {
     toastError("Copying has been disabled by the project owner");
     return false;
@@ -61,14 +84,6 @@ export const initCopyPaste = (plugins: Plugin[]) => {
   const handleCopy = async (event: ClipboardEvent) => {
     if (validateClipboardEvent(event) === false) {
       return;
-    }
-
-    const isInBuilderContext = window.self === window.top;
-
-    if (isInBuilderContext) {
-      if (event.target !== window.document.body) {
-        return;
-      }
     }
 
     for (const { mimeType = defaultMimeType, onCopy } of plugins) {

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -337,7 +337,15 @@ export const TreeItemBody = <Data extends { id: string }>({
           handleClick: (event: MouseEvent) =>
             onSelect(itemSelector, event.altKey),
         }
-      : { handleFocus: () => onSelect(itemSelector) };
+      : {
+          handleFocus: () => onSelect(itemSelector),
+          handleClick: () => {
+            // The intent is to reset the selection on focused item click to ensure the same behavior as on focus change. (For simplicity, we reset for all clicks.)
+            // This resolves an edge case with copy/paste when text is selected (e.g., inside CSS Preview) and a Tree Node is selected.
+            // Visually, it's unclear what will be selected on the 'copy' event.
+            window.getSelection()?.removeAllRanges();
+          },
+        };
   }, [selectionEvent, onSelect, itemSelector]);
 
   const isDragging = dropTargetItemSelector !== undefined;


### PR DESCRIPTION
## Description

In some cases copy/paste didn't work

## Steps for reproduction

1. Focus on an input in the style panel (width, style source) or name input in settings. Select the text, then copy and paste any instance in the Navigator tree or on the Canvas.
2. Edit text in a paragraph on the Canvas. Select text (single or multiple lines), then press Cmd+X. The paragraph should not be deleted.
3. Select CSS preview text, then select an instance in the Navigator. Press Cmd+C, then Cmd+V.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
