### PR TITLE
refactor: migrate project to postgrest

### DIFF
--- a/packages/domain/src/trpc/domain.ts
+++ b/packages/domain/src/trpc/domain.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
-
+import { nanoid } from "nanoid";
+import type { Project } from "@webstudio-is/project";
 import { db as projectDb } from "@webstudio-is/project/index.server";
-import { db } from "../db";
 import { createProductionBuild } from "@webstudio-is/project-build/index.server";
 import { router, procedure } from "@webstudio-is/trpc-interface/index.server";
-import { nanoid } from "nanoid";
 import { Templates } from "@webstudio-is/sdk";
+import { db } from "../db";
 
 export const domainRouter = router({
   getEntriToken: procedure.query(async ({ ctx }) => {
@@ -29,7 +29,10 @@ export const domainRouter = router({
     .input(z.object({ projectId: z.string() }))
     .query(async ({ input, ctx }) => {
       try {
-        const project = await projectDb.project.loadById(input.projectId, ctx);
+        const project: Project = await projectDb.project.loadById(
+          input.projectId,
+          ctx
+        );
 
         return {
           success: true,

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@trpc/server": "^10.45.2",
     "@webstudio-is/asset-uploader": "workspace:*",
-    "@webstudio-is/prisma-client": "workspace:*",
     "@webstudio-is/project-build": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
     "nanoid": "^5.0.1",
     "slugify": "^1.6.6",
+    "type-fest": "^4.3.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1658,9 +1658,6 @@ importers:
       '@webstudio-is/asset-uploader':
         specifier: workspace:*
         version: link:../asset-uploader
-      '@webstudio-is/prisma-client':
-        specifier: workspace:*
-        version: link:../prisma-client
       '@webstudio-is/project-build':
         specifier: workspace:*
         version: link:../project-build
@@ -1673,6 +1670,9 @@ importers:
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
+      type-fest:
+        specifier: ^4.3.1
+        version: 4.3.1
       zod:
         specifier: ^3.22.4
         version: 3.22.4


### PR DESCRIPTION
Switched to postgrest in "project" package.
Do 3 requests now when load project to get
latest build and latest static build since
they are not inferred as related in postgrest.