### PR TITLE
fix: Make Navigation Items editable after opening Binding dialog

### DIFF
--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -44,6 +44,12 @@ import {
 } from "@webstudio-is/design-system";
 import { CrossIcon, MaximizeIcon, MinimizeIcon } from "@webstudio-is/icons";
 
+// This undocumented flag is required to keep contenteditable fields editable after the first activation of EditorView.
+// To reproduce the issue, open any Binding dialog and then try to edit a Navigation Item in the Navigation menu.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+EditorView.EDIT_CONTEXT = false;
+
 const ExternalChange = Annotation.define<boolean>();
 
 const minHeightVar = "--ws-code-editor-min-height";


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
