### PR TITLE
fix: support html form in ssg

### DIFF
--- a/packages/sdk-components-react/src/components.ts
+++ b/packages/sdk-components-react/src/components.ts
@@ -17,6 +17,7 @@ export { Subscript } from "./subscript";
 export { Button } from "./button";
 export { Input } from "./input";
 export { Form } from "./form";
+export { Form as RemixForm } from "./form";
 export { Image } from "./image";
 export { Blockquote } from "./blockquote";
 export { List } from "./list";

--- a/packages/sdk-components-react/src/metas.ts
+++ b/packages/sdk-components-react/src/metas.ts
@@ -18,6 +18,7 @@ export { meta as Subscript } from "./subscript.ws";
 export { meta as Button } from "./button.ws";
 export { meta as Input } from "./input.ws";
 export { meta as Form } from "./form.ws";
+export { meta as RemixForm } from "./form.ws";
 export { meta as Image } from "./image.ws";
 export { meta as Blockquote } from "./blockquote.ws";
 export { meta as List } from "./list.ws";

--- a/packages/sdk-components-react/src/props.ts
+++ b/packages/sdk-components-react/src/props.ts
@@ -17,6 +17,7 @@ export { propsMeta as Subscript } from "./subscript.ws";
 export { propsMeta as Button } from "./button.ws";
 export { propsMeta as Input } from "./input.ws";
 export { propsMeta as Form } from "./form.ws";
+export { propsMeta as RemixForm } from "./form.ws";
 export { propsMeta as Image } from "./image.ws";
 export { propsMeta as Blockquote } from "./blockquote.ws";
 export { propsMeta as List } from "./list.ws";


### PR DESCRIPTION
Here added RemixForm alias to native form in base sdk components. It should allow users to write at least native forms. Naming was not chosen well though.