### PR TITLE
fix: fix blinking navigator item focus ring

### DIFF
--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -417,7 +417,10 @@ export const TreeItemBody = <Data extends { id: string }>({
           style={{ left: (level - 1) * INDENT + ITEM_PADDING_LEFT }}
           // We don't want this trigger to be focusable
           tabIndex={-1}
-          onClick={(event) => onToggle(event.altKey)}
+          onClick={(event) => {
+            event.stopPropagation();
+            onToggle(event.altKey);
+          }}
         >
           {isExpanded ? <ChevronFilledDownIcon /> : <ChevronFilledRightIcon />}
         </CollapsibleTrigger>

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -418,6 +418,9 @@ export const TreeItemBody = <Data extends { id: string }>({
           // We don't want this trigger to be focusable
           tabIndex={-1}
           onClick={(event) => {
+            // If we don't stop propagation, the currently focused item will loose focus and then regain it
+            // which will result in blinking outline.
+            // We prefer to focus the collapsible trigger instead since it is also a button and it was actually clicked.
             event.stopPropagation();
             onToggle(event.altKey);
           }}


### PR DESCRIPTION
Part of https://github.com/webstudio-is/webstudio/issues/3914


## Description

when clicking on collapsible trigger, previously focused item blinks if we don't click event propagation

https://github.com/user-attachments/assets/f31507a3-8ccd-4ef2-97d4-590563724351


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
