### PR TITLE
refactor: load compact data into builder

### DIFF
--- a/apps/builder/app/routes/rest.data.$projectId.ts
+++ b/apps/builder/app/routes/rest.data.$projectId.ts
@@ -1,6 +1,6 @@
 import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { db } from "@webstudio-is/project/index.server";
-import { loadCompactBuildByProjectId } from "@webstudio-is/project-build/index.server";
+import { loadDevBuildByProjectId } from "@webstudio-is/project-build/index.server";
 import { loadAssetsByProject } from "@webstudio-is/asset-uploader/index.server";
 import { createContext } from "~/shared/context.server";
 
@@ -16,7 +16,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
   if (project.userId === null) {
     throw new Error("Project must have project userId defined");
   }
-  const build = await loadCompactBuildByProjectId(context, project.id);
+  const build = await loadDevBuildByProjectId(context, project.id);
   const assets = await loadAssetsByProject(project.id, context);
   return {
     ...build,

--- a/apps/builder/app/routes/rest.data.$projectId.ts
+++ b/apps/builder/app/routes/rest.data.$projectId.ts
@@ -1,6 +1,6 @@
 import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { db } from "@webstudio-is/project/index.server";
-import { loadBuildByProjectId } from "@webstudio-is/project-build/index.server";
+import { loadCompactBuildByProjectId } from "@webstudio-is/project-build/index.server";
 import { loadAssetsByProject } from "@webstudio-is/asset-uploader/index.server";
 import { createContext } from "~/shared/context.server";
 
@@ -16,10 +16,10 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
   if (project.userId === null) {
     throw new Error("Project must have project userId defined");
   }
-  const devBuild = await loadBuildByProjectId(context, project.id);
+  const build = await loadCompactBuildByProjectId(context, project.id);
   const assets = await loadAssetsByProject(project.id, context);
   return {
-    build: devBuild,
+    ...build,
     assets,
   };
 };

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -191,7 +191,7 @@ export const loadBuildByProjectId = async (
   return parseBuild(build);
 };
 
-export const loadCompactBuildByProjectId = async (
+export const loadDevBuildByProjectId = async (
   context: AppContext,
   projectId: Build["projectId"]
 ) => {

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -17,6 +17,8 @@ import {
   type Breakpoint,
   Pages,
   initialBreakpoints,
+  StyleSourceSelection,
+  StyleDecl,
 } from "@webstudio-is/sdk";
 import type { Data } from "@webstudio-is/http-client";
 import type { Build } from "../types";
@@ -26,6 +28,9 @@ import { parseDeployment } from "./deployment";
 import { parsePages, serializePages } from "./pages";
 import { createDefaultPages } from "../shared/pages-utils";
 import type { MarketplaceProduct } from "../shared//marketplace";
+
+const parseCompactData = <Item>(serialized: string) =>
+  JSON.parse(serialized) as Item[];
 
 export const parseData = <Type extends { id: string }>(
   string: string
@@ -87,6 +92,37 @@ const parseBuild = async (
   }
 };
 
+const parseCompactBuild = async (
+  build: Database["public"]["Tables"]["Build"]["Row"]
+) => {
+  try {
+    return {
+      id: build.id,
+      projectId: build.projectId,
+      version: build.version,
+      createdAt: build.createdAt,
+      updatedAt: build.updatedAt,
+      pages: parseConfig<Pages>(build.pages),
+      breakpoints: parseCompactData<Breakpoint>(build.breakpoints),
+      styles: parseCompactData<StyleDecl>(build.styles),
+      styleSources: parseCompactData<StyleSource>(build.styleSources),
+      styleSourceSelections: parseCompactData<StyleSourceSelection>(
+        build.styleSourceSelections
+      ),
+      props: parseCompactData<Prop>(build.props),
+      dataSources: parseCompactData<DataSource>(build.dataSources),
+      resources: parseCompactData<Resource>(build.resources),
+      instances: parseCompactData<Instance>(build.instances),
+      deployment: parseDeployment(build.deployment),
+      marketplaceProduct: parseConfig<MarketplaceProduct>(
+        build.marketplaceProduct
+      ),
+    };
+  } finally {
+    // empty block
+  }
+};
+
 export const loadRawBuildById = async (
   context: AppContext,
   id: Build["id"]
@@ -131,22 +167,36 @@ export const loadBuildIdAndVersionByProjectId = async (
   return build.data;
 };
 
-export const loadBuildByProjectId = async (
+const loadRawBuildByProjectId = async (
   context: AppContext,
   projectId: Build["projectId"]
-): Promise<Build> => {
+) => {
   const build = await context.postgrest.client
     .from("Build")
     .select("*")
     .eq("projectId", projectId)
     .is("deployment", null)
     .single();
-
   if (build.error) {
     throw build.error;
   }
+  return build.data;
+};
 
-  return parseBuild(build.data);
+export const loadBuildByProjectId = async (
+  context: AppContext,
+  projectId: Build["projectId"]
+): Promise<Build> => {
+  const build = await loadRawBuildByProjectId(context, projectId);
+  return parseBuild(build);
+};
+
+export const loadCompactBuildByProjectId = async (
+  context: AppContext,
+  projectId: Build["projectId"]
+) => {
+  const build = await loadRawBuildByProjectId(context, projectId);
+  return parseCompactBuild(build);
 };
 
 export const loadApprovedProdBuildByProjectId = async (


### PR DESCRIPTION
Load only arrays instead of maps from server
and convert data to map on client.

This reduces download size and server cpu usage.

340 kB -> 269 kB
218 kB -> 170 kB
22%