### PR TITLE
feat: tolerate comma instead of dot typo in style value input

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
@@ -14,13 +14,19 @@ export const parseIntermediateOrInvalidValue = (
   property: StyleProperty,
   styleValue: IntermediateStyleValue | InvalidValue
 ): StyleValue => {
-  const value = styleValue.value.trim();
+  let value = styleValue.value.trim();
 
   if (property.startsWith("--")) {
     return {
       type: "unparsed",
       value,
     };
+  }
+
+  // If input contains a number, we assume its either a value or value + unit.
+  // Users often mistype comma instead of dot and we want to be tolerant to that.
+  if (isNaN(parseFloat(value)) === false) {
+    value = value.replace(",", ".");
   }
 
   const valueInfo = properties[property as keyof typeof properties];

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
@@ -25,7 +25,7 @@ export const parseIntermediateOrInvalidValue = (
 
   // If input contains a number, we assume its either a value or value + unit.
   // Users often mistype comma instead of dot and we want to be tolerant to that.
-  if (isNaN(parseFloat(value)) === false) {
+  if (Number.isNaN(Number.parseFloat(value)) === false) {
     value = value.replace(",", ".");
   }
 

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
@@ -118,6 +118,33 @@ describe("Parse intermediate or invalid value without math evaluation", () => {
       value: "border-box",
     });
   });
+
+  test("tolerate comma instead of dot typo", () => {
+    const result = parseIntermediateOrInvalidValue("width", {
+      type: "intermediate",
+      value: "2,5",
+      unit: "rem",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 2.5,
+      unit: "rem",
+    });
+  });
+
+  test("tolerate comma instead of dot typo with unit input", () => {
+    const result = parseIntermediateOrInvalidValue("width", {
+      type: "intermediate",
+      value: "2,5rem",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 2.5,
+      unit: "rem",
+    });
+  });
 });
 
 describe("Parse intermediate or invalid value with math evaluation", () => {


### PR DESCRIPTION
Part of https://github.com/webstudio-is/webstudio/issues/3914

## Description

Users often type comma instead of dot when entering css value numbers, we want to auto convert them to dot.

## Steps for reproduction

1. type 1,2 in width input
2. hit enter, see it was converted to 1.2
3. type 1,2rem
4. hit enter, see it was converted to 1.2 and rem unit was applied

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
