### PR TITLE
experimental: add transform-origin extractor for individual property handling in the style-panel

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-extractors.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-extractors.test.ts
@@ -1,0 +1,174 @@
+import { describe, test, expect } from "@jest/globals";
+import {
+  extractRotatePropertiesFromTransform,
+  extractSkewPropertiesFromTransform,
+  extractTransformOriginValues,
+} from "./transform-extractors";
+import { parseCssValue } from "@webstudio-is/css-data";
+
+describe("extractRotatePropertiesFromTransform", () => {
+  test("parses transform and returns undefined if no rotate values exists", () => {
+    expect(
+      extractRotatePropertiesFromTransform(
+        parseCssValue("transform", "scale(1.5)")
+      )
+    ).toEqual({
+      rotateX: undefined,
+      rotateY: undefined,
+      rotateZ: undefined,
+    });
+  });
+
+  test("parses transform and returns rotate values", () => {
+    expect(
+      extractRotatePropertiesFromTransform(
+        parseCssValue("transform", "rotateX(0deg) rotateY(10deg) scale(1.5)")
+      )
+    ).toEqual({
+      rotateX: {
+        type: "function",
+        args: {
+          type: "layers",
+          value: [
+            {
+              type: "unit",
+              unit: "deg",
+              value: 0,
+            },
+          ],
+        },
+        name: "rotateX",
+      },
+      rotateY: {
+        type: "function",
+        args: {
+          type: "layers",
+          value: [
+            {
+              type: "unit",
+              unit: "deg",
+              value: 10,
+            },
+          ],
+        },
+        name: "rotateY",
+      },
+    });
+  });
+});
+
+describe("extractSkewPropertiesFromTransform", () => {
+  test("parses transform and returns undefined if no skew properties exists", () => {
+    expect(
+      extractSkewPropertiesFromTransform(
+        parseCssValue("transform", "rotateX(0deg) rotateY(0deg) scale(1.5)")
+      )
+    ).toEqual({ skewX: undefined, skewY: undefined });
+  });
+
+  test("parses transform and extracts valid skew properties", () => {
+    expect(
+      extractSkewPropertiesFromTransform(
+        parseCssValue(
+          "transform",
+          "skewX(10deg) skewY(20deg) rotate(30deg) scale(1.5)"
+        )
+      )
+    ).toEqual({
+      skewX: {
+        type: "function",
+        args: {
+          type: "layers",
+          value: [
+            {
+              type: "unit",
+              unit: "deg",
+              value: 10,
+            },
+          ],
+        },
+        name: "skewX",
+      },
+      skewY: {
+        type: "function",
+        args: {
+          type: "layers",
+          value: [
+            {
+              type: "unit",
+              unit: "deg",
+              value: 20,
+            },
+          ],
+        },
+        name: "skewY",
+      },
+    });
+  });
+});
+
+describe("extractTransformOriginValues", () => {
+  test("parses transform-origin and returns the individual properties from the value", () => {
+    expect(
+      extractTransformOriginValues(parseCssValue("transformOrigin", "center"))
+    ).toEqual({
+      x: { type: "keyword", value: "center" },
+      y: { type: "keyword", value: "center" },
+      z: { type: "unit", unit: "px", value: 0 },
+    });
+
+    expect(
+      extractTransformOriginValues(parseCssValue("transformOrigin", "top"))
+    ).toEqual({
+      x: { type: "keyword", value: "center" },
+      y: { type: "keyword", value: "top" },
+      z: { type: "unit", unit: "px", value: 0 },
+    });
+
+    expect(
+      extractTransformOriginValues(parseCssValue("transformOrigin", "right"))
+    ).toEqual({
+      x: { type: "keyword", value: "right" },
+      y: { type: "keyword", value: "center" },
+      z: { type: "unit", unit: "px", value: 0 },
+    });
+
+    expect(
+      extractTransformOriginValues(parseCssValue("transformOrigin", "45px"))
+    ).toEqual({
+      x: { type: "unit", unit: "px", value: 45 },
+      y: { type: "keyword", value: "center" },
+      z: { type: "unit", unit: "px", value: 0 },
+    });
+
+    expect(
+      extractTransformOriginValues(
+        parseCssValue("transformOrigin", "20px 40px")
+      )
+    ).toEqual({
+      x: { type: "unit", unit: "px", value: 20 },
+      y: { type: "unit", unit: "px", value: 40 },
+      z: { type: "unit", unit: "px", value: 0 },
+    });
+
+    expect(
+      extractTransformOriginValues(
+        parseCssValue("transformOrigin", "10px 20px 30px")
+      )
+    ).toEqual({
+      x: { type: "unit", unit: "px", value: 10 },
+      y: { type: "unit", unit: "px", value: 20 },
+      z: { type: "unit", unit: "px", value: 30 },
+    });
+
+    expect(
+      extractTransformOriginValues(
+        parseCssValue("transformOrigin", "left top 30px")
+      )
+    ).toEqual({
+      x: { type: "keyword", value: "left" },
+      y: { type: "keyword", value: "top" },
+      z: { type: "unit", unit: "px", value: 30 },
+    });
+  });
+});

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-extractors.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-extractors.ts
@@ -1,0 +1,112 @@
+import type {
+  FunctionValue,
+  KeywordValue,
+  StyleValue,
+  UnitValue,
+} from "@webstudio-is/css-engine";
+
+export const extractRotatePropertiesFromTransform = (transform: StyleValue) => {
+  let rotateX: FunctionValue | undefined;
+  let rotateY: FunctionValue | undefined;
+  let rotateZ: FunctionValue | undefined;
+
+  if (transform.type !== "tuple") {
+    return { rotateX, rotateY, rotateZ };
+  }
+
+  for (const item of transform.value) {
+    if (item.type === "function" && item.name === "rotateX") {
+      rotateX = item;
+    }
+
+    if (item.type === "function" && item.name === "rotateY") {
+      rotateY = item;
+    }
+
+    if (item.type === "function" && item.name === "rotateZ") {
+      rotateZ = item;
+    }
+  }
+
+  return { rotateX, rotateY, rotateZ };
+};
+
+export const extractSkewPropertiesFromTransform = (skew: StyleValue) => {
+  let skewX: FunctionValue | undefined = undefined;
+  let skewY: FunctionValue | undefined = undefined;
+
+  if (skew.type !== "tuple") {
+    return { skewX, skewY };
+  }
+
+  for (const item of skew.value) {
+    if (item.type === "function" && item.name === "skewX") {
+      skewX = item;
+    }
+
+    if (item.type === "function" && item.name === "skewY") {
+      skewY = item;
+    }
+  }
+
+  return { skewX, skewY };
+};
+
+const isValidTransformOriginValue = (
+  value: StyleValue
+): value is UnitValue | KeywordValue => {
+  return value.type === "unit" || value.type === "keyword";
+};
+
+export const extractTransformOriginValues = (value: StyleValue) => {
+  if (value.type !== "tuple") {
+    return;
+  }
+
+  let x: KeywordValue | UnitValue = { type: "keyword", value: "center" };
+  let y: KeywordValue | UnitValue = { type: "keyword", value: "center" };
+  let z: UnitValue = { type: "unit", unit: "px", value: 0 };
+
+  // https://www.w3.org/TR/css-transforms-1/#transform-origin-property
+  // https://github.com/mdn/content/issues/35411
+  // If only one value is specified, the second value is assumed to be center.
+  if (value.value.length === 1 && value.value[0].type === "unit") {
+    x = value.value[0];
+  }
+
+  if (value.value.length === 1 && value.value[0].type === "keyword") {
+    if (["top", "bottom"].includes(value.value[0].value)) {
+      y = value.value[0];
+    }
+
+    if (["left", "right"].includes(value.value[0].value)) {
+      x = value.value[0];
+    }
+  }
+
+  if (
+    value.value.length === 2 &&
+    isValidTransformOriginValue(value.value[0]) &&
+    isValidTransformOriginValue(value.value[1])
+  ) {
+    x = value.value[0];
+    y = value.value[1];
+  }
+
+  if (
+    value.value.length === 3 &&
+    isValidTransformOriginValue(value.value[0]) &&
+    isValidTransformOriginValue(value.value[1]) &&
+    value.value[2].type === "unit"
+  ) {
+    x = value.value[0];
+    y = value.value[1];
+    z = value.value[2];
+  }
+
+  return {
+    x,
+    y,
+    z,
+  };
+};

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-rotate.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-rotate.tsx
@@ -17,7 +17,7 @@ import {
 } from "@webstudio-is/css-engine";
 import type { StyleUpdateOptions } from "../../shared/use-style-data";
 import { parseCssValue } from "@webstudio-is/css-data";
-import { extractRotatePropertiesFromTransform } from "./transform-utils";
+import { extractRotatePropertiesFromTransform } from "./transform-extractors";
 
 export const RotatePanelContent = (props: TransformPanelProps) => {
   const { propertyValue, setProperty, currentStyle } = props;

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-skew.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-skew.tsx
@@ -1,9 +1,9 @@
 import { Flex, Label, Grid } from "@webstudio-is/design-system";
 import {
   updateRotateOrSkewPropertyValue,
-  extractSkewPropertiesFromTransform,
   type TransformPanelProps,
 } from "./transform-utils";
+import { extractSkewPropertiesFromTransform } from "./transform-extractors";
 import { XAxisIcon, YAxisIcon } from "@webstudio-is/icons";
 import { CssValueInputContainer } from "../../shared/css-value-input";
 import type { StyleUpdateOptions } from "../../shared/use-style-data";

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-utils.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-utils.test.ts
@@ -6,9 +6,8 @@ import {
   isTransformPanelPropertyUsed,
   updateRotateOrSkewPropertyValue,
   updateTransformTuplePropertyValue,
-  extractRotatePropertiesFromTransform,
-  extractSkewPropertiesFromTransform,
 } from "./transform-utils";
+import { extractRotatePropertiesFromTransform } from "./transform-extractors";
 import type { StyleInfo } from "../../shared/style-info";
 import {
   FunctionValue,
@@ -262,106 +261,5 @@ describe("Transform utils CRUD operations", () => {
     expect(toValue(newValue)).toBe(
       "rotateX(10deg) rotateY(50deg) rotateZ(10deg) skewX(10deg) skewY(10deg)"
     );
-  });
-});
-
-describe("extractRotatePropertiesFromTransform", () => {
-  test("parses transform and returns undefined if no rotate values exists", () => {
-    expect(
-      extractRotatePropertiesFromTransform(
-        parseCssValue("transform", "scale(1.5)")
-      )
-    ).toEqual({
-      rotateX: undefined,
-      rotateY: undefined,
-      rotateZ: undefined,
-    });
-  });
-
-  test("parses transform and returns rotate values", () => {
-    expect(
-      extractRotatePropertiesFromTransform(
-        parseCssValue("transform", "rotateX(0deg) rotateY(10deg) scale(1.5)")
-      )
-    ).toEqual({
-      rotateX: {
-        type: "function",
-        args: {
-          type: "layers",
-          value: [
-            {
-              type: "unit",
-              unit: "deg",
-              value: 0,
-            },
-          ],
-        },
-        name: "rotateX",
-      },
-      rotateY: {
-        type: "function",
-        args: {
-          type: "layers",
-          value: [
-            {
-              type: "unit",
-              unit: "deg",
-              value: 10,
-            },
-          ],
-        },
-        name: "rotateY",
-      },
-    });
-  });
-});
-
-describe("extractSkewPropertiesFromTransform", () => {
-  test("parses transform and returns undefined if no skew properties exists", () => {
-    expect(
-      extractSkewPropertiesFromTransform(
-        parseCssValue("transform", "rotateX(0deg) rotateY(0deg) scale(1.5)")
-      )
-    ).toEqual({ skewX: undefined, skewY: undefined });
-  });
-
-  test("parses transform and extracts valid skew properties", () => {
-    expect(
-      extractSkewPropertiesFromTransform(
-        parseCssValue(
-          "transform",
-          "skewX(10deg) skewY(20deg) rotate(30deg) scale(1.5)"
-        )
-      )
-    ).toEqual({
-      skewX: {
-        type: "function",
-        args: {
-          type: "layers",
-          value: [
-            {
-              type: "unit",
-              unit: "deg",
-              value: 10,
-            },
-          ],
-        },
-        name: "skewX",
-      },
-      skewY: {
-        type: "function",
-        args: {
-          type: "layers",
-          value: [
-            {
-              type: "unit",
-              unit: "deg",
-              value: 20,
-            },
-          ],
-        },
-        name: "skewY",
-      },
-    });
   });
 });

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-utils.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-utils.ts
@@ -1,7 +1,6 @@
 import { parseCssValue } from "@webstudio-is/css-data";
 import {
   FunctionValue,
-  StyleValue,
   toValue,
   type TupleValue,
   type TupleValueItem,
@@ -9,6 +8,10 @@ import {
 import type { DeleteProperty, SetProperty } from "../../shared/use-style-data";
 import type { StyleInfo } from "../../shared/style-info";
 import type { TransformPanel, transformPanelDropdown } from "./transforms";
+import {
+  extractRotatePropertiesFromTransform,
+  extractSkewPropertiesFromTransform,
+} from "./transform-extractors";
 
 export type TransformPanelProps = {
   currentStyle: StyleInfo;
@@ -357,51 +360,4 @@ export const updateRotateOrSkewPropertyValue = (props: {
   }
 
   return newPropertyValue;
-};
-
-export const extractRotatePropertiesFromTransform = (transform: StyleValue) => {
-  let rotateX: FunctionValue | undefined;
-  let rotateY: FunctionValue | undefined;
-  let rotateZ: FunctionValue | undefined;
-
-  if (transform.type !== "tuple") {
-    return { rotateX, rotateY, rotateZ };
-  }
-
-  for (const item of transform.value) {
-    if (item.type === "function" && item.name === "rotateX") {
-      rotateX = item;
-    }
-
-    if (item.type === "function" && item.name === "rotateY") {
-      rotateY = item;
-    }
-
-    if (item.type === "function" && item.name === "rotateZ") {
-      rotateZ = item;
-    }
-  }
-
-  return { rotateX, rotateY, rotateZ };
-};
-
-export const extractSkewPropertiesFromTransform = (skew: StyleValue) => {
-  let skewX: FunctionValue | undefined = undefined;
-  let skewY: FunctionValue | undefined = undefined;
-
-  if (skew.type !== "tuple") {
-    return { skewX, skewY };
-  }
-
-  for (const item of skew.value) {
-    if (item.type === "function" && item.name === "skewX") {
-      skewX = item;
-    }
-
-    if (item.type === "function" && item.name === "skewY") {
-      skewY = item;
-    }
-  }
-
-  return { skewX, skewY };
 };


### PR DESCRIPTION
## Description

This PR adds an extractor for `transform-origin` property which helps in handling individual values of the property. Moved all the extractors to an individual file keeping them aside of utils is making the file too big

## Steps for reproduction
- Extract  any `transform-origin` properties using the extractor.

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [x] added tests