### PR TITLE
fix: Incorrect style calculations

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "@jest/globals";
+import { test, expect, describe, jest } from "@jest/globals";
 import { act, renderHook } from "@testing-library/react-hooks";
 import * as defaultMetas from "@webstudio-is/sdk-components-react/metas";
 import {
@@ -15,7 +15,6 @@ import {
   $breakpoints,
   $instances,
   $registeredComponentMetas,
-  $selectedInstanceIntanceToTag,
   $selectedInstanceSelector,
   $selectedStyleSources,
   $styleSourceSelections,
@@ -34,7 +33,16 @@ import {
   useStyleInfo,
 } from "./style-info";
 
-const { getPriorityStyleSource } = __testing__;
+jest.unstable_mockModule("~/shared/canvas-api", () => ({
+  isInitialized: () => {
+    throw new Error("Not implemented");
+  },
+  getElementAndAncestorInstanceTags: () => {
+    throw new Error("Not implemented");
+  },
+}));
+
+const { getPriorityStyleSource, setInstanceToTag } = __testing__;
 
 const toMap = <T extends { id: string }>(list: T[]) =>
   new Map(list.map((item) => [item.id, item]));
@@ -405,7 +413,7 @@ const resetStores = () => {
   $styleSourceSelections.set(new Map());
   $breakpoints.set(new Map());
   $selectedInstanceSelector.set(undefined);
-  $selectedInstanceIntanceToTag.set(new Map());
+  setInstanceToTag(new Map());
   $selectedStyleSources.set(new Map());
   $selectedInstanceStates.set(new Set());
 };
@@ -935,12 +943,14 @@ describe("active states", () => {
         ],
       ])
     );
+
     $selectedInstanceSelector.set(["box"]);
     $selectedInstanceStates.set(new Set([":hover"]));
     $selectedStyleSources.set(new Map([["box", "box.local"]]));
-    $selectedInstanceIntanceToTag.set(new Map([["box", "div"]]));
+    setInstanceToTag(new Map([["box", "div"]]));
 
     const { result } = renderHook(() => useStyleInfo());
+
     expect(getStyleSource(result.current.color)).toEqual("preset");
     expect(result.current.color?.value).toEqual({
       type: "keyword",

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -496,6 +496,10 @@ export const getNextSourceInfo = (
 const $instanceToTag = computed(
   [$selectedInstanceSelector, $loadingState],
   (instanceSelector, loadingState) => {
+    if (__testing__.instanceToTag !== undefined) {
+      return __testing__.instanceToTag;
+    }
+
     if (instanceSelector === undefined) {
       return;
     }
@@ -940,4 +944,15 @@ export const hasInstanceValue = (
 
 export const __testing__ = {
   getPriorityStyleSource,
+  instanceToTag: undefined as Map<Instance["id"], HtmlTags> | undefined,
+  setInstanceToTag: (instanceToTag: Map<Instance["id"], HtmlTags>) => {
+    __testing__.instanceToTag = instanceToTag;
+
+    const selector = $selectedInstanceSelector.get();
+    if (selector === undefined) {
+      return;
+    }
+    // enforce recompute
+    $selectedInstanceSelector.set([...selector]);
+  },
 };

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -21,7 +21,6 @@ import {
   type StyleSourceSelector,
   $instances,
   $selectedInstanceSelector,
-  $selectedInstanceIntanceToTag,
   $stylesIndex,
   $selectedOrLastStyleSourceSelector,
   $breakpoints,
@@ -32,6 +31,9 @@ import {
 import { $selectedBreakpoint } from "~/shared/nano-states";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import type { WsComponentMeta } from "@webstudio-is/react-sdk";
+import { canvasApi } from "~/shared/canvas-api";
+import { computed } from "nanostores";
+import { $loadingState } from "~/builder/shared/nano-states";
 
 type CascadedValueInfo = {
   breakpointId: string;
@@ -334,6 +336,7 @@ export const getInheritedInfo = (
     ];
 
     const tagName = selectedInstanceIntanceToTag.get(instanceId);
+
     const component = getInstanceComponent(instances, instanceId);
     const presetStyle =
       tagName !== undefined && component !== undefined
@@ -490,6 +493,24 @@ export const getNextSourceInfo = (
   return nextSourceStyle;
 };
 
+const $instanceToTag = computed(
+  [$selectedInstanceSelector, $loadingState],
+  (instanceSelector, loadingState) => {
+    if (instanceSelector === undefined) {
+      return;
+    }
+
+    if (loadingState.state !== "ready") {
+      return;
+    }
+
+    const result =
+      canvasApi.getElementAndAncestorInstanceTags(instanceSelector);
+
+    return result;
+  }
+);
+
 /**
  * combine all local, cascaded, inherited and browser styles
  */
@@ -500,16 +521,12 @@ const useStyleInfoByInstanceAndStyleSource = (
   const breakpoints = useStore($breakpoints);
   const selectedBreakpoint = useStore($selectedBreakpoint);
   const selectedBreakpointId = selectedBreakpoint?.id;
-
-  // We do not move $selectedInstanceIntanceToTag out of here as it contains ascendants of selected element
-  // And we do not gonna iterate over children
-  const instanceToTag = useStore($selectedInstanceIntanceToTag);
-
   const instances = useStore($instances);
   const metas = useStore($registeredComponentMetas);
   const { stylesByInstanceId, stylesByStyleSourceId } = useStore($stylesIndex);
   const styleSourceSelections = useStore($styleSourceSelections);
   const selectedInstanceStates = useStore($selectedInstanceStates);
+  const instanceToTag = useStore($instanceToTag);
   const activeStates = useMemo(() => {
     const activeStates = new Set(selectedInstanceStates);
     if (styleSourceSelector?.state !== undefined) {

--- a/apps/builder/app/canvas/collaborative-instance.ts
+++ b/apps/builder/app/canvas/collaborative-instance.ts
@@ -1,6 +1,6 @@
 import {
   getAllElementsBoundingBox,
-  getElementsByInstanceSelector,
+  getVisibleElementsByInstanceSelector,
 } from "~/shared/dom-utils";
 import {
   $collaborativeInstanceSelector,
@@ -35,7 +35,7 @@ export const updateCollaborativeInstanceRect = () => {
       return;
     }
 
-    elements = getElementsByInstanceSelector(selector);
+    elements = getVisibleElementsByInstanceSelector(selector);
 
     if (elements.length > 0) {
       cancelAnimationFrame(frameHandler);

--- a/apps/builder/app/canvas/instance-hovering.ts
+++ b/apps/builder/app/canvas/instance-hovering.ts
@@ -3,7 +3,7 @@ import { $hoveredInstanceSelector, $instances } from "~/shared/nano-states";
 import { $hoveredInstanceOutline } from "~/shared/nano-states";
 import {
   getAllElementsBoundingBox,
-  getElementsByInstanceSelector,
+  getVisibleElementsByInstanceSelector,
   getInstanceSelectorFromElement,
 } from "~/shared/dom-utils";
 import { subscribeScrollState } from "./shared/scroll-state";
@@ -106,7 +106,7 @@ export const subscribeInstanceHovering = () => {
   const unsubscribeHoveredInstanceId = $hoveredInstanceSelector.subscribe(
     (instanceSelector) => {
       if (instanceSelector) {
-        const elements = getElementsByInstanceSelector(instanceSelector);
+        const elements = getVisibleElementsByInstanceSelector(instanceSelector);
         updateHoveredRect(elements, instanceSelector);
       } else {
         $hoveredInstanceOutline.set(undefined);

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -18,7 +18,8 @@ import {
 import htmlTags, { type htmlTags as HtmlTags } from "html-tags";
 import {
   getAllElementsBoundingBox,
-  getElementsByInstanceSelector,
+  getVisibleElementsByInstanceSelector,
+  getAllElementsByInstanceSelector,
 } from "~/shared/dom-utils";
 import { subscribeScrollState } from "~/canvas/shared/scroll-state";
 import { $selectedInstanceOutline } from "~/shared/nano-states";
@@ -78,7 +79,7 @@ const calculateUnitSizes = (element: HTMLElement): UnitSizes => {
 export const getElementAndAncestorInstanceTags = (
   instanceSelector: Readonly<InstanceSelector>
 ) => {
-  const elements = getElementsByInstanceSelector(instanceSelector);
+  const elements = getAllElementsByInstanceSelector(instanceSelector);
 
   if (elements.length === 0) {
     return;
@@ -112,25 +113,28 @@ const subscribeSelectedInstance = (
   }
 
   const instanceId = selectedInstanceSelector[0];
-  // setDataCollapsed
 
-  let elements = getElementsByInstanceSelector(selectedInstanceSelector);
+  let visibleElements = getVisibleElementsByInstanceSelector(
+    selectedInstanceSelector
+  );
 
-  elements[0]?.scrollIntoView({
+  visibleElements[0]?.scrollIntoView({
     behavior: "smooth",
     block: "nearest",
   });
 
   const updateElements = () => {
-    elements = getElementsByInstanceSelector(selectedInstanceSelector);
+    visibleElements = getVisibleElementsByInstanceSelector(
+      selectedInstanceSelector
+    );
   };
 
   const updateDataCollapsed = () => {
-    if (elements.length === 0) {
+    if (visibleElements.length === 0) {
       return;
     }
 
-    for (const element of elements) {
+    for (const element of visibleElements) {
       const selectorId = element.getAttribute(selectorIdAttribute);
       if (selectorId === null) {
         continue;
@@ -155,13 +159,15 @@ const subscribeSelectedInstance = (
     if ($isResizingCanvas.get()) {
       return;
     }
-    setOutline(instanceId, elements);
+    setOutline(instanceId, visibleElements);
   };
   // effect close to rendered element also catches dnd remounts
   // so actual state is always provided here
   showOutline();
 
   const updateStores = () => {
+    const elements = getAllElementsByInstanceSelector(selectedInstanceSelector);
+
     if (elements.length === 0) {
       return;
     }
@@ -242,7 +248,7 @@ const subscribeSelectedInstance = (
   const mutationObserver = new MutationObserver(update);
 
   const updateObservers = () => {
-    for (const element of elements) {
+    for (const element of visibleElements) {
       resizeObserver.observe(element);
 
       const parent = element?.parentElement;

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -75,6 +75,34 @@ const calculateUnitSizes = (element: HTMLElement): UnitSizes => {
   };
 };
 
+export const getElementAndAncestorInstanceTags = (
+  instanceSelector: Readonly<InstanceSelector>
+) => {
+  const elements = getElementsByInstanceSelector(instanceSelector);
+
+  if (elements.length === 0) {
+    return;
+  }
+
+  const [element] = elements;
+
+  const instanceToTag = new Map<Instance["id"], HtmlTags>();
+  for (
+    let ancestorOrSelf: HTMLElement | null = element;
+    ancestorOrSelf !== null;
+    ancestorOrSelf = ancestorOrSelf.parentElement
+  ) {
+    const tagName = ancestorOrSelf.tagName.toLowerCase();
+    const instanceId = ancestorOrSelf.getAttribute(idAttribute);
+
+    if (isHtmlTag(tagName) && instanceId !== null) {
+      instanceToTag.set(instanceId, tagName);
+    }
+  }
+
+  return instanceToTag;
+};
+
 const subscribeSelectedInstance = (
   selectedInstanceSelector: Readonly<InstanceSelector>,
   debounceEffect: (callback: () => void) => void
@@ -143,19 +171,9 @@ const subscribeSelectedInstance = (
     $selectedInstanceBrowserStyle.set(getBrowserStyle(element));
 
     // Map self and ancestor instance ids to tag names
-    const instanceToTag = new Map<Instance["id"], HtmlTags>();
-    for (
-      let ancestorOrSelf: HTMLElement | null = element;
-      ancestorOrSelf !== null;
-      ancestorOrSelf = ancestorOrSelf.parentElement
-    ) {
-      const tagName = ancestorOrSelf.tagName.toLowerCase();
-      const instanceId = ancestorOrSelf.getAttribute(idAttribute);
-
-      if (isHtmlTag(tagName) && instanceId !== null) {
-        instanceToTag.set(instanceId, tagName);
-      }
-    }
+    const instanceToTag = getElementAndAncestorInstanceTags(
+      selectedInstanceSelector
+    );
 
     $selectedInstanceIntanceToTag.set(instanceToTag);
 

--- a/apps/builder/app/shared/canvas-api.ts
+++ b/apps/builder/app/shared/canvas-api.ts
@@ -4,6 +4,7 @@ import { monitorForExternal } from "@atlaskit/pragmatic-drag-and-drop/external/a
 import { createRecursiveProxy } from "@trpc/server/shared";
 import invariant from "tiny-invariant";
 import { $canvasIframeState } from "./nano-states";
+import { getElementAndAncestorInstanceTags } from "~/canvas/instance-selected";
 
 const apiWindowNamespace = "__webstudio__$__canvasApi";
 
@@ -13,6 +14,7 @@ const _canvasApi = {
   resetInert,
   preventUnhandled,
   monitorForExternal,
+  getElementAndAncestorInstanceTags,
 };
 
 declare global {

--- a/apps/builder/app/shared/dom-utils.test.ts
+++ b/apps/builder/app/shared/dom-utils.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { test, expect, beforeEach } from "@jest/globals";
+import {
+  getAllElementsByInstanceSelector,
+  getVisibleElementsByInstanceSelector,
+} from "./dom-utils";
+
+beforeEach(() => {
+  document.body.innerHTML = `
+  <div data-ws-selector="box,body">
+    <select data-ws-selector="select,box,body">
+      <option data-ws-selector="option,select,box,body">test</option>
+    </select>
+    <div style="display:fixed;" data-ws-selector="box-fixed,body"></div>
+    <div style="display:none;" data-ws-selector="box-none,body"></div>
+  </div>`;
+
+  document.body.setAttribute("data-ws-selector", "body");
+});
+
+test("Select body element", () => {
+  expect(getVisibleElementsByInstanceSelector(["body"])).toEqual([
+    document.body,
+  ]);
+});
+
+test("getVisibleElementsByInstanceSelector selects select element", () => {
+  expect(
+    getVisibleElementsByInstanceSelector(["option", "select", "box", "body"])
+  ).toEqual([document.querySelector("select")]);
+});
+
+test("getAllElementsByInstanceSelector selects option element", () => {
+  expect(
+    getAllElementsByInstanceSelector(["option", "select", "box", "body"])
+  ).toEqual([document.querySelector("option")]);
+});
+
+test("getVisibleElementsByInstanceSelector selects parent of box-none element", () => {
+  expect(getVisibleElementsByInstanceSelector(["box-none", "body"])).toEqual([
+    document.querySelector("[data-ws-selector='box,body']"),
+  ]);
+});
+
+test("getAllElementsByInstanceSelector selects box-none element", () => {
+  expect(getAllElementsByInstanceSelector(["box-none", "body"])).toEqual([
+    document.querySelector("[data-ws-selector='box-none,body']"),
+  ]);
+});

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -34,6 +34,26 @@ export const getElementByInstanceSelector = (
   );
 };
 
+// Determine if the element is detached, or lacks visual layout.
+// We want to exclude elements that are display: none, option tags, or are not in the DOM
+const hasLayout = (element: HTMLElement) => {
+  // Detached element
+  if (false === document.documentElement.contains(element)) {
+    return false;
+  }
+
+  if (element.tagName.toLowerCase() === "option") {
+    return false;
+  }
+
+  // Display none
+  if (getComputedStyle(element)?.display?.toLowerCase() === "none") {
+    return false;
+  }
+
+  return true;
+};
+
 /**
  * Get root visible elements, even if instance
  **/
@@ -68,17 +88,12 @@ export const getElementsByInstanceSelector = (
   );
 
   return rootElements.map((element) => {
-    // We are not interested in display:none or option elements (they have offsetParent === null)
     let elementResult: HTMLElement = element;
 
     while (
-      elementResult.offsetParent === null &&
+      false === hasLayout(elementResult) &&
       elementResult.parentElement !== null
     ) {
-      if (getComputedStyle(element).position === "fixed") {
-        return element;
-      }
-
       elementResult = elementResult.parentElement;
     }
 
@@ -119,6 +134,24 @@ export const getAllElementsBoundingBox = (elements: Element[]): DOMRect => {
     }
 
     if (element.children.length === 0) {
+      const textNode = element.firstChild;
+      if (textNode?.nodeType !== Node.TEXT_NODE) {
+        continue;
+      }
+
+      // Create a range object
+      const range = document.createRange();
+      // Set the range to encompass the text node
+      range.selectNodeContents(textNode);
+      // Get the bounding rectangle
+      const rect = range.getBoundingClientRect();
+
+      if (rect.width !== 0 || rect.height !== 0) {
+        rects.push(rect);
+      }
+
+      range.detach();
+
       continue;
     }
 

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -54,17 +54,32 @@ const hasLayout = (element: HTMLElement) => {
   return true;
 };
 
+export const getVisibleElementsByInstanceSelector = (
+  instanceSelector: InstanceSelector | Readonly<InstanceSelector>
+) => {
+  return getElementsByInstanceSelector(instanceSelector, true);
+};
+
+export const getAllElementsByInstanceSelector = (
+  instanceSelector: InstanceSelector | Readonly<InstanceSelector>
+) => {
+  return getElementsByInstanceSelector(instanceSelector, false);
+};
+
 /**
  * Get root visible elements, even if instance
  **/
-export const getElementsByInstanceSelector = (
-  instanceSelector: InstanceSelector | Readonly<InstanceSelector>
+const getElementsByInstanceSelector = (
+  instanceSelector: InstanceSelector | Readonly<InstanceSelector>,
+  skipHidden: boolean
 ) => {
   const descendantsOrSelf = [
     ...document.querySelectorAll<HTMLElement>(
       `[${selectorIdAttribute}$="${instanceSelector.join(",")}"]`
     ),
-  ].filter((element) => getIsVisuallyHidden(element) === false);
+  ].filter((element) =>
+    skipHidden ? getIsVisuallyHidden(element) === false : true
+  );
 
   const visibleIdSelectors = descendantsOrSelf.map(
     (element) => element.getAttribute(selectorIdAttribute) ?? ""
@@ -91,6 +106,7 @@ export const getElementsByInstanceSelector = (
     let elementResult: HTMLElement = element;
 
     while (
+      skipHidden &&
       false === hasLayout(elementResult) &&
       elementResult.parentElement !== null
     ) {


### PR DESCRIPTION
## Description

Closes #3807

Test cases are here 
 - [Failing](https://main.development.webstudio.is/builder/5aecde38-362a-4315-8fd6-df7b94a1baad)
 - [Fixed](https://fix-styles.development.webstudio.is/builder/5aecde38-362a-4315-8fd6-df7b94a1baad)

They are fail on main and works in current PR

### Fixed

- [x] - Body display inline
- [x]  - Switching between elements rendered styles for some period incorrect
- [x] - Selecting display none in menu didn't work
- [x] - Html/Browser styles of invisible elements i.e. `display: none` wasn't picked
- [x] - Unit sizes of invisible elements  wasn't picked

### New

Components with `display: contents` and only text nodes inside now have outline (using range to get rect)
<img width="643" alt="image" src="https://github.com/user-attachments/assets/4ee0eff2-66b5-405a-a88a-41191878bbbb">


## Steps for reproduction

- [Failing](https://main.development.webstudio.is/builder/5aecde38-362a-4315-8fd6-df7b94a1baad)
- [Fixed](https://fix-styles.development.webstudio.is/builder/5aecde38-362a-4315-8fd6-df7b94a1baad)

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
