### PR TITLE
fix: navigator scrolling starts too early

### DIFF
--- a/packages/design-system/src/components/primitives/dnd/use-auto-scroll.ts
+++ b/packages/design-system/src/components/primitives/dnd/use-auto-scroll.ts
@@ -148,7 +148,7 @@ export const useAutoScroll = (
     };
 
     const {
-      edgeDistanceThreshold = 100,
+      edgeDistanceThreshold = 20,
       minSpeed = 1,
       maxSpeed = 500,
     } = latestProps.current;


### PR DESCRIPTION
## Description

When dragging, scrolling starts to early an becomes annoying

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
