### PR TITLE
refactor: upgrade html-tags

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useStore } from "@nanostores/react";
-import type { htmlTags as HtmlTags } from "html-tags";
+import type { HtmlTags } from "html-tags";
 import type {
   Style,
   StyleProperty,

--- a/apps/builder/app/builder/features/style-panel/style-panel.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-panel.tsx
@@ -9,7 +9,7 @@ import {
 import type { Instance } from "@webstudio-is/sdk";
 import { useStore } from "@nanostores/react";
 import { computed } from "nanostores";
-import type { htmlTags as HtmlTag } from "html-tags";
+import type { HtmlTags } from "html-tags";
 
 import { useStyleData } from "./shared/use-style-data";
 
@@ -37,7 +37,7 @@ const $selectedInstanceTag = computed(
 const shouldRenderCategory = (
   category: string,
   parentStyle: StyleInfo,
-  tag: undefined | HtmlTag
+  tag: undefined | HtmlTags
 ) => {
   switch (category) {
     case "flexChild":

--- a/apps/builder/app/canvas/collapsed.ts
+++ b/apps/builder/app/canvas/collapsed.ts
@@ -14,7 +14,7 @@ import {
 } from "~/shared/nano-states";
 import { $selectedBreakpoint } from "~/shared/nano-states";
 import { subscribe } from "~/shared/pubsub";
-import htmlTags, { type htmlTags as HtmlTags } from "html-tags";
+import htmlTags, { voidHtmlTags, type HtmlTags } from "html-tags";
 
 const isHtmlTag = (tag: string): tag is HtmlTags =>
   htmlTags.includes(tag as HtmlTags);
@@ -23,29 +23,13 @@ const instanceIdSet = new Set<string>();
 
 let rafHandle: number;
 
-// Do not add collapsed paddings for void elements
-// https://developer.mozilla.org/en-US/docs/Glossary/Void_element
-const voidHtmlElements = [
-  "AREA",
-  "BASE",
-  "BR",
-  "COL",
-  "EMBED",
-  "HR",
-  "IMG",
-  "INPUT",
-  "LINK",
-  "META",
-  "SOURCE",
-  "TRACK",
-  "WBR",
-];
-
 // Do not add collapsed paddings for replaced elements as at the moment we add them they don't have real size
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Replaced_element
-const replacedHtmlElements = ["IFRAME", "VIDEO", "EMBED", "IMG"];
+const replacedHtmlElements = ["iframe", "video", "embed", "img"];
 
-const skipElementsSet = new Set([...voidHtmlElements, ...replacedHtmlElements]);
+// Do not add collapsed paddings for void elements
+// https://developer.mozilla.org/en-US/docs/Glossary/Void_element
+const skipElementsSet = new Set([...voidHtmlTags, ...replacedHtmlElements]);
 
 const isSelectorSupported = (selector: string) => {
   try {
@@ -151,7 +135,7 @@ const recalculate = () => {
       continue;
     }
 
-    if (skipElementsSet.has(element.tagName)) {
+    if (skipElementsSet.has(element.tagName.toLowerCase())) {
       // Images should not collapse, and have a fallback.
       // The issue that unloaded image has 0 width and height until explicitly set,
       // so at the moment new Image added we detect it as collapsed.

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -15,7 +15,7 @@ import {
   $selectedInstanceStates,
   $styleSourceSelections,
 } from "~/shared/nano-states";
-import htmlTags, { type htmlTags as HtmlTags } from "html-tags";
+import htmlTags, { type HtmlTags } from "html-tags";
 import {
   getAllElementsBoundingBox,
   getVisibleElementsByInstanceSelector,

--- a/apps/builder/app/shared/nano-states/misc.ts
+++ b/apps/builder/app/shared/nano-states/misc.ts
@@ -25,7 +25,7 @@ import { createImageLoader, type ImageLoader } from "@webstudio-is/image";
 import type { DragStartPayload } from "~/canvas/shared/use-drag-drop";
 import { shallowComputed } from "../store-utils";
 import { type InstanceSelector } from "../tree-utils";
-import type { htmlTags as HtmlTags } from "html-tags";
+import type { HtmlTags } from "html-tags";
 import { $instances, $selectedInstanceSelector } from "./instances";
 import { $selectedPage } from "./pages";
 import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";

--- a/apps/builder/app/shared/style-object-model.test.tsx
+++ b/apps/builder/app/shared/style-object-model.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from "@jest/globals";
-import type { htmlTags as HtmlTags } from "html-tags";
+import type { HtmlTags } from "html-tags";
 import {
   getStyleDeclKey,
   Styles,

--- a/apps/builder/app/shared/style-object-model.ts
+++ b/apps/builder/app/shared/style-object-model.ts
@@ -1,4 +1,4 @@
-import type { htmlTags as HtmlTags } from "html-tags";
+import type { HtmlTags } from "html-tags";
 import { html, properties } from "@webstudio-is/css-data";
 import type { StyleValue, StyleProperty } from "@webstudio-is/css-engine";
 import {

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -129,7 +129,7 @@
     "@types/react-dom": "^18.2.25",
     "@webstudio-is/jest-config": "workspace:*",
     "@webstudio-is/tsconfig": "workspace:*",
-    "html-tags": "^3.3.1",
+    "html-tags": "^4.0.0",
     "react-router-dom": "^6.26.0",
     "react-test-renderer": "18.3.0-canary-14898b6a9-20240318",
     "type-fest": "^4.24.0",

--- a/packages/css-data/bin/html.css.ts
+++ b/packages/css-data/bin/html.css.ts
@@ -9,7 +9,7 @@ for (const styleDecl of parsed) {
   result.push([`${styleDecl.selector}:${styleDecl.property}`, styleDecl.value]);
 }
 let code = "";
-code += `import type { htmlTags as HtmlTags } from "html-tags";\n`;
+code += `import type { HtmlTags } from "html-tags";\n`;
 code += `import type { StyleValue } from "@webstudio-is/css-engine";\n\n`;
 const map = "new Map<`${HtmlTags}:${string}`, StyleValue>";
 code += `export const html = ${map}(${JSON.stringify(result)})`;

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -22,7 +22,7 @@
     "@webstudio-is/jest-config": "workspace:*",
     "@webstudio-is/react-sdk": "workspace:*",
     "@webstudio-is/tsconfig": "workspace:*",
-    "html-tags": "^3.3.1",
+    "html-tags": "^4.0.0",
     "mdn-data": "2.8.0",
     "type-fest": "^4.24.0",
     "typescript": "5.5.2",

--- a/packages/css-data/src/__generated__/html.ts
+++ b/packages/css-data/src/__generated__/html.ts
@@ -1,4 +1,4 @@
-import type { htmlTags as HtmlTags } from "html-tags";
+import type { HtmlTags } from "html-tags";
 import type { StyleValue } from "@webstudio-is/css-engine";
 
 export const html = new Map<`${HtmlTags}:${string}`, StyleValue>([

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -36,7 +36,7 @@
     "@webstudio-is/image": "workspace:*",
     "@webstudio-is/sdk": "workspace:*",
     "change-case": "^5.4.4",
-    "html-tags": "^3.3.1",
+    "html-tags": "^4.0.0",
     "nanoid": "^5.0.1",
     "title-case": "^4.1.0"
   },

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { PropMeta } from "../prop-meta";
-import type { htmlTags as HtmlTags } from "html-tags";
+import type { HtmlTags } from "html-tags";
 import { EmbedTemplateStyleDecl, WsEmbedTemplate } from "../embed-template";
 
 export type PresetStyle<Tag extends HtmlTags = HtmlTags> = Partial<

--- a/packages/react-sdk/src/css/normalize-type-check.ts
+++ b/packages/react-sdk/src/css/normalize-type-check.ts
@@ -1,5 +1,5 @@
 import * as normalize from "./normalize";
-import type { htmlTags as HtmlTags } from "html-tags";
+import type { HtmlTags } from "html-tags";
 import type { Style } from "@webstudio-is/css-engine";
 
 // no way I found to check exports https://github.com/microsoft/TypeScript/issues/38511

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,8 +456,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/tsconfig
       html-tags:
-        specifier: ^3.3.1
-        version: 3.3.1
+        specifier: ^4.0.0
+        version: 4.0.0
       react-router-dom:
         specifier: ^6.26.0
         version: 6.26.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
@@ -1148,8 +1148,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       html-tags:
-        specifier: ^3.3.1
-        version: 3.3.1
+        specifier: ^4.0.0
+        version: 4.0.0
       mdn-data:
         specifier: 2.8.0
         version: 2.8.0
@@ -1745,8 +1745,8 @@ importers:
         specifier: ^5.4.4
         version: 5.4.4
       html-tags:
-        specifier: ^3.3.1
-        version: 3.3.1
+        specifier: ^4.0.0
+        version: 4.0.0
       nanoid:
         specifier: ^5.0.1
         version: 5.0.1
@@ -6872,6 +6872,10 @@ packages:
   html-tags@3.3.1:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
+
+  html-tags@4.0.0:
+    resolution: {integrity: sha512-KM1SNmemQtsD+OTInZTYKZNbyPzzVrjMR2Iz1Np+Y+bcxUh0dgKF4NtylJVkGZRLe3NklHizJ5k1Vd3ug1uTPA==}
+    engines: {node: '>=18.20'}
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
@@ -15358,6 +15362,8 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-tags@3.3.1: {}
+
+  html-tags@4.0.0: {}
 
   http-errors@2.0.0:
     dependencies:


### PR DESCRIPTION
The new version exports types with normal casing,
the package is completely esm and reexports json with new syntax.

https://github.com/sindresorhus/html-tags/blob/main/index.js#L1

Also reused voidHtmlTags in collapsed instance logic.