### PR TITLE
fix: Add hflex/vflex styles

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -672,7 +672,15 @@ test("V Flex", async () => {
     },
   });
   equalFragment(fragment, <$.Box />);
-  expect(toCss(fragment)).toMatchInlineSnapshot(`""`);
+  expect(toCss(fragment)).toMatchInlineSnapshot(`
+    "@media all {
+      w-layout-vflex {
+        flex-direction: column;
+        align-items: flex-start;
+        display: flex
+      }
+    }"
+  `);
 });
 
 test("H Flex", async () => {
@@ -693,7 +701,15 @@ test("H Flex", async () => {
     },
   });
   equalFragment(fragment, <$.Box />);
-  expect(toCss(fragment)).toMatchInlineSnapshot(`""`);
+  expect(toCss(fragment)).toMatchInlineSnapshot(`
+    "@media all {
+      w-layout-hflex {
+        flex-direction: row;
+        align-items: flex-start;
+        display: flex
+      }
+    }"
+  `);
 });
 
 test("QuickStack with instance styles", async () => {

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/styles.ts
@@ -366,6 +366,14 @@ const mapComponentAndPresetStyles = (
       presetStyles.push("wf-layout-layout");
       return presetStyles;
     }
+    case "HFlex": {
+      presetStyles.push("w-layout-hflex");
+      return presetStyles;
+    }
+    case "VFlex": {
+      presetStyles.push("w-layout-vflex");
+      return presetStyles;
+    }
     case "FormWrapper": {
       presetStyles.push("w-form");
       return presetStyles;


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3953

## Description

We forgot to use hflex/vflex style presets when copying from webflow.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
