### PR TITLE
refactor: switch to compact build data for marketplace

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/marketplace/marketplace.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/marketplace/marketplace.tsx
@@ -32,8 +32,7 @@ export const TabContent = ({ onSetActiveTab }: TabContentProps) => {
 
   const openAboutItem = items?.find((item) => item.projectId === openAbout);
   const showTemplates =
-    activeOverviewItem &&
-    buildData?.build.projectId === activeOverviewItem.projectId;
+    activeOverviewItem && buildData?.projectId === activeOverviewItem.projectId;
 
   return (
     <>

--- a/apps/builder/app/builder/features/sidebar-left/panels/marketplace/utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/marketplace/utils.ts
@@ -1,15 +1,26 @@
-import type { WebstudioData } from "@webstudio-is/sdk";
-import type { BuildData } from "~/shared/marketplace/types";
+import {
+  getStyleDeclKey,
+  type Asset,
+  type WebstudioData,
+} from "@webstudio-is/sdk";
+import type { CompactBuild } from "@webstudio-is/project-build";
 
-export const toWebstudioData = (data: BuildData): WebstudioData => ({
-  pages: data.build.pages,
-  assets: new Map(data.assets),
-  instances: new Map(data.build.instances),
-  dataSources: new Map(data.build.dataSources),
-  resources: new Map(data.build.resources),
-  props: new Map(data.build.props),
-  styleSourceSelections: new Map(data.build.styleSourceSelections),
-  styleSources: new Map(data.build.styleSources),
-  breakpoints: new Map(data.build.breakpoints),
-  styles: new Map(data.build.styles),
+const getPair = <Item extends { id: string }>(item: Item) =>
+  [item.id, item] as const;
+
+export const toWebstudioData = (
+  data: CompactBuild & { assets: Asset[] }
+): WebstudioData => ({
+  assets: new Map(data.assets.map(getPair)),
+  instances: new Map(data.instances.map(getPair)),
+  dataSources: new Map(data.dataSources.map(getPair)),
+  resources: new Map(data.resources.map(getPair)),
+  props: new Map(data.props.map(getPair)),
+  pages: data.pages,
+  breakpoints: new Map(data.breakpoints.map(getPair)),
+  styleSources: new Map(data.styleSources.map(getPair)),
+  styleSourceSelections: new Map(
+    data.styleSourceSelections.map((item) => [item.instanceId, item])
+  ),
+  styles: new Map(data.styles.map((item) => [getStyleDeclKey(item), item])),
 });

--- a/apps/builder/app/routes/cgi.image.$.ts
+++ b/apps/builder/app/routes/cgi.image.$.ts
@@ -65,7 +65,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   // Allow direct image access, and from the same origin
   const refererRawUrl = request.headers.get("referer");
   const refererUrl = refererRawUrl === null ? url : new URL(refererRawUrl);
-  if (refererUrl.origin !== url.origin) {
+  if (refererUrl.host !== url.host) {
     throw new Response("Forbidden", {
       status: 403,
     });

--- a/apps/builder/app/shared/marketplace/router.server.ts
+++ b/apps/builder/app/shared/marketplace/router.server.ts
@@ -10,8 +10,8 @@ const cacheMiddleware = createCacheMiddleware(60 * 3); // 60 * 3 = 3 minutes cac
 const cachedProcedure = procedure.use(cacheMiddleware);
 
 export const marketplaceRouter = router({
-  getItems: cachedProcedure.query(async () => {
-    return await getItems();
+  getItems: cachedProcedure.query(async ({ ctx }) => {
+    return await getItems(ctx);
   }),
   getBuildData: cachedProcedure
     .input(

--- a/apps/builder/app/shared/marketplace/types.ts
+++ b/apps/builder/app/shared/marketplace/types.ts
@@ -1,14 +1,8 @@
-import type { Project } from "@webstudio-is/prisma-client";
-import type { Build, MarketplaceProduct } from "@webstudio-is/project-build";
+import type { MarketplaceProduct } from "@webstudio-is/project-build";
 import type { Asset } from "@webstudio-is/sdk";
 
 export type MarketplaceOverviewItem = MarketplaceProduct & {
-  projectId: Project["id"];
+  projectId: string;
   authorizationToken?: string | undefined;
   thumbnailAssetName?: Asset["name"];
-};
-
-export type BuildData = {
-  build: Build;
-  assets: Array<[Asset["id"], Asset]>;
 };

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -21,7 +21,7 @@ import {
   StyleDecl,
 } from "@webstudio-is/sdk";
 import type { Data } from "@webstudio-is/http-client";
-import type { Build } from "../types";
+import type { Build, CompactBuild } from "../types";
 import { parseStyles } from "./styles";
 import { parseStyleSourceSelections } from "./style-source-selections";
 import { parseDeployment } from "./deployment";
@@ -117,7 +117,7 @@ const parseCompactBuild = async (
       marketplaceProduct: parseConfig<MarketplaceProduct>(
         build.marketplaceProduct
       ),
-    };
+    } satisfies CompactBuild;
   } finally {
     // empty block
   }
@@ -202,7 +202,7 @@ export const loadDevBuildByProjectId = async (
 export const loadApprovedProdBuildByProjectId = async (
   context: AppContext,
   projectId: Build["projectId"]
-): Promise<Build> => {
+) => {
   const latestBuild = await context.postgrest.client
     .from("LatestBuildPerProject")
     .select(
@@ -230,7 +230,7 @@ export const loadApprovedProdBuildByProjectId = async (
   if (build.error) {
     throw build.error;
   }
-  return parseBuild(build.data);
+  return parseCompactBuild(build.data);
 };
 
 const createNewPageInstances = (): Build["instances"] => {

--- a/packages/project-build/src/types.ts
+++ b/packages/project-build/src/types.ts
@@ -31,3 +31,22 @@ export type Build = {
   deployment?: Deployment | undefined;
   marketplaceProduct: MarketplaceProduct;
 };
+
+export type CompactBuild = {
+  id: string;
+  projectId: string;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  pages: Pages;
+  breakpoints: Breakpoint[];
+  styles: StyleDecl[];
+  styleSources: StyleSource[];
+  styleSourceSelections: StyleSourceSelection[];
+  props: Prop[];
+  dataSources: DataSource[];
+  resources: Resource[];
+  instances: Instance[];
+  deployment?: Deployment;
+  marketplaceProduct: MarketplaceProduct;
+};


### PR DESCRIPTION
Now marketplace will load compact build from server and convert into webstudio data with maps.

Replaced prisma with postgrest for loading marketplace data.

Fixed asset images on dev.