### PR TITLE
chore: Remove single() PostgREST calls from Build to improve compression

### DIFF
--- a/packages/postgrest/src/index.server.ts
+++ b/packages/postgrest/src/index.server.ts
@@ -6,27 +6,9 @@ export type Client = PostgrestClient<Database>;
 
 export const createClient = (url: string, apiKey: string): Client => {
   const client = new PostgrestClient<Database>(url, {
-    async fetch(input: string | URL | globalThis.Request, init?: RequestInit) {
-      const res = await fetch(input, init);
-
-      if (typeof input === "string" || input instanceof URL) {
-        const url = new URL(input);
-
-        if (url.pathname.endsWith("/Build")) {
-          console.info(
-            "======ENCODING IS=====",
-            res.headers.get("content-encoding")
-          );
-        }
-      }
-
-      return res;
-    },
-
     headers: {
       apikey: apiKey,
       Authorization: `Bearer ${apiKey}`,
-      // "Accept-Encoding": "br, gzip, deflate, identity",
     },
   });
 

--- a/packages/postgrest/src/index.server.ts
+++ b/packages/postgrest/src/index.server.ts
@@ -6,9 +6,27 @@ export type Client = PostgrestClient<Database>;
 
 export const createClient = (url: string, apiKey: string): Client => {
   const client = new PostgrestClient<Database>(url, {
+    async fetch(input: string | URL | globalThis.Request, init?: RequestInit) {
+      const res = await fetch(input, init);
+
+      if (typeof input === "string" || input instanceof URL) {
+        const url = new URL(input);
+
+        if (url.pathname.endsWith("/Build")) {
+          console.info(
+            "======ENCODING IS=====",
+            res.headers.get("content-encoding")
+          );
+        }
+      }
+
+      return res;
+    },
+
     headers: {
       apikey: apiKey,
       Authorization: `Bearer ${apiKey}`,
+      // "Accept-Encoding": "br, gzip, deflate, identity",
     },
   });
 

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -130,14 +130,20 @@ export const loadRawBuildById = async (
   const build = await context.postgrest.client
     .from("Build")
     .select("*")
-    .eq("id", id)
-    .single();
+    .eq("id", id);
+  // .single(); Note: Single response is not compressed. Uncomment the following line once the issue is resolved: https://github.com/orgs/supabase/discussions/28757
 
   if (build.error) {
     throw build.error;
   }
 
-  return build.data;
+  if (build.data.length !== 1) {
+    throw new Error(
+      `Results contain ${build.data.length} row(s) requires 1 row`
+    );
+  }
+
+  return build.data[0];
 };
 
 export const loadBuildById = async (
@@ -157,14 +163,20 @@ export const loadBuildIdAndVersionByProjectId = async (
     .from("Build")
     .select("id,version")
     .eq("projectId", projectId)
-    .is("deployment", null)
-    .single();
+    .is("deployment", null);
+  // .single(); Note: Single response is not compressed. Uncomment the following line once the issue is resolved: https://github.com/orgs/supabase/discussions/28757
 
   if (build.error) {
     throw build.error;
   }
 
-  return build.data;
+  if (build.data.length !== 1) {
+    throw new Error(
+      `Results contain ${build.data.length} row(s) requires 1 row`
+    );
+  }
+
+  return build.data[0];
 };
 
 const loadRawBuildByProjectId = async (
@@ -175,12 +187,20 @@ const loadRawBuildByProjectId = async (
     .from("Build")
     .select("*")
     .eq("projectId", projectId)
-    .is("deployment", null)
-    .single();
+    .is("deployment", null);
+  // .single(); Note: Single response is not compressed. Uncomment the following line once the issue is resolved: https://github.com/orgs/supabase/discussions/28757
+
   if (build.error) {
     throw build.error;
   }
-  return build.data;
+
+  if (build.data.length !== 1) {
+    throw new Error(
+      `Results contain ${build.data.length} row(s) requires 1 row`
+    );
+  }
+
+  return build.data[0];
 };
 
 export const loadBuildByProjectId = async (
@@ -225,12 +245,20 @@ export const loadApprovedProdBuildByProjectId = async (
   const build = await context.postgrest.client
     .from("Build")
     .select()
-    .eq("id", latestBuild.data.buildId)
-    .single();
+    .eq("id", latestBuild.data.buildId);
+  // .single(); Note: Single response is not compressed. Uncomment the following line once the issue is resolved: https://github.com/orgs/supabase/discussions/28757
+
   if (build.error) {
     throw build.error;
   }
-  return parseCompactBuild(build.data);
+
+  if (build.data.length !== 1) {
+    throw new Error(
+      `Results contain ${build.data.length} row(s) requires 1 row`
+    );
+  }
+
+  return parseCompactBuild(build.data[0]);
 };
 
 const createNewPageInstances = (): Build["instances"] => {


### PR DESCRIPTION
## Description

[Discussion Link](https://github.com/orgs/supabase/discussions/28757)

To reduce traffic size, temporarily remove the `.single()` call from the “Build” table until the issue under discussion is resolved.

## Test:

### Logs with `.single()` call:

Notice that the `content-encoding` header is null.

<img width="992" alt="image" src="https://github.com/user-attachments/assets/86438c2f-53f0-47ee-9fe9-b44716425bb2">

[View Logs](https://vercel.com/getwebstudio/webstudio-builder/9ua91vyJRZbQQyyJoLXEEEBiWtrE/logs?slug=app-future&slug=en-US&slug=getwebstudio&slug=webstudio-builder&slug=9ua91vyJRZbQQyyJoLXEEEBiWtrE&slug=logs&page=1&timeline=past30Minutes&startDate=1724132921408&endDate=1724134721408&searchQuery=%3D%3D%3D%3D%3D%3DENCODING%20IS%3D)

### Logs without `.single()` call:

Here, the `content-encoding` header is `null` only for Build `update` requests; everything else has `br` encoding.

<img width="967" alt="image" src="https://github.com/user-attachments/assets/c899086a-a175-4761-874b-62626ecd0671">

[View Logs](https://vercel.com/getwebstudio/webstudio-builder/EdRGvZRBKBJbT4Wzp2AnYFCkSYgg/logs?slug=app-future&slug=en-US&slug=getwebstudio&slug=webstudio-builder&slug=EdRGvZRBKBJbT4Wzp2AnYFCkSYgg&slug=logs&page=1&timeline=past30Minutes&startDate=1724133136494&endDate=1724134936494&searchQuery=%3D%3D%3D%3D%3D%3DENCODING%20IS%3D%3D%3D&selectedLogId=1724134923767492376713800000&selectedLogTimestamp=1724134923767&forceEndDate=1724134923859)

_See commits for how to add logs:_

```ts
async fetch(input: string | URL | globalThis.Request, init?: RequestInit) {
  const res = await fetch(input, init);

  if (typeof input === "string" || input instanceof URL) {
    const url = new URL(input);

    if (url.pathname.endsWith("/Build")) {
      console.info(
        "======ENCODING IS=====",
        res.headers.get("content-encoding")
      );
    }
  }

  return res;
},
```