### PR TITLE
fix: increase text contrast for screen size alert

### DIFF
--- a/apps/builder/app/builder/features/blocking-alerts/alert.tsx
+++ b/apps/builder/app/builder/features/blocking-alerts/alert.tsx
@@ -15,7 +15,7 @@ const containerStyle = css({
   left: 0,
   width: "100vw",
   height: "100vh",
-  background: "rgba(0, 0, 0, 0.7)",
+  background: "rgba(0, 0, 0, 0.9)",
 });
 
 const contentStyle = css({


### PR DESCRIPTION
## Description

increase text contrast for screen size alert by making background darker

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
