### PR TITLE
fix: when clicking on canvas reset active sidebar panel state

### DIFF
--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -27,7 +27,6 @@ import {
   toggleActiveSidebarPanel,
 } from "./nano-states";
 import { toast } from "@webstudio-is/design-system";
-import { getSetting } from "./client-settings";
 
 const makeBreakpointCommand = <CommandName extends string>(
   name: CommandName,
@@ -112,10 +111,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "clickCanvas",
       handler: () => {
         $breakpointsMenuView.set(undefined);
-        // Only close the panel if its covering the canvas.
-        if (getSetting("navigatorLayout") === "docked") {
-          setActiveSidebarPanel("none");
-        }
+        setActiveSidebarPanel(undefined);
       },
     },
 
@@ -126,7 +122,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       defaultHotkeys: ["meta+shift+p", "ctrl+shift+p"],
       handler: () => {
         $isPreviewMode.set($isPreviewMode.get() === false);
-        setActiveSidebarPanel();
+        setActiveSidebarPanel(undefined);
       },
     },
     {

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -50,18 +50,8 @@ export const $userPlanFeatures = atom<UserPlanFeatures>({
 export const $dataLoadingState = atom<"idle" | "loading" | "loaded">("idle");
 
 export const $loadingState = computed(
-  [
-    $dataLoadingState,
-    $selectedInstanceRenderState,
-    $canvasIframeState,
-    $isPreviewMode,
-  ],
-  (
-    dataLoadingState,
-    selectedInstanceRenderState,
-    canvasIframeState,
-    isPreviewMode
-  ) => {
+  [$dataLoadingState, $selectedInstanceRenderState, $canvasIframeState],
+  (dataLoadingState, selectedInstanceRenderState, canvasIframeState) => {
     const readyStates = new Map<
       "dataLoadingState" | "selectedInstanceRenderState" | "canvasIframeState",
       boolean
@@ -69,7 +59,7 @@ export const $loadingState = computed(
       ["dataLoadingState", dataLoadingState === "loaded"],
       [
         "selectedInstanceRenderState",
-        selectedInstanceRenderState === "mounted" || isPreviewMode,
+        selectedInstanceRenderState !== "pending",
       ],
       ["canvasIframeState", canvasIframeState === "ready"],
     ]);

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -308,7 +308,7 @@ const subscribeSelectedInstance = (
   return () => {
     clearTimeout(updateStoreTimeouHandle);
     hideOutline();
-    $selectedInstanceRenderState.set("pending");
+    $selectedInstanceRenderState.set("notMounted");
     resizeObserver.disconnect();
     mutationObserver.disconnect();
     bodyStyleMutationObserver.disconnect();


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3984#event-13965863574

## Description
- when clicking on canvas reset active sidebar panel state
- when clicking outside of canvas on workspace or pressing escape, the navigator shouldn't close

## Steps for reproduction

1. undocked
   - click on canvas doesn't close navigator
   - open components panel
   - click on canvas closes components, and shows navigator
3. docked
  - click on canvas always hides any open panel

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
