### PR TITLE
fix: allow inserting instances into the body when it has text content

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -187,8 +187,8 @@ export const usePropsLogic = ({
   });
   const canHaveTextContent =
     instanceMeta?.type === "container" &&
-    instance.component !== collectionComponent &&
-    instance.component !== "Body";
+    instance.component !== collectionComponent;
+
   const hasNoChildren = instance.children.length === 0;
   const hasOnlyTextChild =
     instance.children.length === 1 && instance.children[0].type === "text";

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -187,7 +187,8 @@ export const usePropsLogic = ({
   });
   const canHaveTextContent =
     instanceMeta?.type === "container" &&
-    instance.component !== collectionComponent;
+    instance.component !== collectionComponent &&
+    instance.component !== "Body";
   const hasNoChildren = instance.children.length === 0;
   const hasOnlyTextChild =
     instance.children.length === 1 && instance.children[0].type === "text";

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.stories.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.stories.tsx
@@ -5,7 +5,7 @@ import { $isProjectSettingsOpen } from "~/shared/nano-states/seo";
 import { Grid, theme } from "@webstudio-is/design-system";
 import { $assets, $project } from "~/shared/nano-states";
 import { createDefaultPages } from "@webstudio-is/project-build";
-import { isRoot } from "@webstudio-is/sdk";
+import { isRootFolder } from "@webstudio-is/sdk";
 
 export default {
   component: PageSettings,
@@ -59,7 +59,7 @@ pages.pages.push({
   rootInstanceId: "root-instance-id",
   systemDataSourceId: "systemDataSourceId",
 });
-const rootFolder = pages.folders.find(isRoot);
+const rootFolder = pages.folders.find(isRootFolder);
 rootFolder?.children.push("pageId");
 
 $pages.set(pages);

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -29,7 +29,7 @@ import {
   isLiteralExpression,
   type System,
   documentTypes,
-  isRoot,
+  isRootFolder,
 } from "@webstudio-is/sdk";
 import {
   theme,
@@ -762,7 +762,7 @@ const FormFields = ({
                     “{values.name}” is the home page
                   </Text>
                 </>
-              ) : isRoot({ id: values.parentFolderId }) === false ? (
+              ) : isRootFolder({ id: values.parentFolderId }) === false ? (
                 <>
                   <HomeIcon color={rawTheme.colors.foregroundSubtle} />
                   <Text
@@ -1527,7 +1527,7 @@ const updatePage = (pageId: Page["id"], values: Partial<Values>) => {
       oldHomePage.name = "Old Home";
       oldHomePage.path = nameToPath(pages, oldHomePage.name);
 
-      const rootFolder = pages.folders.find((folder) => isRoot(folder));
+      const rootFolder = pages.folders.find((folder) => isRootFolder(folder));
 
       if (rootFolder === undefined) {
         throw new Error("Root folder not found");

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -29,6 +29,7 @@ import {
   isLiteralExpression,
   type System,
   documentTypes,
+  isRoot,
 } from "@webstudio-is/sdk";
 import {
   theme,
@@ -99,7 +100,6 @@ import {
   deletePageMutable,
   $pageRootScope,
   duplicatePage,
-  isRootId,
   toTreeData,
   isPathAvailable,
 } from "./page-utils";
@@ -762,7 +762,7 @@ const FormFields = ({
                     “{values.name}” is the home page
                   </Text>
                 </>
-              ) : isRootId(values.parentFolderId) === false ? (
+              ) : isRoot({ id: values.parentFolderId }) === false ? (
                 <>
                   <HomeIcon color={rawTheme.colors.foregroundSubtle} />
                   <Text
@@ -1527,7 +1527,7 @@ const updatePage = (pageId: Page["id"], values: Partial<Values>) => {
       oldHomePage.name = "Old Home";
       oldHomePage.path = nameToPath(pages, oldHomePage.name);
 
-      const rootFolder = pages.folders.find((folder) => isRootId(folder.id));
+      const rootFolder = pages.folders.find((folder) => isRoot(folder));
 
       if (rootFolder === undefined) {
         throw new Error("Root folder not found");

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "@jest/globals";
 import { createDefaultPages } from "@webstudio-is/project-build";
 import {
-  isRoot,
+  isRootFolder,
   type Folder,
   ROOT_FOLDER_ID,
   type Page,
@@ -73,7 +73,7 @@ const createPages = () => {
 
   const register = (children: Array<Page | Folder>, root: boolean = true) => {
     const childIds = [];
-    const rootFolder = folders.find(isRoot);
+    const rootFolder = folders.find(isRootFolder);
 
     for (const child of children) {
       childIds.push(child.id);
@@ -274,7 +274,7 @@ describe("reparentOrphansMutable", () => {
       children: [],
     });
     reparentOrphansMutable(pages);
-    const rootFolder = pages.folders.find(isRoot);
+    const rootFolder = pages.folders.find(isRootFolder);
     expect(rootFolder).toEqual({
       id: ROOT_FOLDER_ID,
       name: "Root",
@@ -295,7 +295,7 @@ describe("cleanupChildRefsMutable", () => {
       slug: "folder",
       children: [],
     });
-    const rootFolder = folders.find(isRoot);
+    const rootFolder = folders.find(isRootFolder);
     rootFolder?.children.push("folderId");
     cleanupChildRefsMutable("folderId", folders);
     expect(rootFolder).toEqual({
@@ -320,7 +320,7 @@ describe("isSlugAvailable", () => {
     f("folder2-2", ""),
   ]);
 
-  const rootFolder = folders.find(isRoot)!;
+  const rootFolder = folders.find(isRootFolder)!;
 
   test("available in the root", () => {
     expect(isSlugAvailable("folder", folders, rootFolder.id)).toBe(true);
@@ -394,7 +394,7 @@ describe("registerFolderChildMutable", () => {
       pages: { folders },
     } = createPages();
     registerFolderChildMutable(folders, "folderId");
-    const rootFolder = folders.find(isRoot);
+    const rootFolder = folders.find(isRootFolder);
     expect(rootFolder?.children).toEqual(["homePageId", "folderId"]);
   });
 
@@ -424,7 +424,7 @@ describe("registerFolderChildMutable", () => {
       children: [],
     };
     folders.push(folder);
-    const rootFolder = folders.find(isRoot);
+    const rootFolder = folders.find(isRootFolder);
     registerFolderChildMutable(folders, "folderId", ROOT_FOLDER_ID);
     registerFolderChildMutable(folders, "folderId2", ROOT_FOLDER_ID);
 

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
@@ -2,16 +2,16 @@ import { atom, computed } from "nanostores";
 import { createRootFolder } from "@webstudio-is/project-build";
 import {
   type Page,
-  Pages,
   type Folder,
-  findPageByIdOrPath,
-  ROOT_FOLDER_ID,
-  isRoot,
   type WebstudioData,
+  type System,
+  Pages,
+  findPageByIdOrPath,
   getPagePath,
   findParentFolderByChildId,
   encodeDataSourceVariable,
-  type System,
+  ROOT_FOLDER_ID,
+  isRoot,
 } from "@webstudio-is/sdk";
 import { removeByMutable } from "~/shared/array-utils";
 import {
@@ -49,10 +49,6 @@ type TreeFolder = {
 export type TreeData = TreeFolder | TreePage;
 
 type Index = Map<string, TreeData>;
-
-const PAGES_ROOT_ID = "root";
-
-export const isRootId = (id: string) => id === PAGES_ROOT_ID;
 
 /**
  * Return a nested tree structure from flat pages and folders.
@@ -102,7 +98,7 @@ export const toTreeData = (
       children: Array.from(children.values()),
     } satisfies TreeFolder;
   };
-  const rootFolder = foldersMap.get(PAGES_ROOT_ID);
+  const rootFolder = foldersMap.get(ROOT_FOLDER_ID);
   if (rootFolder === undefined) {
     throw new Error("Root folder not found");
   }

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-utils.ts
@@ -11,7 +11,7 @@ import {
   findParentFolderByChildId,
   encodeDataSourceVariable,
   ROOT_FOLDER_ID,
-  isRoot,
+  isRootFolder,
 } from "@webstudio-is/sdk";
 import { removeByMutable } from "~/shared/array-utils";
 import {
@@ -138,7 +138,7 @@ export const reparentOrphansMutable = (pages: Pages) => {
     children.push(...folder.children);
   }
 
-  let rootFolder = pages.folders.find(isRoot);
+  let rootFolder = pages.folders.find(isRootFolder);
   // Should never happen, but just in case.
   if (rootFolder === undefined) {
     rootFolder = createRootFolder();
@@ -231,7 +231,7 @@ export const registerFolderChildMutable = (
 ) => {
   const parentFolder =
     folders.find((folder) => folder.id === parentFolderId) ??
-    folders.find(isRoot);
+    folders.find(isRootFolder);
   cleanupChildRefsMutable(id, folders);
   parentFolder?.children.push(id);
 };

--- a/apps/builder/app/shared/instance-utils.test.ts
+++ b/apps/builder/app/shared/instance-utils.test.ts
@@ -456,6 +456,23 @@ describe("find closest droppable target", () => {
     });
   });
 
+  test("puts in the end of root instance when root only has text", () => {
+    const instances = new Map([
+      createInstancePair("body", "Body", [{ type: "text", value: "text" }]),
+    ]);
+    expect(
+      findClosestDroppableTarget(
+        defaultMetasMap,
+        instances,
+        ["body"],
+        emptyInsertConstraints
+      )
+    ).toEqual({
+      parentSelector: ["body"],
+      position: "end",
+    });
+  });
+
   test("finds closest container and puts after its child within selection", () => {
     const instances = new Map([
       createInstancePair("body", "Body", [{ type: "id", value: "paragraph" }]),

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -363,6 +363,14 @@ export const findClosestDroppableTarget = (
   instanceSelector: InstanceSelector,
   insertConstraints: InsertConstraints
 ): undefined | DroppableTarget => {
+  // We want to always allow dropping into the root.
+  // For example when body has text content and the only viable option is to insert at the end.
+  if (instanceSelector.length === 1) {
+    return {
+      parentSelector: instanceSelector,
+      position: "end",
+    };
+  }
   const droppableIndex = findClosestDroppableComponentIndex({
     metas,
     constraints: insertConstraints,
@@ -370,6 +378,7 @@ export const findClosestDroppableTarget = (
     instanceSelector,
     allowInsertIntoTextContainer: false,
   });
+
   if (droppableIndex === -1) {
     return;
   }

--- a/packages/sdk/src/page-utils.ts
+++ b/packages/sdk/src/page-utils.ts
@@ -7,7 +7,7 @@ export const ROOT_FOLDER_ID = "root";
 /**
  * Returns true if folder is the root folder.
  */
-export const isRoot = (folder: Folder) => folder.id === ROOT_FOLDER_ID;
+export const isRoot = ({ id }: { id: Folder["id"] }) => id === ROOT_FOLDER_ID;
 
 /**
  * Find a page by id or path.

--- a/packages/sdk/src/page-utils.ts
+++ b/packages/sdk/src/page-utils.ts
@@ -7,7 +7,8 @@ export const ROOT_FOLDER_ID = "root";
 /**
  * Returns true if folder is the root folder.
  */
-export const isRoot = ({ id }: { id: Folder["id"] }) => id === ROOT_FOLDER_ID;
+export const isRootFolder = ({ id }: { id: Folder["id"] }) =>
+  id === ROOT_FOLDER_ID;
 
 /**
  * Find a page by id or path.


### PR DESCRIPTION
closes https://github.com/webstudio-is/webstudio/issues/3941

## Description

Allow inserting instances into the body when it has text content

## Steps for reproduction

1. select body, add text content over props
2. one-click insert any component
3. should insert and wrap text

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
