### PR TITLE
refactor: switch to style object model in color control

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/color/color-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/color/color-control.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useStore } from "@nanostores/react";
+import { useMemo, useState } from "react";
 import { Flex } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
 import type { RgbValue, StyleValue } from "@webstudio-is/css-engine";
@@ -11,6 +12,7 @@ import { getStyleSource } from "../../shared/style-info";
 import { styleConfigByName } from "../../shared/configs";
 import type { ControlProps } from "../types";
 import { AdvancedValueTooltip } from "../advanced-value-tooltip";
+import { createComputedStyleDeclStore } from "../../shared/model";
 
 const parseColor = (color?: StyleValue): RgbValue => {
   const colordValue = colord(toValue(color));
@@ -45,25 +47,26 @@ export const ColorControl = ({
   deleteProperty,
   isAdvanced,
 }: ControlProps) => {
+  const $computedStyleDecl = useMemo(
+    () => createComputedStyleDeclStore(property),
+    [property]
+  );
+  const computedStyleDecl = useStore($computedStyleDecl);
+
   const [intermediateValue, setIntermediateValue] =
     useState<CssColorPickerValueInput>();
 
   const { items: defaultItems } = styleConfigByName(property);
   const styleInfo = currentStyle[property];
 
-  let value = currentStyle[property]?.value ?? {
-    type: "keyword" as const,
-    value: "black",
-  };
-
   const setValue = setProperty(property);
 
+  let value = computedStyleDecl.cascadedValue;
   if (value.type !== "rgb" && value.type !== "keyword") {
     // Support previously set colors
     value = parseColor(value);
   }
-
-  const currentColor = parseColor(currentStyle["color"]?.currentColor);
+  const currentColor = parseColor(computedStyleDecl.usedValue);
 
   return (
     <Flex align="center" gap="1">

--- a/apps/builder/app/builder/features/style-panel/shared/model.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/model.tsx
@@ -14,6 +14,7 @@ import {
   $styleSourceSelections,
 } from "~/shared/nano-states";
 import {
+  getComputedStyleDecl,
   getPresetStyleDeclKey,
   type StyleObjectModel,
 } from "~/shared/style-object-model";
@@ -61,17 +62,6 @@ const $matchingBreakpoints = computed($breakpoints, (breakpoints) => {
     .map((breakpoint) => breakpoint.id);
 });
 
-const $matchingStates = computed(
-  [$selectedInstanceStates, $selectedOrLastStyleSourceSelector],
-  (instanceStates, styleSourceSelector) => {
-    const matchingStates = new Set(instanceStates);
-    if (styleSourceSelector?.state) {
-      matchingStates.add(styleSourceSelector.state);
-    }
-    return matchingStates;
-  }
-);
-
 const $model = computed(
   [
     $styles,
@@ -80,7 +70,7 @@ const $model = computed(
     $selectedInstanceIntanceToTag,
     $instanceComponents,
     $matchingBreakpoints,
-    $matchingStates,
+    $selectedInstanceStates,
   ],
   (
     styles,
@@ -102,6 +92,21 @@ const $model = computed(
     };
   }
 );
+
+export const createComputedStyleDeclStore = (property: string) => {
+  return computed(
+    [$model, $selectedInstanceSelector, $selectedOrLastStyleSourceSelector],
+    (model, instanceSelector, styleSourceSelector) => {
+      return getComputedStyleDecl({
+        model,
+        instanceSelector,
+        styleSourceId: styleSourceSelector?.styleSourceId,
+        state: styleSourceSelector?.state,
+        property,
+      });
+    }
+  );
+};
 
 export const useStyleObjectModel = () => {
   return useStore($model);


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1536 https://github.com/webstudio-is/webstudio/issues/3399

Here switched to computed style declarations in color control. Used only to get value (used value) and currentcolor (computed value).