### PR TITLE
feat: Highlight navigator item when canvas instance is hovered

### DIFF
--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -25,6 +25,7 @@ import { InstanceTree } from "./tree";
 
 export const NavigatorTree = () => {
   const selectedInstanceSelector = useStore($selectedInstanceSelector);
+  const hoveredInstanceSelector = useStore($hoveredInstanceSelector);
   const rootInstance = useStore($rootInstance);
   const instances = useStore($instances);
   const metas = useStore($registeredComponentMetas);
@@ -124,6 +125,7 @@ export const NavigatorTree = () => {
     <InstanceTree
       root={rootInstance}
       selectedItemSelector={selectedInstanceSelector}
+      highlightedItemSelector={hoveredInstanceSelector}
       dragItemSelector={dragItemSelector}
       dropTarget={state.dropTarget}
       isItemHidden={isItemHidden}

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -205,6 +205,11 @@ const ItemContainer = styled(Flex, {
         bc: theme.colors.backgroundItemCurrent,
       },
     },
+    isHighlighted: {
+      true: {
+        bc: theme.colors.backgroundItemCurrent,
+      },
+    },
     parentIsSelected: {
       true: {
         bc: theme.colors.backgroundItemCurrentChild,
@@ -272,6 +277,7 @@ export type TreeItemRenderProps<Data extends { id: string }> = {
   dropTargetItemSelector?: ItemSelector;
   parentIsSelected?: boolean;
   isSelected?: boolean;
+  isHighlighted?: boolean;
   onSelect?: (itemSelector: ItemSelector, all?: boolean) => void;
   level: number;
   isAlwaysExpanded: boolean;
@@ -285,6 +291,7 @@ export const TreeItemBody = <Data extends { id: string }>({
   onSelect,
   parentIsSelected = false,
   isSelected = false,
+  isHighlighted = false,
   dropTargetItemSelector,
   onHover,
   itemData,
@@ -382,6 +389,7 @@ export const TreeItemBody = <Data extends { id: string }>({
       onMouseEnter={onHover && (() => onHover(itemSelector))}
       onMouseLeave={onHover && (() => onHover())}
       isSelected={isSelected}
+      isHighlighted={isHighlighted}
       parentIsSelected={parentIsSelected}
       enableHoverState={isDragging === false}
       forceHoverState={
@@ -390,9 +398,7 @@ export const TreeItemBody = <Data extends { id: string }>({
       suffixVisible={alwaysShowSuffix || focusTarget !== undefined}
       onFocus={updateFocusTarget}
       onBlur={updateFocusTarget}
-      css={{
-        [suffixWidthVar]: suffixWidth,
-      }}
+      css={{ [suffixWidthVar]: suffixWidth }}
     >
       <ItemButton
         type="button"
@@ -483,6 +489,7 @@ export type TreeNodeProps<Data extends { id: ItemId }> = {
   ) => void;
 
   selectedItemSelector?: ItemSelector;
+  highlightedItemSelector?: ItemSelector;
   dropTargetItemSelector?: ItemSelector;
   parentSelector?: ItemSelector;
 
@@ -504,6 +511,7 @@ export const TreeNode = <Data extends { id: string }>({
     getIsExpanded,
     setIsExpanded,
     selectedItemSelector,
+    highlightedItemSelector,
     onSelect,
     onHover,
     dropTargetItemSelector,
@@ -524,7 +532,10 @@ export const TreeNode = <Data extends { id: string }>({
   const isExpandable = itemChildren.length > 0;
   const isExpanded = getIsExpanded(itemSelector) || isAlwaysExpanded;
   const isSelected = areItemSelectorsEqual(itemSelector, selectedItemSelector);
-
+  const isHighlighted = areItemSelectorsEqual(
+    itemSelector,
+    highlightedItemSelector
+  );
   const shouldRenderExpandButton = isExpandable && isAlwaysExpanded === false;
 
   return (
@@ -541,6 +552,7 @@ export const TreeNode = <Data extends { id: string }>({
           itemSelector,
           parentIsSelected,
           isSelected,
+          isHighlighted,
           onSelect,
           level,
           isAlwaysExpanded,

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -206,9 +206,7 @@ const ItemContainer = styled(Flex, {
       },
     },
     isHighlighted: {
-      true: {
-        bc: theme.colors.backgroundItemCurrent,
-      },
+      true: { "&:after": hoverStyle },
     },
     parentIsSelected: {
       true: {

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -33,7 +33,7 @@ import { theme } from "../..";
 export type TreeProps<Data extends { id: string }> = {
   root: Data;
   selectedItemSelector: undefined | ItemSelector;
-  highlightedItemSelector: undefined | ItemSelector;
+  highlightedItemSelector?: ItemSelector;
   dragItemSelector: undefined | ItemSelector;
   dropTarget: undefined | ItemDropTarget;
 

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -33,6 +33,7 @@ import { theme } from "../..";
 export type TreeProps<Data extends { id: string }> = {
   root: Data;
   selectedItemSelector: undefined | ItemSelector;
+  highlightedItemSelector: undefined | ItemSelector;
   dragItemSelector: undefined | ItemSelector;
   dropTarget: undefined | ItemDropTarget;
 
@@ -71,6 +72,7 @@ const sharedDropOptions = {
 export const Tree = <Data extends { id: string }>({
   root,
   selectedItemSelector,
+  highlightedItemSelector,
   dragItemSelector,
   dropTarget,
   canLeaveParent,
@@ -313,6 +315,7 @@ export const Tree = <Data extends { id: string }>({
           onSelect={onSelect}
           onHover={onHover}
           selectedItemSelector={selectedItemSelector}
+          highlightedItemSelector={highlightedItemSelector}
           itemData={root}
           getIsExpanded={getIsExpanded}
           setIsExpanded={(itemSelector, value, all) => {


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3757

## Description

When instance on canvas is hovered, we want to highlihgt the same instance in the navigator

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
