### PR TITLE
chore: make Schema suffix consistent

### DIFF
--- a/apps/builder/app/builder/features/ai/ai-fetch-result.ts
+++ b/apps/builder/app/builder/features/ai/ai-fetch-result.ts
@@ -59,7 +59,7 @@ export const fetchResult = async (
   instanceId: Instance["id"],
   abortSignal: AbortSignal
 ): Promise<void> => {
-  const commandsResponse = await handleAiRequest<commandDetect.Response>(
+  const commandsResponse = await handleAiRequest<commandDetect.AiResponse>(
     fetch(restAi("detect"), {
       method: "POST",
       body: JSON.stringify({ prompt }),
@@ -112,7 +112,7 @@ export const fetchResult = async (
 
   const promises = await Promise.allSettled(
     commandsResponse.data.map((command) =>
-      handleAiRequest<operations.Response>(
+      handleAiRequest<operations.WsOperations>(
         fetch(restAi(), {
           method: "POST",
           body: JSON.stringify({

--- a/apps/builder/app/builder/features/ai/ai-fetch-result.ts
+++ b/apps/builder/app/builder/features/ai/ai-fetch-result.ts
@@ -29,7 +29,7 @@ import {
 import { applyOperations, patchTextInstance } from "./apply-operations";
 import { restAi } from "~/shared/router-utils";
 import untruncateJson from "untruncate-json";
-import { RequestParamsSchema } from "~/routes/rest.ai._index";
+import { RequestParams } from "~/routes/rest.ai._index";
 import {
   AiApiException,
   RateLimitException,
@@ -102,8 +102,8 @@ export const fetchResult = async (
 
   // @todo can be covered by ts
   if (
-    RequestParamsSchema.omit({ command: true }).safeParse(requestParams)
-      .success === false
+    RequestParams.omit({ command: true }).safeParse(requestParams).success ===
+    false
   ) {
     throw new Error("Invalid prompt data");
   }
@@ -141,8 +141,7 @@ export const fetchResult = async (
 
                 const parsedDataArray = unparsedDataArray
                   .map((item) => {
-                    const safeResult =
-                      copywriter.TextInstanceSchema.safeParse(item);
+                    const safeResult = copywriter.TextInstance.safeParse(item);
                     if (safeResult.success) {
                       return safeResult.data;
                     }

--- a/apps/builder/app/routes/rest.ai._index.ts
+++ b/apps/builder/app/routes/rest.ai._index.ts
@@ -19,14 +19,14 @@ import { createContext } from "~/shared/context.server";
 import { authorizeProject } from "@webstudio-is/trpc-interface/index.server";
 import { loadBuildByProjectId } from "@webstudio-is/project-build/index.server";
 
-export const RequestParamsSchema = z.object({
+export const RequestParams = z.object({
   projectId: z.string().min(1, "nonempty"),
   instanceId: z.string().min(1, "nonempty"),
   prompt: z.string().min(1, "nonempty").max(1200),
   components: z.array(z.string()),
   jsx: z.string().min(1, "nonempty"),
   command: z.union([
-    // Using client* friendly imports because RequestParamsSchema
+    // Using client* friendly imports because RequestParams
     // is used to parse the form data on the client too.
     z.literal(clientCopywriter.name),
     z.literal(clientOperations.editStylesName),
@@ -87,7 +87,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
   const PEXELS_API_KEY = env.PEXELS_API_KEY;
 
-  const parsed = RequestParamsSchema.safeParse(await request.json());
+  const parsed = RequestParams.safeParse(await request.json());
 
   if (parsed.success === false) {
     return {

--- a/apps/builder/app/routes/rest.ai.detect.ts
+++ b/apps/builder/app/routes/rest.ai.detect.ts
@@ -12,7 +12,7 @@ import {
 import env from "~/env/env.server";
 import { createContext } from "~/shared/context.server";
 
-export const RequestParamsSchema = z.object({
+export const RequestParams = z.object({
   prompt: z.string().max(1200),
 });
 
@@ -49,7 +49,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   const requestJson = await request.json();
-  const parsed = RequestParamsSchema.safeParse(requestJson);
+  const parsed = RequestParams.safeParse(requestJson);
 
   if (parsed.success === false) {
     return {
@@ -57,7 +57,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       ...createErrorResponse({
         error: "ai.invalidRequest",
         status: 401,
-        message: `RequestParamsSchema.safeParse failed on ${JSON.stringify(
+        message: `RequestParams.safeParse failed on ${JSON.stringify(
           requestJson
         )}`,
         debug: "Invalid request data",

--- a/packages/ai/src/chains/README.md
+++ b/packages/ai/src/chains/README.md
@@ -7,7 +7,7 @@ For example a chain can be used to manipulate some input data, make a LLM call a
 Chain files are modules that export a `createChain` factory. Each instance created by the factory gets a reference to a `model` client and a `context` object which includes input data such as prompt and other relevant methods for the specific chain.
 
 Additionally each chain should export types for `Context` and `Response` data (using these names) both as zod and TypeScript types.
-zod types must have a `Schema` suffix, for example `ResponseSchema`.
+zod types must have a `Schema` suffix, for example `Response`.
 
 Generally you use chains server-side in your API request handler.
 
@@ -24,14 +24,14 @@ import type {
 } from "../../types";
 import { formatPrompt } from "../../utils/format-prompt";
 
-export const ContextSchema = z.object({
+export const Context = z.object({
   // A message from a user.
   message: z.string(),
 });
-export type Context = z.infer<typeof ContextSchema>;
+export type Context = z.infer<typeof Context>;
 
-export const ResponseSchema = z.string();
-export type Response = z.infer<typeof ResponseSchema>;
+export const Response = z.string();
+export type Response = z.infer<typeof Response>;
 
 export const createChain = <ModelMessageFormat>(): ChainStream<
   BaseModel<ModelMessageFormat>,

--- a/packages/ai/src/chains/command-detect/chain.server.ts
+++ b/packages/ai/src/chains/command-detect/chain.server.ts
@@ -3,7 +3,7 @@ import { formatPrompt } from "../../utils/format-prompt";
 import { prompt as promptSystemTemplate } from "./__generated__/command-detect.system.prompt";
 import { prompt as promptUserTemplate } from "./__generated__/command-detect.user.prompt";
 import { createErrorResponse } from "../../utils/create-error-response";
-import { type Context, Response, name } from "./schema";
+import { type AiContext, AiResponse, name } from "./schema";
 
 /**
  * Command Detect Chain
@@ -15,8 +15,8 @@ export { name };
 
 export const createChain = <ModelMessageFormat>(): Chain<
   BaseModel<ModelMessageFormat>,
-  Context,
-  Response
+  AiContext,
+  AiResponse
 > =>
   async function chain({ model, context }) {
     const { prompt, commands } = context;
@@ -53,7 +53,7 @@ export const createChain = <ModelMessageFormat>(): Chain<
 
     let detectedCommands = [];
     try {
-      detectedCommands = Response.parse(JSON.parse(completionText));
+      detectedCommands = AiResponse.parse(JSON.parse(completionText));
       const expectedCommands = new Set(Object.keys(commands));
       for (const command of detectedCommands) {
         if (expectedCommands.has(command) === false) {

--- a/packages/ai/src/chains/command-detect/chain.server.ts
+++ b/packages/ai/src/chains/command-detect/chain.server.ts
@@ -3,7 +3,7 @@ import { formatPrompt } from "../../utils/format-prompt";
 import { prompt as promptSystemTemplate } from "./__generated__/command-detect.system.prompt";
 import { prompt as promptUserTemplate } from "./__generated__/command-detect.user.prompt";
 import { createErrorResponse } from "../../utils/create-error-response";
-import { type Context, type Response, ResponseSchema, name } from "./schema";
+import { type Context, Response, name } from "./schema";
 
 /**
  * Command Detect Chain
@@ -53,7 +53,7 @@ export const createChain = <ModelMessageFormat>(): Chain<
 
     let detectedCommands = [];
     try {
-      detectedCommands = ResponseSchema.parse(JSON.parse(completionText));
+      detectedCommands = Response.parse(JSON.parse(completionText));
       const expectedCommands = new Set(Object.keys(commands));
       for (const command of detectedCommands) {
         if (expectedCommands.has(command) === false) {

--- a/packages/ai/src/chains/command-detect/schema.ts
+++ b/packages/ai/src/chains/command-detect/schema.ts
@@ -2,13 +2,13 @@ import { z } from "zod";
 
 export const name = "command-detect";
 
-export const ContextSchema = z.object({
+export const Context = z.object({
   // The prompt provides the original user request.
   prompt: z.string(),
   // Command name - description pairs.
   commands: z.record(z.string(), z.string()),
 });
-export type Context = z.infer<typeof ContextSchema>;
+export type Context = z.infer<typeof Context>;
 
-export const ResponseSchema = z.array(z.string());
-export type Response = z.infer<typeof ResponseSchema>;
+export const Response = z.array(z.string());
+export type Response = z.infer<typeof Response>;

--- a/packages/ai/src/chains/command-detect/schema.ts
+++ b/packages/ai/src/chains/command-detect/schema.ts
@@ -2,13 +2,13 @@ import { z } from "zod";
 
 export const name = "command-detect";
 
-export const Context = z.object({
+export const AiContext = z.object({
   // The prompt provides the original user request.
   prompt: z.string(),
   // Command name - description pairs.
   commands: z.record(z.string(), z.string()),
 });
-export type Context = z.infer<typeof Context>;
+export type AiContext = z.infer<typeof AiContext>;
 
-export const Response = z.array(z.string());
-export type Response = z.infer<typeof Response>;
+export const AiResponse = z.array(z.string());
+export type AiResponse = z.infer<typeof AiResponse>;

--- a/packages/ai/src/chains/copywriter/README.md
+++ b/packages/ai/src/chains/copywriter/README.md
@@ -151,7 +151,7 @@ const [json, setJson] = useState([]);
 useEffect(() => {
   try {
     const jsonResponse = z
-      .array(copywriter.TextInstanceSchema)
+      .array(copywriter.TextInstance)
       .parse(JSON.parse(untruncateJson(completion)));
 
     const currenTextInstance = jsonResponse.pop();

--- a/packages/ai/src/chains/copywriter/chain.server.ts
+++ b/packages/ai/src/chains/copywriter/chain.server.ts
@@ -6,12 +6,7 @@ import { prompt as promptSystemTemplate } from "./__generated__/copy.system.prom
 import { prompt as promptUserTemplate } from "./__generated__/copy.user.prompt";
 import { createErrorResponse } from "../../utils/create-error-response";
 import type { RemixStreamingTextResponse } from "../../utils/remix-streaming-text-response";
-import {
-  type Context,
-  name,
-  TextInstanceSchema,
-  type TextInstance,
-} from "./schema";
+import { type Context, name, TextInstance } from "./schema";
 
 /**
  * Copywriter chain.
@@ -44,9 +39,7 @@ export const createChain = <ModelMessageFormat>(): Chain<
       };
     }
 
-    if (
-      z.array(TextInstanceSchema).safeParse(textInstances).success === false
-    ) {
+    if (z.array(TextInstance).safeParse(textInstances).success === false) {
       const message = "Invalid nodes list";
       return {
         id: name,

--- a/packages/ai/src/chains/copywriter/schema.ts
+++ b/packages/ai/src/chains/copywriter/schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const name = "copywriter";
 
-export const TextInstanceSchema = z.object({
+export const TextInstance = z.object({
   instanceId: z.string(),
   index: z.number(),
   type: z.union([
@@ -13,15 +13,15 @@ export const TextInstanceSchema = z.object({
   text: z.string(),
 });
 
-export type TextInstance = z.infer<typeof TextInstanceSchema>;
+export type TextInstance = z.infer<typeof TextInstance>;
 
-export const ContextSchema = z.object({
+export const Context = z.object({
   // The prompt provides context about the copy to generate and comes from the user.
   prompt: z.string(),
   // An array of text nodes to generate copy for.
-  textInstances: z.array(TextInstanceSchema),
+  textInstances: z.array(TextInstance),
 });
-export type Context = z.infer<typeof ContextSchema>;
+export type Context = z.infer<typeof Context>;
 
-export const ResponseSchema = z.array(TextInstanceSchema);
-export type Response = z.infer<typeof ResponseSchema>;
+export const Response = z.array(TextInstance);
+export type Response = z.infer<typeof Response>;

--- a/packages/ai/src/chains/operations/chain.server.ts
+++ b/packages/ai/src/chains/operations/chain.server.ts
@@ -6,11 +6,10 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { postProcessTemplate } from "../../utils/jsx-to-template.server";
 import { createErrorResponse } from "../../utils/create-error-response";
 import {
-  type Context,
-  type Response,
   type WsOperations,
   AiOperations,
   name,
+  OperationContext,
 } from "./schema";
 import * as editStyles from "./edit-styles.server";
 import * as generateTemplatePrompt from "./generate-template-prompt.server";
@@ -54,8 +53,8 @@ const aiToWs = (aiOperations: AiOperations) => {
 
 export const createChain = <ModelMessageFormat>(): Chain<
   BaseModel<ModelMessageFormat>,
-  Context,
-  Response
+  OperationContext,
+  WsOperations
 > =>
   async function chain({ model, context }) {
     const { prompt, components, jsx } = context;

--- a/packages/ai/src/chains/operations/chain.server.ts
+++ b/packages/ai/src/chains/operations/chain.server.ts
@@ -8,9 +8,8 @@ import { createErrorResponse } from "../../utils/create-error-response";
 import {
   type Context,
   type Response,
-  type AiOperations,
   type WsOperations,
-  AiOperationsSchema,
+  AiOperations,
   name,
 } from "./schema";
 import * as editStyles from "./edit-styles.server";
@@ -65,8 +64,8 @@ export const createChain = <ModelMessageFormat>(): Chain<
     // a specific operation among the supported ones.
     // This could be passed as context.operations.
     const operationsSchema = zodToJsonSchema(
-      AiOperationsSchema.element,
-      "AiOperationsSchema"
+      AiOperations.element,
+      "AiOperations"
     );
 
     const llmMessages: ModelMessage[] = [
@@ -112,9 +111,7 @@ export const createChain = <ModelMessageFormat>(): Chain<
     let parsedCompletion;
 
     try {
-      parsedCompletion = AiOperationsSchema.safeParse(
-        JSON.parse(completionText)
-      );
+      parsedCompletion = AiOperations.safeParse(JSON.parse(completionText));
     } catch (error) {
       return {
         id: name,

--- a/packages/ai/src/chains/operations/schema.ts
+++ b/packages/ai/src/chains/operations/schema.ts
@@ -30,18 +30,18 @@ export {
 
 export const name = "operations";
 
-export const ContextSchema = z.object({
+export const Context = z.object({
   prompt: z.string().describe("Edit request from the user"),
   components: z.array(z.string()).describe("Available Webstudio components"),
   jsx: z.string().describe("Input JSX to edit"),
 });
-export type Context = z.infer<typeof ContextSchema>;
+export type Context = z.infer<typeof Context>;
 
 // AiOperations are supported LLM operations.
 // A valid completion is then converted to WsOperations
 // which is the final format that we send to the client.
 
-export const AiOperationsSchema = z.array(
+export const AiOperations = z.array(
   z.discriminatedUnion("operation", [
     editStyles.aiOperation,
     generateTemplatePrompt.aiOperation,
@@ -55,9 +55,9 @@ export const AiOperationsSchema = z.array(
     deleteInstance.aiOperation,
   ])
 );
-export type AiOperations = z.infer<typeof AiOperationsSchema>;
+export type AiOperations = z.infer<typeof AiOperations>;
 
-export const WsOperationsSchema = z.array(
+export const WsOperations = z.array(
   z.discriminatedUnion("operation", [
     editStyles.wsOperation,
     generateTemplatePrompt.wsOperation,
@@ -65,7 +65,7 @@ export const WsOperationsSchema = z.array(
     deleteInstance.wsOperation,
   ])
 );
-export type WsOperations = z.infer<typeof WsOperationsSchema>;
+export type WsOperations = z.infer<typeof WsOperations>;
 
-export const ResponseSchema = WsOperationsSchema;
-export type Response = z.infer<typeof ResponseSchema>;
+export const Response = WsOperations;
+export type Response = z.infer<typeof Response>;

--- a/packages/ai/src/chains/operations/schema.ts
+++ b/packages/ai/src/chains/operations/schema.ts
@@ -30,12 +30,12 @@ export {
 
 export const name = "operations";
 
-export const Context = z.object({
+export const OperationContext = z.object({
   prompt: z.string().describe("Edit request from the user"),
   components: z.array(z.string()).describe("Available Webstudio components"),
   jsx: z.string().describe("Input JSX to edit"),
 });
-export type Context = z.infer<typeof Context>;
+export type OperationContext = z.infer<typeof OperationContext>;
 
 // AiOperations are supported LLM operations.
 // A valid completion is then converted to WsOperations
@@ -66,6 +66,3 @@ export const WsOperations = z.array(
   ])
 );
 export type WsOperations = z.infer<typeof WsOperations>;
-
-export const Response = WsOperations;
-export type Response = z.infer<typeof Response>;

--- a/packages/ai/src/chains/template-generator/schema.ts
+++ b/packages/ai/src/chains/template-generator/schema.ts
@@ -3,12 +3,12 @@ import { WsEmbedTemplate } from "@webstudio-is/react-sdk";
 
 export const name = "template-generator";
 
-export const ContextSchema = z.object({
+export const Context = z.object({
   // The prompt provides the original user request.
   prompt: z.string(),
   components: z.array(z.string()),
 });
-export type Context = z.infer<typeof ContextSchema>;
+export type Context = z.infer<typeof Context>;
 
-export const ResponseSchema = WsEmbedTemplate;
-export type Response = z.infer<typeof ResponseSchema>;
+export const Response = WsEmbedTemplate;
+export type Response = z.infer<typeof Response>;

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -74,7 +74,7 @@ export type ModelCompletionStream<ModelMessageFormat> = (args: {
  * and a context object which includes input data such as prompt and other relevant methods for the chain.
  *
  * Additionally each chain should export types for Context and Response data (using these names) both as zod and TypeScript types.
- * zod types must have a Schema suffix. For example ResponseSchema.
+ * zod types must have a Schema suffix. For example Response.
  */
 
 export type ModelResponse<ResponseData> = Response<ResponseData> & {

--- a/packages/design-system/bin/transform-figma-tokens.ts
+++ b/packages/design-system/bin/transform-figma-tokens.ts
@@ -44,36 +44,36 @@ const fontFamilyMapping = {
   "Roboto Mono": fontFamilies.Roboto,
 } as const;
 
-const TreeLeafSchema = z.object({
+const TreeLeaf = z.object({
   type: z.string(),
   value: z.unknown(),
 });
 
-const FontWeightSchema = z.preprocess(
+const FontWeight = z.preprocess(
   (x) => (typeof x === "string" ? x.toLowerCase().replace(/\s+/g, "") : x),
   z.enum(Object.keys(fontWeightMapping) as [keyof typeof fontWeightMapping])
 );
 
-const FontFamilySchema = z.string();
+const FontFamily = z.string();
 
-const LineHeightSchema = z.union([z.string(), z.number()]);
+const LineHeight = z.union([z.string(), z.number()]);
 
-const FontSizeSchema = z.number();
+const FontSize = z.number();
 
-const LetterSpacingSchema = z.union([z.string(), z.number()]);
+const LetterSpacing = z.union([z.string(), z.number()]);
 
-const TextCaseSchema = z.enum(["uppercase", "lowercase", "capitalize", "none"]);
+const TextCase = z.enum(["uppercase", "lowercase", "capitalize", "none"]);
 
-const TextDecorationSchema = z.enum([
+const TextDecoration = z.enum([
   "none",
   "underline",
   "overline",
   "line-through",
 ]);
 
-const DimentionSchema = z.union([z.string(), z.number()]);
+const Dimention = z.union([z.string(), z.number()]);
 
-const TypographySchema = z.object({
+const Typography = z.object({
   fontFamily: z.unknown(),
   fontWeight: z.unknown(),
   lineHeight: z.unknown(),
@@ -84,7 +84,7 @@ const TypographySchema = z.object({
   paragraphIndent: z.unknown(),
 });
 
-const SingleShadowSchema = z.object({
+const SingleShadow = z.object({
   color: z.string(),
   type: z.enum(["dropShadow", "innerShadow"]),
   x: z.number(),
@@ -93,7 +93,7 @@ const SingleShadowSchema = z.object({
   spread: z.number(),
 });
 
-const ShadowSchema = z.union([SingleShadowSchema, z.array(SingleShadowSchema)]);
+const Shadow = z.union([SingleShadow, z.array(SingleShadow)]);
 
 const parse = <Output, Def extends ZodTypeDef, Input>(
   path: string[],
@@ -112,8 +112,8 @@ const parse = <Output, Def extends ZodTypeDef, Input>(
 };
 
 const printShadow = (path: string[], unparsedValue: unknown) => {
-  const shadow = parse(path, unparsedValue, ShadowSchema);
-  const printSingle = (shadow: z.infer<typeof SingleShadowSchema>) => {
+  const shadow = parse(path, unparsedValue, Shadow);
+  const printSingle = (shadow: z.infer<typeof SingleShadow>) => {
     return [
       shadow.type === "innerShadow" ? "inset" : "",
       `${shadow.x}px`,
@@ -131,7 +131,7 @@ const printShadow = (path: string[], unparsedValue: unknown) => {
 };
 
 const printLineHeight = (path: string[], unparsedValue: unknown) => {
-  const value = parse(path, unparsedValue, LineHeightSchema);
+  const value = parse(path, unparsedValue, LineHeight);
 
   if (typeof value === "number") {
     return `${value}px`;
@@ -150,7 +150,7 @@ const printLineHeight = (path: string[], unparsedValue: unknown) => {
 };
 
 const printLetterSpacing = (path: string[], unparsedValue: unknown) => {
-  const value = parse(path, unparsedValue, LetterSpacingSchema);
+  const value = parse(path, unparsedValue, LetterSpacing);
 
   if (typeof value === "number") {
     return `${value}px`;
@@ -165,30 +165,30 @@ const printLetterSpacing = (path: string[], unparsedValue: unknown) => {
 };
 
 const printFontWeight = (path: string[], unparsedValue: unknown) => {
-  const value = parse(path, unparsedValue, FontWeightSchema);
+  const value = parse(path, unparsedValue, FontWeight);
   return fontWeightMapping[value];
 };
 
 const printFontFamily = (path: string[], unparsedValue: unknown) => {
-  const value = parse(path, unparsedValue, FontFamilySchema);
+  const value = parse(path, unparsedValue, FontFamily);
   return fontFamilyMapping[value as keyof typeof fontFamilyMapping] || value;
 };
 
 const printFontSize = (path: string[], unparsedValue: unknown) => {
-  const value = parse(path, unparsedValue, FontSizeSchema);
+  const value = parse(path, unparsedValue, FontSize);
   return `${value}px`;
 };
 
 const printTextCase = (path: string[], unparsedValue: unknown) => {
-  return parse(path, unparsedValue, TextCaseSchema);
+  return parse(path, unparsedValue, TextCase);
 };
 
 const printTextDecoration = (path: string[], unparsedValue: unknown) => {
-  return parse(path, unparsedValue, TextDecorationSchema);
+  return parse(path, unparsedValue, TextDecoration);
 };
 
 const printDimension = (path: string[], unparsedValue: unknown) => {
-  const value = parse(path, unparsedValue, DimentionSchema);
+  const value = parse(path, unparsedValue, Dimention);
   if (typeof value === "number") {
     return `${value}px`;
   }
@@ -196,7 +196,7 @@ const printDimension = (path: string[], unparsedValue: unknown) => {
 };
 
 const printTypography = (path: string[], unparsedValue: unknown) => {
-  const value = parse(path, unparsedValue, TypographySchema);
+  const value = parse(path, unparsedValue, Typography);
   return {
     fontFamily: printFontFamily(path, value.fontFamily),
     fontWeight: printFontWeight(path, value.fontWeight),
@@ -231,7 +231,7 @@ const traverse = (
     return;
   }
 
-  const asLeaf = TreeLeafSchema.safeParse(node);
+  const asLeaf = TreeLeaf.safeParse(node);
   if (asLeaf.success && asLeaf.data.value !== undefined) {
     fn(nodePath, asLeaf.data.type, asLeaf.data.value);
     return;

--- a/packages/prisma-client/prisma/migrations/20220909124542_builds-data/migration.ts
+++ b/packages/prisma-client/prisma/migrations/20220909124542_builds-data/migration.ts
@@ -1,9 +1,9 @@
 import { PrismaClient, Prisma } from "./client";
 import { z } from "zod";
 
-const TreeHistorySchema = z.array(z.string());
+const TreeHistory = z.array(z.string());
 
-const PageSchema = z.object({
+const Page = z.object({
   id: z.string(),
   name: z.string(),
   path: z.string(),
@@ -12,9 +12,9 @@ const PageSchema = z.object({
   treeId: z.string(),
 });
 
-const PagesSchema = z.object({
-  homePage: PageSchema,
-  pages: z.array(PageSchema),
+const Pages = z.object({
+  homePage: Page,
+  pages: z.array(Page),
 });
 
 export default () => {
@@ -34,16 +34,16 @@ export default () => {
           (project) =>
             project.devTreeId === tree.id ||
             project.prodTreeId === tree.id ||
-            TreeHistorySchema.parse(
-              JSON.parse(project.prodTreeIdHistory)
-            ).includes(tree.id)
+            TreeHistory.parse(JSON.parse(project.prodTreeIdHistory)).includes(
+              tree.id
+            )
         );
 
         if (project === undefined) {
           continue;
         }
 
-        const pages = PagesSchema.parse({
+        const pages = Pages.parse({
           homePage: {
             id: crypto.randomUUID(),
             name: "Home",

--- a/packages/prisma-client/prisma/migrations/20220915144008_breakpoints-build_data/migration.ts
+++ b/packages/prisma-client/prisma/migrations/20220915144008_breakpoints-build_data/migration.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from "./client";
 import { z } from "zod";
 
-const PageSchema = z.object({
+const Page = z.object({
   id: z.string(),
   name: z.string(),
   path: z.string(),
@@ -10,9 +10,9 @@ const PageSchema = z.object({
   treeId: z.string(),
 });
 
-const PagesSchema = z.object({
-  homePage: PageSchema,
-  pages: z.array(PageSchema),
+const Pages = z.object({
+  homePage: Page,
+  pages: z.array(Page),
 });
 
 export default () => {
@@ -27,7 +27,7 @@ export default () => {
 
       const buildsParsed = builds.map((build) => ({
         id: build.id,
-        pages: PagesSchema.parse(JSON.parse(build.pages)),
+        pages: Pages.parse(JSON.parse(build.pages)),
       }));
 
       // await Promise.all(


### PR DESCRIPTION
## Description

we decided to stick for now with zod schema naming without suffix. This makes it consistent.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
