### PR TITLE
experimental: generate property tooltip from style object model

### DIFF
--- a/apps/builder/app/builder/features/style-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/style-panel/property-label.tsx
@@ -195,6 +195,7 @@ export const PropertyLabel = ({
       properties.map(createComputedStyleDeclStore),
       (...computedStyles) => computedStyles
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, properties);
   const styles = useStore($styles);
   const colors = styles.map(({ source }) => source.name);

--- a/apps/builder/app/builder/features/style-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/style-panel/property-label.tsx
@@ -1,0 +1,247 @@
+import { computed } from "nanostores";
+import { useStore } from "@nanostores/react";
+import { useMemo, useState } from "react";
+import { ResetIcon } from "@webstudio-is/icons";
+import {
+  hyphenateProperty,
+  type StyleProperty,
+} from "@webstudio-is/css-engine";
+import {
+  Button,
+  Flex,
+  Kbd,
+  Label,
+  Text,
+  theme,
+  Tooltip,
+} from "@webstudio-is/design-system";
+import { humanizeString } from "~/shared/string-utils";
+import {
+  $breakpoints,
+  $instances,
+  $registeredComponentMetas,
+  $selectedInstanceSelector,
+  $styleSources,
+} from "~/shared/nano-states";
+import { getInstanceLabel } from "~/shared/instance-utils";
+import type {
+  ComputedStyleDecl,
+  StyleValueSourceColor,
+} from "~/shared/style-object-model";
+import { createComputedStyleDeclStore } from "./shared/model";
+import { StyleSourceBadge } from "./style-source";
+import { useStyleData } from "./shared/use-style-data";
+
+export const PropertyInfo = ({
+  title,
+  description,
+  styles,
+  onReset,
+}: {
+  title: string;
+  description: string;
+  styles: ComputedStyleDecl[];
+  onReset: () => void;
+}) => {
+  const breakpoints = useStore($breakpoints);
+  const instances = useStore($instances);
+  const styleSources = useStore($styleSources);
+  const metas = useStore($registeredComponentMetas);
+
+  let resettable = false;
+  const properties: string[] = [];
+  const breakpointSet = new Set<string>();
+  const styleSourceNameSet = new Set<string>();
+  const instanceSet = new Set<string>();
+
+  for (const { property, source } of styles) {
+    if (source.name === "local" || source.name === "overwritten") {
+      resettable = true;
+    }
+    properties.push(hyphenateProperty(property));
+    const instance = source.instanceId
+      ? instances.get(source.instanceId)
+      : undefined;
+    if (instance === undefined) {
+      continue;
+    }
+    const meta = metas.get(instance.component);
+    const styleSource = source.styleSourceId
+      ? styleSources.get(source.styleSourceId)
+      : undefined;
+    const breakpoint = source.breakpointId
+      ? breakpoints.get(source.breakpointId)
+      : undefined;
+    if (styleSource) {
+      const styleSourceName =
+        styleSource.type === "token" ? styleSource.name : "Local";
+      if (source.state) {
+        const stateLabel =
+          meta?.states?.find((item) => item.selector === source.state)?.label ??
+          humanizeString(source.state);
+        styleSourceNameSet.add(`${styleSourceName} (${stateLabel})`);
+      } else {
+        styleSourceNameSet.add(styleSourceName);
+      }
+    }
+    if (breakpoint) {
+      breakpointSet.add(
+        breakpoint?.minWidth?.toString() ??
+          breakpoint?.maxWidth?.toString() ??
+          "Base"
+      );
+    }
+    if (instance && meta) {
+      instanceSet.add(getInstanceLabel(instance, meta));
+    }
+  }
+
+  return (
+    <Flex direction="column" gap="2" css={{ maxWidth: theme.spacing[28] }}>
+      <Text variant="titles">{title}</Text>
+      <Text
+        variant="monoBold"
+        color="moreSubtle"
+        userSelect="text"
+        css={{
+          whiteSpace: "break-spaces",
+          maxHeight: "3em",
+          cursor: "text",
+        }}
+      >
+        {properties.join("\n")}
+      </Text>
+      <Text>{description}</Text>
+      {(styleSourceNameSet.size > 0 || instanceSet.size > 0) && (
+        <Flex
+          direction="column"
+          gap="1"
+          css={{ paddingBottom: theme.spacing[5] }}
+        >
+          <Text color="moreSubtle">Value comes from</Text>
+          <Flex gap="1" wrap="wrap">
+            {Array.from(breakpointSet).map((label) => (
+              <StyleSourceBadge key={label} source="breakpoint" variant="small">
+                {label}
+              </StyleSourceBadge>
+            ))}
+            {Array.from(styleSourceNameSet).map((label) => (
+              <StyleSourceBadge
+                key={label}
+                source={label === "Local" ? "local" : "token"}
+                variant="small"
+              >
+                {label}
+              </StyleSourceBadge>
+            ))}
+            {Array.from(instanceSet).map((label) => (
+              <StyleSourceBadge key={label} source="instance" variant="small">
+                {label}
+              </StyleSourceBadge>
+            ))}
+          </Flex>
+        </Flex>
+      )}
+      {resettable && (
+        <Button
+          color="dark"
+          prefix={
+            <Flex justify="end">
+              <ResetIcon />
+            </Flex>
+          }
+          suffix={<Kbd value={["option", "click"]} />}
+          css={{ gridTemplateColumns: "2fr 3fr 1fr" }}
+          onClick={onReset}
+        >
+          Reset value
+        </Button>
+      )}
+    </Flex>
+  );
+};
+
+const getPriorityStyleSource = (
+  styleSources: StyleValueSourceColor[]
+): StyleValueSourceColor => {
+  const customOrder: StyleValueSourceColor[] = [
+    "overwritten",
+    "local",
+    "remote",
+    "preset",
+    "default",
+  ];
+  for (const color of customOrder) {
+    if (styleSources.includes(color)) {
+      return color;
+    }
+  }
+  return "default";
+};
+
+export const PropertyLabel = ({
+  label,
+  description,
+  properties,
+}: {
+  label: string;
+  description: string;
+  properties: [StyleProperty, ...StyleProperty[]];
+}) => {
+  const instanceSelector = useStore($selectedInstanceSelector);
+  const { createBatchUpdate } = useStyleData(instanceSelector?.[0] ?? "");
+  const $styles = useMemo(() => {
+    return computed(
+      properties.map(createComputedStyleDeclStore),
+      (...computedStyles) => computedStyles
+    );
+  }, properties);
+  const styles = useStore($styles);
+  const colors = styles.map(({ source }) => source.name);
+  const styleValueSourceColor = getPriorityStyleSource(colors);
+  const [isOpen, setIsOpen] = useState(false);
+  const resetProperty = () => {
+    const batch = createBatchUpdate();
+    for (const property of properties) {
+      batch.deleteProperty(property);
+    }
+    batch.publish();
+  };
+  return (
+    <Flex align="center">
+      <Tooltip
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        // prevent closing tooltip on content click
+        onPointerDown={(event) => event.preventDefault()}
+        triggerProps={{
+          onClick: (event) => {
+            if (event.altKey) {
+              event.preventDefault();
+              resetProperty();
+              return;
+            }
+            setIsOpen(true);
+          },
+        }}
+        content={
+          <PropertyInfo
+            title={label}
+            description={description}
+            styles={styles}
+            onReset={() => {
+              resetProperty();
+              setIsOpen(false);
+            }}
+          />
+        }
+      >
+        <Flex shrink gap={1} align="center">
+          <Label color={styleValueSourceColor} truncate>
+            {label}
+          </Label>
+        </Flex>
+      </Tooltip>
+    </Flex>
+  );
+};

--- a/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
@@ -6,6 +6,7 @@ import {
   theme,
   IconButton,
 } from "@webstudio-is/design-system";
+import { propertyDescriptions } from "@webstudio-is/css-data";
 import { toValue, type StyleProperty } from "@webstudio-is/css-engine";
 import type { SectionProps } from "../shared/section";
 import { PropertyName } from "../../shared/property-name";
@@ -38,6 +39,7 @@ import { ToggleGroupControl } from "../../controls/toggle-group/toggle-group-con
 import { FloatingPanel } from "~/builder/shared/floating-panel";
 import { getStyleSourceColor, type StyleInfo } from "../../shared/style-info";
 import { CollapsibleSection } from "../../shared/collapsible-section";
+import { PropertyLabel } from "../../property-label";
 
 export const properties = [
   "fontFamily",
@@ -79,11 +81,10 @@ export const TypographySectionFont = (props: SectionProps) => {
 
   return (
     <Grid css={{ gridTemplateColumns: "4fr 6fr" }} gap={2}>
-      <PropertyName
-        style={currentStyle}
+      <PropertyLabel
         label="Family"
+        description={propertyDescriptions.fontFamily}
         properties={["fontFamily"]}
-        onReset={() => deleteProperty("fontFamily")}
       />
       <FontFamilyControl
         property="fontFamily"
@@ -91,11 +92,10 @@ export const TypographySectionFont = (props: SectionProps) => {
         setProperty={setProperty}
         deleteProperty={deleteProperty}
       />
-      <PropertyName
-        style={currentStyle}
+      <PropertyLabel
         label="Weight"
+        description={propertyDescriptions.fontWeight}
         properties={["fontWeight"]}
-        onReset={() => deleteProperty("fontWeight")}
       />
       <FontWeightControl
         property="fontWeight"
@@ -103,11 +103,10 @@ export const TypographySectionFont = (props: SectionProps) => {
         setProperty={setProperty}
         deleteProperty={deleteProperty}
       />
-      <PropertyName
-        style={currentStyle}
+      <PropertyLabel
         label="Color"
+        description={propertyDescriptions.color}
         properties={["color"]}
-        onReset={() => deleteProperty("color")}
       />
       <ColorControl
         property="color"

--- a/apps/builder/app/builder/features/style-panel/shared/model.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/model.tsx
@@ -1,11 +1,12 @@
 import { computed } from "nanostores";
 import { useStore } from "@nanostores/react";
 import { compareMedia, type StyleValue } from "@webstudio-is/css-engine";
-import type { Instance } from "@webstudio-is/sdk";
+import type { Breakpoint, Instance } from "@webstudio-is/sdk";
 import {
   $breakpoints,
   $instances,
   $registeredComponentMetas,
+  $selectedBreakpoint,
   $selectedInstanceIntanceToTag,
   $selectedInstanceSelector,
   $selectedInstanceStates,
@@ -56,11 +57,22 @@ const $instanceComponents = computed(
   }
 );
 
-const $matchingBreakpoints = computed($breakpoints, (breakpoints) => {
-  return Array.from(breakpoints.values())
-    .sort(compareMedia)
-    .map((breakpoint) => breakpoint.id);
-});
+const $matchingBreakpoints = computed(
+  [$breakpoints, $selectedBreakpoint],
+  (breakpoints, selectedBreakpoint) => {
+    const sortedBreakpoints = Array.from(breakpoints.values()).sort(
+      compareMedia
+    );
+    const matchingBreakpoints: Breakpoint["id"][] = [];
+    for (const breakpoint of sortedBreakpoints) {
+      matchingBreakpoints.push(breakpoint.id);
+      if (breakpoint.id === selectedBreakpoint?.id) {
+        break;
+      }
+    }
+    return matchingBreakpoints;
+  }
+);
 
 const $model = computed(
   [

--- a/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
@@ -57,7 +57,7 @@ export type CreateBatchUpdate = () => {
   publish: (options?: StyleUpdateOptions) => void;
 };
 
-export const useStyleData = (selectedInstance: Instance) => {
+export const useStyleData = (selectedInstanceId: Instance["id"]) => {
   const selectedBreakpoint = useStore($selectedBreakpoint);
 
   const currentStyle = useStyleInfo();
@@ -102,7 +102,7 @@ export const useStyleData = (selectedInstance: Instance) => {
       serverSyncStore.createTransaction(
         [$styleSourceSelections, $styleSources, $styles],
         (styleSourceSelections, styleSources, styles) => {
-          const instanceId = selectedInstance.id;
+          const instanceId = selectedInstanceId;
           const breakpointId = selectedBreakpoint.id;
           // set only selected style source and update selection with it
           // generated local style source will not be written if not selected
@@ -145,7 +145,7 @@ export const useStyleData = (selectedInstance: Instance) => {
         }
       );
     },
-    [selectedBreakpoint, selectedInstance]
+    [selectedBreakpoint, selectedInstanceId]
   );
 
   const setProperty = useCallback<SetProperty>(

--- a/apps/builder/app/builder/features/style-panel/style-panel.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-panel.tsx
@@ -54,7 +54,7 @@ type StylePanelProps = {
 
 export const StylePanel = ({ selectedInstance }: StylePanelProps) => {
   const { currentStyle, setProperty, deleteProperty, createBatchUpdate } =
-    useStyleData(selectedInstance);
+    useStyleData(selectedInstance.id);
 
   const selectedInstanceRenderState = useStore($selectedInstanceRenderState);
   const selectedInstanceTag = useStore($selectedInstanceTag);

--- a/apps/builder/app/shared/style-object-model.test.tsx
+++ b/apps/builder/app/shared/style-object-model.test.tsx
@@ -1091,7 +1091,7 @@ describe("style value source", () => {
         instanceSelector: ["body"],
         property: "color",
       }).source
-    ).toEqual({ name: "preset" });
+    ).toEqual({ name: "preset", instanceId: "body" });
   });
 
   test("remote style source", () => {

--- a/apps/builder/app/shared/style-object-model.test.tsx
+++ b/apps/builder/app/shared/style-object-model.test.tsx
@@ -1070,7 +1070,7 @@ describe("style value source", () => {
         instanceSelector: ["body"],
         property: "color",
       }).source
-    ).toEqual("default");
+    ).toEqual({ name: "default" });
   });
 
   test("preset", () => {
@@ -1091,7 +1091,7 @@ describe("style value source", () => {
         instanceSelector: ["body"],
         property: "color",
       }).source
-    ).toEqual("preset");
+    ).toEqual({ name: "preset" });
   });
 
   test("remote style source", () => {
@@ -1120,7 +1120,12 @@ describe("style value source", () => {
         styleSourceId: "first",
         property: "color",
       }).source
-    ).toEqual("remote");
+    ).toEqual({
+      name: "remote",
+      instanceId: "body",
+      breakpointId: "base",
+      styleSourceId: "second",
+    });
     expect(
       getComputedStyleDecl({
         model,
@@ -1128,7 +1133,12 @@ describe("style value source", () => {
         styleSourceId: "second",
         property: "color",
       }).source
-    ).toEqual("local");
+    ).toEqual({
+      name: "local",
+      instanceId: "body",
+      breakpointId: "base",
+      styleSourceId: "second",
+    });
     expect(
       getComputedStyleDecl({
         model,
@@ -1136,7 +1146,12 @@ describe("style value source", () => {
         styleSourceId: "third",
         property: "color",
       }).source
-    ).toEqual("remote");
+    ).toEqual({
+      name: "remote",
+      instanceId: "body",
+      breakpointId: "base",
+      styleSourceId: "second",
+    });
   });
 
   test("overwritten style source", () => {
@@ -1154,7 +1169,7 @@ describe("style value source", () => {
           color: red;
         }
         second {
-          color: blue;
+          color: green;
         }
         third {
           color: blue;
@@ -1171,7 +1186,12 @@ describe("style value source", () => {
         styleSourceId: "first",
         property: "color",
       }).source
-    ).toEqual("overwritten");
+    ).toEqual({
+      name: "overwritten",
+      instanceId: "body",
+      breakpointId: "base",
+      styleSourceId: "third",
+    });
     expect(
       getComputedStyleDecl({
         model,
@@ -1179,7 +1199,12 @@ describe("style value source", () => {
         styleSourceId: "second",
         property: "color",
       }).source
-    ).toEqual("overwritten");
+    ).toEqual({
+      name: "overwritten",
+      instanceId: "body",
+      breakpointId: "base",
+      styleSourceId: "third",
+    });
     expect(
       getComputedStyleDecl({
         model,
@@ -1187,7 +1212,12 @@ describe("style value source", () => {
         styleSourceId: "third",
         property: "color",
       }).source
-    ).toEqual("local");
+    ).toEqual({
+      name: "local",
+      instanceId: "body",
+      breakpointId: "base",
+      styleSourceId: "third",
+    });
   });
 
   test("remote matching state", () => {
@@ -1206,7 +1236,13 @@ describe("style value source", () => {
         instanceSelector: ["body"],
         property: "color",
       }).source
-    ).toEqual("remote");
+    ).toEqual({
+      name: "remote",
+      instanceId: "body",
+      breakpointId: "base",
+      styleSourceId: "local",
+      state: ":hover",
+    });
     expect(
       getComputedStyleDecl({
         model,
@@ -1214,7 +1250,13 @@ describe("style value source", () => {
         state: ":hover",
         property: "color",
       }).source
-    ).toEqual("local");
+    ).toEqual({
+      name: "local",
+      instanceId: "body",
+      breakpointId: "base",
+      styleSourceId: "local",
+      state: ":hover",
+    });
   });
 
   test("overwritten stateless", () => {
@@ -1236,7 +1278,13 @@ describe("style value source", () => {
         instanceSelector: ["body"],
         property: "color",
       }).source
-    ).toEqual("overwritten");
+    ).toEqual({
+      name: "overwritten",
+      instanceId: "body",
+      breakpointId: "base",
+      styleSourceId: "local",
+      state: ":hover",
+    });
     expect(
       getComputedStyleDecl({
         model,
@@ -1244,7 +1292,54 @@ describe("style value source", () => {
         state: ":hover",
         property: "color",
       }).source
-    ).toEqual("local");
+    ).toEqual({
+      name: "local",
+      instanceId: "body",
+      breakpointId: "base",
+      styleSourceId: "local",
+      state: ":hover",
+    });
+  });
+
+  test("remote breakpoint", () => {
+    const model = createModel({
+      css: `
+        local {
+          color: red;
+        }
+        @media small {
+          local {
+            border-top-color: blue;
+          }
+        }
+      `,
+      jsx: <$.Body ws:id="body" ws:tag="body" class="local"></$.Body>,
+      matchingBreakpoints: ["base", "small"],
+    });
+    expect(
+      getComputedStyleDecl({
+        model,
+        instanceSelector: ["body"],
+        property: "color",
+      }).source
+    ).toEqual({
+      name: "remote",
+      instanceId: "body",
+      breakpointId: "base",
+      styleSourceId: "local",
+    });
+    expect(
+      getComputedStyleDecl({
+        model,
+        instanceSelector: ["body"],
+        property: "borderTopColor",
+      }).source
+    ).toEqual({
+      name: "local",
+      instanceId: "body",
+      breakpointId: "small",
+      styleSourceId: "local",
+    });
   });
 
   test("remote inherited", () => {
@@ -1274,20 +1369,30 @@ describe("style value source", () => {
         instanceSelector: ["inner", "box", "outer", "body"],
         property: "color",
       }).source
-    ).toEqual("remote");
+    ).toEqual({
+      name: "remote",
+      instanceId: "box",
+      breakpointId: "base",
+      styleSourceId: "boxLocal",
+    });
     expect(
       getComputedStyleDecl({
         model,
         instanceSelector: ["inner", "box", "outer", "body"],
         property: "width",
       }).source
-    ).toEqual("default");
+    ).toEqual({ name: "default" });
     expect(
       getComputedStyleDecl({
         model,
         instanceSelector: ["box", "outer", "body"],
         property: "color",
       }).source
-    ).toEqual("local");
+    ).toEqual({
+      name: "local",
+      instanceId: "box",
+      breakpointId: "base",
+      styleSourceId: "boxLocal",
+    });
   });
 });

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -113,7 +113,7 @@
     "slugify": "^1.6.6",
     "strip-indent": "^4.0.0",
     "tiny-invariant": "^1.3.3",
-    "title-case": "^4.1.0",
+    "title-case": "^4.3.1",
     "ultraflag": "^0.1.0",
     "untruncate-json": "^0.0.1",
     "urlpattern-polyfill": "^9.0.0",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -38,7 +38,7 @@
     "change-case": "^5.4.4",
     "html-tags": "^4.0.0",
     "nanoid": "^5.0.1",
-    "title-case": "^4.1.0"
+    "title-case": "^4.3.1"
   },
   "exports": {
     ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,8 +413,8 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3
       title-case:
-        specifier: ^4.1.0
-        version: 4.1.0
+        specifier: ^4.3.1
+        version: 4.3.1
       ultraflag:
         specifier: ^0.1.0
         version: 0.1.0
@@ -1760,8 +1760,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       title-case:
-        specifier: ^4.1.0
-        version: 4.1.0
+        specifier: ^4.3.1
+        version: 4.3.1
     devDependencies:
       '@jest/globals':
         specifier: ^29.7.0
@@ -9298,8 +9298,8 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
-  title-case@4.1.0:
-    resolution: {integrity: sha512-X6j4JkYviJJ7jPVuBkd1geC35pq+3J5z3q1N5z57FIhBooKQqrO4B7C6dy3RzSJIKYB6Ze0/G3KcWtinzO7MGg==}
+  title-case@4.3.1:
+    resolution: {integrity: sha512-VnPxQ+/j0X2FZ4ceGq1oLruTLjtN5Ul4sam5ypd4mDZLm1eHwkwip1gLxqhON/j4qyTlUlfPKslE/t4NPSlxhg==}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -18467,7 +18467,7 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
-  title-case@4.1.0: {}
+  title-case@4.3.1: {}
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1536 https://github.com/webstudio-is/webstudio/issues/3399

Here added more information about property value source like breakpoint, instance, style source and state to style object model.

Now this info can be used in property label (simpler version of property name).

Migrated color, font weight and font family properties to new labels.

<img width="350" alt="Screenshot 2024-08-26 at 17 41 23" src="https://github.com/user-attachments/assets/0d643647-7472-44cf-96f7-c7da2307d067">

