### PR TITLE
refactor: add property inline label for complex controls

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/position/position-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/position/position-control.tsx
@@ -1,3 +1,4 @@
+import { propertyDescriptions } from "@webstudio-is/css-data";
 import {
   TupleValue,
   type StyleValue,
@@ -9,7 +10,7 @@ import { styleConfigByName } from "../../shared/configs";
 import { getStyleSource } from "../../shared/style-info";
 import { CssValueInputContainer } from "../../shared/css-value-input";
 import type { SetValue } from "../../shared/use-style-data";
-import { NonResetablePropertyName } from "../../shared/property-name";
+import { PropertyInlineLabel } from "../../property-label";
 
 const toPosition = (value: TupleValue) => {
   // Should never actually happen, just for TS
@@ -74,10 +75,12 @@ export const PositionControl = ({
 
   return (
     <Flex direction="column" gap="1">
-      <NonResetablePropertyName
-        style={currentStyle}
-        properties={[property]}
+      <PropertyInlineLabel
         label="Position"
+        description={
+          propertyDescriptions[property as keyof typeof propertyDescriptions]
+        }
+        properties={[property]}
       />
 
       <Flex gap="6">
@@ -100,11 +103,10 @@ export const PositionControl = ({
           align="center"
           gapX="2"
         >
-          <NonResetablePropertyName
-            style={currentStyle}
-            properties={[property]}
-            description="Left position offset"
+          <PropertyInlineLabel
             label="Left"
+            description="Left position offset"
+            properties={[property]}
           />
 
           <CssValueInputContainer
@@ -117,11 +119,10 @@ export const PositionControl = ({
             disabled={isAdvanced}
           />
 
-          <NonResetablePropertyName
-            style={currentStyle}
-            properties={[property]}
-            description="Top position offset"
+          <PropertyInlineLabel
             label="Top"
+            description="Top position offset"
+            properties={[property]}
           />
 
           <CssValueInputContainer

--- a/apps/builder/app/builder/features/style-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/style-panel/property-label.tsx
@@ -242,3 +242,62 @@ export const PropertyLabel = ({
     </Flex>
   );
 };
+
+/**
+ * Some properties like layered background-image, background-size are non resetable.
+ * UI of background would be unreadable, imagine you have
+ * background-size inherited from one source, background-image from the other,
+ * Every property have different amount of layers. The final result on the screen would be a mess.
+ */
+export const PropertyInlineLabel = ({
+  label,
+  description,
+  properties,
+  disabled,
+}: {
+  label: string;
+  description: string;
+  properties: [StyleProperty, ...StyleProperty[]];
+  disabled?: boolean;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <Flex align="center">
+      <Tooltip
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        // prevent closing tooltip on content click
+        onPointerDown={(event) => event.preventDefault()}
+        triggerProps={{
+          onClick: () => setIsOpen(true),
+        }}
+        content={
+          <>
+            <Flex
+              direction="column"
+              gap="2"
+              css={{ maxWidth: theme.spacing[28] }}
+            >
+              <Text variant="titles">{label}</Text>
+              <Text
+                variant="monoBold"
+                color="moreSubtle"
+                userSelect="text"
+                css={{ whiteSpace: "break-spaces", cursor: "text" }}
+              >
+                {properties.map(hyphenateProperty).join("\n")}
+              </Text>
+              <Text>{description}</Text>
+            </Flex>
+          </>
+        }
+      >
+        <Flex shrink gap={1} align="center">
+          <Label color="default" disabled={disabled} truncate>
+            {label}
+          </Label>
+        </Flex>
+      </Tooltip>
+    </Flex>
+  );
+};

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
@@ -3,7 +3,16 @@
  * as of now just implement feature parity with old backgrounds section
  **/
 
+import { useRef, useState } from "react";
+import { propertyDescriptions } from "@webstudio-is/css-data";
 import type { StyleValue } from "@webstudio-is/css-engine";
+import {
+  RepeatGridIcon,
+  RepeatColumnIcon,
+  RepeatRowIcon,
+  CrossSmallIcon,
+} from "@webstudio-is/icons";
+import { toValue } from "@webstudio-is/css-engine";
 import {
   theme,
   Flex,
@@ -20,29 +29,19 @@ import type {
   SetProperty,
   StyleUpdateOptions,
 } from "../../shared/use-style-data";
-
 import {
   type DeleteBackgroundProperty,
   isBackgroundLayeredProperty,
   isBackgroundStyleValue,
   type SetBackgroundProperty,
 } from "./background-layers";
-
 import { FloatingPanelProvider } from "~/builder/shared/floating-panel";
-import { useRef, useState } from "react";
 import { BackgroundSize } from "./background-size";
 import { ToggleGroupControl } from "../../controls/toggle-group/toggle-group-control";
-import {
-  RepeatGridIcon,
-  RepeatColumnIcon,
-  RepeatRowIcon,
-  CrossSmallIcon,
-} from "@webstudio-is/icons";
-import { toValue } from "@webstudio-is/css-engine";
 import { BackgroundGradient } from "./background-gradient";
-import { NonResetablePropertyName } from "../../shared/property-name";
 import { BackgroundImage } from "./background-image";
 import { BackgroundPosition } from "./background-position";
+import { PropertyInlineLabel } from "../../property-label";
 
 type BackgroundContentProps = {
   currentStyle: StyleInfo;
@@ -160,10 +159,10 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
           {imageGradientToggle === "image" && (
             <>
               <Flex css={{ height: "100%" }} align="start">
-                <NonResetablePropertyName
-                  style={currentStyle}
-                  properties={["backgroundImage"]}
+                <PropertyInlineLabel
                   label="Image"
+                  description={propertyDescriptions.backgroundImage}
+                  properties={["backgroundImage"]}
                 />
               </Flex>
 
@@ -178,10 +177,10 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
             </>
           )}
 
-          <NonResetablePropertyName
-            style={currentStyle}
-            properties={["backgroundClip"]}
+          <PropertyInlineLabel
             label="Clip"
+            description={propertyDescriptions.backgroundClip}
+            properties={["backgroundClip"]}
           />
 
           <SelectControl
@@ -191,10 +190,10 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
             property="backgroundClip"
           />
 
-          <NonResetablePropertyName
-            style={currentStyle}
-            properties={["backgroundOrigin"]}
+          <PropertyInlineLabel
             label="Origin"
+            description={propertyDescriptions.backgroundOrigin}
+            properties={["backgroundOrigin"]}
           />
 
           <SelectControl
@@ -223,7 +222,7 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
 
         <Grid
           css={{
-            gridTemplateColumns: `1fr ${theme.spacing[23]}`,
+            gridTemplateColumns: `1fr ${theme.spacing[22]}`,
             mt: theme.spacing[5],
           }}
           align="center"
@@ -231,10 +230,10 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
         >
           {imageGradientToggle === "image" && (
             <>
-              <NonResetablePropertyName
-                style={currentStyle}
-                properties={["backgroundRepeat"]}
+              <PropertyInlineLabel
                 label="Repeat"
+                description={propertyDescriptions.backgroundRepeat}
+                properties={["backgroundRepeat"]}
               />
 
               <Flex css={{ justifySelf: "end" }}>
@@ -282,10 +281,10 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
             </>
           )}
 
-          <NonResetablePropertyName
-            style={currentStyle}
-            properties={["backgroundAttachment"]}
+          <PropertyInlineLabel
             label="Attachment"
+            description={propertyDescriptions.backgroundAttachment}
+            properties={["backgroundAttachment"]}
           />
 
           <Flex css={{ justifySelf: "end" }}>
@@ -308,10 +307,10 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
             </ToggleGroup>
           </Flex>
 
-          <NonResetablePropertyName
-            style={currentStyle}
-            properties={["backgroundBlendMode"]}
+          <PropertyInlineLabel
             label="Blend mode"
+            description={propertyDescriptions.backgroundBlendMode}
+            properties={["backgroundBlendMode"]}
           />
 
           <SelectControl

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -6,14 +6,17 @@ import type {
 import { parseCssValue } from "@webstudio-is/css-data";
 import {
   Flex,
+  Label,
+  Text,
   TextArea,
   textVariants,
   theme,
+  Tooltip,
 } from "@webstudio-is/design-system";
 import { useEffect, useRef, useState } from "react";
 import type { ControlProps } from "../../controls";
-import { NonResetablePropertyName } from "../../shared/property-name";
 import { parseCssFragment } from "../../shared/parse-css-fragment";
+import { InfoCircleIcon } from "@webstudio-is/icons";
 
 type IntermediateValue = {
   type: "intermediate";
@@ -118,22 +121,27 @@ export const BackgroundGradient = (
         gap: theme.spacing[3],
       }}
     >
-      <NonResetablePropertyName
-        style={props.currentStyle}
-        description={
-          <>
-            Paste a CSS gradient, for example:
-            <br />
-            <br />
-            linear-gradient(...)
-            <br />
-            <br />
-            If pasting from Figma, remove the "background" property name.
-          </>
-        }
-        properties={[property]}
-        label="Code"
-      />
+      <Label>
+        <Flex align="center" gap="1">
+          Code
+          <Tooltip
+            variant="wrapped"
+            content={
+              <Text>
+                Paste a CSS gradient, for example:
+                <br />
+                <br />
+                linear-gradient(...)
+                <br />
+                <br />
+                If pasting from Figma, remove the "background" property name.
+              </Text>
+            }
+          >
+            <InfoCircleIcon />
+          </Tooltip>
+        </Flex>
+      </Label>
       <TextArea
         ref={textAreaRef}
         css={{ ...textVariants.mono }}

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-position.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-position.tsx
@@ -1,4 +1,4 @@
-import { keywordValues } from "@webstudio-is/css-data";
+import { keywordValues, propertyDescriptions } from "@webstudio-is/css-data";
 import { Flex, Grid, PositionGrid } from "@webstudio-is/design-system";
 import {
   getStyleSource,
@@ -6,9 +6,9 @@ import {
   type StyleValueInfo,
 } from "../../shared/style-info";
 import { CssValueInputContainer } from "../../shared/css-value-input";
-import { NonResetablePropertyName } from "../../shared/property-name";
 import type { DeleteProperty, SetProperty } from "../../shared/use-style-data";
 import { useMemo } from "react";
+import { PropertyInlineLabel } from "../../property-label";
 
 const keyworkToValue: Record<string, number> = {
   left: 0,
@@ -46,10 +46,10 @@ export const BackgroundPosition = ({
 
   return (
     <Flex direction="column" gap="1">
-      <NonResetablePropertyName
-        style={currentStyle}
-        properties={["backgroundPositionX", "backgroundPositionY"]}
+      <PropertyInlineLabel
         label="Position"
+        description={propertyDescriptions.backgroundPosition}
+        properties={["backgroundPositionX", "backgroundPositionY"]}
       />
       <Flex gap="6">
         <PositionGrid
@@ -72,11 +72,10 @@ export const BackgroundPosition = ({
           align="center"
           gapX="2"
         >
-          <NonResetablePropertyName
-            style={currentStyle}
-            properties={["backgroundPositionX"]}
-            description="Left position offset"
+          <PropertyInlineLabel
             label="Left"
+            description="Left position offset"
+            properties={["backgroundPositionX"]}
           />
           <CssValueInputContainer
             property="backgroundPositionX"
@@ -89,11 +88,10 @@ export const BackgroundPosition = ({
             setValue={setProperty("backgroundPositionX")}
             deleteProperty={deleteProperty}
           />
-          <NonResetablePropertyName
-            style={currentStyle}
-            properties={["backgroundPositionY"]}
-            description="Top position offset"
+          <PropertyInlineLabel
             label="Top"
+            description="Top position offset"
+            properties={["backgroundPositionY"]}
           />
           <CssValueInputContainer
             property="backgroundPositionY"

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
@@ -1,7 +1,7 @@
 import { Grid, Select, theme } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
 import { styleConfigByName } from "../../shared/configs";
-import { parseCssValue } from "@webstudio-is/css-data";
+import { parseCssValue, propertyDescriptions } from "@webstudio-is/css-data";
 import { CssValueInputContainer } from "../../shared/css-value-input";
 import {
   type StyleValue,
@@ -9,8 +9,8 @@ import {
   TupleValueItem,
 } from "@webstudio-is/css-engine";
 import type { SetValue } from "../../shared/use-style-data";
-import { NonResetablePropertyName } from "../../shared/property-name";
 import type { ControlProps } from "../../controls";
+import { PropertyInlineLabel } from "../../property-label";
 
 const StyleKeywordAuto = { type: "keyword" as const, value: "auto" };
 
@@ -74,10 +74,10 @@ export const BackgroundSize = (
         align="center"
         gap={2}
       >
-        <NonResetablePropertyName
-          style={props.currentStyle}
-          properties={[property]}
+        <PropertyInlineLabel
           label="Size"
+          description={propertyDescriptions.backgroundSize}
+          properties={[property]}
         />
 
         <Select
@@ -129,17 +129,15 @@ export const BackgroundSize = (
         gapX={2}
         gapY={1}
       >
-        <NonResetablePropertyName
-          style={props.currentStyle}
-          properties={[property]}
+        <PropertyInlineLabel
+          properties={["backgroundSize"]}
           label="Width"
           description="The width of the background image."
           disabled={customSizeDisabled}
         />
 
-        <NonResetablePropertyName
-          style={props.currentStyle}
-          properties={[property]}
+        <PropertyInlineLabel
+          properties={["backgroundSize"]}
           label="Height"
           description="The height of the background image."
           disabled={customSizeDisabled}

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
@@ -38,6 +38,7 @@ import { deleteTransitionLayer, editTransitionLayer } from "./transition-utils";
 import type { StyleInfo } from "../../shared/style-info";
 import { parseCssFragment } from "../../shared/parse-css-fragment";
 import { InfoCircleIcon } from "@webstudio-is/icons";
+import { PropertyInlineLabel } from "../../property-label";
 
 type TransitionContentProps = {
   index: number;
@@ -178,25 +179,11 @@ export const TransitionContent = ({
           onPropertySelection={handlePropertyUpdate}
         />
 
-        <Flex align="center">
-          <Tooltip
-            variant="wrapped"
-            content={
-              <Flex gap="2" direction="column">
-                <Text variant="regularBold">Duration</Text>
-                <Text variant="monoBold" color="moreSubtle">
-                  transition-duration
-                </Text>
-                <Text>
-                  Sets the length of time a transition animation should take to
-                  complete.
-                </Text>
-              </Flex>
-            }
-          >
-            <Label css={{ display: "inline" }}>Duration</Label>
-          </Tooltip>
-        </Flex>
+        <PropertyInlineLabel
+          label="Duration"
+          description="Sets the length of time a transition animation should take to complete."
+          properties={["transitionDuration"]}
+        />
         <CssValueInputContainer
           key={"transitionDuration"}
           property={"transitionDuration"}
@@ -220,24 +207,11 @@ export const TransitionContent = ({
           }}
         />
 
-        <Flex align="center">
-          <Tooltip
-            variant="wrapped"
-            content={
-              <Flex gap="2" direction="column">
-                <Text variant="regularBold">Delay</Text>
-                <Text variant="monoBold" color="moreSubtle">
-                  transition-delay
-                </Text>
-                <Text>
-                  Specify the duration to wait before the transition begins.
-                </Text>
-              </Flex>
-            }
-          >
-            <Label css={{ display: "inline" }}>Delay</Label>
-          </Tooltip>
-        </Flex>
+        <PropertyInlineLabel
+          label="Delay"
+          description="Specify the duration to wait before the transition begins."
+          properties={["transitionDelay"]}
+        />
         <CssValueInputContainer
           property={"transitionDelay"}
           key={"transitionDelay"}

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -5,7 +5,6 @@ import {
   isAnimatableProperty,
 } from "@webstudio-is/css-data";
 import {
-  Label,
   InputField,
   ComboboxRoot,
   ComboboxAnchor,
@@ -16,9 +15,6 @@ import {
   ComboboxListboxItem,
   ComboboxSeparator,
   NestedInputButton,
-  Tooltip,
-  Text,
-  Flex,
   ComboboxScrollArea,
 } from "@webstudio-is/design-system";
 import {
@@ -29,6 +25,7 @@ import {
 } from "@webstudio-is/css-engine";
 import { matchSorter } from "match-sorter";
 import { setUnion } from "~/shared/shim";
+import { PropertyInlineLabel } from "../../property-label";
 
 type AnimatableProperties = (typeof animatableProperties)[number];
 type NameAndLabel = { name: string; label?: string };
@@ -143,24 +140,11 @@ export const TransitionProperty = ({
 
   return (
     <>
-      <Flex align="center">
-        <Tooltip
-          variant="wrapped"
-          content={
-            <Flex gap="2" direction="column">
-              <Text variant="regularBold">Property</Text>
-              <Text variant="monoBold" color="moreSubtle">
-                transition-property
-              </Text>
-              <Text>
-                Sets the CSS properties that will be affected by the transition.
-              </Text>
-            </Flex>
-          }
-        >
-          <Label css={{ display: "inline" }}> Property </Label>
-        </Tooltip>
-      </Flex>
+      <PropertyInlineLabel
+        label="Property"
+        description="Sets the CSS properties that will be affected by the transition."
+        properties={["transitionProperty"]}
+      />
       <ComboboxRoot open={isOpen}>
         <div {...getComboboxProps()}>
           <ComboboxAnchor>

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-timing.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-timing.tsx
@@ -7,10 +7,6 @@ import {
 } from "@webstudio-is/css-engine";
 import { parseCssValue } from "@webstudio-is/css-data";
 import {
-  Label,
-  Tooltip,
-  Flex,
-  Text,
   Select,
   SelectGroup,
   SelectLabel,
@@ -25,6 +21,7 @@ import {
   type TimingFunctions,
   findTimingFunctionFromValue,
 } from "./transition-utils";
+import { PropertyInlineLabel } from "../../property-label";
 
 type TransitionTimingProps = {
   timing: StyleValue;
@@ -76,25 +73,11 @@ export const TransitionTiming = ({
 
   return (
     <>
-      <Flex align="center">
-        <Tooltip
-          variant="wrapped"
-          content={
-            <Flex gap="2" direction="column">
-              <Text variant="regularBold">Easing</Text>
-              <Text variant="monoBold" color="moreSubtle">
-                transition-timing-function
-              </Text>
-              <Text>
-                Affects the look and feel of the animation by varying the speed
-                of the transition at different points in its duration.
-              </Text>
-            </Flex>
-          }
-        >
-          <Label css={{ display: "inline" }}>Easing</Label>
-        </Tooltip>
-      </Flex>
+      <PropertyInlineLabel
+        label="Easing"
+        description="Affects the look and feel of the animation by varying the speed of the transition at different points in its duration."
+        properties={["transitionTimingFunction"]}
+      />
       <Select options={options} value={value} onChange={handleTimingChange}>
         <SelectGroup>
           <SelectLabel>Default</SelectLabel>

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -427,35 +427,3 @@ export const PropertyName = ({
     </Flex>
   );
 };
-
-type NonResetablePropertyNameProps = {
-  style: StyleInfo;
-  properties: StyleProperty[];
-  label: string | ReactElement;
-  title?: string;
-  description?: ReactNode;
-  disabled?: boolean;
-};
-/**
- * Some properties like layered background-image, background-size are non resetable.
- * UI of background would be unreadable, imagine you have
- * background-size inherited from one source, background-image from the other,
- * Every property have different amount of layers. The final result on the screen would be a mess.
- */
-export const NonResetablePropertyName = ({
-  style,
-  title,
-  description,
-  properties,
-  label,
-  disabled,
-}: NonResetablePropertyNameProps) => (
-  <PropertyName
-    style={style}
-    title={title}
-    description={description}
-    properties={properties}
-    label={label}
-    disabled={disabled}
-  />
-);


### PR DESCRIPTION
Here replaced NonResettablePropertyName with PropertyInlineLabel. It no longer requires to drill currentStyle. Switched to it in transitions and backgrounds.

<img width="353" alt="Screenshot 2024-08-27 at 11 15 22" src="https://github.com/user-attachments/assets/8396f5af-49ca-4711-b035-bd84032798a8">

Also fixed background labels truncating
<img width="288" alt="Screenshot 2024-08-27 at 02 11 25" src="https://github.com/user-attachments/assets/135cdc7f-07fa-4f7d-9f5b-cf456e66cdfc">
<img width="295" alt="Screenshot 2024-08-27 at 02 11 32" src="https://github.com/user-attachments/assets/7c018f2e-6d8f-4abe-8e1c-997108399ba3">