### PR TITLE
chore: always use error, not e 

### DIFF
--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -430,10 +430,10 @@ const PublishStatic = ({
       try {
         const projectDataStatus = await fetchProjectDataStatus(projectId);
         setProjectDataStatus(projectDataStatus);
-      } catch (e) {
+      } catch (error) {
         setProjectDataStatus({
           status: "FAILED",
-          statusText: e instanceof Error ? e.message : "Unknown error",
+          statusText: error instanceof Error ? error.message : "Unknown error",
         });
       }
     });
@@ -519,8 +519,10 @@ const PublishStatic = ({
                 if (projectDataStatus.status === "PUBLISHED") {
                   window.location.href = `/cgi/static/ssg/${name}`;
                 }
-              } catch (e) {
-                toast.error(e instanceof Error ? e.message : "Unknown error");
+              } catch (error) {
+                toast.error(
+                  error instanceof Error ? error.message : "Unknown error"
+                );
               }
             });
           }}

--- a/apps/builder/app/builder/shared/sync/sync-server.ts
+++ b/apps/builder/app/builder/shared/sync/sync-server.ts
@@ -227,12 +227,14 @@ const syncServer = async function () {
 
           console.info(`Non ok respone: ${text}`);
         }
-      } catch (e) {
+      } catch (error) {
         if (navigator.onLine) {
           // ERR_CONNECTION_REFUSED or like, probably restorable with retries
           // anyway lets's log it
 
-          console.info(e instanceof Error ? e.message : JSON.stringify(e));
+          console.info(
+            error instanceof Error ? error.message : JSON.stringify(error)
+          );
         }
       }
     }

--- a/apps/builder/app/shared/canvas-api.ts
+++ b/apps/builder/app/shared/canvas-api.ts
@@ -26,7 +26,7 @@ declare global {
 const isInIframe = () => {
   try {
     return window.self !== window.top;
-  } catch (e) {
+  } catch (error) {
     return true;
   }
 };

--- a/fixtures/webstudio-custom-template/app/web-vitals.ts
+++ b/fixtures/webstudio-custom-template/app/web-vitals.ts
@@ -189,8 +189,8 @@ const sendToAnalitics: CLSReportCallbackWithAttribution &
         const content = buildElementHumanReadablePath(element);
         params.debug_target_path = content;
       }
-    } catch (e) {
-      console.error(e);
+    } catch (error) {
+      console.error(error);
 
       console.error(`selector: ${selector} seems like not working`);
     }
@@ -219,8 +219,8 @@ export const subscribe = () => {
 
   try {
     _isMobile = window.matchMedia("(hover: none)").matches;
-  } catch (e) {
-    console.error(e);
+  } catch (error) {
+    console.error(error);
   }
 
   const options = {

--- a/fixtures/webstudio-custom-template/custom-template-stage/app/web-vitals.ts
+++ b/fixtures/webstudio-custom-template/custom-template-stage/app/web-vitals.ts
@@ -189,8 +189,8 @@ const sendToAnalitics: CLSReportCallbackWithAttribution &
         const content = buildElementHumanReadablePath(element);
         params.debug_target_path = content;
       }
-    } catch (e) {
-      console.error(e);
+    } catch (error) {
+      console.error(error);
 
       console.error(`selector: ${selector} seems like not working`);
     }
@@ -219,8 +219,8 @@ export const subscribe = () => {
 
   try {
     _isMobile = window.matchMedia("(hover: none)").matches;
-  } catch (e) {
-    console.error(e);
+  } catch (error) {
+    console.error(error);
   }
 
   const options = {

--- a/packages/prisma-client/src/prisma.ts
+++ b/packages/prisma-client/src/prisma.ts
@@ -99,12 +99,12 @@ export const prisma =
         }),
   });
 
-prisma.$on("query", (e) => {
+prisma.$on("query", (error) => {
   // Try to minify the query as vercel/new relic log size is limited
 
   console.info(
     "Query: " +
-      e.query
+      error.query
         .replace(/"public"\./g, "")
         .replace(/"Project"\./g, "")
         .replace(/"Build"\./g, "")
@@ -112,9 +112,9 @@ prisma.$on("query", (e) => {
         .replace(/"Asset"\./g, "")
   );
 
-  console.info("Params: " + e.params.slice(0, 200));
+  console.info("Params: " + error.params.slice(0, 200));
 
-  console.info("Duration: " + e.duration + "ms");
+  console.info("Duration: " + error.duration + "ms");
 });
 
 if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
## Description

This has always been our convention, I have a feeling our linter used to check this. Now its also important so that AI doesn't give you wrong suggestions.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
