### PR TITLE
refactor: migrate to property section label

### DIFF
--- a/apps/builder/app/builder/features/style-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/style-panel/property-label.tsx
@@ -11,6 +11,7 @@ import {
   Flex,
   Kbd,
   Label,
+  SectionTitleLabel,
   Text,
   theme,
   Tooltip,
@@ -237,6 +238,74 @@ export const PropertyLabel = ({
           <Label color={styleValueSourceColor} truncate>
             {label}
           </Label>
+        </Flex>
+      </Tooltip>
+    </Flex>
+  );
+};
+
+export const PropertySectionLabel = ({
+  label,
+  description,
+  properties,
+}: {
+  label: string;
+  description: string;
+  properties: [StyleProperty, ...StyleProperty[]];
+}) => {
+  const instanceSelector = useStore($selectedInstanceSelector);
+  const { createBatchUpdate } = useStyleData(instanceSelector?.[0] ?? "");
+  const $styles = useMemo(() => {
+    return computed(
+      properties.map(createComputedStyleDeclStore),
+      (...computedStyles) => computedStyles
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, properties);
+  const styles = useStore($styles);
+  const colors = styles.map(({ source }) => source.name);
+  const styleValueSourceColor = getPriorityStyleSource(colors);
+  const [isOpen, setIsOpen] = useState(false);
+  const resetProperty = () => {
+    const batch = createBatchUpdate();
+    for (const property of properties) {
+      batch.deleteProperty(property);
+    }
+    batch.publish();
+  };
+  return (
+    <Flex align="center">
+      <Tooltip
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        // prevent closing tooltip on content click
+        onPointerDown={(event) => event.preventDefault()}
+        triggerProps={{
+          onClick: (event) => {
+            if (event.altKey) {
+              event.preventDefault();
+              resetProperty();
+              return;
+            }
+            setIsOpen(true);
+          },
+        }}
+        content={
+          <PropertyInfo
+            title={label}
+            description={description}
+            styles={styles}
+            onReset={() => {
+              resetProperty();
+              setIsOpen(false);
+            }}
+          />
+        }
+      >
+        <Flex shrink gap={1} align="center">
+          <SectionTitleLabel color={styleValueSourceColor}>
+            {label}
+          </SectionTitleLabel>
         </Flex>
       </Tooltip>
     </Flex>

--- a/apps/builder/app/builder/features/style-panel/sections/backdrop-filter/backdrop-filter.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backdrop-filter/backdrop-filter.tsx
@@ -5,21 +5,22 @@ import { useState } from "react";
 import {
   SectionTitle,
   SectionTitleButton,
-  SectionTitleLabel,
   Tooltip,
   Flex,
   Text,
 } from "@webstudio-is/design-system";
 import { parseCssValue } from "@webstudio-is/css-data";
-import { PropertyName } from "../../shared/property-name";
-import { getStyleSource } from "../../shared/style-info";
 import { getDots } from "../../shared/collapsible-section";
 import { InfoCircleIcon, PlusIcon } from "@webstudio-is/icons";
 import { addLayer } from "../../style-layer-utils";
 import { LayersList } from "../../style-layers-list";
 import { FilterSectionContent } from "../../shared/filter-content";
+import { PropertySectionLabel } from "../../property-label";
 
-export const properties = ["backdropFilter"] satisfies Array<StyleProperty>;
+export const properties = ["backdropFilter"] satisfies [
+  StyleProperty,
+  ...StyleProperty[],
+];
 
 const property: StyleProperty = properties[0];
 const label = "Backdrop Filters";
@@ -29,10 +30,6 @@ export const Section = (props: SectionProps) => {
   const { currentStyle, deleteProperty } = props;
   const [isOpen, setIsOpen] = useState(true);
   const value = currentStyle[property]?.value;
-  const sectionStyleSource =
-    value?.type === "unparsed" || value?.type === "guaranteedInvalid"
-      ? undefined
-      : getStyleSource(currentStyle[property]);
 
   return (
     <CollapsibleSectionRoot
@@ -63,17 +60,10 @@ export const Section = (props: SectionProps) => {
             </Tooltip>
           }
         >
-          <PropertyName
-            title={label}
-            style={currentStyle}
-            properties={properties}
+          <PropertySectionLabel
+            label={label}
             description="Backdrop filters are similar to filters, but are applied to the area behind an element. This can be useful for creating frosted glass effects."
-            label={
-              <SectionTitleLabel color={sectionStyleSource}>
-                {label}
-              </SectionTitleLabel>
-            }
-            onReset={() => deleteProperty(property)}
+            properties={properties}
           />
         </SectionTitle>
       }

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
@@ -1,9 +1,5 @@
 import type { LayersValue, StyleValue } from "@webstudio-is/css-engine";
-import {
-  type StyleInfo,
-  type StyleValueInfo,
-  getStyleSource,
-} from "../../shared/style-info";
+import type { StyleInfo, StyleValueInfo } from "../../shared/style-info";
 import type {
   CreateBatchUpdate,
   DeleteProperty,
@@ -41,9 +37,11 @@ export const isBackgroundStyleValue = (
   return false;
 };
 
+type BackgroundProperty = keyof typeof layeredBackgroundPropsDefaults;
+
 export const layeredBackgroundProps = Object.keys(
   layeredBackgroundPropsDefaults
-) as (keyof typeof layeredBackgroundPropsDefaults)[];
+) as [BackgroundProperty, ...BackgroundProperty[]];
 
 export type LayeredBackgroundProperty = (typeof layeredBackgroundProps)[number];
 
@@ -184,18 +182,6 @@ const getLayersValue = (styleValue?: StyleValueInfo) => {
     return clonedStyleValue?.cascaded?.value;
   }
   return { type: "layers" as const, value: [] };
-};
-
-export const getLayersStyleSource = (style: StyleInfo) => {
-  return getStyleSource(...layeredBackgroundProps.map((prop) => style[prop]));
-};
-
-export const deleteLayers = (createBatchUpdate: CreateBatchUpdate) => {
-  const batch = createBatchUpdate();
-  for (const property of layeredBackgroundProps) {
-    batch.deleteProperty(property);
-  }
-  batch.publish();
 };
 
 const isLayerStylesRecord = (value: {

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -10,7 +10,6 @@ import {
   Label,
   SectionTitle,
   SectionTitleButton,
-  SectionTitleLabel,
   SmallIconButton,
   SmallToggleButton,
   theme,
@@ -23,7 +22,6 @@ import {
   PlusIcon,
 } from "@webstudio-is/icons";
 import { $assets } from "~/shared/nano-states";
-import { PropertyName } from "../../shared/property-name";
 import type { StyleInfo } from "../../shared/style-info";
 import { ColorControl } from "../../controls/color/color-control";
 import {
@@ -37,8 +35,6 @@ import {
   getLayerBackgroundStyleInfo,
   deleteLayerProperty,
   swapLayers,
-  getLayersStyleSource,
-  deleteLayers,
 } from "./background-layers";
 import { BackgroundContent } from "./background-content";
 import { getLayerName, LayerThumbnail } from "./background-thumbnail";
@@ -49,6 +45,8 @@ import {
   useOpenState,
 } from "~/builder/shared/collapsible-section";
 import { getDots } from "../../shared/collapsible-section";
+import { PropertyLabel, PropertySectionLabel } from "../../property-label";
+import { propertyDescriptions } from "@webstudio-is/css-data";
 
 const Layer = (props: {
   id: string;
@@ -159,7 +157,6 @@ const BackgroundsCollapsibleSection = ({
 }: SectionProps & { children: React.ReactNode }) => {
   const label = "Backgrounds";
   const [isOpen, setIsOpen] = useOpenState({ label });
-  const layersStyleSource = getLayersStyleSource(currentStyle);
 
   return (
     <CollapsibleSectionRoot
@@ -182,19 +179,10 @@ const BackgroundsCollapsibleSection = ({
             />
           }
         >
-          <PropertyName
-            style={currentStyle}
-            title="Backgrounds"
+          <PropertySectionLabel
+            label="Backgrounds"
             description="Add one or more backgrounds to the instance such as a color, image, or gradient."
             properties={layeredBackgroundProps}
-            label={
-              <SectionTitleLabel color={layersStyleSource}>
-                {label}
-              </SectionTitleLabel>
-            }
-            onReset={() => {
-              deleteLayers(createBatchUpdate);
-            }}
           />
         </SectionTitle>
       }
@@ -277,12 +265,10 @@ export const Section = (props: SectionProps) => {
             gridTemplateColumns: `1fr ${theme.spacing[23]}`,
           }}
         >
-          <PropertyName
-            style={currentStyle}
+          <PropertyLabel
             properties={["backgroundColor"]}
-            title={"Background Color"}
-            label={"Color"}
-            onReset={() => deleteProperty("backgroundColor")}
+            label="Color"
+            description={propertyDescriptions.backgroundColor}
           />
 
           <ColorControl

--- a/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
@@ -1,7 +1,6 @@
 import {
   SectionTitle,
   SectionTitleButton,
-  SectionTitleLabel,
   Tooltip,
   Text,
 } from "@webstudio-is/design-system";
@@ -10,15 +9,17 @@ import type { LayersValue, StyleProperty } from "@webstudio-is/css-engine";
 import { CollapsibleSectionRoot } from "~/builder/shared/collapsible-section";
 import { useState } from "react";
 import { getDots } from "../../shared/collapsible-section";
-import { PropertyName } from "../../shared/property-name";
-import { getStyleSource } from "../../shared/style-info";
 import type { SectionProps } from "../shared/section";
 import { LayersList } from "../../style-layers-list";
 import { addLayer } from "../../style-layer-utils";
 import { parseCssValue } from "@webstudio-is/css-data";
 import { ShadowContent } from "../../shared/shadow-content";
+import { PropertySectionLabel } from "../../property-label";
 
-export const properties = ["boxShadow"] satisfies Array<StyleProperty>;
+export const properties = ["boxShadow"] satisfies [
+  StyleProperty,
+  ...StyleProperty[],
+];
 
 const property: StyleProperty = properties[0];
 const label = "Box Shadows";
@@ -28,10 +29,6 @@ export const Section = (props: SectionProps) => {
   const { currentStyle, deleteProperty } = props;
   const [isOpen, setIsOpen] = useState(true);
   const value = currentStyle[property]?.value;
-  const sectionStyleSource =
-    value?.type === "unparsed" || value?.type === "guaranteedInvalid"
-      ? undefined
-      : getStyleSource(currentStyle[property]);
 
   return (
     <CollapsibleSectionRoot
@@ -57,17 +54,10 @@ export const Section = (props: SectionProps) => {
             />
           }
         >
-          <PropertyName
-            title={label}
-            style={currentStyle}
-            properties={properties}
+          <PropertySectionLabel
+            label={label}
             description="Adds shadow effects around an element's frame."
-            label={
-              <SectionTitleLabel color={sectionStyleSource}>
-                {label}
-              </SectionTitleLabel>
-            }
-            onReset={() => deleteProperty(property)}
+            properties={properties}
           />
         </SectionTitle>
       }

--- a/apps/builder/app/builder/features/style-panel/sections/filter/filter.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/filter/filter.tsx
@@ -5,21 +5,22 @@ import {
   Flex,
   SectionTitle,
   SectionTitleButton,
-  SectionTitleLabel,
   Tooltip,
   Text,
 } from "@webstudio-is/design-system";
 import { parseCssValue } from "@webstudio-is/css-data";
 import { getDots } from "../../shared/collapsible-section";
-import { PropertyName } from "../../shared/property-name";
 import { InfoCircleIcon, PlusIcon } from "@webstudio-is/icons";
 import { LayersValue, type StyleProperty } from "@webstudio-is/css-engine";
-import { getStyleSource } from "../../shared/style-info";
 import { LayersList } from "../../style-layers-list";
 import { addLayer } from "../../style-layer-utils";
 import { FilterSectionContent } from "../../shared/filter-content";
+import { PropertySectionLabel } from "../../property-label";
 
-export const properties = ["filter"] satisfies Array<StyleProperty>;
+export const properties = ["filter"] satisfies [
+  StyleProperty,
+  ...StyleProperty[],
+];
 
 const property: StyleProperty = properties[0];
 const label = "Filters";
@@ -29,10 +30,6 @@ export const Section = (props: SectionProps) => {
   const { currentStyle, deleteProperty } = props;
   const [isOpen, setIsOpen] = useState(true);
   const value = currentStyle[property]?.value;
-  const sectionStyleSource =
-    value?.type === "unparsed" || value?.type === "guaranteedInvalid"
-      ? undefined
-      : getStyleSource(currentStyle[property]);
 
   return (
     <CollapsibleSectionRoot
@@ -60,17 +57,10 @@ export const Section = (props: SectionProps) => {
             </Tooltip>
           }
         >
-          <PropertyName
-            title={label}
-            style={currentStyle}
-            properties={properties}
+          <PropertySectionLabel
+            label={label}
             description="Filter effects allow you to apply graphical effects like blurring, color shifting, and more to elements."
-            label={
-              <SectionTitleLabel color={sectionStyleSource}>
-                {label}
-              </SectionTitleLabel>
-            }
-            onReset={() => deleteProperty(property)}
+            properties={properties}
           />
         </SectionTitle>
       }

--- a/apps/builder/app/builder/features/style-panel/sections/text-shadows/text-shadows.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/text-shadows/text-shadows.tsx
@@ -5,7 +5,6 @@ import { useState } from "react";
 import {
   SectionTitle,
   SectionTitleButton,
-  SectionTitleLabel,
   Tooltip,
   Text,
 } from "@webstudio-is/design-system";
@@ -13,12 +12,14 @@ import { InfoCircleIcon, PlusIcon } from "@webstudio-is/icons";
 import { addLayer } from "../../style-layer-utils";
 import { parseCssValue } from "@webstudio-is/css-data";
 import { getDots } from "../../shared/collapsible-section";
-import { PropertyName } from "../../shared/property-name";
-import { getStyleSource } from "../../shared/style-info";
 import { LayersList } from "../../style-layers-list";
 import { ShadowContent } from "../../shared/shadow-content";
+import { PropertySectionLabel } from "../../property-label";
 
-export const properties = ["textShadow"] satisfies Array<StyleProperty>;
+export const properties = ["textShadow"] satisfies [
+  StyleProperty,
+  ...StyleProperty[],
+];
 
 const property: StyleProperty = properties[0];
 const label = "Text Shadows";
@@ -28,10 +29,6 @@ export const Section = (props: SectionProps) => {
   const { currentStyle, createBatchUpdate, deleteProperty } = props;
   const [isOpen, setIsOpen] = useState(true);
   const value = currentStyle[property]?.value;
-  const sectionStyleSource =
-    value?.type === "unparsed" || value?.type === "guaranteedInvalid"
-      ? undefined
-      : getStyleSource(currentStyle[property]);
 
   return (
     <CollapsibleSectionRoot
@@ -57,17 +54,10 @@ export const Section = (props: SectionProps) => {
             />
           }
         >
-          <PropertyName
-            title={label}
-            style={currentStyle}
-            properties={properties}
+          <PropertySectionLabel
+            label={label}
             description="Adds shadow effects around a text."
-            label={
-              <SectionTitleLabel color={sectionStyleSource}>
-                {label}
-              </SectionTitleLabel>
-            }
-            onReset={() => deleteProperty(property)}
+            properties={properties}
           />
         </SectionTitle>
       }

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transforms.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transforms.tsx
@@ -14,7 +14,6 @@ import {
   Label,
   SectionTitle,
   SectionTitleButton,
-  SectionTitleLabel,
   SmallIconButton,
   SmallToggleButton,
   theme,
@@ -41,11 +40,11 @@ import { SkewPanelContent } from "./transform-skew";
 import { BackfaceVisibility } from "./transform-backface-visibility";
 import { TransformPerspective } from "./transform-perspective";
 import { humanizeString } from "~/shared/string-utils";
-import { getStyleSource } from "../../shared/style-info";
-import { PropertyName } from "../../shared/property-name";
 import { getDots } from "../../shared/collapsible-section";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { TransformAndPerspectiveOrigin } from "./transform-and-perspective-origin";
+import { PropertySectionLabel } from "../../property-label";
+import { propertyDescriptions } from "@webstudio-is/css-data";
 
 export const transformPanels = [
   "translate",
@@ -73,7 +72,7 @@ export const properties = [
   "backfaceVisibility",
   "perspective",
   "perspectiveOrigin",
-] satisfies Array<StyleProperty>;
+] satisfies [StyleProperty, ...StyleProperty[]];
 
 export const Section = (props: SectionProps) => {
   const [isOpen, setIsOpen] = useState(true);
@@ -82,20 +81,7 @@ export const Section = (props: SectionProps) => {
     return;
   }
 
-  const { currentStyle, createBatchUpdate } = props;
-  const translateStyleSource = getStyleSource(currentStyle["translate"]);
-  const scaleStyleSource = getStyleSource(currentStyle["scale"]);
-  const rotateAndSkewStyleSrouce = getStyleSource(currentStyle["transform"]);
-  const backfaceVisibilityStyleSource = getStyleSource(
-    currentStyle["backfaceVisibility"]
-  );
-  const perspectiveStyleSource = getStyleSource(currentStyle["perspective"]);
-  const transformOriginStyleSource = getStyleSource(
-    currentStyle["transformOrigin"]
-  );
-  const perspectiveOriginStyleSource = getStyleSource(
-    currentStyle["perspectiveOrigin"]
-  );
+  const { currentStyle } = props;
 
   const isAnyTransformPropertyAdded = transformPanels.some((panel) =>
     isTransformPanelPropertyUsed({
@@ -103,19 +89,6 @@ export const Section = (props: SectionProps) => {
       panel,
     })
   );
-
-  const handleResetForAllTransformProperties = () => {
-    const batch = createBatchUpdate();
-    batch.deleteProperty("translate");
-    batch.deleteProperty("scale");
-    batch.deleteProperty("transform");
-    batch.deleteProperty("transformOrigin");
-    batch.deleteProperty("backfaceVisibility");
-    batch.deleteProperty("perspective");
-    batch.deleteProperty("perspectiveOrigin");
-
-    batch.publish();
-  };
 
   return (
     <CollapsibleSectionRoot
@@ -164,26 +137,10 @@ export const Section = (props: SectionProps) => {
             </DropdownMenu>
           }
         >
-          <PropertyName
-            title={label}
-            style={currentStyle}
+          <PropertySectionLabel
+            label={label}
+            description={propertyDescriptions.transform}
             properties={properties}
-            label={
-              <SectionTitleLabel
-                color={
-                  translateStyleSource ||
-                  scaleStyleSource ||
-                  rotateAndSkewStyleSrouce ||
-                  backfaceVisibilityStyleSource ||
-                  perspectiveStyleSource ||
-                  transformOriginStyleSource ||
-                  perspectiveOriginStyleSource
-                }
-              >
-                {label}
-              </SectionTitleLabel>
-            }
-            onReset={handleResetForAllTransformProperties}
           />
         </SectionTitle>
       }

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-utils.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-utils.ts
@@ -107,16 +107,6 @@ export const getTransitionProperties = (
   return properties;
 };
 
-export const deleteTransitionProperties = (props: {
-  createBatchUpdate: CreateBatchUpdate;
-}) => {
-  const batch = props.createBatchUpdate();
-  transitionLongHandProperties.forEach((property) => {
-    batch.deleteProperty(property);
-  });
-  batch.publish();
-};
-
 export const deleteTransitionLayer = (props: {
   index: number;
   createBatchUpdate: CreateBatchUpdate;

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.tsx
@@ -4,7 +4,6 @@ import { PlusIcon } from "@webstudio-is/icons";
 import {
   SectionTitle,
   SectionTitleButton,
-  SectionTitleLabel,
   Tooltip,
 } from "@webstudio-is/design-system";
 import {
@@ -14,19 +13,18 @@ import {
 import { CollapsibleSectionRoot } from "~/builder/shared/collapsible-section";
 import type { SectionProps } from "../shared/section";
 import { getDots } from "../../shared/collapsible-section";
-import { PropertyName } from "../../shared/property-name";
 import { $selectedOrLastStyleSourceSelector } from "~/shared/nano-states";
 import { TransitionContent } from "./transition-content";
 import {
-  deleteTransitionProperties,
   findTimingFunctionFromValue,
   type TransitionProperty,
 } from "./transition-utils";
 import { toValue, type LayerValueItem } from "@webstudio-is/css-engine";
 import { humanizeString } from "~/shared/string-utils";
 import { RepeatedStyle } from "../../shared/repeated-style";
-import { getStyleSource, type StyleInfo } from "../../shared/style-info";
+import type { StyleInfo } from "../../shared/style-info";
 import { repeatUntil } from "~/shared/array-utils";
+import { PropertySectionLabel } from "../../property-label";
 
 export { transitionLongHandProperties as properties };
 
@@ -87,12 +85,6 @@ const defaultTransitionLayers: Record<TransitionProperty, LayerValueItem> = {
 export const Section = (props: SectionProps) => {
   const { currentStyle, createBatchUpdate } = props;
   const [isOpen, setIsOpen] = useState(true);
-  const propertyValue = currentStyle?.["transitionProperty"]?.value;
-  const sectionStyleSource =
-    propertyValue?.type === "unparsed" ||
-    propertyValue?.type === "guaranteedInvalid"
-      ? undefined
-      : getStyleSource(currentStyle["transitionProperty"]);
 
   const selectedOrLastStyleSourceSelector = useStore(
     $selectedOrLastStyleSourceSelector
@@ -139,21 +131,10 @@ export const Section = (props: SectionProps) => {
             </Tooltip>
           }
         >
-          <PropertyName
-            title={label}
-            style={currentStyle}
+          <PropertySectionLabel
+            label={label}
             description="Animate the transition between states on this instance."
             properties={transitionLongHandProperties}
-            label={
-              <SectionTitleLabel color={sectionStyleSource}>
-                {label}
-              </SectionTitleLabel>
-            }
-            onReset={() =>
-              deleteTransitionProperties({
-                createBatchUpdate,
-              })
-            }
           />
         </SectionTitle>
       }

--- a/packages/design-system/src/components/section-title.tsx
+++ b/packages/design-system/src/components/section-title.tsx
@@ -191,7 +191,7 @@ export const SectionTitleLabel = forwardRef(
 
     const commonCss = { flex: "0 1 auto" };
 
-    const color = state === "closed" ? "default" : props.color;
+    const color = state === "closed" ? undefined : props.color;
 
     const isButton = isLabelButton(color);
 
@@ -209,7 +209,7 @@ export const SectionTitleLabel = forwardRef(
           // Instead, we need to render the label using a div that has position:absolute and pointer-events:none
           // However, if the label itself is a button, we need to make sure that it remains clickable.
           // @todo: move this logic to css
-          pointerEvents: isButton ? "all" : "inherit",
+          pointerEvents: isButton ? "auto" : "inherit",
         }}
         ref={ref}
       >


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3914

New property label is used for section titles.

<img width="359" alt="Screenshot 2024-08-27 at 21 18 25" src="https://github.com/user-attachments/assets/681cf4d8-c124-45e0-9a9b-6914d12cc838">
