### PR TITLE
feat: Support timestamps in the Time Component

### DIFF
--- a/packages/sdk-components-react/src/time.test.ts
+++ b/packages/sdk-components-react/src/time.test.ts
@@ -21,6 +21,12 @@ test("far future date", () => {
   );
 });
 
+test("parse ISO date string", () => {
+  expect(parseDate("2024-08-29T13:36:17.000Z")).toEqual(
+    new Date("2024-08-29T13:36:17.000Z")
+  );
+});
+
 test("empty string", () => {
   expect(parseDate("")).toEqual(undefined);
 });

--- a/packages/sdk-components-react/src/time.test.ts
+++ b/packages/sdk-components-react/src/time.test.ts
@@ -20,3 +20,7 @@ test("far future date", () => {
     new Date("2286-11-20T17:46:39.999Z")
   );
 });
+
+test("empty string", () => {
+  expect(parseDate("")).toEqual(undefined);
+});

--- a/packages/sdk-components-react/src/time.test.ts
+++ b/packages/sdk-components-react/src/time.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@jest/globals";
+import { parseDate } from "./time";
+
+test("13-digit Unix timestamp", () => {
+  expect(parseDate("1724938577059")).toEqual(
+    new Date("2024-08-29T13:36:17.059Z")
+  );
+});
+
+test("10-digit Unix timestamp ", () => {
+  expect(parseDate("1724938577")).toEqual(new Date("2024-08-29T13:36:17.000Z"));
+});
+
+test("maximum 32-bit signed integer timestamp", () => {
+  expect(parseDate("2147483647")).toEqual(new Date("2038-01-19T03:14:07.000Z"));
+});
+
+test("far future date", () => {
+  expect(parseDate("9999999999999")).toEqual(
+    new Date("2286-11-20T17:46:39.999Z")
+  );
+});

--- a/packages/sdk-components-react/src/time.test.ts
+++ b/packages/sdk-components-react/src/time.test.ts
@@ -24,3 +24,7 @@ test("far future date", () => {
 test("empty string", () => {
   expect(parseDate("")).toEqual(undefined);
 });
+
+test("invalid date string", () => {
+  expect(parseDate("whatever that is")).toEqual(undefined);
+});

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -331,22 +331,15 @@ export const parseDate = (datetimeString: string) => {
   if (datetimeString === "") {
     return;
   }
-  const timestamp = Number(datetimeString);
-  if (
-    isNaN(timestamp) === false &&
-    Number.isNaN(new Date(datetimeString).getTime())
-  ) {
-    // 10 length timestamp is in seconds, convert to milliseconds.
-    datetimeString = new Date(
-      datetimeString.length === 10 ? timestamp * 1000 : timestamp
-    ).toISOString();
-  } else {
-    datetimeString = datetimeString.toString();
+  let timestamp = Number(datetimeString);
+  const isNumber = Number.isNaN(timestamp) === false;
+  if (isNumber && datetimeString.length === 10) {
+    timestamp = timestamp * 1000;
   }
+  const date = new Date(timestamp);
+  const isValid = false === Number.isNaN(date.getTime());
 
-  const date = new Date(datetimeString);
-  const isValidDate = false === Number.isNaN(date.getTime());
-  if (isValidDate) {
+  if (isValid) {
     return date;
   }
 };

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -348,8 +348,18 @@ export const Time = React.forwardRef<React.ElementRef<"time">, TimeProps>(
       timeStyle: timeStyleOrUndefined(timeStyle),
     };
 
-    const datetimeString =
-      datetime === null ? INVALID_DATE_STRING : datetime.toString();
+    let datetimeString;
+    if (datetime === null) {
+      datetimeString = INVALID_DATE_STRING;
+    } else if (isNaN(Number(datetime)) === false) {
+      let timestamp = Number(datetime);
+      if (datetime.length === 10) {
+        timestamp = timestamp * 1000;
+      }
+      datetimeString = new Date(timestamp).toISOString();
+    } else {
+      datetimeString = datetime.toString();
+    }
 
     const date = new Date(datetimeString);
     const isValidDate = false === Number.isNaN(date.getTime());

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -348,17 +348,20 @@ export const Time = React.forwardRef<React.ElementRef<"time">, TimeProps>(
       timeStyle: timeStyleOrUndefined(timeStyle),
     };
 
-    let datetimeString;
-    if (datetime === null) {
-      datetimeString = INVALID_DATE_STRING;
-    } else if (isNaN(Number(datetime)) === false) {
-      let timestamp = Number(datetime);
-      if (datetime.length === 10) {
-        timestamp = timestamp * 1000;
+    let datetimeString = INVALID_DATE_STRING;
+
+    if (datetime !== null) {
+      const timestamp = Number(datetime);
+      if (
+        isNaN(timestamp) === false &&
+        Number.isNaN(new Date(datetime).getTime())
+      ) {
+        datetimeString = new Date(
+          datetime.length === 10 ? timestamp * 1000 : timestamp
+        ).toISOString();
+      } else {
+        datetimeString = datetime.toString();
       }
-      datetimeString = new Date(timestamp).toISOString();
-    } else {
-      datetimeString = datetime.toString();
     }
 
     const date = new Date(datetimeString);

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -327,6 +327,30 @@ const timeStyleOrUndefined = (
   return undefined;
 };
 
+export const parseDate = (datetimeString: string) => {
+  if (datetimeString === "") {
+    return;
+  }
+  const timestamp = Number(datetimeString);
+  if (
+    isNaN(timestamp) === false &&
+    Number.isNaN(new Date(datetimeString).getTime())
+  ) {
+    // 10 length timestamp is in seconds, convert to milliseconds.
+    datetimeString = new Date(
+      datetimeString.length === 10 ? timestamp * 1000 : timestamp
+    ).toISOString();
+  } else {
+    datetimeString = datetimeString.toString();
+  }
+
+  const date = new Date(datetimeString);
+  const isValidDate = false === Number.isNaN(date.getTime());
+  if (isValidDate) {
+    return date;
+  }
+};
+
 export const Time = React.forwardRef<React.ElementRef<"time">, TimeProps>(
   (
     {
@@ -348,29 +372,13 @@ export const Time = React.forwardRef<React.ElementRef<"time">, TimeProps>(
       timeStyle: timeStyleOrUndefined(timeStyle),
     };
 
-    let datetimeString = INVALID_DATE_STRING;
+    const datetimeString =
+      datetime === null ? INVALID_DATE_STRING : datetime.toString();
 
-    if (datetime) {
-      const timestamp = Number(datetime);
-      if (
-        isNaN(timestamp) === false &&
-        Number.isNaN(new Date(datetime).getTime())
-      ) {
-        // 10 length timestamp is in seconds, convert to milliseconds.
-        datetimeString = new Date(
-          datetime.length === 10 ? timestamp * 1000 : timestamp
-        ).toISOString();
-      } else {
-        datetimeString = datetime.toString();
-      }
-    }
-
-    const date = new Date(datetimeString);
-    const isValidDate = false === Number.isNaN(date.getTime());
-
+    const date = parseDate(datetimeString);
     let formattedDate = datetimeString;
 
-    if (isValidDate) {
+    if (date) {
       try {
         formattedDate = new Intl.DateTimeFormat(locale, options).format(date);
       } catch {

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -350,12 +350,13 @@ export const Time = React.forwardRef<React.ElementRef<"time">, TimeProps>(
 
     let datetimeString = INVALID_DATE_STRING;
 
-    if (datetime !== null) {
+    if (datetime) {
       const timestamp = Number(datetime);
       if (
         isNaN(timestamp) === false &&
         Number.isNaN(new Date(datetime).getTime())
       ) {
+        // 10 length timestamp is in seconds, convert to milliseconds.
         datetimeString = new Date(
           datetime.length === 10 ? timestamp * 1000 : timestamp
         ).toISOString();

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -336,7 +336,7 @@ export const parseDate = (datetimeString: string) => {
   if (isNumber && datetimeString.length === 10) {
     timestamp = timestamp * 1000;
   }
-  const date = new Date(timestamp);
+  const date = new Date(isNumber ? timestamp : datetimeString);
   const isValid = false === Number.isNaN(date.getTime());
 
   if (isValid) {


### PR DESCRIPTION
## Description

Working with a blogging system that provides dates as 10-digit timestamps. This enables converting a unix timestamp to human readable date.

I have a 10 length check in code, but let everything else through. I was going to add a condition for ` else if (datetime.length !== 13)`, but it seems like we just pass through any characters anyway, like `asdf` in the datetime field.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
