### PR TITLE
fix: show rotate and skew in the transform property dropdow listn

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -70,18 +70,10 @@ export const TransitionProperty = ({
     getMenuProps,
     getItemProps,
   } = useCombobox<NameAndLabel>({
-    items: properties.map((prop) => {
-      if (prop === "transform") {
-        return {
-          name: prop,
-          label: prop + " (rotate, skew)",
-        };
-      }
-      return {
-        name: prop,
-        label: prop,
-      };
-    }),
+    items: properties.map((prop) => ({
+      name: prop,
+      label: prop === "transform" ? `${prop} (rotate, skew)` : prop,
+    })),
     value: { name: inputValue as AnimatableProperties, label: inputValue },
     selectedItem: undefined,
     itemToString: (value) => value?.label || "",

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -70,10 +70,18 @@ export const TransitionProperty = ({
     getMenuProps,
     getItemProps,
   } = useCombobox<NameAndLabel>({
-    items: properties.map((prop) => ({
-      name: prop,
-      label: prop,
-    })),
+    items: properties.map((prop) => {
+      if (prop === "transform") {
+        return {
+          name: prop,
+          label: prop + " (rotate, skew)",
+        };
+      }
+      return {
+        name: prop,
+        label: prop,
+      };
+    }),
     value: { name: inputValue as AnimatableProperties, label: inputValue },
     selectedItem: undefined,
     itemToString: (value) => value?.label || "",
@@ -138,12 +146,9 @@ export const TransitionProperty = ({
       commonPropertiesSet.has(item.name) === false &&
       propertiesDefinedOnInstanceSet.has(item.name) === false
   );
-  const propertiesDefinedOnInstance: Array<NameAndLabel> = Array.from(
-    propertiesDefinedOnInstanceSet
-  ).map((item) => ({
-    name: item,
-    label: item,
-  }));
+  const propertiesDefinedOnInstance: Array<NameAndLabel> = items.filter(
+    (item) => propertiesDefinedOnInstanceSet.has(item.name)
+  );
 
   const saveAnimatableProperty = (propertyName: string) => {
     if (isAnimatableProperty(propertyName) === false) {
@@ -209,7 +214,7 @@ export const TransitionProperty = ({
                       </>
                     )}
 
-                    <ComboboxLabel role="option">Common</ComboboxLabel>
+                    <ComboboxLabel>Common</ComboboxLabel>
                     {commonProperties.map((property, index) =>
                       renderItem(
                         property,

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.tsx
@@ -56,7 +56,7 @@ const getLayerLabel = ({
   const propertyLayer =
     getTransitionLayers(style, "transitionProperty")[index] ??
     properties.transitionProperty.initial;
-  const property = toValue({ ...propertyLayer, hidden: false });
+  const property = humanizeString(toValue({ ...propertyLayer, hidden: false }));
   const duration = toValue(
     getTransitionLayers(style, "transitionDuration")[index] ??
       properties.transitionDuration.initial
@@ -72,11 +72,7 @@ const getLayerLabel = ({
       properties.transitionDelay.initial
   );
 
-  if (property === "transform") {
-    return `Transform (Rotate, Skew): ${duration} ${humanizedTimingFunction} ${delay}`;
-  }
-
-  return `${humanizeString(property)}: ${duration} ${humanizedTimingFunction} ${delay}`;
+  return `${property}: ${duration} ${humanizedTimingFunction} ${delay}`;
 };
 
 const defaultTransitionLayers: Record<TransitionProperty, LayerValueItem> = {


### PR DESCRIPTION
## Description

Show `rotate` and `skew` next to the transform list dropdown values.  When applied it should show just the transform in the layer list.

<img width="497" alt="Screenshot 2024-08-28 at 9 24 03 PM" src="https://github.com/user-attachments/assets/3dd4bc45-f5a2-46a9-b0fa-91e6ee1646b8">
<img width="492" alt="Screenshot 2024-08-28 at 9 23 53 PM" src="https://github.com/user-attachments/assets/68078d59-9d92-419a-8585-f54540d0d36f">


## Steps for reproduction
- Add a transform layer list.
- Now, click on the layer to edit the layer and search for transform.
- The dropdown list should show `rotate` and `skew` next to the dropdown list. 
- When added it should show `Transform` alone in the label.


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)