### PR TITLE
refactor: switch menu and toggle controls to style object model

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/menu/menu-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/menu/menu-control.tsx
@@ -1,4 +1,4 @@
-import { toValue } from "@webstudio-is/css-engine";
+import { toValue, type StyleProperty } from "@webstudio-is/css-engine";
 import type { IconComponent } from "@webstudio-is/icons";
 import {
   Box,
@@ -15,39 +15,32 @@ import {
   IconButton,
   theme,
 } from "@webstudio-is/design-system";
-import type { ControlProps } from "../types";
-import { getStyleSource } from "../../shared/style-info";
-import { PropertyTooltip } from "../../shared/property-name";
-import { AdvancedValueTooltip } from "../advanced-value-tooltip";
-import { toKebabCase } from "../../shared/keyword-utils";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { declarationDescriptions } from "@webstudio-is/css-data";
+import { setProperty } from "../../shared/use-style-data";
+import { createComputedStyleDeclStore } from "../../shared/model";
+import { useStore } from "@nanostores/react";
+import { PropertyValueTooltip } from "../../property-label";
+import { humanizeString } from "~/shared/string-utils";
 
 export const MenuControl = ({
-  currentStyle,
   property,
   items,
-  setProperty,
-  deleteProperty,
-  isAdvanced,
-}: Omit<ControlProps, "items"> & {
+}: {
+  property: StyleProperty;
   items: Array<{
     name: string;
     label: string;
     icon: IconComponent;
   }>;
 }) => {
-  const styleValue = currentStyle[property];
-  const value = styleValue?.value;
-  const styleSource = getStyleSource(styleValue);
+  const computedStyleDecl = useStore(
+    useMemo(() => createComputedStyleDeclStore(property), [property])
+  );
   const [descriptionValue, setDescriptionValue] = useState<string>();
 
-  if (value === undefined) {
-    return;
-  }
-
   const setValue = setProperty(property);
-  const currentValue = toValue(value);
+  const currentValue = toValue(computedStyleDecl.cascadedValue);
   const currentItem = items.find((item) => item.name === currentValue);
   const Icon = currentItem?.icon ?? items[0].icon;
   const description =
@@ -56,41 +49,33 @@ export const MenuControl = ({
         descriptionValue ?? currentValue
       }` as keyof typeof declarationDescriptions
     ];
-  // If there is no icon, we can't represent the value visually and assume the value comes from advanced section.
-  isAdvanced = isAdvanced ?? currentItem === undefined;
+  // consider defined (not default) value as advanced
+  // when there is no matching item
+  const isAdvanced =
+    computedStyleDecl.source.name !== "default" && currentItem === undefined;
 
   return (
     <DropdownMenu modal={false}>
-      <AdvancedValueTooltip
-        isAdvanced={isAdvanced}
+      <PropertyValueTooltip
+        label={currentItem?.label ?? humanizeString(property)}
         property={property}
-        value={currentValue}
-        currentStyle={currentStyle}
-        deleteProperty={deleteProperty}
+        isAdvanced={isAdvanced}
       >
-        <PropertyTooltip
-          title={currentItem?.label}
-          properties={[property]}
-          scrollableContent={`${toKebabCase(property)}: ${currentValue};`}
-          style={currentStyle}
-          onReset={() => deleteProperty(property)}
-        >
-          <DropdownMenuTrigger asChild>
-            <IconButton
-              disabled={isAdvanced}
-              variant={styleSource}
-              onPointerDown={(event) => {
-                // tooltip reset property when click with altKey
-                if (event.altKey) {
-                  event.preventDefault();
-                }
-              }}
-            >
-              <Icon />
-            </IconButton>
-          </DropdownMenuTrigger>
-        </PropertyTooltip>
-      </AdvancedValueTooltip>
+        <DropdownMenuTrigger asChild>
+          <IconButton
+            aria-disabled={isAdvanced}
+            variant={computedStyleDecl.source.name}
+            onPointerDown={(event) => {
+              // tooltip reset property when click with altKey
+              if (event.altKey) {
+                event.preventDefault();
+              }
+            }}
+          >
+            <Icon />
+          </IconButton>
+        </DropdownMenuTrigger>
+      </PropertyValueTooltip>
       <DropdownMenuPortal>
         <DropdownMenuContent sideOffset={4} collisionPadding={16} side="bottom">
           <DropdownMenuRadioGroup

--- a/apps/builder/app/builder/features/style-panel/controls/menu/menu-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/menu/menu-control.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { toValue, type StyleProperty } from "@webstudio-is/css-engine";
 import type { IconComponent } from "@webstudio-is/icons";
 import {
@@ -15,13 +16,11 @@ import {
   IconButton,
   theme,
 } from "@webstudio-is/design-system";
-import { useMemo, useState } from "react";
 import { declarationDescriptions } from "@webstudio-is/css-data";
-import { setProperty } from "../../shared/use-style-data";
-import { createComputedStyleDeclStore } from "../../shared/model";
-import { useStore } from "@nanostores/react";
-import { PropertyValueTooltip } from "../../property-label";
 import { humanizeString } from "~/shared/string-utils";
+import { setProperty } from "../../shared/use-style-data";
+import { useComputedStyleDecl } from "../../shared/model";
+import { PropertyValueTooltip } from "../../property-label";
 
 export const MenuControl = ({
   property,
@@ -34,9 +33,7 @@ export const MenuControl = ({
     icon: IconComponent;
   }>;
 }) => {
-  const computedStyleDecl = useStore(
-    useMemo(() => createComputedStyleDeclStore(property), [property])
-  );
+  const computedStyleDecl = useComputedStyleDecl(property);
   const [descriptionValue, setDescriptionValue] = useState<string>();
 
   const setValue = setProperty(property);

--- a/apps/builder/app/builder/features/style-panel/controls/toggle/toggle-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/toggle/toggle-control.tsx
@@ -1,70 +1,64 @@
+import { useMemo } from "react";
+import { useStore } from "@nanostores/react";
 import { ToggleButton } from "@webstudio-is/design-system";
-import { styleConfigByName } from "../../shared/configs";
-import { PropertyTooltip } from "../../shared/property-name";
-import type { ControlProps } from "../types";
-import { getStyleSource } from "../../shared/style-info";
+import { toValue, type StyleProperty } from "@webstudio-is/css-engine";
 import type { IconComponent } from "@webstudio-is/icons";
-import { AdvancedValueTooltip } from "../advanced-value-tooltip";
-import { toKebabCase } from "../../shared/keyword-utils";
-
-type Item = {
-  name: string;
-  label: string;
-  icon: IconComponent;
-};
+import { humanizeString } from "~/shared/string-utils";
+import { setProperty } from "../../shared/use-style-data";
+import { createComputedStyleDeclStore } from "../../shared/model";
+import { PropertyValueTooltip } from "../../property-label";
 
 export const ToggleControl = ({
   property,
-  currentStyle,
-  setProperty,
-  deleteProperty,
   items,
-  isAdvanced,
-}: Omit<ControlProps, "items"> & {
-  items: [Item, Item];
+}: {
+  property: StyleProperty;
+  items: Array<{
+    name: string;
+    label: string;
+    icon: IconComponent;
+  }>;
 }) => {
-  const { label } = styleConfigByName(property);
-  const styleValue = currentStyle[property]?.value;
-
-  if (styleValue?.type !== "keyword") {
-    return;
-  }
+  const computedStyleDecl = useStore(
+    useMemo(() => createComputedStyleDeclStore(property), [property])
+  );
+  const currentValue = toValue(computedStyleDecl.cascadedValue);
+  const currentItem = items.find((item) => item.name === currentValue);
+  const setValue = setProperty(property);
 
   // First item is the pressed state
-  const isPressed = items[0].name === styleValue.value ? true : false;
-  const currentItem = items.find((item) => item.name === styleValue.value);
+  const isPressed = items[0].name === currentValue ? true : false;
   const Icon = currentItem?.icon ?? items[0].icon;
-  isAdvanced = isAdvanced ?? currentItem === undefined;
+  // consider defined (not default) value as advanced
+  // when there is no matching item
+  const isAdvanced =
+    computedStyleDecl.source.name !== "default" && currentItem === undefined;
 
   return (
-    <AdvancedValueTooltip
-      isAdvanced={isAdvanced}
+    <PropertyValueTooltip
+      label={currentItem?.label ?? humanizeString(property)}
       property={property}
-      value={styleValue.value}
-      currentStyle={currentStyle}
-      deleteProperty={deleteProperty}
+      isAdvanced={isAdvanced}
     >
-      <PropertyTooltip
-        title={label}
-        scrollableContent={`${toKebabCase(property)}: ${styleValue.value};`}
-        properties={[property]}
-        style={currentStyle}
-        onReset={() => deleteProperty(property)}
+      <ToggleButton
+        aria-disabled={isAdvanced}
+        variant={computedStyleDecl.source.name}
+        pressed={isPressed}
+        onPressedChange={(isPressed) => {
+          setValue({
+            type: "keyword",
+            value: isPressed ? items[0].name : items[1].name,
+          });
+        }}
+        onPointerDown={(event) => {
+          // tooltip reset property when click with altKey
+          if (event.altKey) {
+            event.preventDefault();
+          }
+        }}
       >
-        <ToggleButton
-          disabled={isAdvanced}
-          pressed={isPressed}
-          onPressedChange={(isPressed) => {
-            setProperty(property)({
-              type: "keyword",
-              value: isPressed ? items[0].name : items[1].name,
-            });
-          }}
-          variant={getStyleSource(currentStyle[property])}
-        >
-          <Icon />
-        </ToggleButton>
-      </PropertyTooltip>
-    </AdvancedValueTooltip>
+        <Icon />
+      </ToggleButton>
+    </PropertyValueTooltip>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/controls/toggle/toggle-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/toggle/toggle-control.tsx
@@ -1,11 +1,9 @@
-import { useMemo } from "react";
-import { useStore } from "@nanostores/react";
 import { ToggleButton } from "@webstudio-is/design-system";
 import { toValue, type StyleProperty } from "@webstudio-is/css-engine";
 import type { IconComponent } from "@webstudio-is/icons";
 import { humanizeString } from "~/shared/string-utils";
 import { setProperty } from "../../shared/use-style-data";
-import { createComputedStyleDeclStore } from "../../shared/model";
+import { useComputedStyleDecl } from "../../shared/model";
 import { PropertyValueTooltip } from "../../property-label";
 
 export const ToggleControl = ({
@@ -19,9 +17,7 @@ export const ToggleControl = ({
     icon: IconComponent;
   }>;
 }) => {
-  const computedStyleDecl = useStore(
-    useMemo(() => createComputedStyleDeclStore(property), [property])
-  );
+  const computedStyleDecl = useComputedStyleDecl(property);
   const currentValue = toValue(computedStyleDecl.cascadedValue);
   const currentItem = items.find((item) => item.name === currentValue);
   const setValue = setProperty(property);

--- a/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
@@ -306,24 +306,6 @@ const FlexGap = ({
   );
 };
 
-const mapNormalTo = (
-  style: StyleInfo,
-  property: StyleProperty,
-  newValue: string
-): StyleInfo => {
-  const styleInfoValue = style[property]?.value;
-  if (styleInfoValue?.type === "keyword" && styleInfoValue.value === "normal") {
-    return {
-      ...style,
-      [property]: {
-        ...style[property],
-        value: { type: "keyword", value: newValue },
-      },
-    };
-  }
-  return style;
-};
-
 const LayoutSectionFlex = ({
   currentStyle,
   setProperty,
@@ -367,9 +349,6 @@ const LayoutSectionFlex = ({
                   icon: ArrowUpIcon,
                 },
               ]}
-              currentStyle={currentStyle}
-              setProperty={setProperty}
-              deleteProperty={deleteProperty}
             />
             <ToggleControl
               property="flexWrap"
@@ -385,9 +364,6 @@ const LayoutSectionFlex = ({
           <Flex css={{ gap: theme.spacing[7] }}>
             <MenuControl
               property="alignItems"
-              currentStyle={mapNormalTo(currentStyle, "alignItems", "stretch")}
-              setProperty={setProperty}
-              deleteProperty={deleteProperty}
               items={[
                 { name: "stretch", label: "Stretch", icon: AIStretchIcon },
                 { name: "baseline", label: "Baseline", icon: AIBaselineIcon },
@@ -398,13 +374,6 @@ const LayoutSectionFlex = ({
             />
             <MenuControl
               property="justifyContent"
-              currentStyle={mapNormalTo(
-                currentStyle,
-                "justifyContent",
-                "start"
-              )}
-              setProperty={setProperty}
-              deleteProperty={deleteProperty}
               items={[
                 {
                   name: "space-between",
@@ -424,13 +393,6 @@ const LayoutSectionFlex = ({
             {showAlignContent && (
               <MenuControl
                 property="alignContent"
-                currentStyle={mapNormalTo(
-                  currentStyle,
-                  "alignContent",
-                  "stretch"
-                )}
-                setProperty={setProperty}
-                deleteProperty={deleteProperty}
                 items={[
                   {
                     name: "space-between",

--- a/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
@@ -308,12 +308,10 @@ const FlexGap = ({
 
 const LayoutSectionFlex = ({
   currentStyle,
-  setProperty,
   deleteProperty,
   createBatchUpdate,
 }: {
   currentStyle: SectionProps["currentStyle"];
-  setProperty: SectionProps["setProperty"];
   deleteProperty: SectionProps["deleteProperty"];
   createBatchUpdate: SectionProps["createBatchUpdate"];
 }) => {
@@ -356,9 +354,6 @@ const LayoutSectionFlex = ({
                 { name: "nowrap", label: "No Wrap", icon: NoWrapIcon },
                 { name: "wrap", label: "Wrap", icon: WrapIcon },
               ]}
-              currentStyle={currentStyle}
-              setProperty={setProperty}
-              deleteProperty={deleteProperty}
             />
           </Flex>
           <Flex css={{ gap: theme.spacing[7] }}>
@@ -496,7 +491,6 @@ export const Section = ({
         {(value === "flex" || value === "inline-flex") && (
           <LayoutSectionFlex
             currentStyle={currentStyle}
-            setProperty={setProperty}
             deleteProperty={deleteProperty}
             createBatchUpdate={createBatchUpdate}
           />

--- a/apps/builder/app/builder/features/style-panel/shared/model.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/model.tsx
@@ -19,6 +19,7 @@ import {
   getPresetStyleDeclKey,
   type StyleObjectModel,
 } from "~/shared/style-object-model";
+import { useMemo } from "react";
 
 const $presetStyles = computed($registeredComponentMetas, (metas) => {
   const presetStyles = new Map<string, StyleValue>();
@@ -122,4 +123,12 @@ export const createComputedStyleDeclStore = (property: string) => {
 
 export const useStyleObjectModel = () => {
   return useStore($model);
+};
+
+export const useComputedStyleDecl = (property: string) => {
+  const $store = useMemo(
+    () => createComputedStyleDeclStore(property),
+    [property]
+  );
+  return useStore($store);
 };

--- a/packages/design-system/src/components/icon-button.tsx
+++ b/packages/design-system/src/components/icon-button.tsx
@@ -11,6 +11,15 @@ const openOrHoverStateStyle = {
   backgroundColor: theme.colors.backgroundHover,
 };
 
+const disabledVariantStyles = {
+  "&:disabled, &[aria-disabled=true]": {
+    color: theme.colors.foregroundDisabled,
+    "&:hover": {
+      backgroundColor: theme.colors.backgroundHover,
+    },
+  },
+};
+
 export const IconButton = styled("button", {
   // reset styles
   boxSizing: "border-box",
@@ -34,9 +43,8 @@ export const IconButton = styled("button", {
     outlineOffset: -2,
   },
 
-  "&:disabled": {
+  "&:disabled, &[aria-disabled=true]": {
     borderColor: "transparent",
-    pointerEvents: "none",
     backgroundColor: "transparent",
   },
 
@@ -57,10 +65,7 @@ export const IconButton = styled("button", {
 
           "&:hover, &[data-hovered=true]": openOrHoverStateStyle,
         },
-
-        "&:disabled": {
-          color: theme.colors.foregroundDisabled,
-        },
+        ...disabledVariantStyles,
       },
 
       preset: {
@@ -70,9 +75,7 @@ export const IconButton = styled("button", {
         "&:hover, &[data-hovered=true]": {
           backgroundColor: theme.colors.backgroundPresetHover,
         },
-        "&:disabled": {
-          color: theme.colors.foregroundDisabled,
-        },
+        ...disabledVariantStyles,
       },
 
       local: {
@@ -82,9 +85,7 @@ export const IconButton = styled("button", {
         "&:hover, &[data-hovered=true]": {
           backgroundColor: theme.colors.backgroundLocalHover,
         },
-        "&:disabled": {
-          color: theme.colors.foregroundDisabled,
-        },
+        ...disabledVariantStyles,
       },
 
       overwritten: {
@@ -94,9 +95,7 @@ export const IconButton = styled("button", {
         "&:hover, &[data-hovered=true]": {
           backgroundColor: theme.colors.backgroundOverwrittenHover,
         },
-        "&:disabled": {
-          color: theme.colors.foregroundDisabled,
-        },
+        ...disabledVariantStyles,
       },
 
       remote: {
@@ -106,9 +105,7 @@ export const IconButton = styled("button", {
         "&:hover, &[data-hovered=true]": {
           backgroundColor: theme.colors.backgroundRemoteHover,
         },
-        "&:disabled": {
-          color: theme.colors.foregroundDisabled,
-        },
+        ...disabledVariantStyles,
       },
     },
     state: {


### PR DESCRIPTION
Here migrated menu control and toggle control from style panel
to new style engine and improve UX a bit.

Instead of disabling button, it gets "disabled" style and tooltip with warning. Though user still can use control to override advanced value in place.

<img width="298" alt="Screenshot 2024-08-28 at 18 37 09" src="https://github.com/user-attachments/assets/c1c083aa-5e6e-4dfe-b136-b18eb8d54383">

<img width="261" alt="image" src="https://github.com/user-attachments/assets/7bf8a7cb-d344-4c4d-8bfb-79813b39526d">

