### PR TITLE
refactor: rename position control to inset control

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/position/inset-control.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/position/inset-control.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from "@storybook/react";
-import { PositionControl } from "./position-control";
+import { InsetControl } from "./inset-control";
 import type {
   CreateBatchUpdate,
   DeleteProperty,
@@ -92,7 +92,7 @@ const bigValue = {
   },
 } as const;
 
-export const PositionControlComponent = () => {
+export const InsetControlComponent = () => {
   const { styleInfo, deleteProperty, createBatchUpdate } = useStyleInfo({
     left: defaultValue,
     right: bigValue,
@@ -102,7 +102,7 @@ export const PositionControlComponent = () => {
 
   return (
     <Box css={{ marginLeft: 100 }}>
-      <PositionControl
+      <InsetControl
         createBatchUpdate={createBatchUpdate}
         currentStyle={styleInfo}
         deleteProperty={deleteProperty}
@@ -112,6 +112,6 @@ export const PositionControlComponent = () => {
 };
 
 export default {
-  title: "Style Panel/Position",
-  component: PositionControlComponent,
-} as Meta<typeof PositionControlComponent>;
+  title: "Style Panel/Inset",
+  component: InsetControlComponent,
+} as Meta<typeof InsetControlComponent>;

--- a/apps/builder/app/builder/features/style-panel/sections/position/inset-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/position/inset-control.tsx
@@ -1,17 +1,17 @@
 import { Grid, theme } from "@webstudio-is/design-system";
-import { PositionLayout, type PositionProperty } from "./position-layout";
-import { movementMapPosition, useKeyboardNavigation } from "../shared/keyboard";
 import { useRef, useState } from "react";
+import { movementMapInset, useKeyboardNavigation } from "../shared/keyboard";
 import type {
   CreateBatchUpdate,
   DeleteProperty,
 } from "../../shared/use-style-data";
 import { getStyleSource, type StyleInfo } from "../../shared/style-info";
-import { getPositionModifiersGroup, useScrub } from "../shared/scrub";
+import { getInsetModifiersGroup, useScrub } from "../shared/scrub";
 import { ValueText } from "../shared/value-text";
 import type { StyleValue } from "@webstudio-is/css-engine";
 import { InputPopover } from "../shared/input-popover";
-import { PositionTooltip } from "./position-tooltip";
+import { InsetLayout, type InsetProperty } from "./inset-layout";
+import { InsetTooltip } from "./inset-tooltip";
 
 const Cell = ({
   scrubStatus,
@@ -26,7 +26,7 @@ const Cell = ({
   onPopoverClose: () => void;
   scrubStatus: ReturnType<typeof useScrub>;
   currentStyle: StyleInfo;
-  property: PositionProperty;
+  property: InsetProperty;
   onHover: (target: HoverTarget | undefined) => void;
   createBatchUpdate: CreateBatchUpdate;
 }) => {
@@ -50,7 +50,7 @@ const Cell = ({
         onClose={onPopoverClose}
         createBatchUpdate={createBatchUpdate}
       />
-      <PositionTooltip
+      <InsetTooltip
         property={property}
         style={currentStyle}
         createBatchUpdate={createBatchUpdate}
@@ -73,27 +73,27 @@ const Cell = ({
           }
           onMouseLeave={() => onHover(undefined)}
         />
-      </PositionTooltip>
+      </InsetTooltip>
     </>
   );
 };
 
 type HoverTarget = {
   element: HTMLElement;
-  property: PositionProperty;
+  property: InsetProperty;
 };
 
-type PositionControlProps = {
+type InsetControlProps = {
   deleteProperty: DeleteProperty;
   createBatchUpdate: CreateBatchUpdate;
   currentStyle: StyleInfo;
 };
 
-export const PositionControl = ({
+export const InsetControl = ({
   createBatchUpdate,
   currentStyle,
   deleteProperty,
-}: PositionControlProps) => {
+}: InsetControlProps) => {
   const [hoverTarget, setHoverTarget] = useState<HoverTarget>();
 
   const scrubStatus = useScrub({
@@ -102,7 +102,7 @@ export const PositionControl = ({
         ? undefined
         : currentStyle[hoverTarget.property]?.value,
     target: hoverTarget,
-    getModifiersGroup: getPositionModifiersGroup,
+    getModifiersGroup: getInsetModifiersGroup,
     onChange: (values, options) => {
       const batch = createBatchUpdate();
       for (const property of ["top", "right", "bottom", "left"] as const) {
@@ -115,13 +115,13 @@ export const PositionControl = ({
     },
   });
 
-  const [openProperty, setOpenProperty] = useState<PositionProperty>();
+  const [openProperty, setOpenProperty] = useState<InsetProperty>();
 
   const layoutRef = useRef<HTMLDivElement>(null);
 
   const keyboardNavigation = useKeyboardNavigation({
     onOpen: setOpenProperty,
-    movementMap: movementMapPosition,
+    movementMap: movementMapInset,
   });
 
   // by deafult highlight hovered or scrubbed properties
@@ -172,7 +172,7 @@ export const PositionControl = ({
         setOpenProperty(property);
       }}
     >
-      <PositionLayout
+      <InsetLayout
         activeProperties={activeProperties}
         renderCell={(property) => (
           <Cell

--- a/apps/builder/app/builder/features/style-panel/sections/position/inset-layout.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/position/inset-layout.stories.tsx
@@ -1,17 +1,17 @@
 import type { Meta } from "@storybook/react";
 import type * as React from "react";
-import { PositionLayout } from "./position-layout";
+import { InsetLayout } from "./inset-layout";
 import { Grid, theme, Text } from "@webstudio-is/design-system";
 
 const Cell = () => (
   <Text variant={"spaceSectionValueText"}>auto{/*1.275&#8203;rem*/}</Text>
 );
 
-export const PositionLayoutComponent = (
-  args: Omit<React.ComponentProps<typeof PositionLayout>, "renderCell">
+export const InsetLayoutComponent = (
+  args: Omit<React.ComponentProps<typeof InsetLayout>, "renderCell">
 ) => (
   <Grid css={{ width: theme.spacing[22], height: theme.spacing[18] }}>
-    <PositionLayout
+    <InsetLayout
       renderCell={() => <Cell />}
       activeProperties={args.activeProperties}
       onHover={(hoverProps) => {
@@ -22,8 +22,8 @@ export const PositionLayoutComponent = (
 );
 
 export default {
-  title: "Style Panel/Position",
-  component: PositionLayoutComponent,
+  title: "Style Panel/Inset",
+  component: InsetLayoutComponent,
 
   argTypes: {
     activeProperties: {
@@ -31,4 +31,4 @@ export default {
       control: { type: "check" },
     },
   },
-} as Meta<typeof PositionLayoutComponent>;
+} as Meta<typeof InsetLayoutComponent>;

--- a/apps/builder/app/builder/features/style-panel/sections/position/inset-layout.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/position/inset-layout.tsx
@@ -34,14 +34,14 @@ const LeftRight = styled(Trapezoid, {
   backgroundColor: theme.colors.backgroundSpacingLeftRight,
 });
 
-export type PositionProperty = "top" | "right" | "bottom" | "left";
+export type InsetProperty = "top" | "right" | "bottom" | "left";
 
-type PositionLayoutProps = {
-  renderCell: (property: PositionProperty) => React.ReactNode;
+type InsetLayoutProps = {
+  renderCell: (property: InsetProperty) => React.ReactNode;
   onHover: (
-    args: { element: HTMLElement; property: PositionProperty } | undefined
+    args: { element: HTMLElement; property: InsetProperty } | undefined
   ) => void;
-  activeProperties: readonly PositionProperty[];
+  activeProperties: readonly InsetProperty[];
 };
 /**
  *  Grid schema for graphical layout
@@ -56,12 +56,12 @@ type PositionLayoutProps = {
  *  ```
  *
  **/
-export const PositionLayout = ({
+export const InsetLayout = ({
   renderCell,
   onHover,
   activeProperties,
-}: PositionLayoutProps) => {
-  const createHandleHover = (property: PositionProperty) => ({
+}: InsetLayoutProps) => {
+  const createHandleHover = (property: InsetProperty) => ({
     onMouseEnter: (e: MouseEvent<HTMLDivElement>) => {
       onHover({
         element: e.currentTarget,

--- a/apps/builder/app/builder/features/style-panel/sections/position/inset-tooltip.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/position/inset-tooltip.tsx
@@ -2,9 +2,9 @@ import { PropertyTooltip } from "../../shared/property-name";
 import type { StyleInfo } from "../../shared/style-info";
 import { useState, type ReactElement } from "react";
 import { useModifierKeys } from "../../shared/modifier-keys";
-import { getPositionModifiersGroup } from "../shared/scrub";
+import { getInsetModifiersGroup } from "../shared/scrub";
 import type { CreateBatchUpdate } from "../../shared/use-style-data";
-import type { PositionProperty } from "./position-layout";
+import type { InsetProperty } from "./inset-layout";
 
 const sides = {
   top: "top",
@@ -14,7 +14,7 @@ const sides = {
 } as const;
 
 const propertyContents: {
-  properties: PositionProperty[];
+  properties: InsetProperty[];
   label: string;
   description: string;
 }[] = [
@@ -52,14 +52,14 @@ const isSameUnorderedArrays = (
   return union.size === arrA.length;
 };
 
-export const PositionTooltip = ({
+export const InsetTooltip = ({
   property,
   style,
   children,
   createBatchUpdate,
   preventOpen,
 }: {
-  property: PositionProperty;
+  property: InsetProperty;
   style: StyleInfo;
   children: ReactElement;
   createBatchUpdate: CreateBatchUpdate;
@@ -69,7 +69,7 @@ export const PositionTooltip = ({
 
   const modifiers = useModifierKeys();
 
-  const properties = [...getPositionModifiersGroup(property, modifiers)];
+  const properties = [...getInsetModifiersGroup(property, modifiers)];
 
   const propertyContent = propertyContents.find((propertyContent) =>
     isSameUnorderedArrays(propertyContent.properties, properties)

--- a/apps/builder/app/builder/features/style-panel/sections/position/position.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/position/position.tsx
@@ -4,7 +4,7 @@ import { CollapsibleSection } from "../../shared/collapsible-section";
 import { Grid, theme } from "@webstudio-is/design-system";
 import { SelectControl, TextControl } from "../../controls";
 import { styleConfigByName } from "../../shared/configs";
-import { PositionControl } from "./position-control";
+import { InsetControl } from "./inset-control";
 import { useParentStyle } from "../../parent-style";
 import { PropertyLabel } from "../../property-label";
 import { propertyDescriptions } from "@webstudio-is/css-data";
@@ -92,7 +92,7 @@ export const Section = ({
 
         {showPositionControls && (
           <Grid gap={3} columns={2}>
-            <PositionControl
+            <InsetControl
               currentStyle={currentStyle}
               deleteProperty={deleteProperty}
               createBatchUpdate={createBatchUpdate}

--- a/apps/builder/app/builder/features/style-panel/sections/shared/input-popover.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/shared/input-popover.tsx
@@ -18,9 +18,9 @@ import type {
   StyleUpdateOptions,
 } from "../../shared/use-style-data";
 import { theme } from "@webstudio-is/design-system";
-import { getPositionModifiersGroup, getSpaceModifiersGroup } from "./scrub";
+import { getInsetModifiersGroup, getSpaceModifiersGroup } from "./scrub";
 import type { SpaceStyleProperty } from "../space/types";
-import type { PositionProperty } from "../position/position-layout";
+import type { InsetProperty } from "../position/inset-layout";
 
 const slideUpAndFade = keyframes({
   "0%": { opacity: 0, transform: "scale(0.8)" },
@@ -40,7 +40,7 @@ const Input = ({
   createBatchUpdate,
 }: {
   styleSource: StyleSource;
-  property: SpaceStyleProperty | PositionProperty;
+  property: SpaceStyleProperty | InsetProperty;
   value: StyleValue;
   onClosePopover: () => void;
   createBatchUpdate: CreateBatchUpdate;
@@ -101,7 +101,7 @@ const Input = ({
         const modifiers = { shiftKey, altKey };
         const properties = isSpace(property)
           ? getSpaceModifiersGroup(property as SpaceStyleProperty, modifiers)
-          : getPositionModifiersGroup(property as PositionProperty, modifiers);
+          : getInsetModifiersGroup(property as InsetProperty, modifiers);
 
         setIntermediateValue(undefined);
 

--- a/apps/builder/app/builder/features/style-panel/sections/shared/keyboard.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/shared/keyboard.ts
@@ -20,7 +20,7 @@ export const movementMapSpace = {
   paddingLeft: ["paddingTop", "paddingTop", "paddingBottom", "marginLeft"],
 } as const;
 
-export const movementMapPosition = {
+export const movementMapInset = {
   top: ["bottom", "right", "bottom", "left"],
   right: ["top", "left", "bottom", "left"],
   bottom: ["top", "right", "top", "left"],

--- a/apps/builder/app/builder/features/style-panel/sections/shared/scrub.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/shared/scrub.tsx
@@ -12,7 +12,7 @@ import { isValidDeclaration } from "@webstudio-is/css-data";
 import { parseIntermediateOrInvalidValue } from "../../shared/css-value-input/parse-intermediate-or-invalid-value";
 import { toValue } from "@webstudio-is/css-engine";
 import type { CssValueInputValue } from "../../shared/css-value-input/css-value-input";
-import type { PositionProperty } from "../position/position-layout";
+import type { InsetProperty } from "../position/inset-layout";
 
 type ScrubStatus<P extends string> = {
   isActive: boolean;
@@ -182,23 +182,23 @@ export const getSpaceModifiersGroup = (
   return groups.find((group) => group.includes(property)) ?? [property];
 };
 
-const opposingPositionGroups = [
+const opposingInsetGroups = [
   ["top", "bottom"],
   ["left", "right"],
 ] as const;
 
-const circlePositionGroups = [["top", "right", "bottom", "left"]] as const;
+const circleInsetGroups = [["top", "right", "bottom", "left"]] as const;
 
-export const getPositionModifiersGroup = (
-  property: PositionProperty,
+export const getInsetModifiersGroup = (
+  property: InsetProperty,
   modifiers: { shiftKey: boolean; altKey: boolean }
 ) => {
-  let groups: ReadonlyArray<ReadonlyArray<PositionProperty>> = [];
+  let groups: ReadonlyArray<ReadonlyArray<InsetProperty>> = [];
 
   if (modifiers.shiftKey) {
-    groups = circlePositionGroups;
+    groups = circleInsetGroups;
   } else if (modifiers.altKey) {
-    groups = opposingPositionGroups;
+    groups = opposingInsetGroups;
   }
 
   return groups.find((group) => group.includes(property)) ?? [property];


### PR DESCRIPTION
We have two position controls which drive me crazy when I try to work with any of them. `inset` is a shorthand for top/right/bottom/left so should be a more straightforward name rather than "position" which we use for background-position and object-position in another control already.