### PR TITLE
experimental: migrate color control to style object model

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/color/color-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/color/color-control.tsx
@@ -1,57 +1,24 @@
-import { useStore } from "@nanostores/react";
-import { useMemo } from "react";
-import { Flex } from "@webstudio-is/design-system";
-import { toValue } from "@webstudio-is/css-engine";
+import type { StyleProperty } from "@webstudio-is/css-engine";
 import { ColorPicker } from "../../shared/color-picker";
 import { styleConfigByName } from "../../shared/configs";
-import type { ControlProps } from "../types";
-import { AdvancedValueTooltip } from "../advanced-value-tooltip";
-import { createComputedStyleDeclStore } from "../../shared/model";
+import { useComputedStyleDecl } from "../../shared/model";
+import { deleteProperty, setProperty } from "../../shared/use-style-data";
 
-export const ColorControl = ({
-  property,
-  items,
-  currentStyle,
-  setProperty,
-  deleteProperty,
-  isAdvanced,
-}: ControlProps) => {
-  const $computedStyleDecl = useMemo(
-    () => createComputedStyleDeclStore(property),
-    [property]
-  );
-  const computedStyleDecl = useStore($computedStyleDecl);
-
-  const { items: defaultItems } = styleConfigByName(property);
-
-  const setValue = setProperty(property);
-
+export const ColorControl = ({ property }: { property: StyleProperty }) => {
+  const computedStyleDecl = useComputedStyleDecl(property);
+  const { items } = styleConfigByName(property);
   const value = computedStyleDecl.cascadedValue;
   const currentColor = computedStyleDecl.usedValue;
-
+  const setValue = setProperty(property);
   return (
-    <Flex align="center" gap="1">
-      <AdvancedValueTooltip
-        isAdvanced={isAdvanced}
-        property={property}
-        value={toValue(currentColor)}
-        currentStyle={currentStyle}
-        deleteProperty={deleteProperty}
-      >
-        <ColorPicker
-          disabled={isAdvanced}
-          currentColor={currentColor}
-          property={property}
-          value={value}
-          keywords={(items ?? defaultItems).map((item) => ({
-            type: "keyword",
-            value: item.name,
-          }))}
-          onChange={(styleValue) => setValue(styleValue, { isEphemeral: true })}
-          onChangeComplete={setValue}
-          onAbort={() => deleteProperty(property, { isEphemeral: true })}
-        />
-      </AdvancedValueTooltip>
-    </Flex>
+    <ColorPicker
+      property={property}
+      value={value}
+      currentColor={currentColor}
+      keywords={items.map((item) => ({ type: "keyword", value: item.name }))}
+      onChange={(styleValue) => setValue(styleValue, { isEphemeral: true })}
+      onChangeComplete={setValue}
+      onAbort={() => deleteProperty(property, { isEphemeral: true })}
+    />
   );
 };

--- a/apps/builder/app/builder/features/style-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/style-panel/property-label.tsx
@@ -400,46 +400,44 @@ export const PropertyValueTooltip = ({
       `${property}:${value}` as keyof typeof declarationDescriptions
     ];
   return (
-    <Flex align="center">
-      <Tooltip
-        open={isOpen}
-        onOpenChange={setIsOpen}
-        // prevent closing tooltip on content click
-        onPointerDown={(event) => event.preventDefault()}
-        triggerProps={{
-          onClick: (event) => {
-            if (event.altKey) {
-              event.preventDefault();
-              resetProperty();
-              return;
-            }
-          },
-        }}
-        content={
-          <PropertyInfo
-            title={label}
-            code={css}
-            description={
-              <Flex gap="2" direction="column">
-                {description}
-                {isAdvanced && (
-                  <Flex gap="1">
-                    <AlertIcon color={rawTheme.colors.backgroundAlertMain} />{" "}
-                    This value was defined in the Advanced section.
-                  </Flex>
-                )}
-              </Flex>
-            }
-            styles={[computedStyleDecl]}
-            onReset={() => {
-              resetProperty();
-              setIsOpen(false);
-            }}
-          />
-        }
-      >
-        {children}
-      </Tooltip>
-    </Flex>
+    <Tooltip
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      // prevent closing tooltip on content click
+      onPointerDown={(event) => event.preventDefault()}
+      triggerProps={{
+        onClick: (event) => {
+          if (event.altKey) {
+            event.preventDefault();
+            resetProperty();
+            return;
+          }
+        },
+      }}
+      content={
+        <PropertyInfo
+          title={label}
+          code={css}
+          description={
+            <Flex gap="2" direction="column">
+              {description}
+              {isAdvanced && (
+                <Flex gap="1">
+                  <AlertIcon color={rawTheme.colors.backgroundAlertMain} /> This
+                  value was defined in the Advanced section.
+                </Flex>
+              )}
+            </Flex>
+          }
+          styles={[computedStyleDecl]}
+          onReset={() => {
+            resetProperty();
+            setIsOpen(false);
+          }}
+        />
+      }
+    >
+      {children}
+    </Tooltip>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -1,6 +1,5 @@
 import { useStore } from "@nanostores/react";
 import type { SectionProps } from "../shared/section";
-import { styleConfigByName } from "../../shared/configs";
 import { FloatingPanel } from "~/builder/shared/floating-panel";
 import {
   CssValueListItem,
@@ -197,8 +196,6 @@ export const Section = (props: SectionProps) => {
     props;
   const layersCount = getLayerCount(currentStyle);
 
-  const { items } = styleConfigByName("backgroundColor");
-
   const sortableItems = useMemo(
     () =>
       Array.from(Array(layersCount), (_, index) => ({
@@ -266,18 +263,11 @@ export const Section = (props: SectionProps) => {
           }}
         >
           <PropertyLabel
-            properties={["backgroundColor"]}
             label="Color"
             description={propertyDescriptions.backgroundColor}
+            properties={["backgroundColor"]}
           />
-
-          <ColorControl
-            property={"backgroundColor"}
-            items={items}
-            currentStyle={currentStyle}
-            setProperty={setProperty}
-            deleteProperty={deleteProperty}
-          />
+          <ColorControl property="backgroundColor" />
         </Grid>
       </Flex>
     </BackgroundsCollapsibleSection>

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-color.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-color.tsx
@@ -1,15 +1,12 @@
-import { type StyleProperty } from "@webstudio-is/css-engine";
+import { toValue, type StyleProperty } from "@webstudio-is/css-engine";
 import { Box, Grid } from "@webstudio-is/design-system";
-import { ColorControl } from "../../controls";
 import { styleConfigByName } from "../../shared/configs";
 import type { SectionProps } from "../shared/section";
-import {
-  deleteAllProperties,
-  setAllProperties,
-  rowCss,
-  isAdvancedValue,
-} from "./utils";
-import { PropertyLabel } from "../../property-label";
+import { rowCss } from "./utils";
+import { PropertyLabel, PropertyValueTooltip } from "../../property-label";
+import { ColorPicker } from "../../shared/color-picker";
+import { useComputedStyleDecl } from "../../shared/model";
+import { createBatchUpdate } from "../../shared/use-style-data";
 
 export const properties = [
   "borderTopColor",
@@ -18,21 +15,29 @@ export const properties = [
   "borderLeftColor",
 ] satisfies [StyleProperty, ...StyleProperty[]];
 
-// We do not use shorthand properties such as borderWidth or borderRadius in our code.
-// However, in the UI, we can display a single field, and in that case, we can use any property
-// from the shorthand property set and pass it instead.
-const borderColorProperty = properties[0];
-
 const { items } = styleConfigByName("borderTopColor");
 
-export const BorderColor = (props: SectionProps) => {
-  const { currentStyle, createBatchUpdate } = props;
-  const deleteColorProperties = deleteAllProperties(
-    properties,
-    createBatchUpdate
+export const BorderColor = (_props: SectionProps) => {
+  const styles = [
+    useComputedStyleDecl("borderTopColor"),
+    useComputedStyleDecl("borderRightColor"),
+    useComputedStyleDecl("borderBottomColor"),
+    useComputedStyleDecl("borderLeftColor"),
+  ];
+  const serialized = styles.map((styleDecl) =>
+    toValue(styleDecl.cascadedValue)
   );
+  const isAdvanced = new Set(serialized).size > 1;
+  // display first set value and reference it in tooltip
+  const local =
+    styles.find(
+      (styleDecl) =>
+        styleDecl.source.name === "local" ||
+        styleDecl.source.name === "overwritten"
+    ) ?? styles[0];
 
-  const setAllproperties = setAllProperties(properties, createBatchUpdate);
+  const value = local.cascadedValue;
+  const currentColor = local.usedValue;
 
   return (
     <Grid css={rowCss}>
@@ -41,17 +46,45 @@ export const BorderColor = (props: SectionProps) => {
         description="Sets the color of the border"
         properties={properties}
       />
-
-      <Box css={{ gridColumn: `span 2` }}>
-        <ColorControl
-          isAdvanced={isAdvancedValue(properties, currentStyle)}
-          property={borderColorProperty}
-          items={items}
-          currentStyle={currentStyle}
-          setProperty={setAllproperties}
-          deleteProperty={deleteColorProperties}
-        />
-      </Box>
+      <PropertyValueTooltip
+        label="Color"
+        property={local.property as StyleProperty}
+        isAdvanced={isAdvanced}
+      >
+        <Box css={{ gridColumn: `span 2` }}>
+          <ColorPicker
+            disabled={isAdvanced}
+            currentColor={currentColor}
+            property={local.property as StyleProperty}
+            value={value}
+            keywords={items.map((item) => ({
+              type: "keyword",
+              value: item.name,
+            }))}
+            onChange={(styleValue) => {
+              const batch = createBatchUpdate();
+              for (const property of properties) {
+                batch.setProperty(property)(styleValue);
+              }
+              batch.publish({ isEphemeral: true });
+            }}
+            onChangeComplete={(styleValue) => {
+              const batch = createBatchUpdate();
+              for (const property of properties) {
+                batch.setProperty(property)(styleValue);
+              }
+              batch.publish();
+            }}
+            onAbort={() => {
+              const batch = createBatchUpdate();
+              for (const property of properties) {
+                batch.deleteProperty(property);
+              }
+              batch.publish({ isEphemeral: true });
+            }}
+          />
+        </Box>
+      </PropertyValueTooltip>
     </Grid>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-color.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-color.tsx
@@ -46,45 +46,47 @@ export const BorderColor = (_props: SectionProps) => {
         description="Sets the color of the border"
         properties={properties}
       />
-      <PropertyValueTooltip
-        label="Color"
-        property={local.property as StyleProperty}
-        isAdvanced={isAdvanced}
-      >
-        <Box css={{ gridColumn: `span 2` }}>
-          <ColorPicker
-            disabled={isAdvanced}
-            currentColor={currentColor}
-            property={local.property as StyleProperty}
-            value={value}
-            keywords={items.map((item) => ({
-              type: "keyword",
-              value: item.name,
-            }))}
-            onChange={(styleValue) => {
-              const batch = createBatchUpdate();
-              for (const property of properties) {
-                batch.setProperty(property)(styleValue);
-              }
-              batch.publish({ isEphemeral: true });
-            }}
-            onChangeComplete={(styleValue) => {
-              const batch = createBatchUpdate();
-              for (const property of properties) {
-                batch.setProperty(property)(styleValue);
-              }
-              batch.publish();
-            }}
-            onAbort={() => {
-              const batch = createBatchUpdate();
-              for (const property of properties) {
-                batch.deleteProperty(property);
-              }
-              batch.publish({ isEphemeral: true });
-            }}
-          />
-        </Box>
-      </PropertyValueTooltip>
+      <Box css={{ gridColumn: `span 2` }}>
+        <PropertyValueTooltip
+          label="Color"
+          property={local.property as StyleProperty}
+          isAdvanced={isAdvanced}
+        >
+          <div>
+            <ColorPicker
+              disabled={isAdvanced}
+              currentColor={currentColor}
+              property={local.property as StyleProperty}
+              value={value}
+              keywords={items.map((item) => ({
+                type: "keyword",
+                value: item.name,
+              }))}
+              onChange={(styleValue) => {
+                const batch = createBatchUpdate();
+                for (const property of properties) {
+                  batch.setProperty(property)(styleValue);
+                }
+                batch.publish({ isEphemeral: true });
+              }}
+              onChangeComplete={(styleValue) => {
+                const batch = createBatchUpdate();
+                for (const property of properties) {
+                  batch.setProperty(property)(styleValue);
+                }
+                batch.publish();
+              }}
+              onAbort={() => {
+                const batch = createBatchUpdate();
+                for (const property of properties) {
+                  batch.deleteProperty(property);
+                }
+                batch.publish({ isEphemeral: true });
+              }}
+            />
+          </div>
+        </PropertyValueTooltip>
+      </Box>
     </Grid>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/sections/outline/outline.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/outline/outline.tsx
@@ -49,18 +49,8 @@ export const Section = (props: SectionProps) => {
                 description={propertyDescriptions.outlineColor}
                 properties={["outlineColor"]}
               />
-
-              <Box
-                css={{
-                  gridColumn: `span 2`,
-                }}
-              >
-                <ColorControl
-                  property="outlineColor"
-                  currentStyle={currentStyle}
-                  setProperty={setProperty}
-                  deleteProperty={deleteProperty}
-                />
+              <Box css={{ gridColumn: `span 2` }}>
+                <ColorControl property="outlineColor" />
               </Box>
             </Grid>
 

--- a/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
@@ -107,12 +107,7 @@ export const TypographySectionFont = (props: SectionProps) => {
         description={propertyDescriptions.color}
         properties={["color"]}
       />
-      <ColorControl
-        property="color"
-        currentStyle={currentStyle}
-        setProperty={setProperty}
-        deleteProperty={deleteProperty}
-      />
+      <ColorControl property="color" />
     </Grid>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -249,7 +249,7 @@ export const ColorPicker = ({
 
   return (
     <CssValueInput
-      disabled={disabled}
+      aria-disabled={disabled}
       styleSource="default"
       prefix={prefix}
       showSuffix={false}

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -298,6 +298,7 @@ type CssValueInputProps = Pick<
   | "text"
   | "autoFocus"
   | "disabled"
+  | "aria-disabled"
   | "fieldSizing"
   | "prefix"
   | "inputRef"
@@ -379,6 +380,7 @@ export const CssValueInput = ({
   onHighlight,
   onAbort,
   disabled,
+  ["aria-disabled"]: ariaDisabled,
   fieldSizing,
   variant,
   size,
@@ -698,6 +700,7 @@ export const CssValueInput = ({
             size={size}
             variant={variant}
             disabled={disabled}
+            aria-disabled={ariaDisabled}
             fieldSizing={fieldSizing}
             {...inputProps}
             onFocus={() => {

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -29,13 +29,13 @@ import { useMemo, useState } from "react";
 import type { IntermediateStyleValue } from "../shared/css-value-input";
 import { CssValueInputContainer } from "../shared/css-value-input";
 import { toPascalCase } from "../shared/keyword-utils";
-import { ColorControl } from "../controls";
 import type {
   DeleteProperty,
-  SetProperty,
   StyleUpdateOptions,
 } from "../shared/use-style-data";
 import { parseCssFragment } from "./parse-css-fragment";
+import { styleConfigByName } from "./configs";
+import { ColorPicker } from "./color-picker";
 
 /*
   When it comes to checking and validating individual CSS properties for the box-shadow,
@@ -153,12 +153,6 @@ export const ShadowContent = ({
       value: toValue(newLayer),
     });
     onEditLayer(index, { type: "layers", value: [newLayer] }, options);
-  };
-
-  const colorControlCallback: SetProperty = () => {
-    return (value, options) => {
-      handlePropertyChange({ color: value }, options);
-    };
   };
 
   return (
@@ -333,18 +327,21 @@ export const ShadowContent = ({
           >
             <Label css={{ width: "fit-content" }}>Color</Label>
           </Tooltip>
-          <ColorControl
+          <ColorPicker
             property="color"
-            currentStyle={{
-              color: {
-                value: colorControlProp,
-                currentColor: colorControlProp,
-              },
-            }}
-            setProperty={colorControlCallback}
-            deleteProperty={() =>
-              handlePropertyChange({ color: colorControlProp })
+            value={colorControlProp}
+            currentColor={colorControlProp}
+            keywords={styleConfigByName("color").items.map((item) => ({
+              type: "keyword",
+              value: item.name,
+            }))}
+            onChange={(styleValue) =>
+              handlePropertyChange({ color: styleValue }, { isEphemeral: true })
             }
+            onChangeComplete={(styleValue) =>
+              handlePropertyChange({ color: styleValue })
+            }
+            onAbort={() => handlePropertyChange({ color: colorControlProp })}
           />
         </Flex>
 

--- a/packages/design-system/src/components/input-field.tsx
+++ b/packages/design-system/src/components/input-field.tsx
@@ -44,12 +44,15 @@ const inputStyle = css({
   height: "100%",
   paddingRight: theme.spacing[2],
   paddingLeft: theme.spacing[3],
-  "&[data-color=placeholder]:not(:hover, :disabled, :focus), &::placeholder": {
-    color: theme.colors.foregroundSubtle,
-  },
+  "&[data-color=placeholder]:not(:hover, :disabled, [aria-disabled=true], :focus), &::placeholder":
+    {
+      color: theme.colors.foregroundSubtle,
+    },
   "&[data-color=error]": { color: theme.colors.foregroundDestructive },
-  "&:disabled, &:disabled::placeholder": {
-    color: theme.colors.foregroundDisabled,
+  "&:disabled, &[aria-disabled=true]": {
+    "&, &::placeholder": {
+      color: theme.colors.foregroundDisabled,
+    },
   },
   '&[type="number"]': {
     MozAppearance: "textfield",
@@ -89,7 +92,7 @@ const containerStyle = css({
     outlineColor: theme.colors.borderDestructiveMain,
   },
 
-  "&:has([data-input-field-input]:disabled)": {
+  "&:has([data-input-field-input]:is(:disabled, [aria-disabled=true]))": {
     backgroundColor: theme.colors.backgroundInputDisabled,
   },
   variants: {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1536 https://github.com/webstudio-is/webstudio/issues/3399

Simplified color control and reimplemented border color and shadow color as separate controls based on new color picker.

Relaxed "advanced" state in border color, so text field only visually look disabled but still accessible.

Test color, border color, border bottom color and box shadow color.