### PR TITLE
chore: fix types generator in time component

### DIFF
--- a/packages/sdk-components-react/src/time.test.ts
+++ b/packages/sdk-components-react/src/time.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@jest/globals";
-import { parseDate } from "./time";
+import { __testing__ } from "./time";
+
+const { parseDate } = __testing__;
 
 test("13-digit Unix timestamp", () => {
   expect(parseDate("1724938577059")).toEqual(

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { forwardRef, type ElementRef } from "react";
 
 const languages = [
   "af",
@@ -281,14 +281,6 @@ type Country = (typeof countries)[number];
 type DateStyle = Intl.DateTimeFormatOptions["dateStyle"] | "none";
 type TimeStyle = Intl.DateTimeFormatOptions["timeStyle"] | "none";
 
-export type TimeProps = {
-  datetime?: string;
-  language?: Language;
-  country?: Country;
-  dateStyle?: DateStyle;
-  timeStyle?: TimeStyle;
-};
-
 const INITIAL_DATE_STRING = "dateTime attribute is not set";
 const INVALID_DATE_STRING = "";
 
@@ -327,7 +319,7 @@ const timeStyleOrUndefined = (
   return undefined;
 };
 
-export const parseDate = (datetimeString: string) => {
+const parseDate = (datetimeString: string) => {
   if (datetimeString === "") {
     return;
   }
@@ -353,7 +345,15 @@ export const parseDate = (datetimeString: string) => {
   }
 };
 
-export const Time = React.forwardRef<React.ElementRef<"time">, TimeProps>(
+type TimeProps = {
+  datetime?: string;
+  language?: Language;
+  country?: Country;
+  dateStyle?: DateStyle;
+  timeStyle?: TimeStyle;
+};
+
+export const Time = forwardRef<ElementRef<"time">, TimeProps>(
   (
     {
       language = DEFAULT_LANGUAGE,
@@ -395,3 +395,7 @@ export const Time = React.forwardRef<React.ElementRef<"time">, TimeProps>(
     );
   }
 );
+
+export const __testing__ = {
+  parseDate,
+};


### PR DESCRIPTION
## Description

Last PR broke the generator because if there are multiple types exported it starts getting a different namespace

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
