### PR TITLE
feat: Hide the label of the instance when mouse is not hovering it

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import { css, keyframes, type Rect } from "@webstudio-is/design-system";
 import { theme } from "@webstudio-is/design-system";
 
@@ -63,7 +63,7 @@ const useDynamicStyle = (rect?: Rect) => {
 };
 
 type OutlineProps = {
-  children?: JSX.Element;
+  children?: ReactNode;
   rect?: Rect;
   variant?: "default" | "collaboration" | "slot";
 };

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
@@ -1,5 +1,6 @@
 import { useStore } from "@nanostores/react";
 import {
+  $hoveredInstanceSelector,
   $instances,
   $selectedInstanceOutlineAndInstance,
   $selectedInstanceSelector,
@@ -16,10 +17,17 @@ import { $ephemeralStyles } from "~/canvas/stores";
 export const SelectedInstanceOutline = () => {
   const instances = useStore($instances);
   const selectedInstanceSelector = useStore($selectedInstanceSelector);
+  const hoveredInstanceSelector = useStore($hoveredInstanceSelector);
   const textEditingInstanceSelector = useStore($textEditingInstanceSelector);
   const outline = useStore($selectedInstanceOutlineAndInstance);
   const scale = useStore($scale);
   const ephemeralStyles = useStore($ephemeralStyles);
+
+  const isHoveringSelectedInstance = areInstanceSelectorsEqual(
+    selectedInstanceSelector,
+    hoveredInstanceSelector
+  );
+
   const isEditingCurrentInstance =
     textEditingInstanceSelector !== undefined &&
     areInstanceSelectorsEqual(
@@ -43,11 +51,13 @@ export const SelectedInstanceOutline = () => {
 
   return (
     <Outline rect={rect} variant={variant}>
-      <Label
-        variant={variant}
-        instance={outline.instance}
-        instanceRect={rect}
-      />
+      {isHoveringSelectedInstance && (
+        <Label
+          variant={variant}
+          instance={outline.instance}
+          instanceRect={rect}
+        />
+      )}
     </Outline>
   );
 };


### PR DESCRIPTION
## Description

When instance is selected the label often gets in the way of seeing the element behind the label, we think its better to only show the label when user is hovering the instance

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
