### PR TITLE
fix: Support new project links in the cli

### DIFF
--- a/.github/actions/vercel/action.yaml
+++ b/.github/actions/vercel/action.yaml
@@ -61,7 +61,7 @@ runs:
             "framework": "remix",
             "devCommand": "pnpm dev",
             "installCommand": "pnpm install",
-            "buildCommand": "pnpm --filter=@webstudio-is/prisma-client build:prod && pnpm --filter=@webstudio-is/builder build",
+            "buildCommand": "pnpm --filter=@webstudio-is/prisma-client build:prod && pnpm --filter=@webstudio-is/http-client build && pnpm --filter=@webstudio-is/builder build",
             "outputDirectory": null,
             "rootDirectory": "apps/builder",
             "directoryListing": false,

--- a/.github/workflows/fixtures-test.yml
+++ b/.github/workflows/fixtures-test.yml
@@ -6,6 +6,9 @@ on:
       builder-url:
         required: true
         type: string
+      builder-host:
+        required: true
+        type: string
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -23,7 +26,8 @@ jobs:
     env:
       DATABASE_URL: postgres://
       AUTH_SECRET: test
-      BUILDER_URL: ${{ inputs.builder-url }}
+      BUILDER_URL_DEPRECATED: ${{ inputs.builder-url }}
+      BUILDER_HOST: ${{ inputs.builder-host }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/vercel-deploy-staging.yml
+++ b/.github/workflows/vercel-deploy-staging.yml
@@ -77,12 +77,14 @@ jobs:
 
     outputs:
       builder-url: "https://${{ steps.vercel.outputs.alias }}.${{ matrix.environment }}.webstudio.is"
+      builder-host: "${{ steps.vercel.outputs.alias }}.${{ matrix.environment }}.webstudio.is"
 
   fixtures-test:
     needs: deployment
     uses: ./.github/workflows/fixtures-test.yml
     with:
       builder-url: ${{ needs.deployment.outputs.builder-url }}
+      builder-host: ${{ needs.deployment.outputs.builder-host }}
 
   delete-github-deployments:
     needs: fixtures-test

--- a/apps/builder/app/routes/_ui.(builder).tsx
+++ b/apps/builder/app/routes/_ui.(builder).tsx
@@ -24,7 +24,7 @@ import env from "~/env/env.server";
 import builderStyles from "~/builder/builder.css?url";
 import prismStyles from "prismjs/themes/prism-solarizedlight.min.css?url";
 import { ClientOnly } from "~/shared/client-only";
-import { parseBuilderUrl } from "~/shared/router-utils/origins";
+import { parseBuilderUrl } from "@webstudio-is/http-client";
 import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import { redirect } from "~/services/no-store-redirect";
 import { builderSessionStorage } from "~/services/builder-session.server";

--- a/apps/builder/app/services/builder-auth.server.ts
+++ b/apps/builder/app/services/builder-auth.server.ts
@@ -9,8 +9,8 @@ import {
 import {
   getAuthorizationServerOrigin,
   getRequestOrigin,
-  parseBuilderUrl,
 } from "~/shared/router-utils/origins";
+import { parseBuilderUrl } from "@webstudio-is/http-client";
 import { createDebug } from "~/shared/debug";
 import { readAccessToken } from "./token.server";
 import { isUserAuthorizedForProject } from "./builder-access.server";

--- a/apps/builder/app/shared/$resources/sitemap.xml.server.ts
+++ b/apps/builder/app/shared/$resources/sitemap.xml.server.ts
@@ -2,7 +2,7 @@ import { json } from "@remix-run/server-runtime";
 import { prisma } from "@webstudio-is/prisma-client";
 import { parsePages } from "@webstudio-is/project-build/index.server";
 import { getStaticSiteMapXml } from "@webstudio-is/sdk";
-import { parseBuilderUrl } from "../router-utils/origins";
+import { parseBuilderUrl } from "@webstudio-is/http-client";
 import { isBuilder } from "../router-utils";
 
 /**

--- a/apps/builder/app/shared/context.server.ts
+++ b/apps/builder/app/shared/context.server.ts
@@ -12,7 +12,7 @@ import { builderAuthenticator } from "~/services/builder-auth.server";
 import { readLoginSessionBloomFilter } from "~/services/session.server";
 import type { BloomFilter } from "~/services/bloom-filter.server";
 import { isBuilder, isCanvas, isDashboard } from "./router-utils";
-import { parseBuilderUrl } from "./router-utils/origins";
+import { parseBuilderUrl } from "@webstudio-is/http-client";
 
 const createAuthorizationContext = async (
   request: Request

--- a/apps/builder/app/shared/router-utils/origins.ts
+++ b/apps/builder/app/shared/router-utils/origins.ts
@@ -1,3 +1,5 @@
+import { parseBuilderUrl } from "@webstudio-is/http-client";
+
 export const getRequestOrigin = (urlStr: string) => {
   const url = new URL(urlStr);
 
@@ -9,49 +11,6 @@ export const isCanvas = (urlStr: string): boolean => {
   const projectId = url.searchParams.get("projectId");
 
   return projectId !== null;
-};
-
-// For easier detecting the builder URL
-const buildProjectDomainPrefix = "p-";
-
-export const parseBuilderUrl = (urlStr: string) => {
-  const url = new URL(urlStr);
-
-  const fragments = url.host.split(".");
-  // Regular expression to match the prefix, UUID, and any optional string after '-dot-'
-  const re =
-    /^(?<prefix>[a-z-]+)(?<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})(-dot-(?<branch>.*))?/;
-  const match = fragments[0].match(re);
-
-  // Extract prefix, projectId (UUID), and branch (if exists)
-  const prefix = match?.groups?.prefix;
-  const projectId = match?.groups?.uuid;
-  const branch = match?.groups?.branch;
-
-  if (prefix !== buildProjectDomainPrefix) {
-    return {
-      projectId: undefined,
-      sourceOrigin: url.origin,
-    };
-  }
-
-  if (projectId === undefined) {
-    return {
-      projectId: undefined,
-      sourceOrigin: url.origin,
-    };
-  }
-
-  fragments[0] = fragments[0].replace(re, branch ?? "");
-
-  const sourceUrl = new URL(url.origin);
-  sourceUrl.protocol = "https";
-  sourceUrl.host = fragments.filter(Boolean).join(".");
-
-  return {
-    projectId,
-    sourceOrigin: sourceUrl.origin,
-  };
 };
 
 export const isBuilderUrl = (urlStr: string): boolean => {

--- a/fixtures/ssg/package.json
+++ b/fixtures/ssg/package.json
@@ -8,7 +8,7 @@
     "dev": "vite dev",
     "typecheck": "tsc",
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
-    "fixtures:link": "pnpm cli link --link ${BUILDER_URL:-https://main.development.webstudio.is}'/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
+    "fixtures:link": "pnpm cli link --link ${BUILDER_URL_DEPRECATED:-https://main.development.webstudio.is}'/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
     "fixtures:sync": "pnpm cli sync --buildId a2e8de30-03d5-4514-a3a6-406b3266a3af && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "rm -rf pages && pnpm cli build --template ssg --template internal --preview && prettier --write ."
   },

--- a/fixtures/webstudio-cloudflare-template/package.json
+++ b/fixtures/webstudio-cloudflare-template/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "scripts": {
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
-    "fixtures:link": "pnpm cli link --link ${BUILDER_URL:-https://main.development.webstudio.is}'/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
+    "fixtures:link": "pnpm cli link --link https://p-d845c167-ea07-4875-b08d-83e97c09dcce-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
     "fixtures:sync": "pnpm cli sync --buildId a2e8de30-03d5-4514-a3a6-406b3266a3af && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "pnpm cli build --template cloudflare --template saas-helpers --template internal --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json",
     "build": "remix vite:build",

--- a/fixtures/webstudio-custom-template/package.json
+++ b/fixtures/webstudio-custom-template/package.json
@@ -5,7 +5,7 @@
     "dev": "remix vite:dev",
     "typecheck": "tsc",
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
-    "fixtures:link": "pnpm cli link --link ${BUILDER_URL:-https://main.development.webstudio.is}'/builder/0d856812-61d8-4014-a20a-82e01c0eb8ee?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f'",
+    "fixtures:link": "pnpm cli link --link https://p-0d856812-61d8-4014-a20a-82e01c0eb8ee-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f'",
     "fixtures:sync": "pnpm cli sync --buildId d48c7c5e-fdd3-4ef6-9173-ff2eaaf851d9 && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "pnpm cli build --template defaults --template ./custom-template --template ./custom-template-stage --template internal --preview --assets false && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },

--- a/fixtures/webstudio-remix-netlify-edge-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/package.json
@@ -6,7 +6,7 @@
     "dev": "remix vite:dev",
     "typecheck": "tsc",
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
-    "fixtures:link": "pnpm cli link --link ${BUILDER_URL:-https://main.development.webstudio.is}'/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
+    "fixtures:link": "pnpm cli link --link https://p-d845c167-ea07-4875-b08d-83e97c09dcce-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
     "fixtures:sync": "pnpm cli sync --buildId a2e8de30-03d5-4514-a3a6-406b3266a3af && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "pnpm cli build --template netlify-edge-functions --template internal --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },

--- a/fixtures/webstudio-remix-netlify-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-functions/package.json
@@ -5,7 +5,7 @@
     "start": "netlify serve",
     "typecheck": "tsc",
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
-    "fixtures:link": "pnpm cli link --link ${BUILDER_URL:-https://main.development.webstudio.is}'/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
+    "fixtures:link": "pnpm cli link --link https://p-d845c167-ea07-4875-b08d-83e97c09dcce-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
     "fixtures:sync": "pnpm cli sync --buildId a2e8de30-03d5-4514-a3a6-406b3266a3af && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "pnpm cli build --template netlify-functions --template internal --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },

--- a/fixtures/webstudio-remix-vercel/package.json
+++ b/fixtures/webstudio-remix-vercel/package.json
@@ -5,7 +5,7 @@
     "dev": "remix vite:dev",
     "typecheck": "tsc",
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
-    "fixtures:link": "pnpm cli link --link ${BUILDER_URL:-https://main.development.webstudio.is}'/builder/cddc1d44-af37-4cb6-a430-d300cf6f932d?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d'",
+    "fixtures:link": "pnpm cli link --link https://p-cddc1d44-af37-4cb6-a430-d300cf6f932d-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d'",
     "fixtures:sync": "pnpm cli sync --buildId 0f80ffe8-7059-4577-8ef3-232f3aded028 && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "pnpm cli build --template vercel --template internal --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },

--- a/packages/http-client/jest.config.js
+++ b/packages/http-client/jest.config.js
@@ -1,0 +1,1 @@
+export { default } from "@webstudio-is/jest-config";

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -26,7 +26,8 @@
     "import": "./lib/index.js"
   },
   "files": [
-    "lib/*"
+    "lib/*",
+    "src/*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -8,12 +8,15 @@
   "scripts": {
     "build": "rm -rf lib && esbuild src/index.ts --outdir=lib --bundle --format=esm --packages=external",
     "dts": "tsc --project tsconfig.dts.json",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "@webstudio-is/sdk": "workspace:*"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@webstudio-is/jest-config": "workspace:*",
     "@webstudio-is/tsconfig": "workspace:*",
     "typescript": "5.5.2"
   },

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -27,7 +27,7 @@
   },
   "files": [
     "lib/*",
-    "src/*"
+    "!*.{test,stories}.*"
   ],
   "license": "AGPL-3.0-or-later",
   "private": false,

--- a/packages/http-client/src/index.test.ts
+++ b/packages/http-client/src/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@jest/globals";
-import { parseBuilderUrl } from "./origins";
+import { parseBuilderUrl } from "./index";
 
 test("parseBuilderUrl wstd.dev", async () => {
   expect(

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -119,3 +119,46 @@ export const getLatestBuildUsingProjectId = async (params: {
   const message = await response.text();
   throw new Error(message.slice(0, 1000));
 };
+
+// For easier detecting the builder URL
+const buildProjectDomainPrefix = "p-";
+
+export const parseBuilderUrl = (urlStr: string) => {
+  const url = new URL(urlStr);
+
+  const fragments = url.host.split(".");
+  // Regular expression to match the prefix, UUID, and any optional string after '-dot-'
+  const re =
+    /^(?<prefix>[a-z-]+)(?<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})(-dot-(?<branch>.*))?/;
+  const match = fragments[0].match(re);
+
+  // Extract prefix, projectId (UUID), and branch (if exists)
+  const prefix = match?.groups?.prefix;
+  const projectId = match?.groups?.uuid;
+  const branch = match?.groups?.branch;
+
+  if (prefix !== buildProjectDomainPrefix) {
+    return {
+      projectId: undefined,
+      sourceOrigin: url.origin,
+    };
+  }
+
+  if (projectId === undefined) {
+    return {
+      projectId: undefined,
+      sourceOrigin: url.origin,
+    };
+  }
+
+  fragments[0] = fragments[0].replace(re, branch ?? "");
+
+  const sourceUrl = new URL(url.origin);
+  sourceUrl.protocol = "https";
+  sourceUrl.host = fragments.filter(Boolean).join(".");
+
+  return {
+    projectId,
+    sourceOrigin: sourceUrl.origin,
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1498,6 +1498,12 @@ importers:
         specifier: workspace:*
         version: link:../sdk
     devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      '@webstudio-is/jest-config':
+        specifier: workspace:*
+        version: link:../jest-config
       '@webstudio-is/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig


### PR DESCRIPTION
## Description

closes #4048

## Steps for reproduction

see fixtures
We are still supporting `BUILDER_URL_DEPRECATED` (in a single fixture) and all other fixtures uses modern link format 


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
