### PR TITLE
feat: Add support for css-transforms in style panel

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transforms.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transforms.tsx
@@ -41,7 +41,6 @@ import { BackfaceVisibility } from "./transform-backface-visibility";
 import { TransformPerspective } from "./transform-perspective";
 import { humanizeString } from "~/shared/string-utils";
 import { getDots } from "../../shared/collapsible-section";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { TransformAndPerspectiveOrigin } from "./transform-and-perspective-origin";
 import { PropertySectionLabel } from "../../property-label";
 import { propertyDescriptions } from "@webstudio-is/css-data";
@@ -76,10 +75,6 @@ export const properties = [
 
 export const Section = (props: SectionProps) => {
   const [isOpen, setIsOpen] = useState(true);
-
-  if (isFeatureEnabled("transforms") === false) {
-    return;
-  }
 
   const { currentStyle } = props;
 

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -7,5 +7,4 @@ export const cms = false;
 export const cssVars = false;
 export const filters = false;
 export const xmlElement = false;
-export const transforms = false;
 export const staticExport = false;


### PR DESCRIPTION
fixes #3411 

## Description

This PR removes the feature flag for css-transforms which makes it available to all the users. So, we might want to test the whole section once.

## Steps for reproduction

- Add `translate`, `rotate`, `skew`, `scale`, `perspective`, `backface-visibility`, `perspective-origin` properties in the style panel.
- When any of these properties are added, the property need to be disabled in the dropdown that comes up when clicked on the `+` button at the top.
- Ability to show/hide the first four (translate, rotate, skew, scale) properties.
- Scale `x` and `y` properties can be updated together or individually using the locked behaviour. 
- Ability to set the `x-offset` and `y-offset` properties for the `transform-origin` property.
- When users adds the `z-offset` property too for `transform-origin` using the advanced tab. It should allow to control it from the UI under the `transform-origin` section. 
- Able to set the `x-position`, `y-position` properties for the `perspective-origin` property.
- Clicking the `Reset` on the `Transforms` section label should reset all the properties that fall under it.
- `perspective` and `transform` origin values can be managed using the position indicator. And it should accept the keyword values like `left`, `top` for the x and y axis. 
- All the property values in the text-controls can be managed using the `keyboard`, `scrub` and `mouse` up and down actions.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)