### PR TITLE
feat: allow deleting style layers even when in hidden state

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transforms.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transforms.tsx
@@ -242,7 +242,6 @@ const TransformSection = (
             <SmallIconButton
               variant="destructive"
               tabIndex={-1}
-              disabled={properties.value.hidden}
               icon={<SubtractIcon />}
               onClick={() =>
                 handleDeleteTransformProperty({

--- a/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
@@ -168,7 +168,6 @@ export const RepeatedStyle = (props: {
                     <SmallIconButton
                       variant="destructive"
                       tabIndex={-1}
-                      disabled={primaryValue.hidden}
                       icon={<SubtractIcon />}
                       onClick={() =>
                         transformLayers((value) => deleteLayer(value, index))

--- a/apps/builder/app/builder/features/style-panel/style-layers-list.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-layers-list.tsx
@@ -198,7 +198,6 @@ export const LayersList = (props: LayerListProps) => {
                     <SmallIconButton
                       variant="destructive"
                       tabIndex={-1}
-                      disabled={layer.hidden}
                       icon={<SubtractIcon />}
                       onClick={() => handleDeleteLayer(index)}
                     />


### PR DESCRIPTION
fixes #3797 

## Description

Allow layers to be deleted even when the layers are in hidden state. This change should reflect for all the following layer based properties.

- transforms
- translate
- filter
- backdrop-filter
- box-shadow
- text-shadow
- backgrounds


## Steps for reproduction
- Add a layer to any of the following layer based proeprties.
- Hide a layer in the list
- Now, delete the layer that is hidden

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review


## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)