### PR TITLE
chore: Add  postMessage token to secure against Canvas script execution

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -57,6 +57,7 @@ import { initBuilderApi } from "~/shared/builder-api";
 import { updateWebstudioData } from "~/shared/instance-utils";
 import { migrateWebstudioDataMutable } from "~/shared/webstudio-data-migrator";
 import { Loading, LoadingBackground } from "./shared/loading";
+import { mergeRefs } from "@react-aria/utils";
 
 registerContainers();
 
@@ -288,13 +289,20 @@ export const Builder = ({
   // because the events will fire in either one, depending on where the focus is
   useCopyPaste();
   useSetWindowTitle();
-  const iframeRefCallback = useCallback(
+
+  const iframeRefCallback = mergeRefs((element: HTMLIFrameElement | null) => {
+    onRefReadCanvas(element);
+  }, publishRef);
+
+  /*
+  useCallback(
     (element: HTMLIFrameElement) => {
-      publishRef.current = element;
+
       onRefReadCanvas(element);
     },
     [publishRef, onRefReadCanvas]
   );
+  */
 
   const { navigatorLayout } = useStore($settings);
   const dataLoadingState = useStore($dataLoadingState);

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -294,16 +294,6 @@ export const Builder = ({
     onRefReadCanvas(element);
   }, publishRef);
 
-  /*
-  useCallback(
-    (element: HTMLIFrameElement) => {
-
-      onRefReadCanvas(element);
-    },
-    [publishRef, onRefReadCanvas]
-  );
-  */
-
   const { navigatorLayout } = useStore($settings);
   const dataLoadingState = useStore($dataLoadingState);
   const [loadingState, setLoadingState] = useState(() => $loadingState.get());

--- a/apps/builder/app/shared/pubsub/create.ts
+++ b/apps/builder/app/shared/pubsub/create.ts
@@ -1,6 +1,21 @@
 import { createNanoEvents } from "nanoevents";
 import { useCallback, useEffect, useRef } from "react";
 import { batchUpdate } from "./raf-queue";
+import { useEffectEvent } from "../hook-utils/effect-event";
+import invariant from "tiny-invariant";
+
+const apiTokenKey = "__webstudio__$__api_token";
+declare global {
+  interface Window {
+    [apiTokenKey]: string | undefined;
+  }
+}
+
+const getRandomToken = () => {
+  const randomBytes = new Uint8Array(10);
+  window.crypto.getRandomValues(randomBytes);
+  return btoa(String.fromCharCode(...randomBytes));
+};
 
 export const createPubsub = <PublishMap>() => {
   type Action<Type extends keyof PublishMap> =
@@ -8,51 +23,138 @@ export const createPubsub = <PublishMap>() => {
       ? { type: Type; payload?: undefined }
       : { type: Type; payload: PublishMap[Type] };
 
+  if (typeof window === "undefined") {
+    return {
+      publish: () => {
+        throw new Error("publish is not available in this environment");
+      },
+      usePublish: () => {
+        throw new Error("usePublish is not available in this environment");
+      },
+      useSubscribe: () => {
+        throw new Error("useSubscribe is not available in this environment");
+      },
+      subscribe: () => {
+        throw new Error("subscribe is not available in this environment");
+      },
+    } as never; // Prevent type exposure
+  }
+
+  /**
+   * To avoid postMessage interception from the canvas, i.e., `globalThis.postMessage = () => console.log('INTERCEPTED');`,
+   */
+  const postMessageInternal = window.postMessage;
+  const parentPostMessageInternal = window.parent.postMessage;
+
+  /**
+   * Similar to a CSRF token, we use a token to ensure that the postMessage is coming from a trusted source.
+   */
+  let token =
+    window.self === window.top ? getRandomToken() : window.top?.[apiTokenKey];
+
+  if (window.top) {
+    // Initialize token at the Builder, reset it on the Canvas after reading
+    window.top[apiTokenKey] = window.self === window.top ? token : undefined;
+  }
+
+  // Use a fixed token in development to handle HMR updates consistently
+  if (process.env.NODE_ENV !== "production") {
+    token = "development-token";
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const emitter = createNanoEvents<Record<any, any>>();
 
-  if (typeof window === "object") {
-    window.addEventListener(
-      "message",
-      (event: MessageEvent) => {
-        // @todo this has no type safety built in, could be anything from any source.
-        // we could potentially maintain a list of valid event types at runtime
-        // at the very least we could add a brand property or something to our events
-        if (typeof event.data?.type === "string") {
-          // Execute all updates within a single batch to improve performance
-          batchUpdate(() => emitter.emit(event.data.type, event.data.payload));
-        }
-      },
-      false
-    );
-  }
+  const wrapAction = (action: unknown) => {
+    return { action, token };
+  };
+
+  const unwrapAction = (payload: unknown) => {
+    if (typeof payload !== "object" || payload === null) {
+      console.error("Invalid payload", payload);
+      throw new Error("Invalid payload");
+    }
+
+    if (false === "token" in payload) {
+      throw new Error("Invalid payload, not wrapped");
+    }
+
+    if (payload.token !== token) {
+      throw new Error("Invalid token");
+    }
+
+    if (false === "action" in payload) {
+      throw new Error("Invalid payload, not wrapped");
+    }
+
+    return payload.action as Action<keyof PublishMap>;
+  };
+
+  window.addEventListener(
+    "message",
+    (event: MessageEvent) => {
+      const action = unwrapAction(event.data);
+      const type = action.type;
+
+      // Execute all updates within a single batch to improve performance
+      batchUpdate(() => emitter.emit(type, action.payload));
+    },
+    false
+  );
 
   return {
     /**
      * To publish a postMessage event on the current window and parent window from the iframe.
      */
     publish<Type extends keyof PublishMap>(action: Action<Type>) {
-      window.parent.postMessage(action, "*");
-      window.postMessage(action, "*");
+      invariant(
+        window.self !== window.top,
+        "publish is not available in the Builder environment"
+      );
+
+      parentPostMessageInternal(wrapAction(action), "*");
+      postMessageInternal(wrapAction(action), "*");
     },
 
     /**
      * To publish a postMessage event on the iframe and parent window from the parent window.
      */
     usePublish() {
-      const iframeRef = useRef<HTMLIFrameElement | null>(null);
-      const publishCallback = useCallback(
-        <Type extends keyof PublishMap>(action: Action<Type>) => {
-          const element = iframeRef.current;
-          if (element?.contentWindow == null) {
+      const postMessageRef = useRef<typeof window.postMessage>();
+
+      const iframeRefCallback = useCallback(
+        (element: HTMLIFrameElement | null) => {
+          if (element == null) {
+            postMessageRef.current = undefined;
             return;
           }
-          element.contentWindow.postMessage(action, "*");
-          window.postMessage(action, "*");
+          /**
+           * To avoid postMessage interception from the canvas, i.e., `globalThis.postMessage = () => console.log('INTERCEPTED');`,
+           */
+          postMessageRef.current = element.contentWindow!.postMessage;
         },
-        [iframeRef]
+        []
       );
-      return [publishCallback, iframeRef] as const;
+
+      const publish = useCallback(
+        <Type extends keyof PublishMap>(action: Action<Type>) => {
+          invariant(
+            window.self === window.top,
+            "publish is not available in the Canvas environment"
+          );
+
+          if (postMessageRef.current === undefined) {
+            return;
+          }
+          // This ensures the method is called with the correct context.
+          const postMessageIframe = postMessageRef.current;
+
+          postMessageIframe(wrapAction(action), "*");
+          postMessageInternal(wrapAction(action), "*");
+        },
+        []
+      );
+      return [publish, iframeRefCallback] as const;
     },
 
     /**
@@ -62,9 +164,11 @@ export const createPubsub = <PublishMap>() => {
       type: Type,
       onAction: (payload: PublishMap[Type]) => void
     ) {
+      const handleOnAction = useEffectEvent(onAction);
+
       useEffect(() => {
-        return emitter.on(type, onAction);
-      }, [type, onAction]);
+        return emitter.on(type, handleOnAction);
+      }, [type, handleOnAction]);
     },
 
     subscribe<Type extends keyof PublishMap>(

--- a/apps/builder/app/shared/pubsub/create.ts
+++ b/apps/builder/app/shared/pubsub/create.ts
@@ -89,7 +89,7 @@ export const createPubsub = <PublishMap>() => {
     }
 
     // Hide the token from the subsequent subscribers
-    payload.token = "";
+    payload.token = undefined;
     return payload.action as Action<keyof PublishMap>;
   };
 


### PR DESCRIPTION
## Description

https://github.com/webstudio-is/webstudio-saas/issues/317#issuecomment-2317121292

See postMessage

Doesn't work as can be intercepted using `addEventListener`.

## Steps for reproduction

In chrome dev console in window and canvas context 

```js
globalThis.postMessage = (...args) => console.log(...args); // no messages
```

```js
globalThis.postMessage({
    "action": {
        "type": "sendStoreData",
        "payload": {
            "source": "builder",
            "data": [
                {
                    "namespace": "hoveredInstanceSelector",
                    "value": [
                        "w2emY6HYI160BmYG9WA6C",
                        "_BKGofOEhOFV_zLiN0iZk"
                    ]
                }
            ]
        }
    },
    "token": "development-token-2"
}, '*'); // Error in console "Invalid token"
```

```js
window["__webstudio__$__api_token"] // is undefined
```


```js
window.addEventListener(
    "message",
    e=>console.log({...e.data}), {capture: true}); // token prop is undefined
```

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
