### PR TITLE
experimental: migrate borders section to style object model

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-radius.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-radius.tsx
@@ -6,7 +6,6 @@ import {
   BorderRadiusTopRightIcon,
   BorderRadiusBottomLeftIcon,
 } from "@webstudio-is/icons";
-import type { SectionProps } from "../shared/section";
 import { BorderProperty } from "./border-property";
 
 export const properties = [
@@ -31,18 +30,9 @@ const borderPropertyOptions = {
   },
 } as const satisfies Partial<{ [property in StyleProperty]: unknown }>;
 
-export const BorderRadius = (
-  props: Pick<
-    SectionProps,
-    "currentStyle" | "setProperty" | "deleteProperty" | "createBatchUpdate"
-  >
-) => {
+export const BorderRadius = () => {
   return (
     <BorderProperty
-      currentStyle={props.currentStyle}
-      setProperty={props.setProperty}
-      deleteProperty={props.deleteProperty}
-      createBatchUpdate={props.createBatchUpdate}
       label="Radius"
       description="Sets the radius of border"
       borderPropertyOptions={borderPropertyOptions}

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-width.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-width.tsx
@@ -6,8 +6,6 @@ import {
   BorderWidthBottomIcon,
   BorderWidthLeftIcon,
 } from "@webstudio-is/icons";
-
-import type { SectionProps } from "../shared/section";
 import { BorderProperty } from "./border-property";
 
 export const properties = [
@@ -32,18 +30,9 @@ const borderPropertyOptions = {
   },
 } as const satisfies Partial<{ [property in StyleProperty]: unknown }>;
 
-export const BorderWidth = (
-  props: Pick<
-    SectionProps,
-    "currentStyle" | "setProperty" | "deleteProperty" | "createBatchUpdate"
-  >
-) => {
+export const BorderWidth = () => {
   return (
     <BorderProperty
-      currentStyle={props.currentStyle}
-      setProperty={props.setProperty}
-      deleteProperty={props.deleteProperty}
-      createBatchUpdate={props.createBatchUpdate}
       label="Width"
       description="Sets the width of the border"
       borderPropertyOptions={borderPropertyOptions}

--- a/apps/builder/app/builder/features/style-panel/sections/borders/borders.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/borders.stories.tsx
@@ -1,19 +1,5 @@
 import { styled, theme } from "@webstudio-is/design-system";
-import { useRef, useState } from "react";
-import type { StyleInfo } from "../../shared/style-info";
-import type {
-  CreateBatchUpdate,
-  DeleteProperty,
-  SetProperty,
-} from "../../shared/use-style-data";
 import { Section } from "./borders";
-
-const styleInfoInitial: StyleInfo = {
-  borderTopColor: {
-    local: { type: "rgb", r: 0, g: 0, b: 0, alpha: 1 },
-    value: { type: "rgb", r: 0, g: 0, b: 0, alpha: 1 },
-  },
-};
 
 const Panel = styled("div", {
   width: theme.spacing[30],
@@ -21,69 +7,9 @@ const Panel = styled("div", {
 });
 
 export const Borders = () => {
-  const [styleInfo, setStyleInfo] = useState(() => styleInfoInitial);
-
-  const setProperty: SetProperty = (name) => (value, options) => {
-    if (options?.isEphemeral) {
-      return;
-    }
-
-    setStyleInfo((styleInfo) => ({
-      ...styleInfo,
-      [name]: {
-        ...styleInfo[name],
-        value: value,
-        local: value,
-      },
-    }));
-  };
-
-  const deleteProperty: DeleteProperty = (name, options) => {
-    if (options?.isEphemeral) {
-      return;
-    }
-
-    setStyleInfo((styleInfo) => {
-      const { [name]: _, ...rest } = styleInfo;
-      return rest;
-    });
-  };
-
-  const execCommands = useRef<(() => void)[]>([]);
-
-  const createBatchUpdate: CreateBatchUpdate = () => ({
-    deleteProperty: (property) => {
-      execCommands.current.push(() => {
-        deleteProperty(property);
-      });
-    },
-    setProperty: (property) => (style) => {
-      execCommands.current.push(() => {
-        setProperty(property)(style);
-      });
-    },
-    publish: (options) => {
-      if (options?.isEphemeral) {
-        execCommands.current = [];
-        return;
-      }
-
-      for (const command of execCommands.current) {
-        command();
-      }
-
-      execCommands.current = [];
-    },
-  });
-
   return (
     <Panel>
-      <Section
-        currentStyle={styleInfo}
-        setProperty={setProperty}
-        deleteProperty={deleteProperty}
-        createBatchUpdate={createBatchUpdate}
-      />
+      <Section />
     </Panel>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/sections/borders/borders.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/borders.tsx
@@ -1,6 +1,5 @@
 import { Flex } from "@webstudio-is/design-system";
 import type { StyleProperty } from "@webstudio-is/css-engine";
-import type { SectionProps } from "../shared/section";
 import { StyleSection } from "../../shared/style-section";
 import {
   BorderRadius,
@@ -26,14 +25,14 @@ export const properties = [
   ...borderWidthProperties,
 ] satisfies Array<StyleProperty>;
 
-export const Section = (props: SectionProps) => {
+export const Section = () => {
   return (
     <StyleSection label="Borders" properties={properties}>
       <Flex direction="column" gap={2}>
         <BorderStyle />
         <BorderColor />
-        <BorderWidth {...props} />
-        <BorderRadius {...props} />
+        <BorderWidth />
+        <BorderRadius />
       </Flex>
     </StyleSection>
   );

--- a/apps/builder/app/builder/features/style-panel/sections/borders/utils.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/utils.ts
@@ -1,36 +1,4 @@
 import { theme, type CSS } from "@webstudio-is/design-system";
-import type { StyleProperty } from "@webstudio-is/css-engine";
-import type {
-  CreateBatchUpdate,
-  DeleteProperty,
-  SetProperty,
-} from "../../shared/use-style-data";
-
-export const deleteAllProperties: (
-  styleProperties: readonly StyleProperty[],
-  createBatchUpdate: CreateBatchUpdate
-) => DeleteProperty =
-  (styleProperties, createBatchUpdate) => (_propertyName, options) => {
-    const batch = createBatchUpdate();
-    for (const property of styleProperties) {
-      batch.deleteProperty(property);
-    }
-    batch.publish(options);
-  };
-
-export const setAllProperties: (
-  styleProperties: readonly StyleProperty[],
-  createBatchUpdate: CreateBatchUpdate
-) => SetProperty =
-  (styleProperties, createBatchUpdate) =>
-  (_propertyName) =>
-  (value, options) => {
-    const batch = createBatchUpdate();
-    for (const property of styleProperties) {
-      batch.setProperty(property)(value);
-    }
-    batch.publish(options);
-  };
 
 export const rowCss: CSS = {
   // Our aim is to maintain consistent styling throughout the property and align


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1536 https://github.com/webstudio-is/webstudio/issues/3399

Fixes https://discord.com/channels/955905230107738152/1281501486580502568/1281501486580502568

Refactored borders section with new style engine. And fixed the issue with default border radius in shorthand input.

<img width="257" alt="Screenshot 2024-09-06 at 17 29 12" src="https://github.com/user-attachments/assets/bf0df9ff-d8ed-413c-a260-3aa1d6ce1678">
