### PR TITLE
fix: fix comma parsing in style value and support comma in numbers with math expressions

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
@@ -145,6 +145,20 @@ describe("Parse intermediate or invalid value without math evaluation", () => {
       unit: "rem",
     });
   });
+
+  test("tolerate comma instead of dot typo while correctly parsing legit comma inside value", () => {
+    const result = parseIntermediateOrInvalidValue("transitionDuration", {
+      type: "intermediate",
+      value: "1s, 2s",
+    });
+    expect(result).toEqual({
+      type: "layers",
+      value: [
+        { type: "unit", unit: "s", value: 1 },
+        { type: "unit", unit: "s", value: 2 },
+      ],
+    });
+  });
 });
 
 describe("Parse intermediate or invalid value with math evaluation", () => {
@@ -174,6 +188,36 @@ describe("Parse intermediate or invalid value with math evaluation", () => {
       expect(result).toEqual({
         type: "unit",
         value: 20,
+        unit: "px",
+      });
+    }
+  });
+
+  test("tolerate comma instead of dot", () => {
+    for (const propery of properties) {
+      const result = parseIntermediateOrInvalidValue(propery, {
+        type: "intermediate",
+        value: "1,1 + 1,2",
+      });
+
+      expect(result).toEqual({
+        type: "unit",
+        value: 2.3,
+        unit: "px",
+      });
+    }
+  });
+
+  test("tolerate comma instead of dot with unit", () => {
+    for (const propery of properties) {
+      const result = parseIntermediateOrInvalidValue(propery, {
+        type: "intermediate",
+        value: "1,1px + 1,2rem",
+      });
+
+      expect(result).toEqual({
+        type: "unit",
+        value: 2.3,
         unit: "px",
       });
     }


### PR DESCRIPTION
## Description

Fixes a number of style panel value parsing errors:
- `transition-duration: 1s, 2s;`
- `width: 1.5px + 1.5rem`



## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
