### PR TITLE
fix: Image upload via share link

### DIFF
--- a/apps/builder/app/builder/shared/assets/use-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/use-assets.tsx
@@ -171,9 +171,15 @@ const uploadAsset = async ({
     // should be removed after fix
     metaFormData.append("filename", sanitizeS3Key(fileName));
 
-    const metaResponse = await fetch(restAssetsPath({ authToken }), {
+    const authHeaders = new Headers();
+    if (authToken !== undefined) {
+      authHeaders.set("x-auth-token", authToken);
+    }
+
+    const metaResponse = await fetch(restAssetsPath(), {
       method: "POST",
       body: metaFormData,
+      headers: authHeaders,
     });
 
     const metaData: { name: string } | { errors: string } =
@@ -188,7 +194,7 @@ const uploadAsset = async ({
         ? fileOrUrl
         : JSON.stringify({ url: fileOrUrl.href });
 
-    const headers = new Headers();
+    const headers = new Headers(authHeaders);
 
     if (fileOrUrl instanceof URL) {
       headers.set("Content-Type", "application/json");

--- a/apps/builder/app/builder/shared/sync/sync-server.ts
+++ b/apps/builder/app/builder/shared/sync/sync-server.ts
@@ -157,19 +157,21 @@ const syncServer = async function () {
     for await (const _ of retry()) {
       // in case of any error continue retrying
       try {
-        const response = await fetch(
-          restPatchPath({ authToken: details.authToken }),
-          {
-            method: "post",
-            body: JSON.stringify({
-              transactions,
-              buildId: details.buildId,
-              projectId,
-              // provide latest stored version to server
-              version: details.version,
-            }),
-          }
-        );
+        const headers = new Headers();
+        if (details.authToken) {
+          headers.append("x-auth-token", details.authToken);
+        }
+        const response = await fetch(restPatchPath(), {
+          method: "post",
+          body: JSON.stringify({
+            transactions,
+            buildId: details.buildId,
+            projectId,
+            // provide latest stored version to server
+            version: details.version,
+            headers,
+          }),
+        });
 
         if (response.ok) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/builder/app/shared/builder-data.ts
+++ b/apps/builder/app/shared/builder-data.ts
@@ -66,12 +66,9 @@ export const loadBuilderData = async ({
   signal: AbortSignal;
 }) => {
   const currentUrl = new URL(location.href);
-  const authToken = currentUrl.searchParams.get("authToken");
   const url = new URL(`/rest/data/${projectId}`, currentUrl.origin);
-  if (authToken) {
-    url.searchParams.set("authToken", authToken);
-  }
-  const response = await fetch(url, { signal });
+  const headers = new Headers();
+  const response = await fetch(url, { headers, signal });
 
   if (response.ok) {
     const data: Awaited<ReturnType<typeof loader>> = await response.json();

--- a/apps/builder/app/shared/fetch.client.ts
+++ b/apps/builder/app/shared/fetch.client.ts
@@ -1,5 +1,6 @@
 import { toast } from "@webstudio-is/design-system";
 import { csrfToken } from "./csrf.client";
+import { $authToken } from "./nano-states";
 
 /**
  * To avoid fetch interception from the canvas, i.e., `globalThis.fetch = () => console.log('INTERCEPTED');`,
@@ -19,6 +20,14 @@ export const fetch: typeof globalThis.fetch = (requestInfo, requestInit) => {
   const headers = new Headers(requestInit?.headers);
 
   headers.set("X-CSRF-Token", csrfToken);
+
+  const authToken = $authToken.get();
+
+  // Do not override the existing x-auth-token header.
+  // As some mutations are queue based and they need to be authenticated with the same token as in the queue.
+  if (authToken !== undefined && headers.get("x-auth-token") === null) {
+    headers.set("x-auth-token", authToken);
+  }
 
   const modifiedInit: RequestInit = {
     ...requestInit,

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -32,7 +32,6 @@ import {
   $uploadingFilesDataStore,
   $memoryProps,
   $isPreviewMode,
-  $authToken,
 } from "./misc";
 import { $selectedPage, $pages } from "./pages";
 import type { InstanceSelector } from "../tree-utils";
@@ -643,15 +642,9 @@ export const $areResourcesLoading = computed(
 
 const loadResources = async (resourceRequests: ResourceRequest[]) => {
   $resourcesLoadingCount.set($resourcesLoadingCount.get() + 1);
-  const authToken = $authToken.get();
-  const headers = new Headers();
-  if (authToken !== undefined) {
-    headers.set("x-auth-token", authToken);
-  }
   const response = await fetch(restResourcesLoader(), {
     method: "POST",
     body: JSON.stringify(resourceRequests),
-    headers,
   });
   $resourcesLoadingCount.set($resourcesLoadingCount.get() - 1);
   if (response.ok === false) {

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -1,5 +1,4 @@
 import type { AUTH_PROVIDERS } from "~/shared/session";
-import { $authToken } from "../nano-states";
 import { publicStaticEnv } from "~/env/env.static";
 import { getAuthorizationServerOrigin } from "./origins";
 
@@ -86,32 +85,6 @@ export const cloneProjectUrl = (props: {
   return `${authServerOrigin}/dashboard?${searchParams.toString()}`;
 };
 
-export const builderDomainsPath = (method: string) => {
-  const authToken = $authToken.get();
-  const urlSearchParams = new URLSearchParams();
-  if (authToken !== undefined) {
-    urlSearchParams.set("authToken", authToken);
-  }
-  const urlSearchParamsString = urlSearchParams.toString();
-
-  return `/builder/domains/${method}${
-    urlSearchParamsString ? `?${urlSearchParamsString}` : ""
-  }`;
-};
-
-export const projectsPath = (
-  method: string,
-  { authToken }: { authToken?: string } = {}
-) => {
-  const path = `/rest/projects/${method}`;
-  if (authToken === undefined) {
-    return path;
-  }
-  const urlSearchParams = new URLSearchParams();
-  urlSearchParams.set("authToken", authToken);
-  return path + `?${urlSearchParams.toString()}`;
-};
-
 export const loginPath = (params: {
   error?: (typeof AUTH_PROVIDERS)[keyof typeof AUTH_PROVIDERS];
   message?: string;
@@ -139,27 +112,16 @@ export const authPath = ({
   provider: "google" | "github" | "dev";
 }) => `/auth/${provider}`;
 
-export const restAssetsPath = ({ authToken }: { authToken?: string }) => {
-  const urlSearchParams = new URLSearchParams();
-  if (authToken !== undefined) {
-    urlSearchParams.set("authToken", authToken);
-  }
-  const urlSearchParamsString = urlSearchParams.toString();
-
-  return `/rest/assets${
-    urlSearchParamsString ? `?${urlSearchParamsString}` : ""
-  }`;
+export const restAssetsPath = () => {
+  return `/rest/assets`;
 };
 
 export const restAssetsUploadPath = ({ name }: { name: string }) => {
   return `/rest/assets/${name}`;
 };
 
-export const restPatchPath = (props: { authToken?: string }) => {
+export const restPatchPath = () => {
   const urlSearchParams = new URLSearchParams();
-  if (props.authToken !== undefined) {
-    urlSearchParams.set("authToken", props.authToken);
-  }
 
   urlSearchParams.set("client-version", publicStaticEnv.VERSION);
 

--- a/apps/builder/app/shared/trpc/trpc-client.ts
+++ b/apps/builder/app/shared/trpc/trpc-client.ts
@@ -9,7 +9,6 @@ import type {
 } from "@trpc/server";
 import { createRecursiveProxy } from "@trpc/server/shared";
 import { useMemo, useState } from "react";
-import { $authToken } from "../nano-states";
 import { fetch } from "~/shared/fetch.client";
 
 export const nativeClient = createTRPCProxyClient<AppRouter>({
@@ -17,18 +16,6 @@ export const nativeClient = createTRPCProxyClient<AppRouter>({
     httpBatchLink({
       fetch,
       url: "/trpc",
-      // You can pass any HTTP headers you wish here
-      async headers(_opts) {
-        const authToken = $authToken.get();
-
-        if (authToken == null) {
-          return {};
-        }
-        // Pass token to api call
-        return {
-          "x-auth-token": authToken,
-        };
-      },
     }),
   ],
 });


### PR DESCRIPTION
## Description

Use authToken token implicitly. Except queue cases like image upload and patches.

## Steps for reproduction

Open any project with build or admin share link, upload image.
https://p-a82eaa2b-698e-4d3f-aa46-d4f3eee05fe0-dot-img-fix.development.webstudio.is/?authToken=a74ddf79-2638-47af-9dd1-e62f78187a8d&mode=edit

<img width="1025" alt="image" src="https://github.com/user-attachments/assets/1de48271-f8c3-4df8-aa51-e61d74eb5c32">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
