### PR TITLE
experimental: migrate transitions to style object model

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -1,9 +1,11 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
+import { computed } from "nanostores";
+import { useStore } from "@nanostores/react";
+import { matchSorter } from "match-sorter";
 import {
   animatableProperties,
   commonTransitionProperties,
   isAnimatableProperty,
-  propertyDescriptions,
 } from "@webstudio-is/css-data";
 import {
   InputField,
@@ -19,45 +21,72 @@ import {
   ComboboxScrollArea,
 } from "@webstudio-is/design-system";
 import {
+  hyphenateProperty,
   toValue,
   type KeywordValue,
   type StyleValue,
   type UnparsedValue,
 } from "@webstudio-is/css-engine";
-import { matchSorter } from "match-sorter";
 import { setUnion } from "~/shared/shim";
-import { type StyleInfo } from "../../shared/style-info";
-import { getAnimatablePropertiesOnInstance } from "./transition-utils";
-import { PropertyInlineLabel } from "../../property-label";
+import {
+  $selectedInstanceSelector,
+  $selectedOrLastStyleSourceSelector,
+} from "~/shared/nano-states";
+import { getComputedStyleDecl } from "~/shared/style-object-model";
+import { $definedProperties, $model } from "../../shared/model";
 
 type AnimatableProperties = (typeof animatableProperties)[number];
 type NameAndLabel = { name: string; label?: string };
 type TransitionPropertyProps = {
-  property: StyleValue;
-  currentStyle: StyleInfo;
-  onPropertySelection: (params: {
-    property: KeywordValue | UnparsedValue;
-  }) => void;
+  value: StyleValue;
+  onChange: (value: KeywordValue | UnparsedValue) => void;
 };
 
 const commonPropertiesSet = new Set(commonTransitionProperties);
 
+const $animatableDefinedProperties = computed(
+  [
+    $definedProperties,
+    $model,
+    $selectedInstanceSelector,
+    $selectedOrLastStyleSourceSelector,
+  ],
+  (definedProperties, model, instanceSelector, styleSourceSelector) => {
+    const animatableProperties = new Set<string>();
+    for (const property of definedProperties) {
+      if (isAnimatableProperty(hyphenateProperty(property))) {
+        const styleDecl = getComputedStyleDecl({
+          model,
+          instanceSelector,
+          styleSourceId: styleSourceSelector?.styleSourceId,
+          state: styleSourceSelector?.state,
+          property,
+        });
+        if (
+          styleDecl.source.name === "remote" ||
+          styleDecl.source.name === "local" ||
+          styleDecl.source.name === "overwritten"
+        ) {
+          animatableProperties.add(property);
+        }
+      }
+    }
+    return animatableProperties;
+  }
+);
+
 export const TransitionProperty = ({
-  property,
-  currentStyle,
-  onPropertySelection,
+  value,
+  onChange,
 }: TransitionPropertyProps) => {
-  const valueString = toValue(property);
+  const animatableDefinedProperties = useStore($animatableDefinedProperties);
+  const valueString = toValue(value);
   const [inputValue, setInputValue] = useState<string>(valueString);
   useEffect(() => setInputValue(valueString), [valueString]);
-  const propertiesDefinedOnInstanceSet = useMemo(
-    () => getAnimatablePropertiesOnInstance(currentStyle),
-    [currentStyle]
-  );
 
   const properties = Array.from(
     setUnion(
-      setUnion(propertiesDefinedOnInstanceSet, commonPropertiesSet),
+      setUnion(animatableDefinedProperties, commonPropertiesSet),
       new Set(animatableProperties)
     )
   );
@@ -105,10 +134,10 @@ export const TransitionProperty = ({
             }
 
             // Keep the proeprties on instance at the top
-            if (propertiesDefinedOnInstanceSet.has(a.item.name)) {
+            if (animatableDefinedProperties.has(a.item.name)) {
               return -1;
             }
-            if (propertiesDefinedOnInstanceSet.has(b.item.name)) {
+            if (animatableDefinedProperties.has(b.item.name)) {
               return 1;
             }
 
@@ -132,15 +161,15 @@ export const TransitionProperty = ({
   const commonProperties = items.filter(
     (item) =>
       commonPropertiesSet.has(item.name) === true &&
-      propertiesDefinedOnInstanceSet.has(item.name) === false
+      animatableDefinedProperties.has(item.name) === false
   );
   const filteredProperties = items.filter(
     (item) =>
       commonPropertiesSet.has(item.name) === false &&
-      propertiesDefinedOnInstanceSet.has(item.name) === false
+      animatableDefinedProperties.has(item.name) === false
   );
   const propertiesDefinedOnInstance: Array<NameAndLabel> = items.filter(
-    (item) => propertiesDefinedOnInstanceSet.has(item.name)
+    (item) => animatableDefinedProperties.has(item.name)
   );
 
   const saveAnimatableProperty = (propertyName: string) => {
@@ -148,9 +177,7 @@ export const TransitionProperty = ({
       return;
     }
     setInputValue(propertyName);
-    onPropertySelection({
-      property: { type: "unparsed", value: propertyName },
-    });
+    onChange({ type: "unparsed", value: propertyName });
   };
 
   const renderItem = (item: NameAndLabel, index: number) => {
@@ -169,68 +196,61 @@ export const TransitionProperty = ({
   };
 
   return (
-    <>
-      <PropertyInlineLabel
-        label="Property"
-        description={propertyDescriptions.transitionProperty}
-        properties={["transitionProperty"]}
-      />
-      <ComboboxRoot open={isOpen}>
-        <div {...getComboboxProps()}>
-          <ComboboxAnchor>
-            <InputField
-              autoFocus
-              {...getInputProps({
-                onKeyDown: (event) => {
-                  if (event.key === "Enter") {
-                    saveAnimatableProperty(inputValue);
-                  }
-                  event.stopPropagation();
-                },
-              })}
-              placeholder="all"
-              suffix={<NestedInputButton {...getToggleButtonProps()} />}
-            />
-          </ComboboxAnchor>
-          <ComboboxContent align="end" sideOffset={5}>
-            <ComboboxListbox {...getMenuProps()}>
-              <ComboboxScrollArea>
-                {isOpen && (
-                  <>
-                    {propertiesDefinedOnInstance.length > 0 && (
-                      <>
-                        <ComboboxLabel>Defined</ComboboxLabel>
-                        {propertiesDefinedOnInstance.map((property, index) =>
-                          renderItem(property, index)
-                        )}
-                        <ComboboxSeparator />
-                      </>
-                    )}
+    <ComboboxRoot open={isOpen}>
+      <div {...getComboboxProps()}>
+        <ComboboxAnchor>
+          <InputField
+            autoFocus
+            {...getInputProps({
+              onKeyDown: (event) => {
+                if (event.key === "Enter") {
+                  saveAnimatableProperty(inputValue);
+                }
+                event.stopPropagation();
+              },
+            })}
+            placeholder="all"
+            suffix={<NestedInputButton {...getToggleButtonProps()} />}
+          />
+        </ComboboxAnchor>
+        <ComboboxContent align="end" sideOffset={5}>
+          <ComboboxListbox {...getMenuProps()}>
+            <ComboboxScrollArea>
+              {isOpen && (
+                <>
+                  {propertiesDefinedOnInstance.length > 0 && (
+                    <>
+                      <ComboboxLabel>Defined</ComboboxLabel>
+                      {propertiesDefinedOnInstance.map((property, index) =>
+                        renderItem(property, index)
+                      )}
+                      <ComboboxSeparator />
+                    </>
+                  )}
 
-                    <ComboboxLabel>Common</ComboboxLabel>
-                    {commonProperties.map((property, index) =>
-                      renderItem(
-                        property,
-                        propertiesDefinedOnInstance.length + index
-                      )
-                    )}
-                    <ComboboxSeparator />
+                  <ComboboxLabel>Common</ComboboxLabel>
+                  {commonProperties.map((property, index) =>
+                    renderItem(
+                      property,
+                      propertiesDefinedOnInstance.length + index
+                    )
+                  )}
+                  <ComboboxSeparator />
 
-                    {filteredProperties.map((property, index) =>
-                      renderItem(
-                        property,
-                        propertiesDefinedOnInstance.length +
-                          commonProperties.length +
-                          index
-                      )
-                    )}
-                  </>
-                )}
-              </ComboboxScrollArea>
-            </ComboboxListbox>
-          </ComboboxContent>
-        </div>
-      </ComboboxRoot>
-    </>
+                  {filteredProperties.map((property, index) =>
+                    renderItem(
+                      property,
+                      propertiesDefinedOnInstance.length +
+                        commonProperties.length +
+                        index
+                    )
+                  )}
+                </>
+              )}
+            </ComboboxScrollArea>
+          </ComboboxListbox>
+        </ComboboxContent>
+      </div>
+    </ComboboxRoot>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -54,7 +54,8 @@ const $animatableDefinedProperties = computed(
   (definedProperties, model, instanceSelector, styleSourceSelector) => {
     const animatableProperties = new Set<string>();
     for (const property of definedProperties) {
-      if (isAnimatableProperty(hyphenateProperty(property))) {
+      const hyphenatedProperty = hyphenateProperty(property);
+      if (isAnimatableProperty(hyphenatedProperty)) {
         const styleDecl = getComputedStyleDecl({
           model,
           instanceSelector,
@@ -67,7 +68,7 @@ const $animatableDefinedProperties = computed(
           styleDecl.source.name === "local" ||
           styleDecl.source.name === "overwritten"
         ) {
-          animatableProperties.add(property);
+          animatableProperties.add(hyphenatedProperty);
         }
       }
     }

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.stories.tsx
@@ -1,11 +1,14 @@
 import { styled, theme } from "@webstudio-is/design-system";
-import { useRef, useState } from "react";
-import type { StyleInfo } from "../../shared/style-info";
-import type {
-  CreateBatchUpdate,
-  DeleteProperty,
-  SetProperty,
-} from "../../shared/use-style-data";
+import { getStyleDeclKey, StyleDecl } from "@webstudio-is/sdk";
+import {
+  $breakpoints,
+  $selectedBreakpointId,
+  $selectedInstanceSelector,
+  $styles,
+  $styleSources,
+  $styleSourceSelections,
+} from "~/shared/nano-states";
+import { registerContainers } from "~/shared/sync";
 import { Section } from "./transitions";
 
 const Panel = styled("div", {
@@ -13,88 +16,46 @@ const Panel = styled("div", {
   boxShadow: theme.shadows.panelSectionDropShadow,
 });
 
-const useStyleInfo = (styleInfoInitial: StyleInfo) => {
-  const [styleInfo, setStyleInfo] = useState(() => styleInfoInitial);
-
-  const setProperty: SetProperty = (name) => (value, options) => {
-    if (options?.isEphemeral) {
-      return;
-    }
-
-    setStyleInfo((styleInfo) => ({
-      ...styleInfo,
-      [name]: {
-        ...styleInfo[name],
-        value: value,
-        local: value,
-      },
-    }));
-  };
-
-  const deleteProperty: DeleteProperty = (name, options) => {
-    if (options?.isEphemeral) {
-      return;
-    }
-
-    setStyleInfo((styleInfo) => {
-      const { [name]: _, ...rest } = styleInfo;
-      return rest;
-    });
-  };
-
-  const execCommands = useRef<(() => void)[]>([]);
-
-  const createBatchUpdate: CreateBatchUpdate = () => ({
-    deleteProperty: (property) => {
-      execCommands.current.push(() => {
-        deleteProperty(property);
-      });
-    },
-    setProperty: (property) => (style) => {
-      execCommands.current.push(() => {
-        setProperty(property)(style);
-      });
-    },
-    publish: (options) => {
-      if (options?.isEphemeral) {
-        execCommands.current = [];
-        return;
-      }
-
-      for (const command of execCommands.current) {
-        command();
-      }
-
-      execCommands.current = [];
-    },
-  });
-
-  return { styleInfo, setProperty, deleteProperty, createBatchUpdate };
+const transitionProperty: StyleDecl = {
+  breakpointId: "base",
+  styleSourceId: "local",
+  property: "transitionProperty",
+  value: {
+    type: "layers",
+    value: [
+      { type: "unparsed", value: "opacity" },
+      { type: "unparsed", value: "transform" },
+      { type: "keyword", value: "all" },
+    ],
+  },
 };
 
-export const Transitions = () => {
-  const { styleInfo, setProperty, deleteProperty, createBatchUpdate } =
-    useStyleInfo({
-      transitionProperty: {
-        value: {
-          type: "layers",
-          value: [
-            { type: "unparsed", value: "opacity" },
-            { type: "unparsed", value: "transform" },
-            { type: "keyword", value: "all" },
-          ],
-        },
+registerContainers();
+$breakpoints.set(new Map([["base", { id: "base", label: "" }]]));
+$selectedBreakpointId.set("base");
+$styleSources.set(
+  new Map([
+    [
+      "local",
+      {
+        id: "local",
+        type: "local",
       },
-    });
+    ],
+  ])
+);
+$styles.set(
+  new Map([[getStyleDeclKey(transitionProperty), transitionProperty]])
+);
+$styleSourceSelections.set(
+  new Map([["box", { instanceId: "box", values: ["local"] }]])
+);
+$selectedInstanceSelector.set(["box"]);
 
+export const Transitions = () => {
   return (
     <Panel>
-      <Section
-        currentStyle={styleInfo}
-        setProperty={setProperty}
-        deleteProperty={deleteProperty}
-        createBatchUpdate={createBatchUpdate}
-      />
+      <Section />
     </Panel>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/shared/model.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/model.tsx
@@ -79,7 +79,50 @@ const $matchingBreakpoints = computed(
   }
 );
 
-const $model = computed(
+export const $definedProperties = computed(
+  [
+    $selectedInstanceSelector,
+    $styleSourceSelections,
+    $matchingBreakpoints,
+    $styles,
+  ],
+  (
+    instanceSelector,
+    styleSourceSelections,
+    matchingBreakpointsArray,
+    styles
+  ) => {
+    const definedProperties = new Set<StyleProperty>();
+    if (instanceSelector === undefined) {
+      return definedProperties;
+    }
+    const matchingStyleSources = new Set();
+    const matchingBreakpoints = new Set(matchingBreakpointsArray);
+    for (const instanceId of instanceSelector) {
+      const styleSources = styleSourceSelections.get(instanceId)?.values;
+      if (styleSources) {
+        for (const styleSourceId of styleSources) {
+          matchingStyleSources.add(styleSourceId);
+        }
+      }
+    }
+    for (const styleDecl of styles.values()) {
+      if (
+        matchingBreakpoints.has(styleDecl.breakpointId) &&
+        matchingStyleSources.has(styleDecl.styleSourceId)
+      ) {
+        definedProperties.add(styleDecl.property);
+      }
+    }
+    return definedProperties;
+  }
+);
+
+/**
+ * Do not use directly
+ * only transition property is permitted
+ */
+export const $model = computed(
   [
     $styles,
     $styleSourceSelections,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1536 https://github.com/webstudio-is/webstudio/issues/3399

Here migrated transitions section to new style engine along with "repeated style" control.

Changed behavior of transition code blue to write non-ephemeral changes caz ephemeral do not have enough visual feedback.

Note: review with hidden spaces