### PR TITLE
feat: forgive semicolon in css value inputs

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
@@ -14,7 +14,10 @@ export const parseIntermediateOrInvalidValue = (
   property: StyleProperty,
   styleValue: IntermediateStyleValue | InvalidValue
 ): StyleValue => {
-  const value = styleValue.value.trim();
+  let value = styleValue.value.trim();
+  if (value.endsWith(";")) {
+    value = value.slice(0, -1);
+  }
 
   if (property.startsWith("--")) {
     return {

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
@@ -9,6 +9,21 @@ const propertiesAndKeywords = [
   ["lineHeight", "normal" as string],
 ] as const;
 
+test("forgive trailing semicolon", () => {
+  expect(
+    parseIntermediateOrInvalidValue("width", {
+      type: "intermediate",
+      value: "20px;",
+    })
+  ).toEqual({ type: "unit", value: 20, unit: "px" });
+  expect(
+    parseIntermediateOrInvalidValue("color", {
+      type: "intermediate",
+      value: "red;",
+    })
+  ).toEqual({ type: "keyword", value: "red" });
+});
+
 describe("Parse intermediate or invalid value without math evaluation", () => {
   test("not lost unit value", () => {
     for (const propery of properties) {


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/4075

<img width="256" alt="Screenshot 2024-09-08 at 16 57 17" src="https://github.com/user-attachments/assets/d3a3ab56-244c-4111-be7e-4fc08c01027a">
