### PR TITLE
experimental: migrate image control to style object model

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/image/image-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/image/image-control.tsx
@@ -3,9 +3,13 @@ import { Button, InputField, Flex } from "@webstudio-is/design-system";
 import { $assets } from "~/shared/nano-states";
 import { FloatingPanel } from "~/builder/shared/floating-panel";
 import { ImageManager } from "~/builder/shared/image-manager";
-import type { ControlProps } from "../types";
 import { useEffect, useState } from "react";
-import type { InvalidValue } from "@webstudio-is/css-engine";
+import type { InvalidValue, StyleProperty } from "@webstudio-is/css-engine";
+import { useComputedStyleDecl } from "../../shared/model";
+import {
+  getRepeatedStyleItem,
+  setRepeatedStyleItem,
+} from "../../shared/repeated-style";
 
 const isValidURL = (value: string) => {
   try {
@@ -22,12 +26,14 @@ type IntermediateValue = {
 
 export const ImageControl = ({
   property,
-  currentStyle,
-  setProperty,
-}: ControlProps) => {
+  index,
+}: {
+  property: StyleProperty;
+  index: number;
+}) => {
   const assets = useStore($assets);
-  const setValue = setProperty(property);
-  const styleValue = currentStyle[property]?.value;
+  const styleDecl = useComputedStyleDecl(property);
+  const styleValue = getRepeatedStyleItem(styleDecl.cascadedValue, index);
   const [remoteImageURL, setRemoteImageURL] = useState<
     IntermediateValue | InvalidValue | undefined
   >(undefined);
@@ -65,7 +71,7 @@ export const ImageControl = ({
       remoteImageURL?.type === "intermediate" &&
       isValidURL(remoteImageURL.value) === true
     ) {
-      setValue({
+      setRepeatedStyleItem(styleDecl, index, {
         type: "image",
         value: { type: "url", url: remoteImageURL.value },
       });
@@ -93,7 +99,7 @@ export const ImageControl = ({
         content={
           <ImageManager
             onChange={(assetId) => {
-              setValue({
+              setRepeatedStyleItem(styleDecl, index, {
                 type: "image",
                 value: { type: "asset", value: assetId },
               });

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.stories.tsx
@@ -49,6 +49,7 @@ export const BackgroundContentStory = () => {
           title="Background"
           content={
             <BackgroundContent
+              index={0}
               currentStyle={currentStyle}
               deleteProperty={deleteProperty}
               setProperty={setProperty}

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.stories.tsx
@@ -6,13 +6,38 @@ import {
 } from "~/builder/shared/floating-panel";
 import { useRef, useState } from "react";
 import type { SetProperty } from "../../shared/use-style-data";
+import {
+  $breakpoints,
+  $selectedBreakpointId,
+  $selectedInstanceSelector,
+  $styles,
+  $styleSourceSelections,
+} from "~/shared/nano-states";
+import { registerContainers } from "~/shared/sync";
+import { getStyleDeclKey, type StyleDecl } from "@webstudio-is/sdk";
+
+const backgroundImage: StyleDecl = {
+  breakpointId: "base",
+  styleSourceId: "local",
+  property: "backgroundImage",
+  value: {
+    type: "layers",
+    value: [{ type: "keyword", value: "none" }],
+  },
+};
+
+registerContainers();
+$breakpoints.set(new Map([["base", { id: "base", label: "" }]]));
+$selectedBreakpointId.set("base");
+$styles.set(new Map([[getStyleDeclKey(backgroundImage), backgroundImage]]));
+$styleSourceSelections.set(
+  new Map([["box", { instanceId: "box", values: ["local"] }]])
+);
+$selectedInstanceSelector.set(["box"]);
 
 const defaultCurrentStyle = getLayerBackgroundStyleInfo(0, {
   backgroundImage: {
-    value: {
-      type: "layers",
-      value: [{ type: "keyword", value: "none" }],
-    },
+    value: backgroundImage.value,
   },
 });
 const deleteProperty = () => () => {

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
@@ -44,6 +44,7 @@ import { PropertyInlineLabel } from "../../property-label";
 import { ToggleGroupTooltip } from "../../controls/toggle-group/toggle-group-control";
 
 type BackgroundContentProps = {
+  index: number;
   currentStyle: StyleInfo;
   setProperty: SetBackgroundProperty;
   deleteProperty: DeleteBackgroundProperty;
@@ -198,7 +199,7 @@ const BackgroundRepeat = (props: BackgroundContentProps) => {
 export const BackgroundContent = (props: BackgroundContentProps) => {
   const setProperty = safeSetProperty(props.setProperty);
   const deleteProperty = safeDeleteProperty(props.deleteProperty);
-  const { currentStyle } = props;
+  const { currentStyle, index } = props;
 
   const elementRef = useRef<HTMLDivElement>(null);
   const [imageGradientToggle, setImageGradientToggle] = useState<
@@ -252,12 +253,7 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
               </Flex>
 
               <FloatingPanelProvider container={elementRef}>
-                <ImageControl
-                  setProperty={setProperty}
-                  deleteProperty={deleteProperty}
-                  currentStyle={currentStyle}
-                  property="backgroundImage"
-                />
+                <ImageControl property="backgroundImage" index={index} />
               </FloatingPanelProvider>
             </>
           )}

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -86,6 +86,7 @@ const Layer = (props: {
       collisionPadding={{ bottom: 200, top: 200 }}
       content={
         <BackgroundContent
+          index={props.index}
           currentStyle={props.layerStyle}
           setProperty={props.setProperty}
           deleteProperty={props.deleteProperty}

--- a/apps/builder/app/builder/features/style-panel/shared/repeated-style.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/repeated-style.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, expect, test } from "@jest/globals";
+import type { StyleValue } from "@webstudio-is/css-engine";
 import {
   addRepeatedStyleItem,
   deleteRepeatedStyleItem,
   editRepeatedStyleItem,
+  getRepeatedStyleItem,
+  setRepeatedStyleItem,
   swapRepeatedStyleItems,
   toggleRepeatedStyleItem,
 } from "./repeated-style";
@@ -23,6 +26,42 @@ beforeEach(() => {
   $selectedBreakpointId.set("base");
   $selectedInstanceSelector.set(["box"]);
   $styles.set(new Map());
+});
+
+test("get repeated style item by index", () => {
+  const styleValue: StyleValue = {
+    type: "layers",
+    value: [
+      { type: "keyword", value: "red" },
+      { type: "keyword", value: "green" },
+      { type: "keyword", value: "blue" },
+    ],
+  };
+  expect(getRepeatedStyleItem(styleValue, 0)).toEqual({
+    type: "keyword",
+    value: "red",
+  });
+  expect(getRepeatedStyleItem(styleValue, 1)).toEqual({
+    type: "keyword",
+    value: "green",
+  });
+  expect(getRepeatedStyleItem(styleValue, 2)).toEqual({
+    type: "keyword",
+    value: "blue",
+  });
+  // repeat values
+  expect(getRepeatedStyleItem(styleValue, 3)).toEqual({
+    type: "keyword",
+    value: "red",
+  });
+  expect(getRepeatedStyleItem(styleValue, 4)).toEqual({
+    type: "keyword",
+    value: "green",
+  });
+  expect(getRepeatedStyleItem(styleValue, 5)).toEqual({
+    type: "keyword",
+    value: "blue",
+  });
 });
 
 test("add layer to repeated style", () => {
@@ -137,6 +176,44 @@ test("edit tuple in repeated style", () => {
           value: [{ type: "unit", unit: "%", value: 200 }],
         },
       },
+    ],
+  });
+});
+
+test("set layers item into repeated style", () => {
+  const $transitionProperty =
+    createComputedStyleDeclStore("transitionProperty");
+  addRepeatedStyleItem(
+    [$transitionProperty.get()],
+    parseCssFragment("opacity", "transitionProperty")
+  );
+  addRepeatedStyleItem(
+    [$transitionProperty.get()],
+    parseCssFragment("transform", "transitionProperty")
+  );
+  setRepeatedStyleItem($transitionProperty.get(), 0, {
+    type: "unparsed",
+    value: "width",
+  });
+  expect($transitionProperty.get().cascadedValue).toEqual({
+    type: "layers",
+    value: [
+      { type: "unparsed", value: "width" },
+      { type: "unparsed", value: "transform" },
+    ],
+  });
+  // out of bounds will repeat existing values
+  setRepeatedStyleItem($transitionProperty.get(), 3, {
+    type: "unparsed",
+    value: "left",
+  });
+  expect($transitionProperty.get().cascadedValue).toEqual({
+    type: "layers",
+    value: [
+      { type: "unparsed", value: "width" },
+      { type: "unparsed", value: "transform" },
+      { type: "unparsed", value: "width" },
+      { type: "unparsed", value: "left" },
     ],
   });
 });

--- a/apps/builder/app/shared/array-utils.test.ts
+++ b/apps/builder/app/shared/array-utils.test.ts
@@ -36,4 +36,5 @@ test("removeByMutable", () => {
 
 test("repeatUntil", () => {
   expect(repeatUntil([1, 2, 3], 5)).toEqual([1, 2, 3, 1, 2]);
+  expect(repeatUntil([1, 2, 3], 1)).toEqual([1, 2, 3]);
 });

--- a/apps/builder/app/shared/array-utils.ts
+++ b/apps/builder/app/shared/array-utils.ts
@@ -14,7 +14,7 @@ export const removeByMutable = <Item>(
 
 export const repeatUntil = <Item>(array: Item[], count: number) => {
   const repeatedArray: Item[] = [];
-  for (let index = 0; index < count; index += 1) {
+  for (let index = 0; index < Math.max(count, array.length); index += 1) {
     repeatedArray.push(array[index % array.length]);
   }
   return repeatedArray;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1536 https://github.com/webstudio-is/webstudio/issues/3399

Refactored image control to maintain styles internally. Important to not this is the first repeated style control. It accepts property and additionally index of repeated style. Would work with future sections like mask-image

We can also improve it to support both singular and repeated styles in the future.

<img width="231" alt="Screenshot 2024-09-10 at 19 52 17" src="https://github.com/user-attachments/assets/a0d27b1b-ae72-4454-b31e-d1f5af3bc4d1">
