### PR TITLE
fix: robots.txt to allow login and nothing else

### DIFF
--- a/apps/builder/public/robots.txt
+++ b/apps/builder/public/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
-Allow: /
 Allow: /login
-Disallow: /*
+Disallow: /


### PR DESCRIPTION
Login was blocked with current rule set and order. I don't know of any other URLs that should be allowed.

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
