### PR TITLE
fix: use backdrop-filter styles in section

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backdrop-filter/backdrop-filter.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backdrop-filter/backdrop-filter.tsx
@@ -34,7 +34,7 @@ const getItemProps = (_index: number, value: StyleValue) => {
 };
 
 export const Section = () => {
-  const styleDecl = useComputedStyleDecl("filter");
+  const styleDecl = useComputedStyleDecl("backdropFilter");
 
   return (
     <RepeatedStyleSection


### PR DESCRIPTION
Fixes https://discord.com/channels/955905230107738152/1283966766258585621/1283966766258585621

Accidentally made "backdrop filters" section to render "filter" styles.