### PR TITLE
refactor: migrate transform panels to new style engine

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-rotate.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-rotate.tsx
@@ -1,67 +1,42 @@
 import { Flex, Grid } from "@webstudio-is/design-system";
 import {
-  updateRotateOrSkewPropertyValue,
-  type TransformPanelProps,
-} from "./transform-utils";
-import {
   XAxisRotateIcon,
   YAxisRotateIcon,
   ZAxisRotateIcon,
 } from "@webstudio-is/icons";
+import type { StyleValue } from "@webstudio-is/css-engine";
+import { propertySyntaxes } from "@webstudio-is/css-data";
 import { CssValueInputContainer } from "../../shared/css-value-input";
-import {
-  toValue,
-  UnitValue,
-  type FunctionValue,
-  type StyleValue,
-} from "@webstudio-is/css-engine";
-import type { StyleUpdateOptions } from "../../shared/use-style-data";
-import { parseCssValue, propertySyntaxes } from "@webstudio-is/css-data";
-import { extractRotatePropertiesFromTransform } from "./transform-extractors";
 import { PropertyInlineLabel } from "../../property-label";
+import { useComputedStyleDecl } from "../../shared/model";
+import { updateTransformFunction } from "./transform-utils";
 
-export const RotatePanelContent = (props: TransformPanelProps) => {
-  const { propertyValue, setProperty, currentStyle } = props;
-  const { rotateX, rotateY, rotateZ } =
-    extractRotatePropertiesFromTransform(propertyValue);
-
-  const handlePropertyUpdate = (
-    index: number,
-    prop: string,
-    value: StyleValue,
-    options?: StyleUpdateOptions
-  ) => {
-    let newValue: UnitValue = { type: "unit", value: 0, unit: "deg" };
-
-    if (value.type === "unit") {
-      newValue = value;
+export const RotatePanelContent = () => {
+  const styleDecl = useComputedStyleDecl("transform");
+  const tuple =
+    styleDecl.cascadedValue.type === "tuple"
+      ? styleDecl.cascadedValue
+      : undefined;
+  let rotateX: StyleValue = { type: "unit", value: 0, unit: "deg" };
+  let rotateY: StyleValue = { type: "unit", value: 0, unit: "deg" };
+  let rotateZ: StyleValue = { type: "unit", value: 0, unit: "deg" };
+  for (const item of tuple?.value ?? []) {
+    if (
+      item.type === "function" &&
+      item.args.type === "layers" &&
+      item.args.value[0].type === "unit"
+    ) {
+      if (item.name === "rotateX") {
+        rotateX = item.args.value[0];
+      }
+      if (item.name === "rotateY") {
+        rotateY = item.args.value[0];
+      }
+      if (item.name === "rotateZ") {
+        rotateZ = item.args.value[0];
+      }
     }
-
-    if (value.type === "tuple" && value.value[0].type === "unit") {
-      newValue = value.value[0];
-    }
-
-    const newFunctionValue: FunctionValue = {
-      type: "function",
-      name: prop,
-      args: { type: "layers", value: [newValue] },
-    };
-
-    const newPropertyValue = updateRotateOrSkewPropertyValue({
-      panel: "rotate",
-      index,
-      currentStyle,
-      value: newFunctionValue,
-      propertyValue,
-    });
-
-    const rotate = parseCssValue("transform", toValue(newPropertyValue));
-    if (rotate.type === "invalid") {
-      return;
-    }
-
-    setProperty("transform")(rotate, options);
-  };
+  }
 
   return (
     <Flex direction="column" gap={2}>
@@ -75,18 +50,13 @@ export const RotatePanelContent = (props: TransformPanelProps) => {
           description={propertySyntaxes.rotateX}
         />
         <CssValueInputContainer
-          key="rotateX"
           styleSource="local"
           property="rotate"
-          value={
-            rotateX?.type === "function" && rotateX.args.type === "layers"
-              ? rotateX.args.value[0]
-              : { type: "unit", value: 0, unit: "deg" }
-          }
+          value={rotateX}
           keywords={[]}
-          setValue={(value, options) => {
-            handlePropertyUpdate(0, "rotateX", value, options);
-          }}
+          setValue={(value, options) =>
+            updateTransformFunction(styleDecl, "rotateX", value, options)
+          }
           deleteProperty={() => {}}
         />
       </Grid>
@@ -100,18 +70,13 @@ export const RotatePanelContent = (props: TransformPanelProps) => {
           description={propertySyntaxes.rotateY}
         />
         <CssValueInputContainer
-          key="rotateY"
           styleSource="local"
           property="rotate"
-          value={
-            rotateY?.type === "function" && rotateY.args.type === "layers"
-              ? rotateY.args.value[0]
-              : { type: "unit", value: 0, unit: "deg" }
-          }
+          value={rotateY}
           keywords={[]}
-          setValue={(value, options) => {
-            handlePropertyUpdate(1, "rotateY", value, options);
-          }}
+          setValue={(value, options) =>
+            updateTransformFunction(styleDecl, "rotateY", value, options)
+          }
           deleteProperty={() => {}}
         />
       </Grid>
@@ -125,18 +90,13 @@ export const RotatePanelContent = (props: TransformPanelProps) => {
           description={propertySyntaxes.rotateZ}
         />
         <CssValueInputContainer
-          key="rotateZ"
           styleSource="local"
           property="rotate"
-          value={
-            rotateZ?.type === "function" && rotateZ.args.type === "layers"
-              ? rotateZ.args.value[0]
-              : { type: "unit", value: 0, unit: "deg" }
-          }
+          value={rotateZ}
           keywords={[]}
-          setValue={(value, options) => {
-            handlePropertyUpdate(2, "rotateZ", value, options);
-          }}
+          setValue={(value, options) =>
+            updateTransformFunction(styleDecl, "rotateZ", value, options)
+          }
           deleteProperty={() => {}}
         />
       </Grid>

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-skew.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-skew.tsx
@@ -1,67 +1,39 @@
 import { Flex, Grid } from "@webstudio-is/design-system";
-import {
-  updateRotateOrSkewPropertyValue,
-  type TransformPanelProps,
-} from "./transform-utils";
-import { extractSkewPropertiesFromTransform } from "./transform-extractors";
 import { XAxisIcon, YAxisIcon } from "@webstudio-is/icons";
+import type { StyleValue } from "@webstudio-is/css-engine";
+import { propertySyntaxes } from "@webstudio-is/css-data";
 import { CssValueInputContainer } from "../../shared/css-value-input";
-import type { StyleUpdateOptions } from "../../shared/use-style-data";
-import {
-  StyleValue,
-  toValue,
-  UnitValue,
-  type FunctionValue,
-} from "@webstudio-is/css-engine";
-import { parseCssValue, propertySyntaxes } from "@webstudio-is/css-data";
 import { PropertyInlineLabel } from "../../property-label";
+import { useComputedStyleDecl } from "../../shared/model";
+import { updateTransformFunction } from "./transform-utils";
 
 // We use fakeProperty to pass for the CssValueInputContainer.
 // https://developer.mozilla.org/en-US/docs/Web/CSS/rotate#formal_syntax
 // angle
 const fakeProperty = "rotate";
 
-export const SkewPanelContent = (props: TransformPanelProps) => {
-  const { propertyValue, setProperty, currentStyle } = props;
-  const { skewX, skewY } = extractSkewPropertiesFromTransform(propertyValue);
-
-  const handlePropertyUpdate = (
-    index: number,
-    prop: string,
-    value: StyleValue,
-    options?: StyleUpdateOptions
-  ) => {
-    let newValue: UnitValue = { type: "unit", value: 0, unit: "deg" };
-
-    if (value.type === "unit") {
-      newValue = value;
+export const SkewPanelContent = () => {
+  const styleDecl = useComputedStyleDecl("transform");
+  const tuple =
+    styleDecl.cascadedValue.type === "tuple"
+      ? styleDecl.cascadedValue
+      : undefined;
+  let skewX: StyleValue = { type: "unit", value: 0, unit: "deg" };
+  let skewY: StyleValue = { type: "unit", value: 0, unit: "deg" };
+  for (const item of tuple?.value ?? []) {
+    if (
+      item.type === "function" &&
+      item.args.type === "layers" &&
+      item.args.value[0].type === "unit"
+    ) {
+      if (item.name === "skewx") {
+        skewX = item.args.value[0];
+      }
+      if (item.name === "skewY") {
+        skewY = item.args.value[0];
+      }
     }
-
-    if (value.type === "tuple" && value.value[0].type === "unit") {
-      newValue = value.value[0];
-    }
-
-    const newFunctionValue: FunctionValue = {
-      type: "function",
-      name: prop,
-      args: { type: "layers", value: [newValue] },
-    };
-
-    const newPropertyValue = updateRotateOrSkewPropertyValue({
-      panel: "skew",
-      index,
-      currentStyle,
-      value: newFunctionValue,
-      propertyValue,
-    });
-
-    const skew = parseCssValue("transform", toValue(newPropertyValue));
-    if (skew.type === "invalid") {
-      return;
-    }
-
-    setProperty("transform")(skew, options);
-  };
+  }
 
   return (
     <Flex direction="column" gap={2}>
@@ -75,18 +47,13 @@ export const SkewPanelContent = (props: TransformPanelProps) => {
           description={propertySyntaxes.skewX}
         />
         <CssValueInputContainer
-          key="skewX"
           styleSource="local"
           property={fakeProperty}
-          value={
-            skewX?.type === "function" && skewX.args.type === "layers"
-              ? skewX.args.value[0]
-              : { type: "unit", value: 0, unit: "deg" }
-          }
+          value={skewX}
           keywords={[]}
-          setValue={(value, options) => {
-            handlePropertyUpdate(0, "skewX", value, options);
-          }}
+          setValue={(value, options) =>
+            updateTransformFunction(styleDecl, "skewX", value, options)
+          }
           deleteProperty={() => {}}
         />
       </Grid>
@@ -100,18 +67,13 @@ export const SkewPanelContent = (props: TransformPanelProps) => {
           description={propertySyntaxes.skewY}
         />
         <CssValueInputContainer
-          key="skewY"
           styleSource="local"
           property={fakeProperty}
-          value={
-            skewY?.type === "function" && skewY.args.type === "layers"
-              ? skewY.args.value[0]
-              : { type: "unit", value: 0, unit: "deg" }
-          }
+          value={skewY}
           keywords={[]}
-          setValue={(value, options) => {
-            handlePropertyUpdate(1, "skewY", value, options);
-          }}
+          setValue={(value, options) =>
+            updateTransformFunction(styleDecl, "skewY", value, options)
+          }
           deleteProperty={() => {}}
         />
       </Grid>

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-utils.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-utils.test.ts
@@ -4,12 +4,9 @@ import {
   handleDeleteTransformProperty,
   handleHideTransformProperty,
   isTransformPanelPropertyUsed,
-  updateRotateOrSkewPropertyValue,
-  updateTransformTuplePropertyValue,
 } from "./transform-utils";
 import type { StyleInfo } from "../../shared/style-info";
 import {
-  FunctionValue,
   toValue,
   TupleValue,
   type StyleProperty,
@@ -210,56 +207,5 @@ describe("Transform utils CRUD operations", () => {
     expect(rotate.rotateX?.hidden).toBe(true);
     expect(rotate.rotateY?.hidden).toBe(true);
     expect(rotate.rotateZ?.hidden).toBe(true);
-  });
-
-  test("update translate property value", () => {
-    const translate = parseCssValue("translate", "0px 0px 0px");
-    const newValue = updateTransformTuplePropertyValue(
-      1,
-      { type: "unit", value: 50, unit: "px" },
-      translate as TupleValue
-    );
-
-    expect(toValue(newValue)).toBe("0px 50px 0px");
-  });
-
-  test("update rotate values in transform property", () => {
-    const { currentStyle, setProperty } = initializeStyleInfo();
-    const transform = parseCssValue(
-      "transform",
-      "rotateX(10deg) rotateY(10deg) rotateZ(10deg) skewX(10deg) skewY(10deg)"
-    );
-    setProperty("transform")(transform);
-
-    const updatedRotateYValue: FunctionValue = {
-      type: "function",
-      name: "rotateY",
-      args: {
-        type: "layers",
-        value: [{ type: "unit", value: 50, unit: "deg" }],
-      },
-    };
-    const { rotateX, rotateY, rotateZ } =
-      extractRotatePropertiesFromTransform(transform);
-    const newValue = updateRotateOrSkewPropertyValue({
-      index: 1,
-      panel: "rotate",
-      currentStyle,
-      value: updatedRotateYValue,
-      propertyValue: {
-        type: "tuple",
-        value: [
-          rotateX as FunctionValue,
-          rotateY as FunctionValue,
-          rotateZ as FunctionValue,
-        ],
-      },
-    });
-
-    const result = extractRotatePropertiesFromTransform(newValue);
-    expect(result.rotateY).toEqual(updatedRotateYValue);
-    expect(toValue(newValue)).toBe(
-      "rotateX(10deg) rotateY(50deg) rotateZ(10deg) skewX(10deg) skewY(10deg)"
-    );
   });
 });

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transforms.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transforms.tsx
@@ -30,7 +30,9 @@ import {
   handleDeleteTransformProperty,
   handleHideTransformProperty,
   getHumanizedTextFromTransformLayer,
-  type TransformPanelProps,
+  transformPanels,
+  transformPanelDropdown,
+  type TransformPanel,
 } from "./transform-utils";
 import { FloatingPanel } from "~/builder/shared/floating-panel";
 import { TranslatePanelContent } from "./transform-translate";
@@ -46,24 +48,8 @@ import { PropertySectionLabel } from "../../property-label";
 import { propertyDescriptions } from "@webstudio-is/css-data";
 import { useComputedStyles } from "../../shared/model";
 
-export const transformPanels = [
-  "translate",
-  "scale",
-  "rotate",
-  "skew",
-] as const;
-
-export const transformPanelDropdown = [
-  ...transformPanels,
-  "backfaceVisibility",
-  "transformOrigin",
-  "perspective",
-  "perspectiveOrigin",
-] as const;
-
-export type TransformPanel = (typeof transformPanels)[number];
-
 const label = "Transforms";
+
 export const properties = [
   "translate",
   "scale",
@@ -194,24 +180,15 @@ const TransformSection = (
     return;
   }
 
-  const contentPanelProps: TransformPanelProps = {
-    currentStyle,
-    setProperty,
-    deleteProperty,
-    propertyValue: properties.value,
-  };
-
   return (
     <FloatingPanel
       title={humanizeString(panel)}
       content={
         <Flex direction="column" css={{ p: theme.spacing[9] }}>
-          {panel === "translate" && (
-            <TranslatePanelContent {...contentPanelProps} />
-          )}
-          {panel === "scale" && <ScalePanelContent {...contentPanelProps} />}
-          {panel === "rotate" && <RotatePanelContent {...contentPanelProps} />}
-          {panel === "skew" && <SkewPanelContent {...contentPanelProps} />}
+          {panel === "translate" && <TranslatePanelContent />}
+          {panel === "scale" && <ScalePanelContent />}
+          {panel === "rotate" && <RotatePanelContent />}
+          {panel === "skew" && <SkewPanelContent />}
         </Flex>
       }
     >

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select-options.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select-options.ts
@@ -1,10 +1,5 @@
 import type { CssValueInputValue } from "./css-value-input";
-import {
-  keywordValues,
-  properties,
-  units,
-  isValidDeclaration,
-} from "@webstudio-is/css-data";
+import { properties, units, isValidDeclaration } from "@webstudio-is/css-data";
 import type { UnitOption } from "./unit-select";
 
 // To make sorting stable
@@ -119,40 +114,6 @@ export const buildOptions = (
       indexSortValue(preferedSorting.indexOf(optionA.id)) -
       indexSortValue(preferedSorting.indexOf(optionB.id))
   );
-
-  // This value can't have units, skip select
-  // (show keywords menu instead)
-  if (options.length === 0) {
-    return [];
-  }
-
-  const propertyKeywordsSet = new Set(
-    keywordValues[property as keyof typeof keywordValues]
-  );
-
-  // Opinionated set of keywords to show
-  const webstudioKeywords = ["auto", "normal", "none"].filter((keyword) =>
-    propertyKeywordsSet.has(keyword as never)
-  );
-
-  for (const keyword of webstudioKeywords) {
-    options.push({
-      id: keyword,
-      label: keyword,
-      type: "keyword",
-    });
-  }
-
-  if (
-    value.type === "keyword" &&
-    options.some((option) => option.id === value.value) === false
-  ) {
-    options.push({
-      id: value.value,
-      label: value.value,
-      type: "keyword",
-    });
-  }
 
   return options;
 };

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.test.ts
@@ -58,11 +58,6 @@ describe("Unit menu options", () => {
     "label": "ch",
     "type": "unit",
   },
-  {
-    "id": "auto",
-    "label": "auto",
-    "type": "keyword",
-  },
 ]
 `);
   });
@@ -131,11 +126,6 @@ describe("Unit menu options", () => {
     "label": "ch",
     "type": "unit",
   },
-  {
-    "id": "auto",
-    "label": "auto",
-    "type": "keyword",
-  },
 ]
 `);
   });
@@ -147,16 +137,6 @@ describe("Unit menu options", () => {
         { value: 10, type: "unit", unit: "ch" },
         nestedSelectButtonUnitless
       ).some((option) => option.id === "ch")
-    ).toBe(true);
-  });
-
-  test("Should add keyword to options", () => {
-    expect(
-      buildOptions(
-        "width",
-        { value: "inherit", type: "keyword" },
-        nestedSelectButtonUnitless
-      ).some((option) => option.id === "inherit")
     ).toBe(true);
   });
 });


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1536

Switched translate, scale, rotate and skew panels to new style engine. Simplified style updates.

<img width="286" alt="image" src="https://github.com/user-attachments/assets/01e6b7cf-d3d9-430b-a1bd-efcd0db2b125">
<img width="257" alt="image" src="https://github.com/user-attachments/assets/ede684ad-a029-4a03-9c1b-05878d4ba1f8">
<img width="264" alt="image" src="https://github.com/user-attachments/assets/6270a781-b311-4759-a379-d9fe3627efd4">
<img width="253" alt="image" src="https://github.com/user-attachments/assets/040d5463-38e0-4bf0-bf9b-c823a284a48f">
