### PR TITLE
feat: move canvas size and extended breakpoints button next to the breakpoints list

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/breakpoints-selector-container.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-selector-container.tsx
@@ -6,7 +6,7 @@ export const BreakpointsSelectorContainer = () => {
   const breakpoints = useStore($breakpoints);
   const selectedBreakpoint = useStore($selectedBreakpoint);
   if (selectedBreakpoint === undefined) {
-    return null;
+    return;
   }
   return (
     <BreakpointsSelector

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -8,6 +8,7 @@ import {
   ToolbarButton,
   Text,
   type CSS,
+  Box,
 } from "@webstudio-is/design-system";
 import type { Project } from "@webstudio-is/project";
 import { $pages, $selectedPage } from "~/shared/nano-states";
@@ -87,15 +88,15 @@ export const Topbar = ({ project, hasProPlan, css, loading }: TopbarProps) => {
         <>
           <Flex align="center">
             <PagesButton />
-            <AddressBarPopover />
-          </Flex>
-          <Flex css={{ minWidth: theme.spacing[23], ...hideOnMobile }}>
-            <BreakpointsPopover />
+            <Box css={hideOnMobile}>
+              <AddressBarPopover />
+            </Box>
           </Flex>
           <Flex grow></Flex>
           <Flex align="center" justify="center" css={hideOnMobile}>
             <BreakpointsSelectorContainer />
           </Flex>
+          <BreakpointsPopover />
         </>
       )}
       <Flex grow></Flex>
@@ -112,8 +113,13 @@ export const Topbar = ({ project, hasProPlan, css, loading }: TopbarProps) => {
           <ViewMode />
           <SyncStatus />
           <PreviewButton />
-          <ShareButton projectId={project.id} hasProPlan={hasProPlan} />
-          <PublishButton projectId={project.id} />
+          <Box css={hideOnMobile}>
+            <ShareButton projectId={project.id} hasProPlan={hasProPlan} />
+          </Box>
+          <Box css={hideOnMobile}>
+            <PublishButton projectId={project.id} />
+          </Box>
+
           <CloneButton />
         </ToolbarToggleGroup>
       </Toolbar>


### PR DESCRIPTION
## Description

A number of people found this position more intuitive

<img width="366" alt="image" src="https://github.com/user-attachments/assets/f12fe913-1078-45fe-a65d-40bb3ee79ba5">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
