### PR TITLE
feat: Preview by publishing to subdomain only aka staging

### DIFF
--- a/apps/builder/app/builder/features/topbar/collapsible-domain-section.tsx
+++ b/apps/builder/app/builder/features/topbar/collapsible-domain-section.tsx
@@ -4,6 +4,7 @@ import {
   Label,
   theme,
   SectionTitle,
+  Grid,
 } from "@webstudio-is/design-system";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { CollapsibleSectionRoot } from "~/builder/shared/collapsible-section";
@@ -13,9 +14,11 @@ export const CollapsibleDomainSection = ({
   children,
   title,
   suffix,
+  prefix,
 }: {
   initiallyOpen?: boolean;
   children: ReactNode;
+  prefix: ReactNode;
   suffix: ReactNode;
   title: string;
 }) => {
@@ -53,7 +56,10 @@ export const CollapsibleDomainSection = ({
             </Box>
           }
         >
-          <Label truncate>{title}</Label>
+          <Grid flow={"column"} align="center" justify={"start"}>
+            {prefix}
+            <Label truncate>{title}</Label>
+          </Grid>
         </SectionTitle>
       }
     >

--- a/apps/builder/app/builder/features/topbar/domain-checkbox.tsx
+++ b/apps/builder/app/builder/features/topbar/domain-checkbox.tsx
@@ -9,6 +9,7 @@ import {
   Checkbox,
 } from "@webstudio-is/design-system";
 import { $userPlanFeatures } from "~/builder/shared/nano-states";
+import { $project } from "~/shared/nano-states";
 
 export const domainToPublishName = "domainToPublish[]";
 
@@ -21,6 +22,11 @@ interface DomainCheckboxProps {
 
 const DomainCheckbox = (props: DomainCheckboxProps) => {
   const hasProPlan = useStore($userPlanFeatures).hasProPlan;
+  const project = useStore($project);
+
+  if (project === undefined) {
+    return;
+  }
 
   const tooltipContentForFreeUsers = hasProPlan ? undefined : (
     <Flex direction="column" gap="2" css={{ maxWidth: theme.spacing[28] }}>
@@ -52,17 +58,24 @@ const DomainCheckbox = (props: DomainCheckboxProps) => {
   const defaultChecked = hasProPlan ? props.defaultChecked : true;
   const disabled = hasProPlan ? props.disabled : true;
 
+  const hideDomainCheckbox =
+    project.domainsVirtual.filter(
+      (domain) => domain.status === "ACTIVE" && domain.verified
+    ).length === 0 && hasProPlan;
+
   return (
-    <Tooltip content={tooltipContentForFreeUsers} variant="wrapped">
-      <Checkbox
-        disabled={disabled}
-        key={props.buildId ?? "-"}
-        defaultChecked={defaultChecked}
-        css={{ pointerEvents: "all" }}
-        name={domainToPublishName}
-        value={props.domain}
-      />
-    </Tooltip>
+    <div style={{ display: hideDomainCheckbox ? "none" : "contents" }}>
+      <Tooltip content={tooltipContentForFreeUsers} variant="wrapped">
+        <Checkbox
+          disabled={disabled}
+          key={props.buildId ?? "-"}
+          defaultChecked={hideDomainCheckbox || defaultChecked}
+          css={{ pointerEvents: "all" }}
+          name={domainToPublishName}
+          value={props.domain}
+        />
+      </Tooltip>
+    </div>
   );
 };
 

--- a/apps/builder/app/builder/features/topbar/domain-checkbox.tsx
+++ b/apps/builder/app/builder/features/topbar/domain-checkbox.tsx
@@ -1,0 +1,69 @@
+import { useStore } from "@nanostores/react";
+import {
+  Flex,
+  Tooltip,
+  Text,
+  theme,
+  Link,
+  buttonStyle,
+  Checkbox,
+} from "@webstudio-is/design-system";
+import { $userPlanFeatures } from "~/builder/shared/nano-states";
+
+export const domainToPublishName = "domainToPublish[]";
+
+interface DomainCheckboxProps {
+  defaultChecked?: boolean;
+  domain: string;
+  buildId: string | undefined;
+  disabled?: boolean;
+}
+
+const DomainCheckbox = (props: DomainCheckboxProps) => {
+  const hasProPlan = useStore($userPlanFeatures).hasProPlan;
+
+  const tooltipContentForFreeUsers = hasProPlan ? undefined : (
+    <Flex direction="column" gap="2" css={{ maxWidth: theme.spacing[28] }}>
+      <Text variant="titles">Publish to Staging</Text>
+      <Text>
+        <Flex direction="column">
+          Staging allows you to preview a production version of your site
+          without potentially breaking what production site visitors will see.
+          <>
+            <br />
+            <br />
+            Upgrade to Pro to be able to publish to each domain individually.
+            <br /> <br />
+            <Link
+              className={buttonStyle({ color: "gradient" })}
+              color="contrast"
+              underline="none"
+              href="https://webstudio.is/pricing"
+              target="_blank"
+            >
+              Upgrade
+            </Link>
+          </>
+        </Flex>
+      </Text>
+    </Flex>
+  );
+
+  const defaultChecked = hasProPlan ? props.defaultChecked : true;
+  const disabled = hasProPlan ? props.disabled : true;
+
+  return (
+    <Tooltip content={tooltipContentForFreeUsers} variant="wrapped">
+      <Checkbox
+        disabled={disabled}
+        key={props.buildId ?? "-"}
+        defaultChecked={defaultChecked}
+        css={{ pointerEvents: "all" }}
+        name={domainToPublishName}
+        value={props.domain}
+      />
+    </Tooltip>
+  );
+};
+
+export default DomainCheckbox;

--- a/apps/builder/app/builder/features/topbar/domain-checkbox.tsx
+++ b/apps/builder/app/builder/features/topbar/domain-checkbox.tsx
@@ -32,7 +32,7 @@ const DomainCheckbox = (props: DomainCheckboxProps) => {
           <>
             <br />
             <br />
-            Upgrade to Pro to be able to publish to each domain individually.
+            Upgrade to Pro account to publish to each domain individually.
             <br /> <br />
             <Link
               className={buttonStyle({ color: "gradient" })}

--- a/apps/builder/app/builder/features/topbar/domains.tsx
+++ b/apps/builder/app/builder/features/topbar/domains.tsx
@@ -10,6 +10,7 @@ import {
   Flex,
   NestedInputButton,
   Separator,
+  toast,
 } from "@webstudio-is/design-system";
 import type { Project } from "@webstudio-is/project";
 import {
@@ -20,14 +21,21 @@ import {
 } from "@webstudio-is/icons";
 import type { DomainStatus } from "@webstudio-is/prisma-client";
 import { CollapsibleDomainSection } from "./collapsible-domain-section";
-import { useCallback, useEffect, useState } from "react";
+import {
+  startTransition,
+  useEffect,
+  useOptimistic,
+  useRef,
+  useState,
+} from "react";
 import { formatDistance } from "date-fns/formatDistance";
 import { Entri } from "./entri";
-import { trpcClient } from "~/shared/trpc/trpc-client";
+import { nativeClient } from "~/shared/trpc/trpc-client";
 import { useStore } from "@nanostores/react";
 import { $publisherHost } from "~/shared/nano-states";
 import { extractCname } from "./cname";
-import type { Database } from "@webstudio-is/postrest/index.server";
+import { useEffectEvent } from "~/shared/hook-utils/effect-event";
+import DomainCheckbox from "./domain-checkbox";
 
 export type Domain = Project["domainsVirtual"][number];
 
@@ -41,6 +49,7 @@ const CopyToClipboard = (props: { text: string }) => {
   return (
     <Tooltip content={"Copy to clipboard"}>
       <NestedInputButton
+        type="button"
         onClick={() => {
           navigator.clipboard.writeText(props.text);
         }}
@@ -58,40 +67,6 @@ export const getStatus = (projectDomain: Domain) =>
 
 export const PENDING_TIMEOUT =
   process.env.NODE_ENV === "production" ? 60 * 3 * 1000 : 35000;
-
-export const getPublishStatusAndTextNew = ({
-  createdAt,
-  publishStatus,
-}: Pick<
-  Database["public"]["Tables"]["latestBuildVirtual"]["Row"],
-  "createdAt" | "publishStatus"
->) => {
-  let status = publishStatus;
-
-  const delta = Date.now() - new Date(createdAt).getTime();
-  // Assume build failed after 3 minutes
-
-  if (publishStatus === "PENDING" && delta > PENDING_TIMEOUT) {
-    status = "FAILED";
-  }
-
-  const textStart =
-    status === "PUBLISHED"
-      ? "Published"
-      : status === "FAILED"
-        ? "Publish failed"
-        : "Publishing started";
-
-  const statusText = `${textStart} ${formatDistance(
-    new Date(createdAt),
-    new Date(),
-    {
-      addSuffix: true,
-    }
-  )}`;
-
-  return { statusText, status };
-};
 
 export const getPublishStatusAndText = ({
   createdAt,
@@ -207,151 +182,113 @@ const StatusIcon = (props: { projectDomain: Domain; isLoading: boolean }) => {
 const DomainItem = (props: {
   initiallyOpen: boolean;
   projectDomain: Domain;
-  refreshDomainResult: (
-    input: { projectId: Project["id"] },
-    onSuccess?: () => void
-  ) => void;
-  domainState: "idle" | "submitting";
-  isPublishing: boolean;
+  refresh: () => Promise<void>;
+  project: Project;
 }) => {
-  const {
-    send: verify,
-    state: verifyState,
-    data: verifyData,
-    error: verifySystemError,
-  } = trpcClient.domain.verify.useMutation();
+  const timeSinceLastUpdateMs =
+    Date.now() - new Date(props.projectDomain.updatedAt).getTime();
 
-  const {
-    send: remove,
-    state: removeState,
-    data: removeData,
-    error: removeSystemError,
-  } = trpcClient.domain.remove.useMutation();
-
-  const {
-    send: updateStatus,
-    state: updateStatusState,
-    data: updateStatusData,
-    error: updateStatusError,
-  } = trpcClient.domain.updateStatus.useMutation();
-
-  const [isStatusLoading, setIsStatusLoading] = useState(true);
-
-  const isRemoveInProgress =
-    removeState !== "idle" || props.domainState !== "idle";
-
-  const isCheckStateInProgress =
-    verifyState !== "idle" ||
-    updateStatusState !== "idle" ||
-    props.domainState !== "idle";
+  const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
   const status = props.projectDomain.verified
     ? (`VERIFIED_${props.projectDomain.status}` as `VERIFIED_${DomainStatus}`)
     : `UNVERIFIED`;
 
-  const { initiallyOpen } = props;
+  const [isStatusLoading, setIsStatusLoading] = useState(
+    props.initiallyOpen ||
+      status === "VERIFIED_ACTIVE" ||
+      timeSinceLastUpdateMs > DAY_IN_MS
+      ? false
+      : true
+  );
 
-  const domainId = props.projectDomain.domainId;
-  const domain = props.projectDomain.domain;
-  const domainStatus = props.projectDomain.status;
-  const domainError = props.projectDomain.error;
-  const domainUpdatedAt = props.projectDomain.updatedAt;
+  const [isCheckStateInProgress, setIsCheckStateInProgress] =
+    useOptimistic(false);
 
-  const projectId = props.projectDomain.projectId;
-  // const domain
+  const [isRemoveInProgress, setIsRemoveInProgress] = useOptimistic(false);
 
-  const refreshDomainResult = props.refreshDomainResult;
+  const handleRemoveDomain = async () => {
+    setIsRemoveInProgress(true);
+    const result = await nativeClient.domain.remove.mutate({
+      projectId: props.projectDomain.projectId,
+      domainId: props.projectDomain.domainId,
+    });
 
-  // @todo this should gone https://github.com/webstudio-is/webstudio/issues/1723
-  const handleVerify = useCallback(() => {
-    verify(
-      {
-        domainId,
-        projectId,
-      },
-      (verifyResponse) => {
-        setIsStatusLoading(false);
+    if (result.success === false) {
+      toast.error(result.error);
+      return;
+    }
 
-        if (verifyResponse.success) {
-          refreshDomainResult({
-            projectId,
-          });
-        }
-      }
-    );
-  }, [domainId, projectId, refreshDomainResult, verify]);
+    await props.refresh();
+  };
 
-  // @todo this should gone https://github.com/webstudio-is/webstudio/issues/1723
-  const handleUpdateStatus = useCallback(() => {
-    updateStatus(
-      {
-        domain,
-        projectId,
-      },
-      (data) => {
-        setIsStatusLoading(false);
+  const [verifyError, setVerifyError] = useState<string | undefined>(undefined);
 
-        if (data.success) {
-          if (
-            domainStatus !== data.domain.status ||
-            domainError !== data.domain.error
-          ) {
-            refreshDomainResult({
-              projectId,
-            });
-          }
-        }
-      }
-    );
-  }, [
-    domain,
-    domainError,
-    domainStatus,
-    projectId,
-    refreshDomainResult,
-    updateStatus,
-  ]);
+  const handleVerify = useEffectEvent(async () => {
+    setVerifyError(undefined);
+    setIsCheckStateInProgress(true);
 
-  // @todo this should gone https://github.com/webstudio-is/webstudio/issues/1723
+    const verifyResult = await nativeClient.domain.verify.mutate({
+      projectId: props.projectDomain.projectId,
+      domainId: props.projectDomain.domainId,
+    });
+
+    if (verifyResult.success === false) {
+      setVerifyError(verifyResult.error);
+      return;
+    }
+
+    await props.refresh();
+  });
+
+  const [updateStatusError, setUpdateStatusError] = useState<
+    string | undefined
+  >(undefined);
+
+  const handleUpdateStatus = useEffectEvent(async () => {
+    setUpdateStatusError(undefined);
+    setIsCheckStateInProgress(true);
+
+    const updateStatusResult = await nativeClient.domain.updateStatus.mutate({
+      projectId: props.projectDomain.projectId,
+      domain: props.projectDomain.domain,
+    });
+
+    setIsStatusLoading(false);
+
+    if (updateStatusResult.success === false) {
+      setUpdateStatusError(updateStatusResult.error);
+      return;
+    }
+
+    await props.refresh();
+  });
+
+  const onceRef = useRef(false);
   useEffect(() => {
-    if (initiallyOpen) {
-      setIsStatusLoading(false);
+    if (onceRef.current) {
       return;
     }
+    onceRef.current = true;
 
-    if (status === "VERIFIED_ACTIVE") {
-      setIsStatusLoading(false);
-      return;
-    }
-
-    const timeSinceLastUpdateMs =
-      Date.now() - new Date(domainUpdatedAt).getTime();
-
-    const DAY_IN_MS = 24 * 60 * 60 * 1000;
-    // Do not check status if it updated more than one day ago
-    if (timeSinceLastUpdateMs > DAY_IN_MS) {
-      setIsStatusLoading(false);
+    if (isStatusLoading === false) {
       return;
     }
 
     if (status === "UNVERIFIED") {
-      handleVerify();
+      startTransition(async () => {
+        await handleVerify();
+        await handleUpdateStatus();
+      });
       return;
     }
-
-    handleUpdateStatus();
-
-    // Update status automatically
-  }, [
-    status,
-    initiallyOpen,
-    handleVerify,
-    handleUpdateStatus,
-    domainUpdatedAt,
-  ]);
+    startTransition(async () => {
+      await handleUpdateStatus();
+    });
+  }, [status, handleVerify, handleUpdateStatus, isStatusLoading]);
 
   const publisherHost = useStore($publisherHost);
-  const cnameEntryName = extractCname(domain);
+  const cnameEntryName = extractCname(props.projectDomain.domain);
   const cnameEntryValue = `${props.projectDomain.cname}.customers.${publisherHost}`;
 
   const txtEntryName =
@@ -359,10 +296,7 @@ const DomainItem = (props: {
       ? "_webstudio_is"
       : `_webstudio_is.${cnameEntryName}`;
 
-  const { isVerifiedActive, text } = getStatusText({
-    projectDomain: props.projectDomain,
-    isLoading: false,
-  });
+  const domainStatus = getStatus(props.projectDomain);
 
   const cnameRecord = {
     type: "CNAME",
@@ -380,10 +314,27 @@ const DomainItem = (props: {
 
   const dnsRecords = [cnameRecord, txtRecord];
 
+  const { isVerifiedActive, text } = getStatusText({
+    projectDomain: props.projectDomain,
+    isLoading: false,
+  });
+
   return (
     <CollapsibleDomainSection
+      prefix={
+        <DomainCheckbox
+          buildId={props.projectDomain.latestBuildVirtual?.buildId}
+          defaultChecked={
+            props.projectDomain.latestBuildVirtual?.buildId != null &&
+            props.projectDomain.latestBuildVirtual?.buildId ===
+              props.project.latestBuildVirtual?.buildId
+          }
+          domain={props.projectDomain.domain}
+          disabled={domainStatus !== "VERIFIED_ACTIVE"}
+        />
+      }
       initiallyOpen={props.initiallyOpen}
-      title={domain}
+      title={props.projectDomain.domain}
       suffix={
         <Grid flow="column">
           <StatusIcon
@@ -391,12 +342,12 @@ const DomainItem = (props: {
             projectDomain={props.projectDomain}
           />
 
-          <Tooltip content={`Proceed to ${domain}`}>
+          <Tooltip content={`Proceed to ${props.projectDomain.domain}`}>
             <IconButton
               tabIndex={-1}
               disabled={status !== "VERIFIED_ACTIVE"}
               onClick={(event) => {
-                const url = new URL(`https://${domain}`);
+                const url = new URL(`https://${props.projectDomain.domain}`);
                 window.open(url.href, "_blank");
                 event.preventDefault();
               }}
@@ -409,14 +360,11 @@ const DomainItem = (props: {
     >
       {status === "UNVERIFIED" && (
         <>
-          {verifySystemError !== undefined && (
-            <Text color="destructive">{verifySystemError}</Text>
-          )}
           <Button
-            disabled={props.isPublishing || isCheckStateInProgress}
+            formAction={handleVerify}
+            state={isCheckStateInProgress ? "pending" : undefined}
             color="primary"
             css={{ width: "100%", flexShrink: 0, mt: theme.spacing[3] }}
-            onClick={handleVerify}
           >
             Check status
           </Button>
@@ -425,40 +373,25 @@ const DomainItem = (props: {
 
       {status !== "UNVERIFIED" && (
         <>
-          {updateStatusData?.success === false && (
-            <Text color="destructive">{updateStatusData.error}</Text>
-          )}
-          {updateStatusError !== undefined && (
+          {updateStatusError && (
             <Text color="destructive">{updateStatusError}</Text>
           )}
           <Button
-            disabled={props.isPublishing || isCheckStateInProgress}
+            formAction={handleUpdateStatus}
+            state={isCheckStateInProgress ? "pending" : undefined}
             color="primary"
             css={{ width: "100%", flexShrink: 0, mt: theme.spacing[3] }}
-            onClick={handleUpdateStatus}
           >
             Check status
           </Button>
         </>
       )}
 
-      {removeData?.success === false && (
-        <Text color="destructive">{removeData.error}</Text>
-      )}
-
-      {removeSystemError !== undefined && (
-        <Text color="destructive">{removeSystemError}</Text>
-      )}
-
       <Button
-        disabled={props.isPublishing || isRemoveInProgress}
+        formAction={handleRemoveDomain}
+        state={isRemoveInProgress ? "pending" : undefined}
         color="neutral"
         css={{ width: "100%", flexShrink: 0 }}
-        onClick={() => {
-          remove({ projectId, domainId }, () => {
-            props.refreshDomainResult({ projectId });
-          });
-        }}
       >
         Remove domain
       </Button>
@@ -467,11 +400,11 @@ const DomainItem = (props: {
         <Grid gap={1}>
           {status === "UNVERIFIED" && (
             <>
-              {verifyData?.success === false ? (
+              {verifyError ? (
                 <Text color="destructive">
                   Status: Failed to verify
                   <br />
-                  {verifyData.error}
+                  {verifyError}
                 </Text>
               ) : (
                 <>
@@ -558,18 +491,21 @@ const DomainItem = (props: {
 
         <Entri
           dnsRecords={dnsRecords}
-          domain={domain}
+          domain={props.projectDomain.domain}
           onClose={() => {
             // Sometimes Entri modal dialog hangs even if it's successful,
             // until they fix that, we'll just refresh the status here on every onClose event
             if (status === "UNVERIFIED") {
-              handleVerify();
+              startTransition(async () => {
+                await handleVerify();
+                await handleUpdateStatus();
+              });
               return;
             }
-
-            handleUpdateStatus();
+            startTransition(async () => {
+              await handleUpdateStatus();
+            });
           }}
-          isPublishing={props.isPublishing}
         />
       </Grid>
     </CollapsibleDomainSection>
@@ -579,20 +515,15 @@ const DomainItem = (props: {
 type DomainsProps = {
   newDomains: Set<string>;
   domains: Domain[];
-  refreshDomainResult: (
-    input: { projectId: Project["id"] },
-    onSuccess?: () => void
-  ) => void;
-  domainState: "idle" | "submitting";
-  isPublishing: boolean;
+  refresh: () => Promise<void>;
+  project: Project;
 };
 
 export const Domains = ({
   newDomains,
   domains,
-  refreshDomainResult,
-  domainState,
-  isPublishing,
+  refresh,
+  project,
 }: DomainsProps) => {
   return (
     <>
@@ -601,9 +532,8 @@ export const Domains = ({
           key={projectDomain.domain}
           projectDomain={projectDomain}
           initiallyOpen={newDomains.has(projectDomain.domain)}
-          refreshDomainResult={refreshDomainResult}
-          domainState={domainState}
-          isPublishing={isPublishing}
+          refresh={refresh}
+          project={project}
         />
       ))}
     </>

--- a/apps/builder/app/builder/features/topbar/entri.tsx
+++ b/apps/builder/app/builder/features/topbar/entri.tsx
@@ -10,12 +10,10 @@ export const Entri = ({
   dnsRecords,
   domain,
   onClose,
-  isPublishing,
 }: {
   dnsRecords: DnsRecord[];
   domain: string;
   onClose: (detail: EntriCloseDetail) => void;
-  isPublishing: boolean;
 }) => {
   entriGlobalStyles();
   const { error, isOpen, showDialog } = useEntri({
@@ -29,9 +27,10 @@ export const Entri = ({
       {error !== undefined && <Text color="destructive">{error}</Text>}
 
       <Button
-        disabled={isOpen || isPublishing}
+        disabled={isOpen}
         color="neutral"
         css={{ width: "100%", flexShrink: 0 }}
+        type="button"
         onClick={() => {
           showDialog();
         }}

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -512,9 +512,19 @@ const PublishStatic = ({
 const useCanAddDomain = () => {
   const { load, data } = trpcClient.domain.countTotalDomains.useQuery();
   const { maxDomainsAllowedPerUser, hasProPlan } = useStore($userPlanFeatures);
+  const project = useStore($project);
+
+  const activeDomainsCount = project?.domainsVirtual.filter(
+    (domain) => domain.status === "ACTIVE" && domain.verified
+  ).length;
+
   useEffect(() => {
     load();
-  }, [load]);
+  }, [load, activeDomainsCount]);
+
+  if (hasProPlan) {
+    return { canAddDomain: true, maxDomainsAllowedPerUser };
+  }
 
   if (data?.success === false) {
     return { canAddDomain: false, maxDomainsAllowedPerUser };
@@ -524,6 +534,7 @@ const useCanAddDomain = () => {
     ? data.success && data.data < maxDomainsAllowedPerUser
     : true;
   const canAddDomain = hasProPlan || withinFreeLimit;
+
   return { canAddDomain, maxDomainsAllowedPerUser };
 };
 

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -70,6 +70,7 @@ const ChangeProjectDomain = ({
 }: ChangeProjectDomainProps) => {
   const id = useId();
   const publishedOrigin = useStore($publishedOrigin);
+  const hasProPlan = useStore($userPlanFeatures).hasProPlan;
 
   const [domain, setDomain] = useState(project.domain);
   const [error, setError] = useState<string>();
@@ -111,15 +112,19 @@ const ChangeProjectDomain = ({
           status: "PENDING" as const,
         };
 
+  const hideDomainCheckbox = project.domainsVirtual.length === 0 && hasProPlan;
+
   return (
     <CollapsibleDomainSection
       title={new URL(publishedOrigin).host}
       prefix={
-        <DomainCheckbox
-          defaultChecked={project.latestBuildVirtual?.domain === domain}
-          buildId={project.latestBuildVirtual?.buildId}
-          domain={domain}
-        ></DomainCheckbox>
+        hideDomainCheckbox ? null : (
+          <DomainCheckbox
+            defaultChecked={project.latestBuildVirtual?.domain === domain}
+            buildId={project.latestBuildVirtual?.buildId}
+            domain={domain}
+          ></DomainCheckbox>
+        )
       }
       suffix={
         <Grid flow="column" align="center">
@@ -521,7 +526,7 @@ const Content = (props: {
               <Text variant="regularBold" inline>
                 Upgrade to a Pro account
               </Text>{" "}
-              to add unlimited domains.
+              to add unlimited domains and publish to each domain individually.
             </Text>
             <Link
               className={buttonStyle({ color: "gradient" })}

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -1,10 +1,9 @@
 import {
-  useCallback,
   useEffect,
-  useMemo,
   useState,
   useOptimistic,
   useTransition,
+  startTransition,
 } from "react";
 import { useStore } from "@nanostores/react";
 import {
@@ -24,7 +23,6 @@ import {
   InputField,
   Separator,
   ScrollArea,
-  Box,
   rawTheme,
   Select,
   theme,
@@ -33,6 +31,7 @@ import {
   PanelBanner,
   buttonStyle,
   toast,
+  RadioGroup,
 } from "@webstudio-is/design-system";
 import stripIndent from "strip-indent";
 import {
@@ -41,13 +40,7 @@ import {
 } from "../../shared/nano-states";
 import { validateProjectDomain, type Project } from "@webstudio-is/project";
 import { $authPermit, $project, $publishedOrigin } from "~/shared/nano-states";
-import {
-  Domains,
-  getStatus,
-  type Domain,
-  PENDING_TIMEOUT,
-  getPublishStatusAndTextNew,
-} from "./domains";
+import { Domains, PENDING_TIMEOUT, getPublishStatusAndText } from "./domains";
 import { CollapsibleDomainSection } from "./collapsible-domain-section";
 import {
   CheckCircleIcon,
@@ -61,74 +54,29 @@ import { trpcClient, nativeClient } from "~/shared/trpc/trpc-client";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import type { Templates } from "@webstudio-is/sdk";
 import { formatDistance } from "date-fns/formatDistance";
-
-type ProjectData =
-  | {
-      success: true;
-      project: Project;
-    }
-  | {
-      success: false;
-      error: string;
-    };
+import DomainCheckbox, { domainToPublishName } from "./domain-checkbox";
 
 type ChangeProjectDomainProps = {
   project: Project;
   projectState: "idle" | "submitting";
-  isPublishing: boolean;
-  projectLoad: (
-    props: { projectId: Project["id"] },
-    callback: (projectData: ProjectData) => void
-  ) => void;
+  refresh: () => void;
 };
 
-type TimeoutId = undefined | ReturnType<typeof setTimeout>;
+// type TimeoutId = undefined | ReturnType<typeof setTimeout>;
 
 const ChangeProjectDomain = ({
   project,
-  projectLoad,
-  projectState,
-  isPublishing,
+  refresh,
 }: ChangeProjectDomainProps) => {
   const id = useId();
   const publishedOrigin = useStore($publishedOrigin);
 
-  const {
-    send: updateProjectDomain,
-    state: updateProjectDomainState,
-    error: updateProjectSystemError,
-  } = trpcClient.domain.updateProjectDomain.useMutation();
-
   const [domain, setDomain] = useState(project.domain);
   const [error, setError] = useState<string>();
+  const [isUpdateInProgress, setIsUpdateInProgress] = useOptimistic(false);
 
-  const refreshProject = useCallback(
-    () =>
-      projectLoad({ projectId: project.id }, (projectData) => {
-        if (projectData?.success === false) {
-          setError(projectData.error);
-          return;
-        }
-
-        const currenProject = $project.get();
-
-        if (currenProject?.id === projectData.project.id) {
-          $project.set({
-            ...currenProject,
-            domain: projectData.project.domain,
-          });
-        }
-
-        setDomain(projectData.project.domain);
-      }),
-    [projectLoad, project.id]
-  );
-
-  useEffect(() => {
-    refreshProject();
-  }, [refreshProject]);
-
-  const handleUpdateProjectDomain = () => {
+  const updateProjectDomain = async () => {
+    setIsUpdateInProgress(true);
     const validationResult = validateProjectDomain(domain);
 
     if (validationResult.success === false) {
@@ -136,26 +84,28 @@ const ChangeProjectDomain = ({
       return;
     }
 
-    if (updateProjectDomainState !== "idle") {
-      return;
-    }
-    if (domain === project.domain) {
+    const updateResult = await nativeClient.domain.updateProjectDomain.mutate({
+      domain,
+      projectId: project.id,
+    });
+
+    if (updateResult.success === false) {
+      setError(updateResult.error);
       return;
     }
 
-    updateProjectDomain({ domain, projectId: project.id }, (data) => {
-      if (data?.success === false) {
-        setError(data.error);
-        return;
-      }
+    await refresh();
+  };
 
-      refreshProject();
+  const handleUpdateProjectDomain = () => {
+    startTransition(async () => {
+      await updateProjectDomain();
     });
   };
 
   const { statusText, status } =
     project.latestBuildVirtual != null
-      ? getPublishStatusAndTextNew(project.latestBuildVirtual)
+      ? getPublishStatusAndText(project.latestBuildVirtual)
       : {
           statusText: "Not published",
           status: "PENDING" as const,
@@ -164,8 +114,15 @@ const ChangeProjectDomain = ({
   return (
     <CollapsibleDomainSection
       title={new URL(publishedOrigin).host}
+      prefix={
+        <DomainCheckbox
+          defaultChecked={project.latestBuildVirtual?.domain === domain}
+          buildId={project.latestBuildVirtual?.buildId}
+          domain={domain}
+        ></DomainCheckbox>
+      }
       suffix={
-        <Grid flow="column">
+        <Grid flow="column" align="center">
           <Tooltip content={error !== undefined ? error : statusText}>
             <Flex
               align={"center"}
@@ -190,7 +147,6 @@ const ChangeProjectDomain = ({
           <Tooltip content={`Proceed to ${publishedOrigin}`}>
             <IconButton
               tabIndex={-1}
-              disabled={error !== undefined || status !== "PUBLISHED"}
               onClick={(event) => {
                 window.open(publishedOrigin, "_blank");
                 event.preventDefault();
@@ -210,11 +166,7 @@ const ChangeProjectDomain = ({
             id={id}
             placeholder="Domain"
             value={domain}
-            disabled={
-              isPublishing ||
-              updateProjectDomainState !== "idle" ||
-              projectState !== "idle"
-            }
+            disabled={isUpdateInProgress}
             onChange={(event) => {
               setError(undefined);
               setDomain(event.target.value);
@@ -232,16 +184,9 @@ const ChangeProjectDomain = ({
                 }
               }
             }}
-            color={
-              error !== undefined || updateProjectSystemError !== undefined
-                ? "error"
-                : undefined
-            }
+            color={error !== undefined ? "error" : undefined}
           />
           {error !== undefined && <Text color="destructive">{error}</Text>}
-          {updateProjectSystemError !== undefined && (
-            <Text color="destructive">{updateProjectSystemError}</Text>
-          )}
         </Grid>
       </Grid>
     </CollapsibleDomainSection>
@@ -250,55 +195,90 @@ const ChangeProjectDomain = ({
 
 const Publish = ({
   project,
-  domainsToPublish,
   refresh,
-
-  isPublishing,
-  setIsPublishing,
 }: {
   project: Project;
-  domainsToPublish: Domain[];
-  refresh: () => void;
 
-  isPublishing: boolean;
-  setIsPublishing: (isPublishing: boolean) => void;
+  refresh: () => Promise<void>;
 }) => {
-  const {
-    send: publish,
-    state: publishState,
-    data: publishData,
-    error: publishSystemError,
-  } = trpcClient.domain.publish.useMutation();
+  const [publishError, setPublishError] = useState<string | undefined>();
+  const [isPublishing, setIsPublishing] = useOptimistic(false);
 
-  useEffect(() => {
-    if (isPublishing) {
-      let timeoutHandle: TimeoutId;
-      let totalCalls = 0;
-      const timeout = 10000;
-      // Repeat few more times than timeout
-      const repeat = PENDING_TIMEOUT / timeout + 5;
+  const handlePublish = async (formData: FormData) => {
+    setPublishError(undefined);
+    setIsPublishing(true);
 
-      // Call refresh
-      const execRefresh = () => {
-        if (totalCalls < repeat) {
-          totalCalls += 1;
-          clearTimeout(timeoutHandle);
-          timeoutHandle = setTimeout(() => {
-            refresh();
-            execRefresh();
-          }, timeout);
-        }
-      };
+    const domains = formData
+      .getAll(domainToPublishName)
+      .map((domainEntry) => domainEntry.toString());
 
-      execRefresh();
-
-      return () => {
-        clearTimeout(timeoutHandle);
-      };
+    if (domains.length === 0) {
+      toast.error("Please select at least one domain to publish");
+      return;
     }
-  }, [isPublishing, refresh]);
 
-  const isPublishInProgress = publishState !== "idle" || isPublishing;
+    const publishResult = await nativeClient.domain.publish.mutate({
+      projectId: project.id,
+      domains,
+      destination: "saas",
+    });
+
+    if (publishResult.success === false) {
+      console.error(publishResult.error);
+
+      setPublishError(publishResult.error);
+      toast.error(publishResult.error);
+
+      if (process.env.NODE_ENV === "development") {
+        // Refresh locally as it's always an error
+        await refresh();
+      }
+
+      return;
+    }
+
+    let sleepTime = 15000;
+    const timeToFinish = Date.now() + PENDING_TIMEOUT + 2 * sleepTime;
+
+    // Wait until project is published or failed
+    while (Date.now() < timeToFinish) {
+      await refresh();
+
+      const project = $project.get();
+
+      if (project == null) {
+        throw new Error("Project not found");
+      }
+
+      const { statusText, status } =
+        project.latestBuildVirtual != null
+          ? getPublishStatusAndText(project.latestBuildVirtual)
+          : {
+              statusText: "Not published",
+              status: "PENDING" as const,
+            };
+
+      if (status === "PUBLISHED") {
+        break;
+      }
+
+      if (status === "FAILED") {
+        toast.error(statusText);
+        setPublishError(statusText);
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, sleepTime));
+
+      sleepTime = Math.max(5000, sleepTime - 5000);
+    }
+  };
+
+  const hasPendingState = project.latestBuildVirtual
+    ? getPublishStatusAndText(project.latestBuildVirtual).status === "PENDING"
+    : false;
+
+  const isPublishInProgress = isPublishing || hasPendingState;
 
   return (
     <Flex
@@ -312,13 +292,7 @@ const Publish = ({
       shrink={false}
       direction={"column"}
     >
-      {publishSystemError !== undefined && (
-        <Text color="destructive">{publishSystemError}</Text>
-      )}
-
-      {publishData?.success === false && (
-        <Text color="destructive">{publishData.error}</Text>
-      )}
+      {publishError && <Text color="destructive">{publishError}</Text>}
 
       <Tooltip
         content={
@@ -326,24 +300,9 @@ const Publish = ({
         }
       >
         <Button
+          formAction={handlePublish}
           color="positive"
           state={isPublishInProgress ? "pending" : undefined}
-          onClick={() => {
-            setIsPublishing(true);
-
-            publish(
-              {
-                projectId: project.id,
-                domains: domainsToPublish.map(
-                  (projectDomain) => projectDomain.domain
-                ),
-                destination: "saas",
-              },
-              () => {
-                refresh();
-              }
-            );
-          }}
         >
           Publish
         </Button>
@@ -386,33 +345,6 @@ const getStaticPublishStatusAndText = ({
   return { statusText, status };
 };
 
-const fetchProjectDataStatus = async (projectId: Project["id"]) => {
-  const projectData = await nativeClient.domain.project.query({
-    projectId,
-  });
-
-  if (projectData.success === false) {
-    throw new Error(projectData.error);
-  }
-
-  if (projectData.project.latestStaticBuild == null) {
-    return {
-      status: "LOADED" as const,
-      statusText: "Not published",
-    };
-  }
-
-  const { status, statusText } = getStaticPublishStatusAndText(
-    projectData.project.latestStaticBuild
-  );
-
-  return { status, statusText };
-};
-
-type StaticProjectStatus =
-  | Awaited<ReturnType<typeof fetchProjectDataStatus>>
-  | { status: "INITIAL"; statusText: string };
-
 const PublishStatic = ({
   projectId,
   templates,
@@ -420,58 +352,38 @@ const PublishStatic = ({
   projectId: Project["id"];
   templates: readonly Templates[];
 }) => {
+  const project = useStore($project);
   const [_, startTransition] = useTransition();
 
-  const [projectDataStatus, setProjectDataStatus] =
-    useState<StaticProjectStatus>({
-      status: "INITIAL",
-      statusText: "Loading",
-    });
+  if (project == null) {
+    throw new Error("Project not found");
+  }
 
-  useEffect(() => {
-    startTransition(async () => {
-      try {
-        const projectDataStatus = await fetchProjectDataStatus(projectId);
-        setProjectDataStatus(projectDataStatus);
-      } catch (error) {
-        setProjectDataStatus({
-          status: "FAILED",
-          statusText: error instanceof Error ? error.message : "Unknown error",
-        });
-      }
-    });
-  }, [projectId]);
+  const { status, statusText } =
+    project.latestStaticBuild == null
+      ? { status: "LOADED" as const, statusText: "Not published" }
+      : getStaticPublishStatusAndText(project.latestStaticBuild);
 
-  const [optimisticPendingStatus, setOptimisticPendingStatus] = useOptimistic(
-    projectDataStatus,
-    (_currentState, optimisticValue: StaticProjectStatus) => {
-      return optimisticValue;
-    }
-  );
+  const [isPending, setIsPendingOptimistic] = useOptimistic(false);
 
   const isPublishInProgress =
-    optimisticPendingStatus.status === "PENDING" ||
-    optimisticPendingStatus.status === "INITIAL";
+    project.latestStaticBuild?.publishStatus === "PENDING" || isPending;
 
   return (
     <Flex gap={2} shrink={false} direction={"column"}>
-      {optimisticPendingStatus.status === "FAILED" && (
-        <Text color="destructive">{optimisticPendingStatus.statusText}</Text>
-      )}
+      {status === "FAILED" && <Text color="destructive">{statusText}</Text>}
 
       <Tooltip
         content={isPublishInProgress ? "Preparing static site" : undefined}
       >
         <Button
+          type="button"
           color="positive"
           state={isPublishInProgress ? "pending" : undefined}
           onClick={() => {
             startTransition(async () => {
               try {
-                setOptimisticPendingStatus({
-                  status: "PENDING",
-                  statusText: "Publishing",
-                });
+                setIsPendingOptimistic(true);
 
                 const result = await nativeClient.domain.publish.mutate({
                   projectId,
@@ -496,30 +408,40 @@ const PublishStatic = ({
                 // Repeat few more times than timeout
                 const repeat = PENDING_TIMEOUT / timeout + 5;
 
-                let projectDataStatus: StaticProjectStatus | undefined;
-
                 for (let i = 0; i !== repeat; i++) {
                   await new Promise((resolve) => setTimeout(resolve, timeout));
 
-                  projectDataStatus = await fetchProjectDataStatus(projectId);
+                  await refreshProject();
 
-                  if (projectDataStatus.status !== "PENDING") {
+                  const latestStaticBuild = $project.get()?.latestStaticBuild;
+
+                  if (latestStaticBuild == null) {
+                    continue;
+                  }
+
+                  const { status } =
+                    getStaticPublishStatusAndText(latestStaticBuild);
+
+                  if (status !== "PENDING") {
                     break;
                   }
                 }
 
-                if (projectDataStatus == null) {
-                  return;
+                const latestStaticBuild = $project.get()?.latestStaticBuild;
+
+                if (latestStaticBuild == null) {
+                  throw new Error("Static build not found");
                 }
 
-                setProjectDataStatus(projectDataStatus);
+                const { status, statusText } =
+                  getStaticPublishStatusAndText(latestStaticBuild);
 
-                if (projectDataStatus.status === "FAILED") {
+                if (status === "FAILED") {
                   // Report if Export failed
-                  toast.error(projectDataStatus.statusText);
+                  toast.error(statusText);
                 }
 
-                if (projectDataStatus.status === "PUBLISHED") {
+                if (status === "PUBLISHED") {
                   window.location.href = `/cgi/static/ssg/${name}`;
                 }
               } catch (error) {
@@ -536,20 +458,6 @@ const PublishStatic = ({
     </Flex>
   );
 };
-
-const ErrorText = ({ children }: { children: string }) => (
-  <Flex
-    css={{
-      m: theme.spacing[9],
-      overflowWrap: "anywhere",
-    }}
-    gap={2}
-    direction={"column"}
-  >
-    <Text color="destructive">{children}</Text>
-    <Text color="subtle">Please try again later</Text>
-  </Flex>
-);
 
 const useCanAddDomain = () => {
   const { load, data } = trpcClient.domain.countTotalDomains.useQuery();
@@ -569,53 +477,40 @@ const useCanAddDomain = () => {
   return { canAddDomain, maxDomainsAllowedPerUser };
 };
 
+const refreshProject = async () => {
+  const result = await nativeClient.domain.project.query(
+    {
+      projectId: $project.get()!.id,
+    }
+    // Pass abort signal
+    // { signal: undefined }
+  );
+
+  if (result.success) {
+    $project.set(result.project);
+    return;
+  }
+
+  toast.error(result.error);
+};
+
 const Content = (props: {
   projectId: Project["id"];
   onExportClick: () => void;
 }) => {
   const [newDomains, setNewDomains] = useState(new Set<string>());
 
-  const {
-    load: projectLoad,
-    data: projectData,
-    state: projectState,
-    error: projectSystemError,
-  } = trpcClient.domain.project.useQuery();
+  const project = useStore($project);
 
-  useEffect(() => {
-    projectLoad({ projectId: props.projectId });
-  }, [props.projectId, projectLoad]);
-
-  projectData?.success;
-
-  const domainsToPublish = useMemo(
-    () =>
-      projectData?.success
-        ? projectData.project.domainsVirtual.filter(
-            (projectDomain) => getStatus(projectDomain) === "VERIFIED_ACTIVE"
-          )
-        : [],
-    [projectData]
-  );
-
-  const latestBuildVirtual = projectData?.success
-    ? (projectData.project.latestBuildVirtual ?? undefined)
-    : undefined;
-
-  const hasPendingState = latestBuildVirtual
-    ? getPublishStatusAndTextNew(latestBuildVirtual).status === "PENDING"
-    : false;
-
-  const [isPublishing, setIsPublishing] = useState(hasPendingState);
-
-  useEffect(() => {
-    setIsPublishing(hasPendingState);
-  }, [hasPendingState, setIsPublishing]);
+  if (project == null) {
+    throw new Error("Project not found");
+  }
+  const projectState = "idle";
 
   const { canAddDomain, maxDomainsAllowedPerUser } = useCanAddDomain();
 
   return (
-    <>
+    <form>
       <ScrollArea>
         {canAddDomain === false && (
           <PanelBanner>
@@ -639,59 +534,38 @@ const Content = (props: {
             </Link>
           </PanelBanner>
         )}
-        {projectSystemError !== undefined && (
-          <ErrorText>{projectSystemError}</ErrorText>
-        )}
-
-        {projectData?.success && (
+        <RadioGroup name="publishDomain">
           <ChangeProjectDomain
-            projectLoad={projectLoad}
+            refresh={refreshProject}
             projectState={projectState}
-            project={projectData.project}
-            isPublishing={isPublishing}
+            project={project}
           />
-        )}
 
-        {projectData?.success && (
           <Domains
             newDomains={newDomains}
-            domains={projectData.project.domainsVirtual}
-            refreshDomainResult={projectLoad}
-            domainState={projectState}
-            isPublishing={isPublishing}
+            domains={project.domainsVirtual}
+            refresh={refreshProject}
+            project={project}
           />
-        )}
+        </RadioGroup>
       </ScrollArea>
       <Flex direction="column" justify="end" css={{ height: 0 }}>
         <Separator />
       </Flex>
+
       <AddDomain
         projectId={props.projectId}
-        refreshDomainResult={projectLoad}
-        domainState={projectState}
+        refresh={refreshProject}
         onCreate={(domain) => {
           setNewDomains((prev) => {
             return new Set([...prev, domain]);
           });
         }}
-        isPublishing={isPublishing}
         onExportClick={props.onExportClick}
       />
-      {projectData?.success === true && (
-        <Publish
-          project={projectData.project}
-          domainsToPublish={domainsToPublish}
-          refresh={() => {
-            projectLoad({ projectId: props.projectId });
-          }}
-          isPublishing={isPublishing}
-          setIsPublishing={setIsPublishing}
-        />
-      )}
-      {projectData?.success !== true && (
-        <Box css={{ height: theme.spacing[8] }} />
-      )}
-    </>
+
+      <Publish project={project} refresh={refreshProject} />
+    </form>
   );
 };
 
@@ -845,6 +719,7 @@ const ExportContent = (props: { projectId: Project["id"] }) => {
 
           <Tooltip content={"Copy to clipboard"}>
             <Button
+              type="button"
               color="neutral"
               onClick={() => {
                 navigator.clipboard.writeText(npxCommand);
@@ -886,6 +761,7 @@ const ExportContent = (props: { projectId: Project["id"] }) => {
           />
           <Tooltip content={"Copy to clipboard"}>
             <Button
+              type="button"
               css={{ flexShrink: 0 }}
               color="neutral"
               onClick={() => {
@@ -959,7 +835,11 @@ export const PublishButton = ({ projectId }: PublishProps) => {
           sideOffset={Number.parseFloat(rawTheme.spacing[5])}
         >
           <FloatingPanelPopoverTrigger asChild>
-            <Button disabled={isPublishEnabled === false} color="positive">
+            <Button
+              type="button"
+              disabled={isPublishEnabled === false}
+              color="positive"
+            >
               Publish
             </Button>
           </FloatingPanelPopoverTrigger>

--- a/apps/builder/app/shared/db/canvas.server.ts
+++ b/apps/builder/app/shared/db/canvas.server.ts
@@ -34,13 +34,15 @@ export const loadProductionCanvasData = async (
   // Check that build deployment domains are still active and verified
   // for examle: redeploy created few days later
   if (deployment.destination !== "static") {
-    deployment.domains = deployment.domains.filter((domain) =>
-      currentProjectDomains.some(
-        (projectDomain) =>
-          projectDomain.domain === domain &&
-          projectDomain.status === "ACTIVE" &&
-          projectDomain.verified
-      )
+    deployment.domains = deployment.domains.filter(
+      (domain) =>
+        project.domain === domain ||
+        currentProjectDomains.some(
+          (projectDomain) =>
+            projectDomain.domain === domain &&
+            projectDomain.status === "ACTIVE" &&
+            projectDomain.verified
+        )
     );
   }
 

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -430,23 +430,25 @@ export const prebuild = async (options: {
 
   const assetsToDownload: Promise<void>[] = [];
 
-  const appDomain = options.preview ? "wstd.work" : "wstd.io";
-
-  const domain =
-    siteData.build.deployment?.destination === "static"
-      ? siteData.build.deployment?.assetsDomain
-      : siteData.build.deployment?.projectDomain;
-  if (domain === undefined) {
-    throw new Error(`Project domain is missing from the project data`);
-  }
-
-  const assetBuildUrl = `https://${domain}.${appDomain}/cgi/asset/`;
-
-  const imageLoader = createImageLoader({
-    imageBaseUrl: assetBuildUrl,
-  });
-
   if (options.assets === true) {
+    const appDomain = options.preview ? "wstd.work" : "wstd.io";
+    const domain =
+      siteData.build.deployment?.assetsDomain ??
+      // fallback to project domain should not be used since 2025-01-01 (for now is used for backward compatibility)
+      (siteData.build.deployment?.destination !== "static"
+        ? siteData.build.deployment?.projectDomain
+        : undefined);
+
+    if (domain === undefined) {
+      throw new Error(`Project domain is missing from the project data`);
+    }
+
+    const assetBuildUrl = `https://${domain}.${appDomain}/cgi/asset/`;
+
+    const imageLoader = createImageLoader({
+      imageBaseUrl: assetBuildUrl,
+    });
+
     for (const asset of siteData.assets) {
       if (asset.type === "image") {
         const imageSrc = imageLoader({

--- a/packages/design-system/src/components/checkbox.stories.tsx
+++ b/packages/design-system/src/components/checkbox.stories.tsx
@@ -1,6 +1,7 @@
 import { Label } from "./label";
 import { Checkbox, CheckboxAndLabel } from "./checkbox";
 import { StorySection, StoryGrid } from "./storybook";
+import { Tooltip } from "./tooltip";
 
 export default {
   title: "Library/Checkbox",
@@ -44,6 +45,15 @@ export const Demo = () => {
           <Checkbox id="B" />
           <Label htmlFor="B">Label B</Label>
         </CheckboxAndLabel>
+      </StorySection>
+
+      <StorySection title="With Tooltip">
+        <Tooltip content="Tooltip content">
+          <Checkbox defaultChecked />
+        </Tooltip>
+        <Tooltip content="Tooltip content">
+          <Checkbox disabled />
+        </Tooltip>
       </StorySection>
     </>
   );

--- a/packages/design-system/src/components/checkbox.tsx
+++ b/packages/design-system/src/components/checkbox.tsx
@@ -56,24 +56,49 @@ const iconByState = {
   indeterminate: CheckboxMixedFilledIcon,
 };
 
+type ButtonProps = ComponentProps<"button"> &
+  Pick<ComponentProps<typeof Primitive.Checkbox>, "aria-checked">;
+
+type AriaChecked = ComponentProps<typeof Primitive.Checkbox>["aria-checked"];
+
+const ariaCheckedToDataState = (
+  ariaChecked: AriaChecked
+): keyof typeof iconByState => {
+  if (ariaChecked === "true" || ariaChecked === true) {
+    return "checked";
+  }
+  if (ariaChecked === "false" || ariaChecked === false) {
+    return "unchecked";
+  }
+
+  if (ariaChecked === "mixed" || ariaChecked === undefined) {
+    return "indeterminate";
+  }
+
+  ariaChecked satisfies never;
+  return "indeterminate";
+};
+
 // We need this component basicslly just to get access to "data-state".
 // We could render all icons and hide one using CSS,
 // but that probably will be less performant.
-const Button = forwardRef(
-  (
-    props: ComponentProps<"button"> & {
-      "data-state"?: "checked" | "unchecked" | "indeterminate";
-    },
-    ref: Ref<HTMLButtonElement>
-  ) => {
-    const Icon = iconByState[props["data-state"] ?? "unchecked"];
-    return (
-      <button {...props} ref={ref}>
-        <Icon className={iconStyle()} />
-      </button>
-    );
-  }
-);
+const Button = forwardRef((props: ButtonProps, ref: Ref<HTMLButtonElement>) => {
+  // Using aria-checked instead of data-state ensures compatibility with Tooltip,
+  // as Tooltip overrides the Checkbox's data-state attribute.
+  const dataState = ariaCheckedToDataState(props["aria-checked"]);
+  const Icon = iconByState[dataState];
+
+  return (
+    <button
+      {...props}
+      data-state={dataState}
+      type={props.type ?? "button"}
+      ref={ref}
+    >
+      <Icon className={iconStyle()} />
+    </button>
+  );
+});
 Button.displayName = "Button";
 
 export const Checkbox = forwardRef(

--- a/packages/design-system/src/components/section-title.tsx
+++ b/packages/design-system/src/components/section-title.tsx
@@ -32,6 +32,9 @@ const containerStyle = css({
   height: theme.spacing[15],
   [buttonContentColor]: theme.colors.foregroundIconMain,
   [labelTextColor]: theme.colors.foregroundMain,
+  "&:hover": {
+    [chevronOpacity]: 1,
+  },
 });
 
 const titleButtonLayoutStyle = css({
@@ -54,9 +57,6 @@ const labelContainerStyle = css({
 
 const titleButtonStyle = css(titleButtonLayoutStyle, {
   "&:focus-visible": focusRingStyle(),
-  "&:hover": {
-    [chevronOpacity]: 1,
-  },
 });
 
 const suffixSlotStyle = css({

--- a/packages/domain/src/trpc/domain.ts
+++ b/packages/domain/src/trpc/domain.ts
@@ -62,18 +62,31 @@ export const domainRouter = router({
 
         const name = `${project.id}-${nanoid()}.zip`;
 
-        let domains: string[] = [];
+        const domains: string[] = [];
+
+        let hasCustomDomain = false;
 
         if (input.destination === "saas") {
           const currentProjectDomains = project.domainsVirtual;
 
-          domains = input.domains.filter((domain) =>
-            currentProjectDomains.some(
-              (projectDomain) =>
-                projectDomain.domain === domain &&
-                projectDomain.status === "ACTIVE" &&
-                projectDomain.verified
+          if (input.domains.includes(project.domain)) {
+            domains.push(project.domain);
+          }
+
+          domains.push(
+            ...input.domains.filter((domain) =>
+              currentProjectDomains.some(
+                (projectDomain) =>
+                  projectDomain.domain === domain &&
+                  projectDomain.status === "ACTIVE" &&
+                  projectDomain.verified
+              )
             )
+          );
+
+          hasCustomDomain = currentProjectDomains.some(
+            (projectDomain) =>
+              projectDomain.status === "ACTIVE" && projectDomain.verified
           );
         }
 
@@ -85,7 +98,8 @@ export const domainRouter = router({
                 ? {
                     destination: input.destination,
                     domains: domains,
-                    projectDomain: project.domain,
+                    assetsDomain: project.domain,
+                    excludeWstdDomainFromSearch: hasCustomDomain,
                   }
                 : {
                     destination: input.destination,
@@ -114,7 +128,7 @@ export const domainRouter = router({
           branchName: env.GITHUB_REF_NAME,
           destination: input.destination,
           // action log helper (not used for deployment, but for action logs readablity)
-          projectDomainName: project.domain,
+          logProjectName: `${project.title} - ${project.id}`,
         });
 
         if (input.destination === "static" && result.success) {

--- a/packages/postgrest/supabase/tests/cleanup-builds.sql
+++ b/packages/postgrest/supabase/tests/cleanup-builds.sql
@@ -1,0 +1,227 @@
+BEGIN;
+SET LOCAL search_path = pgtap, public;
+-- Initialize the testing environment without planning any specific number of tests
+-- We are using SELECT no_plan() because we don't specify the exact number of tests upfront.
+SELECT no_plan();
+
+-- =========================================
+-- Setup: Insert initial data for Users, Projects, Domains, ProjectDomains, and Builds
+-- =========================================
+
+-- Insert a user into the "User" table
+INSERT INTO "public"."User" ("id", "createdAt", "email", "username")
+VALUES
+  ('user1', '2023-01-01 00:00:00+00', 'user1@517cce32-9af3-example.com', 'user1');
+
+-- Insert projects associated with the user into the "Project" table
+INSERT INTO "public"."Project" ("id", "title", "domain", "userId", "isDeleted", "createdAt")
+VALUES
+  ('project1', 'Project One', '517cce32-9af3-project1-domain1', 'user1', false, '2023-01-01 00:00:00+00'),
+  ('project2', 'Project Two', '517cce32-9af3-project2-domain1', 'user1', false, '2023-01-01 00:00:00+00');
+
+-- Insert custom domains into the "Domain" table
+INSERT INTO "public"."Domain" ("id", "domain", "createdAt", "status", "updatedAt")
+VALUES
+  ('project-1-custom-domain-1', '517cce32-9af3-project-1-custom-domain-1.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00'),
+  ('project-1-custom-domain-2', '517cce32-9af3-project-1-custom-domain-2.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00'),
+  ('project-2-custom-domain-1', '517cce32-9af3-project-2-custom-domain-1.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00'),
+  ('project-2-custom-domain-2', '517cce32-9af3-project-2-custom-domain-2.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00');
+
+-- Establish relationships between projects and custom domains in the "ProjectDomain" table
+INSERT INTO "public"."ProjectDomain" ("projectId", "domainId", "createdAt", "txtRecord", "cname")
+VALUES
+  ('project1', 'project-1-custom-domain-1', '2023-01-01 00:00:00+00', 'txtRecord1', 'cname1'),
+  ('project1', 'project-1-custom-domain-2', '2023-01-01 00:00:00+00', 'txtRecord2', 'cname2'),
+  ('project2', 'project-2-custom-domain-1', '2023-01-01 00:00:00+00', 'p2-txtRecord1', 'cname1'),
+  ('project2', 'project-2-custom-domain-2', '2023-01-01 00:00:00+00', 'p2-txtRecord2', 'cname2');
+
+-- Insert initial builds into the "Build" table
+INSERT INTO "public"."Build" (
+    "id",
+    "createdAt",
+    "pages",
+    "projectId",
+    "deployment",
+    "updatedAt",
+    "publishStatus"
+)
+VALUES
+  -- Development Build for Project1
+  (
+    'build1-development',
+    '1990-01-01 00:00:00+00',
+    'home',
+    'project1',
+    NULL,
+    '1990-01-01 00:00:00+00',
+    'PENDING'
+  ),
+  -- Development Build for Project2
+  (
+    'project2-build1-development',
+    '1990-01-01 00:00:00+00',
+    'home',
+    'project2',
+    NULL,
+    '1990-01-01 00:00:00+00',
+    'PENDING'
+  ),
+  -- Custom Domain Build for Project2
+  (
+    'project2-build1-for-custom-domain-1',
+    '1990-01-02 00:00:00+00',
+    'home',
+    'project2',
+    '{"domains": ["517cce32-9af3-project-2-custom-domain-1.com"]}'::text,
+    '1990-01-02 00:00:00+00',
+    'PUBLISHED'
+  ),
+  -- Project Domain Build for Project2
+  (
+    'project2-build1-for-project-domain-1',
+    '1990-01-01 00:00:00+00',
+    'home',
+    'project2',
+    '{"domains": ["517cce32-9af3-project2-domain1"]}'::text,
+    '1990-01-01 00:00:00+00',
+    'PUBLISHED'
+  ),
+  -- Custom Domain Build for Project1
+  (
+    'build1-for-custom-domain-1',
+    '1990-01-02 00:00:00+00',
+    'home',
+    'project1',
+    '{"domains": ["517cce32-9af3-project-1-custom-domain-1.com"]}'::text,
+    '1990-01-02 00:00:00+00',
+    'PUBLISHED'
+  ),
+  -- Project Domain Build for Project1
+  (
+    'build1-for-project-domain-1',
+    '1990-01-01 00:00:00+00',
+    'home',
+    'project1',
+    '{"domains": ["517cce32-9af3-project1-domain1"]}'::text,
+    '1990-01-01 00:00:00+00',
+    'PUBLISHED'
+  );
+
+-- =========================================
+-- Test 1: Verify that initial cleanup does not clean any builds
+-- =========================================
+
+-- Run the database cleanup function for builds created in 1990
+SELECT database_cleanup('1990-01-01 00:00:00', '1990-12-31 23:59:59');
+
+-- Assert that no builds have been cleaned up initially
+SELECT is(
+  (SELECT count(*)::integer FROM "Build" WHERE "createdAt" BETWEEN '1990-01-01' AND '1990-12-31' AND "isCleaned" = TRUE),
+  0,
+  'Test 1: No builds should be cleaned up on initial cleanup'
+);
+
+-- =========================================
+-- Test 2: Insert a new project domain build and verify cleanup
+-- =========================================
+
+-- Insert a new build for the project domain
+INSERT INTO "public"."Build" (
+    "id",
+    "createdAt",
+    "pages",
+    "projectId",
+    "deployment",
+    "updatedAt",
+    "publishStatus"
+)
+VALUES
+  -- New Project Domain Build for Project1
+  (
+    'build2-for-project-domain-1',
+    '1990-01-02 00:00:00+00',  -- A later date than the previous build
+    'home',
+    'project1',
+    '{"domains": ["517cce32-9af3-project1-domain1"]}'::text,
+    '1990-01-02 00:00:00+00',
+    'PUBLISHED'
+  );
+
+-- Run the database cleanup function again
+SELECT database_cleanup('1990-01-01 00:00:00', '1990-12-31 23:59:59');
+
+-- Assert that one build has been cleaned (the previous project domain build)
+SELECT is(
+  (SELECT count(*)::integer FROM "Build" WHERE "createdAt" BETWEEN '1990-01-01' AND '1990-12-31' AND "isCleaned" = TRUE),
+  1,
+  'Test 2: Previous project domain build should be cleaned up after new build is published'
+);
+
+-- Assert that the specific build cleaned is 'build1-for-project-domain-1'
+SELECT is(
+  (SELECT id FROM "Build" WHERE "createdAt" BETWEEN '1990-01-01' AND '1990-12-31' AND "isCleaned" = TRUE),
+  'build1-for-project-domain-1',
+  'Test 2: Build "build1-for-project-domain-1" should be marked as cleaned'
+);
+
+-- =========================================
+-- Test 3: Insert a new custom domain build and verify cleanup
+-- =========================================
+
+-- Insert a new build for the custom domain
+INSERT INTO "public"."Build" (
+    "id",
+    "createdAt",
+    "pages",
+    "projectId",
+    "deployment",
+    "updatedAt",
+    "publishStatus"
+)
+VALUES
+  -- New Custom Domain Build for Project1
+  (
+    'build2-for-custom-domain-1',
+    '1990-01-03 00:00:00+00',  -- A later date than the previous build
+    'home',
+    'project1',
+    '{"domains": ["517cce32-9af3-project-1-custom-domain-1.com"]}'::text,
+    '1990-01-03 00:00:00+00',
+    'PUBLISHED'
+  );
+
+-- Run the database cleanup function again
+SELECT database_cleanup('1990-01-01 00:00:00', '1990-12-31 23:59:59');
+
+-- Assert that two builds have been cleaned (the previous project domain and custom domain builds)
+SELECT is(
+  (SELECT count(*)::integer FROM "Build" WHERE "createdAt" BETWEEN '1990-01-01' AND '1990-12-31' AND "isCleaned" = TRUE),
+  2,
+  'Test 3: Previous custom domain build should be cleaned up after new build is published'
+);
+
+-- Assert that the builds cleaned are 'build1-for-custom-domain-1' and 'build1-for-project-domain-1'
+SELECT results_eq(
+  $$
+      SELECT id FROM "Build" WHERE "createdAt" BETWEEN '1990-01-01' AND '1990-12-31' AND "isCleaned" = TRUE ORDER BY id
+  $$,
+  $$
+    SELECT * FROM (
+        VALUES
+            ('build1-for-custom-domain-1'),
+            ('build1-for-project-domain-1')
+    ) AS expected(id)
+    ORDER BY "id"
+  $$,
+  'Test 3: Builds "build1-for-custom-domain-1" and "build1-for-project-domain-1" should be marked as cleaned'
+);
+
+-- =========================================
+-- Finish the test
+-- =========================================
+
+-- Finish the test by calling the finish() function, which outputs the test summary
+SELECT finish();
+
+-- Rollback the transaction to ensure no changes are persisted in the database
+ROLLBACK;

--- a/packages/postgrest/supabase/tests/latest-builds-domains.sql
+++ b/packages/postgrest/supabase/tests/latest-builds-domains.sql
@@ -9,19 +9,19 @@ SELECT no_plan();
 -- Insert a new user into the User table
 INSERT INTO "public"."User" ("id", "createdAt", "email", "username")
 VALUES
-  ('user1', '2023-01-01 00:00:00+00', 'user1@example.com', 'user1');
+  ('user1', '2023-01-01 00:00:00+00', 'user1@517cce32-9af3-example.com', 'user1');
 
 -- Insert projects associated with the user
 INSERT INTO "public"."Project" ("id", "title", "domain", "userId", "isDeleted", "createdAt")
 VALUES
-  ('project1', 'Project One', 'project1-domain1', 'user1', false, '2023-01-01 00:00:00+00'),
-  ('project2', 'Project Two', 'project2-domain1', 'user1', false, '2023-01-01 00:00:00+00');
+  ('project1', 'Project One', '517cce32-9af3-project1-domain1', 'user1', false, '2023-01-01 00:00:00+00'),
+  ('project2', 'Project Two', '517cce32-9af3-project2-domain1', 'user1', false, '2023-01-01 00:00:00+00');
 
 -- Insert custom domains into the Domain table
 INSERT INTO "public"."Domain" ("id", "domain", "createdAt", "status", "updatedAt")
 VALUES
-  ('project-1-custom-domain-1', 'project-1-custom-domain-1.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00'),
-  ('project-1-custom-domain-2', 'project-1-custom-domain-2.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00');
+  ('project-1-custom-domain-1', '517cce32-9af3-project-1-custom-domain-1.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00'),
+  ('project-1-custom-domain-2', '517cce32-9af3-project-1-custom-domain-2.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00');
 
 -- Establish relationships between projects and custom domains
 INSERT INTO "public"."ProjectDomain" ("projectId", "domainId", "createdAt", "txtRecord", "cname")
@@ -76,7 +76,7 @@ VALUES
     '2023-01-02 00:00:00+00',
     'home',
     'project1',
-    '{"domains": ["some-other-domain.com", "project-1-custom-domain-1.com"]}'::text,
+    '{"domains": ["some-other-domain.com", "517cce32-9af3-project-1-custom-domain-1.com"]}'::text,
     '2023-01-02 00:00:00+00',
     'PUBLISHED'
 );
@@ -113,7 +113,7 @@ VALUES
     '2024-01-02 00:00:00+00',
     'home',
     'project1',
-    '{"domains": ["some-other-domain.com", "project-1-custom-domain-1.com"]}'::text,
+    '{"domains": ["some-other-domain.com", "517cce32-9af3-project-1-custom-domain-1.com"]}'::text,
     '2024-01-02 00:00:00+00',
     'PUBLISHED'
 );
@@ -150,7 +150,7 @@ VALUES
     '2024-01-03 00:00:00+00',
     'home',
     'project1',
-    '{"domains": ["some-other-domain.com", "project-1-custom-domain-2.com"]}'::text,
+    '{"domains": ["some-other-domain.com", "517cce32-9af3-project-1-custom-domain-2.com"]}'::text,
     '2024-01-03 00:00:00+00',
     'PUBLISHED'
 );
@@ -187,7 +187,7 @@ VALUES
     '2024-01-04 00:00:00+00',
     'home',
     'project1',
-    '{"domains": ["some-other-domain.com", "project-1-custom-domain-2.com", "project-1-custom-domain-1.com"]}'::text,
+    '{"domains": ["some-other-domain.com", "517cce32-9af3-project-1-custom-domain-2.com", "517cce32-9af3-project-1-custom-domain-1.com"]}'::text,
     '2024-01-04 00:00:00+00',
     'PUBLISHED'
 );
@@ -230,7 +230,7 @@ VALUES
     '2025-01-04 00:00:00+00',
     'home',
     'project2',
-    '{"domains": ["some-other-domain.com", "project-1-custom-domain-2.com", "project-1-custom-domain-1.com"]}'::text,
+    '{"domains": ["some-other-domain.com", "517cce32-9af3-project-1-custom-domain-2.com", "517cce32-9af3-project-1-custom-domain-1.com"]}'::text,
     '2025-01-04 00:00:00+00',
     'PUBLISHED'
 );

--- a/packages/postgrest/supabase/tests/latest-builds-projects.sql
+++ b/packages/postgrest/supabase/tests/latest-builds-projects.sql
@@ -83,7 +83,7 @@ VALUES
 --------------------------------------------------------------------------------
 SELECT is (
     (
-        SELECT "buildId"
+        SELECT ARRAY["buildId", "domain"]
         FROM "public"."latestBuildVirtual"(
             (
                 SELECT (p.*)::"Project"
@@ -92,7 +92,7 @@ SELECT is (
             )
         )
     ),
-    'build1',
+    ARRAY['build1', 'project1-domain1'],
     'Test Case 1: Should return the latest build for project1 with domain matching projectDomain.'
 );
 
@@ -165,7 +165,7 @@ VALUES
 -- Verify that the latest build now reflects the updated domain
 SELECT is (
     (
-        SELECT "buildId"
+        SELECT ARRAY["buildId", "domain"]
         FROM "public"."latestBuildVirtual"(
             (
                 SELECT (p.*)::"Project"
@@ -174,7 +174,7 @@ SELECT is (
             )
         )
     ),
-    'build1-for-domain2',
+    ARRAY['build1-for-domain2','project1-domain2'],
     'Test Case 4: Should return the latest build for project1 with the updated domain in domains array.'
 );
 
@@ -229,7 +229,7 @@ VALUES
 -- Verify that the latest build reflects the custom domain association
 SELECT is (
     (
-        SELECT "buildId"
+        SELECT ARRAY["buildId", "domain"]
         FROM "public"."latestBuildVirtual"(
             (
                 SELECT (p.*)::"Project"
@@ -238,7 +238,7 @@ SELECT is (
             )
         )
     ),
-    'build1-for-custom-domain-1',
+    ARRAY['build1-for-custom-domain-1','project-1-custom-domain-1.com'],
     'Test Case 5: Should return the latest build for project1 with a registered custom domain in domains array.'
 );
 
@@ -261,7 +261,7 @@ VALUES
     '2023-01-03 00:00:00+00',
     'home',
     'project1',
-    '{"domains": ["project1-domain2"]}'::text,
+    '{"domains": ["project-1-custom-domain-1.com", "project1-domain2"]}'::text,
     '2023-01-03 00:00:00+00',
     'PUBLISHED'
   );
@@ -269,7 +269,7 @@ VALUES
 -- Verify that the latest build reflects the preview domain
 SELECT is (
     (
-        SELECT "buildId"
+        SELECT ARRAY["buildId", "domain"]
         FROM "public"."latestBuildVirtual"(
             (
                 SELECT (p.*)::"Project"
@@ -278,7 +278,7 @@ SELECT is (
             )
         )
     ),
-    'build1-for-domain2-new',
+    ARRAY['build1-for-domain2-new', 'project1-domain2'],
     'Test Case 6: Should return the latest build for project1 with the preview domain in domains array.'
 );
 

--- a/packages/postgrest/supabase/tests/latest-builds-projects.sql
+++ b/packages/postgrest/supabase/tests/latest-builds-projects.sql
@@ -16,8 +16,8 @@ VALUES
 -- Insert projects associated with the user
 INSERT INTO "public"."Project" ("id", "title", "domain", "userId", "isDeleted", "createdAt")
 VALUES
-  ('project1', 'Project One', 'project1-domain1', 'user1', false, '2023-01-01 00:00:00+00'),
-  ('project2', 'Project Two', 'project2-domain1', 'user1', false, '2023-01-01 00:00:00+00');
+  ('project1', 'Project One', '517cce32-9af3-project1-domain1', 'user1', false, '2023-01-01 00:00:00+00'),
+  ('project2', 'Project Two', '517cce32-9af3-project2-domain1', 'user1', false, '2023-01-01 00:00:00+00');
 
 -- Insert builds with different deployment formats
 INSERT INTO "public"."Build" (
@@ -36,7 +36,7 @@ VALUES
     '2023-01-01 00:00:00+00',
     'home',
     'project1',
-    '{"projectDomain": "project1-domain1", "domains": [""]}'::text,
+    '{"projectDomain": "517cce32-9af3-project1-domain1", "domains": [""]}'::text,
     '2023-01-01 00:00:00+00',
     'PUBLISHED'
   ),
@@ -45,7 +45,7 @@ VALUES
     '2022-01-01 00:00:00+00',
     'home',
     'project1',
-    '{"projectDomain": "project1-domain1", "domains": [""]}'::text,
+    '{"projectDomain": "517cce32-9af3-project1-domain1", "domains": [""]}'::text,
     '2022-01-01 00:00:00+00',
     'PUBLISHED'
   ),
@@ -64,7 +64,7 @@ VALUES
     '2023-01-02 00:00:00+00',
     'home',
     'project2',
-    '{"domains": ["project2-domain1"]}'::text,
+    '{"domains": ["517cce32-9af3-project2-domain1"]}'::text,
     '2023-01-02 00:00:00+00',
     'PENDING'
   ),
@@ -73,7 +73,7 @@ VALUES
     '2022-01-02 00:00:00+00',
     'home',
     'project2',
-    '{"domains": ["project2-domain1"]}'::text,
+    '{"domains": ["517cce32-9af3-project2-domain1"]}'::text,
     '2022-01-02 00:00:00+00',
     'PENDING'
   );
@@ -92,8 +92,24 @@ SELECT is (
             )
         )
     ),
-    ARRAY['build1', 'project1-domain1'],
-    'Test Case 1: Should return the latest build for project1 with domain matching projectDomain.'
+    ARRAY['build1', '517cce32-9af3-project1-domain1'],
+    'Test Case 1.1: Should return the latest build for project1 with domain matching projectDomain.'
+);
+
+
+SELECT is (
+    (
+        SELECT ARRAY["buildId", "domain"]
+        FROM "public"."latestProjectDomainBuildVirtual"(
+            (
+                SELECT (p.*)::"Project"
+                FROM "public"."Project" p
+                WHERE p."id" = 'project1'
+            )
+        )
+    ),
+    ARRAY['build1', '517cce32-9af3-project1-domain1'],
+    'Test Case 1.2: Should return the latest build for project1 with domain matching projectDomain.'
 );
 
 --------------------------------------------------------------------------------
@@ -111,9 +127,23 @@ SELECT is (
         )
     ),
     'build2',
-    'Test Case 2: Should return the latest build for project2 with domain present in domains array.'
+    'Test Case 2.1: Should return the latest build for project2 with domain present in domains array.'
 );
 
+SELECT is (
+    (
+        SELECT "buildId"
+        FROM "public"."latestProjectDomainBuildVirtual"(
+            (
+                SELECT (p.*)::"Project"
+                FROM "public"."Project" p
+                WHERE p."id" = 'project2'
+            )
+        )
+    ),
+    'build2',
+    'Test Case 2.2: Should return the latest build for project2 domain with domain present in domains array.'
+);
 --------------------------------------------------------------------------------
 -- Test Case 3: Update Project Domain and Verify No Build Exists for the New Domain
 --------------------------------------------------------------------------------
@@ -135,7 +165,22 @@ SELECT is (
         )
     ),
     0,
-    'Test Case 3: Should return 0 as no build exists for the updated domain project1-domain2.'
+    'Test Case 3.1: Should return 0 as no build exists for the updated domain project1-domain2.'
+);
+
+SELECT is (
+    (
+        SELECT COUNT(*)::integer
+        FROM "public"."latestProjectDomainBuildVirtual"(
+            (
+                SELECT (p.*)::"Project"
+                FROM "public"."Project" p
+                WHERE p."id" = 'project1'
+            )
+        )
+    ),
+    0,
+    'Test Case 3.2: Should return 0 as no build exists for the updated domain project1-domain2.'
 );
 
 --------------------------------------------------------------------------------
@@ -175,8 +220,24 @@ SELECT is (
         )
     ),
     ARRAY['build1-for-domain2','project1-domain2'],
-    'Test Case 4: Should return the latest build for project1 with the updated domain in domains array.'
+    'Test Case 4.1: Should return the latest build for project1 with the updated domain in domains array.'
 );
+
+SELECT is (
+    (
+        SELECT ARRAY["buildId", "domain"]
+        FROM "public"."latestProjectDomainBuildVirtual"(
+            (
+                SELECT (p.*)::"Project"
+                FROM "public"."Project" p
+                WHERE p."id" = 'project1'
+            )
+        )
+    ),
+    ARRAY['build1-for-domain2','project1-domain2'],
+    'Test Case 4.2: Should return the latest build for project1 domain with the updated domain in domains array.'
+);
+
 
 --------------------------------------------------------------------------------
 -- Test Case 5: Register Custom Domains and Verify Latest Build for a Custom Domain
@@ -190,8 +251,8 @@ INSERT INTO "public"."Domain" (
     "updatedAt"
 )
 VALUES
-  ('project-1-custom-domain-1', 'project-1-custom-domain-1.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00'),
-  ('project-1-custom-domain-2', 'project-1-custom-domain-2.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00');
+  ('project-1-custom-domain-1', '517cce32-9af3-project-1-custom-domain-1.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00'),
+  ('project-1-custom-domain-2', '517cce32-9af3-project-1-custom-domain-2.com', '2023-01-01 00:00:00+00', 'INITIALIZING', '2023-01-01 00:00:00+00');
 
 -- Establish relationships between project1 and custom domains
 INSERT INTO "public"."ProjectDomain" (
@@ -221,7 +282,7 @@ VALUES
     '2023-01-02 00:00:00+00',
     'home',
     'project1',
-    '{"domains": ["some-other-domain.com", "project-1-custom-domain-1.com"]}'::text,
+    '{"domains": ["some-other-domain.com", "517cce32-9af3-project-1-custom-domain-1.com"]}'::text,
     '2023-01-02 00:00:00+00',
     'PUBLISHED'
   );
@@ -238,8 +299,26 @@ SELECT is (
             )
         )
     ),
-    ARRAY['build1-for-custom-domain-1','project-1-custom-domain-1.com'],
-    'Test Case 5: Should return the latest build for project1 with a registered custom domain in domains array.'
+    ARRAY['build1-for-custom-domain-1','517cce32-9af3-project-1-custom-domain-1.com'],
+    'Test Case 5.1: Should return the latest build for project1 with a registered custom domain in domains array.'
+);
+
+
+-- Ensure the latest project domain build has not changed
+-- The difference between latestProjectDomainBuildVirtual and latestBuildVirtual is that the first returns data only for the project domain
+SELECT is (
+    (
+        SELECT ARRAY["buildId", "domain"]
+        FROM "public"."latestProjectDomainBuildVirtual"(
+            (
+                SELECT (p.*)::"Project"
+                FROM "public"."Project" p
+                WHERE p."id" = 'project1'
+            )
+        )
+    ),
+    ARRAY['build1-for-domain2','project1-domain2'],
+    'Test Case 5.2: Should return the latest build for project1 domain and not affected by custom domains'
 );
 
 --------------------------------------------------------------------------------
@@ -261,7 +340,7 @@ VALUES
     '2023-01-03 00:00:00+00',
     'home',
     'project1',
-    '{"domains": ["project-1-custom-domain-1.com", "project1-domain2"]}'::text,
+    '{"domains": ["517cce32-9af3-project-1-custom-domain-1.com", "project1-domain2"]}'::text,
     '2023-01-03 00:00:00+00',
     'PUBLISHED'
   );
@@ -279,8 +358,24 @@ SELECT is (
         )
     ),
     ARRAY['build1-for-domain2-new', 'project1-domain2'],
-    'Test Case 6: Should return the latest build for project1 with the preview domain in domains array.'
+    'Test Case 6.1: Should return the latest build for project1 with the preview domain in domains array.'
 );
+
+SELECT is (
+    (
+        SELECT ARRAY["buildId", "domain"]
+        FROM "public"."latestProjectDomainBuildVirtual"(
+            (
+                SELECT (p.*)::"Project"
+                FROM "public"."Project" p
+                WHERE p."id" = 'project1'
+            )
+        )
+    ),
+    ARRAY['build1-for-domain2-new', 'project1-domain2'],
+    'Test Case 6.2: Should return the latest build for project1 with the preview domain in domains array.'
+);
+
 
 --------------------------------------------------------------------------------
 -- Test Case 7: Publish a New Build for a Custom Domain, Delete the Custom Domain, and Verify Latest Build Update
@@ -301,7 +396,7 @@ VALUES
     '2023-01-04 00:00:00+00',
     'home',
     'project1',
-    '{"domains": ["some-other-domain.com", "project-1-custom-domain-1.com"]}'::text,
+    '{"domains": ["some-other-domain.com", "517cce32-9af3-project-1-custom-domain-1.com"]}'::text,
     '2023-01-04 00:00:00+00',
     'PUBLISHED'
   );

--- a/packages/postgrest/supabase/tests/project-domains.sql
+++ b/packages/postgrest/supabase/tests/project-domains.sql
@@ -8,19 +8,19 @@ SELECT no_plan();
 -- We're inserting user_1 as the user for the test projects
 INSERT INTO "public"."User" ("id", "createdAt", "email", "username")
 VALUES
-  ('user_1', '2023-01-01 00:00:00+00', 'user1@example.com', 'user1');
+  ('user_1', '2023-01-01 00:00:00+00', 'user1@517cce32-9af3-example.com', 'user1');
 
 -- Insert test projects into the Project table
 -- project_1 and project_2 belong to user_1 and are not deleted (isDeleted = false)
 INSERT INTO "Project" (id, title, domain, "userId", "isDeleted") VALUES
-('project_1', 'Test Project 1', 'testproject1.com', 'user_1', false),
-('project_2', 'Test Project 1', 'testproject2.com', 'user_1', false);
+('project_1', 'Test Project 1', '517cce32-9af3-testproject1.com', 'user_1', false),
+('project_2', 'Test Project 1', '517cce32-9af3-testproject2.com', 'user_1', false);
 
 -- Insert test domains into the Domain table
--- We are inserting two domains: example.com and example.org with different statuses
+-- We are inserting two domains: 517cce32-9af3-example.com and 517cce32-9af3-example.org with different statuses
 INSERT INTO "Domain" (id, domain, status, "txtRecord") VALUES
-('domain_1', 'example.com', 'INITIALIZING', 'txtRecord1'),
-('domain_2', 'example.org', 'ACTIVE', 'txtRecord21');
+('domain_1', '517cce32-9af3-example.com', 'INITIALIZING', 'txtRecord1'),
+('domain_2', '517cce32-9af3-example.org', 'ACTIVE', 'txtRecord21');
 
 -- Insert test data into the ProjectDomain table
 -- Mapping domains to projects, project_1 has two domains, project_2 has one domain
@@ -43,8 +43,8 @@ SELECT results_eq(
   $$
     SELECT * FROM (
         VALUES
-            ('example.com','INITIALIZING'::"DomainStatus",NULL,E'txtRecord1',E'txtRecord1',TRUE), -- Verified domain (TXT records match)
-            ('example.org','ACTIVE'::"DomainStatus",NULL,E'txtRecord21',E'txtRecord22',FALSE) -- Not verified domain (TXT records do not match)
+            ('517cce32-9af3-example.com','INITIALIZING'::"DomainStatus",NULL,E'txtRecord1',E'txtRecord1',TRUE), -- Verified domain (TXT records match)
+            ('517cce32-9af3-example.org','ACTIVE'::"DomainStatus",NULL,E'txtRecord21',E'txtRecord22',FALSE) -- Not verified domain (TXT records do not match)
     ) AS expected(domain, status, error, "domainTxtRecord", "expectedTxtRecord", verified)
     ORDER BY "domain"
   $$,
@@ -63,7 +63,7 @@ SELECT results_eq(
   $$
     SELECT * FROM (
         VALUES
-            ('example.com','INITIALIZING'::"DomainStatus",NULL,E'txtRecord1',E'txtRecord3',FALSE) -- Not verified domain (TXT records do not match)
+            ('517cce32-9af3-example.com','INITIALIZING'::"DomainStatus",NULL,E'txtRecord1',E'txtRecord3',FALSE) -- Not verified domain (TXT records do not match)
     ) AS expected(domain, status, error, "domainTxtRecord", "expectedTxtRecord", verified)
     ORDER BY "domain"
   $$,

--- a/packages/prisma-client/prisma/migrations/20240920091253_domain-ordering/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20240920091253_domain-ordering/migration.sql
@@ -1,0 +1,34 @@
+-- Create the "domainsVirtual" function to return all domain-related data for a specific project.
+CREATE OR REPLACE FUNCTION "domainsVirtual"("Project")
+RETURNS SETOF "domainsVirtual" AS $$
+    -- This function retrieves all the domain information associated with a specific project by joining the Domain and ProjectDomain tables.
+    -- It returns a result set conforming to the "domainsVirtual" structure, including fields such as domain status, error, verification status, etc.
+    SELECT
+        "Domain".id || '-' || "ProjectDomain"."projectId" as id,
+        "Domain".id AS "domainId", -- Domain ID from Domain table
+        "ProjectDomain"."projectId", -- Project ID from ProjectDomain table
+        "Domain".domain, -- Domain name
+        "Domain".status, -- Current domain status
+        "Domain".error, -- Error message, if any
+        "Domain"."txtRecord" AS "domainTxtRecord", -- Current TXT record from Domain table
+        "ProjectDomain"."txtRecord" AS "expectedTxtRecord", -- Expected TXT record from ProjectDomain table
+        "ProjectDomain"."cname" AS "cname",
+        CASE
+            WHEN "Domain"."txtRecord" = "ProjectDomain"."txtRecord" THEN true -- If TXT records match, domain is verified
+            ELSE false
+        END AS "verified", -- Boolean flag for verification status
+        "ProjectDomain"."createdAt", -- Creation timestamp from ProjectDomain table
+        "Domain"."updatedAt" -- Last updated timestamp from Domain table
+    FROM
+        "Domain"
+    JOIN
+        "ProjectDomain" ON "Domain".id = "ProjectDomain"."domainId" -- Joining Domain and ProjectDomain on domainId
+    WHERE
+        "ProjectDomain"."projectId" = $1.id -- Filtering by projectId passed as an argument to the function
+    ORDER BY "ProjectDomain"."createdAt", "Domain".id; -- Stable sort
+$$
+STABLE
+LANGUAGE sql;
+
+-- Add function-specific comments to explain its behavior.
+COMMENT ON FUNCTION "domainsVirtual"("Project") IS 'Function that retrieves domain-related data for a given project by joining the Domain and ProjectDomain tables. It returns a result set that conforms to the structure defined in the domainsVirtual virtual table.';

--- a/packages/prisma-client/prisma/migrations/20240924174536_cleanup/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20240924174536_cleanup/migration.sql
@@ -1,0 +1,81 @@
+ALTER TABLE "Build" ADD COLUMN "isCleaned" BOOLEAN DEFAULT FALSE;
+
+-- PostgREST will use this function as a computed field
+-- See: https://docs.postgrest.org/en/v12/references/api/resource_embedding.html#computed-relationships
+CREATE OR REPLACE FUNCTION "latestProjectDomainBuildVirtual"("Project")
+RETURNS SETOF "latestBuildVirtual"
+ROWS 1 AS $$ -- The function is expected to return 1 row
+
+-- This function selects the latest build for a given project domain where:
+-- 1. The "deployment" field is not NULL, ensuring it is a production build.
+-- 2. The 'destination' field in the JSONB "deployment" is either NULL (for backward compatibility)
+--    or equal to 'saas', indicating a non-static build.
+-- 3. The selected "domain" must exist in the "Domain" table (many-to-many relation with "Project" via "ProjectDomain")
+--    or it must match the "Project.domain" field directly.
+-- 4. If 'projectDomain' exists in the JSONB "deployment", it is used as the "domain".
+--    If not, the first element of 'domains' in the JSONB "deployment" array is used as the "domain".
+-- The function returns the most recent (by "createdAt") valid build.
+SELECT
+    b.id AS "buildId",
+    b."projectId",
+    '' as "domainsVirtualId",
+    p.domain AS "domain",
+    b."createdAt",
+    b."publishStatus"
+FROM "Build" b
+JOIN "Project" p ON b."projectId" = p.id
+LEFT JOIN "ProjectDomain" pd ON pd."projectId" = p.id
+WHERE b."projectId" = $1.id
+  AND b.deployment IS NOT NULL
+  -- 'destination' IS NULL for backward compatibility; 'destination' = 'saas' for non-static builds
+  AND ((b.deployment::jsonb ->> 'destination') IS NULL OR (b.deployment::jsonb ->> 'destination') = 'saas')
+  AND (
+      -- Check if 'projectDomain' matches p.domain
+      (b.deployment::jsonb ->> 'projectDomain') = p.domain
+      -- Check if 'domains' contains p.domain or d.domain
+      OR (b.deployment::jsonb -> 'domains') @> to_jsonb(array[p.domain])
+  )
+ORDER BY b."createdAt" DESC
+LIMIT 1;
+$$
+STABLE
+LANGUAGE sql;
+
+-- Comment on the function to provide additional context
+COMMENT ON FUNCTION "latestProjectDomainBuildVirtual"("Project") IS 'This function computes the latest build for a project domain, ensuring it is a production (non-static) build, where the domain matches either the Project.domain field or exists in the related Domain table. It provides backward compatibility for older records with a missing "destination" field.';
+
+
+
+CREATE OR REPLACE FUNCTION database_cleanup(
+  from_date timestamp DEFAULT '2020-01-01 00:00:00',
+  to_date timestamp DEFAULT '2099-12-31 23:59:59' -- SQL should die long before this date!
+) RETURNS VOID AS $$
+BEGIN
+  WITH latest_builds AS (
+    SELECT "buildId" FROM "Project" p, LATERAL "latestProjectDomainBuildVirtual"(p)
+    UNION
+    SELECT "buildId" FROM "Project" p, LATERAL "latestBuildVirtual"(p)
+    UNION
+    SELECT lb."buildId"
+    FROM "Project" p, LATERAL "domainsVirtual"(p) dv, LATERAL "latestBuildVirtual"(dv) lb
+  )
+  UPDATE "Build"
+  SET
+    "styleSources" = '[]'::text,
+    styles = '[]'::text,
+    breakpoints = '[]'::text,
+    "styleSourceSelections" = '[]'::text,
+    props = '[]'::text,
+    instances = '[]'::text,
+    "dataSources" = '[]'::text,
+    resources = '[]'::text,
+    "marketplaceProduct" = '{}'::text,
+    "isCleaned" = TRUE
+  WHERE deployment IS NOT NULL
+  AND id NOT IN (SELECT "buildId" FROM latest_builds)
+  AND "isCleaned" = FALSE
+  AND "createdAt" BETWEEN from_date AND to_date;  -- Filter by date range (for testing purposes)
+END;
+$$ LANGUAGE plpgsql;
+
+-- SELECT database_cleanup();

--- a/packages/sdk/src/schema/deployment.ts
+++ b/packages/sdk/src/schema/deployment.ts
@@ -23,7 +23,12 @@ export const Deployment = z.union([
   z.object({
     destination: z.literal("saas").optional(),
     domains: z.array(z.string()),
-    projectDomain: z.string(),
+    assetsDomain: z.string().optional(),
+    /**
+     * @deprecated This field is deprecated, use `domains` instead.
+     */
+    projectDomain: z.string().optional(),
+    excludeWstdDomainFromSearch: z.boolean().optional(),
   }),
 ]);
 

--- a/packages/trpc-interface/src/shared/deployment.ts
+++ b/packages/trpc-interface/src/shared/deployment.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { router, procedure } from "./trpc";
 
-const PublishInput = z.object({
+// Has corresponding type in saas
+export const PublishInput = z.object({
   // used to load build data from the builder see routes/rest.build.$buildId.ts
   buildId: z.string(),
   builderOrigin: z.string(),
@@ -11,10 +12,10 @@ const PublishInput = z.object({
   // preview support
   branchName: z.string(),
   // action log helper (not used for deployment, but for action logs readablity)
-  projectDomainName: z.string(),
+  logProjectName: z.string(),
 });
 
-const Output = z.discriminatedUnion("success", [
+export const Output = z.discriminatedUnion("success", [
   z.object({
     success: z.literal(true),
   }),


### PR DESCRIPTION
## Description

closes #2644

- [x] - Merge this https://github.com/webstudio-is/webstudio/pull/4156 into this PR

- If the user has no custom domains:
  - [x] Checkbox for Pro users is not shown.
  - [x] Checkbox for Free users is shown but disabled (Tooltip enabled).

- If the user has custom domains:
  - No Pro:
    - [x] Checkboxes are shown disabled with Tooltips.
  - Pro:
    - Users can select any checkbox (no Tooltips).

- Current indexing logic:
  - If a user has custom domain(s), upon publishing, the `*.wstd.io` domain will receive the meta tag:
    ```html
    <meta name="robots" content="noindex, nofollow">
    ```

- [x] - Fix example.com in tests (NEXT PR #4156) 
- [ ] - saas cleanup should be changed (we need to preserve latest build by domain now) (NEXT PR)
- [x] - Disable Publish Button if no checkboxes are selected

- "With the Pro, you’ll gain the ability to publish to each domain independently!"
<img width="477" alt="image" src="https://github.com/user-attachments/assets/105577e5-318f-4146-a3eb-38c2117f6f79">

## Steps for reproduction

### Non Pro

- Login as a new non Pro User `pass:vaska@pupkin.ru`
- Create a new Project, Click Publish. Expect  Disabled Checkbox with Tolltip is visible. Publish is Enabled.
<img width="445" alt="image" src="https://github.com/user-attachments/assets/e48654af-1969-4f96-b048-a3fa72303b8f">
- Publish, check it published.
- Add custom domain, Publish, check both are published.

### Pro

- Login as a Pro User `pass`
- Open new Project. Expect No checkbox. One wstd domain.
<img width="351" alt="image" src="https://github.com/user-attachments/assets/c62f9ae5-669a-46ad-a2f2-32ba333068f9">
- Publish. Expect it published.
- Add domain. See checkboxes visible after domain activated.
- Publish. Expect both published.
- Uncheck checkboxes, see publish button disabled. See it has tooltip.



## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
