### PR TITLE
fix: allow user to define a custom font stack

### DIFF
--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -46,7 +46,7 @@ describe("Convert WS CSS Values to native CSS strings", () => {
     expect(value).toBe("var(--namespace, normal, 10px)");
   });
 
-  test("fontFamily predefined stack", () => {
+  test("fontFamily is known stack name", () => {
     expect(
       toValue({
         type: "fontFamily",
@@ -57,7 +57,7 @@ describe("Convert WS CSS Values to native CSS strings", () => {
     );
   });
 
-  test("fontFamily custom stack", () => {
+  test("fontFamily is a custom stack", () => {
     expect(
       toValue({
         type: "fontFamily",
@@ -66,13 +66,22 @@ describe("Convert WS CSS Values to native CSS strings", () => {
     ).toBe('"DejaVu Sans Mono", monospace');
   });
 
-  test("fontFamily unknown", () => {
+  test("fontFamily is unknown family name", () => {
     expect(
       toValue({
         type: "fontFamily",
         value: ["something-random"],
       })
     ).toBe("something-random, sans-serif");
+  });
+
+  test("fontFamily is empty", () => {
+    expect(
+      toValue({
+        type: "fontFamily",
+        value: [],
+      })
+    ).toBe("sans-serif");
   });
 
   test("Transform font family value to override default fallback", () => {

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -46,7 +46,7 @@ describe("Convert WS CSS Values to native CSS strings", () => {
     expect(value).toBe("var(--namespace, normal, 10px)");
   });
 
-  test("fontFamily stack", () => {
+  test("fontFamily predefined stack", () => {
     expect(
       toValue({
         type: "fontFamily",
@@ -55,6 +55,15 @@ describe("Convert WS CSS Values to native CSS strings", () => {
     ).toBe(
       'Seravek, "Gill Sans Nova", Ubuntu, Calibri, "DejaVu Sans", source-sans-pro, sans-serif'
     );
+  });
+
+  test("fontFamily custom stack", () => {
+    expect(
+      toValue({
+        type: "fontFamily",
+        value: ["DejaVu Sans Mono", "monospace"],
+      })
+    ).toBe('"DejaVu Sans Mono", monospace');
   });
 
   test("fontFamily unknown", () => {

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -84,6 +84,15 @@ describe("Convert WS CSS Values to native CSS strings", () => {
     ).toBe("sans-serif");
   });
 
+  test("fontFamily has duplicates", () => {
+    expect(
+      toValue({
+        type: "fontFamily",
+        value: ["a", "a", "b"],
+      })
+    ).toBe("a, b");
+  });
+
   test("Transform font family value to override default fallback", () => {
     const value = toValue(
       {

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -6,10 +6,12 @@ export type TransformValue = (styleValue: StyleValue) => undefined | StyleValue;
 
 const fallbackTransform: TransformValue = (styleValue) => {
   if (styleValue.type === "fontFamily") {
-    const fonts = SYSTEM_FONTS.get(styleValue.value[0])?.stack ?? [
-      styleValue.value[0],
-      DEFAULT_FONT_FALLBACK,
-    ];
+    const fallback =
+      styleValue.value.length > 1
+        ? // Its a custom stack, we won't add a fallback
+          styleValue.value
+        : [...styleValue.value, DEFAULT_FONT_FALLBACK];
+    const fonts = SYSTEM_FONTS.get(styleValue.value[0])?.stack ?? fallback;
     const value = Array.from(new Set(fonts));
 
     return {

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -9,34 +9,23 @@ const fallbackTransform: TransformValue = (styleValue) => {
     return;
   }
 
+  // By default we assume its a custom font stack.
+  let { value } = styleValue;
+
   // Shouldn't be possible, but just in case.
-  if (styleValue.value.length === 0) {
-    return {
-      type: "fontFamily",
-      value: [DEFAULT_FONT_FALLBACK],
-    };
+  if (value.length === 0) {
+    value = [DEFAULT_FONT_FALLBACK];
   }
 
   // User provided a single name. It could be a specific font name or a stack name.
-  if (styleValue.value.length === 1) {
-    const stack = SYSTEM_FONTS.get(styleValue.value[0])?.stack;
-    if (stack !== undefined) {
-      return {
-        type: "fontFamily",
-        value: stack,
-      };
-    }
-    // It's a specific font family.
-    return {
-      type: "fontFamily",
-      value: [styleValue.value[0], DEFAULT_FONT_FALLBACK],
-    };
+  if (value.length === 1) {
+    const stack = SYSTEM_FONTS.get(value[0])?.stack;
+    value = stack ?? [value[0], DEFAULT_FONT_FALLBACK];
   }
 
-  // Its a custom stack, we won't add a fallback
   return {
     type: "fontFamily",
-    value: styleValue.value,
+    value: Array.from(new Set(value)),
   };
 };
 


### PR DESCRIPTION
## Description

Previously defining a custom stack - comma separated list of fonts, was broken, we only used the first font

## Steps for reproduction

1. comma separated fonts, more than one
2. see that its rendered in dev tools and that we don't add a default fallback to it

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
