### PR TITLE
experimental: add gradient controller to update color stops using ui

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/gradient-control.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/gradient-control.stories.tsx
@@ -1,64 +1,65 @@
 import {
   parseLinearGradient,
+  reconstructLinearGradient,
   type ParsedGradient,
 } from "@webstudio-is/css-data";
 import { GradientControl } from "./gradient-control";
-import { toValue } from "@webstudio-is/css-engine";
+import { Flex, Text } from "@webstudio-is/design-system";
+import { useState } from "react";
 
 export default {
   title: "Library/GradientControl",
 };
 
 export const GradientWithoutAngle = () => {
+  const gradientString = "linear-gradient(#e66465 0%, #9198e5 100%)";
+  const [gradient, setGradient] = useState<string>(gradientString);
+
   return (
-    <GradientControl
-      gradient={
-        parseLinearGradient(
-          "linear-gradient(#e66465 0%, #9198e5 100%)"
-        ) as ParsedGradient
-      }
-      onChange={() => {}}
-    />
+    <Flex direction="column" gap="4">
+      <GradientControl
+        gradient={parseLinearGradient(gradientString) as ParsedGradient}
+        onChange={(value) => {
+          setGradient(reconstructLinearGradient(value));
+        }}
+      />
+      <Text>{gradient}</Text>
+    </Flex>
   );
 };
 
-// The GradientControl is to just modify the stop values or add new ones.
-// It always shows the angle as 90deg, unless the stops can't be showin in a rectangle.
-// So, the gradient shouldn't modify even if the stop values are changed at the end,
-export const GradientWithAngle = () => {
+export const GradientWithAngleAndHints = () => {
+  const gradientString =
+    "linear-gradient(145deg, #ff00fa 0%, #00f497 34% 34%, #ffa800 56% 56%, #00eaff 100%)";
+  const [gradient, setGradient] = useState<string>(gradientString);
+
   return (
-    <GradientControl
-      gradient={
-        parseLinearGradient(
-          "linear-gradient(145deg, #ff00fa 0%, #00f497 34% 34%, #ffa800 56% 56%, #00eaff 100%)"
-        ) as ParsedGradient
-      }
-      onChange={(value) => {
-        if (toValue(value.angle) !== "145deg") {
-          throw new Error(
-            `Gradient control modified the angle that is passed. \nReceived ${JSON.stringify(value.angle, null, 2)}`
-          );
-        }
-      }}
-    />
+    <Flex direction="column" gap="4">
+      <GradientControl
+        gradient={parseLinearGradient(gradientString) as ParsedGradient}
+        onChange={(value) => {
+          setGradient(reconstructLinearGradient(value));
+        }}
+      />
+      <Text>{gradient}</Text>
+    </Flex>
   );
 };
 
 export const GradientWithSideOrCorner = () => {
+  const gradientString = "linear-gradient(to left top, blue 0%, red 100%)";
+
+  const [gradient, setGradient] = useState<string>(gradientString);
+
   return (
-    <GradientControl
-      gradient={
-        parseLinearGradient(
-          "linear-gradient(to left top, blue 0%, red 100%)"
-        ) as ParsedGradient
-      }
-      onChange={(value) => {
-        if (toValue(value.sideOrCorner) !== "to left top") {
-          throw new Error(
-            `Gradient control modified the side-or-corner value that is passed. \nReceived ${JSON.stringify(value.sideOrCorner, null, 2)}`
-          );
-        }
-      }}
-    />
+    <Flex direction="column" gap="4">
+      <GradientControl
+        gradient={parseLinearGradient(gradientString) as ParsedGradient}
+        onChange={(value) => {
+          setGradient(reconstructLinearGradient(value));
+        }}
+      />
+      <Text>{gradient}</Text>
+    </Flex>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/gradient-control.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/gradient-control.stories.tsx
@@ -1,0 +1,64 @@
+import {
+  parseLinearGradient,
+  type ParsedGradient,
+} from "@webstudio-is/css-data";
+import { GradientControl } from "./gradient-control";
+import { toValue } from "@webstudio-is/css-engine";
+
+export default {
+  title: "Library/GradientControl",
+};
+
+export const GradientWithoutAngle = () => {
+  return (
+    <GradientControl
+      gradient={
+        parseLinearGradient(
+          "linear-gradient(#e66465 0%, #9198e5 100%)"
+        ) as ParsedGradient
+      }
+      onChange={() => {}}
+    />
+  );
+};
+
+// The GradientControl is to just modify the stop values or add new ones.
+// It always shows the angle as 90deg, unless the stops can't be showin in a rectangle.
+// So, the gradient shouldn't modify even if the stop values are changed at the end,
+export const GradientWithAngle = () => {
+  return (
+    <GradientControl
+      gradient={
+        parseLinearGradient(
+          "linear-gradient(145deg, #ff00fa 0%, #00f497 34% 34%, #ffa800 56% 56%, #00eaff 100%)"
+        ) as ParsedGradient
+      }
+      onChange={(value) => {
+        if (toValue(value.angle) !== "145deg") {
+          throw new Error(
+            `Gradient control modified the angle that is passed. \nReceived ${JSON.stringify(value.angle, null, 2)}`
+          );
+        }
+      }}
+    />
+  );
+};
+
+export const GradientWithSideOrCorner = () => {
+  return (
+    <GradientControl
+      gradient={
+        parseLinearGradient(
+          "linear-gradient(to left top, blue 0%, red 100%)"
+        ) as ParsedGradient
+      }
+      onChange={(value) => {
+        if (toValue(value.sideOrCorner) !== "to left top") {
+          throw new Error(
+            `Gradient control modified the side-or-corner value that is passed. \nReceived ${JSON.stringify(value.sideOrCorner, null, 2)}`
+          );
+        }
+      }}
+    />
+  );
+};

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/gradient-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/gradient-control.tsx
@@ -1,0 +1,135 @@
+import { toValue, UnitValue } from "@webstudio-is/css-engine";
+import { Root, Range, Thumb, Track } from "@radix-ui/react-slider";
+import { useEffect, useState, useCallback } from "react";
+import {
+  reconstructLinearGradient,
+  type GradientStop,
+  type ParsedGradient,
+} from "@webstudio-is/css-data";
+import { styled, theme, Flex } from "@webstudio-is/design-system";
+
+type GradientControlProps = {
+  gradient: ParsedGradient;
+  onChange: (value: ParsedGradient) => void;
+};
+
+const defaultAngle: UnitValue = {
+  type: "unit",
+  value: 90,
+  unit: "deg",
+};
+
+export const GradientControl = (props: GradientControlProps) => {
+  const [stops, setStops] = useState<Array<GradientStop>>(props.gradient.stops);
+  const [selectedStop, setSelectedStop] = useState<number | undefined>();
+  const positions = stops.map((stop) => stop.position?.value) as number[];
+  const background = reconstructLinearGradient({
+    stops,
+    sideOrCorner: props.gradient.sideOrCorner,
+    angle: defaultAngle,
+  });
+
+  useEffect(() => {
+    const newStops: Array<GradientStop> = [];
+    for (const stop of props.gradient.stops || []) {
+      if (stop.color !== undefined && stop.position?.value !== undefined) {
+        newStops.push({
+          color: stop.color,
+          position: stop.position,
+        });
+      }
+    }
+    setStops(newStops);
+  }, [props.gradient]);
+
+  const handleValueChange = useCallback(
+    (newPositions: number[]) => {
+      const newStops: GradientStop[] = stops.map((stop, index) => ({
+        ...stop,
+        position: { type: "unit", value: newPositions[index], unit: "%" },
+      }));
+
+      setStops(newStops);
+      props.onChange({
+        angle: props.gradient.angle,
+        stops,
+        sideOrCorner: props.gradient.sideOrCorner,
+      });
+    },
+    [stops, props]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "Backspace" && selectedStop !== undefined) {
+        const newStops = stops;
+        newStops.splice(selectedStop, 1);
+        setStops(newStops);
+        setSelectedStop(undefined);
+      }
+    },
+    [stops, selectedStop]
+  );
+
+  return (
+    <Flex
+      align="end"
+      css={{
+        width: theme.spacing[28],
+        height: theme.spacing[14],
+      }}
+    >
+      <SliderRoot
+        css={{ background }}
+        max={100}
+        step={1}
+        value={positions}
+        onValueChange={handleValueChange}
+        onKeyDown={handleKeyDown}
+      >
+        <Track>
+          <SliderRange css={{ cursor: "copy" }} />
+        </Track>
+        {stops.map((stop, index) => (
+          <SliderThumb
+            key={index}
+            onClick={() => {
+              setSelectedStop(index);
+            }}
+            style={{
+              background: toValue(stop.color),
+            }}
+          />
+        ))}
+      </SliderRoot>
+    </Flex>
+  );
+};
+
+const SliderRoot = styled(Root, {
+  position: "relative",
+  width: "100%",
+  height: theme.spacing[9],
+  border: `1px solid ${theme.colors.borderInfo}`,
+  borderRadius: theme.borderRadius[3],
+  touchAction: "none",
+  userSelect: "none",
+});
+
+const SliderRange = styled(Range, {
+  position: "absolute",
+  background: "transparent",
+  borderRadius: theme.borderRadius[3],
+});
+
+const SliderThumb = styled(Thumb, {
+  position: "absolute",
+  width: theme.spacing[9],
+  height: theme.spacing[9],
+  border: `1px solid ${theme.colors.borderInfo}`,
+  borderRadius: theme.borderRadius[3],
+  top: `-${theme.spacing[11]}`,
+  translate: "-9px",
+});
+
+export default GradientControl;

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/gradient-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/gradient-control.tsx
@@ -1,12 +1,13 @@
 import { toValue, UnitValue } from "@webstudio-is/css-engine";
 import { Root, Range, Thumb, Track } from "@radix-ui/react-slider";
-import { useEffect, useState, useCallback } from "react";
+import { useState, useCallback } from "react";
 import {
   reconstructLinearGradient,
   type GradientStop,
   type ParsedGradient,
 } from "@webstudio-is/css-data";
 import { styled, theme, Flex } from "@webstudio-is/design-system";
+import { ChevronBigUpIcon } from "@webstudio-is/icons";
 
 type GradientControlProps = {
   gradient: ParsedGradient;
@@ -22,25 +23,15 @@ const defaultAngle: UnitValue = {
 export const GradientControl = (props: GradientControlProps) => {
   const [stops, setStops] = useState<Array<GradientStop>>(props.gradient.stops);
   const [selectedStop, setSelectedStop] = useState<number | undefined>();
-  const positions = stops.map((stop) => stop.position?.value) as number[];
+  const positions = stops.map((stop) => stop.position?.value);
+  const hints = props.gradient.stops
+    .map((stop) => stop.hint?.value)
+    .filter(Boolean);
   const background = reconstructLinearGradient({
     stops,
     sideOrCorner: props.gradient.sideOrCorner,
     angle: defaultAngle,
   });
-
-  useEffect(() => {
-    const newStops: Array<GradientStop> = [];
-    for (const stop of props.gradient.stops || []) {
-      if (stop.color !== undefined && stop.position?.value !== undefined) {
-        newStops.push({
-          color: stop.color,
-          position: stop.position,
-        });
-      }
-    }
-    setStops(newStops);
-  }, [props.gradient]);
 
   const handleValueChange = useCallback(
     (newPositions: number[]) => {
@@ -52,7 +43,7 @@ export const GradientControl = (props: GradientControlProps) => {
       setStops(newStops);
       props.onChange({
         angle: props.gradient.angle,
-        stops,
+        stops: newStops,
         sideOrCorner: props.gradient.sideOrCorner,
       });
     },
@@ -101,6 +92,23 @@ export const GradientControl = (props: GradientControlProps) => {
             }}
           />
         ))}
+
+        {hints.map((hint) => {
+          return (
+            <Flex
+              key={hint}
+              align="center"
+              justify="center"
+              css={{
+                position: "absolute",
+                left: `${hint}%`,
+                top: theme.spacing[9],
+              }}
+            >
+              <ChevronBigUpIcon color={theme.colors.borderMain} />
+            </Flex>
+          );
+        })}
       </SliderRoot>
     </Flex>
   );

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -40,6 +40,7 @@
     "@nanostores/react": "^0.7.1",
     "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-tooltip": "^1.1.2",
+    "@radix-ui/react-slider": "^1.2.0",
     "@react-aria/interactions": "^3.19.0",
     "@react-aria/utils": "^3.21.0",
     "@remix-run/node": "^2.11.0",

--- a/packages/css-data/src/property-parsers/index.ts
+++ b/packages/css-data/src/property-parsers/index.ts
@@ -1,2 +1,3 @@
 export * from "./transition";
 export * from "./shadow-properties-extractor";
+export * from "./linear-gradient";

--- a/packages/css-data/src/property-parsers/linear-gradient.ts
+++ b/packages/css-data/src/property-parsers/linear-gradient.ts
@@ -12,13 +12,13 @@ import namesPlugin from "colord/plugins/names";
 
 extend([namesPlugin]);
 
-interface GradientStop {
+export interface GradientStop {
   color?: RgbValue;
   position?: UnitValue;
   hint?: UnitValue;
 }
 
-interface ParsedGradient {
+export interface ParsedGradient {
   angle?: UnitValue;
   sideOrCorner?: KeywordValue;
   stops: GradientStop[];

--- a/packages/css-data/src/property-parsers/linear-gradient.ts
+++ b/packages/css-data/src/property-parsers/linear-gradient.ts
@@ -182,7 +182,7 @@ const getColor = (
 };
 
 export const reconstructLinearGradient = (parsed: ParsedGradient): string => {
-  const direction = parsed.angle || parsed.sideOrCorner;
+  const direction = parsed?.angle || parsed?.sideOrCorner;
   const stops = parsed.stops
     .map((stop: GradientStop) => {
       let result = toValue(stop.color);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       '@radix-ui/react-select':
         specifier: ^2.1.1
         version: 2.1.1(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-slider':
+        specifier: ^1.2.0
+        version: 1.2.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       '@radix-ui/react-tooltip':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
@@ -4607,6 +4610,19 @@ packages:
 
   '@radix-ui/react-separator@1.1.0':
     resolution: {integrity: sha512-3uBAs+egzvJBDZAzvb/n4NxxOYpnspmWxO2u5NbZ8Y6FM/NdrGSF9bop3Cf6F6C71z1rTSn8KV0Fo2ZVd79lGA==}
+    peerDependencies:
+      '@types/react': ^18.2.70
+      '@types/react-dom': ^18.2.25
+      react: 18.3.0-canary-14898b6a9-20240318
+      react-dom: 18.3.0-canary-14898b6a9-20240318
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.2.0':
+    resolution: {integrity: sha512-dAHCDA4/ySXROEPaRtaMV5WHL8+JB/DbtyTbJjYkY0RXmKMO2Ln8DFZhywG5/mVQ4WqHDBc8smc14yPXPqZHYA==}
     peerDependencies:
       '@types/react': ^18.2.70
       '@types/react-dom': ^18.2.25
@@ -12682,6 +12698,25 @@ snapshots:
   '@radix-ui/react-separator@1.1.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
+      react: 18.3.0-canary-14898b6a9-20240318
+      react-dom: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+
+  '@radix-ui/react-slider@1.2.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)':
+    dependencies:
+      '@radix-ui/number': 1.1.0
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.79)(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.2.79)(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.2.79)(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.79)(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.79)(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.2.79)(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.2.79)(react@18.3.0-canary-14898b6a9-20240318)
       react: 18.3.0-canary-14898b6a9-20240318
       react-dom: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
     optionalDependencies:


### PR DESCRIPTION
The `GradientControl` is coming along. There are a lot of edge-cases when it comes to gradients and how lenient browsers can be with them. So, documenting and implementing them alone. This is still a in-progress PR. But if you want to give a try, you can check the storybook. 

<img width="299" alt="Screenshot 2024-09-25 at 10 32 47 AM" src="https://github.com/user-attachments/assets/d65e6af5-bba9-490d-96ff-0e58b8fb93bc">
<img width="289" alt="Screenshot 2024-09-25 at 10 32 43 AM" src="https://github.com/user-attachments/assets/a3ac83e1-d379-49dc-a5d8-42936960f761">
<img width="560" alt="Screenshot 2024-09-25 at 10 32 38 AM" src="https://github.com/user-attachments/assets/fef11d9e-2d0c-4d71-8587-227f22551edb">
## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
