### PR TITLE
fix: fix font family control when value is inherit

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
@@ -61,10 +61,6 @@ export const FontFamilyControl = () => {
     return toValue(value, (value) => value).replace(/"/g, "");
   }, [value]);
 
-  if (value.type !== "fontFamily") {
-    return;
-  }
-
   return (
     <Flex>
       <Combobox<Item>
@@ -73,7 +69,7 @@ export const FontFamilyControl = () => {
             title="Fonts"
             content={
               <FontsManager
-                value={value}
+                value={value.type === "fontFamily" ? value : undefined}
                 onChange={(newValue = itemValue) => {
                   setValue({ type: "fontFamily", value: [newValue] });
                 }}

--- a/apps/builder/app/builder/shared/fonts-manager/fonts-manager.tsx
+++ b/apps/builder/app/builder/shared/fonts-manager/fonts-manager.tsx
@@ -63,7 +63,7 @@ const useLogic = ({ onChange, value }: FontsManagerProps) => {
   );
 
   const currentIndex = useMemo(() => {
-    return groupedItems.findIndex((item) => item.label === value.value[0]);
+    return groupedItems.findIndex((item) => item.label === value?.value[0]);
   }, [groupedItems, value]);
 
   const handleChangeCurrent = (nextCurrentIndex: number) => {
@@ -104,7 +104,7 @@ const useLogic = ({ onChange, value }: FontsManagerProps) => {
 };
 
 type FontsManagerProps = {
-  value: FontFamilyValue;
+  value?: FontFamilyValue;
   onChange: (value?: string) => void;
 };
 


### PR DESCRIPTION
## Description

Turns out value in controls can also be {type: 'inherit'}, not just type fontFamily

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
