### PR TITLE
experimental: add :root support

### DIFF
--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import { computed } from "nanostores";
 import { useStore } from "@nanostores/react";
 import type { Instance } from "@webstudio-is/sdk";
+import { rootComponent } from "@webstudio-is/react-sdk";
 import {
   theme,
   PanelTabs,
@@ -103,7 +104,9 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
 
   const availablePanels = {
     style: documentType === "html" && (meta?.stylable ?? true),
-    settings: true,
+    // @todo hide root component settings until
+    // global data sources are implemented
+    settings: selectedInstance.component !== rootComponent,
   };
 
   return (
@@ -119,7 +122,7 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
             value={
               availablePanels[activeInspectorPanel]
                 ? activeInspectorPanel
-                : "settings"
+                : Object.keys(availablePanels)[0]
             }
             onValueChange={(panel) => {
               $activeInspectorPanel.set(panel as keyof typeof availablePanels);
@@ -143,22 +146,24 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
                     </div>
                   </Tooltip>
                 )}
-                <Tooltip
-                  variant="wrapped"
-                  content={
-                    <Text>
-                      Settings, properties and attributes of the selected
-                      instance&nbsp;&nbsp;
-                      <Kbd value={["D"]} color="moreSubtle" />
-                    </Text>
-                  }
-                >
-                  <div>
-                    <PanelTabsTrigger value="settings">
-                      Settings
-                    </PanelTabsTrigger>
-                  </div>
-                </Tooltip>
+                {availablePanels.settings && (
+                  <Tooltip
+                    variant="wrapped"
+                    content={
+                      <Text>
+                        Settings, properties and attributes of the selected
+                        instance&nbsp;&nbsp;
+                        <Kbd value={["D"]} color="moreSubtle" />
+                      </Text>
+                    }
+                  >
+                    <div>
+                      <PanelTabsTrigger value="settings">
+                        Settings
+                      </PanelTabsTrigger>
+                    </div>
+                  </Tooltip>
+                )}
               </PanelTabsList>
               <Separator />
               <PanelTabsContent value="style" css={contentStyle} tabIndex={-1}>

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/insert.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/insert.ts
@@ -5,6 +5,7 @@ import {
   $registeredComponentMetas,
   $selectedInstanceSelector,
   $selectedPage,
+  ROOT_INSTANCE_ID,
 } from "~/shared/nano-states";
 import {
   computeInstancesConstraints,
@@ -52,6 +53,10 @@ export const insert = (component: string) => {
   const instanceSelector = $selectedInstanceSelector.get() ?? [
     selectedPage.rootInstanceId,
   ];
+  if (instanceSelector[0] === ROOT_INSTANCE_ID) {
+    toast.error(`${component} cannot be added into :root`);
+    return;
+  }
   const metas = $registeredComponentMetas.get();
   const dropTarget = findClosestDroppableTarget(
     metas,

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/insert.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/insert.ts
@@ -54,7 +54,7 @@ export const insert = (component: string) => {
     selectedPage.rootInstanceId,
   ];
   if (instanceSelector[0] === ROOT_INSTANCE_ID) {
-    toast.error(`${component} cannot be added into :root`);
+    toast.error(`${component} cannot be added into Global Root`);
     return;
   }
   const metas = $registeredComponentMetas.get();

--- a/apps/builder/app/builder/features/sidebar-left/panels/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/navigator/navigator-tree.tsx
@@ -484,7 +484,7 @@ export const NavigatorTree = () => {
             }}
           >
             <TreeNodeLabel prefix={<MetaIcon icon={rootMeta.icon} />}>
-              :root
+              {rootMeta.label}
             </TreeNodeLabel>
           </TreeNode>
         )}

--- a/apps/builder/app/builder/features/sidebar-left/panels/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/navigator/navigator-tree.tsx
@@ -3,6 +3,7 @@ import { nanoid } from "nanoid";
 import { atom, computed } from "nanostores";
 import { mergeRefs } from "@react-aria/utils";
 import { useStore } from "@nanostores/react";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import {
   rawTheme,
   ScrollArea,
@@ -20,6 +21,7 @@ import {
 } from "@webstudio-is/design-system";
 import {
   collectionComponent,
+  rootComponent,
   showAttribute,
   WsComponentMeta,
 } from "@webstudio-is/react-sdk";
@@ -37,6 +39,7 @@ import {
   $selectedInstanceSelector,
   $selectedPage,
   getIndexedInstanceId,
+  ROOT_INSTANCE_ID,
 } from "~/shared/nano-states";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { serverSyncStore } from "~/shared/sync";
@@ -438,6 +441,7 @@ export const NavigatorTree = () => {
   const editingItemSelector = useStore($editingItemSelector);
   const dragAndDropState = useStore($dragAndDropState);
   const dropTargetKey = dragAndDropState.dropTarget?.itemSelector.join();
+  const rootMeta = metas.get(rootComponent);
 
   // expand selected instance ancestors
   useEffect(() => {
@@ -470,6 +474,21 @@ export const NavigatorTree = () => {
       }}
     >
       <TreeRoot>
+        {isFeatureEnabled("cssVars") && rootMeta && (
+          <TreeNode
+            level={0}
+            isSelected={selectedKey === ROOT_INSTANCE_ID}
+            buttonProps={{
+              onClick: () => $selectedInstanceSelector.set([ROOT_INSTANCE_ID]),
+              onFocus: () => $selectedInstanceSelector.set([ROOT_INSTANCE_ID]),
+            }}
+          >
+            <TreeNodeLabel prefix={<MetaIcon icon={rootMeta.icon} />}>
+              :root
+            </TreeNodeLabel>
+          </TreeNode>
+        )}
+
         {flatTree.map((item) => {
           const key = item.selector.join();
           const propValues = propValuesByInstanceSelector.get(

--- a/apps/builder/app/builder/features/style-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/style-panel/property-label.tsx
@@ -23,6 +23,7 @@ import {
   $instances,
   $registeredComponentMetas,
   $styleSources,
+  $virtualInstances,
 } from "~/shared/nano-states";
 import { getInstanceLabel } from "~/shared/instance-utils";
 import type {
@@ -58,6 +59,7 @@ export const PropertyInfo = ({
 }) => {
   const breakpoints = useStore($breakpoints);
   const instances = useStore($instances);
+  const virtualInstances = useStore($virtualInstances);
   const styleSources = useStore($styleSources);
   const metas = useStore($registeredComponentMetas);
 
@@ -71,7 +73,8 @@ export const PropertyInfo = ({
       resettable = true;
     }
     const instance = source.instanceId
-      ? instances.get(source.instanceId)
+      ? (instances.get(source.instanceId) ??
+        virtualInstances.get(source.instanceId))
       : undefined;
     if (instance === undefined) {
       continue;

--- a/apps/builder/app/builder/features/style-panel/shared/model.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/model.tsx
@@ -19,6 +19,7 @@ import {
   $selectedOrLastStyleSourceSelector,
   $styles,
   $styleSourceSelections,
+  ROOT_INSTANCE_ID,
 } from "~/shared/nano-states";
 import {
   getComputedStyleDecl,
@@ -98,14 +99,15 @@ export const $definedStyles = computed(
     if (instanceSelector === undefined) {
       return definedProperties;
     }
+    const instanceAndRootSelector = [...instanceSelector, ROOT_INSTANCE_ID];
     const inheritedStyleSources = new Set();
     const instanceStyleSources = new Set();
     const matchingBreakpoints = new Set(matchingBreakpointsArray);
-    for (const instanceId of instanceSelector) {
+    for (const instanceId of instanceAndRootSelector) {
       const styleSources = styleSourceSelections.get(instanceId)?.values;
       if (styleSources) {
         for (const styleSourceId of styleSources) {
-          if (instanceId === instanceSelector[0]) {
+          if (instanceId === instanceAndRootSelector[0]) {
             instanceStyleSources.add(styleSourceId);
           } else {
             inheritedStyleSources.add(styleSourceId);
@@ -171,9 +173,12 @@ export const createComputedStyleDeclStore = (property: StyleProperty) => {
   return computed(
     [$model, $selectedInstanceSelector, $selectedOrLastStyleSourceSelector],
     (model, instanceSelector, styleSourceSelector) => {
+      const instanceAndRootSelector = instanceSelector
+        ? [...instanceSelector, ROOT_INSTANCE_ID]
+        : undefined;
       return getComputedStyleDecl({
         model,
-        instanceSelector,
+        instanceSelector: instanceAndRootSelector,
         styleSourceId: styleSourceSelector?.styleSourceId,
         state: styleSourceSelector?.state,
         property,

--- a/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
@@ -48,7 +48,7 @@ const normalizeStyleValue = (
   // prefill initial value when no items to repeated
   if (items.length === 0 && primaryItemsCount > 0) {
     const meta = properties[styleDecl.property as keyof typeof properties];
-    items.push(meta.initial);
+    items.push(meta.initial as unknown as UnparsedValue);
   }
   return {
     type: itemType,

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -14,6 +14,7 @@ import {
   $styles,
   $selectedInstanceStates,
   $styleSourceSelections,
+  ROOT_INSTANCE_ID,
 } from "~/shared/nano-states";
 import htmlTags, { type HtmlTags } from "html-tags";
 import {
@@ -87,7 +88,9 @@ export const getElementAndAncestorInstanceTags = (
 
   const [element] = elements;
 
-  const instanceToTag = new Map<Instance["id"], HtmlTags>();
+  const instanceToTag = new Map<Instance["id"], HtmlTags>([
+    [ROOT_INSTANCE_ID, "html"],
+  ]);
   for (
     let ancestorOrSelf: HTMLElement | null = element;
     ancestorOrSelf !== null;

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -447,7 +447,9 @@ const subscribeEphemeralStyle = () => {
           property: styleDecl.property,
           value: toVarValue(styleDecl) ?? styleDecl.value,
         });
-        document.body.style.removeProperty(getEphemeralProperty(styleDecl));
+        document.documentElement.style.removeProperty(
+          getEphemeralProperty(styleDecl)
+        );
       }
       userSheet.setTransformer($transformValue.get());
       userSheet.render();
@@ -462,7 +464,7 @@ const subscribeEphemeralStyle = () => {
       let ephemetalSheetUpdated = false;
       for (const styleDecl of ephemeralStyles) {
         // update custom property
-        document.body.style.setProperty(
+        document.documentElement.style.setProperty(
           getEphemeralProperty(styleDecl),
           toValue(styleDecl.value, $transformValue.get())
         );

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -32,6 +32,7 @@ import {
   $selectedStyleState,
   $styleSourceSelections,
   $styles,
+  ROOT_INSTANCE_ID,
 } from "~/shared/nano-states";
 import { setDifference } from "~/shared/shim";
 import { $ephemeralStyles, $params } from "../stores";
@@ -262,7 +263,10 @@ export const subscribeStyles = () => {
       const addedSelections = setDifference(selectionsSet, prevSelectionsSet);
       prevSelectionsSet = selectionsSet;
       for (const { instanceId, values } of addedSelections) {
-        const selector = `[${idAttribute}="${instanceId}"]`;
+        const selector =
+          instanceId === ROOT_INSTANCE_ID
+            ? ":root"
+            : `[${idAttribute}="${instanceId}"]`;
         const rule = userSheet.addNestingRule(selector);
         rule.applyMixins(values);
       }

--- a/apps/builder/app/shared/instance-utils.test.ts
+++ b/apps/builder/app/shared/instance-utils.test.ts
@@ -545,6 +545,44 @@ describe("find closest droppable target", () => {
       position: 2,
     });
   });
+
+  test("finds closest container that doesn't have an expression as a child", () => {
+    const instances = new Map([
+      createInstancePair("body", "Body", [
+        { type: "id", value: "box1" },
+        { type: "id", value: "paragraph" },
+        { type: "id", value: "box2" },
+      ]),
+      createInstancePair("paragraph", "Paragraph", [
+        { type: "expression", value: '"bla"' },
+      ]),
+      createInstancePair("box1", "Box1", []),
+      createInstancePair("box2", "Box2", []),
+    ]);
+    expect(
+      findClosestDroppableTarget(
+        defaultMetasMap,
+        instances,
+        ["paragraph", "body"],
+        emptyInsertConstraints
+      )
+    ).toEqual({
+      parentSelector: ["body"],
+      position: 2,
+    });
+  });
+
+  test("forbids inserting into :root", () => {
+    const instances = new Map([createInstancePair("body", "Body", [])]);
+    expect(
+      findClosestDroppableTarget(
+        defaultMetasMap,
+        instances,
+        [":root"],
+        emptyInsertConstraints
+      )
+    ).toEqual(undefined);
+  });
 });
 
 describe("insert instance children", () => {

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -46,6 +46,7 @@ import {
   $pages,
   $resources,
   $selectedPage,
+  ROOT_INSTANCE_ID,
 } from "./nano-states";
 import {
   type DroppableTarget,
@@ -376,6 +377,9 @@ export const findClosestDroppableTarget = (
   instanceSelector: InstanceSelector,
   insertConstraints: InsertConstraints
 ): undefined | DroppableTarget => {
+  if (instanceSelector[0] === ROOT_INSTANCE_ID) {
+    return;
+  }
   // We want to always allow dropping into the root.
   // For example when body has text content and the only viable option is to insert at the end.
   if (instanceSelector.length === 1) {

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -35,10 +35,6 @@ export const $virtualInstances = computed($selectedPage, (selectedPage) => {
   return virtualInstances;
 });
 
-export const $rootInstance = computed($virtualInstances, (virtualInstances) =>
-  virtualInstances.get(ROOT_INSTANCE_ID)
-);
-
 export const $selectedInstance = computed(
   [$instances, $virtualInstances, $selectedInstanceSelector],
   (instances, virtualInstances, selectedInstanceSelector) => {

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -1,6 +1,8 @@
 import { atom, computed } from "nanostores";
 import type { Instances } from "@webstudio-is/sdk";
 import type { InstanceSelector } from "../tree-utils";
+import { $selectedPage } from "./pages";
+import { rootComponent } from "@webstudio-is/react-sdk";
 
 export const $isResizingCanvas = atom(false);
 
@@ -18,14 +20,36 @@ export const $textEditingInstanceSelector = atom<
 
 export const $instances = atom<Instances>(new Map());
 
+export const ROOT_INSTANCE_ID = ":root";
+
+export const $virtualInstances = computed($selectedPage, (selectedPage) => {
+  const virtualInstances: Instances = new Map();
+  if (selectedPage) {
+    virtualInstances.set(ROOT_INSTANCE_ID, {
+      type: "instance",
+      id: ROOT_INSTANCE_ID,
+      component: rootComponent,
+      children: [{ type: "id", value: selectedPage.rootInstanceId }],
+    });
+  }
+  return virtualInstances;
+});
+
+export const $rootInstance = computed($virtualInstances, (virtualInstances) =>
+  virtualInstances.get(ROOT_INSTANCE_ID)
+);
+
 export const $selectedInstance = computed(
-  [$instances, $selectedInstanceSelector],
-  (instances, selectedInstanceSelector) => {
+  [$instances, $virtualInstances, $selectedInstanceSelector],
+  (instances, virtualInstances, selectedInstanceSelector) => {
     if (selectedInstanceSelector === undefined) {
       return;
     }
     const [selectedInstanceId] = selectedInstanceSelector;
-    return instances.get(selectedInstanceId);
+    return (
+      instances.get(selectedInstanceId) ??
+      virtualInstances.get(selectedInstanceId)
+    );
   }
 );
 

--- a/apps/builder/app/shared/nano-states/misc.ts
+++ b/apps/builder/app/shared/nano-states/misc.ts
@@ -23,8 +23,7 @@ import { createImageLoader, type ImageLoader } from "@webstudio-is/image";
 import type { DragStartPayload } from "~/canvas/shared/use-drag-drop";
 import { type InstanceSelector } from "../tree-utils";
 import type { HtmlTags } from "html-tags";
-import { $instances, $selectedInstanceSelector } from "./instances";
-import { $selectedPage } from "./pages";
+import { $selectedInstanceSelector } from "./instances";
 import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
 import type { Simplify } from "type-fest";
 import type { AssetType } from "@webstudio-is/asset-uploader";
@@ -40,16 +39,6 @@ export const $imageLoader = atom<ImageLoader>(
 export const $publishedOrigin = computed(
   [$project, $publisherHost],
   (project, publisherHost) => `https://${project?.domain}.${publisherHost}`
-);
-
-export const $rootInstance = computed(
-  [$instances, $selectedPage],
-  (instances, selectedPage) => {
-    if (selectedPage === undefined) {
-      return undefined;
-    }
-    return instances.get(selectedPage.rootInstanceId);
-  }
 );
 
 export const $dataSources = atom<DataSources>(new Map());

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -14,6 +14,7 @@ import type {
   Unit,
   UnitValue,
   UnparsedValue,
+  FontFamilyValue,
 } from "@webstudio-is/css-engine";
 import * as customData from "../src/custom-data";
 
@@ -39,11 +40,6 @@ const units: Record<customData.UnitGroup, Array<string>> = {
 type Property = keyof typeof properties;
 type Value = (typeof properties)[Property];
 
-const inheritValue = {
-  type: "keyword",
-  value: "inherit",
-} as const;
-
 const autoValue = {
   type: "keyword",
   value: "auto",
@@ -51,9 +47,11 @@ const autoValue = {
 
 // Normalize browser dependant properties.
 const normalizedValues = {
-  "font-family": inheritValue,
-  "font-size": inheritValue,
-  "line-height": inheritValue,
+  // dependsOnUserAgent
+  "font-family": {
+    type: "fontFamily",
+    value: ["serif"],
+  } satisfies FontFamilyValue,
   // startOrNamelessValueIfLTRRightIfRTL
   "text-align": { type: "keyword", value: "start" },
   // canvastext

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -1016,8 +1016,8 @@ export const properties = {
     unitGroups: [],
     inherited: true,
     initial: {
-      type: "keyword",
-      value: "inherit",
+      type: "fontFamily",
+      value: ["serif"],
     },
   },
   fontFeatureSettings: {
@@ -1065,7 +1065,7 @@ export const properties = {
     inherited: true,
     initial: {
       type: "keyword",
-      value: "inherit",
+      value: "medium",
     },
   },
   fontSizeAdjust: {
@@ -1409,7 +1409,7 @@ export const properties = {
     inherited: true,
     initial: {
       type: "keyword",
-      value: "inherit",
+      value: "normal",
     },
   },
   listStyleImage: {

--- a/packages/design-system/src/components/tree.tsx
+++ b/packages/design-system/src/components/tree.tsx
@@ -423,18 +423,19 @@ export const TreeNode = ({
   tabbable?: boolean;
   isSelected: boolean;
   isHighlighted?: boolean;
-  isExpanded: undefined | boolean;
-  onExpand: (expanded: boolean, all: boolean) => void;
+  isExpanded?: undefined | boolean;
+  onExpand?: (expanded: boolean, all: boolean) => void;
   nodeProps?: ComponentPropsWithoutRef<"div">;
   buttonProps: ComponentPropsWithoutRef<"button">;
   action?: ReactNode;
   children: ReactNode;
 }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   // scroll the selected button into view when selected from canvas.
   useEffect(() => {
     if (isSelected) {
-      containerRef.current?.scrollIntoView({
+      buttonRef.current?.focus();
+      buttonRef.current?.scrollIntoView({
         // smooth behavior in both canvas and navigator confuses chrome
         behavior: "auto",
         block: "nearest",
@@ -447,17 +448,17 @@ export const TreeNode = ({
       return;
     }
     if (event.key === "ArrowLeft" && isExpanded === true) {
-      onExpand(false, event.altKey);
+      onExpand?.(false, event.altKey);
       // allow to collapse and then navigate to previous node
       event.preventDefault();
     }
     if (event.key === "ArrowRight" && isExpanded === false) {
-      onExpand(true, event.altKey);
+      onExpand?.(true, event.altKey);
       // allow to expand and then navigate to next node
       event.preventDefault();
     }
     if (event.key === " ") {
-      onExpand(isExpanded === false, event.altKey);
+      onExpand?.(isExpanded === false, event.altKey);
       // prevent scrolling
       event.preventDefault();
     }
@@ -466,13 +467,13 @@ export const TreeNode = ({
   return (
     <NodeContainer
       {...nodeProps}
-      ref={containerRef}
       css={{ [treeNodeLevel]: level }}
       onKeyDown={handleKeydown}
     >
       <DepthBars />
       <NodeButton
         {...buttonProps}
+        ref={buttonRef}
         tabIndex={tabbable || level === 0 ? undefined : -1}
         aria-selected={isSelected}
         aria-current={isHighlighted}
@@ -483,7 +484,7 @@ export const TreeNode = ({
       {isExpanded !== undefined && (
         <ExpandButton
           tabIndex={-1}
-          onClick={(event) => onExpand(isExpanded === false, event.altKey)}
+          onClick={(event) => onExpand?.(isExpanded === false, event.altKey)}
         >
           {isExpanded ? <ChevronFilledDownIcon /> : <ChevronFilledRightIcon />}
         </ExpandButton>

--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -1,8 +1,25 @@
-import { ListViewIcon, PaintBrushIcon } from "@webstudio-is/icons/svg";
+import {
+  ListViewIcon,
+  PaintBrushIcon,
+  EmbedIcon,
+} from "@webstudio-is/icons/svg";
 import type {
   WsComponentMeta,
   WsComponentPropsMeta,
 } from "./components/component-meta";
+
+export const rootComponent = "ws:root";
+
+const rootMeta: WsComponentMeta = {
+  category: "hidden",
+  type: "container",
+  label: ":root",
+  icon: EmbedIcon,
+};
+
+const rootPropsMeta: WsComponentPropsMeta = {
+  props: {},
+};
 
 export const portalComponent = "Slot";
 
@@ -104,11 +121,13 @@ const descendantPropsMeta: WsComponentPropsMeta = {
 };
 
 export const coreMetas = {
+  [rootComponent]: rootMeta,
   [collectionComponent]: collectionMeta,
   [descendantComponent]: descendantMeta,
 };
 
 export const corePropsMetas = {
+  [rootComponent]: rootPropsMeta,
   [collectionComponent]: collectionPropsMeta,
   [descendantComponent]: descendantPropsMeta,
 };
@@ -116,4 +135,6 @@ export const corePropsMetas = {
 // components with custom implementation
 // should not be imported as react component
 export const isCoreComponent = (component: string) =>
-  component === collectionComponent || component === descendantComponent;
+  component === rootComponent ||
+  component === collectionComponent ||
+  component === descendantComponent;

--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -13,7 +13,7 @@ export const rootComponent = "ws:root";
 const rootMeta: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: ":root",
+  label: "Global Root",
   icon: EmbedIcon,
 };
 

--- a/packages/sdk-components-react/src/body.ws.ts
+++ b/packages/sdk-components-react/src/body.ws.ts
@@ -28,6 +28,7 @@ export const meta: WsComponentMeta = {
   icon: BodyIcon,
   states: defaultStates,
   presetStyle,
+  detachable: false,
 };
 
 export const propsMeta: WsComponentPropsMeta = {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

Now we have a way to change rem and define global css variables

- show root node in navigator behind flag
- show style panel when root is selected
- inherit styles from root
- show advanced styles defined on root in descendents
- show browser styles for root (`html { display: block }`)
- show initial values instead of `inherit` in root typography
- render root styles on canvas
- property label shows root as the source

Note: generated sites are not supported yet
<img width="825" alt="Screenshot 2024-09-27 at 19 24 41" src="https://github.com/user-attachments/assets/4c17f86a-74d8-4518-8145-854dbdbee11a">

<img width="1304" alt="Screenshot 2024-09-27 at 19 09 51" src="https://github.com/user-attachments/assets/6003fd49-5ecb-46cd-9df7-85c571f82e32">
