### PR TITLE
experimental: generate root styles for published sites

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/insert.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/insert.ts
@@ -1,11 +1,11 @@
-import { type WsComponentMeta } from "@webstudio-is/react-sdk";
+import { ROOT_INSTANCE_ID } from "@webstudio-is/sdk";
+import type { WsComponentMeta } from "@webstudio-is/react-sdk";
 import { toast } from "@webstudio-is/design-system";
 import {
   $instances,
   $registeredComponentMetas,
   $selectedInstanceSelector,
   $selectedPage,
-  ROOT_INSTANCE_ID,
 } from "~/shared/nano-states";
 import {
   computeInstancesConstraints,

--- a/apps/builder/app/builder/features/sidebar-left/panels/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/navigator/navigator-tree.tsx
@@ -25,7 +25,7 @@ import {
   showAttribute,
   WsComponentMeta,
 } from "@webstudio-is/react-sdk";
-import type { Instance } from "@webstudio-is/sdk";
+import { ROOT_INSTANCE_ID, type Instance } from "@webstudio-is/sdk";
 import { EyeconClosedIcon, EyeconOpenIcon } from "@webstudio-is/icons";
 import {
   $dragAndDropState,
@@ -39,7 +39,6 @@ import {
   $selectedInstanceSelector,
   $selectedPage,
   getIndexedInstanceId,
-  ROOT_INSTANCE_ID,
 } from "~/shared/nano-states";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { serverSyncStore } from "~/shared/sync";

--- a/apps/builder/app/builder/features/style-panel/shared/model.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/model.tsx
@@ -7,7 +7,13 @@ import {
   type StyleProperty,
   type StyleValue,
 } from "@webstudio-is/css-engine";
-import type { Breakpoint, Instance, StyleDecl } from "@webstudio-is/sdk";
+import {
+  ROOT_INSTANCE_ID,
+  type Breakpoint,
+  type Instance,
+  type StyleDecl,
+} from "@webstudio-is/sdk";
+import { rootComponent } from "@webstudio-is/react-sdk";
 import {
   $breakpoints,
   $instances,
@@ -19,7 +25,6 @@ import {
   $selectedOrLastStyleSourceSelector,
   $styles,
   $styleSourceSelections,
-  ROOT_INSTANCE_ID,
 } from "~/shared/nano-states";
 import {
   getComputedStyleDecl,
@@ -49,7 +54,9 @@ const $presetStyles = computed($registeredComponentMetas, (metas) => {
 const $instanceComponents = computed(
   [$selectedInstanceSelector, $instances],
   (instanceSelector, instances) => {
-    const instanceComponents = new Map<Instance["id"], Instance["component"]>();
+    const instanceComponents = new Map<Instance["id"], Instance["component"]>([
+      [ROOT_INSTANCE_ID, rootComponent],
+    ]);
     if (instanceSelector === undefined) {
       return instanceComponents;
     }

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -233,17 +233,6 @@ test("compute inherited styles", () => {
           "value": "antialiased",
         },
       },
-      "fontFamily": {
-        "instanceId": "1",
-        "value": {
-          "type": "fontFamily",
-          "value": [
-            "Arial",
-            "Roboto",
-            "sans-serif",
-          ],
-        },
-      },
       "fontSize": {
         "instanceId": "1",
         "styleSourceId": "styleSourceId1",
@@ -259,14 +248,6 @@ test("compute inherited styles", () => {
         "value": {
           "type": "keyword",
           "value": "600",
-        },
-      },
-      "lineHeight": {
-        "instanceId": "1",
-        "value": {
-          "type": "unit",
-          "unit": "number",
-          "value": 1.2,
         },
       },
     }

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -1,4 +1,4 @@
-import type { Instance } from "@webstudio-is/sdk";
+import { ROOT_INSTANCE_ID, type Instance } from "@webstudio-is/sdk";
 import { idAttribute, selectorIdAttribute } from "@webstudio-is/react-sdk";
 import { subscribeWindowResize } from "~/shared/dom-hooks";
 import {
@@ -14,7 +14,6 @@ import {
   $styles,
   $selectedInstanceStates,
   $styleSourceSelections,
-  ROOT_INSTANCE_ID,
 } from "~/shared/nano-states";
 import htmlTags, { type HtmlTags } from "html-tags";
 import {

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -3,6 +3,7 @@ import { computed } from "nanostores";
 import { useStore } from "@nanostores/react";
 import {
   Instance,
+  ROOT_INSTANCE_ID,
   getStyleDeclKey,
   type StyleDecl,
   type StyleSourceSelection,
@@ -14,6 +15,7 @@ import {
   createImageValueTransformer,
   descendantComponent,
   type Params,
+  rootComponent,
 } from "@webstudio-is/react-sdk";
 import {
   type VarValue,
@@ -32,7 +34,6 @@ import {
   $selectedStyleState,
   $styleSourceSelections,
   $styles,
-  ROOT_INSTANCE_ID,
 } from "~/shared/nano-states";
 import { setDifference } from "~/shared/shim";
 import { $ephemeralStyles, $params } from "../stores";
@@ -330,9 +331,11 @@ export const GlobalStyles = ({ params }: { params: Params }) => {
     presetSheet.addMediaRule("presets");
     for (const [component, meta] of metas) {
       for (const [tag, styles] of Object.entries(meta.presetStyle ?? {})) {
-        const rule = presetSheet.addNestingRule(
-          `${tag}:where([data-ws-component="${component}"])`
-        );
+        const selector =
+          component === rootComponent
+            ? ":root"
+            : `${tag}:where([data-ws-component="${component}"])`;
+        const rule = presetSheet.addNestingRule(selector);
         for (const declaration of styles) {
           rule.setDeclaration({
             breakpoint: "presets",

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -24,6 +24,7 @@ import {
   encodeDataSourceVariable,
   transpileExpression,
   getExpressionIdentifiers,
+  ROOT_INSTANCE_ID,
 } from "@webstudio-is/sdk";
 import {
   type WsComponentMeta,
@@ -46,7 +47,6 @@ import {
   $pages,
   $resources,
   $selectedPage,
-  ROOT_INSTANCE_ID,
 } from "./nano-states";
 import {
   type DroppableTarget,

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -1,5 +1,5 @@
 import { atom, computed } from "nanostores";
-import type { Instances } from "@webstudio-is/sdk";
+import { ROOT_INSTANCE_ID, type Instances } from "@webstudio-is/sdk";
 import type { InstanceSelector } from "../tree-utils";
 import { $selectedPage } from "./pages";
 import { rootComponent } from "@webstudio-is/react-sdk";
@@ -19,8 +19,6 @@ export const $textEditingInstanceSelector = atom<
 >();
 
 export const $instances = atom<Instances>(new Map());
-
-export const ROOT_INSTANCE_ID = ":root";
 
 export const $virtualInstances = computed($selectedPage, (selectedPage) => {
   const virtualInstances: Instances = new Map();

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -113,7 +113,7 @@
     "slugify": "^1.6.6",
     "strip-indent": "^4.0.0",
     "tiny-invariant": "^1.3.3",
-    "title-case": "^4.3.1",
+    "title-case": "^4.3.2",
     "ultraflag": "^0.1.0",
     "untruncate-json": "^0.0.1",
     "urlpattern-polyfill": "^9.0.0",

--- a/fixtures/ssg-netlify-by-project-id/app/__generated__/index.css
+++ b/fixtures/ssg-netlify-by-project-id/app/__generated__/index.css
@@ -1,9 +1,8 @@
-html {
-  margin: 0;
-  display: grid;
-  min-height: 100%;
-}
 @media all {
+  :root {
+    display: grid;
+    min-height: 100%;
+  }
   :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;

--- a/fixtures/ssg-netlify-by-project-id/app/__generated__/index.css
+++ b/fixtures/ssg-netlify-by-project-id/app/__generated__/index.css
@@ -2,11 +2,11 @@
   :root {
     display: grid;
     min-height: 100%;
-  }
-  :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;
     line-height: 1.2;
+  }
+  :where(body.w-body) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;

--- a/fixtures/ssg/app/__generated__/index.css
+++ b/fixtures/ssg/app/__generated__/index.css
@@ -1,9 +1,8 @@
-html {
-  margin: 0;
-  display: grid;
-  min-height: 100%;
-}
 @media all {
+  :root {
+    display: grid;
+    min-height: 100%;
+  }
   :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;

--- a/fixtures/ssg/app/__generated__/index.css
+++ b/fixtures/ssg/app/__generated__/index.css
@@ -2,11 +2,11 @@
   :root {
     display: grid;
     min-height: 100%;
-  }
-  :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;
     line-height: 1.2;
+  }
+  :where(body.w-body) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/index.css
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/index.css
@@ -1,9 +1,8 @@
-html {
-  margin: 0;
-  display: grid;
-  min-height: 100%;
-}
 @media all {
+  :root {
+    display: grid;
+    min-height: 100%;
+  }
   :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/index.css
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/index.css
@@ -2,11 +2,11 @@
   :root {
     display: grid;
     min-height: 100%;
-  }
-  :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;
     line-height: 1.2;
+  }
+  :where(body.w-body) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;

--- a/fixtures/webstudio-custom-template/app/__generated__/index.css
+++ b/fixtures/webstudio-custom-template/app/__generated__/index.css
@@ -10,11 +10,11 @@
   :root {
     display: grid;
     min-height: 100%;
-  }
-  :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;
     line-height: 1.2;
+  }
+  :where(body.w-body) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;

--- a/fixtures/webstudio-custom-template/app/__generated__/index.css
+++ b/fixtures/webstudio-custom-template/app/__generated__/index.css
@@ -6,12 +6,11 @@
   src: url("/custom-folder/CormorantGaramond-Medium_-nWJ-OtHncaW9xDHQ9hSA_CBl88Oo59QKH_z9pCWva2.woff2")
     format("woff2");
 }
-html {
-  margin: 0;
-  display: grid;
-  min-height: 100%;
-}
 @media all {
+  :root {
+    display: grid;
+    min-height: 100%;
+  }
   :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/index.css
@@ -1,9 +1,8 @@
-html {
-  margin: 0;
-  display: grid;
-  min-height: 100%;
-}
 @media all {
+  :root {
+    display: grid;
+    min-height: 100%;
+  }
   :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/index.css
@@ -2,11 +2,11 @@
   :root {
     display: grid;
     min-height: 100%;
-  }
-  :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;
     line-height: 1.2;
+  }
+  :where(body.w-body) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/index.css
@@ -1,9 +1,8 @@
-html {
-  margin: 0;
-  display: grid;
-  min-height: 100%;
-}
 @media all {
+  :root {
+    display: grid;
+    min-height: 100%;
+  }
   :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/index.css
@@ -2,11 +2,11 @@
   :root {
     display: grid;
     min-height: 100%;
-  }
-  :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;
     line-height: 1.2;
+  }
+  :where(body.w-body) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;

--- a/fixtures/webstudio-remix-vercel/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/index.css
@@ -1,9 +1,8 @@
-html {
-  margin: 0;
-  display: grid;
-  min-height: 100%;
-}
 @media all {
+  :root {
+    display: grid;
+    min-height: 100%;
+  }
   :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;

--- a/fixtures/webstudio-remix-vercel/app/__generated__/index.css
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/index.css
@@ -2,11 +2,11 @@
   :root {
     display: grid;
     min-height: 100%;
-  }
-  :where(body.w-body) {
     font-family: Arial, Roboto, sans-serif;
     font-size: 16px;
     line-height: 1.2;
+  }
+  :where(body.w-body) {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -25,6 +25,7 @@ import {
   generateRemixRoute,
   generateRemixParams,
   isCoreComponent,
+  coreMetas,
 } from "@webstudio-is/react-sdk";
 import type {
   Instance,
@@ -294,7 +295,9 @@ export const prebuild = async (options: {
     }
   }
 
-  const projectMetas = new Map<Instance["component"], WsComponentMeta>();
+  const projectMetas = new Map<Instance["component"], WsComponentMeta>(
+    Object.entries(coreMetas)
+  );
   const componentsByPage: ComponentsByPage = {};
   const siteDataByPage: SiteDataByPage = {};
   const fontAssetsByPage: Record<Page["id"], FontAsset[]> = {};

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -12,7 +12,7 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
-    "@emotion/hash": "^0.9.1",
+    "@emotion/hash": "^0.9.2",
     "@webstudio-is/error-utils": "workspace:*",
     "@webstudio-is/fonts": "workspace:*",
     "zod": "^3.22.4"

--- a/packages/css-engine/src/core/atomic.ts
+++ b/packages/css-engine/src/core/atomic.ts
@@ -4,7 +4,8 @@ import { NestingRule } from "./rules";
 import { toValue, type TransformValue } from "./to-value";
 
 type Options = {
-  getKey: (rule: NestingRule) => string;
+  /** in case of undefined the rule will not be split into atomics */
+  getKey: (rule: NestingRule) => string | undefined;
   transformValue?: TransformValue;
   classes?: Map<string, string[]>;
 };
@@ -16,6 +17,10 @@ export const generateAtomic = (sheet: StyleSheet, options: Options) => {
   for (const rule of sheet.nestingRules.values()) {
     const descendantSuffix = rule.getDescendantSuffix();
     const groupKey = getKey(rule);
+    if (groupKey === undefined) {
+      atomicRules.set(rule.getSelector(), rule);
+      continue;
+    }
     // a few rules can be in the same group
     // when rule have descendant suffix
     let classList = classes.get(groupKey);

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -38,7 +38,7 @@
     "change-case": "^5.4.4",
     "html-tags": "^4.0.0",
     "nanoid": "^5.0.1",
-    "title-case": "^4.3.1"
+    "title-case": "^4.3.2"
   },
   "exports": {
     ".": {

--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -3,6 +3,7 @@ import {
   PaintBrushIcon,
   EmbedIcon,
 } from "@webstudio-is/icons/svg";
+import { html } from "@webstudio-is/sdk/normalize.css";
 import type {
   WsComponentMeta,
   WsComponentPropsMeta,
@@ -15,6 +16,9 @@ const rootMeta: WsComponentMeta = {
   type: "container",
   label: "Global Root",
   icon: EmbedIcon,
+  presetStyle: {
+    html: [...html],
+  },
 };
 
 const rootPropsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -17,7 +17,7 @@ const rootMeta: WsComponentMeta = {
   label: "Global Root",
   icon: EmbedIcon,
   presetStyle: {
-    html: [...html],
+    html,
   },
 };
 

--- a/packages/react-sdk/src/css/css.test.tsx
+++ b/packages/react-sdk/src/css/css.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from "@jest/globals";
 import type { Breakpoint } from "@webstudio-is/sdk";
 import { generateCss, type CssConfig } from "./css";
-import { descendantComponent } from "../core-components";
+import { descendantComponent, rootComponent } from "../core-components";
 import { $, renderJsx } from "@webstudio-is/sdk/testing";
 
 const toMap = <T extends { id: string }>(list: T[]) =>
@@ -53,7 +53,7 @@ test("generate css for one instance with two tokens", () => {
     assetBaseUrl: "",
   });
   expect(cssText).toMatchInlineSnapshot(`
-"html {margin: 0; display: grid; min-height: 100%}
+"
 @media all {
   .w-box {
     color: red
@@ -61,7 +61,7 @@ test("generate css for one instance with two tokens", () => {
 }"
 `);
   expect(atomicCssText).toMatchInlineSnapshot(`
-"html {margin: 0; display: grid; min-height: 100%}
+"
 @media all {
   .cawkhls {
     color: red
@@ -133,7 +133,7 @@ test("generate descendant selector", () => {
     assetBaseUrl: "",
   });
   expect(cssText).toMatchInlineSnapshot(`
-"html {margin: 0; display: grid; min-height: 100%}
+"
 @media all {
   .w-body {
     color: blue
@@ -150,7 +150,7 @@ test("generate descendant selector", () => {
 }"
 `);
   expect(atomicCssText).toMatchInlineSnapshot(`
-"html {margin: 0; display: grid; min-height: 100%}
+"
 @media all {
   .c17hlgoh {
     color: blue
@@ -212,8 +212,7 @@ test("generate component presets with multiple tags", () => {
     assetBaseUrl: "",
   });
   expect(cssText).toMatchInlineSnapshot(`
-"html {margin: 0; display: grid; min-height: 100%}
-@media all {
+"@media all {
   :where(div.w-list-item) {
     display: block
   }
@@ -287,8 +286,7 @@ test("deduplicate component presets for similarly named components", () => {
     assetBaseUrl: "",
   });
   expect(cssText).toMatchInlineSnapshot(`
-"html {margin: 0; display: grid; min-height: 100%}
-@media all {
+"@media all {
   :where(div.w-list-item) {
     display: block
   }
@@ -374,8 +372,7 @@ test("expose preset classes to instances", () => {
     assetBaseUrl: "",
   });
   expect(atomicCssText).toMatchInlineSnapshot(`
-"html {margin: 0; display: grid; min-height: 100%}
-@media all {
+"@media all {
   :where(div.w-body) {
     display: block
   }
@@ -488,8 +485,7 @@ test("generate classes with instance and meta label", () => {
     assetBaseUrl: "",
   });
   expect(cssText).toMatchInlineSnapshot(`
-"html {margin: 0; display: grid; min-height: 100%}
-@media all {
+"@media all {
   :where(div.w-body-meta-label) {
     display: block
   }
@@ -518,4 +514,62 @@ Map {
   ],
 }
 `);
+});
+
+test("generate :root preset and user styles", () => {
+  const { cssText, classes } = generateAllCss({
+    assets: new Map(),
+    ...renderJsx(
+      <$.Body ws:id="body">
+        <$.Box ws:id="box"></$.Box>
+      </$.Body>
+    ),
+    breakpoints: toMap([{ id: "base", label: "" }]),
+    styleSourceSelections: new Map([
+      [":root", { instanceId: ":root", values: ["local"] }],
+    ]),
+    styles: new Map([
+      [
+        "local:base:color",
+        {
+          styleSourceId: "local",
+          breakpointId: "base",
+          property: "color",
+          value: { type: "keyword", value: "blue" },
+        },
+      ],
+    ]),
+    componentMetas: new Map([
+      [
+        rootComponent,
+        {
+          type: "container",
+          icon: "",
+          label: "Global Root",
+          presetStyle: {
+            html: [
+              {
+                property: "display",
+                value: { type: "keyword", value: "grid" },
+              },
+            ],
+          },
+        },
+      ],
+    ]),
+    assetBaseUrl: "",
+  });
+  expect(cssText).toMatchInlineSnapshot(`
+"@media all {
+  :root {
+    display: grid
+  }
+}
+@media all {
+  :root {
+    color: blue
+  }
+}"
+`);
+  expect(classes).toEqual(new Map());
 });

--- a/packages/react-sdk/src/css/css.test.tsx
+++ b/packages/react-sdk/src/css/css.test.tsx
@@ -517,7 +517,7 @@ Map {
 });
 
 test("generate :root preset and user styles", () => {
-  const { cssText, classes } = generateAllCss({
+  const { cssText, atomicCssText, classes, atomicClasses } = generateAllCss({
     assets: new Map(),
     ...renderJsx(
       <$.Body ws:id="body">
@@ -536,6 +536,15 @@ test("generate :root preset and user styles", () => {
           breakpointId: "base",
           property: "color",
           value: { type: "keyword", value: "blue" },
+        },
+      ],
+      [
+        "local:base:fontSize",
+        {
+          styleSourceId: "local",
+          breakpointId: "base",
+          property: "fontSize",
+          value: { type: "keyword", value: "medium" },
         },
       ],
     ]),
@@ -567,9 +576,24 @@ test("generate :root preset and user styles", () => {
 }
 @media all {
   :root {
-    color: blue
+    color: blue;
+    font-size: medium
   }
 }"
 `);
   expect(classes).toEqual(new Map());
+  expect(atomicCssText).toMatchInlineSnapshot(`
+"@media all {
+  :root {
+    display: grid
+  }
+}
+@media all {
+  :root {
+    color: blue;
+    font-size: medium
+  }
+}"
+`);
+  expect(atomicClasses).toEqual(new Map());
 });

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -154,7 +154,7 @@ export const generateCss = ({
     if (instanceId === ROOT_INSTANCE_ID) {
       const rule = sheet.addNestingRule(`:root`);
       rule.applyMixins(values);
-      instanceByRule.set(rule, instanceId);
+      // avoid storing in instanceByRule to prevent conversion into atomic styles
       continue;
     }
     let descendantSuffix = "";
@@ -187,7 +187,7 @@ export const generateCss = ({
 
   if (atomic) {
     const { cssText } = generateAtomic(sheet, {
-      getKey: (rule) => instanceByRule.get(rule) ?? "",
+      getKey: (rule) => instanceByRule.get(rule),
       transformValue: imageValueTransformer,
       classes,
     });

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -5,6 +5,7 @@ import {
   type TransformValue,
 } from "@webstudio-is/css-engine";
 import {
+  ROOT_INSTANCE_ID,
   createScope,
   parseComponentName,
   type Assets,
@@ -16,7 +17,7 @@ import {
   type Styles,
 } from "@webstudio-is/sdk";
 import type { WsComponentMeta } from "../components/component-meta";
-import { descendantComponent } from "../core-components";
+import { descendantComponent, rootComponent } from "../core-components";
 import { addGlobalRules } from "./global-rules";
 import { kebabCase } from "change-case";
 
@@ -90,7 +91,10 @@ export const generateCss = ({
       // use :where() to reset specificity of preset selector
       // and let user styles completely override it
       // ideally switch to @layer when better supported
-      const rule = globalSheet.addNestingRule(`:where(${tag}.${className})`);
+      // render root preset styles without changes
+      const selector =
+        component === rootComponent ? ":root" : `:where(${tag}.${className})`;
+      const rule = globalSheet.addNestingRule(selector);
       for (const declaration of styles) {
         rule.setDeclaration({
           breakpoint: "presets",
@@ -146,6 +150,13 @@ export const generateCss = ({
   for (const selection of styleSourceSelections.values()) {
     let { instanceId } = selection;
     const { values } = selection;
+    // special case for :root styles
+    if (instanceId === ROOT_INSTANCE_ID) {
+      const rule = sheet.addNestingRule(`:root`);
+      rule.applyMixins(values);
+      instanceByRule.set(rule, instanceId);
+      continue;
+    }
     let descendantSuffix = "";
     // render selector component as descendant selector
     const instance = instances.get(instanceId);

--- a/packages/react-sdk/src/css/global-rules.ts
+++ b/packages/react-sdk/src/css/global-rules.ts
@@ -6,12 +6,6 @@ export const addGlobalRules = (
   sheet: StyleSheetRegular,
   { assets, assetBaseUrl }: { assets: Assets; assetBaseUrl: string }
 ) => {
-  // @todo we need to figure out all global resets while keeping
-  // the engine aware of all of them.
-  // Ideally, the user is somehow aware and in control of the reset
-  // Layout source https://twitter.com/ChallengesCss/status/1471128244720181258
-  sheet.addPlaintextRule("html {margin: 0; display: grid; min-height: 100%}");
-
   const fontAssets: FontAsset[] = [];
   for (const asset of assets.values()) {
     if (asset.type === "font") {

--- a/packages/sdk/src/__generated__/normalize.css.ts
+++ b/packages/sdk/src/__generated__/normalize.css.ts
@@ -77,29 +77,8 @@ export const p = div;
 export const span = div;
 
 export const html: StyleDecl[] = [
-  {
-    property: "lineHeight",
-    value: { type: "unit", unit: "number", value: 1.15 },
-  },
-  {
-    property: "textSizeAdjust",
-    value: { type: "unit", unit: "%", value: 100 },
-  },
-  { property: "tabSize", value: { type: "unit", unit: "number", value: 4 } },
-  { property: "boxSizing", value: { type: "keyword", value: "border-box" } },
-  { property: "borderTopWidth", value: { type: "unit", unit: "px", value: 1 } },
-  {
-    property: "borderRightWidth",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "borderBottomWidth",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "borderLeftWidth",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
+  { property: "display", value: { type: "keyword", value: "grid" } },
+  { property: "minHeight", value: { type: "unit", unit: "%", value: 100 } },
 ];
 
 export const body: StyleDecl[] = [

--- a/packages/sdk/src/__generated__/normalize.css.ts
+++ b/packages/sdk/src/__generated__/normalize.css.ts
@@ -79,6 +79,15 @@ export const span = div;
 export const html: StyleDecl[] = [
   { property: "display", value: { type: "keyword", value: "grid" } },
   { property: "minHeight", value: { type: "unit", unit: "%", value: 100 } },
+  {
+    property: "fontFamily",
+    value: { type: "fontFamily", value: ["Arial", "Roboto", "sans-serif"] },
+  },
+  { property: "fontSize", value: { type: "unit", unit: "px", value: 16 } },
+  {
+    property: "lineHeight",
+    value: { type: "unit", unit: "number", value: 1.2 },
+  },
 ];
 
 export const body: StyleDecl[] = [
@@ -92,15 +101,6 @@ export const body: StyleDecl[] = [
     value: { type: "unit", unit: "number", value: 0 },
   },
   { property: "marginLeft", value: { type: "unit", unit: "number", value: 0 } },
-  {
-    property: "fontFamily",
-    value: { type: "fontFamily", value: ["Arial", "Roboto", "sans-serif"] },
-  },
-  { property: "fontSize", value: { type: "unit", unit: "px", value: 16 } },
-  {
-    property: "lineHeight",
-    value: { type: "unit", unit: "number", value: 1.2 },
-  },
   { property: "boxSizing", value: { type: "keyword", value: "border-box" } },
   { property: "borderTopWidth", value: { type: "unit", unit: "px", value: 1 } },
   {

--- a/packages/sdk/src/instances-utils.ts
+++ b/packages/sdk/src/instances-utils.ts
@@ -1,5 +1,7 @@
 import type { Instance, Instances } from "./schema/instances";
 
+export const ROOT_INSTANCE_ID = ":root";
+
 const traverseInstances = (
   instances: Instances,
   instanceId: Instance["id"],

--- a/packages/sdk/src/normalize.css
+++ b/packages/sdk/src/normalize.css
@@ -60,22 +60,10 @@ span {
   outline-width: 1px;
 }
 
-/* @todo for now not applied to html, as we don't have html element */
-/**
- * 1. Correct the line height in all browsers.
- * 2. Prevent adjustments of font size after orientation changes in iOS.
- * 3. Use a more readable tab size (opinionated).
- */
 html {
-  /* 1 */
-  line-height: 1.15;
-  /* 2 */
-  -webkit-text-size-adjust: 100%;
-  /* 3 */
-  tab-size: 4;
-  /* webstudio custom opinionated presets */
-  box-sizing: border-box;
-  border-width: 1px;
+  /* Layout source https://twitter.com/ChallengesCss/status/1471128244720181258 */
+  display: grid;
+  min-height: 100%;
 }
 
 /**

--- a/packages/sdk/src/normalize.css
+++ b/packages/sdk/src/normalize.css
@@ -60,23 +60,26 @@ span {
   outline-width: 1px;
 }
 
-html {
-  /* Layout source https://twitter.com/ChallengesCss/status/1471128244720181258 */
-  display: grid;
-  min-height: 100%;
-}
-
 /**
- * 1. Remove the margin in all browsers.
+ * 1. Layout source https://twitter.com/ChallengesCss/status/1471128244720181258
  * 2. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
  */
-body {
+html {
   /* 1 */
-  margin: 0;
+  display: grid;
+  min-height: 100%;
   /* 2 */
   font-family: Arial, Roboto, sans-serif;
   font-size: 16px;
   line-height: 1.2;
+}
+
+/**
+ * 1. Remove the margin in all browsers.
+ */
+body {
+  /* 1 */
+  margin: 0;
   /* webstudio custom opinionated presets */
   box-sizing: border-box;
   border-width: 1px;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,8 +413,8 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3
       title-case:
-        specifier: ^4.3.1
-        version: 4.3.1
+        specifier: ^4.3.2
+        version: 4.3.2
       ultraflag:
         specifier: ^0.1.0
         version: 0.1.0
@@ -1236,8 +1236,8 @@ importers:
   packages/css-engine:
     dependencies:
       '@emotion/hash':
-        specifier: ^0.9.1
-        version: 0.9.1
+        specifier: ^0.9.2
+        version: 0.9.2
       '@webstudio-is/error-utils':
         specifier: workspace:*
         version: link:../error-utils
@@ -1836,8 +1836,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       title-case:
-        specifier: ^4.3.1
-        version: 4.3.1
+        specifier: ^4.3.2
+        version: 4.3.2
     devDependencies:
       '@jest/globals':
         specifier: ^29.7.0
@@ -2655,8 +2655,8 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@emotion/hash@0.9.1':
-    resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
+  '@emotion/hash@0.9.2':
+    resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
 
   '@esbuild-plugins/node-globals-polyfill@0.2.3':
     resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
@@ -8812,8 +8812,8 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
-  title-case@4.3.1:
-    resolution: {integrity: sha512-VnPxQ+/j0X2FZ4ceGq1oLruTLjtN5Ul4sam5ypd4mDZLm1eHwkwip1gLxqhON/j4qyTlUlfPKslE/t4NPSlxhg==}
+  title-case@4.3.2:
+    resolution: {integrity: sha512-I/nkcBo73mO42Idfv08jhInV61IMb61OdIFxk+B4Gu1oBjWBPOLmhZdsli+oJCVaD+86pYQA93cJfFt224ZFAA==}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -10025,7 +10025,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@emotion/hash@0.9.1': {}
+  '@emotion/hash@0.9.2': {}
 
   '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19)':
     dependencies:
@@ -12569,7 +12569,7 @@ snapshots:
 
   '@vanilla-extract/css@1.15.3':
     dependencies:
-      '@emotion/hash': 0.9.1
+      '@emotion/hash': 0.9.2
       '@vanilla-extract/private': 1.0.5
       css-what: 6.1.0
       cssesc: 3.0.0
@@ -17158,7 +17158,7 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
-  title-case@4.3.1: {}
+  title-case@4.3.2: {}
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

- render layout hack (display: grid; min-height: 100%) as root preset styles
- generate root user styles on published sites
- moved typography preset from body to the root
- bumped a couple of deps

<img width="240" alt="Screenshot 2024-09-28 at 23 25 08" src="https://github.com/user-attachments/assets/eaf7476e-f488-4f1f-89db-6d464c05b35f">
