### PR TITLE
fix: find proper drop target in collections

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/navigator/navigator-tree.tsx
@@ -143,9 +143,7 @@ const $flatTree = computed(
             for (let index = 0; index < instance.children.length; index += 1) {
               const child = instance.children[index];
               if (child.type === "id") {
-                const isLastChild =
-                  index * dataIndex ===
-                  instance.children.length * dataIndex - 1;
+                const isLastChild = index === instance.children.length - 1;
                 lastItem = traverse(
                   child.value,
                   [
@@ -160,7 +158,7 @@ const $flatTree = computed(
                   // but level is still increased to show proper drop indicator
                   // and address instance selector
                   level + 2,
-                  index * dataIndex
+                  index
                 );
               }
             }
@@ -344,7 +342,17 @@ const getBuilderDropTarget = (
   }
   const instances = $instances.get();
   const parentSelector = selector.slice(-treeDropTarget.parentLevel - 1);
-  const parentInstance = instances.get(parentSelector[0]);
+  let parentInstance = instances.get(parentSelector[0]);
+  const grandParentInstance = instances.get(parentSelector[1]);
+  // collection item fake instance
+  if (parentInstance === undefined && grandParentInstance) {
+    parentInstance = {
+      type: "instance",
+      id: parentSelector[0],
+      component: "Fragment",
+      children: grandParentInstance.children,
+    };
+  }
   if (parentInstance === undefined) {
     return;
   }

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -54,7 +54,7 @@ const getCollectionDropTarget = (
   dropTarget: DroppableTarget
 ) => {
   const [parentId, grandparentId] = dropTarget.parentSelector;
-  let parent = instances.get(parentId);
+  const parent = instances.get(parentId);
   const grandparent = instances.get(grandparentId);
   if (parent === undefined && grandparent?.component === collectionComponent) {
     return {

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -49,6 +49,21 @@ export type DroppableTarget = {
   position: number | "end";
 };
 
+const getCollectionDropTarget = (
+  instances: Instances,
+  dropTarget: DroppableTarget
+) => {
+  const [parentId, grandparentId] = dropTarget.parentSelector;
+  let parent = instances.get(parentId);
+  const grandparent = instances.get(grandparentId);
+  if (parent === undefined && grandparent?.component === collectionComponent) {
+    return {
+      parentSelector: dropTarget.parentSelector.slice(1),
+      position: dropTarget.position,
+    };
+  }
+};
+
 export const getInstanceOrCreateFragmentIfNecessary = (
   instances: Instances,
   dropTarget: DroppableTarget
@@ -219,6 +234,7 @@ export const getReparentDropTargetMutable = (
     prevParent = grandparentInstance;
   }
 
+  dropTarget = getCollectionDropTarget(instances, dropTarget) ?? dropTarget;
   dropTarget =
     getInstanceOrCreateFragmentIfNecessary(instances, dropTarget) ?? dropTarget;
   dropTarget =


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/4192 https://github.com/webstudio-is/webstudio/issues/4202

Figured the way we address instances and render tree should be the same to compute proper drop targets. As a result collection got extra level of depth.

![Screenshot 2024-10-02 at 13 19 00](https://github.com/user-attachments/assets/9ff5b1ac-7515-41fc-a9f1-f9c77115ecb9)
