### PR TITLE
fix: delete settings autofocus

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -181,11 +181,8 @@ export const PropsSection = (props: PropsSectionProps) => {
               }}
             />
           )}
-          {logic.addedProps.map((item, index) =>
-            renderProperty(props, item, {
-              deletable: true,
-              autoFocus: index === 0,
-            })
+          {logic.addedProps.map((item) =>
+            renderProperty(props, item, { deletable: true })
           )}
           {logic.initialProps.map((item) => renderProperty(props, item))}
         </Flex>


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/3996

## Description

Auto focusing the first property value in settings when switching to settings seemed like a good idea until the point if you leave settings open and switch instances, you don't want that focus to be taken away from navigator or anything else.

Seems like better to not have it autofocus at all in this case.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
