### PR TITLE
fix: fix color thumb vertical alignment

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/color-thumb.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-thumb.tsx
@@ -45,6 +45,7 @@ const lerpColor = (a: RgbaColor, b: RgbaColor, t: number) => {
 };
 
 const thumbStyle = css({
+  display: "block",
   width: theme.spacing[10],
   height: theme.spacing[10],
   backgroundBlendMode: "difference",


### PR DESCRIPTION
## Description

Noticed this 1px misalignment because display inline-block is affected by line-height.

<img width="55" alt="image" src="https://github.com/user-attachments/assets/729e1a37-be3b-44dd-a672-855e6d87f4ad">

<img width="50" alt="image" src="https://github.com/user-attachments/assets/f9930925-800c-4930-8a75-12383d8babe3">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
