### PR TITLE
refactor: autocomplete variables lazily

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -114,7 +114,7 @@ const AddPropertyOrAttribute = ({
         autoFocus
         color={isValid ? undefined : "error"}
         placeholder="Select or create"
-        items={availableProps}
+        getItems={() => availableProps}
         itemToString={itemToString}
         onItemSelect={(item) => {
           if (

--- a/apps/builder/app/builder/features/style-panel/controls/color/color-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/color/color-control.tsx
@@ -1,4 +1,3 @@
-import { useStore } from "@nanostores/react";
 import type { StyleProperty } from "@webstudio-is/css-engine";
 import { ColorPicker } from "../../shared/color-picker";
 import { styleConfigByName } from "../../shared/configs";
@@ -7,8 +6,6 @@ import { deleteProperty, setProperty } from "../../shared/use-style-data";
 
 export const ColorControl = ({ property }: { property: StyleProperty }) => {
   const computedStyleDecl = useComputedStyleDecl(property);
-  const { items } = styleConfigByName(property);
-  const availableVariables = useStore($availableVariables);
   const value = computedStyleDecl.cascadedValue;
   const currentColor = computedStyleDecl.usedValue;
   const setValue = setProperty(property);
@@ -18,11 +15,11 @@ export const ColorControl = ({ property }: { property: StyleProperty }) => {
       value={value}
       currentColor={currentColor}
       options={[
-        ...items.map((item) => ({
+        ...styleConfigByName(property).items.map((item) => ({
           type: "keyword" as const,
           value: item.name,
         })),
-        ...availableVariables,
+        ...$availableVariables.get(),
       ]}
       onChange={(styleValue) => setValue(styleValue, { isEphemeral: true })}
       onChangeComplete={setValue}

--- a/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
@@ -82,7 +82,7 @@ export const FontFamilyControl = () => {
           </FloatingPanel>
         }
         defaultHighlightedIndex={0}
-        items={items}
+        getItems={() => items}
         itemToString={(item) => item?.label ?? item?.value ?? ""}
         onItemHighlight={(item) => {
           if (item === null) {

--- a/apps/builder/app/builder/features/style-panel/controls/position/position-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/position/position-control.tsx
@@ -110,7 +110,7 @@ export const PositionControl = ({
           <CssValueInputContainer
             property={property}
             styleSource={styleDecl.source.name}
-            options={keywords}
+            getOptions={() => keywords}
             value={value.value[0]}
             setValue={setValueX}
             deleteProperty={deleteProperty}
@@ -123,7 +123,7 @@ export const PositionControl = ({
           <CssValueInputContainer
             property={property}
             styleSource={styleDecl.source.name}
-            options={keywords}
+            getOptions={() => keywords}
             value={value.value[1]}
             setValue={setValueY}
             deleteProperty={deleteProperty}

--- a/apps/builder/app/builder/features/style-panel/controls/text/text-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/text/text-control.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useStore } from "@nanostores/react";
 import type { StyleProperty, StyleValue } from "@webstudio-is/css-engine";
 import {
   CssValueInput,
@@ -16,20 +15,18 @@ export const TextControl = ({ property }: { property: StyleProperty }) => {
   const [intermediateValue, setIntermediateValue] = useState<
     StyleValue | IntermediateStyleValue
   >();
-  const items = styleConfigByName(property).items;
-  const availableVariables = useStore($availableVariables);
   return (
     <CssValueInput
       styleSource={computedStyleDecl.source.name}
       property={property}
       value={value}
       intermediateValue={intermediateValue}
-      options={[
-        ...items.map((item) => ({
+      getOptions={() => [
+        ...styleConfigByName(property).items.map((item) => ({
           type: "keyword" as const,
           value: item.name,
         })),
-        ...availableVariables,
+        ...$availableVariables.get(),
       ]}
       onChange={(styleValue) => {
         setIntermediateValue(styleValue);

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -143,7 +143,7 @@ const AdvancedSearch = ({
     <Combobox
       autoFocus
       placeholder="Find or create a property"
-      items={availableProperties}
+      getItems={() => availableProperties}
       defaultHighlightedIndex={0}
       value={item}
       itemToString={(item) => item?.label ?? ""}
@@ -218,8 +218,6 @@ const AdvancedPropertyValue = ({
   property: StyleProperty;
 }) => {
   const styleDecl = useComputedStyleDecl(property);
-  const availableVariables = useStore($availableVariables);
-  const { items } = styleConfigByName(property);
   const inputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     if (autoFocus) {
@@ -255,12 +253,12 @@ const AdvancedPropertyValue = ({
       }
       property={property}
       styleSource={styleDecl.source.name}
-      options={[
-        ...items.map((item) => ({
+      getOptions={() => [
+        ...styleConfigByName(property).items.map((item) => ({
           type: "keyword" as const,
           value: item.name,
         })),
-        ...availableVariables,
+        ...$availableVariables.get(),
       ]}
       value={styleDecl.cascadedValue}
       setValue={(styleValue, options) => {

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-position.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-position.tsx
@@ -73,7 +73,7 @@ export const BackgroundPosition = ({ index }: { index: number }) => {
           <CssValueInputContainer
             property="backgroundPositionX"
             styleSource="default"
-            options={[
+            getOptions={() => [
               { type: "keyword", value: "center" },
               { type: "keyword", value: "left" },
               { type: "keyword", value: "right" },
@@ -96,7 +96,7 @@ export const BackgroundPosition = ({ index }: { index: number }) => {
           <CssValueInputContainer
             property="backgroundPositionY"
             styleSource="default"
-            options={[
+            getOptions={() => [
               { type: "keyword", value: "center" },
               { type: "keyword", value: "top" },
               { type: "keyword", value: "bottom" },

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
@@ -146,7 +146,7 @@ export const BackgroundSize = ({ index }: { index: number }) => {
           disabled={customSizeDisabled}
           property={property}
           styleSource="default"
-          options={customSizeOptions}
+          getOptions={() => customSizeOptions}
           value={customSizeValue.value[0]}
           setValue={setValueX}
           deleteProperty={() => {}}
@@ -156,7 +156,7 @@ export const BackgroundSize = ({ index }: { index: number }) => {
           disabled={customSizeDisabled}
           property={property}
           styleSource="default"
-          options={customSizeOptions}
+          getOptions={() => customSizeOptions}
           value={customSizeValue.value[1]}
           setValue={setValueY}
           deleteProperty={() => {}}

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-property.tsx
@@ -85,7 +85,7 @@ export const BorderProperty = ({
           <CssValueInputContainer
             property={firstPropertyName}
             styleSource={styleValueSourceColor}
-            options={keywords}
+            getOptions={() => keywords}
             value={value}
             setValue={(newValue, options) => {
               const batch = createBatchUpdate();
@@ -123,7 +123,7 @@ export const BorderProperty = ({
               }
               property={styleDecl.property as StyleProperty}
               styleSource={styleDecl.source.name}
-              options={keywords}
+              getOptions={() => keywords}
               value={styleDecl.cascadedValue}
               setValue={setProperty(styleDecl.property as StyleProperty)}
               deleteProperty={deleteProperty}

--- a/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
@@ -152,10 +152,9 @@ const GapInput = ({
         property={property}
         value={styleDecl.cascadedValue}
         intermediateValue={intermediateValue}
-        options={items.map((item) => ({
-          type: "keyword",
-          value: item.name,
-        }))}
+        getOptions={() =>
+          items.map((item) => ({ type: "keyword", value: item.name }))
+        }
         onChange={(styleValue) => {
           onIntermediateChange(styleValue);
           if (styleValue === undefined) {

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-and-perspective-origin.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-and-perspective-origin.tsx
@@ -159,7 +159,7 @@ export const TransformAndPerspectiveOrigin = (
               />
               <CssValueInputContainer
                 value={origin.x}
-                options={xOriginKeywords}
+                getOptions={() => xOriginKeywords}
                 styleSource="local"
                 property={fakePropertyX}
                 deleteProperty={() => {}}
@@ -186,7 +186,7 @@ export const TransformAndPerspectiveOrigin = (
               />
               <CssValueInputContainer
                 value={origin.y}
-                options={yOriginKeywords}
+                getOptions={() => yOriginKeywords}
                 styleSource="local"
                 property={fakePropertyY}
                 deleteProperty={() => {}}

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -82,10 +82,11 @@ export const TransitionProperty = ({
     getMenuProps,
     getItemProps,
   } = useCombobox<NameAndLabel>({
-    items: properties.map((prop) => ({
-      name: prop,
-      label: prop === "transform" ? `${prop} (rotate, skew)` : prop,
-    })),
+    getItems: () =>
+      properties.map((prop) => ({
+        name: prop,
+        label: prop === "transform" ? `${prop} (rotate, skew)` : prop,
+      })),
     value: { name: inputValue as AnimatableProperties, label: inputValue },
     selectedItem: undefined,
     itemToString: (value) => value?.label || "",

--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -276,7 +276,7 @@ export const ColorPicker = ({
       property={property}
       value={value}
       intermediateValue={intermediateValue}
-      options={options}
+      getOptions={() => options ?? []}
       onChange={(styleValue) => {
         if (styleValue === undefined) {
           setIntermediateValue(styleValue);

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input-container.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input-container.tsx
@@ -17,7 +17,6 @@ type CssValueInputContainerProps = {
 
 export const CssValueInputContainer = ({
   property,
-  options,
   setValue,
   deleteProperty,
   ...props
@@ -31,7 +30,6 @@ export const CssValueInputContainer = ({
       {...props}
       property={property}
       intermediateValue={intermediateValue}
-      options={options}
       onChange={(styleValue) => {
         setIntermediateValue(styleValue);
 

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.stories.tsx
@@ -26,7 +26,7 @@ export const WithKeywords = () => {
       property="width"
       value={value}
       intermediateValue={intermediateValue}
-      options={[
+      getOptions={() => [
         { type: "keyword", value: "auto" },
         { type: "keyword", value: "min-content" },
         { type: "keyword", value: "max-content" },
@@ -67,7 +67,7 @@ export const WithIcons = () => {
       property="alignItems"
       value={value}
       intermediateValue={intermediateValue}
-      options={[
+      getOptions={() => [
         { type: "keyword", value: "normal" },
         { type: "keyword", value: "start" },
         { type: "keyword", value: "end" },
@@ -113,7 +113,7 @@ export const WithUnits = () => {
         property="rowGap"
         value={value}
         intermediateValue={intermediateValue}
-        options={[
+        getOptions={() => [
           { type: "keyword", value: "auto" },
           { type: "keyword", value: "min-content" },
           { type: "keyword", value: "max-content" },

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -311,7 +311,7 @@ type CssValueInputProps = Pick<
   /**
    * Selected item in the dropdown
    */
-  options?: Array<KeywordValue | VarValue>;
+  getOptions?: () => Array<KeywordValue | VarValue>;
   onChange: (value: CssValueInputValue | undefined) => void;
   onChangeComplete: (event: ChangeCompleteEvent) => void;
   onHighlight: (value: StyleValue | undefined) => void;
@@ -376,7 +376,7 @@ export const CssValueInput = ({
   showSuffix = true,
   styleSource,
   property,
-  options = [],
+  getOptions = () => [],
   onHighlight,
   onAbort,
   disabled,
@@ -446,7 +446,7 @@ export const CssValueInput = ({
     highlightedIndex,
   } = useCombobox<CssValueInputValue>({
     // Used for description to match the item when nothing is highlighted yet and value is still in non keyword mode
-    items: options,
+    getItems: getOptions,
     value,
     selectedItem: props.value,
     itemToString,

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -476,7 +476,7 @@ export const StyleSourceInput = (
     getItemProps,
     isOpen,
   } = useCombobox<IntermediateItem>({
-    items: markAddedValues(props.items ?? [], value),
+    getItems: () => markAddedValues(props.items ?? [], value),
     value: {
       label,
       disabled: false,

--- a/packages/design-system/src/components/combobox.stories.tsx
+++ b/packages/design-system/src/components/combobox.stories.tsx
@@ -24,7 +24,7 @@ export const Basic = () => {
     <Combobox<string>
       value={value}
       itemToString={(item) => item ?? ""}
-      items={["Apple", "Banana", "Orange"]}
+      getItems={() => ["Apple", "Banana", "Orange"]}
       onItemSelect={setValue}
       onChange={(value) => {
         setValue(value ?? "");
@@ -79,7 +79,7 @@ export const Complex = () => {
     getInputProps,
     isOpen,
   } = useCombobox<string>({
-    items: ["Apple", "Banana", "Orange"],
+    getItems: () => ["Apple", "Banana", "Orange"],
     value,
     selectedItem: value,
     itemToString: (item) => item ?? "",

--- a/packages/design-system/src/components/menu.stories.tsx
+++ b/packages/design-system/src/components/menu.stories.tsx
@@ -154,7 +154,7 @@ const ComboboxDemo = () => {
     getMenuProps,
     getItemProps,
   } = useCombobox<Fruit>({
-    items: fruits,
+    getItems: () => fruits,
     itemToString: (item) => item ?? "",
     value: null,
     selectedItem,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

Here improved combobox component to accept
options factory instead of ready to use array.
This function is invoked only when combobox is open.

As a result each of 500 css variables will no longer subscribe to available variables which should reduce scripting time and lagging.

Here's local test

![Screenshot 2024-10-05 at 02 03 02](https://github.com/user-attachments/assets/968b3123-9d02-4898-9f82-76a198b35577)

![Screenshot 2024-10-05 at 02 05 16](https://github.com/user-attachments/assets/610dbf7a-e142-4255-9c68-0085a2b40835)


Preview test

![Screenshot 2024-10-05 at 02 23 58](https://github.com/user-attachments/assets/fd8e4c91-3841-4a7e-b960-2763fe40a50a)
![Screenshot 2024-10-05 at 02 22 44](https://github.com/user-attachments/assets/3d7aa1c4-ce3a-4ab8-a36d-197888723c58)

