### PR TITLE
experimental: preview css variables on highlight in combobox

### DIFF
--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -20,7 +20,6 @@ import {
 import {
   type VarValue,
   createRegularStyleSheet,
-  isValidStaticStyleValue,
   toValue,
 } from "@webstudio-is/css-engine";
 import {
@@ -148,20 +147,14 @@ const getEphemeralProperty = (styleDecl: StyleDecl) => {
 // between all token usages
 const toVarValue = (styleDecl: StyleDecl): undefined | VarValue => {
   const { value } = styleDecl;
-  if (value.type === "var") {
-    return value;
-  }
-  // Values like InvalidValue, UnsetValue, VarValue don't need to be wrapped
-  if (isValidStaticStyleValue(value)) {
-    return {
-      type: "var",
-      // var style value is relying on name without leading "--"
-      // escape complex selectors in state like ":hover"
-      // setProperty and removeProperty escape automatically
-      value: CSS.escape(getEphemeralProperty(styleDecl).slice(2)),
-      fallback: { type: "unparsed", value: toValue(value) },
-    };
-  }
+  return {
+    type: "var",
+    // var style value is relying on name without leading "--"
+    // escape complex selectors in state like ":hover"
+    // setProperty and removeProperty escape automatically
+    value: CSS.escape(getEphemeralProperty(styleDecl).slice(2)),
+    fallback: { type: "unparsed", value: toValue(value) },
+  };
 };
 
 const $descendantSelectors = computed(

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -151,45 +151,6 @@ export const LayersValue = z.object({
 
 export type LayersValue = z.infer<typeof LayersValue>;
 
-const ValidStaticStyleValue = z.union([
-  ImageValue,
-  LayersValue,
-  UnitValue,
-  KeywordValue,
-  FontFamilyValue,
-  RgbValue,
-  UnparsedValue,
-  TupleValue,
-  FunctionValue,
-  GuaranteedInvalidValue,
-]);
-
-export type ValidStaticStyleValue = z.infer<typeof ValidStaticStyleValue>;
-
-/**
- * All StyleValue types that going to need wrapping into a CSS variable when rendered
- * on canvas inside builder.
- * Values like InvalidValue, UnsetValue, VarValue don't need to be wrapped
- */
-export const isValidStaticStyleValue = (
-  styleValue: StyleValue
-): styleValue is ValidStaticStyleValue => {
-  // guard against invalid checks
-  const staticStyleValue = styleValue as ValidStaticStyleValue;
-  return (
-    staticStyleValue.type === "image" ||
-    staticStyleValue.type === "layers" ||
-    staticStyleValue.type === "unit" ||
-    staticStyleValue.type === "keyword" ||
-    staticStyleValue.type === "fontFamily" ||
-    staticStyleValue.type === "rgb" ||
-    staticStyleValue.type === "unparsed" ||
-    staticStyleValue.type === "tuple" ||
-    staticStyleValue.type === "function" ||
-    staticStyleValue.type === "guaranteedInvalid"
-  );
-};
-
 export const VarFallback = z.union([UnparsedValue, KeywordValue]);
 export type VarFallback = z.infer<typeof VarFallback>;
 
@@ -202,7 +163,16 @@ const VarValue = z.object({
 export type VarValue = z.infer<typeof VarValue>;
 
 export const StyleValue = z.union([
-  ValidStaticStyleValue,
+  ImageValue,
+  LayersValue,
+  UnitValue,
+  KeywordValue,
+  FontFamilyValue,
+  RgbValue,
+  UnparsedValue,
+  TupleValue,
+  FunctionValue,
+  GuaranteedInvalidValue,
   InvalidValue,
   UnsetValue,
   VarValue,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

Here relaxed converting to css variables for fast preview in canvas. Now variables can be used as fallbacks for preview variables.

![Screenshot 2024-10-05 at 23 59 53](https://github.com/user-attachments/assets/e6ef71b5-c71e-4e75-9696-eb9faf616a8b)
