### PR TITLE
experimental: support css variables for borders

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/color/color-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/color/color-control.tsx
@@ -14,7 +14,7 @@ export const ColorControl = ({ property }: { property: StyleProperty }) => {
       property={property}
       value={value}
       currentColor={currentColor}
-      options={[
+      getOptions={() => [
         ...styleConfigByName(property).items.map((item) => ({
           type: "keyword" as const,
           value: item.name,

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-color.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-color.tsx
@@ -4,7 +4,7 @@ import { styleConfigByName } from "../../shared/configs";
 import { rowCss } from "./utils";
 import { PropertyLabel, PropertyValueTooltip } from "../../property-label";
 import { ColorPicker } from "../../shared/color-picker";
-import { useComputedStyleDecl } from "../../shared/model";
+import { $availableVariables, useComputedStyles } from "../../shared/model";
 import { createBatchUpdate } from "../../shared/use-style-data";
 
 export const properties = [
@@ -17,12 +17,7 @@ export const properties = [
 const { items } = styleConfigByName("borderTopColor");
 
 export const BorderColor = () => {
-  const styles = [
-    useComputedStyleDecl("borderTopColor"),
-    useComputedStyleDecl("borderRightColor"),
-    useComputedStyleDecl("borderBottomColor"),
-    useComputedStyleDecl("borderLeftColor"),
-  ];
+  const styles = useComputedStyles(properties);
   const serialized = styles.map((styleDecl) =>
     toValue(styleDecl.cascadedValue)
   );
@@ -58,10 +53,13 @@ export const BorderColor = () => {
               currentColor={currentColor}
               property={local.property as StyleProperty}
               value={value}
-              options={items.map((item) => ({
-                type: "keyword",
-                value: item.name,
-              }))}
+              getOptions={() => [
+                ...items.map((item) => ({
+                  type: "keyword" as const,
+                  value: item.name,
+                })),
+                ...$availableVariables.get(),
+              ]}
               onChange={(styleValue) => {
                 const batch = createBatchUpdate();
                 for (const property of properties) {

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-property.tsx
@@ -15,7 +15,7 @@ import {
   deleteProperty,
   setProperty,
 } from "../../shared/use-style-data";
-import { useComputedStyles } from "../../shared/model";
+import { $availableVariables, useComputedStyles } from "../../shared/model";
 
 export const BorderProperty = ({
   individualModeIcon,
@@ -52,13 +52,6 @@ export const BorderProperty = ({
     allPropertyValuesAreEqual === false && individualModeIcon !== undefined
   );
 
-  const { items: borderPropertyItems } = styleConfigByName(firstPropertyName);
-
-  const keywords = borderPropertyItems.map((item) => ({
-    type: "keyword" as const,
-    value: item.name,
-  }));
-
   /**
    * If the property is displayed in a non-individual mode, we need to provide a value for it.
    * In Webflow, an empty value is shown. In Figma, the "Mixed" keyword is shown.
@@ -85,7 +78,13 @@ export const BorderProperty = ({
           <CssValueInputContainer
             property={firstPropertyName}
             styleSource={styleValueSourceColor}
-            getOptions={() => keywords}
+            getOptions={() => [
+              ...styleConfigByName(firstPropertyName).items.map((item) => ({
+                type: "keyword" as const,
+                value: item.name,
+              })),
+              ...$availableVariables.get(),
+            ]}
             value={value}
             setValue={(newValue, options) => {
               const batch = createBatchUpdate();
@@ -123,7 +122,12 @@ export const BorderProperty = ({
               }
               property={styleDecl.property as StyleProperty}
               styleSource={styleDecl.source.name}
-              getOptions={() => keywords}
+              getOptions={() =>
+                styleConfigByName(firstPropertyName).items.map((item) => ({
+                  type: "keyword" as const,
+                  value: item.name,
+                }))
+              }
               value={styleDecl.cascadedValue}
               setValue={setProperty(styleDecl.property as StyleProperty)}
               deleteProperty={deleteProperty}

--- a/apps/builder/app/builder/features/style-panel/sections/borders/borders.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/borders.tsx
@@ -1,4 +1,3 @@
-import { Flex } from "@webstudio-is/design-system";
 import type { StyleProperty } from "@webstudio-is/css-engine";
 import { StyleSection } from "../../shared/style-section";
 import {
@@ -28,12 +27,10 @@ export const properties = [
 export const Section = () => {
   return (
     <StyleSection label="Borders" properties={properties}>
-      <Flex direction="column" gap={2}>
-        <BorderStyle />
-        <BorderColor />
-        <BorderWidth />
-        <BorderRadius />
-      </Flex>
+      <BorderStyle />
+      <BorderColor />
+      <BorderWidth />
+      <BorderRadius />
     </StyleSection>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -172,7 +172,7 @@ type ColorPickerProps = {
   onAbort: () => void;
   value: StyleValue;
   currentColor: StyleValue;
-  options?: Array<KeywordValue | VarValue>;
+  getOptions?: () => Array<KeywordValue | VarValue>;
   property: StyleProperty;
   disabled?: boolean;
 };
@@ -240,7 +240,7 @@ export const ColorPopover = ({
 export const ColorPicker = ({
   value,
   currentColor,
-  options,
+  getOptions,
   property,
   disabled,
   onChange,
@@ -276,7 +276,7 @@ export const ColorPicker = ({
       property={property}
       value={value}
       intermediateValue={intermediateValue}
-      getOptions={() => options ?? []}
+      getOptions={getOptions}
       onChange={(styleValue) => {
         if (styleValue === undefined) {
           setIntermediateValue(styleValue);

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -316,10 +316,12 @@ export const ShadowContent = ({
             property="color"
             value={colorControlProp}
             currentColor={colorControlProp}
-            options={styleConfigByName("color").items.map((item) => ({
-              type: "keyword",
-              value: item.name,
-            }))}
+            getOptions={() =>
+              styleConfigByName("color").items.map((item) => ({
+                type: "keyword",
+                value: item.name,
+              }))
+            }
             onChange={(styleValue) =>
               handlePropertyChange({ color: styleValue }, { isEphemeral: true })
             }


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

Added autocomplete for css variables in border width, color and radius. Sadly no support for blob and drawn radius because they require shorthand.

![Screenshot 2024-10-06 at 01 26 28](https://github.com/user-attachments/assets/c0557175-f65f-4827-b6a5-360bdf12c976)
