### PR TITLE
experimental: preserve numeric order in css variables autocomplete

### DIFF
--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -225,6 +225,10 @@ const defaultMatch = <Item,>(
 ) =>
   matchSorter(items, search, {
     keys: [itemToString],
+    baseSort: (left, right) =>
+      left.rankedValue.localeCompare(right.rankedValue, undefined, {
+        numeric: true,
+      }),
   });
 
 type ItemToString<Item> = (item: Item | null) => string;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

![Screenshot 2024-10-06 at 12 57 51](https://github.com/user-attachments/assets/7cbe9697-101d-4258-93d3-a9ada012507a)
