### PR TITLE
fix: duplicate local style sources

### DIFF
--- a/apps/builder/app/shared/instance-utils.test.tsx
+++ b/apps/builder/app/shared/instance-utils.test.tsx
@@ -3175,7 +3175,7 @@ describe("insert webstudio fragment copy", () => {
   });
 });
 
-describe("support copy paste of :root styles", () => {
+describe("copy paste", () => {
   const css = (strings: TemplateStringsArray, ...values: string[]) => {
     let cssString = "";
     strings.forEach((string, index) => {
@@ -3264,6 +3264,41 @@ describe("support copy paste of :root styles", () => {
     }).toEqual(css`
       :root__newprojectlocalid {
         font-size: medium;
+        color: red;
+      }
+    `);
+  });
+
+  test("should copy local styles of duplicated instance", () => {
+    const project = getWebstudioDataStub({
+      ...renderJsx(
+        <$.Body ws:id="bodyId">
+          <$.Box ws:id="boxId"></$.Box>
+        </$.Body>
+      ),
+      ...css`
+        boxId__boxlocalid {
+          color: red;
+        }
+      `,
+    });
+    const fragment = extractWebstudioFragment(project, "boxId");
+    insertWebstudioFragmentCopy({
+      data: project,
+      fragment,
+      availableDataSources: new Set(),
+    });
+    const [_bodyId, _boxId, newBoxId] = project.instances.keys();
+    const [_boxLocalId, newBoxLocalId] = project.styleSources.keys();
+    expect({
+      styleSourceSelections: project.styleSourceSelections,
+      styleSources: project.styleSources,
+      styles: project.styles,
+    }).toEqual(css`
+      boxId__boxlocalid {
+        color: red;
+      }
+      ${newBoxId}__${newBoxLocalId} {
         color: red;
       }
     `);

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -1513,7 +1513,8 @@ export const insertWebstudioFragmentCopy = ({
     for (let styleSourceId of values) {
       const newLocalStyleSource = newLocalStyleSources.get(styleSourceId);
       if (newLocalStyleSource) {
-        if (existingLocalStyleSource) {
+        // merge only :root styles and duplicate others
+        if (instanceId === ROOT_INSTANCE_ID && existingLocalStyleSource) {
           // write local styles into existing local style source
           styleSourceId = existingLocalStyleSource.id;
         } else {


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/4233

When added support for merging root styles when import from marketplace forgot to check only :root styles should be merged and others duplicated.