### PR TITLE
experimental: support gradient variables

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/image/image-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/image/image-control.tsx
@@ -33,7 +33,7 @@ export const ImageControl = ({
 }) => {
   const assets = useStore($assets);
   const styleDecl = useComputedStyleDecl(property);
-  const styleValue = getRepeatedStyleItem(styleDecl.cascadedValue, index);
+  const styleValue = getRepeatedStyleItem(styleDecl, index);
   const [remoteImageURL, setRemoteImageURL] = useState<
     IntermediateValue | InvalidValue | undefined
   >(undefined);

--- a/apps/builder/app/builder/features/style-panel/controls/select/select-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/select/select-control.tsx
@@ -31,7 +31,7 @@ export const SelectControl = ({
   const value =
     index === undefined
       ? styleDecl.cascadedValue
-      : getRepeatedStyleItem(styleDecl.cascadedValue, index);
+      : getRepeatedStyleItem(styleDecl, index);
   const setValue = (value: StyleValue, options?: StyleUpdateOptions) => {
     if (index === undefined) {
       setProperty(property)(value, options);

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -36,7 +36,7 @@ export const BackgroundGradient = ({ index }: { index: number }) => {
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const property = "backgroundImage";
   const styleDecl = useComputedStyleDecl(property);
-  const styleValue = getRepeatedStyleItem(styleDecl.cascadedValue, index);
+  const styleValue = getRepeatedStyleItem(styleDecl, index);
 
   const [intermediateValue, setIntermediateValue] = useState<
     IntermediateValue | InvalidValue | undefined

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
@@ -39,7 +39,7 @@ export const BackgroundImage = ({ index }: { index: number }) => {
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const assets = useStore($assets);
   const styleDecl = useComputedStyleDecl("backgroundImage");
-  const styleValue = getRepeatedStyleItem(styleDecl.cascadedValue, index);
+  const styleValue = getRepeatedStyleItem(styleDecl, index);
   const [errors, setErrors] = useState<string[]>([]);
   const [intermediateValue, setIntermediateValue] = useState<
     IntermediateValue | InvalidValue | undefined

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-position.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-position.tsx
@@ -32,8 +32,8 @@ export const BackgroundPosition = ({ index }: { index: number }) => {
     "backgroundPositionX",
     "backgroundPositionY",
   ]);
-  const xValue = getRepeatedStyleItem(backgroundPositionX.cascadedValue, index);
-  const yValue = getRepeatedStyleItem(backgroundPositionY.cascadedValue, index);
+  const xValue = getRepeatedStyleItem(backgroundPositionX, index);
+  const yValue = getRepeatedStyleItem(backgroundPositionY, index);
   const x = calculateBackgroundPosition(xValue);
   const y = calculateBackgroundPosition(yValue);
 

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
@@ -39,7 +39,7 @@ const toTuple = (
 export const BackgroundSize = ({ index }: { index: number }) => {
   const property = "backgroundSize";
   const styleDecl = useComputedStyleDecl(property);
-  const styleValue = getRepeatedStyleItem(styleDecl.cascadedValue, index);
+  const styleValue = getRepeatedStyleItem(styleDecl, index);
 
   const { items: defaultItems } = styleConfigByName(property);
 

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
@@ -113,10 +113,7 @@ export const BackgroundThumbnail = ({ index }: { index: number }) => {
   const imageLoader = useStore($imageLoader);
   const styles = useComputedStyles(repeatedProperties);
   const [backgroundImage] = styles;
-  const backgroundImageValue = getRepeatedStyleItem(
-    backgroundImage.cascadedValue,
-    index
-  );
+  const backgroundImageValue = getRepeatedStyleItem(backgroundImage, index);
 
   if (
     backgroundImageValue?.type === "image" &&
@@ -154,9 +151,9 @@ export const BackgroundThumbnail = ({ index }: { index: number }) => {
 
   if (backgroundImageValue?.type === "unparsed") {
     const cssStyle: { [property in RepeatedProperty]?: string } = {};
-    for (const { property, cascadedValue } of styles) {
-      const value = getRepeatedStyleItem(cascadedValue, index);
-      cssStyle[property as RepeatedProperty] = toValue(value);
+    for (const styleDecl of styles) {
+      const itemValue = getRepeatedStyleItem(styleDecl, index);
+      cssStyle[styleDecl.property as RepeatedProperty] = toValue(itemValue);
     }
     return <Thumbnail css={cssStyle} />;
   }

--- a/apps/builder/app/builder/features/style-panel/shared/repeated-style.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/repeated-style.test.ts
@@ -19,6 +19,7 @@ import {
 } from "~/shared/nano-states";
 import { registerContainers } from "~/shared/sync";
 import { setProperty } from "./use-style-data";
+import type { ComputedStyleDecl } from "~/shared/style-object-model";
 
 registerContainers();
 
@@ -30,7 +31,7 @@ beforeEach(() => {
 });
 
 test("get repeated style item by index", () => {
-  const styleValue: StyleValue = {
+  const cascadedValue: StyleValue = {
     type: "layers",
     value: [
       { type: "keyword", value: "red" },
@@ -38,28 +39,37 @@ test("get repeated style item by index", () => {
       { type: "keyword", value: "blue" },
     ],
   };
-  expect(getRepeatedStyleItem(styleValue, 0)).toEqual({
+  const styleDecl: ComputedStyleDecl = {
+    property: "color",
+    source: {
+      name: "default",
+    },
+    cascadedValue,
+    computedValue: cascadedValue,
+    usedValue: cascadedValue,
+  };
+  expect(getRepeatedStyleItem(styleDecl, 0)).toEqual({
     type: "keyword",
     value: "red",
   });
-  expect(getRepeatedStyleItem(styleValue, 1)).toEqual({
+  expect(getRepeatedStyleItem(styleDecl, 1)).toEqual({
     type: "keyword",
     value: "green",
   });
-  expect(getRepeatedStyleItem(styleValue, 2)).toEqual({
+  expect(getRepeatedStyleItem(styleDecl, 2)).toEqual({
     type: "keyword",
     value: "blue",
   });
   // repeat values
-  expect(getRepeatedStyleItem(styleValue, 3)).toEqual({
+  expect(getRepeatedStyleItem(styleDecl, 3)).toEqual({
     type: "keyword",
     value: "red",
   });
-  expect(getRepeatedStyleItem(styleValue, 4)).toEqual({
+  expect(getRepeatedStyleItem(styleDecl, 4)).toEqual({
     type: "keyword",
     value: "green",
   });
-  expect(getRepeatedStyleItem(styleValue, 5)).toEqual({
+  expect(getRepeatedStyleItem(styleDecl, 5)).toEqual({
     type: "keyword",
     value: "blue",
   });


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

Here used computed values with resolved variables to get the list of gradients and preview in backgrounds list.

Though the new gradient field sets whole background-image property when variables are used.

![Screenshot 2024-10-07 at 14 20 20](https://github.com/user-attachments/assets/fb2905f4-cd21-49ee-9870-6d5b8a8d1584)
