### PR TITLE
fix: Expression Editor cursor position jumps to wrong place

### DIFF
--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -112,6 +112,10 @@ const editorContentStyle = css({
     minHeight: `var(${minHeightVar}, auto)`,
     maxHeight: `var(${maxHeightVar}, none)`,
   },
+  ".cm-lintRange-error": {
+    textDecoration: "underline wavy red",
+    backgroundColor: "rgba(255, 0, 0, 0.1)",
+  },
 });
 
 // https://thememirror.net/clouds

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -370,7 +370,8 @@ const replaceWithWsVariables = EditorState.transactionFilter.of((tr) => {
   // 1. A variable is replaced while typing its name. In this case, we preserve the cursor position from the end of the text.
   // 2. A variable is replaced when an operation makes the expression valid. For example, ('' b) -> ('' + b).
   //    In this case, we preserve the cursor position from the start of the text.
-  // This does not cover cases like (a b) -> (a + b). For simplicity, we are not handling it. We can improve it if issues arise.
+  // This does not cover cases like (a b) -> (a + b). We are not handling it because I haven't found a way to enter such a case into real input.
+  // We can improve it if issues arise.
 
   const cursorPos = tr.selection?.main.head ?? 0;
   const cursorPosFromEnd = tr.newDoc.length - cursorPos;

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -24,6 +24,7 @@
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/lang-markdown": "^6.2.5",
     "@codemirror/language": "^6.10.2",
+    "@codemirror/lint": "^6.8.2",
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.30.0",
     "@floating-ui/dom": "^1.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@codemirror/language':
         specifier: ^6.10.2
         version: 6.10.2
+      '@codemirror/lint':
+        specifier: ^6.8.2
+        version: 6.8.2
       '@codemirror/state':
         specifier: ^6.4.1
         version: 6.4.1
@@ -2704,8 +2707,8 @@ packages:
   '@codemirror/language@6.10.2':
     resolution: {integrity: sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==}
 
-  '@codemirror/lint@6.4.2':
-    resolution: {integrity: sha512-wzRkluWb1ptPKdzlsrbwwjYCPLgzU6N88YBAmlZi8WFyuiEduSd05MnJYNogzyc8rPK7pj6m95ptUApc8sHKVA==}
+  '@codemirror/lint@6.8.2':
+    resolution: {integrity: sha512-PDFG5DjHxSEjOXk9TQYYVjZDqlZTFaDBfhQixHnQOEVDDNHUbEh/hstAjcQJaA6FQdZTD1hquXTK0rVBLADR1g==}
 
   '@codemirror/state@6.4.1':
     resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
@@ -10351,7 +10354,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.18.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.30.0)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.2
-      '@codemirror/lint': 6.4.2
+      '@codemirror/lint': 6.8.2
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.30.0
       '@lezer/common': 1.2.1
@@ -10376,7 +10379,7 @@ snapshots:
       '@lezer/lr': 1.3.14
       style-mod: 4.1.0
 
-  '@codemirror/lint@6.4.2':
+  '@codemirror/lint@6.8.2':
     dependencies:
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.30.0


### PR DESCRIPTION
## Description

closes #3940

Removed logic with undefined replacement on paste as it doesn't look stable.
Seems like `undefined` variables must be decorated or replaced on blur.

Anyway now it has linter

<img width="534" alt="image" src="https://github.com/user-attachments/assets/43518bbc-798d-4332-a89f-238ecd6986c4">

<img width="509" alt="image" src="https://github.com/user-attachments/assets/279b7895-9371-49bd-b5c8-5ce5c391acce">



## Steps for reproduction

In any expression editor enter
1. `'aaa'  + system` see system is decorated (blue) cursor is after the system
<img width="193" alt="image" src="https://github.com/user-attachments/assets/f180f401-b5b0-41c5-a548-6ee432d278ca">


2. `'aaa' system` see system is not decorated 
<img width="249" alt="image" src="https://github.com/user-attachments/assets/4056a601-9374-487f-a934-f2e1c06bbb96">

then add `+` after 'aaa' see system now decorated, cursor is after `+`



## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
