### PR TITLE
fix: Publish crashes on pages with dynamic paths ending in ‘?’

### DIFF
--- a/apps/builder/app/builder/shared/url-pattern.test.ts
+++ b/apps/builder/app/builder/shared/url-pattern.test.ts
@@ -216,3 +216,9 @@ test(`forbid named group with static parts before or after`, () => {
     `Static parts cannot be mixed with dynamic parameters at 'prefix-:id-suffix'.`,
   ]);
 });
+
+test(`? should be allowed in named groups only`, () => {
+  expect(validatePathnamePattern("/name?")).toEqual([
+    `Optional parameter indicator ? must be at the end of the named parameter. Correct usage: /:param?`,
+  ]);
+});

--- a/apps/builder/app/builder/shared/url-pattern.ts
+++ b/apps/builder/app/builder/shared/url-pattern.ts
@@ -147,6 +147,10 @@ export const validatePathnamePattern = (pathname: string) => {
           `Static parts cannot be mixed with dynamic parameters at '${segment}'.`
         );
       }
+    } else if (segment.includes("?")) {
+      messages.push(
+        `Optional parameter indicator ? must be at the end of the named parameter. Correct usage: /:param?`
+      );
     }
   }
 


### PR DESCRIPTION
## Description

ref #4247

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/f7ce191a-7146-4bf2-9d96-12d360fbd3ec">


## Steps for reproduction

see tests

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
