### PR TITLE
refactor: support css vars in repeated values

### DIFF
--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -535,6 +535,14 @@ test("support custom properties as unparsed values", () => {
     type: "unparsed",
     value: "url(https://my-image.com)",
   });
+  expect(parseCssValue("--my-property", "blue red")).toEqual({
+    type: "unparsed",
+    value: "blue red",
+  });
+  expect(parseCssValue("--my-property", "blue, red")).toEqual({
+    type: "unparsed",
+    value: "blue, red",
+  });
 });
 
 test("support custom properties var reference", () => {
@@ -546,21 +554,6 @@ test("support custom properties var reference", () => {
     type: "var",
     value: "color",
     fallback: { type: "unparsed", value: "red" },
-  });
-});
-
-test("support deeply nested var reference", () => {
-  expect(parseCssValue("color", "rgb(var(--r), var(--g), var(--b))")).toEqual({
-    type: "unparsed",
-    value: "rgb(var(--r), var(--g), var(--b))",
-  });
-  expect(parseCssValue("transitionDuration", "var(--time)")).toEqual({
-    type: "layers",
-    value: [{ type: "unparsed", value: "var(--time)" }],
-  });
-  expect(parseCssValue("filter", "var(--filter)")).toEqual({
-    type: "tuple",
-    value: [{ type: "unparsed", value: "var(--filter)" }],
   });
 });
 
@@ -619,6 +612,52 @@ test("support custom properties var reference in custom property", () => {
     type: "var",
     value: "color",
     fallback: { type: "unparsed", value: "red" },
+  });
+});
+
+test("parse single var in repeated value without layers or tuples", () => {
+  expect(parseCssValue("backgroundImage", "var(--gradient)")).toEqual({
+    type: "var",
+    value: "gradient",
+  });
+  expect(parseCssValue("filter", "var(--noise)")).toEqual({
+    type: "var",
+    value: "noise",
+  });
+});
+
+test("parse multiple var in repeated value as layers and tuples", () => {
+  expect(
+    parseCssValue("backgroundImage", "var(--gradient-1), var(--gradient-2)")
+  ).toEqual({
+    type: "layers",
+    value: [
+      { type: "var", value: "gradient-1" },
+      { type: "var", value: "gradient-2" },
+    ],
+  });
+  expect(parseCssValue("filter", "var(--noise-1) var(--noise-2)")).toEqual({
+    type: "tuple",
+    value: [
+      { type: "var", value: "noise-1" },
+      { type: "var", value: "noise-2" },
+    ],
+  });
+});
+
+test("parse var in box-shadow", () => {
+  expect(parseCssValue("boxShadow", "var(--shadow)")).toEqual({
+    type: "var",
+    value: "shadow",
+  });
+  expect(
+    parseCssValue("boxShadow", "var(--shadow-1), var(--shadow-2)")
+  ).toEqual({
+    type: "layers",
+    value: [
+      { type: "var", value: "shadow-1" },
+      { type: "var", value: "shadow-2" },
+    ],
   });
 });
 

--- a/packages/css-data/src/parse-css.ts
+++ b/packages/css-data/src/parse-css.ts
@@ -71,7 +71,7 @@ const parseCssValue = (
     }
 
     // @todo https://github.com/webstudio-is/webstudio/issues/3399
-    if (customProperties === false && value.startsWith("var(")) {
+    if (customProperties === false && value.includes("var(")) {
       final.set(property, { type: "keyword", value: "unset" });
       continue;
     }

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -110,6 +110,17 @@ const UnsetValue = z.object({
 });
 export type UnsetValue = z.infer<typeof UnsetValue>;
 
+export const VarFallback = z.union([UnparsedValue, KeywordValue]);
+export type VarFallback = z.infer<typeof VarFallback>;
+
+const VarValue = z.object({
+  type: z.literal("var"),
+  value: z.string(),
+  fallback: VarFallback.optional(),
+  hidden: z.boolean().optional(),
+});
+export type VarValue = z.infer<typeof VarValue>;
+
 export const TupleValueItem = z.union([
   UnitValue,
   KeywordValue,
@@ -117,6 +128,7 @@ export const TupleValueItem = z.union([
   ImageValue,
   RgbValue,
   FunctionValue,
+  VarValue,
 ]);
 export type TupleValueItem = z.infer<typeof TupleValueItem>;
 
@@ -137,6 +149,7 @@ const LayerValueItem = z.union([
   RgbValue,
   InvalidValue,
   FunctionValue,
+  VarValue,
 ]);
 
 export type LayerValueItem = z.infer<typeof LayerValueItem>;
@@ -150,17 +163,6 @@ export const LayersValue = z.object({
 });
 
 export type LayersValue = z.infer<typeof LayersValue>;
-
-export const VarFallback = z.union([UnparsedValue, KeywordValue]);
-export type VarFallback = z.infer<typeof VarFallback>;
-
-const VarValue = z.object({
-  type: z.literal("var"),
-  value: z.string(),
-  fallback: VarFallback.optional(),
-  hidden: z.boolean().optional(),
-});
-export type VarValue = z.infer<typeof VarValue>;
 
 export const StyleValue = z.union([
   ImageValue,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

Here added support for computing css variables inside layers and tuples to support cases like

```css
transition-timing-function: var(--ease), var(--ease-in);
```
