### PR TITLE
fix: Can't save Dynamic Page Setting when Title is undefined

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -433,7 +433,7 @@ const StatusField = ({
             value={value}
             onChange={onChange}
             onRemove={(evaluatedValue) =>
-              onChange(JSON.stringify(evaluatedValue))
+              onChange(JSON.stringify(evaluatedValue ?? ""))
             }
           />
         )}
@@ -495,7 +495,7 @@ const RedirectField = ({
             value={value}
             onChange={onChange}
             onRemove={(evaluatedValue) =>
-              onChange(JSON.stringify(evaluatedValue))
+              onChange(JSON.stringify(evaluatedValue ?? ""))
             }
           />
         )}
@@ -538,7 +538,7 @@ const LanguageField = ({
           value={value}
           onChange={onChange}
           onRemove={(evaluatedValue) =>
-            onChange(JSON.stringify(evaluatedValue))
+            onChange(JSON.stringify(evaluatedValue ?? ""))
           }
         />
         <InputErrorsTooltip errors={errors}>
@@ -967,7 +967,7 @@ const FormFields = ({
                     onRemove={(evaluatedValue) => {
                       onChange({
                         field: "title",
-                        value: JSON.stringify(evaluatedValue),
+                        value: JSON.stringify(evaluatedValue ?? ""),
                       });
                     }}
                   />
@@ -1013,7 +1013,7 @@ const FormFields = ({
                     onRemove={(evaluatedValue) => {
                       onChange({
                         field: "description",
-                        value: JSON.stringify(evaluatedValue),
+                        value: JSON.stringify(evaluatedValue ?? ""),
                       });
                     }}
                   />
@@ -1063,7 +1063,7 @@ const FormFields = ({
                       onRemove={(evaluatedValue) => {
                         onChange({
                           field: "excludePageFromSearch",
-                          value: JSON.stringify(evaluatedValue),
+                          value: JSON.stringify(evaluatedValue ?? ""),
                         });
                       }}
                     />
@@ -1137,7 +1137,7 @@ const FormFields = ({
                   onRemove={(evaluatedValue) => {
                     onChange({
                       field: "socialImageUrl",
-                      value: JSON.stringify(evaluatedValue),
+                      value: JSON.stringify(evaluatedValue ?? ""),
                     });
                   }}
                 />

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { z } from "zod";
+import { boolean, z } from "zod";
 import {
   type FocusEventHandler,
   useState,
@@ -107,6 +107,7 @@ import { $userPlanFeatures } from "~/builder/shared/nano-states";
 import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 import { useUnmount } from "~/shared/hook-utils/use-mount";
 import { Card } from "../marketplace/card";
+import { language } from "@codemirror/language";
 
 const fieldDefaultValues = {
   name: "Untitled",
@@ -227,10 +228,16 @@ const validateValues = (
   variableValues: Map<string, unknown>,
   userPlanFeatures: UserPlanFeatures
 ): Errors => {
+  // Null or undefined in the field value is only possible if it’s a dynamic (expression) value.
+  // We do not validate dynamic values but instead provide a default value for validation.
+  const excludeFromValidationDefault = "exclude from validation";
+
   const computedValues = {
     name: values.name,
     path: values.path,
-    title: computeExpression(values.title, variableValues),
+    title:
+      computeExpression(values.title, variableValues) ??
+      excludeFromValidationDefault,
     description: computeExpression(values.description, variableValues),
     excludePageFromSearch: computeExpression(
       values.excludePageFromSearch,

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/page-settings.tsx
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { boolean, z } from "zod";
+import { z } from "zod";
 import {
   type FocusEventHandler,
   useState,
@@ -107,7 +107,6 @@ import { $userPlanFeatures } from "~/builder/shared/nano-states";
 import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 import { useUnmount } from "~/shared/hook-utils/use-mount";
 import { Card } from "../marketplace/card";
-import { language } from "@codemirror/language";
 
 const fieldDefaultValues = {
   name: "Untitled",


### PR DESCRIPTION
## Description

closes #3965

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
