### PR TITLE
fix: Form filters reset scroll position

### DIFF
--- a/packages/sdk-components-react-remix/src/remix-form.tsx
+++ b/packages/sdk-components-react-remix/src/remix-form.tsx
@@ -30,7 +30,15 @@ export const RemixForm = forwardRef<
     // which makes it hard to handle intercepted submit events
     // render remix form only in published sites
     if (renderer !== "canvas" && renderer !== "preview") {
-      return <Form action={action} {...props} ref={ref} />;
+      return (
+        <Form
+          action={action}
+          {...props}
+          ref={ref}
+          // Preserve scroll position for navigation on the same path, as it's used for filtering and sorting
+          preventScrollReset={action === undefined || action === ""}
+        />
+      );
     }
   }
   return <form {...props} ref={ref} />;


### PR DESCRIPTION
## Description

closes #4229

## Steps for reproduction

https://form-scroll-reset-iodju.wstd.work/?opt=c


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
