### PR TITLE
experimental: support css variables in transforms

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-rotate.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-rotate.tsx
@@ -8,7 +8,7 @@ import type { StyleValue } from "@webstudio-is/css-engine";
 import { propertySyntaxes } from "@webstudio-is/css-data";
 import { CssValueInputContainer } from "../../shared/css-value-input";
 import { PropertyInlineLabel } from "../../property-label";
-import { useComputedStyleDecl } from "../../shared/model";
+import { $availableVariables, useComputedStyleDecl } from "../../shared/model";
 import { updateTransformFunction } from "./transform-utils";
 
 export const RotatePanelContent = () => {
@@ -21,11 +21,7 @@ export const RotatePanelContent = () => {
   let rotateY: StyleValue = { type: "unit", value: 0, unit: "deg" };
   let rotateZ: StyleValue = { type: "unit", value: 0, unit: "deg" };
   for (const item of tuple?.value ?? []) {
-    if (
-      item.type === "function" &&
-      item.args.type === "layers" &&
-      item.args.value[0].type === "unit"
-    ) {
+    if (item.type === "function" && item.args.type === "layers") {
       if (item.name === "rotateX") {
         rotateX = item.args.value[0];
       }
@@ -52,6 +48,7 @@ export const RotatePanelContent = () => {
         <CssValueInputContainer
           styleSource="local"
           property="rotate"
+          getOptions={() => $availableVariables.get()}
           value={rotateX}
           setValue={(value, options) =>
             updateTransformFunction(styleDecl, "rotateX", value, options)
@@ -71,6 +68,7 @@ export const RotatePanelContent = () => {
         <CssValueInputContainer
           styleSource="local"
           property="rotate"
+          getOptions={() => $availableVariables.get()}
           value={rotateY}
           setValue={(value, options) =>
             updateTransformFunction(styleDecl, "rotateY", value, options)
@@ -90,6 +88,7 @@ export const RotatePanelContent = () => {
         <CssValueInputContainer
           styleSource="local"
           property="rotate"
+          getOptions={() => $availableVariables.get()}
           value={rotateZ}
           setValue={(value, options) =>
             updateTransformFunction(styleDecl, "rotateZ", value, options)

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-scale.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-scale.tsx
@@ -25,7 +25,7 @@ import {
 } from "../../shared/use-style-data";
 import type { IntermediateStyleValue } from "../../shared/css-value-input/css-value-input";
 import { PropertyInlineLabel } from "../../property-label";
-import { useComputedStyleDecl } from "../../shared/model";
+import { $availableVariables, useComputedStyleDecl } from "../../shared/model";
 
 const property: StyleProperty = "scale";
 
@@ -59,7 +59,7 @@ export const ScalePanelContent = () => {
     if (newValue.type === "tuple") {
       [newValue] = newValue.value;
     }
-    if (newValue.type !== "unit") {
+    if (newValue.type !== "unit" && newValue.type !== "var") {
       newValue = { type: "unit", value: 100, unit: "%" };
     }
 
@@ -97,6 +97,7 @@ export const ScalePanelContent = () => {
           <CssValueInput
             styleSource="local"
             property={property}
+            getOptions={() => $availableVariables.get()}
             value={scaleX}
             intermediateValue={intermediateScalingX}
             onChange={(value) => {
@@ -137,6 +138,7 @@ export const ScalePanelContent = () => {
           <CssValueInput
             styleSource="local"
             property={property}
+            getOptions={() => $availableVariables.get()}
             value={scaleY}
             intermediateValue={intermediateScalingY}
             onChange={(value) => {
@@ -177,6 +179,7 @@ export const ScalePanelContent = () => {
           <CssValueInput
             styleSource="local"
             property={property}
+            getOptions={() => $availableVariables.get()}
             value={scaleZ}
             intermediateValue={intermediateScalingZ}
             onChange={(value) => {

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-translate.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-translate.tsx
@@ -8,7 +8,7 @@ import {
   type StyleUpdateOptions,
 } from "../../shared/use-style-data";
 import { PropertyInlineLabel } from "../../property-label";
-import { useComputedStyleDecl } from "../../shared/model";
+import { $availableVariables, useComputedStyleDecl } from "../../shared/model";
 
 const property: StyleProperty = "translate";
 
@@ -34,7 +34,7 @@ export const TranslatePanelContent = () => {
     if (newValue.type === "tuple") {
       [newValue] = newValue.value;
     }
-    if (newValue.type !== "unit") {
+    if (newValue.type !== "unit" && newValue.type !== "var") {
       newValue = { type: "unit", value: 0, unit: "px" };
     }
 
@@ -58,9 +58,12 @@ export const TranslatePanelContent = () => {
         <CssValueInputContainer
           styleSource="local"
           property={property}
+          getOptions={() => $availableVariables.get()}
           value={translateX}
           setValue={(newValue, options) => setAxis(0, newValue, options)}
-          deleteProperty={() => {}}
+          deleteProperty={(property, options) =>
+            setProperty(property)(styleDecl.cascadedValue, options)
+          }
         />
       </Grid>
       <Grid
@@ -75,9 +78,12 @@ export const TranslatePanelContent = () => {
         <CssValueInputContainer
           styleSource="local"
           property={property}
+          getOptions={() => $availableVariables.get()}
           value={translateY}
           setValue={(newValue, options) => setAxis(1, newValue, options)}
-          deleteProperty={() => {}}
+          deleteProperty={(property, options) =>
+            setProperty(property)(styleDecl.cascadedValue, options)
+          }
         />
       </Grid>
       <Grid
@@ -92,9 +98,12 @@ export const TranslatePanelContent = () => {
         <CssValueInputContainer
           styleSource="local"
           property={property}
+          getOptions={() => $availableVariables.get()}
           value={translateZ}
           setValue={(newValue, options) => setAxis(2, newValue, options)}
-          deleteProperty={() => {}}
+          deleteProperty={(property, options) =>
+            setProperty(property)(styleDecl.cascadedValue, options)
+          }
         />
       </Grid>
     </Flex>

--- a/apps/builder/app/builder/features/style-panel/sections/transforms/transform-utils.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/transforms/transform-utils.ts
@@ -337,7 +337,7 @@ export const updateTransformFunction = (
   if (newValue.type === "tuple") {
     [newValue] = newValue.value;
   }
-  if (newValue.type !== "unit") {
+  if (newValue.type !== "unit" && newValue.type !== "var") {
     newValue = { type: "unit", value: 0, unit: "deg" };
   }
 


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

![Screenshot 2024-10-11 at 23 34 48](https://github.com/user-attachments/assets/aade8738-3b52-4c22-aad0-1411d45bf1ef)


One thing I noticed, our implementation does not compose scale and rotate well.
According to spec rotate should be computed before scale but in our implementation rotate goes after scale.

https://www.w3.org/TR/css-transforms-2/#ctm