### PR TITLE
experimental: improve css variables parsing

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/parse-css-fragment.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/parse-css-fragment.ts
@@ -1,7 +1,10 @@
 import { parseCss } from "@webstudio-is/css-data";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 export const parseCssFragment = (css: string, fallbackProperty: string) => {
-  let parsed = parseCss(`.styles{${css}}`);
+  let parsed = parseCss(`.styles{${css}}`, {
+    customProperties: isFeatureEnabled("cssVars"),
+  });
   if (parsed.length === 0) {
     parsed = parseCss(`.styles{${fallbackProperty}: ${css}}`);
   }

--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -399,7 +399,9 @@ const pasteStyles = async (
   state: undefined | string
 ) => {
   const text = await navigator.clipboard.readText();
-  const parsedStyles = parseCss(`selector{${text}}`);
+  const parsedStyles = parseCss(`selector{${text}}`, {
+    customProperties: true,
+  });
   const breakpointId = $selectedBreakpoint.get()?.id;
   const instanceId = $selectedInstanceSelector.get()?.[0];
   if (breakpointId === undefined || instanceId === undefined) {

--- a/apps/builder/app/shared/style-object-model.test.tsx
+++ b/apps/builder/app/shared/style-object-model.test.tsx
@@ -579,6 +579,37 @@ test("resolve non-cyclic references in custom properties", () => {
   ).toEqual({ type: "unparsed", value: "red" });
 });
 
+test("allow multiple usages of the same custom property", () => {
+  const model = createModel({
+    css: `
+      bodyLocal {
+        --gradient: linear-gradient(#fff, #000);
+      }
+      boxLocal {
+        background-image: var(--gradient), var(--gradient);
+      }
+    `,
+    jsx: (
+      <$.Body ws:id="body" class="bodyLocal">
+        <$.Box ws:id="box" class="boxLocal"></$.Box>
+      </$.Body>
+    ),
+  });
+  expect(
+    getComputedStyleDecl({
+      model,
+      instanceSelector: ["box", "body"],
+      property: "backgroundImage",
+    }).usedValue
+  ).toEqual({
+    type: "layers",
+    value: [
+      { type: "unparsed", value: "linear-gradient(#fff,#000)" },
+      { type: "unparsed", value: "linear-gradient(#fff,#000)" },
+    ],
+  });
+});
+
 test("cascade value from matching breakpoints", () => {
   const model = createModel({
     css: `

--- a/apps/builder/app/shared/style-object-model.ts
+++ b/apps/builder/app/shared/style-object-model.ts
@@ -373,10 +373,15 @@ export const getComputedStyleDecl = ({
     computedValue = specifiedValue;
 
     let invalid = false;
+    // check whether the property was used with parent node
+    // to support var(--var1), var(--var1) layers
+    const parentUsedCustomProperties = usedCustomProperties;
+    usedCustomProperties = new Set<string>(usedCustomProperties);
+    customPropertiesGraph.set(instanceId, usedCustomProperties);
     computedValue = substituteVars(computedValue, (varValue) => {
       const customProperty = `--${varValue.value}`;
       // https://www.w3.org/TR/css-variables-1/#cycles
-      if (usedCustomProperties.has(customProperty)) {
+      if (parentUsedCustomProperties.has(customProperty)) {
         invalid = true;
         return varValue;
       }


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

Here added support for parsing var() when paste styles and fixed cyclic dependency when use the same var() a few times like `background-image: var(--gradient), var(--gradient)`.