### PR TITLE
experimental: improve repeated styles with css variables

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
@@ -89,12 +89,10 @@ const setGradientProperty = (
   }
   const unpackedItem = newItem.type === "layers" ? newItem.value[0] : newItem;
   if (items.length === 1 && unpackedItem.type === "var") {
-    console.log(unpackedItem);
     setProperty(property)(unpackedItem, options);
   } else {
     const newValue = { type: "layers", value: items } as LayersValue;
     newValue.value[index] = newItem as UnparsedValue;
-    console.log(newValue, unpackedItem);
     setProperty(property)(newValue, options);
   }
 };

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
@@ -11,7 +11,13 @@ import {
   RepeatRowIcon,
   CrossSmallIcon,
 } from "@webstudio-is/icons";
-import { type StyleValue, toValue } from "@webstudio-is/css-engine";
+import {
+  LayersValue,
+  type StyleProperty,
+  type StyleValue,
+  toValue,
+  UnparsedValue,
+} from "@webstudio-is/css-engine";
 import {
   theme,
   Flex,
@@ -35,7 +41,11 @@ import {
   setRepeatedStyleItem,
 } from "../../shared/repeated-style";
 import { CssValueInputContainer } from "../../shared/css-value-input";
-import { setProperty } from "../../shared/use-style-data";
+import {
+  setProperty,
+  type StyleUpdateOptions,
+} from "../../shared/use-style-data";
+import type { ComputedStyleDecl } from "~/shared/style-object-model";
 
 const detectImageOrGradientToggle = (styleValue?: StyleValue) => {
   if (styleValue?.type === "image") {
@@ -63,6 +73,32 @@ const Spacer = styled("div", {
   height: theme.spacing[5],
 });
 
+const setGradientProperty = (
+  styleDecl: ComputedStyleDecl,
+  index: number,
+  newItem: StyleValue,
+  options?: StyleUpdateOptions
+) => {
+  const property = styleDecl.property as StyleProperty;
+  let items: StyleValue[] = [];
+  if (styleDecl.cascadedValue.type === "var") {
+    items = [styleDecl.cascadedValue];
+  }
+  if (styleDecl.cascadedValue.type === "layers") {
+    items = styleDecl.cascadedValue.value;
+  }
+  const unpackedItem = newItem.type === "layers" ? newItem.value[0] : newItem;
+  if (items.length === 1 && unpackedItem.type === "var") {
+    console.log(unpackedItem);
+    setProperty(property)(unpackedItem, options);
+  } else {
+    const newValue = { type: "layers", value: items } as LayersValue;
+    newValue.value[index] = newItem as UnparsedValue;
+    console.log(newValue, unpackedItem);
+    setProperty(property)(newValue, options);
+  }
+};
+
 const GradientControl = ({ index }: { index: number }) => {
   const styleDecl = useComputedStyleDecl("backgroundImage");
   const value =
@@ -76,17 +112,11 @@ const GradientControl = ({ index }: { index: number }) => {
       getOptions={() => $availableVariables.get()}
       value={value}
       setValue={(newValue, options) => {
-        if (newValue.type === "var") {
-          setProperty("backgroundImage")(newValue, options);
-        } else {
-          setRepeatedStyleItem(styleDecl, index, newValue, options);
-        }
+        setGradientProperty(styleDecl, index, newValue, options);
       }}
       deleteProperty={() => {
-        if (styleDecl.cascadedValue.type === "var") {
-          setProperty("backgroundImage")(styleDecl.cascadedValue);
-        } else if (value) {
-          setRepeatedStyleItem(styleDecl, index, value);
+        if (value) {
+          setGradientProperty(styleDecl, index, value);
         }
       }}
     />

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
@@ -11,7 +11,7 @@ import { $assets, $imageLoader } from "~/shared/nano-states";
 import brokenImage from "~/shared/images/broken-image-placeholder.svg";
 import { toPascalCase } from "../../shared/keyword-utils";
 import { useComputedStyles } from "../../shared/model";
-import { getRepeatedStyleItem } from "../../shared/repeated-style";
+import { getComputedRepeatedItem } from "../../shared/repeated-style";
 
 export const repeatedProperties = [
   "backgroundImage",
@@ -113,7 +113,7 @@ export const BackgroundThumbnail = ({ index }: { index: number }) => {
   const imageLoader = useStore($imageLoader);
   const styles = useComputedStyles(repeatedProperties);
   const [backgroundImage] = styles;
-  const backgroundImageValue = getRepeatedStyleItem(backgroundImage, index);
+  const backgroundImageValue = getComputedRepeatedItem(backgroundImage, index);
 
   if (
     backgroundImageValue?.type === "image" &&
@@ -152,7 +152,7 @@ export const BackgroundThumbnail = ({ index }: { index: number }) => {
   if (backgroundImageValue?.type === "unparsed") {
     const cssStyle: { [property in RepeatedProperty]?: string } = {};
     for (const styleDecl of styles) {
-      const itemValue = getRepeatedStyleItem(styleDecl, index);
+      const itemValue = getComputedRepeatedItem(styleDecl, index);
       cssStyle[styleDecl.property as RepeatedProperty] = toValue(itemValue);
     }
     return <Thumbnail css={cssStyle} />;

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
@@ -75,9 +75,12 @@ const gradientNames = [
 ];
 
 export const getBackgroundLabel = (
-  backgroundImageStyle: StyleValue,
+  backgroundImageStyle: undefined | StyleValue,
   assets: Assets
 ) => {
+  if (backgroundImageStyle?.type === "var") {
+    return `--${backgroundImageStyle.value}`;
+  }
   if (
     backgroundImageStyle?.type === "image" &&
     backgroundImageStyle.value.type === "asset"

--- a/apps/builder/app/builder/features/style-panel/shared/repeated-style.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/repeated-style.test.ts
@@ -1,5 +1,10 @@
-import { beforeEach, expect, test } from "@jest/globals";
-import type { StyleValue } from "@webstudio-is/css-engine";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import {
+  toValue,
+  type StyleProperty,
+  type StyleValue,
+} from "@webstudio-is/css-engine";
+import { parseCssValue } from "@webstudio-is/css-data";
 import {
   addRepeatedStyleItem,
   deleteRepeatedStyleItem,
@@ -16,6 +21,8 @@ import {
   $selectedBreakpointId,
   $selectedInstanceSelector,
   $styles,
+  $styleSources,
+  $styleSourceSelections,
 } from "~/shared/nano-states";
 import { registerContainers } from "~/shared/sync";
 import { setProperty } from "./use-style-data";
@@ -27,8 +34,14 @@ beforeEach(() => {
   $breakpoints.set(new Map([["base", { id: "base", label: "" }]]));
   $selectedBreakpointId.set("base");
   $selectedInstanceSelector.set(["box"]);
+  $styleSourceSelections.set(new Map());
+  $styleSources.set(new Map());
   $styles.set(new Map());
 });
+
+const setRawProperty = (property: StyleProperty, value: string) => {
+  setProperty(property)(parseCssValue(property, value));
+};
 
 test("get repeated style item by index", () => {
   const cascadedValue: StyleValue = {
@@ -75,422 +88,299 @@ test("get repeated style item by index", () => {
   });
 });
 
-test("add layer to repeated style", () => {
-  const $transitionProperty =
-    createComputedStyleDeclStore("transitionProperty");
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("opacity", "transitionProperty")
-  );
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("transform", "transitionProperty")
-  );
-  expect($transitionProperty.get().cascadedValue).toEqual({
-    type: "layers",
-    value: [
-      { type: "unparsed", value: "opacity" },
-      { type: "unparsed", value: "transform" },
-    ],
+describe("add repeated item", () => {
+  test("add layer to var", () => {
+    const $transitionProperty =
+      createComputedStyleDeclStore("transitionProperty");
+    setRawProperty("transitionProperty", "var(--my-property)");
+    expect($transitionProperty.get().cascadedValue.type).toEqual("var");
+    addRepeatedStyleItem(
+      [$transitionProperty.get()],
+      parseCssFragment("opacity", "transitionProperty")
+    );
+    expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+      "var(--my-property), opacity"
+    );
   });
-});
 
-test("add tuple to repeated style", () => {
-  const $filter = createComputedStyleDeclStore("filter");
-  addRepeatedStyleItem(
-    [$filter.get()],
-    parseCssFragment("blur(5px)", "filter")
-  );
-  addRepeatedStyleItem(
-    [$filter.get()],
-    parseCssFragment("brightness(0.5)", "filter")
-  );
-  expect($filter.get().cascadedValue).toEqual({
-    type: "tuple",
-    value: [
-      {
-        type: "function",
-        name: "blur",
-        args: {
-          type: "tuple",
-          value: [{ type: "unit", unit: "px", value: 5 }],
-        },
-      },
-      {
-        type: "function",
-        name: "brightness",
-        args: {
-          type: "tuple",
-          value: [{ type: "unit", unit: "number", value: 0.5 }],
-        },
-      },
-    ],
+  test("add layer to repeated style", () => {
+    const $transitionProperty =
+      createComputedStyleDeclStore("transitionProperty");
+    addRepeatedStyleItem(
+      [$transitionProperty.get()],
+      parseCssFragment("opacity", "transitionProperty")
+    );
+    addRepeatedStyleItem(
+      [$transitionProperty.get()],
+      parseCssFragment("transform", "transitionProperty")
+    );
+    expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+      "opacity, transform"
+    );
   });
-});
 
-test("ignore when new item is not layers or tuple", () => {
-  const $backgroundColor = createComputedStyleDeclStore("backgroundColor");
-  addRepeatedStyleItem(
-    [$backgroundColor.get()],
-    parseCssFragment("none", "background")
-  );
-  expect($backgroundColor.get().source.name).toEqual("default");
-  expect($backgroundColor.get().cascadedValue).toEqual({
-    type: "keyword",
-    value: "transparent",
+  test("add tuple to repeated style", () => {
+    const $filter = createComputedStyleDeclStore("filter");
+    addRepeatedStyleItem(
+      [$filter.get()],
+      parseCssFragment("blur(5px)", "filter")
+    );
+    addRepeatedStyleItem(
+      [$filter.get()],
+      parseCssFragment("brightness(0.5)", "filter")
+    );
+    expect(toValue($filter.get().cascadedValue)).toEqual(
+      "blur(5px) brightness(0.5)"
+    );
+  });
+
+  test("ignore when new item is not layers or tuple", () => {
+    const $backgroundColor = createComputedStyleDeclStore("backgroundColor");
+    addRepeatedStyleItem(
+      [$backgroundColor.get()],
+      parseCssFragment("none", "background")
+    );
+    expect($backgroundColor.get().source.name).toEqual("default");
+    expect(toValue($backgroundColor.get().cascadedValue)).toEqual(
+      "transparent"
+    );
+  });
+
+  test("align properties with primary property", () => {
+    const $transitionProperty =
+      createComputedStyleDeclStore("transitionProperty");
+    const $transitionDuration =
+      createComputedStyleDeclStore("transitionDuration");
+    const $transitionDelay = createComputedStyleDeclStore("transitionDelay");
+    setRawProperty("transitionProperty", "opacity, transform");
+    setRawProperty("transitionDuration", "1s");
+    addRepeatedStyleItem(
+      [
+        $transitionProperty.get(),
+        $transitionDuration.get(),
+        $transitionDelay.get(),
+      ],
+      parseCssFragment("width 2s", "transition")
+    );
+    expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+      "opacity, transform, width"
+    );
+    expect(toValue($transitionDuration.get().cascadedValue)).toEqual(
+      "1s, 1s, 2s"
+    );
+    expect(toValue($transitionDelay.get().cascadedValue)).toEqual("0s, 0s, 0s");
   });
 });
 
 test("edit layer in repeated style", () => {
   const $transitionProperty =
     createComputedStyleDeclStore("transitionProperty");
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("opacity", "transitionProperty")
-  );
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("transform", "transitionProperty")
-  );
+  setRawProperty("transitionProperty", "opacity, transform");
   editRepeatedStyleItem(
     [$transitionProperty.get()],
     1,
     parseCssFragment("width", "transitionProperty")
   );
-  expect($transitionProperty.get().cascadedValue).toEqual({
-    type: "layers",
-    value: [
-      { type: "unparsed", value: "opacity" },
-      { type: "unparsed", value: "width" },
-    ],
-  });
+  expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+    "opacity, width"
+  );
 });
 
 test("edit tuple in repeated style", () => {
   const $filter = createComputedStyleDeclStore("filter");
-  addRepeatedStyleItem(
-    [$filter.get()],
-    parseCssFragment("blur(5px)", "filter")
-  );
-  addRepeatedStyleItem(
-    [$filter.get()],
-    parseCssFragment("brightness(0.5)", "filter")
-  );
+  setRawProperty("filter", "blur(5px) brightness(0.5)");
   editRepeatedStyleItem(
     [$filter.get()],
     1,
     parseCssFragment("contrast(200%)", "filter")
   );
-  expect($filter.get().cascadedValue).toEqual({
-    type: "tuple",
-    value: [
-      {
-        type: "function",
-        name: "blur",
-        args: {
-          type: "tuple",
-          value: [{ type: "unit", unit: "px", value: 5 }],
-        },
-      },
-      {
-        type: "function",
-        name: "contrast",
-        args: {
-          type: "tuple",
-          value: [{ type: "unit", unit: "%", value: 200 }],
-        },
-      },
-    ],
-  });
+  expect(toValue($filter.get().cascadedValue)).toEqual(
+    "blur(5px) contrast(200%)"
+  );
 });
 
 test("set layers item into repeated style", () => {
   const $transitionProperty =
     createComputedStyleDeclStore("transitionProperty");
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("opacity", "transitionProperty")
-  );
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("transform", "transitionProperty")
-  );
+  setRawProperty("transitionProperty", "opacity, transform");
   setRepeatedStyleItem($transitionProperty.get(), 0, {
     type: "unparsed",
     value: "width",
   });
-  expect($transitionProperty.get().cascadedValue).toEqual({
-    type: "layers",
-    value: [
-      { type: "unparsed", value: "width" },
-      { type: "unparsed", value: "transform" },
-    ],
-  });
+  expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+    "width, transform"
+  );
   // out of bounds will repeat existing values
   setRepeatedStyleItem($transitionProperty.get(), 3, {
     type: "unparsed",
     value: "left",
   });
-  expect($transitionProperty.get().cascadedValue).toEqual({
-    type: "layers",
-    value: [
-      { type: "unparsed", value: "width" },
-      { type: "unparsed", value: "transform" },
-      { type: "unparsed", value: "width" },
-      { type: "unparsed", value: "left" },
-    ],
-  });
+  expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+    "width, transform, width, left"
+  );
 });
 
 test("unpack item from layers value in repeated style", () => {
   const $transitionProperty =
     createComputedStyleDeclStore("transitionProperty");
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("opacity", "transitionProperty")
-  );
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("transform", "transitionProperty")
-  );
+  setRawProperty("transitionProperty", "opacity, transform");
   setRepeatedStyleItem($transitionProperty.get(), 1, {
     type: "layers",
     value: [{ type: "unparsed", value: "width" }],
   });
-  expect($transitionProperty.get().cascadedValue).toEqual({
-    type: "layers",
-    value: [
-      { type: "unparsed", value: "opacity" },
-      { type: "unparsed", value: "width" },
-    ],
+  expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+    "opacity, width"
+  );
+});
+
+describe("delete repeated item", () => {
+  test("delete var or other not releated value in repeated style", () => {
+    const $backgroundImage = createComputedStyleDeclStore("backgroundImage");
+    // var()
+    setRawProperty("backgroundImage", "var(--my-bg)");
+    deleteRepeatedStyleItem([$backgroundImage.get()], 0);
+    expect(toValue($backgroundImage.get().cascadedValue)).toEqual("none");
+    // inherit
+    setRawProperty("backgroundImage", "inherit");
+    deleteRepeatedStyleItem([$backgroundImage.get()], 0);
+    expect(toValue($backgroundImage.get().cascadedValue)).toEqual("none");
+  });
+
+  test("convert to var when it is the only left in repeated style", () => {
+    const $backgroundImage = createComputedStyleDeclStore("backgroundImage");
+    // var()
+    setRawProperty("backgroundImage", "var(--bg1), var(--bg2)");
+    deleteRepeatedStyleItem([$backgroundImage.get()], 1);
+    expect(toValue($backgroundImage.get().cascadedValue)).toEqual("var(--bg1)");
+    expect($backgroundImage.get().cascadedValue.type).toEqual("var");
+  });
+
+  test("delete layer from repeated style", () => {
+    const $transitionProperty =
+      createComputedStyleDeclStore("transitionProperty");
+    setRawProperty("transitionProperty", "opacity, transform");
+    deleteRepeatedStyleItem([$transitionProperty.get()], 0);
+    expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+      "transform"
+    );
+  });
+
+  test("delete value without layers from repeated style", () => {
+    const $transitionProperty =
+      createComputedStyleDeclStore("transitionProperty");
+    setRawProperty("transitionProperty", "opacity");
+    expect($transitionProperty.get().source.name).toEqual("local");
+    deleteRepeatedStyleItem([$transitionProperty.get()], 0);
+    expect($transitionProperty.get().source.name).toEqual("default");
+    expect(toValue($transitionProperty.get().cascadedValue)).toEqual("all");
+  });
+
+  test("align layers with primary when toggling toggle", () => {
+    const $transitionProperty =
+      createComputedStyleDeclStore("transitionProperty");
+    const $transitionDuration =
+      createComputedStyleDeclStore("transitionDuration");
+    setRawProperty("transitionProperty", "opacity, transform, color");
+    setRawProperty("transitionDuration", "1s, 2s");
+    deleteRepeatedStyleItem(
+      [$transitionProperty.get(), $transitionDuration.get()],
+      0
+    );
+    expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+      "transform, color"
+    );
+    // color should not switch to 1s when hide first layer
+    expect(toValue($transitionDuration.get().cascadedValue)).toEqual("2s, 1s");
+  });
+
+  test("delete tuple from repeated style", () => {
+    const $filter = createComputedStyleDeclStore("filter");
+    setRawProperty("filter", "blur(5px) brightness(0.5)");
+    deleteRepeatedStyleItem([$filter.get()], 0);
+    expect(toValue($filter.get().cascadedValue)).toEqual("brightness(0.5)");
   });
 });
 
-test("delete layer from repeated style", () => {
-  const $transitionProperty =
-    createComputedStyleDeclStore("transitionProperty");
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("opacity", "transitionProperty")
-  );
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("transform", "transitionProperty")
-  );
-  deleteRepeatedStyleItem([$transitionProperty.get()], 0);
-  expect($transitionProperty.get().cascadedValue).toEqual({
-    type: "layers",
-    value: [{ type: "unparsed", value: "transform" }],
+describe("toggle repeated item", () => {
+  test("toggle var in repeated style", () => {
+    const $backgroundImage = createComputedStyleDeclStore("backgroundImage");
+    setRawProperty("backgroundImage", "var(--my-bg)");
+    toggleRepeatedStyleItem([$backgroundImage.get()], 0);
+    expect(toValue($backgroundImage.get().cascadedValue)).toEqual("");
+    toggleRepeatedStyleItem([$backgroundImage.get()], 0);
+    expect(toValue($backgroundImage.get().cascadedValue)).toEqual(
+      "var(--my-bg)"
+    );
+  });
+
+  test("ignore toggling not repeated value in repeated style", () => {
+    const $backgroundImage = createComputedStyleDeclStore("backgroundImage");
+    setRawProperty("backgroundImage", "inherit");
+    toggleRepeatedStyleItem([$backgroundImage.get()], 0);
+    expect(toValue($backgroundImage.get().cascadedValue)).toEqual("inherit");
+  });
+
+  test("toggle layer in repeated style", () => {
+    const $transitionProperty =
+      createComputedStyleDeclStore("transitionProperty");
+    setRawProperty("transitionProperty", "opacity, transform");
+    toggleRepeatedStyleItem([$transitionProperty.get()], 0);
+    expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+      "transform"
+    );
+    toggleRepeatedStyleItem([$transitionProperty.get()], 0);
+    expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+      "opacity, transform"
+    );
+  });
+
+  test("toggle tuple in repeated style", () => {
+    const $filter = createComputedStyleDeclStore("filter");
+    setRawProperty("filter", "blur(5px) brightness(0.5)");
+    toggleRepeatedStyleItem([$filter.get()], 0);
+    expect(toValue($filter.get().cascadedValue)).toEqual("brightness(0.5)");
+    toggleRepeatedStyleItem([$filter.get()], 0);
+    expect(toValue($filter.get().cascadedValue)).toEqual(
+      "blur(5px) brightness(0.5)"
+    );
+  });
+
+  test("align layers with primary when toggling toggle", () => {
+    const $transitionProperty =
+      createComputedStyleDeclStore("transitionProperty");
+    const $transitionDuration =
+      createComputedStyleDeclStore("transitionDuration");
+    setRawProperty("transitionProperty", "opacity, transform, color");
+    setRawProperty("transitionDuration", "1s, 2s");
+    toggleRepeatedStyleItem(
+      [$transitionProperty.get(), $transitionDuration.get()],
+      0
+    );
+    expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+      "transform, color"
+    );
+    // color should not switch to 1s when hide first layer
+    expect(toValue($transitionDuration.get().cascadedValue)).toEqual("2s, 1s");
   });
 });
 
-test("delete value without layers from repeated style", () => {
-  const $transitionProperty =
-    createComputedStyleDeclStore("transitionProperty");
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("opacity", "transitionProperty")
-  );
-  expect($transitionProperty.get().source.name).toEqual("local");
-  deleteRepeatedStyleItem([$transitionProperty.get()], 0);
-  expect($transitionProperty.get().source.name).toEqual("default");
-  expect($transitionProperty.get().cascadedValue).toEqual({
-    type: "keyword",
-    value: "all",
+describe("swap repeated items", () => {
+  test("swap layers in repeated style", () => {
+    const $transitionProperty =
+      createComputedStyleDeclStore("transitionProperty");
+    setRawProperty("transitionProperty", "opacity, transform");
+    swapRepeatedStyleItems([$transitionProperty.get()], 0, 1);
+    expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
+      "transform, opacity"
+    );
   });
-});
 
-test("delete tuple from repeated style", () => {
-  const $filter = createComputedStyleDeclStore("filter");
-  addRepeatedStyleItem(
-    [$filter.get()],
-    parseCssFragment("blur(5px)", "filter")
-  );
-  addRepeatedStyleItem(
-    [$filter.get()],
-    parseCssFragment("brightness(0.5)", "filter")
-  );
-  deleteRepeatedStyleItem([$filter.get()], 0);
-  expect($filter.get().cascadedValue).toEqual({
-    type: "tuple",
-    value: [
-      {
-        type: "function",
-        name: "brightness",
-        args: {
-          type: "tuple",
-          value: [{ type: "unit", unit: "number", value: 0.5 }],
-        },
-      },
-    ],
-  });
-});
-
-test("toggle layer in repeated style", () => {
-  const $transitionProperty =
-    createComputedStyleDeclStore("transitionProperty");
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("opacity", "transitionProperty")
-  );
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("transform", "transitionProperty")
-  );
-  toggleRepeatedStyleItem([$transitionProperty.get()], 0);
-  expect($transitionProperty.get().cascadedValue).toEqual({
-    type: "layers",
-    value: [
-      { type: "unparsed", value: "opacity", hidden: true },
-      { type: "unparsed", value: "transform" },
-    ],
-  });
-  toggleRepeatedStyleItem([$transitionProperty.get()], 0);
-  expect($transitionProperty.get().cascadedValue).toEqual({
-    type: "layers",
-    value: [
-      { type: "unparsed", value: "opacity", hidden: false },
-      { type: "unparsed", value: "transform" },
-    ],
-  });
-});
-
-test("toggle tuple in repeated style", () => {
-  const $filter = createComputedStyleDeclStore("filter");
-  addRepeatedStyleItem(
-    [$filter.get()],
-    parseCssFragment("blur(5px)", "filter")
-  );
-  addRepeatedStyleItem(
-    [$filter.get()],
-    parseCssFragment("brightness(0.5)", "filter")
-  );
-  toggleRepeatedStyleItem([$filter.get()], 0);
-  expect($filter.get().cascadedValue).toEqual({
-    type: "tuple",
-    value: [
-      {
-        type: "function",
-        name: "blur",
-        args: {
-          type: "tuple",
-          value: [{ type: "unit", unit: "px", value: 5 }],
-        },
-        hidden: true,
-      },
-      {
-        type: "function",
-        name: "brightness",
-        args: {
-          type: "tuple",
-          value: [{ type: "unit", unit: "number", value: 0.5 }],
-        },
-      },
-    ],
-  });
-  toggleRepeatedStyleItem([$filter.get()], 0);
-  expect($filter.get().cascadedValue).toEqual({
-    type: "tuple",
-    value: [
-      {
-        type: "function",
-        name: "blur",
-        args: {
-          type: "tuple",
-          value: [{ type: "unit", unit: "px", value: 5 }],
-        },
-        hidden: false,
-      },
-      {
-        type: "function",
-        name: "brightness",
-        args: {
-          type: "tuple",
-          value: [{ type: "unit", unit: "number", value: 0.5 }],
-        },
-      },
-    ],
-  });
-});
-
-test("toggle repeated style item when value is not repeated", () => {
-  const $transitionProperty =
-    createComputedStyleDeclStore("transitionProperty");
-  const $transitionBehavior =
-    createComputedStyleDeclStore("transitionBehavior");
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("all", "transition")
-  );
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("opacity", "transition")
-  );
-  setProperty("transitionBehavior")({ type: "keyword", value: "inherit" });
-  toggleRepeatedStyleItem(
-    [$transitionProperty.get(), $transitionBehavior.get()],
-    1
-  );
-  expect($transitionBehavior.get().cascadedValue).toEqual({
-    type: "layers",
-    value: [
-      { type: "keyword", value: "normal" },
-      { type: "keyword", value: "normal", hidden: true },
-    ],
-  });
-});
-
-test("swap layers in repeated style", () => {
-  const $transitionProperty =
-    createComputedStyleDeclStore("transitionProperty");
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("opacity", "transitionProperty")
-  );
-  addRepeatedStyleItem(
-    [$transitionProperty.get()],
-    parseCssFragment("transform", "transitionProperty")
-  );
-  swapRepeatedStyleItems([$transitionProperty.get()], 0, 1);
-  expect($transitionProperty.get().cascadedValue).toEqual({
-    type: "layers",
-    value: [
-      { type: "unparsed", value: "transform" },
-      { type: "unparsed", value: "opacity" },
-    ],
-  });
-});
-
-test("add tuple items in repeated style", () => {
-  const $filter = createComputedStyleDeclStore("filter");
-  addRepeatedStyleItem(
-    [$filter.get()],
-    parseCssFragment("blur(5px)", "filter")
-  );
-  addRepeatedStyleItem(
-    [$filter.get()],
-    parseCssFragment("brightness(0.5)", "filter")
-  );
-  swapRepeatedStyleItems([$filter.get()], 0, 1);
-  expect($filter.get().cascadedValue).toEqual({
-    type: "tuple",
-    value: [
-      {
-        type: "function",
-        name: "brightness",
-        args: {
-          type: "tuple",
-          value: [{ type: "unit", unit: "number", value: 0.5 }],
-        },
-      },
-      {
-        type: "function",
-        name: "blur",
-        args: {
-          type: "tuple",
-          value: [{ type: "unit", unit: "px", value: 5 }],
-        },
-      },
-    ],
+  test("add tuple items in repeated style", () => {
+    const $filter = createComputedStyleDeclStore("filter");
+    setRawProperty("filter", "blur(5px) brightness(0.5)");
+    swapRepeatedStyleItems([$filter.get()], 0, 1);
+    expect(toValue($filter.get().cascadedValue)).toEqual(
+      "brightness(0.5) blur(5px)"
+    );
   });
 });

--- a/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
@@ -312,11 +312,17 @@ export const RepeatedStyle = (props: {
   const { label, styles, getItemProps, renderThumbnail, renderItemContent } =
     props;
   // first property should describe the amount of layers or tuple items
-  const primaryValue =
-    styles[0].cascadedValue.type === "var"
-      ? reparseComputedValue(styles[0])
-      : styles[0].cascadedValue;
-  const primaryItems = isRepeatedValue(primaryValue) ? primaryValue.value : [];
+  const primaryValue = styles[0].cascadedValue;
+  let primaryItems: StyleValue[] = [];
+  if (primaryValue.type === "var") {
+    const reparsed = reparseComputedValue(styles[0]);
+    if (isRepeatedValue(reparsed)) {
+      primaryItems = repeatUntil([primaryValue], reparsed.value.length);
+    }
+  }
+  if (isRepeatedValue(primaryValue)) {
+    primaryItems = primaryValue.value;
+  }
 
   const sortableItems = useMemo(
     () =>

--- a/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
@@ -20,6 +20,7 @@ import {
   Label,
   SmallIconButton,
   SmallToggleButton,
+  toast,
   useSortable,
 } from "@webstudio-is/design-system";
 import { FloatingPanel } from "~/builder/shared/floating-panel";
@@ -28,6 +29,43 @@ import type { ComputedStyleDecl } from "~/shared/style-object-model";
 import { createBatchUpdate, type StyleUpdateOptions } from "./use-style-data";
 import { ColorThumb } from "./color-thumb";
 import { parseCssValue, properties } from "@webstudio-is/css-data";
+
+const isRepeatedValue = (
+  styleValue: StyleValue
+): styleValue is LayersValue | TupleValue =>
+  styleValue.type === "layers" || styleValue.type === "tuple";
+
+const reparseComputedValue = (styleDecl: ComputedStyleDecl) => {
+  const property = styleDecl.property as StyleProperty;
+  const serialized = toValue(styleDecl.computedValue);
+  return parseCssValue(property, serialized);
+};
+
+export const getComputedRepeatedItem = (
+  styleDecl: ComputedStyleDecl,
+  index: number
+) => {
+  const value = reparseComputedValue(styleDecl);
+  const items = isRepeatedValue(value) ? value.value : [];
+  if (
+    isRepeatedValue(styleDecl.cascadedValue) &&
+    styleDecl.cascadedValue.value.length !== items.length
+  ) {
+    return;
+  }
+  return items[index % items.length];
+};
+
+const isItemHidden = (styleValue: StyleValue, index: number) => {
+  let hidden = false;
+  if (styleValue.type === "var") {
+    hidden = styleValue.hidden ?? false;
+  }
+  if (isRepeatedValue(styleValue)) {
+    hidden = styleValue.value[index].hidden ?? false;
+  }
+  return hidden;
+};
 
 /**
  * shows cascaded value
@@ -80,31 +118,49 @@ export const addRepeatedStyleItem = (
   styles: ComputedStyleDecl[],
   newItems: Map<StyleProperty, StyleValue>
 ) => {
+  if (styles[0].cascadedValue.type === "var") {
+    const primaryValue = reparseComputedValue(styles[0]);
+    if (isRepeatedValue(primaryValue) && primaryValue.value.length > 1) {
+      toast.error("Cannot add styles to css variable");
+      return;
+    }
+  }
   const batch = createBatchUpdate();
   const currentStyles = new Map(
     styles.map((styleDecl) => [styleDecl.property, styleDecl])
   );
   const primaryValue = styles[0].cascadedValue;
-  for (const [property, value] of newItems) {
-    if (value.type !== "layers" && value.type !== "tuple") {
+  let primaryCount = 0;
+  if (isRepeatedValue(primaryValue)) {
+    primaryCount = primaryValue.value.length;
+  }
+  if (primaryValue.type === "var") {
+    primaryCount = 1;
+  }
+  for (const [property, newValue] of newItems) {
+    if (newValue.type !== "layers" && newValue.type !== "tuple") {
       continue;
     }
     // infer type from new items
     // because current values could be css wide keywords
-    const itemType: ItemType = value.type;
+    const valueType: ItemType = newValue.type;
     const styleDecl = currentStyles.get(property);
     if (styleDecl === undefined) {
       continue;
     }
-    const newValue = normalizeStyleValue(styleDecl, primaryValue, itemType);
-    if (value.type !== itemType) {
-      console.error(
-        `Unexpected item type "${value.type}" for ${property} repeated value`
-      );
-      continue;
+    let oldItems: StyleValue[] = [];
+    if (styleDecl.cascadedValue.type === "var") {
+      oldItems = repeatUntil([styleDecl.cascadedValue], primaryCount);
+    } else if (styleDecl.cascadedValue.type === valueType) {
+      oldItems = repeatUntil(styleDecl.cascadedValue.value, primaryCount);
+    } else if (primaryCount > 0) {
+      const meta = properties[property as keyof typeof properties];
+      oldItems = repeatUntil([meta.initial], primaryCount);
     }
-    newValue.value.push(...(value.value as UnparsedValue[]));
-    batch.setProperty(property)(newValue);
+    batch.setProperty(property)({
+      type: valueType,
+      value: [...oldItems, ...newValue.value] as UnparsedValue[],
+    });
   }
   batch.publish();
 };
@@ -164,14 +220,25 @@ export const deleteRepeatedStyleItem = (
 ) => {
   const batch = createBatchUpdate();
   const primaryValue = styles[0].cascadedValue;
+  const primaryCount = isRepeatedValue(primaryValue)
+    ? primaryValue.value.length
+    : index + 1;
   for (const styleDecl of styles) {
-    const newValue = normalizeStyleValue(styleDecl, primaryValue);
-    newValue.value.splice(index, 1);
-    if (newValue.value.length > 0) {
-      batch.setProperty(styleDecl.property as StyleProperty)(newValue);
+    const property = styleDecl.property as StyleProperty;
+    const newValue = structuredClone(styleDecl.cascadedValue);
+    if (isRepeatedValue(newValue)) {
+      newValue.value = repeatUntil(newValue.value, primaryCount);
+      newValue.value.splice(index, 1);
+      if (newValue.value.length === 1 && newValue.value[0].type === "var") {
+        batch.setProperty(property)(newValue.value[0]);
+      } else if (newValue.value.length > 0) {
+        batch.setProperty(property)(newValue);
+      } else {
+        // delete empty layers or tuple
+        batch.deleteProperty(property);
+      }
     } else {
-      // delete empty layers or tuple
-      batch.deleteProperty(styleDecl.property as StyleProperty);
+      batch.deleteProperty(property);
     }
   }
   batch.publish();
@@ -183,13 +250,25 @@ export const toggleRepeatedStyleItem = (
 ) => {
   const batch = createBatchUpdate();
   const primaryValue = styles[0].cascadedValue;
+  const primaryCount = isRepeatedValue(primaryValue)
+    ? primaryValue.value.length
+    : index + 1;
+  const isHidden = isItemHidden(primaryValue, index);
   for (const styleDecl of styles) {
-    const newValue = normalizeStyleValue(styleDecl, primaryValue);
-    newValue.value[index] = {
-      ...newValue.value[index],
-      hidden: false === (newValue.value[index].hidden ?? false),
-    };
-    batch.setProperty(styleDecl.property as StyleProperty)(newValue);
+    const property = styleDecl.property as StyleProperty;
+    const newValue = structuredClone(styleDecl.cascadedValue);
+    if (newValue.type === "var") {
+      newValue.hidden = !isHidden;
+      batch.setProperty(property)(newValue);
+    }
+    if (isRepeatedValue(newValue)) {
+      newValue.value = repeatUntil(newValue.value, primaryCount);
+      newValue.value[index] = structuredClone(newValue.value[index]);
+      newValue.value[index].hidden = !isHidden;
+      batch.setProperty(property)(newValue);
+    }
+    // other values are repeated automatically
+    // and it is irrelevant to change their visibility
   }
   batch.publish();
 };
@@ -199,6 +278,10 @@ export const swapRepeatedStyleItems = (
   oldIndex: number,
   newIndex: number
 ) => {
+  if (styles[0].cascadedValue.type === "var") {
+    toast.error("Cannot reorder styles from css variable");
+    return;
+  }
   const batch = createBatchUpdate();
   const primaryValue = styles[0].cascadedValue;
   for (const styleDecl of styles) {
@@ -223,17 +306,17 @@ export const RepeatedStyle = (props: {
     index: number,
     primaryValue: StyleValue
   ) => { label: string; color?: RgbaColor };
-  renderThumbnail?: (index: number, primaryValue: StyleValue) => JSX.Element;
-  renderItemContent: (index: number, primaryValue: StyleValue) => JSX.Element;
+  renderThumbnail?: (index: number, primaryItem: StyleValue) => JSX.Element;
+  renderItemContent: (index: number, primaryItem: StyleValue) => JSX.Element;
 }) => {
   const { label, styles, getItemProps, renderThumbnail, renderItemContent } =
     props;
   // first property should describe the amount of layers or tuple items
-  const primaryValue = getComputedValue(styles[0]);
-  const primaryItems =
-    primaryValue.type === "layers" || primaryValue.type === "tuple"
-      ? primaryValue.value
-      : [];
+  const primaryValue =
+    styles[0].cascadedValue.type === "var"
+      ? reparseComputedValue(styles[0])
+      : styles[0].cascadedValue;
+  const primaryItems = isRepeatedValue(primaryValue) ? primaryValue.value : [];
 
   const sortableItems = useMemo(
     () =>
@@ -257,12 +340,15 @@ export const RepeatedStyle = (props: {
   return (
     <CssValueListArrowFocus dragItemId={dragItemId}>
       <Flex direction="column" ref={sortableRefCallback}>
-        {primaryItems.map((primaryValue, index) => {
+        {primaryItems.map((primaryItem, index) => {
           const id = String(index);
           const { label: itemLabel, color: itemColor } = getItemProps(
             index,
-            primaryValue
+            primaryItem
           );
+          const isHidden = isItemHidden(styles[0].cascadedValue, index);
+          const canBeChanged =
+            styles[0].cascadedValue.type === "var" ? index === 0 : true;
           return (
             <FloatingPanel
               key={index}
@@ -275,7 +361,7 @@ export const RepeatedStyle = (props: {
               // too much when the tabs are changed from the popover trigger.
               align="center"
               collisionPadding={{ bottom: 200, top: 200 }}
-              content={renderItemContent(index, primaryValue)}
+              content={renderItemContent(index, primaryItem)}
             >
               <CssValueListItem
                 id={id}
@@ -283,31 +369,28 @@ export const RepeatedStyle = (props: {
                 active={dragItemId === id}
                 index={index}
                 label={<Label truncate>{itemLabel}</Label>}
-                hidden={primaryValue.hidden}
+                hidden={isHidden}
                 thumbnail={
-                  renderThumbnail?.(index, primaryValue) ??
+                  renderThumbnail?.(index, primaryItem) ??
                   (itemColor && <ColorThumb color={itemColor} />)
                 }
                 buttons={
                   <>
                     <SmallToggleButton
                       variant="normal"
-                      pressed={primaryValue.hidden}
-                      disabled={false}
+                      pressed={isHidden}
+                      disabled={false === canBeChanged}
                       tabIndex={-1}
+                      icon={
+                        isHidden ? <EyeconClosedIcon /> : <EyeconOpenIcon />
+                      }
                       onPressedChange={() =>
                         toggleRepeatedStyleItem(styles, index)
-                      }
-                      icon={
-                        primaryValue.hidden ? (
-                          <EyeconClosedIcon />
-                        ) : (
-                          <EyeconOpenIcon />
-                        )
                       }
                     />
                     <SmallIconButton
                       variant="destructive"
+                      disabled={false === canBeChanged}
                       tabIndex={-1}
                       icon={<SubtractIcon />}
                       onClick={() => deleteRepeatedStyleItem(styles, index)}

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -53,6 +53,9 @@ export const toValue = (
     return families.join(", ");
   }
   if (value.type === "var") {
+    if (value.hidden) {
+      return "";
+    }
     let fallbacksString = "";
     if (value.fallback) {
       fallbacksString = `, ${toValue(value.fallback, transformValue)}`;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

Here added a few improvements to repeated style to handle variables properly. For now all changes affects only backgrounds section.

- single layer can use css variable with multiple gradients
- with multiple layers each can have css variable with single gradient
- when single variable inside multiple layers has multiple gradients all thumbnails become transparent, it should be and indicator of invalid gradients
- fixed toggling hidden considering variables
- fixed deleting layers considering variables
- now when single layer has variable with multiple gradients only first gradient can be deleted or toggled