### PR TITLE
fix: show custom option in easing dropdow only when used

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-timing.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-timing.tsx
@@ -88,9 +88,11 @@ export const TransitionTiming = ({
               </SelectItem>
             );
           })}
-          <SelectItem key="custom" value="custom">
-            Custom
-          </SelectItem>
+          {value === "custom" && (
+            <SelectItem key="custom" value="custom">
+              Custom
+            </SelectItem>
+          )}
         </SelectGroup>
         <SelectGroup>
           <SelectLabel>Ease In</SelectLabel>


### PR DESCRIPTION
fixes #4197 

## Description

This PR improves the UX for `custom` option in the easing functions. Currently it is displaying every time, with the PR we show them only when value added by the users are `custom` and hides it when the entered value doesn't come under custom category.

## Steps for reproduction

- Add a transition on a node and then select a value from the dropdown.
- When the dropdown is open and the easing that is added is a valid one. The `Custom` option should be hidden.
- When a custom value is added under the text-area, then the select box should show `Custom` value.


https://github.com/user-attachments/assets/938a8452-ae77-48d9-a395-db6b5ca23851



## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)