### PR TITLE
fix: show "delete variable" in variable tooltip

### DIFF
--- a/apps/builder/app/builder/features/style-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/style-panel/property-label.tsx
@@ -183,10 +183,12 @@ export const PropertyInfo = ({
             </Flex>
           }
           suffix={<Kbd value={["option", "click"]} color="moreSubtle" />}
-          css={{ gridTemplateColumns: "2fr 3fr 1fr" }}
+          css={{ gridTemplateColumns: "1fr max-content 1fr" }}
           onClick={onReset}
         >
-          Reset value
+          {styles[0].property.startsWith("--")
+            ? "Delete variable"
+            : "Reset value"}
         </Button>
       )}
     </Flex>


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3399

![Screenshot 2024-10-20 at 10 41 55](https://github.com/user-attachments/assets/d194cc13-efec-40fa-8021-13d2473188a1)
