### PR TITLE
feat: Add resource control to webhook form action

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
@@ -10,6 +10,7 @@ import { UrlControl } from "./url";
 import type { ControlProps } from "../shared";
 import { JsonControl } from "./json";
 import { TextContent } from "./text-content";
+import { ResourceControl } from "./resource-control";
 
 export const renderControl = ({
   meta,
@@ -94,6 +95,10 @@ export const renderControl = ({
 
   if (meta.control === "url") {
     return <UrlControl key={key} meta={meta} prop={prop} {...rest} />;
+  }
+
+  if (meta.control === "resource") {
+    return <ResourceControl key={key} meta={meta} prop={prop} {...rest} />;
   }
 
   // Type in meta can be changed at some point without updating props in DB that are still using the old type

--- a/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
@@ -217,11 +217,9 @@ export const ResourceControl = ({
               }
               // attempt to save form on close
               if (areAllFormErrorsVisible(form.current)) {
-                console.log("submit");
                 form.current?.requestSubmit();
                 setIsResourceOpen(false);
               } else {
-                console.log("validate");
                 form.current?.checkValidity();
                 // prevent closing when not all errors are shown to user
               }

--- a/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
@@ -1,0 +1,267 @@
+import { nanoid } from "nanoid";
+import { computed } from "nanostores";
+import {
+  forwardRef,
+  useId,
+  useRef,
+  useState,
+  type ComponentProps,
+} from "react";
+import {
+  EnhancedTooltip,
+  Flex,
+  InputField,
+  NestedInputButton,
+  theme,
+} from "@webstudio-is/design-system";
+import { useStore } from "@nanostores/react";
+import { encodeDataSourceVariable, Prop, Resource } from "@webstudio-is/sdk";
+import { GearIcon } from "@webstudio-is/icons";
+import { $resources, $selectedPage } from "~/shared/nano-states";
+import { updateWebstudioData } from "~/shared/instance-utils";
+import { FloatingPanel } from "~/builder/shared/floating-panel";
+import {
+  BindingPopoverProvider,
+  evaluateExpressionWithinScope,
+} from "~/builder/shared/binding-popover";
+import {
+  humanizeAttribute,
+  Label,
+  ResponsiveLayout,
+  setPropMutable,
+  type ControlProps,
+} from "../shared";
+import {
+  $selectedInstanceResourceScope,
+  Headers,
+  MethodField,
+  parseResource,
+  UrlField,
+} from "../resource-panel";
+
+const ResourceButton = forwardRef<
+  HTMLButtonElement,
+  ComponentProps<typeof NestedInputButton>
+>((props, ref) => {
+  return (
+    <EnhancedTooltip content="Edit Resource">
+      <NestedInputButton {...props} ref={ref} aria-label="Edit Resource">
+        <GearIcon />
+      </NestedInputButton>
+    </EnhancedTooltip>
+  );
+});
+ResourceButton.displayName = "ResourceButton";
+
+// resource scope has access to system parameter
+// which cannot be used in action resource
+const $scope = computed(
+  [$selectedInstanceResourceScope, $selectedPage],
+  ({ scope, aliases }, page) => {
+    if (page === undefined) {
+      return { scope, aliases };
+    }
+    const newScope: Record<string, unknown> = { ...scope };
+    const newAliases = new Map(aliases);
+    const systemIdentifier = encodeDataSourceVariable(page.systemDataSourceId);
+    delete newScope[systemIdentifier];
+    newAliases.delete(systemIdentifier);
+    return { scope: newScope, aliases: newAliases };
+  }
+);
+
+const ResourceForm = ({ resource }: { resource: undefined | Resource }) => {
+  const bindingPopoverContainerRef = useRef<HTMLDivElement>(null);
+  // @todo exclude collection item and system
+  // basically all parameter variables
+  const { scope, aliases } = useStore($scope);
+  const [url, setUrl] = useState(resource?.url ?? `""`);
+  const [method, setMethod] = useState<Resource["method"]>(
+    resource?.method ?? "post"
+  );
+  const [headers, setHeaders] = useState<Resource["headers"]>(
+    resource?.headers ?? []
+  );
+  return (
+    <Flex
+      ref={bindingPopoverContainerRef}
+      direction="column"
+      css={{
+        width: theme.spacing[30],
+        overflow: "hidden",
+        gap: theme.spacing[9],
+        p: theme.spacing[9],
+      }}
+    >
+      <BindingPopoverProvider
+        value={{ containerRef: bindingPopoverContainerRef }}
+      >
+        <UrlField
+          scope={scope}
+          aliases={aliases}
+          value={url}
+          onChange={setUrl}
+          onCurlPaste={(curl) => {
+            // update all feilds when curl is paste into url field
+            setUrl(JSON.stringify(curl.url));
+            setMethod(curl.method);
+            setHeaders(
+              curl.headers.map((header) => ({
+                name: header.name,
+                value: JSON.stringify(header.value),
+              }))
+            );
+          }}
+        />
+        <MethodField value={method} onChange={setMethod} />
+        <Headers
+          scope={scope}
+          aliases={aliases}
+          headers={headers}
+          onChange={setHeaders}
+        />
+      </BindingPopoverProvider>
+    </Flex>
+  );
+};
+
+const setResource = ({
+  instanceId,
+  propId,
+  propName,
+  resource,
+}: {
+  instanceId: Prop["instanceId"];
+  propId?: Prop["id"];
+  propName: Prop["name"];
+  resource: Resource;
+}) => {
+  updateWebstudioData((data) => {
+    setPropMutable({
+      data,
+      update: {
+        id: propId ?? nanoid(),
+        instanceId,
+        name: propName,
+        type: "resource",
+        value: resource.id,
+      },
+    });
+    data.resources.set(resource.id, resource);
+  });
+};
+
+const areAllFormErrorsVisible = (form: null | HTMLFormElement) => {
+  if (form === null) {
+    return true;
+  }
+  // check all errors in form fields are visible
+  for (const element of form.elements) {
+    if (
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLTextAreaElement
+    ) {
+      // field is invalid and the error is not visible
+      if (
+        element.validity.valid === false &&
+        // rely on data-color=error convention in webstudio design system
+        element.getAttribute("data-color") !== "error"
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+export const ResourceControl = ({
+  meta,
+  prop,
+  instanceId,
+  propName,
+  deletable,
+  onDelete,
+}: ControlProps<"resource">) => {
+  const resources = useStore($resources);
+  const { scope } = useStore($scope);
+  const resourceId = prop?.type === "resource" ? prop.value : undefined;
+  const resource = resources.get(resourceId ?? "");
+  const urlExpression = resource?.url ?? `""`;
+  const url = String(evaluateExpressionWithinScope(urlExpression, scope));
+  const id = useId();
+  const label = humanizeAttribute(meta.label ?? propName);
+  const [isResourceOpen, setIsResourceOpen] = useState(false);
+  const form = useRef<HTMLFormElement>(null);
+
+  return (
+    <ResponsiveLayout
+      label={
+        <Label htmlFor={id} description={meta.description}>
+          {label}
+        </Label>
+      }
+      deletable={deletable}
+      onDelete={onDelete}
+    >
+      <InputField
+        id={id}
+        disabled={true}
+        suffix={
+          <FloatingPanel
+            title="Edit Resource"
+            isOpen={isResourceOpen}
+            onIsOpenChange={(isOpen) => {
+              if (isOpen) {
+                setIsResourceOpen(true);
+                return;
+              }
+              // attempt to save form on close
+              if (areAllFormErrorsVisible(form.current)) {
+                console.log("submit");
+                form.current?.requestSubmit();
+                setIsResourceOpen(false);
+              } else {
+                console.log("validate");
+                form.current?.checkValidity();
+                // prevent closing when not all errors are shown to user
+              }
+            }}
+            content={
+              <form
+                ref={form}
+                // ref={formRef}
+                noValidate={true}
+                // exclude from the flow
+                style={{ display: "contents" }}
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  if (event.currentTarget.checkValidity()) {
+                    const formData = new FormData(event.currentTarget);
+                    const resource = parseResource({
+                      id: resourceId ?? nanoid(),
+                      name: propName,
+                      formData,
+                    });
+                    setResource({
+                      instanceId,
+                      propId: prop?.id,
+                      propName: propName,
+                      resource,
+                    });
+                  }
+                }}
+              >
+                {/* submit is not triggered when press enter on input without submit button */}
+                <button hidden></button>
+                <ResourceForm resource={resource} />
+              </form>
+            }
+          >
+            <ResourceButton />
+          </FloatingPanel>
+        }
+        value={url}
+      />
+    </ResponsiveLayout>
+  );
+};

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -633,7 +633,6 @@ export const ResourceForm = forwardRef<
 
   useImperativeHandle(ref, () => ({
     save: (formData) => {
-      console.log(Object.fromEntries(formData));
       const instanceSelector = $selectedInstanceSelector.get();
       if (instanceSelector === undefined) {
         return;

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -16,7 +16,7 @@ import {
   decodeDataSourceVariable,
   encodeDataSourceVariable,
 } from "@webstudio-is/sdk";
-import type { Prop, Asset } from "@webstudio-is/sdk";
+import type { Prop, Asset, WebstudioData } from "@webstudio-is/sdk";
 import { HelpIcon, SubtractIcon } from "@webstudio-is/icons";
 import {
   SmallIconButton,
@@ -49,6 +49,27 @@ export type PropValue =
   | { type: "asset"; value: Asset["id"] }
   | { type: "page"; value: Extract<Prop, { type: "page" }>["value"] }
   | { type: "action"; value: Extract<Prop, { type: "action" }>["value"] };
+
+export const setPropMutable = ({
+  data,
+  update,
+}: {
+  data: WebstudioData;
+  update: Prop;
+}) => {
+  // fixing a bug that caused some props to be duplicated on unmount by removing duplicates.
+  // see for details https://github.com/webstudio-is/webstudio/pull/2170
+  for (const prop of data.props.values()) {
+    if (
+      prop.instanceId === update.instanceId &&
+      prop.name === update.name &&
+      prop.id !== update.id
+    ) {
+      data.props.delete(prop.id);
+    }
+  }
+  data.props.set(update.id, update);
+};
 
 // Weird code is to make type distributive
 // https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types

--- a/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
@@ -122,13 +122,11 @@ const FontsManagerButton = forwardRef<
   ComponentProps<typeof NestedInputButton>
 >((props, ref) => {
   return (
-    <Flex>
-      <EnhancedTooltip content="Open Font Manager">
-        <NestedInputButton {...props} ref={ref} tabIndex={-1}>
-          <UploadIcon />
-        </NestedInputButton>
-      </EnhancedTooltip>
-    </Flex>
+    <EnhancedTooltip content="Open Font Manager">
+      <NestedInputButton {...props} ref={ref} tabIndex={-1}>
+        <UploadIcon />
+      </NestedInputButton>
+    </EnhancedTooltip>
   );
 });
 FontsManagerButton.displayName = "FontsManagerButton";

--- a/apps/builder/app/shared/webstudio-data-migrator.ts
+++ b/apps/builder/app/shared/webstudio-data-migrator.ts
@@ -1,6 +1,7 @@
 import { camelCase } from "change-case";
 import {
   getStyleDeclKey,
+  replaceFormActionsWithResources,
   type StyleDecl,
   type WebstudioData,
 } from "@webstudio-is/sdk";
@@ -51,4 +52,5 @@ export const migrateWebstudioDataMutable = (data: WebstudioData) => {
       }
     }
   }
+  replaceFormActionsWithResources(data);
 };

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -312,6 +312,9 @@ export const prebuild = async (options: {
     const instances: [Instance["id"], Instance][] =
       siteData.build.instances.filter(([id]) => pageInstanceSet.has(id));
     const dataSources: [DataSource["id"], DataSource][] = [];
+    const props: [Prop["id"], Prop][] = [];
+    const resourceIds = new Set<Resource["id"]>();
+    const resources: [Resource["id"], Resource][] = [];
 
     // use whole project props to access id props from other pages
     const normalizedProps = normalizeProps({
@@ -323,14 +326,15 @@ export const prebuild = async (options: {
       source: "prebuild",
     });
 
-    const props: [Prop["id"], Prop][] = [];
     for (const prop of normalizedProps) {
       if (pageInstanceSet.has(prop.instanceId)) {
         props.push([prop.id, prop]);
+        if (prop.type === "resource") {
+          resourceIds.add(prop.value);
+        }
       }
     }
 
-    const resourceIds = new Set<Resource["id"]>();
     for (const [dataSourceId, dataSource] of siteData.build.dataSources) {
       if (
         dataSource.scopeInstanceId === undefined ||
@@ -343,7 +347,6 @@ export const prebuild = async (options: {
       }
     }
 
-    const resources: [Resource["id"], Resource][] = [];
     for (const [resourceId, resource] of siteData.build.resources ?? []) {
       if (resourceIds.has(resourceId)) {
         resources.push([resourceId, resource]);

--- a/packages/design-system/src/components/nested-input-button.tsx
+++ b/packages/design-system/src/components/nested-input-button.tsx
@@ -17,7 +17,7 @@ const style = css({
   ...textVariants.unit,
   color: theme.colors.foregroundSubtle,
   borderRadius: theme.borderRadius[2],
-  display: "inline-flex",
+  display: "flex",
   alignItems: "center",
   justifyContent: "center",
   whiteSpace: "pre", // to make nestedSelectButtonUnitless work as expected

--- a/packages/react-sdk/src/prop-meta.ts
+++ b/packages/react-sdk/src/prop-meta.ts
@@ -167,6 +167,13 @@ const TextContent = z.object({
   defaultValue: z.string().optional(),
 });
 
+const Resource = z.object({
+  ...common,
+  control: z.literal("resource"),
+  type: z.literal("resource"),
+  defaultValue: z.undefined().optional(),
+});
+
 export const PropMeta = z.union([
   Number,
   Range,
@@ -187,6 +194,7 @@ export const PropMeta = z.union([
   Date,
   Action,
   TextContent,
+  Resource,
 ]);
 
 export type PropMeta = z.infer<typeof PropMeta>;

--- a/packages/sdk-components-react-remix/src/webhook-form.ws.ts
+++ b/packages/sdk-components-react-remix/src/webhook-form.ws.ts
@@ -127,6 +127,13 @@ export const meta: WsComponentMeta = {
 };
 
 export const propsMeta: WsComponentPropsMeta = {
-  props,
+  props: {
+    ...props,
+    action: {
+      control: "resource",
+      type: "resource",
+      required: true,
+    },
+  },
   initialProps: ["id", "className", "state", "action"],
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/4093 https://github.com/webstudio-is/webstudio/issues/3871

Here added new resource control for out properties. It is replaced action and method properties webhook form. Now users will be able to additionally provide headers. In another PR headers will let user to customize body format.

Also migrated "action" in existing webhook forms to resource prop type.

![Screenshot 2024-10-22 at 16 07 38](https://github.com/user-attachments/assets/f80f329d-77fb-4980-802c-ded8f617bce2)
