### PR TITLE
refactor: drop display: contents

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
@@ -1,5 +1,4 @@
 import { useState, type ReactNode } from "react";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import {
   theme,
   Box,
@@ -464,10 +463,6 @@ const orderedDisplayValues = [
   "inline",
   "none",
 ];
-
-if (isFeatureEnabled("displayContents")) {
-  orderedDisplayValues.push("contents");
-}
 
 export const properties = [
   "display",

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -1,5 +1,4 @@
 // Only for development, is not supposed to be enabled at all.
-export const displayContents = false;
 export const internalComponents = false;
 export const unsupportedBrowsers = false;
 export const aiRadixComponents = false;


### PR DESCRIPTION
We have advanced panel which allows to set any value. No need to have display: contents behind the flag anymore.