### PR TITLE
fix: allow project redirects to dynamic paths

### DIFF
--- a/apps/builder/app/builder/features/project-settings/section-redirects.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-redirects.tsx
@@ -1,3 +1,6 @@
+import { useState, type ChangeEvent, useRef } from "react";
+import { flushSync } from "react-dom";
+import { useStore } from "@nanostores/react";
 import {
   Grid,
   Flex,
@@ -15,16 +18,14 @@ import {
   Tooltip,
 } from "@webstudio-is/design-system";
 import { ArrowRightIcon, TrashIcon } from "@webstudio-is/icons";
-import { useState, type ChangeEvent, useRef } from "react";
 import {
   PagePath,
   PageRedirect,
   ProjectNewRedirectPath,
 } from "@webstudio-is/sdk";
-import { useStore } from "@nanostores/react";
 import { $pages, $publishedOrigin } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
-import { flushSync } from "react-dom";
+import { matchPathnamePattern } from "~/builder/shared/url-pattern";
 import { getExistingRoutePaths, sectionSpacing } from "./utils";
 
 export const SectionRedirects = () => {
@@ -93,7 +94,13 @@ export const SectionRedirects = () => {
       }
 
       if (newPath.startsWith("/") === true) {
-        if (existingPaths.has(newPath) === false) {
+        let matched = false;
+        for (const pattern of existingPaths) {
+          if (matchPathnamePattern(pattern, newPath)) {
+            matched = true;
+          }
+        }
+        if (matched === false) {
           return ["This path doesn't exist in the project"];
         }
       }


### PR DESCRIPTION
Fixes https://discord.com/channels/955905230107738152/1300622567740018730

Users cannot specify dynamic path in redirect new path.