### PR TITLE
fix: XML Node with title tag nested in any other XML Node breaks document

### DIFF
--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml]._index.tsx
@@ -25,7 +25,7 @@ export const pageFontAssets: FontAsset[] = [];
 
 export const pageBackgroundImageAssets: ImageAsset[] = [];
 
-const Body = (props: any) => props.children;
+const Body = (props: any) => <svg>{props.children}</svg>;
 
 const Page = ({ system: system }: { system: any }) => {
   let sitemapxml = useResource("sitemapxml_1");

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap.xml]._index.tsx
@@ -60,7 +60,7 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
-  const text = renderToString(
+  let text = renderToString(
     <ReactSdkContext.Provider
       value={{
         imageLoader,
@@ -72,6 +72,10 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       <Page system={system} />
     </ReactSdkContext.Provider>
   );
+
+  // Xml is wrapped with <svg> to prevent React from hoisting elements like <title>, <meta>, and <link> out of their intended scope during rendering.
+  // More details: https://github.com/facebook/react/blob/7c8e5e7ab8bb63de911637892392c5efd8ce1d0f/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js#L3083
+  text = text.replace(/^<svg>/g, "").replace(/<\/svg>$/g, "");
 
   return new Response(`<?xml version="1.0" encoding="UTF-8"?>\n${text}`, {
     headers: { "Content-Type": "application/xml" },

--- a/fixtures/webstudio-remix-vercel/.webstudio/data.json
+++ b/fixtures/webstudio-remix-vercel/.webstudio/data.json
@@ -1,10 +1,10 @@
 {
   "build": {
-    "id": "1710e6a3-6f3b-44c9-8e4f-4176be77673e",
+    "id": "5646b5e6-a161-4fbc-8312-6e2852e1d4b3",
     "projectId": "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    "version": 341,
-    "createdAt": "2024-10-28T17:19:04.754+00:00",
-    "updatedAt": "2024-10-28T17:19:04.754+00:00",
+    "version": 345,
+    "createdAt": "2024-11-04T04:15:27.144+00:00",
+    "updatedAt": "2024-11-04T04:15:27.144+00:00",
     "pages": {
       "meta": {
         "siteName": "KittyGuardedZone",
@@ -2601,6 +2601,16 @@
           "type": "string",
           "value": "http://www.w3.org/1999/xhtml"
         }
+      ],
+      [
+        "kQb_yRWDNAsug8p2lhSxN",
+        {
+          "id": "kQb_yRWDNAsug8p2lhSxN",
+          "instanceId": "wLYkMGH-OJP4SnFB4F-bs",
+          "name": "tag",
+          "type": "string",
+          "value": "title"
+        }
       ]
     ],
     "dataSources": [
@@ -4075,6 +4085,10 @@
             {
               "type": "id",
               "value": "bBAE2vpcCLzlcin29wQYA"
+            },
+            {
+              "type": "id",
+              "value": "wLYkMGH-OJP4SnFB4F-bs"
             }
           ]
         }
@@ -4123,6 +4137,20 @@
           "id": "yDQOMG0BUdvM5g5hDV7JP",
           "component": "XmlNode",
           "children": []
+        }
+      ],
+      [
+        "wLYkMGH-OJP4SnFB4F-bs",
+        {
+          "type": "instance",
+          "id": "wLYkMGH-OJP4SnFB4F-bs",
+          "component": "XmlNode",
+          "children": [
+            {
+              "type": "text",
+              "value": "Hello"
+            }
+          ]
         }
       ]
     ],

--- a/fixtures/webstudio-remix-vercel/app/__generated__/$resources.sitemap.xml.ts
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/$resources.sitemap.xml.ts
@@ -1,26 +1,26 @@
 export const sitemap = [
   {
     path: "/",
-    lastModified: "2024-10-28",
+    lastModified: "2024-11-04",
   },
   {
     path: "/_route_with_symbols_",
-    lastModified: "2024-10-28",
+    lastModified: "2024-11-04",
   },
   {
     path: "/form",
-    lastModified: "2024-10-28",
+    lastModified: "2024-11-04",
   },
   {
     path: "/heading-with-id",
-    lastModified: "2024-10-28",
+    lastModified: "2024-11-04",
   },
   {
     path: "/resources",
-    lastModified: "2024-10-28",
+    lastModified: "2024-11-04",
   },
   {
     path: "/nested/nested-page",
-    lastModified: "2024-10-28",
+    lastModified: "2024-11-04",
   },
 ];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml]._index.tsx
@@ -25,7 +25,7 @@ export const pageFontAssets: FontAsset[] = [];
 
 export const pageBackgroundImageAssets: ImageAsset[] = [];
 
-const Body = (props: any) => props.children;
+const Body = (props: any) => <svg>{props.children}</svg>;
 const Heading = (props: any) => null;
 
 const Page = ({ system: system }: { system: any }) => {
@@ -73,6 +73,7 @@ const Page = ({ system: system }: { system: any }) => {
             hreflang={"en"}
             href={"custom-en-location"}
           />
+          <XmlNode tag={"title"}>{"Hello"}</XmlNode>
         </XmlNode>
       </XmlNode>
     </Body>

--- a/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml]._index.tsx
@@ -60,7 +60,7 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
-  const text = renderToString(
+  let text = renderToString(
     <ReactSdkContext.Provider
       value={{
         imageLoader,
@@ -72,6 +72,10 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       <Page system={system} />
     </ReactSdkContext.Provider>
   );
+
+  // Xml is wrapped with <svg> to prevent React from hoisting elements like <title>, <meta>, and <link> out of their intended scope during rendering.
+  // More details: https://github.com/facebook/react/blob/7c8e5e7ab8bb63de911637892392c5efd8ce1d0f/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js#L3083
+  text = text.replace(/^<svg>/g, "").replace(/<\/svg>$/g, "");
 
   return new Response(`<?xml version="1.0" encoding="UTF-8"?>\n${text}`, {
     headers: { "Content-Type": "application/xml" },

--- a/fixtures/webstudio-remix-vercel/package.json
+++ b/fixtures/webstudio-remix-vercel/package.json
@@ -6,7 +6,7 @@
     "typecheck": "tsc",
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link https://p-cddc1d44-af37-4cb6-a430-d300cf6f932d-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d'",
-    "fixtures:sync": "pnpm cli sync --buildId 1710e6a3-6f3b-44c9-8e4f-4176be77673e && pnpm prettier --write ./.webstudio/",
+    "fixtures:sync": "pnpm cli sync --buildId 5646b5e6-a161-4fbc-8312-6e2852e1d4b3 && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "pnpm cli build --template vercel --template internal --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },
   "private": true,

--- a/packages/cli/templates/defaults/app/route-templates/xml.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/xml.tsx
@@ -56,7 +56,7 @@ export const loader = async (arg: LoaderFunctionArgs) => {
   // typecheck
   arg.context.EXCLUDE_FROM_SEARCH satisfies boolean;
 
-  const text = renderToString(
+  let text = renderToString(
     <ReactSdkContext.Provider
       value={{
         imageLoader,
@@ -68,6 +68,10 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       <Page system={system} />
     </ReactSdkContext.Provider>
   );
+
+  // Xml is wrapped with <svg> to prevent React from hoisting elements like <title>, <meta>, and <link> out of their intended scope during rendering.
+  // More details: https://github.com/facebook/react/blob/7c8e5e7ab8bb63de911637892392c5efd8ce1d0f/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js#L3083
+  text = text.replace(/^<svg>/g, "").replace(/<\/svg>$/g, "");
 
   return new Response(`<?xml version="1.0" encoding="UTF-8"?>\n${text}`, {
     headers: { "Content-Type": "application/xml" },


### PR DESCRIPTION
## Description

closes #3715

## Steps for reproduction
paste in chrome
`view-source:https://webstudio-fixture-project-a-0su3o.wstd.work/sitemap.xml`

See title tag exists

<img width="412" alt="image" src="https://github.com/user-attachments/assets/66df98b3-8d41-4890-8957-6f0bf6a758bb">

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
