### PR TITLE
refactor: move selected page into awareness state

### DIFF
--- a/apps/builder/app/builder/features/address-bar.stories.tsx
+++ b/apps/builder/app/builder/features/address-bar.stories.tsx
@@ -7,10 +7,9 @@ import {
   $dataSourceVariables,
   $dataSources,
   $pages,
-  $selectedPage,
-  $selectedPageId,
 } from "~/shared/nano-states";
 import { registerContainers } from "~/shared/sync";
+import { $awareness, $selectedPage } from "~/shared/awareness";
 
 registerContainers();
 
@@ -98,7 +97,7 @@ export default {
 } satisfies Meta;
 
 export const AddressBar: StoryFn = () => {
-  $selectedPageId.set("dynamicId");
+  $awareness.set({ pageId: "dynamicId" });
   return (
     <>
       <Box

--- a/apps/builder/app/builder/features/address-bar.tsx
+++ b/apps/builder/app/builder/features/address-bar.tsx
@@ -37,7 +37,6 @@ import {
   $dataSourceVariables,
   $pages,
   $publishedOrigin,
-  $selectedPage,
   $selectedPageDefaultSystem,
   updateSystem,
 } from "~/shared/nano-states";
@@ -48,6 +47,7 @@ import {
   tokenizePathnamePattern,
 } from "~/builder/shared/url-pattern";
 import { savePathInHistory } from "~/shared/pages";
+import { $selectedPage } from "~/shared/awareness";
 
 const $selectedPagePath = computed([$selectedPage, $pages], (page, pages) => {
   if (pages === undefined || page === undefined) {

--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -30,7 +30,6 @@ import { useRef, useState, type ComponentPropsWithoutRef } from "react";
 import {
   $collaborativeInstanceSelector,
   $selectedInstanceSelector,
-  $selectedPage,
 } from "~/shared/nano-states";
 import { useMediaRecorder } from "./hooks/media-recorder";
 import { useLongPressToggle } from "./hooks/long-press-toggle";
@@ -41,6 +40,7 @@ import { useEffectEvent } from "~/shared/hook-utils/effect-event";
 import { AiApiException, RateLimitException } from "./api-exceptions";
 import { getSetting, setSetting } from "~/builder/shared/client-settings";
 import { flushSync } from "react-dom";
+import { $selectedPage } from "~/shared/awareness";
 
 type PartialButtonProps<T = ComponentPropsWithoutRef<typeof Button>> = {
   [key in keyof T]?: T[key];

--- a/apps/builder/app/builder/features/components/components.tsx
+++ b/apps/builder/app/builder/features/components/components.tsx
@@ -26,7 +26,7 @@ import {
 import { CollapsibleSection } from "~/builder/shared/collapsible-section";
 import { dragItemAttribute, useDraggable } from "./use-draggable";
 import { MetaIcon } from "~/builder/shared/meta-icon";
-import { $registeredComponentMetas, $selectedPage } from "~/shared/nano-states";
+import { $registeredComponentMetas } from "~/shared/nano-states";
 import {
   getMetaMaps,
   type MetaByCategory,
@@ -38,6 +38,7 @@ import { insert } from "./insert";
 import { matchSorter } from "match-sorter";
 import { parseComponentName } from "@webstudio-is/sdk";
 import type { Publish } from "~/shared/pubsub";
+import { $selectedPage } from "~/shared/awareness";
 
 const matchComponents = (
   metas: Array<WsComponentMeta>,

--- a/apps/builder/app/builder/features/components/insert.ts
+++ b/apps/builder/app/builder/features/components/insert.ts
@@ -5,7 +5,6 @@ import {
   $instances,
   $registeredComponentMetas,
   $selectedInstanceSelector,
-  $selectedPage,
 } from "~/shared/nano-states";
 import {
   computeInstancesConstraints,
@@ -13,6 +12,7 @@ import {
   getComponentTemplateData,
   insertTemplateData,
 } from "~/shared/instance-utils";
+import { $selectedPage } from "~/shared/awareness";
 
 const formatInsertionError = (component: string, meta: WsComponentMeta) => {
   const or = new Intl.ListFormat("en", {

--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -25,7 +25,6 @@ import {
   $selectedInstance,
   $registeredComponentMetas,
   $dragAndDropState,
-  $selectedPage,
 } from "~/shared/nano-states";
 import { NavigatorTree } from "~/builder/features/navigator";
 import type { Settings } from "~/builder/shared/client-settings";
@@ -33,6 +32,7 @@ import { MetaIcon } from "~/builder/shared/meta-icon";
 import { getInstanceLabel } from "~/shared/instance-utils";
 import { BindingPopoverProvider } from "~/builder/shared/binding-popover";
 import { $activeInspectorPanel } from "~/builder/shared/nano-states";
+import { $selectedPage } from "~/shared/awareness";
 
 const InstanceInfo = ({ instance }: { instance: Instance }) => {
   const metas = useStore($registeredComponentMetas);

--- a/apps/builder/app/builder/features/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator-tree.tsx
@@ -41,7 +41,6 @@ import {
   $propValuesByInstanceSelector,
   $registeredComponentMetas,
   $selectedInstanceSelector,
-  $selectedPage,
   getIndexedInstanceId,
   type ItemDropTarget,
 } from "~/shared/nano-states";
@@ -56,6 +55,7 @@ import {
 } from "~/shared/instance-utils";
 import { emitCommand } from "~/builder/shared/commands";
 import { useContentEditable } from "~/shared/dom-hooks";
+import { $selectedPage } from "~/shared/awareness";
 
 type TreeItem = {
   level: number;

--- a/apps/builder/app/builder/features/pages/page-utils.test.ts
+++ b/apps/builder/app/builder/features/pages/page-utils.test.ts
@@ -23,9 +23,9 @@ import {
   $dataSources,
   $pages,
   $resourceValues,
-  $selectedPageId,
 } from "~/shared/nano-states";
 import { registerContainers } from "~/shared/sync";
+import { $awareness } from "~/shared/awareness";
 
 setEnv("*");
 registerContainers();
@@ -413,7 +413,7 @@ test("page root scope should rely on selected page", () => {
     systemDataSourceId: "system",
   });
   $pages.set(pages);
-  $selectedPageId.set("pageId");
+  $awareness.set({ pageId: "pageId" });
   $dataSources.set(
     toMap([
       {
@@ -447,7 +447,7 @@ test("page root scope should use variable and resource values", () => {
       systemDataSourceId: "system",
     })
   );
-  $selectedPageId.set("homePageId");
+  $awareness.set({ pageId: "homePageId" });
   $dataSources.set(
     toMap([
       {
@@ -494,7 +494,7 @@ test("page root scope should prefill default system variable value", () => {
       systemDataSourceId: "systemId",
     })
   );
-  $selectedPageId.set("homePageId");
+  $awareness.set({ pageId: "homePageId" });
   $dataSources.set(
     toMap([
       {

--- a/apps/builder/app/builder/features/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/pages/page-utils.ts
@@ -21,11 +21,10 @@ import {
   $dataSources,
   $pages,
   $selectedInstanceSelector,
-  $selectedPage,
-  $selectedPageId,
   $variableValuesByInstanceSelector,
 } from "~/shared/nano-states";
 import { insertPageCopyMutable } from "~/shared/page-utils";
+import { $awareness, $selectedPage } from "~/shared/awareness";
 
 /**
  * When page or folder needs to be deleted or moved to a different parent,
@@ -206,8 +205,8 @@ export const getAllChildrenAndSelf = (
 export const deletePageMutable = (pageId: Page["id"], data: WebstudioData) => {
   const { pages } = data;
   // deselect page before deleting to avoid flash of content
-  if ($selectedPageId.get() === pageId) {
-    $selectedPageId.set(pages.homePage.id);
+  if ($awareness.get()?.pageId === pageId) {
+    $awareness.set({ pageId: pages.homePage.id });
     $selectedInstanceSelector.set(undefined);
   }
   const rootInstanceId = findPageByIdOrPath(pageId, pages)?.rootInstanceId;

--- a/apps/builder/app/builder/features/pages/pages.tsx
+++ b/apps/builder/app/builder/features/pages/pages.tsx
@@ -27,7 +27,7 @@ import {
 } from "@webstudio-is/icons";
 import { ExtendedPanel } from "../../shared/extended-sidebar-panel";
 import { NewPageSettings, PageSettings } from "./page-settings";
-import { $editingPageId, $pages, $selectedPageId } from "~/shared/nano-states";
+import { $editingPageId, $pages } from "~/shared/nano-states";
 import { switchPage } from "~/shared/pages";
 import {
   getAllChildrenAndSelf,
@@ -50,6 +50,7 @@ import {
 import { atom, computed } from "nanostores";
 import { isPathnamePattern } from "~/builder/shared/url-pattern";
 import { updateWebstudioData } from "~/shared/instance-utils";
+import { $selectedPage } from "~/shared/awareness";
 
 const ItemSuffix = ({
   isParentSelected,
@@ -439,7 +440,7 @@ const PageEditor = ({
   editingPageId: string;
   onClose: () => void;
 }) => {
-  const currentPageId = useStore($selectedPageId);
+  const currentPage = useStore($selectedPage);
 
   if (editingPageId === newPageId) {
     return (
@@ -459,7 +460,7 @@ const PageEditor = ({
       onDelete={() => {
         onClose();
         // switch to home page when deleted currently selected page
-        if (editingPageId === currentPageId) {
+        if (editingPageId === currentPage?.id) {
           const pages = $pages.get();
           if (pages) {
             switchPage(pages.homePage.id);
@@ -504,11 +505,11 @@ const FolderEditor = ({
 };
 
 export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
-  const currentPageId = useStore($selectedPageId);
+  const currentPage = useStore($selectedPage);
   const editingItemId = useStore($editingPageId);
   const pages = useStore($pages);
 
-  if (currentPageId === undefined || pages === undefined) {
+  if (currentPage === undefined || pages === undefined) {
     return;
   }
 
@@ -557,7 +558,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
       <Separator />
 
       <PagesTree
-        selectedPageId={currentPageId}
+        selectedPageId={currentPage.id}
         onSelect={(itemId) => {
           switchPage(itemId);
           onClose();
@@ -566,7 +567,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
         onEdit={(itemId) => {
           // always select page when edit its settings
           if (itemId && isFolder(itemId, pages.folders) === false) {
-            $selectedPageId.set(itemId);
+            switchPage(itemId);
           }
           $editingPageId.set(itemId);
         }}

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.stories.tsx
@@ -10,9 +10,9 @@ import {
   $pages,
   $props,
   registerComponentLibrary,
-  $selectedPageId,
 } from "~/shared/nano-states";
 import { createDefaultPages } from "@webstudio-is/project-build";
+import { $awareness } from "~/shared/awareness";
 
 let id = 0;
 const unique = () => `${++id}`;
@@ -95,7 +95,7 @@ const rootInstance = addLinkableSections(
   ["company", "employees"],
   $pages.get()?.pages[0]
 );
-$selectedPageId.set($pages.get()?.homePage.id);
+$awareness.set({ pageId: $pages.get()?.homePage.id ?? "" });
 
 const instance: Instance = {
   id: instanceId,

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -41,7 +41,6 @@ import {
   $dataSources,
   $resources,
   $selectedInstanceSelector,
-  $selectedPage,
   $variableValuesByInstanceSelector,
 } from "~/shared/nano-states";
 import {
@@ -56,6 +55,7 @@ import {
   EditorDialogControl,
 } from "~/builder/shared/code-editor-base";
 import { parseCurl, type CurlRequest } from "./curl";
+import { $selectedPage } from "~/shared/awareness";
 
 const validateUrl = (value: string, scope: Record<string, unknown>) => {
   const evaluatedValue = evaluateExpressionWithinScope(value, scope);

--- a/apps/builder/app/builder/features/settings-panel/variables-section.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.stories.tsx
@@ -4,12 +4,12 @@ import { VariablesSection as VariablesSectionComponent } from "./variables-secti
 import {
   $pages,
   $selectedInstanceSelector,
-  $selectedPageId,
   $instances,
 } from "~/shared/nano-states";
 import { registerContainers } from "~/shared/sync";
 import { createDefaultPages } from "@webstudio-is/project-build";
 import { $userPlanFeatures } from "~/builder/shared/nano-states";
+import { $awareness } from "~/shared/awareness";
 
 $userPlanFeatures.set({
   ...$userPlanFeatures.get(),
@@ -28,7 +28,7 @@ $instances.set(
     ["root", { id: "root", type: "instance", component: "Box", children: [] }],
   ])
 );
-$selectedPageId.set("home");
+$awareness.set({ pageId: "home" });
 $pages.set(
   createDefaultPages({ rootInstanceId: "root", systemDataSourceId: "system" })
 );

--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -31,7 +31,6 @@ import {
   $props,
   $resources,
   $selectedInstanceSelector,
-  $selectedPage,
   $variableValuesByInstanceSelector,
 } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
@@ -47,6 +46,7 @@ import {
   VariablePopoverProvider,
   VariablePopoverTrigger,
 } from "./variable-popover";
+import { $selectedPage } from "~/shared/awareness";
 
 /**
  * find variables defined specifically on this selected instance

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -12,7 +12,7 @@ import {
   Kbd,
 } from "@webstudio-is/design-system";
 import type { Project } from "@webstudio-is/project";
-import { $editingPageId, $pages, $selectedPage } from "~/shared/nano-states";
+import { $editingPageId, $pages } from "~/shared/nano-states";
 import { PreviewButton } from "./preview";
 import { ShareButton } from "./share";
 import { PublishButton } from "./publish";
@@ -27,6 +27,7 @@ import { AddressBarPopover } from "../address-bar";
 import { toggleActiveSidebarPanel } from "~/builder/shared/nano-states";
 import type { ReactNode } from "react";
 import { CloneButton } from "./clone";
+import { $selectedPage } from "~/shared/awareness";
 
 const PagesButton = () => {
   const page = useStore($selectedPage);

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -41,7 +41,6 @@ import {
   $assets,
   $pages,
   $instances,
-  $selectedPage,
   registerComponentLibrary,
   $registeredComponents,
   subscribeComponentHooks,
@@ -66,6 +65,7 @@ import { subscribeFontLoadingDone } from "./shared/font-weight-support";
 import { useDebounceEffect } from "~/shared/hook-utils/use-debounce-effect";
 import { subscribeSelected } from "./instance-selected";
 import { subscribeScrollNewInstanceIntoView } from "./shared/scroll-new-instance-into-view";
+import { $selectedPage } from "~/shared/awareness";
 
 registerContainers();
 

--- a/apps/builder/app/canvas/collapsed.ts
+++ b/apps/builder/app/canvas/collapsed.ts
@@ -1,3 +1,4 @@
+import htmlTags, { voidHtmlTags, type HtmlTags } from "html-tags";
 import { collapsedAttribute, idAttribute } from "@webstudio-is/react-sdk";
 import {
   getCascadedBreakpointIds,
@@ -9,12 +10,11 @@ import {
   $breakpoints,
   $instances,
   $registeredComponentMetas,
-  $selectedPage,
   $stylesIndex,
 } from "~/shared/nano-states";
 import { $selectedBreakpoint } from "~/shared/nano-states";
 import { subscribe } from "~/shared/pubsub";
-import htmlTags, { voidHtmlTags, type HtmlTags } from "html-tags";
+import { $selectedPage } from "~/shared/awareness";
 
 const isHtmlTag = (tag: string): tag is HtmlTags =>
   htmlTags.includes(tag as HtmlTags);

--- a/apps/builder/app/canvas/features/text-editor/text-editor.stories.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.stories.tsx
@@ -10,13 +10,13 @@ import {
   $instances,
   $pages,
   $registeredComponentMetas,
-  $selectedPageId,
   $textEditingInstanceSelector,
   $textToolbar,
 } from "~/shared/nano-states";
 import { TextEditor } from "./text-editor";
 import { emitCommand, subscribeCommands } from "~/canvas/shared/commands";
 import { $, renderJsx } from "@webstudio-is/sdk/testing";
+import { $awareness } from "~/shared/awareness";
 
 export default {
   component: TextEditor,
@@ -238,7 +238,7 @@ export const CursorPositioningUpDown: StoryFn<typeof TextEditor> = () => {
       ],
     });
 
-    $selectedPageId.set("pageId");
+    $awareness.set({ pageId: "pageId" });
 
     $registeredComponentMetas.set(
       new Map([

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -53,7 +53,6 @@ import { findAllEditableInstanceSelector } from "~/shared/instance-utils";
 import {
   $registeredComponentMetas,
   $selectedInstanceSelector,
-  $selectedPage,
   $textEditingInstanceSelector,
 } from "~/shared/nano-states";
 import {
@@ -62,6 +61,7 @@ import {
 } from "~/shared/dom-utils";
 import deepEqual from "fast-deep-equal";
 import { setDataCollapsed } from "~/canvas/collapsed";
+import { $selectedPage } from "~/shared/awareness";
 // import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
 
 const BindInstanceToNodePlugin = ({ refs }: { refs: Refs }) => {

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -8,7 +8,7 @@ import {
   Fragment,
   type ReactNode,
 } from "react";
-
+import { $getSelection, $isRangeSelection } from "lexical";
 import { computed } from "nanostores";
 import { useStore } from "@nanostores/react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
@@ -37,7 +37,6 @@ import {
   $registeredComponentMetas,
   $selectedInstanceRenderState,
   $selectedInstanceSelector,
-  $selectedPage,
 } from "~/shared/nano-states";
 import { $textEditingInstanceSelector } from "~/shared/nano-states";
 import {
@@ -48,7 +47,7 @@ import { setDataCollapsed } from "~/canvas/collapsed";
 import { getIsVisuallyHidden } from "~/shared/visually-hidden";
 import { serverSyncStore } from "~/shared/sync";
 import { TextEditor } from "../text-editor";
-import { $getSelection, $isRangeSelection } from "lexical";
+import { $selectedPage } from "~/shared/awareness";
 
 const ContentEditable = ({
   renderComponentWithRef,

--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -4,11 +4,11 @@ import {
   matchPathnamePattern,
   tokenizePathnamePattern,
 } from "~/builder/shared/url-pattern";
+import { $selectedPage } from "~/shared/awareness";
 import {
   $dataSourceVariables,
   $isPreviewMode,
   $pages,
-  $selectedPage,
   updateSystem,
 } from "~/shared/nano-states";
 import { savePathInHistory, switchPage } from "~/shared/pages";

--- a/apps/builder/app/shared/awareness.ts
+++ b/apps/builder/app/shared/awareness.ts
@@ -1,0 +1,19 @@
+import { atom, computed } from "nanostores";
+import { findPageByIdOrPath } from "@webstudio-is/sdk";
+import { $pages } from "./nano-states/pages";
+
+type Awareness = {
+  pageId: string;
+};
+
+export const $awareness = atom<undefined | Awareness>();
+
+export const $selectedPage = computed(
+  [$pages, $awareness],
+  (pages, awareness) => {
+    if (pages === undefined || awareness === undefined) {
+      return;
+    }
+    return findPageByIdOrPath(awareness.pageId, pages);
+  }
+);

--- a/apps/builder/app/shared/copy-paste/plugin-embed-template.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-embed-template.ts
@@ -6,7 +6,6 @@ import {
 import {
   $selectedInstanceSelector,
   $instances,
-  $selectedPage,
   $registeredComponentMetas,
   $breakpoints,
 } from "../nano-states";
@@ -16,6 +15,7 @@ import {
   insertTemplateData,
 } from "../instance-utils";
 import { isBaseBreakpoint } from "../breakpoints";
+import { $selectedPage } from "~/shared/awareness";
 
 const version = "@webstudio/template";
 

--- a/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
@@ -25,10 +25,10 @@ import {
   $project,
   $props,
   $registeredComponentMetas,
-  $selectedPageId,
 } from "../nano-states";
 import { onCopy, onCut, onPaste } from "./plugin-instance";
 import { createDefaultPages } from "@webstudio-is/project-build";
+import { $awareness } from "../awareness";
 
 const expectString = expect.any(String) as unknown as string;
 
@@ -46,7 +46,7 @@ $pages.set(
     systemDataSourceId: "",
   })
 );
-$selectedPageId.set("home-page");
+$awareness.set({ pageId: "home-page" });
 
 const createInstance = (
   id: Instance["id"],

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -1,6 +1,7 @@
 import { shallowEqual } from "shallow-equal";
 import { z } from "zod";
 import { toast } from "@webstudio-is/design-system";
+import { portalComponent } from "@webstudio-is/react-sdk";
 import {
   Instance,
   Instances,
@@ -9,7 +10,6 @@ import {
 } from "@webstudio-is/sdk";
 import {
   $selectedInstanceSelector,
-  $selectedPage,
   $project,
   $registeredComponentMetas,
   $instances,
@@ -27,7 +27,7 @@ import {
   getWebstudioData,
   insertInstanceChildrenMutable,
 } from "../instance-utils";
-import { portalComponent } from "@webstudio-is/react-sdk";
+import { $selectedPage } from "~/shared/awareness";
 
 const version = "@webstudio/instance/v0.1";
 

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.ts
@@ -17,10 +17,10 @@ import {
   $instances,
   $registeredComponentMetas,
   $selectedInstanceSelector,
-  $selectedPage,
 } from "../nano-states";
 import { isBaseBreakpoint } from "../breakpoints";
 import { denormalizeSrcProps } from "./asset-upload";
+import { $selectedPage } from "~/shared/awareness";
 
 const micromarkOptions = {
   extensions: [gfm()],

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
@@ -11,7 +11,6 @@ import {
   $instances,
   $registeredComponentMetas,
   $selectedInstanceSelector,
-  $selectedPage,
   $project,
 } from "../../nano-states";
 import {
@@ -26,6 +25,7 @@ import { addStyles } from "./styles";
 import { builderApi } from "~/shared/builder-api";
 import { denormalizeSrcProps } from "../asset-upload";
 import { nanoHash } from "~/shared/nano-hash";
+import { $selectedPage } from "~/shared/awareness";
 
 const { toast } = builderApi;
 

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -46,7 +46,6 @@ import {
   $breakpoints,
   $pages,
   $resources,
-  $selectedPage,
 } from "./nano-states";
 import {
   type DroppableTarget,
@@ -64,6 +63,7 @@ import { humanizeString } from "./string-utils";
 import { serverSyncStore } from "./sync";
 import { setDifference, setUnion } from "./shim";
 import { breakCyclesMutable, findCycles } from "@webstudio-is/project-build";
+import { $selectedPage } from "./awareness";
 
 export const updateWebstudioData = (mutate: (data: WebstudioData) => void) => {
   serverSyncStore.createTransaction(

--- a/apps/builder/app/shared/nano-states/components.ts
+++ b/apps/builder/app/shared/nano-states/components.ts
@@ -1,3 +1,4 @@
+import { nanoid } from "nanoid";
 import { shallowEqual } from "shallow-equal";
 import type { ExoticComponent } from "react";
 import { atom } from "nanostores";
@@ -15,9 +16,8 @@ import { decodeDataSourceVariable } from "@webstudio-is/sdk";
 import type { InstanceSelector } from "../tree-utils";
 import { $dataSources, $memoryProps, $props } from "./misc";
 import { $instances, $selectedInstanceSelector } from "./instances";
-import { $selectedPage } from "./pages";
 import { $dataSourceVariables } from "./variables";
-import { nanoid } from "nanoid";
+import { $selectedPage } from "../awareness";
 
 const createHookContext = (): HookContext => {
   const metas = $registeredComponentMetas.get();

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -1,8 +1,8 @@
 import { atom, computed } from "nanostores";
 import { ROOT_INSTANCE_ID, type Instances } from "@webstudio-is/sdk";
-import type { InstanceSelector } from "../tree-utils";
-import { $selectedPage } from "./pages";
 import { rootComponent } from "@webstudio-is/react-sdk";
+import type { InstanceSelector } from "../tree-utils";
+import { $selectedPage } from "../awareness";
 
 export const $isResizingCanvas = atom(false);
 

--- a/apps/builder/app/shared/nano-states/pages.ts
+++ b/apps/builder/app/shared/nano-states/pages.ts
@@ -1,19 +1,8 @@
-import { atom, computed } from "nanostores";
-import { findPageByIdOrPath, type Page, type Pages } from "@webstudio-is/sdk";
+import { atom } from "nanostores";
+import type { Page, Pages } from "@webstudio-is/sdk";
 
 export const $pages = atom<undefined | Pages>(undefined);
 
-export const $selectedPageId = atom<undefined | Page["id"]>(undefined);
 export const $selectedPageHash = atom<string>("");
-
-export const $selectedPage = computed(
-  [$pages, $selectedPageId],
-  (pages, selectedPageId) => {
-    if (pages === undefined || selectedPageId === undefined) {
-      return;
-    }
-    return findPageByIdOrPath(selectedPageId, pages);
-  }
-);
 
 export const $editingPageId = atom<undefined | Page["id"]>();

--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -13,10 +13,11 @@ import {
   $variableValuesByInstanceSelector,
   computeExpression,
 } from "./props";
-import { $pages, $selectedPageId } from "./pages";
+import { $pages } from "./pages";
 import { $assets, $dataSources, $props, $resources } from "./misc";
 import { $params } from "~/canvas/stores";
 import { $dataSourceVariables, $resourceValues } from "./variables";
+import { $awareness } from "../awareness";
 
 setEnv("*");
 
@@ -39,7 +40,7 @@ const selectPageRoot = (rootInstanceId: Instance["id"]) => {
     systemDataSourceId: "systemId",
   });
   $pages.set(defaultPages);
-  $selectedPageId.set(defaultPages.homePage.id);
+  $awareness.set({ pageId: defaultPages.homePage.id });
 };
 
 beforeEach(() => {

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -33,7 +33,7 @@ import {
   $memoryProps,
   $isPreviewMode,
 } from "./misc";
-import { $selectedPage, $pages } from "./pages";
+import { $pages } from "./pages";
 import type { InstanceSelector } from "../tree-utils";
 import { $params } from "~/canvas/stores";
 import { restResourcesLoader } from "../router-utils";
@@ -45,6 +45,7 @@ import {
 } from "./variables";
 import { uploadingFileDataToAsset } from "~/builder/shared/assets/asset-utils";
 import { fetch } from "~/shared/fetch.client";
+import { $selectedPage } from "../awareness";
 
 export const getIndexedInstanceId = (
   instanceId: Instance["id"],

--- a/apps/builder/app/shared/nano-states/variables.ts
+++ b/apps/builder/app/shared/nano-states/variables.ts
@@ -5,7 +5,7 @@ import {
   tokenizePathnamePattern,
 } from "~/builder/shared/url-pattern";
 import { $publishedOrigin } from "./misc";
-import { $selectedPage } from "./pages";
+import { $selectedPage } from "../awareness";
 
 export const $dataSourceVariables = atom<Map<DataSource["id"], unknown>>(
   new Map()

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -6,13 +6,12 @@ import {
   $authToken,
   $pages,
   $project,
-  $selectedPage,
-  $selectedPageId,
   $selectedPageHash,
   $selectedInstanceSelector,
   $isPreviewMode,
 } from "~/shared/nano-states";
 import { builderPath } from "~/shared/router-utils";
+import { $awareness, $selectedPage } from "../awareness";
 
 export const switchPage = (pageId: Page["id"], pageHash: string = "") => {
   const pages = $pages.get();
@@ -28,7 +27,7 @@ export const switchPage = (pageId: Page["id"], pageHash: string = "") => {
   }
 
   $selectedPageHash.set(pageHash);
-  $selectedPageId.set(page.id);
+  $awareness.set({ pageId: page.id });
   $selectedInstanceSelector.set([page.rootInstanceId]);
 };
 

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -15,7 +15,6 @@ import {
   $styleSources,
   $styleSourceSelections,
   $assets,
-  $selectedPageId,
   $selectedPageHash,
   $selectedInstanceSelector,
   $selectedInstanceBrowserStyle,
@@ -44,6 +43,7 @@ import {
   $detectedFontsWeights,
 } from "~/shared/nano-states";
 import { $ephemeralStyles } from "~/canvas/stores";
+import { $awareness } from "../awareness";
 
 enableMapSet();
 // safari structuredClone fix
@@ -98,9 +98,9 @@ export const registerContainers = () => {
   clientStores.set("project", $project);
   clientStores.set("dataSourceVariables", $dataSourceVariables);
   clientStores.set("resourceValues", $resourceValues);
-  clientStores.set("selectedPageId", $selectedPageId);
   clientStores.set("selectedPageHash", $selectedPageHash);
   clientStores.set("selectedInstanceSelector", $selectedInstanceSelector);
+  clientStores.set("awareness", $awareness);
   clientStores.set(
     "selectedInstanceBrowserStyle",
     $selectedInstanceBrowserStyle


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/4364

We need to implement universal linking of current user view. For this I added "awareness" state which reflects terminology from collaboration libraries.

First migrated selected page id and fixed usages.