### PR TITLE
feat: Add builderMode, add mode "edit"

### DIFF
--- a/apps/builder/app/builder/features/ai/ai-command-bar.tsx
+++ b/apps/builder/app/builder/features/ai/ai-command-bar.tsx
@@ -61,7 +61,7 @@ const initialPrompts = [
   "Create a testimonials section on 2 rows. The first row has a heading and subheading, the second row has 3 testimonial cards with an image, headline, description and link.",
 ];
 
-export const AiCommandBar = ({ isPreviewMode }: { isPreviewMode: boolean }) => {
+export const AiCommandBar = () => {
   const [value, setValue] = useState("");
   const [prompts, setPrompts] = useState<string[]>(initialPrompts);
   const isMenuOpen = getSetting("isAiMenuOpen");
@@ -166,10 +166,6 @@ export const AiCommandBar = ({ isPreviewMode }: { isPreviewMode: boolean }) => {
       enableCanvasPointerEvents();
     },
   });
-
-  if (isPreviewMode) {
-    return;
-  }
 
   const handleAiRequest = async (prompt: string) => {
     if (abortController.current) {

--- a/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-popover.tsx
@@ -28,6 +28,7 @@ import {
   $styles,
   $selectedBreakpointId,
   $selectedBreakpoint,
+  $isContentMode,
 } from "~/shared/nano-states";
 import {
   $breakpointsMenuView,
@@ -47,6 +48,7 @@ export const BreakpointsPopover = () => {
   const breakpoints = useStore($breakpoints);
   const selectedBreakpoint = useStore($selectedBreakpoint);
   const scale = useStore($scale);
+  const isContentMode = useStore($isContentMode);
 
   if (selectedBreakpoint === undefined) {
     return null;
@@ -183,18 +185,27 @@ export const BreakpointsPopover = () => {
                 padding: theme.spacing[5],
               }}
             >
-              <Button
-                color="neutral"
-                css={{ flexGrow: 1 }}
-                onClick={(event) => {
-                  event.preventDefault();
-                  $breakpointsMenuView.set(
-                    view === "initial" ? "editor" : "initial"
-                  );
-                }}
+              <Tooltip
+                content={
+                  isContentMode
+                    ? "Editing is not allowed in content mode"
+                    : undefined
+                }
               >
-                {view === "editor" ? "Done" : "Edit breakpoints"}
-              </Button>
+                <Button
+                  color="neutral"
+                  css={{ flexGrow: 1 }}
+                  disabled={isContentMode}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    $breakpointsMenuView.set(
+                      view === "initial" ? "editor" : "initial"
+                    );
+                  }}
+                >
+                  {view === "editor" ? "Done" : "Edit breakpoints"}
+                </Button>
+              </Tooltip>
             </Flex>
           </>
         )}

--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -24,6 +24,7 @@ import { FloatingPanelProvider } from "~/builder/shared/floating-panel";
 import {
   $registeredComponentMetas,
   $dragAndDropState,
+  $isDesignMode,
 } from "~/shared/nano-states";
 import { NavigatorTree } from "~/builder/features/navigator";
 import type { Settings } from "~/builder/shared/client-settings";
@@ -78,6 +79,7 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
   const metas = useStore($registeredComponentMetas);
   const selectedPage = useStore($selectedPage);
   const activeInspectorPanel = useStore($activeInspectorPanel);
+  const isDesignMode = useStore($isDesignMode);
 
   if (navigatorLayout === "docked" && isDragging) {
     return <NavigatorTree />;
@@ -100,7 +102,7 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
   type PanelName = "style" | "settings";
 
   const availablePanels = new Set<PanelName>();
-  if (documentType === "html" && (meta?.stylable ?? true)) {
+  if (documentType === "html" && (meta?.stylable ?? true) && isDesignMode) {
     availablePanels.add("style");
   }
   // @todo hide root component settings until

--- a/apps/builder/app/builder/features/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator-tree.tsx
@@ -36,6 +36,7 @@ import {
   $editingItemSelector,
   $hoveredInstanceSelector,
   $instances,
+  $isContentMode,
   $props,
   $propsIndex,
   $propValuesByInstanceSelector,
@@ -404,6 +405,10 @@ const getBuilderDropTarget = (
 };
 
 const canDrag = (instance: Instance) => {
+  if ($isContentMode.get()) {
+    return false;
+  }
+
   const meta = $registeredComponentMetas.get().get(instance.component);
   if (meta === undefined) {
     return true;

--- a/apps/builder/app/builder/features/navigator/navigator.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator.tsx
@@ -8,8 +8,11 @@ import {
 import { CrossIcon } from "@webstudio-is/icons";
 import { CssPreview } from "./css-preview";
 import { NavigatorTree } from "./navigator-tree";
+import { $isDesignMode } from "~/shared/nano-states";
+import { useStore } from "@nanostores/react";
 
 export const NavigatorPanel = ({ onClose }: { onClose: () => void }) => {
+  const isDesignMode = useStore($isDesignMode);
   return (
     <>
       <PanelTitle
@@ -30,7 +33,7 @@ export const NavigatorPanel = ({ onClose }: { onClose: () => void }) => {
       <Flex grow direction="column" justify="end">
         <NavigatorTree />
         <Separator />
-        <CssPreview />
+        {isDesignMode && <CssPreview />}
       </Flex>
     </>
   );

--- a/apps/builder/app/builder/features/pages/pages.tsx
+++ b/apps/builder/app/builder/features/pages/pages.tsx
@@ -27,7 +27,7 @@ import {
 } from "@webstudio-is/icons";
 import { ExtendedPanel } from "../../shared/extended-sidebar-panel";
 import { NewPageSettings, PageSettings } from "./page-settings";
-import { $editingPageId, $pages } from "~/shared/nano-states";
+import { $editingPageId, $isContentMode, $pages } from "~/shared/nano-states";
 import {
   getAllChildrenAndSelf,
   reparentOrphansMutable,
@@ -334,6 +334,10 @@ const PagesTree = ({
               isLastChild={item.isLastChild}
               data={item}
               canDrag={() => {
+                if ($isContentMode.get()) {
+                  return false;
+                }
+
                 // forbid dragging home page
                 if (item.id === pages.homePage.id) {
                   toast.error("Home page cannot be moved");

--- a/apps/builder/app/builder/features/settings-panel/controls/text.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text.tsx
@@ -64,6 +64,7 @@ export const TextControl = ({
         onBlur={localValue.save}
         onSubmit={localValue.save}
       />
+
       <BindingPopover
         scope={scope}
         aliases={aliases}

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -9,6 +9,7 @@ import {
   Separator,
   Flex,
   Box,
+  Grid,
 } from "@webstudio-is/design-system";
 import {
   descendantComponent,
@@ -18,11 +19,12 @@ import {
   $propValuesByInstanceSelector,
   $propsIndex,
   $props,
+  $isDesignMode,
+  $isContentMode,
 } from "~/shared/nano-states";
 import { CollapsibleSectionWithAddButton } from "~/builder/shared/collapsible-section";
 import { renderControl } from "../controls/combined";
 import { usePropsLogic, type PropAndMeta } from "./use-props-logic";
-import { Row } from "../shared";
 import { serverSyncStore } from "~/shared/sync";
 import { $selectedInstanceKey } from "~/shared/awareness";
 
@@ -155,41 +157,57 @@ type PropsSectionProps = {
 // A UI componet with minimum logic that can be demoed in Storybook etc.
 export const PropsSection = (props: PropsSectionProps) => {
   const { propsLogic: logic } = props;
-
   const [addingProp, setAddingProp] = useState(false);
+  const isDesignMode = useStore($isDesignMode);
+  const isContentMode = useStore($isContentMode);
 
   const hasItems =
     logic.addedProps.length > 0 || addingProp || logic.initialProps.length > 0;
 
+  const showPropertiesSection =
+    isDesignMode || (isContentMode && logic.initialProps.length > 0);
+
   return (
     <>
-      <Row css={{ py: theme.panel.paddingBlock }}>
-        {logic.systemProps.map((item) => renderProperty(props, item))}
-      </Row>
+      <Grid
+        css={{
+          paddingBottom: theme.panel.paddingBlock,
+        }}
+      >
+        {logic.systemProps.map((item) => (
+          <Box
+            key={item.propName}
+            css={{ paddingInline: theme.panel.paddingInline }}
+          >
+            {renderProperty(props, item)}
+          </Box>
+        ))}
+      </Grid>
 
       <Separator />
-
-      <CollapsibleSectionWithAddButton
-        label="Properties & Attributes"
-        onAdd={() => setAddingProp(true)}
-        hasItems={hasItems}
-      >
-        <Flex gap="1" direction="column">
-          {addingProp && (
-            <AddPropertyOrAttribute
-              availableProps={logic.availableProps}
-              onPropSelected={(propName) => {
-                setAddingProp(false);
-                logic.handleAdd(propName);
-              }}
-            />
-          )}
-          {logic.addedProps.map((item) =>
-            renderProperty(props, item, { deletable: true })
-          )}
-          {logic.initialProps.map((item) => renderProperty(props, item))}
-        </Flex>
-      </CollapsibleSectionWithAddButton>
+      {showPropertiesSection && (
+        <CollapsibleSectionWithAddButton
+          label="Properties & Attributes"
+          onAdd={isDesignMode ? () => setAddingProp(true) : undefined}
+          hasItems={hasItems}
+        >
+          <Flex gap="1" direction="column">
+            {addingProp && (
+              <AddPropertyOrAttribute
+                availableProps={logic.availableProps}
+                onPropSelected={(propName) => {
+                  setAddingProp(false);
+                  logic.handleAdd(propName);
+                }}
+              />
+            )}
+            {logic.addedProps.map((item) =>
+              renderProperty(props, item, { deletable: true })
+            )}
+            {logic.initialProps.map((item) => renderProperty(props, item))}
+          </Flex>
+        </CollapsibleSectionWithAddButton>
+      )}
     </>
   );
 };

--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -15,6 +15,7 @@ import { UpgradeIcon } from "@webstudio-is/icons";
 import { useStore } from "@nanostores/react";
 import { $userPlanFeatures } from "~/builder/shared/nano-states";
 import cmsUpgradeBanner from "./cms-upgrade-banner.svg?url";
+import { $isDesignMode } from "~/shared/nano-states";
 
 export const SettingsPanelContainer = ({
   selectedInstance,
@@ -22,11 +23,16 @@ export const SettingsPanelContainer = ({
   selectedInstance: Instance;
 }) => {
   const { allowDynamicData } = useStore($userPlanFeatures);
+  const isDesignMode = useStore($isDesignMode);
+
   return (
     <Box css={{ pt: theme.spacing[5] }}>
       <SettingsSection />
+
       <PropsSectionContainer selectedInstance={selectedInstance} />
-      <VariablesSection />
+
+      {isDesignMode && <VariablesSection />}
+
       {allowDynamicData === false && (
         <PanelBanner>
           <img

--- a/apps/builder/app/builder/features/topbar/editor.tsx
+++ b/apps/builder/app/builder/features/topbar/editor.tsx
@@ -1,0 +1,24 @@
+import { useStore } from "@nanostores/react";
+import { TextIcon } from "@webstudio-is/icons";
+import { ToolbarToggleItem, Tooltip } from "@webstudio-is/design-system";
+import { $isContentMode } from "~/shared/nano-states";
+import { emitCommand } from "~/builder/shared/commands";
+
+export const EditorButton = () => {
+  const isContentMode = useStore($isContentMode);
+
+  return (
+    <Tooltip content="Toggle editor">
+      <ToolbarToggleItem
+        value="editor"
+        aria-label="Toggle editor"
+        variant="preview"
+        data-state={isContentMode ? "on" : "off"}
+        onClick={() => emitCommand("toggleEditor")}
+        tabIndex={0}
+      >
+        <TextIcon />
+      </ToolbarToggleItem>
+    </Tooltip>
+  );
+};

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -28,6 +28,8 @@ import { toggleActiveSidebarPanel } from "~/builder/shared/nano-states";
 import type { ReactNode } from "react";
 import { CloneButton } from "./clone";
 import { $selectedPage } from "~/shared/awareness";
+import { EditorButton } from "./editor";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 const PagesButton = () => {
   const page = useStore($selectedPage);
@@ -123,6 +125,7 @@ export const Topbar = ({ project, hasProPlan, css, loading }: TopbarProps) => {
         >
           <ViewMode />
           <SyncStatus />
+          {isFeatureEnabled("contentEditableMode") && <EditorButton />}
           <PreviewButton />
           <ShareButton projectId={project.id} hasProPlan={hasProPlan} />
           <PublishButton projectId={project.id} />

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -45,7 +45,12 @@ import {
   type EditorApi,
 } from "./expression-editor";
 import { useSideOffset } from "./floating-panel";
-import { $dataSourceVariables, computeExpression } from "~/shared/nano-states";
+import {
+  $dataSourceVariables,
+  $isDesignMode,
+  computeExpression,
+} from "~/shared/nano-states";
+import { useStore } from "@nanostores/react";
 
 export const evaluateExpressionWithinScope = (
   expression: string,
@@ -360,6 +365,11 @@ export const BindingPopover = ({
   });
   const hasUnsavedChange = useRef<boolean>(false);
   const preventedClosing = useRef<boolean>(false);
+  const isDesignMode = useStore($isDesignMode);
+
+  if (!isDesignMode) {
+    return;
+  }
 
   const valueError = validate?.(evaluateExpressionWithinScope(value, scope));
   return (

--- a/apps/builder/app/builder/shared/collapsible-section.tsx
+++ b/apps/builder/app/builder/shared/collapsible-section.tsx
@@ -107,7 +107,7 @@ export const CollapsibleSectionWithAddButton = ({
   hasItems = true,
   ...props
 }: Omit<CollapsibleSectionProps, "trigger" | "categoryProps"> & {
-  onAdd: () => void;
+  onAdd?: () => void;
 
   /**
    * If set to `true`, dots aren't shown,
@@ -139,15 +139,17 @@ export const CollapsibleSectionWithAddButton = ({
         <SectionTitle
           dots={Array.isArray(hasItems) ? hasItems : []}
           suffix={
-            <SectionTitleButton
-              prefix={<PlusIcon />}
-              onClick={() => {
-                if (isOpenFinal === false) {
-                  setIsOpen(true);
-                }
-                onAdd();
-              }}
-            />
+            onAdd ? (
+              <SectionTitleButton
+                prefix={<PlusIcon />}
+                onClick={() => {
+                  if (isOpenFinal === false) {
+                    setIsOpen(true);
+                  }
+                  onAdd();
+                }}
+              />
+            ) : undefined
           }
         >
           <SectionTitleLabel>{props.label}</SectionTitleLabel>

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -1,10 +1,10 @@
 import { createCommandsEmitter, type Command } from "~/shared/commands-emitter";
 import {
-  $isPreviewMode,
   $editingItemSelector,
   $instances,
   $selectedInstanceSelector,
   $textEditingInstanceSelector,
+  $builderMode,
 } from "~/shared/nano-states";
 import {
   $breakpointsMenuView,
@@ -123,8 +123,26 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "togglePreview",
       defaultHotkeys: ["meta+shift+p", "ctrl+shift+p"],
       handler: () => {
-        $isPreviewMode.set($isPreviewMode.get() === false);
         setActiveSidebarPanel("auto");
+
+        if ($builderMode.get() === "preview") {
+          $builderMode.set("design");
+        } else {
+          $builderMode.set("preview");
+        }
+      },
+    },
+    {
+      name: "toggleEditor",
+      defaultHotkeys: ["meta+shift+e", "ctrl+shift+e"],
+      handler: () => {
+        setActiveSidebarPanel("auto");
+
+        if ($builderMode.get() === "content") {
+          $builderMode.set("design");
+        } else {
+          $builderMode.set("content");
+        }
       },
     },
     {

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -5,6 +5,7 @@ import {
   $selectedInstanceSelector,
   $textEditingInstanceSelector,
   $builderMode,
+  $isDesignMode,
 } from "~/shared/nano-states";
 import {
   $breakpointsMenuView,
@@ -26,9 +27,9 @@ import {
   setActiveSidebarPanel,
   toggleActiveSidebarPanel,
 } from "./nano-states";
-import { toast } from "@webstudio-is/design-system";
 import { selectInstance } from "~/shared/awareness";
 import { openCommandPanel } from "../features/command-panel";
+import { builderApi } from "~/shared/builder-api";
 
 const makeBreakpointCommand = <CommandName extends string>(
   name: CommandName,
@@ -44,6 +45,11 @@ const makeBreakpointCommand = <CommandName extends string>(
 });
 
 const deleteSelectedInstance = () => {
+  if ($isDesignMode.get() === false) {
+    builderApi.toast.info("Deleting is only allowed in design mode.");
+    return;
+  }
+
   const textEditingInstanceSelector = $textEditingInstanceSelector.get();
   const selectedInstanceSelector = $selectedInstanceSelector.get();
   // cannot delete instance while editing
@@ -155,6 +161,12 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "toggleComponentsPanel",
       defaultHotkeys: ["a"],
       handler: () => {
+        if ($isDesignMode.get() === false) {
+          builderApi.toast.info(
+            "Components panel is only available in design mode."
+          );
+          return;
+        }
         toggleActiveSidebarPanel("components");
       },
       disableHotkeyOnFormTags: true,
@@ -173,6 +185,12 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "openStylePanel",
       defaultHotkeys: ["s"],
       handler: () => {
+        if ($isDesignMode.get() === false) {
+          builderApi.toast.info(
+            "Style panel is only available in design mode."
+          );
+          return;
+        }
         $activeInspectorPanel.set("style");
       },
       disableHotkeyOnFormTags: true,
@@ -226,13 +244,18 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "duplicateInstance",
       defaultHotkeys: ["meta+d", "ctrl+d"],
       handler: () => {
+        if ($isDesignMode.get() === false) {
+          builderApi.toast.info("Duplicating is only allowed in design mode.");
+          return;
+        }
+
         const instanceSelector = $selectedInstanceSelector.get();
         if (instanceSelector === undefined) {
           return;
         }
         const instances = $instances.get();
         if (isInstanceDetachable(instances, instanceSelector) === false) {
-          toast.error(
+          builderApi.toast.error(
             "This instance can not be moved outside of its parent component."
           );
           return;

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -32,6 +32,7 @@ import {
   subscribeStyles,
   mountStyles,
   manageDesignModeStyles,
+  manageContentEditModeStyles,
 } from "./shared/styles";
 import {
   WebstudioComponentCanvas,
@@ -45,9 +46,11 @@ import {
   $registeredComponents,
   subscribeComponentHooks,
   $isPreviewMode,
+  $isDesignMode,
+  $isContentMode,
 } from "~/shared/nano-states";
 import { useDragAndDrop } from "./shared/use-drag-drop";
-import { initCopyPaste } from "~/shared/copy-paste";
+import { initCopyPaste } from "~/shared/copy-paste/init-copy-paste";
 import { setDataCollapsed, subscribeCollapsedToPubSub } from "./collapsed";
 import { useWindowResizeDebounced } from "~/shared/dom-hooks";
 import { subscribeInstanceSelection } from "./instance-selection";
@@ -181,6 +184,39 @@ const DesignMode = () => {
   return null;
 };
 
+const ContentEditMode = () => {
+  const debounceEffect = useDebounceEffect();
+  const ref = useRef<Instances>();
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    subscribeScrollNewInstanceIntoView(
+      debounceEffect,
+      ref,
+      abortController.signal
+    );
+    const unsubscribeSelected = subscribeSelected(debounceEffect);
+    return () => {
+      unsubscribeSelected();
+      abortController.abort();
+    };
+  }, [debounceEffect]);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    const options = { signal: abortController.signal };
+    manageContentEditModeStyles(options);
+    subscribeInstanceSelection(options);
+    subscribeInstanceHovering(options);
+    subscribeInspectorEdits(options);
+    subscribeFontLoadingDone(options);
+    return () => {
+      abortController.abort();
+    };
+  }, []);
+  return null;
+};
+
 type CanvasProps = {
   params: Params;
   imageLoader: ImageLoader;
@@ -188,7 +224,8 @@ type CanvasProps = {
 
 export const Canvas = ({ params, imageLoader }: CanvasProps) => {
   useCanvasStore(publish);
-  const isPreviewMode = useStore($isPreviewMode);
+  const isDesignMode = useStore($isDesignMode);
+  const isContentMode = useStore($isContentMode);
 
   useMount(() => {
     registerComponentLibrary({
@@ -283,7 +320,8 @@ export const Canvas = ({ params, imageLoader }: CanvasProps) => {
         // Call hooks after render to ensure effects are last.
         // Helps improve outline calculations as all styles are then applied.
       }
-      {isPreviewMode === false && isInitialized && <DesignMode />}
+      {isDesignMode && isInitialized && <DesignMode />}
+      {isContentMode && isInitialized && <ContentEditMode />}
     </>
   );
 };

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -50,7 +50,10 @@ import {
   $isContentMode,
 } from "~/shared/nano-states";
 import { useDragAndDrop } from "./shared/use-drag-drop";
-import { initCopyPaste } from "~/shared/copy-paste/init-copy-paste";
+import {
+  initCopyPaste,
+  initCopyPasteForContentEditMode,
+} from "~/shared/copy-paste/init-copy-paste";
 import { setDataCollapsed, subscribeCollapsedToPubSub } from "./collapsed";
 import { useWindowResizeDebounced } from "~/shared/dom-hooks";
 import { subscribeInstanceSelection } from "./instance-selection";
@@ -210,6 +213,7 @@ const ContentEditMode = () => {
     subscribeInstanceHovering(options);
     subscribeInspectorEdits(options);
     subscribeFontLoadingDone(options);
+    initCopyPasteForContentEditMode(options);
     return () => {
       abortController.abort();
     };

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -28,7 +28,6 @@ import {
   $assets,
   $breakpoints,
   $instances,
-  $isPreviewMode,
   $props,
   $registeredComponentMetas,
   $selectedStyleState,
@@ -38,7 +37,9 @@ import {
 import { setDifference } from "~/shared/shim";
 import { $ephemeralStyles, $params } from "../stores";
 import { canvasApi } from "~/shared/canvas-api";
-import { $selectedInstance } from "~/shared/awareness";
+import { $selectedInstance, $selectedPage } from "~/shared/awareness";
+import { findAllEditableInstanceSelector } from "~/shared/instance-utils";
+import type { InstanceSelector } from "~/shared/tree-utils";
 
 const userSheet = createRegularStyleSheet({ name: "user-styles" });
 const stateSheet = createRegularStyleSheet({ name: "state-styles" });
@@ -60,23 +61,7 @@ export const mountStyles = () => {
   helpersSheet.render();
 };
 
-// Helper styles on for canvas in design mode
-// - Only instances that would collapse without helper should receive helper
-// - Helper is removed when any CSS property is changed on that instance that would prevent collapsing, so that helper is not needed
-// - Helper doesn't show on the preview or publish
-// - Helper goes away if an instance inserted as a child
-// - There is no need to set padding-right or padding-bottom if you just need a small div with a defined or layout-based size, as soon as div is not collapsing, helper should not apply
-// - Padding will be only added on the side that would collapse otherwise
-//
-// For example when I add a div, it is a block element, it grows automatically full width but has 0 height, in this case spacing helper with padidng-top: 50px should apply, so that it doesn't collapse.
-// If user sets `height: 100px` or does anything that would give it a height - we remove the helper padding right away, so user can actually see the height they set
-//
-// In other words we prevent elements from collapsing when they have 0 height or width by making them non-zero on canvas, but then we remove those paddings as soon as element doesn't collapse.
-const helperStyles = [
-  // When double clicking into an element to edit text, it should not select the word.
-  `[${idAttribute}] {
-    user-select: none;
-  }`,
+const helperStylesShared = [
   // Using :where allows to prevent increasing specificity, so that helper is overwritten by user styles.
   `[${idAttribute}]:where([${collapsedAttribute}]:not(body)) {
     outline: 1px dashed rgba(0,0,0,0.7);
@@ -110,25 +95,105 @@ const helperStyles = [
   }`,
 ];
 
-const subscribePreviewMode = () => {
-  let isRendered = false;
+// Helper styles on for canvas in design mode
+// - Only instances that would collapse without helper should receive helper
+// - Helper is removed when any CSS property is changed on that instance that would prevent collapsing, so that helper is not needed
+// - Helper doesn't show on the preview or publish
+// - Helper goes away if an instance inserted as a child
+// - There is no need to set padding-right or padding-bottom if you just need a small div with a defined or layout-based size, as soon as div is not collapsing, helper should not apply
+// - Padding will be only added on the side that would collapse otherwise
+//
+// For example when I add a div, it is a block element, it grows automatically full width but has 0 height, in this case spacing helper with padidng-top: 50px should apply, so that it doesn't collapse.
+// If user sets `height: 100px` or does anything that would give it a height - we remove the helper padding right away, so user can actually see the height they set
+//
+// In other words we prevent elements from collapsing when they have 0 height or width by making them non-zero on canvas, but then we remove those paddings as soon as element doesn't collapse.
+const helperStyles = [
+  // When double clicking into an element to edit text, it should not select the word.
+  `[${idAttribute}] {
+    user-select: none;
+  }`,
+  ...helperStylesShared,
+];
 
-  const unsubscribe = $isPreviewMode.subscribe((isPreviewMode) => {
-    helpersSheet.setAttribute("media", isPreviewMode ? "not all" : "all");
-    if (isRendered === false) {
-      for (const style of helperStyles) {
-        helpersSheet.addPlaintextRule(style);
-      }
-      helpersSheet.render();
-      isRendered = true;
-    }
-  });
+// Find all editable elements and set cursor text inside
+const helperStylesContentEdit = [...helperStylesShared];
+
+const subscribeDesignModeHelperStyles = () => {
+  helpersSheet.setAttribute("media", "all");
+
+  for (const style of helperStyles) {
+    helpersSheet.addPlaintextRule(style);
+  }
+  helpersSheet.render();
 
   return () => {
     helpersSheet.clear();
     helpersSheet.render();
-    unsubscribe();
-    isRendered = false;
+  };
+};
+
+const subscribeContentEditModeHelperStyles = () => {
+  helpersSheet.setAttribute("media", "all");
+
+  for (const style of helperStylesContentEdit) {
+    helpersSheet.addPlaintextRule(style);
+  }
+
+  // Show text cursor on all editable elements (including links and buttons)
+  // to indicate they are editable in the content editor mode
+  //
+  // @todo Consider setting cursor: pointer on non-editable elements by default
+  // to better distinguish clickable vs editable elements, needs more investigation
+  const rootInstanceId = $selectedPage.get()?.rootInstanceId;
+  if (rootInstanceId !== undefined) {
+    const editableInstanceSelectors: InstanceSelector[] = [];
+    const instances = $instances.get();
+
+    findAllEditableInstanceSelector(
+      rootInstanceId,
+      [],
+      instances,
+      $registeredComponentMetas.get(),
+      editableInstanceSelectors
+    );
+
+    // Group IDs into chunks of 20 since :is() allows for more efficient grouping
+    const chunkSize = 20;
+    for (let i = 0; i < editableInstanceSelectors.length; i += chunkSize) {
+      const chunk = editableInstanceSelectors
+        .slice(i, i + chunkSize)
+        .filter((selector) => {
+          const instance = instances.get(selector[0]);
+          if (instance === undefined) {
+            return false;
+          }
+
+          const hasExpressionChildren = instance.children.some(
+            (child) => child.type === "expression"
+          );
+
+          if (hasExpressionChildren) {
+            return false;
+          }
+
+          return true;
+        });
+
+      const selectors = chunk.map(
+        (selector) => `[${idAttribute}="${selector[0]}"]`
+      );
+
+      helpersSheet.addPlaintextRule(
+        `:is(${selectors.join(", ")}), :is(${selectors.join(", ")}) a { cursor: text; }`
+      );
+    }
+  }
+
+  helpersSheet.render();
+
+  return () => {
+    helpersSheet.clear();
+    helpersSheet.render();
   };
 };
 
@@ -315,10 +380,21 @@ export const subscribeStyles = () => {
   };
 };
 
+export const manageContentEditModeStyles = ({
+  signal,
+}: {
+  signal: AbortSignal;
+}) => {
+  const unsubscribePreviewMode = subscribeContentEditModeHelperStyles();
+  signal.addEventListener("abort", () => {
+    unsubscribePreviewMode();
+  });
+};
+
 export const manageDesignModeStyles = ({ signal }: { signal: AbortSignal }) => {
   const unsubscribeStateStyles = subscribeStateStyles();
   const unsubscribeEphemeralStyle = subscribeEphemeralStyle();
-  const unsubscribePreviewMode = subscribePreviewMode();
+  const unsubscribePreviewMode = subscribeDesignModeHelperStyles();
   signal.addEventListener("abort", () => {
     unsubscribeStateStyles();
     unsubscribeEphemeralStyle();

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -116,7 +116,12 @@ const helperStyles = [
 ];
 
 // Find all editable elements and set cursor text inside
-const helperStylesContentEdit = [...helperStylesShared];
+const helperStylesContentEdit = [
+  `[${idAttribute}] {
+  user-select: none;
+}`,
+  ...helperStylesShared,
+];
 
 const subscribeDesignModeHelperStyles = () => {
   helpersSheet.setAttribute("media", "all");

--- a/apps/builder/app/routes/builder.$projectId.tsx
+++ b/apps/builder/app/routes/builder.$projectId.tsx
@@ -18,7 +18,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       projectId: params.projectId,
       origin: request.url,
       authToken: url.searchParams.get("authToken") ?? undefined,
-      mode: url.searchParams.get("mode") === "preview" ? "preview" : "edit",
+      mode: url.searchParams.get("mode") === "preview" ? "preview" : "design",
     })
   );
 };

--- a/apps/builder/app/shared/copy-paste/index.ts
+++ b/apps/builder/app/shared/copy-paste/index.ts
@@ -1,1 +1,0 @@
-export { initCopyPaste } from "./init-copy-paste";

--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -7,6 +7,7 @@ import * as instance from "./plugin-instance";
 import * as embedTemplate from "./plugin-embed-template";
 import * as markdown from "./plugin-markdown";
 import * as webflow from "./plugin-webflow/plugin-webflow";
+import { builderApi } from "../builder-api";
 
 const isTextEditing = (event: ClipboardEvent) => {
   // Text is edited on the Canvas using the default Canvas text editor settings.
@@ -147,6 +148,31 @@ const initPlugins = ({
 export const initCopyPaste = ({ signal }: { signal: AbortSignal }) => {
   initPlugins({
     plugins: [instance, embedTemplate, markdown, webflow],
+    signal,
+  });
+};
+
+export const initCopyPasteForContentEditMode = ({
+  signal,
+}: {
+  signal: AbortSignal;
+}) => {
+  const handleClipboard = (event: ClipboardEvent) => {
+    if (validateClipboardEvent(event) === false) {
+      return;
+    }
+
+    builderApi.toast.info(
+      "Copying and pasting is allowed in design mode only."
+    );
+  };
+
+  document.addEventListener("copy", handleClipboard, { signal });
+  document.addEventListener("cut", handleClipboard, { signal });
+  // Capture is required so we get the element before content-editable removes it
+  // This way we can detect when we are inside content-editable and ignore the event
+  document.addEventListener("paste", handleClipboard, {
+    capture: true,
     signal,
   });
 };

--- a/apps/builder/app/shared/nano-states/misc.ts
+++ b/apps/builder/app/shared/nano-states/misc.ts
@@ -297,7 +297,24 @@ export const $hoveredInstanceSelector = atom<undefined | InstanceSelector>(
   undefined
 );
 
-export const $isPreviewMode = atom<boolean>(false);
+const builderModes = ["design", "preview", "content"] as const;
+export type BuilderMode = (typeof builderModes)[number];
+export const isBuilderMode = (mode: string | null): mode is BuilderMode =>
+  builderModes.includes(mode as BuilderMode);
+export const $builderMode = atom<BuilderMode>("design");
+
+export const $isPreviewMode = computed(
+  $builderMode,
+  (mode) => mode === "preview"
+);
+export const $isContentMode = computed(
+  $builderMode,
+  (mode) => mode === "content"
+);
+export const $isDesignMode = computed(
+  $builderMode,
+  (mode) => mode === "design"
+);
 
 export const $authPermit = atom<AuthPermit>("view");
 export const $authTokenPermissions = atom<TokenPermissions>({

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -6,10 +6,13 @@ import {
   $pages,
   $project,
   $selectedPageHash,
+  $builderMode,
+  isBuilderMode,
   $isPreviewMode,
 } from "~/shared/nano-states";
 import { builderPath } from "~/shared/router-utils";
 import { $selectedPage, selectPage } from "../awareness";
+import invariant from "tiny-invariant";
 
 const setPageStateFromUrl = () => {
   const searchParams = new URLSearchParams(window.location.search);
@@ -19,7 +22,15 @@ const setPageStateFromUrl = () => {
   }
   const pageId = searchParams.get("pageId") ?? pages.homePage.id;
 
-  $isPreviewMode.set(searchParams.get("mode") === "preview");
+  const mode = searchParams.get("mode");
+
+  // Check in case of BuilderMode rename
+  invariant(
+    mode === null || isBuilderMode(mode),
+    `Invalid search param mode: ${mode}`
+  );
+
+  $builderMode.set(isBuilderMode(mode) ? mode : "design");
 
   $selectedPageHash.set(searchParams.get("pageHash") ?? "");
   selectPage(pageId);

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -1,6 +1,7 @@
 import type { AUTH_PROVIDERS } from "~/shared/session";
 import { publicStaticEnv } from "~/env/env.static";
 import { getAuthorizationServerOrigin } from "./origins";
+import type { BuilderMode } from "../nano-states/misc";
 
 const searchParams = (params: Record<string, string | undefined | null>) => {
   const searchParams = new URLSearchParams();
@@ -37,7 +38,7 @@ export const builderUrl = (props: {
   pageId?: string;
   origin: string;
   authToken?: string;
-  mode?: "edit" | "preview";
+  mode?: BuilderMode;
 }) => {
   const authServerOrigin = getAuthorizationServerOrigin(props.origin);
 

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -303,7 +303,7 @@ type SharedLinkItemType = {
   onDelete: () => void;
   builderUrl: (props: {
     authToken: string;
-    mode: "preview" | "edit";
+    mode: "preview" | "design";
   }) => string;
   hasProPlan: boolean;
 };
@@ -323,7 +323,7 @@ const SharedLinkItem = ({
       <CopyToClipboard
         text={builderUrl({
           authToken: value.token,
-          mode: value.relation === "viewers" ? "preview" : "edit",
+          mode: value.relation === "viewers" ? "preview" : "design",
         })}
         copyText="Copy link"
       >

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -22,7 +22,6 @@ import {
   $selectedInstanceIntanceToTag,
   $selectedInstanceRenderState,
   $hoveredInstanceSelector,
-  $isPreviewMode,
   $authTokenPermissions,
   $toastErrors,
   synchronizedCanvasStores,
@@ -41,6 +40,7 @@ import {
   $uploadingFilesDataStore,
   $memoryProps,
   $detectedFontsWeights,
+  $builderMode,
 } from "~/shared/nano-states";
 import { $ephemeralStyles } from "~/canvas/stores";
 import { $awareness } from "../awareness";
@@ -115,7 +115,7 @@ export const registerContainers = () => {
     $selectedInstanceRenderState
   );
   clientStores.set("hoveredInstanceSelector", $hoveredInstanceSelector);
-  clientStores.set("isPreviewMode", $isPreviewMode);
+  clientStores.set("builderMode", $builderMode);
   clientStores.set("authTokenPermissions", $authTokenPermissions);
   clientStores.set("toastErrors", $toastErrors);
 

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -6,4 +6,5 @@ export const cms = false;
 export const filters = false;
 export const xmlElement = false;
 export const staticExport = false;
+export const contentEditableMode = false;
 export const command = false;


### PR DESCRIPTION
## Description
Part 1 Of #3994 

This PR introduces a feature flag, `contentEditableMode`, that hides the `EditorButton` in the top bar. This button is now intended for **testing purposes only** and will **never be used in production**.

<img width="154" alt="image" src="https://github.com/user-attachments/assets/f4a37334-71b9-43d8-b4a8-afd518fc6833">

## Most Notable Things In The Content Edit Mode

1. **Notion-like Editing**: Elements are editable with a single click.
2. **Restricted Element Editing**: Binded elements, such as expressions, are non-editable.
3. **Selective Property Editing**: Only properties for `img` and `link` elements are editable.

Additional changes:
- **Copy/Paste and Drag/Drop**: Disabled to maintain a controlled testing environment.

Refer to the issue `Part 1` for further details on upcoming changes and planned enhancements.


## Steps for reproduction

Play play 

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
