### PR TITLE
refactor: move selected instance store into awareness

### DIFF
--- a/apps/builder/app/builder/features/ai/ai-fetch-result.ts
+++ b/apps/builder/app/builder/features/ai/ai-fetch-result.ts
@@ -22,7 +22,6 @@ import {
   $project,
   $props,
   $registeredComponentMetas,
-  $selectedInstanceSelector,
   $styleSourceSelections,
   $styles,
 } from "~/shared/nano-states";
@@ -37,6 +36,7 @@ import {
 } from "./api-exceptions";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { fetch } from "~/shared/fetch.client";
+import { $selectedInstance } from "~/shared/awareness";
 
 const unknownArray = z.array(z.unknown());
 
@@ -253,7 +253,7 @@ const restoreComponentsNamespace = (operations: operations.WsOperations) => {
 
 const $jsx = computed(
   [
-    $selectedInstanceSelector,
+    $selectedInstance,
     $instances,
     $props,
     $dataSources,
@@ -262,7 +262,7 @@ const $jsx = computed(
     $styleSourceSelections,
   ],
   (
-    selectedInstanceSelector,
+    instance,
     instances,
     props,
     dataSources,
@@ -270,17 +270,12 @@ const $jsx = computed(
     styles,
     styleSourceSelections
   ) => {
-    if (selectedInstanceSelector === undefined) {
-      return;
-    }
-
-    const [rootInstanceId] = selectedInstanceSelector;
-    const instance = instances.get(rootInstanceId);
     if (instance === undefined) {
       return;
     }
+
     const indexesWithinAncestors = getIndexesWithinAncestors(metas, instances, [
-      rootInstanceId,
+      instance.id,
     ]);
     const scope = createScope();
 
@@ -303,7 +298,7 @@ const $jsx = computed(
       }),
     });
 
-    const treeInstanceIds = findTreeInstanceIds(instances, rootInstanceId);
+    const treeInstanceIds = findTreeInstanceIds(instances, instance.id);
 
     const sheet = createRegularStyleSheet({ name: "ssr" });
     for (const styleDecl of styles.values()) {

--- a/apps/builder/app/builder/features/ai/apply-operations.ts
+++ b/apps/builder/app/builder/features/ai/apply-operations.ts
@@ -1,6 +1,8 @@
-import { serverSyncStore } from "~/shared/sync";
+import { nanoid } from "nanoid";
+import { getStyleDeclKey, Instance, type StyleSource } from "@webstudio-is/sdk";
 import { generateDataFromEmbedTemplate } from "@webstudio-is/react-sdk";
 import type { copywriter, operations } from "@webstudio-is/ai";
+import { serverSyncStore } from "~/shared/sync";
 import { isBaseBreakpoint } from "~/shared/breakpoints";
 import {
   deleteInstanceMutable,
@@ -12,14 +14,12 @@ import {
   $instances,
   $registeredComponentMetas,
   $selectedInstanceSelector,
-  $selectedInstance,
   $styleSourceSelections,
   $styleSources,
   $styles,
 } from "~/shared/nano-states";
 import type { DroppableTarget, InstanceSelector } from "~/shared/tree-utils";
-import { getStyleDeclKey, Instance, type StyleSource } from "@webstudio-is/sdk";
-import { nanoid } from "nanoid";
+import { $selectedInstance } from "~/shared/awareness";
 
 export const applyOperations = (operations: operations.WsOperations) => {
   for (const operation of operations) {

--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -22,7 +22,6 @@ import { StylePanel } from "~/builder/features/style-panel";
 import { SettingsPanelContainer } from "~/builder/features/settings-panel";
 import { FloatingPanelProvider } from "~/builder/shared/floating-panel";
 import {
-  $selectedInstance,
   $registeredComponentMetas,
   $dragAndDropState,
 } from "~/shared/nano-states";
@@ -32,7 +31,7 @@ import { MetaIcon } from "~/builder/shared/meta-icon";
 import { getInstanceLabel } from "~/shared/instance-utils";
 import { BindingPopoverProvider } from "~/builder/shared/binding-popover";
 import { $activeInspectorPanel } from "~/builder/shared/nano-states";
-import { $selectedPage } from "~/shared/awareness";
+import { $selectedInstance, $selectedPage } from "~/shared/awareness";
 
 const InstanceInfo = ({ instance }: { instance: Instance }) => {
   const metas = useStore($registeredComponentMetas);

--- a/apps/builder/app/builder/features/navigator/css-preview.tsx
+++ b/apps/builder/app/builder/features/navigator/css-preview.tsx
@@ -15,8 +15,8 @@ import type { StyleMap, StyleProperty } from "@webstudio-is/css-engine";
 import { CollapsibleSection } from "~/builder/shared/collapsible-section";
 import { highlightCss } from "~/builder/shared/code-highlight";
 import type { ComputedStyleDecl } from "~/shared/style-object-model";
-import { $selectedInstanceSelector } from "~/shared/nano-states";
 import { $definedComputedStyles } from "~/builder/features/style-panel/shared/model";
+import { $selectedInstance } from "~/shared/awareness";
 
 const preStyle = css(textVariants.mono, {
   margin: 0,
@@ -80,13 +80,12 @@ const getCssText = (
 };
 
 const $highlightedCss = computed(
-  [$selectedInstanceSelector, $definedComputedStyles],
-  (instanceSelector, computedStyles) => {
-    if (instanceSelector === undefined) {
+  [$selectedInstance, $definedComputedStyles],
+  (instance, computedStyles) => {
+    if (instance === undefined) {
       return;
     }
-    const [instanceId] = instanceSelector;
-    const cssText = getCssText(computedStyles, instanceId);
+    const cssText = getCssText(computedStyles, instance.id);
     return highlightCss(cssText);
   }
 );

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -55,7 +55,7 @@ import {
   EditorDialogControl,
 } from "~/builder/shared/code-editor-base";
 import { parseCurl, type CurlRequest } from "./curl";
-import { $selectedPage } from "~/shared/awareness";
+import { $selectedInstance, $selectedPage } from "~/shared/awareness";
 
 const validateUrl = (value: string, scope: Record<string, unknown>) => {
   const evaluatedValue = evaluateExpressionWithinScope(value, scope);
@@ -581,12 +581,11 @@ export const ResourceForm = forwardRef<
 
   useImperativeHandle(ref, () => ({
     save: (formData) => {
-      const instanceSelector = $selectedInstanceSelector.get();
-      if (instanceSelector === undefined) {
+      const instanceId = $selectedInstance.get()?.id;
+      if (instanceId === undefined) {
         return;
       }
       const name = z.string().parse(formData.get("name"));
-      const [instanceId] = instanceSelector;
       const newResource: Resource = {
         id: resource?.id ?? nanoid(),
         name,
@@ -715,12 +714,11 @@ export const SystemResourceForm = forwardRef<
 
   useImperativeHandle(ref, () => ({
     save: (formData) => {
-      const instanceSelector = $selectedInstanceSelector.get();
-      if (instanceSelector === undefined) {
+      const instanceId = $selectedInstance.get()?.id;
+      if (instanceId === undefined) {
         return;
       }
       const name = z.string().parse(formData.get("name"));
-      const [instanceId] = instanceSelector;
       const newResource: Resource = {
         id: resource?.id ?? nanoid(),
         name,
@@ -826,8 +824,8 @@ export const GraphqlResourceForm = forwardRef<
 
   useImperativeHandle(ref, () => ({
     save: (formData) => {
-      const instanceSelector = $selectedInstanceSelector.get();
-      if (instanceSelector === undefined) {
+      const instanceId = $selectedInstance.get()?.id;
+      if (instanceId === undefined) {
         return;
       }
       const name = z.string().parse(formData.get("name"));
@@ -837,7 +835,6 @@ export const GraphqlResourceForm = forwardRef<
           ["variables", variables],
         ])
       );
-      const [instanceId] = instanceSelector;
       const newResource: Resource = {
         id: resource?.id ?? nanoid(),
         name,

--- a/apps/builder/app/builder/features/settings-panel/settings-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-section.tsx
@@ -1,14 +1,11 @@
 import { useStore } from "@nanostores/react";
+import type { Instance } from "@webstudio-is/sdk";
 import { InputField, useId } from "@webstudio-is/design-system";
-import {
-  $instances,
-  $registeredComponentMetas,
-  $selectedInstance,
-} from "~/shared/nano-states";
+import { $instances, $registeredComponentMetas } from "~/shared/nano-states";
 import { HorizontalLayout, Label, Row, useLocalValue } from "./shared";
 import { getInstanceLabel } from "~/shared/instance-utils";
 import { serverSyncStore } from "~/shared/sync";
-import type { Instance } from "@webstudio-is/sdk";
+import { $selectedInstance } from "~/shared/awareness";
 
 const saveLabel = (label: string, selectedInstance: Instance) => {
   serverSyncStore.createTransaction([$instances], (instances) => {

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -52,7 +52,6 @@ import {
   $dataSources,
   $resources,
   $areResourcesLoading,
-  $selectedInstanceSelector,
   invalidateResource,
   getComputedResource,
 } from "~/shared/nano-states";
@@ -71,6 +70,7 @@ import {
   SystemResourceForm,
 } from "./resource-panel";
 import { generateCurl } from "./curl";
+import { $selectedInstance } from "~/shared/awareness";
 
 const validateName = (value: string) =>
   value.trim().length === 0 ? "Name is required" : "";
@@ -241,11 +241,10 @@ const useValuePanelRef = ({
 }) => {
   useImperativeHandle(ref, () => ({
     save: (formData) => {
-      const instanceSelector = $selectedInstanceSelector.get();
-      if (instanceSelector === undefined) {
+      const instanceId = $selectedInstance.get()?.id;
+      if (instanceId === undefined) {
         return;
       }
-      const [instanceId] = instanceSelector;
       const dataSourceId = variable?.id ?? nanoid();
       // preserve existing instance scope when edit
       const scopeInstanceId = variable?.scopeInstanceId ?? instanceId;

--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -46,21 +46,20 @@ import {
   VariablePopoverProvider,
   VariablePopoverTrigger,
 } from "./variable-popover";
-import { $selectedPage } from "~/shared/awareness";
+import { $selectedInstance, $selectedPage } from "~/shared/awareness";
 
 /**
  * find variables defined specifically on this selected instance
  */
 const $instanceVariables = computed(
-  [$selectedInstanceSelector, $dataSources],
-  (instanceSelector, dataSources) => {
+  [$selectedInstance, $dataSources],
+  (instance, dataSources) => {
     const matchedVariables: DataSource[] = [];
-    if (instanceSelector === undefined) {
+    if (instance === undefined) {
       return matchedVariables;
     }
-    const [instanceId] = instanceSelector;
     for (const dataSource of dataSources.values()) {
-      if (instanceId === dataSource.scopeInstanceId) {
+      if (instance.id === dataSource.scopeInstanceId) {
         matchedVariables.push(dataSource);
       }
     }

--- a/apps/builder/app/builder/features/style-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/style-panel/property-label.tsx
@@ -24,7 +24,6 @@ import {
   $instances,
   $registeredComponentMetas,
   $styleSources,
-  $virtualInstances,
 } from "~/shared/nano-states";
 import { getInstanceLabel } from "~/shared/instance-utils";
 import type {
@@ -34,6 +33,7 @@ import type {
 import { useComputedStyles } from "./shared/model";
 import { StyleSourceBadge } from "./style-source";
 import { createBatchUpdate } from "./shared/use-style-data";
+import { $virtualInstances } from "~/shared/awareness";
 
 const $isAltPressed = atom(false);
 if (typeof window !== "undefined") {

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.stories.tsx
@@ -3,6 +3,7 @@ import { registerContainers } from "~/shared/sync";
 import { Section } from "./advanced";
 import {
   $breakpoints,
+  $instances,
   $selectedBreakpointId,
   $styles,
   $styleSourceSelections,
@@ -26,6 +27,11 @@ $selectedBreakpointId.set("base");
 $styles.set(new Map([[getStyleDeclKey(backgroundImage), backgroundImage]]));
 $styleSourceSelections.set(
   new Map([["box", { instanceId: "box", values: ["local"] }]])
+);
+$instances.set(
+  new Map([
+    ["box", { type: "instance", id: "box", component: "Box", children: [] }],
+  ])
 );
 $awareness.set({
   pageId: "",

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
@@ -40,6 +40,11 @@ $styles.set(new Map([[getStyleDeclKey(backgroundImage), backgroundImage]]));
 $styleSourceSelections.set(
   new Map([["box", { instanceId: "box", values: ["local"] }]])
 );
+$instances.set(
+  new Map([
+    ["box", { type: "instance", id: "box", component: "Box", children: [] }],
+  ])
+);
 $awareness.set({
   pageId: "",
   instanceSelector: ["box"],

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
@@ -3,6 +3,7 @@ import { styled, theme } from "@webstudio-is/design-system";
 import { registerContainers } from "~/shared/sync";
 import {
   $breakpoints,
+  $instances,
   $selectedBreakpointId,
   $styles,
   $styleSourceSelections,

--- a/apps/builder/app/builder/features/style-panel/shared/instances-kv.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/instances-kv.ts
@@ -1,7 +1,7 @@
 import { useStore } from "@nanostores/react";
 import { map } from "nanostores";
 import { useCallback } from "react";
-import { $selectedInstanceSelector } from "~/shared/nano-states";
+import { $selectedInstance } from "~/shared/awareness";
 
 const instancesKv = map<Record<string, unknown>>({});
 
@@ -11,24 +11,19 @@ const instancesKv = map<Record<string, unknown>>({});
  * allowing the default UI behavior to be used until the user modifies the state.
  */
 export const useSelectedInstanceKv = <T>(key: string, defaultValue: T) => {
-  const instanceSelector = useStore($selectedInstanceSelector);
-  const keyInstanceSelector = instanceSelector
-    ? `${instanceSelector.join(",")}-${key}`
-    : `undefined-${key}`;
+  const instance = useStore($selectedInstance);
+  const instanceKey = `${instance?.id}-${key}`;
 
   const mapStore = useStore(instancesKv, {
-    keys: [keyInstanceSelector],
+    keys: [instanceKey],
   });
 
   const setValue = useCallback(
     (value: T) => {
-      instancesKv.setKey(keyInstanceSelector, value);
+      instancesKv.setKey(instanceKey, value);
     },
-    [keyInstanceSelector]
+    [instanceKey]
   );
 
-  return [
-    (mapStore[keyInstanceSelector] as T) ?? defaultValue,
-    setValue,
-  ] as const;
+  return [(mapStore[instanceKey] as T) ?? defaultValue, setValue] as const;
 };

--- a/apps/builder/app/builder/features/style-panel/shared/repeated-style.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/repeated-style.test.ts
@@ -19,6 +19,7 @@ import { createComputedStyleDeclStore } from "./model";
 import { parseCssFragment } from "./css-fragment";
 import {
   $breakpoints,
+  $instances,
   $selectedBreakpointId,
   $styles,
   $styleSources,
@@ -39,6 +40,11 @@ beforeEach(() => {
     pageId: "",
     instanceSelector: ["box"],
   });
+  $instances.set(
+    new Map([
+      ["box", { type: "instance", id: "box", component: "Box", children: [] }],
+    ])
+  );
   $styleSourceSelections.set(new Map());
   $styleSources.set(new Map());
   $styles.set(new Map());

--- a/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
@@ -7,7 +7,6 @@ import {
 import type { StyleProperty, StyleValue } from "@webstudio-is/css-engine";
 import {
   $selectedBreakpoint,
-  $selectedInstanceSelector,
   $selectedOrLastStyleSourceSelector,
   $selectedStyleSource,
   $styleSourceSelections,
@@ -16,6 +15,7 @@ import {
 } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
 import { $ephemeralStyles } from "~/canvas/stores";
+import { $selectedInstance } from "~/shared/awareness";
 
 export type StyleUpdate =
   | {
@@ -64,14 +64,13 @@ const publishUpdates = (
     return;
   }
 
-  const selectedInstanceSelector = $selectedInstanceSelector.get();
-  const selectedInstanceId = selectedInstanceSelector?.[0];
+  const selectedInstance = $selectedInstance.get();
   const selectedBreakpoint = $selectedBreakpoint.get();
   const selectedStyleSource = $selectedStyleSource.get();
   const styleSourceSelector = $selectedOrLastStyleSourceSelector.get();
 
   if (
-    selectedInstanceId === undefined ||
+    selectedInstance === undefined ||
     selectedBreakpoint === undefined ||
     selectedStyleSource === undefined ||
     styleSourceSelector === undefined
@@ -101,7 +100,7 @@ const publishUpdates = (
   serverSyncStore.createTransaction(
     [$styleSourceSelections, $styleSources, $styles],
     (styleSourceSelections, styleSources, styles) => {
-      const instanceId = selectedInstanceId;
+      const instanceId = selectedInstance.id;
       const breakpointId = selectedBreakpoint.id;
       // set only selected style source and update selection with it
       // generated local style source will not be written if not selected

--- a/apps/builder/app/builder/features/style-panel/style-panel.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-panel.tsx
@@ -10,21 +10,19 @@ import { useStore } from "@nanostores/react";
 import { computed } from "nanostores";
 import { StyleSourcesSection } from "./style-source-section";
 import { $selectedInstanceRenderState } from "~/shared/nano-states";
-import {
-  $selectedInstanceIntanceToTag,
-  $selectedInstanceSelector,
-} from "~/shared/nano-states";
+import { $selectedInstanceIntanceToTag } from "~/shared/nano-states";
 import { sections } from "./sections";
 import { toValue } from "@webstudio-is/css-engine";
 import { useParentComputedStyleDecl } from "./shared/model";
+import { $selectedInstance } from "~/shared/awareness";
 
 const $selectedInstanceTag = computed(
-  [$selectedInstanceSelector, $selectedInstanceIntanceToTag],
-  (instanceSelector, instanceToTag) => {
-    if (instanceSelector === undefined || instanceToTag === undefined) {
+  [$selectedInstance, $selectedInstanceIntanceToTag],
+  (selectedInstance, instanceToTag) => {
+    if (selectedInstance === undefined || instanceToTag === undefined) {
       return;
     }
-    return instanceToTag.get(instanceSelector[0]);
+    return instanceToTag.get(selectedInstance.id);
   }
 );
 

--- a/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
@@ -5,6 +5,7 @@ import type { WsComponentMeta } from "@webstudio-is/react-sdk";
 import { registerContainers } from "~/shared/sync";
 import {
   $breakpoints,
+  $instances,
   $registeredComponentMetas,
   $selectedStyleSources,
   $styleSourceSelections,
@@ -108,6 +109,14 @@ test("generate styles from preset tokens", () => {
 });
 
 test("add style source to instance", () => {
+  $instances.set(
+    new Map([
+      [
+        "body",
+        { type: "instance", id: "body", component: "Body", children: [] },
+      ],
+    ])
+  );
   $awareness.set({
     pageId: "",
     instanceSelector: ["body"],

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -1,8 +1,6 @@
-import { atom, computed } from "nanostores";
-import { ROOT_INSTANCE_ID, type Instances } from "@webstudio-is/sdk";
-import { rootComponent } from "@webstudio-is/react-sdk";
+import { atom } from "nanostores";
+import type { Instances } from "@webstudio-is/sdk";
 import type { InstanceSelector } from "../tree-utils";
-import { $selectedPage } from "../awareness";
 
 export const $isResizingCanvas = atom(false);
 
@@ -34,33 +32,6 @@ export const $textEditingInstanceSelector = atom<
 >();
 
 export const $instances = atom<Instances>(new Map());
-
-export const $virtualInstances = computed($selectedPage, (selectedPage) => {
-  const virtualInstances: Instances = new Map();
-  if (selectedPage) {
-    virtualInstances.set(ROOT_INSTANCE_ID, {
-      type: "instance",
-      id: ROOT_INSTANCE_ID,
-      component: rootComponent,
-      children: [{ type: "id", value: selectedPage.rootInstanceId }],
-    });
-  }
-  return virtualInstances;
-});
-
-export const $selectedInstance = computed(
-  [$instances, $virtualInstances, $selectedInstanceSelector],
-  (instances, virtualInstances, selectedInstanceSelector) => {
-    if (selectedInstanceSelector === undefined) {
-      return;
-    }
-    const [selectedInstanceId] = selectedInstanceSelector;
-    return (
-      instances.get(selectedInstanceId) ??
-      virtualInstances.get(selectedInstanceId)
-    );
-  }
-);
 
 export const $synchronizedInstances = [
   ["textEditingInstanceSelector", $textEditingInstanceSelector],

--- a/apps/builder/app/shared/nano-states/misc.ts
+++ b/apps/builder/app/shared/nano-states/misc.ts
@@ -28,6 +28,7 @@ import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-
 import type { Simplify } from "type-fest";
 import type { AssetType } from "@webstudio-is/asset-uploader";
 import type { ChildrenOrientation } from "node_modules/@webstudio-is/design-system/src/components/primitives/dnd/geometry-utils";
+import { $selectedInstance } from "../awareness";
 
 export const $project = atom<Project | undefined>();
 
@@ -178,14 +179,14 @@ export const $selectedInstanceRenderState = atom<
 >("notMounted");
 
 export const $selectedInstanceStatesByStyleSourceId = computed(
-  [$styles, $styleSourceSelections, $selectedInstanceSelector],
-  (styles, styleSourceSelections, selectedInstanceSelector) => {
+  [$styles, $styleSourceSelections, $selectedInstance],
+  (styles, styleSourceSelections, selectedInstance) => {
     const statesByStyleSourceId = new Map<StyleSource["id"], string[]>();
-    if (selectedInstanceSelector === undefined) {
+    if (selectedInstance === undefined) {
       return statesByStyleSourceId;
     }
     const styleSourceIds = new Set(
-      styleSourceSelections.get(selectedInstanceSelector[0])?.values
+      styleSourceSelections.get(selectedInstance.id)?.values
     );
     for (const styleDecl of styles.values()) {
       if (
@@ -208,15 +209,14 @@ export const $selectedInstanceStatesByStyleSourceId = computed(
 );
 
 export const $selectedInstanceStyleSources = computed(
-  [$styleSourceSelections, $styleSources, $selectedInstanceSelector],
-  (styleSourceSelections, styleSources, selectedInstanceSelector) => {
+  [$styleSourceSelections, $styleSources, $selectedInstance],
+  (styleSourceSelections, styleSources, selectedInstance) => {
     const selectedInstanceStyleSources: StyleSource[] = [];
-    if (selectedInstanceSelector === undefined) {
+    if (selectedInstance === undefined) {
       return selectedInstanceStyleSources;
     }
-    const [selectedInstanceId] = selectedInstanceSelector;
     const styleSourceIds =
-      styleSourceSelections.get(selectedInstanceId)?.values ?? [];
+      styleSourceSelections.get(selectedInstance.id)?.values ?? [];
     let hasLocal = false;
     for (const styleSourceId of styleSourceIds) {
       const styleSource = styleSources.get(styleSourceId);
@@ -244,20 +244,19 @@ export const $selectedOrLastStyleSourceSelector = computed(
   [
     $selectedInstanceStyleSources,
     $selectedStyleSources,
-    $selectedInstanceSelector,
+    $selectedInstance,
     $selectedStyleState,
   ],
   (
     styleSources,
     selectedStyleSources,
-    selectedInstanceSelector,
+    selectedInstance,
     selectedStyleState
   ) => {
-    if (selectedInstanceSelector === undefined) {
+    if (selectedInstance === undefined) {
       return;
     }
-    const [instanceId] = selectedInstanceSelector;
-    const styleSourceId = selectedStyleSources.get(instanceId);
+    const styleSourceId = selectedStyleSources.get(selectedInstance.id);
     // always fallback to local (the last one) style source
     const lastStyleSource = styleSources.at(-1);
     const matchedStyleSource = styleSources.find(
@@ -275,17 +274,12 @@ export const $selectedOrLastStyleSourceSelector = computed(
  * to the last style source of selected instance
  */
 export const $selectedStyleSource = computed(
-  [
-    $selectedInstanceStyleSources,
-    $selectedStyleSources,
-    $selectedInstanceSelector,
-  ],
-  (styleSources, selectedStyleSources, selectedInstanceSelector) => {
-    if (selectedInstanceSelector === undefined) {
+  [$selectedInstanceStyleSources, $selectedStyleSources, $selectedInstance],
+  (styleSources, selectedStyleSources, selectedInstance) => {
+    if (selectedInstance === undefined) {
       return;
     }
-    const [instanceId] = selectedInstanceSelector;
-    const selectedStyleSourceId = selectedStyleSources.get(instanceId);
+    const selectedStyleSourceId = selectedStyleSources.get(selectedInstance.id);
     return (
       styleSources.find((item) => item.id === selectedStyleSourceId) ??
       styleSources.at(-1)


### PR DESCRIPTION
We need to avoid accessing instance selector where possible to make logic hookable.

Here moved `$selectedInstance` into awareness and switch to it in many places instance selector is accessed directly.