### PR TITLE
refactor: generalize insertable lookup

### DIFF
--- a/apps/builder/app/builder/features/components/insert.ts
+++ b/apps/builder/app/builder/features/components/insert.ts
@@ -1,18 +1,11 @@
-import { ROOT_INSTANCE_ID } from "@webstudio-is/sdk";
 import type { WsComponentMeta } from "@webstudio-is/react-sdk";
 import { toast } from "@webstudio-is/design-system";
+import { $registeredComponentMetas } from "~/shared/nano-states";
 import {
-  $instances,
-  $registeredComponentMetas,
-  $selectedInstanceSelector,
-} from "~/shared/nano-states";
-import {
-  computeInstancesConstraints,
-  findClosestDroppableTarget,
+  findClosestInsertable,
   getComponentTemplateData,
   insertTemplateData,
 } from "~/shared/instance-utils";
-import { $selectedPage } from "~/shared/awareness";
 
 const formatInsertionError = (component: string, meta: WsComponentMeta) => {
   const or = new Intl.ListFormat("en", {
@@ -36,41 +29,18 @@ const formatInsertionError = (component: string, meta: WsComponentMeta) => {
 // Insert a component depending on currently selected instance.
 // Used for 1-click insert from the components panel.
 export const insert = (component: string) => {
-  const selectedPage = $selectedPage.get();
-  if (selectedPage === undefined) {
+  const fragment = getComponentTemplateData(component);
+  if (fragment === undefined) {
     return;
   }
-  const templateData = getComponentTemplateData(component);
-  if (templateData === undefined) {
-    return;
-  }
-  const newInstances = new Map(
-    templateData.instances.map((instance) => [instance.id, instance])
-  );
-  const rootInstanceIds = templateData.children
-    .filter((child) => child.type === "id")
-    .map((child) => child.value);
-  const instanceSelector = $selectedInstanceSelector.get() ?? [
-    selectedPage.rootInstanceId,
-  ];
-  if (instanceSelector[0] === ROOT_INSTANCE_ID) {
-    toast.error(`${component} cannot be added into Global Root`);
-    return;
-  }
-  const metas = $registeredComponentMetas.get();
-  const dropTarget = findClosestDroppableTarget(
-    metas,
-    $instances.get(),
-    // fallback to root as drop target
-    instanceSelector,
-    computeInstancesConstraints(metas, newInstances, rootInstanceIds)
-  );
-  if (dropTarget === undefined) {
+  const insertable = findClosestInsertable(fragment);
+  if (insertable === undefined) {
+    const metas = $registeredComponentMetas.get();
     const meta = metas.get(component);
     if (meta) {
       toast.error(formatInsertionError(component, meta));
     }
     return;
   }
-  insertTemplateData(templateData, dropTarget);
+  insertTemplateData(fragment, insertable);
 };

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -35,7 +35,6 @@ import {
 import {
   $props,
   $styles,
-  $selectedInstanceSelector,
   $styleSourceSelections,
   $styleSources,
   $instances,
@@ -63,7 +62,7 @@ import { humanizeString } from "./string-utils";
 import { serverSyncStore } from "./sync";
 import { setDifference, setUnion } from "./shim";
 import { breakCyclesMutable, findCycles } from "@webstudio-is/project-build";
-import { $selectedPage, selectInstance } from "./awareness";
+import { $awareness, $selectedPage, selectInstance } from "./awareness";
 
 export const updateWebstudioData = (mutate: (data: WebstudioData) => void) => {
   serverSyncStore.createTransaction(
@@ -420,31 +419,22 @@ export const findClosestDroppableComponentIndex = ({
   return -1;
 };
 
-export const findClosestDroppableTarget = (
+const findClosestDroppableTarget = (
   metas: Map<string, WsComponentMeta>,
   instances: Instances,
   instanceSelector: InstanceSelector,
   insertConstraints: InsertConstraints
 ): undefined | DroppableTarget => {
-  if (instanceSelector[0] === ROOT_INSTANCE_ID) {
-    return;
-  }
-  // We want to always allow dropping into the root.
-  // For example when body has text content and the only viable option is to insert at the end.
-  if (instanceSelector.length === 1) {
-    return {
-      parentSelector: instanceSelector,
-      position: "end",
-    };
-  }
   const droppableIndex = findClosestDroppableComponentIndex({
     metas,
     constraints: insertConstraints,
     instances,
     instanceSelector,
-    allowInsertIntoTextContainer: false,
+    // We want to always allow dropping into the root.
+    // For example when body has text content
+    // and the only viable option is to insert at the end.
+    allowInsertIntoTextContainer: instanceSelector.length === 1,
   });
-
   if (droppableIndex === -1) {
     return;
   }
@@ -517,30 +507,8 @@ export const insertInstanceChildrenMutable = (
 
 export const findTargetAndInsertFragment = (fragment: WebstudioFragment) => {
   let isSuccess = false;
-
-  const selectedPage = $selectedPage.get();
-  if (selectedPage === undefined) {
-    return isSuccess;
-  }
-  const metas = $registeredComponentMetas.get();
-  const newInstances = new Map(
-    fragment.instances.map((instance) => [instance.id, instance])
-  );
-  const rootInstanceIds = fragment.children
-    .filter((child) => child.type === "id")
-    .map((child) => child.value);
-  // paste to the root if nothing is selected
-  const instanceSelector = $selectedInstanceSelector.get() ?? [
-    selectedPage.rootInstanceId,
-  ];
-  const target = findClosestDroppableTarget(
-    metas,
-    $instances.get(),
-    instanceSelector,
-    computeInstancesConstraints(metas, newInstances, rootInstanceIds)
-  );
-
-  if (target === undefined) {
+  const insertable = findClosestInsertable(fragment);
+  if (insertable === undefined) {
     return isSuccess;
   }
 
@@ -551,7 +519,7 @@ export const findTargetAndInsertFragment = (fragment: WebstudioFragment) => {
       availableDataSources: findAvailableDataSources(
         data.dataSources,
         data.instances,
-        instanceSelector
+        insertable.parentSelector
       ),
     });
     const newRootInstanceId = newInstanceIds.get(fragment.instances[0].id);
@@ -562,7 +530,7 @@ export const findTargetAndInsertFragment = (fragment: WebstudioFragment) => {
     const children: Instance["children"] = [
       { type: "id", value: newRootInstanceId },
     ];
-    insertInstanceChildrenMutable(data, children, target);
+    insertInstanceChildrenMutable(data, children, insertable);
     isSuccess = true;
   });
 
@@ -1620,4 +1588,41 @@ export const findClosestSlot = (
       return instance;
     }
   }
+};
+
+export type Insertable = {
+  parentSelector: InstanceSelector;
+  position: number | "end";
+};
+
+export const findClosestInsertable = (
+  fragment: WebstudioFragment
+): undefined | Insertable => {
+  const selectedPage = $selectedPage.get();
+  const awareness = $awareness.get();
+  if (selectedPage === undefined) {
+    return;
+  }
+  // paste to the page root if nothing is selected
+  const instanceSelector = awareness?.instanceSelector ?? [
+    selectedPage.rootInstanceId,
+  ];
+  if (instanceSelector[0] === ROOT_INSTANCE_ID) {
+    toast.error(`Cannot insert into Global Root`);
+    return;
+  }
+  const metas = $registeredComponentMetas.get();
+  const instances = $instances.get();
+  const rootInstanceIds = fragment.children
+    .filter((child) => child.type === "id")
+    .map((child) => child.value);
+  const newInstances = new Map(
+    fragment.instances.map((instance) => [instance.id, instance])
+  );
+  return findClosestDroppableTarget(
+    metas,
+    instances,
+    instanceSelector,
+    computeInstancesConstraints(metas, newInstances, rootInstanceIds)
+  );
 };

--- a/packages/sdk/src/jsx.ts
+++ b/packages/sdk/src/jsx.ts
@@ -62,6 +62,9 @@ const traverseJsx = (
     if (typeof child === "string") {
       continue;
     }
+    if (child instanceof ExpressionValue) {
+      continue;
+    }
     traverseJsx(child, callback);
   }
 };
@@ -137,7 +140,9 @@ export const renderJsx = (root: JSX.Element) => {
       children: children.map((child) =>
         typeof child === "string"
           ? { type: "text", value: child }
-          : { type: "id", value: child.props?.["ws:id"] ?? getId(child) }
+          : child instanceof ExpressionValue
+            ? { type: "expression", value: child.value }
+            : { type: "id", value: child.props?.["ws:id"] ?? getId(child) }
       ),
     });
   });
@@ -151,7 +156,7 @@ type ComponentProps = Record<string, unknown> &
   Record<`${string}:expression`, string> & {
     "ws:id"?: string;
     "ws:label"?: string;
-    children?: ReactNode;
+    children?: ReactNode | ExpressionValue;
   };
 
 type Component = { displayName: string } & ((


### PR DESCRIPTION
Here replaced a bunch boilerplaty code with more general findClosestInsertable. This also reduced amount of explicit instance selector calls. Prevented inserting list item into body. Refactored tests with jsx.