### PR TITLE
fix: Remove uppercasing on dashboard card titles and also enable user-select.

### DIFF
--- a/apps/builder/app/dashboard/projects/project-card.tsx
+++ b/apps/builder/app/dashboard/projects/project-card.tsx
@@ -36,11 +36,6 @@ import type { DashboardProject } from "@webstudio-is/dashboard";
 import { Card, CardContent, CardFooter } from "../shared/card";
 import { CloneProjectDialog } from "~/shared/clone-project";
 
-const titleStyle = css({
-  userSelect: "text",
-  ...truncate(),
-});
-
 const infoIconStyle = css({ flexShrink: 0 });
 
 const PublishedLink = ({
@@ -248,7 +243,12 @@ export const ProjectCard = ({
       <CardFooter>
         <Flex direction="column" justify="around" grow>
           <Flex gap="1">
-            <Text variant="titles" className={titleStyle()}>
+            <Text
+              variant="titles"
+              userSelect="text"
+              truncate
+              css={{ textTransform: "none" }}
+            >
               {title}
             </Text>
             <Tooltip


### PR DESCRIPTION
## Description

Remove uppercasing on dashboard card titles and also enable user-select.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
