### PR TITLE
experimental: add tabbable command actions

### DIFF
--- a/apps/builder/app/builder/features/command-panel/command-panel.tsx
+++ b/apps/builder/app/builder/features/command-panel/command-panel.tsx
@@ -23,6 +23,7 @@ import {
   Kbd,
   Text,
   CommandFooter,
+  Separator,
 } from "@webstudio-is/design-system";
 import { compareMedia } from "@webstudio-is/css-engine";
 import type { Breakpoint, Page } from "@webstudio-is/sdk";
@@ -347,6 +348,7 @@ const CommandDialogContent = () => {
           </CommandList>
         </ScrollArea>
       </Flex>
+      <Separator />
       <CommandFooter />
     </>
   );

--- a/apps/builder/app/builder/features/command-panel/command-panel.tsx
+++ b/apps/builder/app/builder/features/command-panel/command-panel.tsx
@@ -22,6 +22,7 @@ import {
   Flex,
   Kbd,
   Text,
+  CommandFooter,
 } from "@webstudio-is/design-system";
 import { compareMedia } from "@webstudio-is/css-engine";
 import type { Breakpoint, Page } from "@webstudio-is/sdk";
@@ -346,6 +347,7 @@ const CommandDialogContent = () => {
           </CommandList>
         </ScrollArea>
       </Flex>
+      <CommandFooter />
     </>
   );
 };

--- a/apps/builder/app/builder/features/command-panel/command-panel.tsx
+++ b/apps/builder/app/builder/features/command-panel/command-panel.tsx
@@ -17,12 +17,11 @@ import {
   CommandGroupHeading,
   CommandItem,
   CommandIcon,
+  useSelectedAction,
   ScrollArea,
   Flex,
   Kbd,
   Text,
-  CommandActions,
-  useSelectedAction,
 } from "@webstudio-is/design-system";
 import { compareMedia } from "@webstudio-is/css-engine";
 import type { Breakpoint, Page } from "@webstudio-is/sdk";
@@ -131,7 +130,7 @@ const $componentOptions = computed(
 const ComponentGroup = ({ options }: { options: ComponentOption[] }) => {
   return (
     <CommandGroup
-      value="component"
+      name="component"
       heading={<CommandGroupHeading>Components</CommandGroupHeading>}
       actions={["add"]}
     >
@@ -210,7 +209,7 @@ const getBreakpointLabel = (breakpoint: Breakpoint) => {
 const BreakpointGroup = ({ options }: { options: BreakpointOption[] }) => {
   return (
     <CommandGroup
-      value="breakpoint"
+      name="breakpoint"
       heading={<CommandGroupHeading>Breakpoints</CommandGroupHeading>}
       actions={["select"]}
     >
@@ -265,7 +264,7 @@ const PageGroup = ({ options }: { options: PageOption[] }) => {
   const action = useSelectedAction();
   return (
     <CommandGroup
-      value="page"
+      name="page"
       heading={<CommandGroupHeading>Pages</CommandGroupHeading>}
       actions={["select", "settings"]}
     >
@@ -317,7 +316,6 @@ const CommandDialogContent = () => {
   return (
     <>
       <CommandInput value={search} onValueChange={setSearch} />
-      <CommandActions />
       <Flex direction="column" css={{ maxHeight: 300 }}>
         <ScrollArea>
           <CommandList>

--- a/apps/builder/app/builder/features/style-panel/sections/shared/input-popover.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/shared/input-popover.tsx
@@ -139,7 +139,6 @@ export const InputPopover = ({
         <Trigger />
       </PopoverTrigger>
       <PopoverContentStyled
-        hideArrow
         sideOffset={-24}
         // prevent propagating click on input or combobox menu
         // and closing popover before applying changes

--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -219,6 +219,13 @@ export const Menu = () => {
 
           <DropdownMenuSeparator />
 
+          <DropdownMenuItem onSelect={() => emitCommand("openCommandPanel")}>
+            Search & Commands
+            <DropdownMenuItemRightSlot>
+              <Kbd value={["cmd", "k"]} />
+            </DropdownMenuItemRightSlot>
+          </DropdownMenuItem>
+
           <DropdownMenuItem
             onSelect={() => {
               window.open(

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -349,7 +349,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
     },
 
     {
-      name: "search",
+      name: "openCommandPanel",
       defaultHotkeys: ["meta+k", "ctrl+k"],
       handler: openCommandPanel,
     },

--- a/packages/design-system/src/components/command.stories.tsx
+++ b/packages/design-system/src/components/command.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import {
+  CommandActions,
   Command as CommandComponent,
   CommandGroup,
   CommandGroupHeading,
@@ -11,6 +12,7 @@ import {
 import { Text } from "./text";
 import { InfoCircleIcon } from "@webstudio-is/icons";
 import { Kbd } from "./kbd";
+import { Flex } from "./flex";
 
 const meta: Meta = {
   title: "Library/Command",
@@ -21,51 +23,66 @@ export const Command: StoryFn = () => {
   return (
     <CommandComponent>
       <CommandInput />
+      <CommandActions />
       <CommandList>
         <CommandGroup
           heading={<CommandGroupHeading>Suggestions</CommandGroupHeading>}
+          actions={["select", "edit", "delete"]}
         >
           <CommandItem>
-            <CommandIcon>
-              <InfoCircleIcon />
-            </CommandIcon>
-            <Text variant="labelsTitleCase">Calendar</Text>
+            <Flex gap={2}>
+              <CommandIcon>
+                <InfoCircleIcon />
+              </CommandIcon>
+              <Text variant="labelsTitleCase">Calendar</Text>
+            </Flex>
           </CommandItem>
           <CommandItem>
-            <CommandIcon>
-              <InfoCircleIcon />
-            </CommandIcon>
-            <Text variant="labelsTitleCase">Search Emoji</Text>
+            <Flex gap={2}>
+              <CommandIcon>
+                <InfoCircleIcon />
+              </CommandIcon>
+              <Text variant="labelsTitleCase">Search Emoji</Text>
+            </Flex>
           </CommandItem>
           <CommandItem>
-            <CommandIcon>
-              <InfoCircleIcon />
-            </CommandIcon>
-            <Text variant="labelsTitleCase">Calculator</Text>
+            <Flex gap={2}>
+              <CommandIcon>
+                <InfoCircleIcon />
+              </CommandIcon>
+              <Text variant="labelsTitleCase">Calculator</Text>
+            </Flex>
           </CommandItem>
         </CommandGroup>
         <CommandGroup
           heading={<CommandGroupHeading>Settings</CommandGroupHeading>}
+          actions={["open"]}
         >
           <CommandItem>
-            <CommandIcon>
-              <InfoCircleIcon />
-            </CommandIcon>
-            <Text variant="labelsTitleCase">Profile</Text>
+            <Flex gap={2}>
+              <CommandIcon>
+                <InfoCircleIcon />
+              </CommandIcon>
+              <Text variant="labelsTitleCase">Profile</Text>
+            </Flex>
             <Kbd value={["cmd", "p"]} />
           </CommandItem>
           <CommandItem>
-            <CommandIcon>
-              <InfoCircleIcon />
-            </CommandIcon>
-            <Text variant="labelsTitleCase">Billing</Text>
+            <Flex gap={2}>
+              <CommandIcon>
+                <InfoCircleIcon />
+              </CommandIcon>
+              <Text variant="labelsTitleCase">Billing</Text>
+            </Flex>
             <Kbd value={["cmd", "b"]} />
           </CommandItem>
           <CommandItem>
-            <CommandIcon>
-              <InfoCircleIcon />
-            </CommandIcon>
-            <Text variant="labelsTitleCase">Settings</Text>
+            <Flex gap={2}>
+              <CommandIcon>
+                <InfoCircleIcon />
+              </CommandIcon>
+              <Text variant="labelsTitleCase">Settings</Text>
+            </Flex>
             <Kbd value={["cmd", "s"]} />
           </CommandItem>
         </CommandGroup>

--- a/packages/design-system/src/components/command.stories.tsx
+++ b/packages/design-system/src/components/command.stories.tsx
@@ -7,7 +7,6 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-  useSelectedAction,
 } from "./command";
 import { Text } from "./text";
 import { InfoCircleIcon } from "@webstudio-is/icons";
@@ -20,7 +19,6 @@ const meta: Meta = {
 export default meta;
 
 const CommandContent = () => {
-  const action = useSelectedAction();
   return (
     <>
       <CommandInput />
@@ -30,7 +28,7 @@ const CommandContent = () => {
           name="suggestions"
           actions={["select", "edit", "delete"]}
         >
-          <CommandItem onSelect={() => console.log(action, "Calendar")}>
+          <CommandItem>
             <Flex gap={2}>
               <CommandIcon>
                 <InfoCircleIcon />

--- a/packages/design-system/src/components/command.stories.tsx
+++ b/packages/design-system/src/components/command.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import {
   Command as CommandComponent,
+  CommandFooter,
   CommandGroup,
   CommandGroupHeading,
   CommandIcon,
@@ -12,6 +13,7 @@ import { Text } from "./text";
 import { InfoCircleIcon } from "@webstudio-is/icons";
 import { Kbd } from "./kbd";
 import { Flex } from "./flex";
+import { Separator } from "./separator";
 
 const meta: Meta = {
   title: "Library/Command",
@@ -87,6 +89,8 @@ const CommandContent = () => {
           </CommandItem>
         </CommandGroup>
       </CommandList>
+      <Separator />
+      <CommandFooter />
     </>
   );
 };

--- a/packages/design-system/src/components/command.stories.tsx
+++ b/packages/design-system/src/components/command.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import {
-  CommandActions,
   Command as CommandComponent,
   CommandGroup,
   CommandGroupHeading,
@@ -8,6 +7,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  useSelectedAction,
 } from "./command";
 import { Text } from "./text";
 import { InfoCircleIcon } from "@webstudio-is/icons";
@@ -19,17 +19,18 @@ const meta: Meta = {
 };
 export default meta;
 
-export const Command: StoryFn = () => {
+const CommandContent = () => {
+  const action = useSelectedAction();
   return (
-    <CommandComponent>
+    <>
       <CommandInput />
-      <CommandActions />
       <CommandList>
         <CommandGroup
           heading={<CommandGroupHeading>Suggestions</CommandGroupHeading>}
+          name="suggestions"
           actions={["select", "edit", "delete"]}
         >
-          <CommandItem>
+          <CommandItem onSelect={() => console.log(action, "Calendar")}>
             <Flex gap={2}>
               <CommandIcon>
                 <InfoCircleIcon />
@@ -56,6 +57,7 @@ export const Command: StoryFn = () => {
         </CommandGroup>
         <CommandGroup
           heading={<CommandGroupHeading>Settings</CommandGroupHeading>}
+          name="settings"
           actions={["open"]}
         >
           <CommandItem>
@@ -87,6 +89,14 @@ export const Command: StoryFn = () => {
           </CommandItem>
         </CommandGroup>
       </CommandList>
+    </>
+  );
+};
+
+export const Command: StoryFn = () => {
+  return (
+    <CommandComponent>
+      <CommandContent />
     </CommandComponent>
   );
 };

--- a/packages/design-system/src/components/command.tsx
+++ b/packages/design-system/src/components/command.tsx
@@ -1,5 +1,18 @@
-import type { ComponentPropsWithoutRef } from "react";
-import { Command as CommandPrimitive, defaultFilter } from "cmdk";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentPropsWithoutRef,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import {
+  Command as CommandPrimitive,
+  defaultFilter,
+  useCommandState,
+} from "cmdk";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import {
   DialogTitle,
@@ -11,6 +24,8 @@ import {
 import { MagnifyingGlassIcon } from "@webstudio-is/icons";
 import { styled, theme } from "../stitches.config";
 import { textVariants } from "./text";
+import { Flex } from "./flex";
+import { Button } from "./button";
 
 const panelWidth = "400px";
 const itemHeight = "32px";
@@ -46,8 +61,48 @@ const lowerCasedFilter: CommandProps["filter"] = (
     aliases
   );
 
+type CommandState = {
+  highlightedGroup: string;
+  actions: string[];
+  actionIndex: number;
+};
+
+const CommandContext = createContext<
+  [CommandState, Dispatch<SetStateAction<CommandState>>]
+>([
+  {
+    highlightedGroup: "",
+    actions: [],
+    actionIndex: 0,
+  },
+  () => {},
+]);
+
+const getLoopedIndex = (state: CommandState) => {
+  let loopedIndex = state.actionIndex % state.actions.length;
+  if (loopedIndex < 0) {
+    loopedIndex += state.actions.length;
+  }
+  return loopedIndex;
+};
+
+export const useSelectedAction = () => {
+  const [state] = useContext(CommandContext);
+  const loopedIndex = getLoopedIndex(state);
+  return state.actions[loopedIndex];
+};
+
 export const Command = (props: CommandProps) => {
-  return <StyledCommand loop={true} filter={lowerCasedFilter} {...props} />;
+  const state = useState<CommandState>({
+    highlightedGroup: "",
+    actions: [],
+    actionIndex: 0,
+  });
+  return (
+    <CommandContext.Provider value={state}>
+      <StyledCommand loop={true} filter={lowerCasedFilter} {...props} />
+    </CommandContext.Provider>
+  );
 };
 
 const CommandDialogContent = styled(DialogContent, {
@@ -120,14 +175,92 @@ export const CommandInput = (
   );
 };
 
+export const CommandActions = () => {
+  const [state, setState] = useContext(CommandContext);
+  const highlightedValue = useCommandState((state) => state.value);
+  useEffect(() => {
+    const root = actionsRef.current?.closest("[cmdk-root]");
+    const selectedGroup = root?.querySelector(
+      "[cmdk-group]:has([aria-selected=true])"
+    );
+    const highlightedGroup = selectedGroup?.getAttribute("data-value") ?? "";
+    const actions =
+      selectedGroup?.getAttribute("data-actions")?.split(",") ?? [];
+    setState((prev) => {
+      // reset index only when group is changed
+      if (prev.highlightedGroup === highlightedGroup) {
+        return prev;
+      }
+      return { highlightedGroup, actions, actionIndex: 0 };
+    });
+  }, [highlightedValue]);
+
+  const actionsRef = useRef<HTMLDivElement>(null);
+  const loopedSelectedIndex = getLoopedIndex(state);
+  useEffect(() => {
+    const controller = new AbortController();
+    const root = actionsRef.current?.closest("[cmdk-root]");
+    if (root instanceof HTMLElement) {
+      root.addEventListener(
+        "keydown",
+        (event) => {
+          if (event.key === "Tab") {
+            event.preventDefault();
+            const direction = event.shiftKey ? -1 : 1;
+            setState((prev) => ({
+              ...prev,
+              actionIndex: prev.actionIndex + direction,
+            }));
+          }
+        },
+        { signal: controller.signal }
+      );
+    }
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <Flex gap={1} css={{ padding: 8 }} ref={actionsRef}>
+      {state.actions.map((action, actionIndex) => (
+        <Button
+          key={action}
+          tabIndex={-1}
+          color="ghost"
+          state={loopedSelectedIndex === actionIndex ? "focus" : undefined}
+          data-action={action}
+          onClick={() => {
+            setState((prev) => ({ ...prev, actionIndex }));
+            const root = actionsRef.current?.closest("[cmdk-root]");
+            const input = root?.querySelector("[cmdk-input]");
+            if (input instanceof HTMLElement) {
+              input.focus();
+            }
+          }}
+        >
+          {action}
+        </Button>
+      ))}
+    </Flex>
+  );
+};
+
 export const CommandList = CommandPrimitive.List;
 
-export const CommandGroup = CommandPrimitive.Group;
+type CommandGroupProps = ComponentPropsWithoutRef<
+  typeof CommandPrimitive.Group
+> & {
+  actions: string[];
+};
+
+export const CommandGroup = ({ actions, ...props }: CommandGroupProps) => {
+  return <CommandPrimitive.Group {...props} data-actions={actions.join()} />;
+};
 
 export const CommandGroupHeading = styled("div", {
   ...textVariants.titles,
   color: theme.colors.foregroundMoreSubtle,
   display: "flex",
+  gap: 8,
   alignItems: "center",
   paddingInline: 8,
   height: itemHeight,
@@ -135,10 +268,10 @@ export const CommandGroupHeading = styled("div", {
 
 export const CommandItem = styled(CommandPrimitive.Item, {
   display: "grid",
-  gridTemplateColumns: `${itemHeight} 1fr max-content`,
+  gridTemplateColumns: `1fr max-content`,
   alignItems: "center",
   minHeight: itemHeight,
-  paddingRight: 16,
+  paddingInline: 16,
   "&[aria-selected=true]": {
     backgroundColor: theme.colors.backgroundHover,
   },

--- a/packages/design-system/src/components/command.tsx
+++ b/packages/design-system/src/components/command.tsx
@@ -176,6 +176,7 @@ export const CommandInput = (
 };
 
 export const CommandActions = () => {
+  const actionsRef = useRef<HTMLDivElement>(null);
   const [state, setState] = useContext(CommandContext);
   const highlightedValue = useCommandState((state) => state.value);
   useEffect(() => {
@@ -193,9 +194,8 @@ export const CommandActions = () => {
       }
       return { highlightedGroup, actions, actionIndex: 0 };
     });
-  }, [highlightedValue]);
+  }, [highlightedValue, setState]);
 
-  const actionsRef = useRef<HTMLDivElement>(null);
   const loopedSelectedIndex = getLoopedIndex(state);
   useEffect(() => {
     const controller = new AbortController();
@@ -217,7 +217,7 @@ export const CommandActions = () => {
       );
     }
     return () => controller.abort();
-  }, []);
+  }, [setState]);
 
   return (
     <Flex gap={1} css={{ padding: 8 }} ref={actionsRef}>

--- a/packages/design-system/src/components/command.tsx
+++ b/packages/design-system/src/components/command.tsx
@@ -28,6 +28,7 @@ import { Text, textVariants } from "./text";
 import { Flex } from "./flex";
 import { Button } from "./button";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+import { Kbd } from "./kbd";
 
 const panelWidth = "400px";
 const itemHeight = "32px";
@@ -156,6 +157,7 @@ const CommandInputField = styled(CommandPrimitive.Input, {
 export const CommandInput = (
   props: ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 ) => {
+  const action = useSelectedAction();
   return (
     <CommandInputContainer>
       <CommandInputIcon />
@@ -164,7 +166,13 @@ export const CommandInput = (
         placeholder="Type a command or search..."
         {...props}
       />
-      <CommandActions />
+      <Text
+        variant="labelsTitleCase"
+        color="moreSubtle"
+        css={{ alignSelf: "center", paddingInline: 8 }}
+      >
+        {action} <Kbd value={["enter"]} />
+      </Text>
     </CommandInputContainer>
   );
 };
@@ -185,7 +193,7 @@ const useDebounceEffect = () => {
   }, []);
 };
 
-const CommandActions = () => {
+export const CommandFooter = () => {
   const [isActionOpen, setIsActionOpen] = useState(false);
   const scheduleEffect = useDebounceEffect();
 
@@ -231,14 +239,20 @@ const CommandActions = () => {
   }, [setState]);
 
   return (
-    <Flex alignSelf="center" css={{ paddingInline: 4 }} ref={actionsRef}>
+    <Flex
+      justify="end"
+      align="center"
+      css={{ height: itemHeight, paddingInline: 4 }}
+      ref={actionsRef}
+    >
       <Popover open={isActionOpen} onOpenChange={setIsActionOpen}>
         <PopoverTrigger asChild>
           <Button tabIndex={-1} color="ghost" data-action-trigger>
-            {state.actions[state.actionIndex]}
+            Actions <Kbd value={["tab"]} />
           </Button>
         </PopoverTrigger>
         <PopoverContent
+          side="top"
           onCloseAutoFocus={(event) => {
             event.preventDefault();
             // restore focus to the input instead of button

--- a/packages/design-system/src/components/command.tsx
+++ b/packages/design-system/src/components/command.tsx
@@ -171,7 +171,7 @@ export const CommandInput = (
         color="moreSubtle"
         css={{ alignSelf: "center", paddingInline: 8 }}
       >
-        {action} <Kbd value={["enter"]} />
+        {action} <Kbd value={["enter"]} color="moreSubtle" />
       </Text>
     </CommandInputContainer>
   );

--- a/packages/design-system/src/components/kbd.tsx
+++ b/packages/design-system/src/components/kbd.tsx
@@ -9,6 +9,8 @@ const shortcutSymbolMap: Record<string, string> = {
   shift: "⇧",
   option: "⌥",
   backspace: "⌫",
+  enter: "↵",
+  tab: "tab",
   click: "+click",
 };
 

--- a/packages/design-system/src/components/popover.tsx
+++ b/packages/design-system/src/components/popover.tsx
@@ -21,31 +21,15 @@ const contentStyle = css({
   },
 });
 
-const ArrowBackground = styled("path", { fill: theme.colors.backgroundMenu });
-const ArrowInnerBorder = styled("path", { fill: theme.colors.borderMenuInner });
-const ArrowOuterBorder = styled("path", { fill: theme.colors.borderMain });
-const ArrowSgv = styled("svg", { transform: "translateY(-3px)" });
-const Arrow = () => (
-  <Primitive.Arrow width={16} height={11} asChild>
-    <ArrowSgv xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 11">
-      <ArrowOuterBorder d="M8.73 9.76a1 1 0 0 1-1.46 0L.5 2.54h15L8.73 9.76Z" />
-      <ArrowInnerBorder d="M8.146 8.909a.2.2 0 0 1-.292 0L.5 1.065h15L8.146 8.909Z" />
-      <ArrowBackground d="M8.073 7.52a.1.1 0 0 1-.146 0L.877 0h14.246l-7.05 7.52Z" />
-    </ArrowSgv>
-  </Primitive.Arrow>
-);
-
 export const PopoverContent = forwardRef(
   (
     {
       children,
       className,
       css,
-      hideArrow,
       sideOffset,
       ...props
     }: ComponentProps<typeof Primitive.Content> & {
-      hideArrow?: boolean;
       css?: CSS;
     },
     ref: Ref<HTMLDivElement>
@@ -59,7 +43,6 @@ export const PopoverContent = forwardRef(
         ref={ref}
       >
         {children}
-        {hideArrow !== true && <Arrow />}
       </Primitive.Content>
     </Primitive.Portal>
   )


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/1696

Here adding new idea into command search.
User searches for an object and can navigate actions over this object. In case of pages user can open page or open pangel settings panel.



https://github.com/user-attachments/assets/a5d6c039-ba6b-4dbb-b0b4-bb9f1782dd20
