### PR TITLE
fix: Tooltips trigger without a delay

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Breakpoint, Breakpoints } from "@webstudio-is/sdk";
 import {
-  EnhancedTooltip,
   Flex,
   Text,
   Toolbar,
@@ -156,10 +155,11 @@ export const BreakpointsSelector = ({
         {groupBreakpoints(Array.from(breakpoints.values())).map(
           (breakpoint) => {
             return (
-              <EnhancedTooltip
+              <Tooltip
                 key={breakpoint.id}
                 content={getTooltipContent(breakpoint)}
                 variant="wrapped"
+                disableHoverableContent
               >
                 <ToolbarToggleItem
                   variant="subtle"
@@ -180,7 +180,7 @@ export const BreakpointsSelector = ({
                       <BpStarOffIcon size={22} />
                     ))}
                 </ToolbarToggleItem>
-              </EnhancedTooltip>
+              </Tooltip>
             );
           }
         )}


### PR DESCRIPTION
Partially (or may be fully) Fixes #4406
Closes #4410
Some issues can't be fixed with current tooltips - i.e. if hover from tooltip is going onto the canvas we can't set delay on hover back.


## Description

1. Fixes focusable buttons had tooltip.
2. 

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
