### PR TITLE
feat: Add Content Editor share permission

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -31,6 +31,7 @@ import {
   $textEditingInstanceSelector,
   $isDesignMode,
   $isContentMode,
+  $userPlanFeatures,
 } from "~/shared/nano-states";
 import { $settings, type Settings } from "./shared/client-settings";
 import { builderUrl, getCanvasUrl } from "~/shared/router-utils";
@@ -46,7 +47,6 @@ import {
   $dataLoadingState,
   $isCloneDialogOpen,
   $loadingState,
-  $userPlanFeatures,
   type SidebarPanelName,
 } from "./shared/nano-states";
 import { CloneProjectDialog } from "~/shared/clone-project";

--- a/apps/builder/app/builder/features/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings.tsx
@@ -75,6 +75,7 @@ import {
   $dataSourceVariables,
   $publishedOrigin,
   $project,
+  $userPlanFeatures,
 } from "~/shared/nano-states";
 import {
   BindingControl,
@@ -103,7 +104,6 @@ import {
   isPathAvailable,
 } from "./page-utils";
 import { Form } from "./form";
-import { $userPlanFeatures } from "~/builder/shared/nano-states";
 import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 import { useUnmount } from "~/shared/hook-utils/use-mount";
 import { Card } from "../marketplace/card";

--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -20,11 +20,15 @@ import { InfoCircleIcon } from "@webstudio-is/icons";
 import { ImageControl } from "./image-control";
 import { Image } from "@webstudio-is/image";
 import type { ProjectMeta } from "@webstudio-is/sdk";
-import { $assets, $imageLoader, $pages } from "~/shared/nano-states";
+import {
+  $assets,
+  $imageLoader,
+  $pages,
+  $userPlanFeatures,
+} from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
 import { sectionSpacing } from "./utils";
 import { CodeEditor } from "~/builder/shared/code-editor";
-import { $userPlanFeatures } from "~/builder/shared/nano-states";
 
 const imgStyle = css({
   objectFit: "contain",

--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -13,9 +13,8 @@ import {
 } from "@webstudio-is/design-system";
 import { UpgradeIcon } from "@webstudio-is/icons";
 import { useStore } from "@nanostores/react";
-import { $userPlanFeatures } from "~/builder/shared/nano-states";
 import cmsUpgradeBanner from "./cms-upgrade-banner.svg?url";
-import { $isDesignMode } from "~/shared/nano-states";
+import { $isDesignMode, $userPlanFeatures } from "~/shared/nano-states";
 
 export const SettingsPanelContainer = ({
   selectedInstance,

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -54,9 +54,10 @@ import {
   $areResourcesLoading,
   invalidateResource,
   getComputedResource,
+  $userPlanFeatures,
 } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
-import { $userPlanFeatures } from "~/builder/shared/nano-states";
+
 import { BindingPopoverProvider } from "~/builder/shared/binding-popover";
 import { useSideOffset } from "~/builder/shared/floating-panel";
 import {

--- a/apps/builder/app/builder/features/settings-panel/variables-section.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.stories.tsx
@@ -1,9 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Box } from "@webstudio-is/design-system";
 import { createDefaultPages } from "@webstudio-is/project-build";
-import { $pages, $instances } from "~/shared/nano-states";
+import { $pages, $instances, $userPlanFeatures } from "~/shared/nano-states";
 import { registerContainers } from "~/shared/sync";
-import { $userPlanFeatures } from "~/builder/shared/nano-states";
 import { $awareness } from "~/shared/awareness";
 import { VariablesSection as VariablesSectionComponent } from "./variables-section";
 

--- a/apps/builder/app/builder/features/topbar/domain-checkbox.tsx
+++ b/apps/builder/app/builder/features/topbar/domain-checkbox.tsx
@@ -8,8 +8,8 @@ import {
   buttonStyle,
   Checkbox,
 } from "@webstudio-is/design-system";
-import { $userPlanFeatures } from "~/builder/shared/nano-states";
-import { $project } from "~/shared/nano-states";
+
+import { $project, $userPlanFeatures } from "~/shared/nano-states";
 
 export const domainToPublishName = "domainToPublish[]";
 

--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -16,7 +16,6 @@ import {
   menuItemCss,
 } from "@webstudio-is/design-system";
 import {
-  $userPlanFeatures,
   $isCloneDialogOpen,
   $isShareDialogOpen,
   $isPublishDialogOpen,
@@ -26,6 +25,7 @@ import {
   $authPermit,
   $authToken,
   $authTokenPermissions,
+  $userPlanFeatures,
 } from "~/shared/nano-states";
 import { emitCommand } from "~/builder/shared/commands";
 import { MenuButton } from "./menu-button";

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -35,12 +35,14 @@ import {
   RadioGroup,
 } from "@webstudio-is/design-system";
 import stripIndent from "strip-indent";
-import {
-  $isPublishDialogOpen,
-  $userPlanFeatures,
-} from "../../shared/nano-states";
+import { $isPublishDialogOpen } from "../../shared/nano-states";
 import { validateProjectDomain, type Project } from "@webstudio-is/project";
-import { $authPermit, $project, $publishedOrigin } from "~/shared/nano-states";
+import {
+  $authPermit,
+  $project,
+  $publishedOrigin,
+  $userPlanFeatures,
+} from "~/shared/nano-states";
 import { Domains, PENDING_TIMEOUT, getPublishStatusAndText } from "./domains";
 import { CollapsibleDomainSection } from "./collapsible-domain-section";
 import {

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -6,6 +6,8 @@ import {
   $textEditingInstanceSelector,
   $builderMode,
   $isDesignMode,
+  $isDesignModeAllowed,
+  setBuilderMode,
 } from "~/shared/nano-states";
 import {
   $breakpointsMenuView,
@@ -131,10 +133,15 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       handler: () => {
         setActiveSidebarPanel("auto");
 
+        // @todo: This is temporary until we have a combo to switch modes
         if ($builderMode.get() === "preview") {
-          $builderMode.set("design");
+          if ($isDesignModeAllowed.get()) {
+            setBuilderMode("design");
+          } else {
+            setBuilderMode("content");
+          }
         } else {
-          $builderMode.set("preview");
+          setBuilderMode("preview");
         }
       },
     },
@@ -144,10 +151,15 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       handler: () => {
         setActiveSidebarPanel("auto");
 
+        // @todo: This is temporary until we have a combo to switch modes
         if ($builderMode.get() === "content") {
-          $builderMode.set("design");
+          if ($isDesignModeAllowed.get()) {
+            setBuilderMode("design");
+          } else {
+            setBuilderMode("preview");
+          }
         } else {
-          $builderMode.set("content");
+          setBuilderMode("content");
         }
       },
     },

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -1,5 +1,4 @@
 import { atom, computed } from "nanostores";
-import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 import {
   $isPreviewMode,
   $selectedInstanceRenderState,
@@ -36,16 +35,6 @@ export const $scale = computed(
 );
 
 export const $activeInspectorPanel = atom<"style" | "settings">("style");
-
-// keep in sync with user-plan-features.server
-export const $userPlanFeatures = atom<UserPlanFeatures>({
-  allowShareAdminLinks: false,
-  allowDynamicData: false,
-  maxContactEmails: 0,
-  maxDomainsAllowedPerUser: 1,
-  hasSubscription: false,
-  hasProPlan: false,
-});
 
 export const $dataLoadingState = atom<"idle" | "loading" | "loaded">("idle");
 

--- a/apps/builder/app/routes/_ui.(builder).tsx
+++ b/apps/builder/app/routes/_ui.(builder).tsx
@@ -134,7 +134,7 @@ export const loader = async (loaderArgs: LoaderFunctionArgs) => {
           projectId: project.id,
           // At this point we already knew that if project loaded we have at least "view" permit
           // having that getProjectPermit is heavy operation we can skip check "view" permit
-          permits: ["own", "admin", "build"] as const,
+          permits: ["own", "admin", "build", "edit"] as const,
         },
         context
       )) ?? "view";

--- a/apps/builder/app/shared/nano-states/misc.ts
+++ b/apps/builder/app/shared/nano-states/misc.ts
@@ -1,7 +1,7 @@
 import { atom, computed, onSet } from "nanostores";
 import { nanoid } from "nanoid";
 import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
-import type { Placement } from "@webstudio-is/design-system";
+import { toast, type Placement } from "@webstudio-is/design-system";
 import type {
   Assets,
   DataSources,
@@ -29,6 +29,7 @@ import type { Simplify } from "type-fest";
 import type { AssetType } from "@webstudio-is/asset-uploader";
 import type { ChildrenOrientation } from "node_modules/@webstudio-is/design-system/src/components/primitives/dnd/geometry-utils";
 import { $selectedInstance } from "../awareness";
+import type { UserPlanFeatures } from "../db/user-plan-features.server";
 
 export const $project = atom<Project | undefined>();
 
@@ -297,6 +298,16 @@ export const $hoveredInstanceSelector = atom<undefined | InstanceSelector>(
   undefined
 );
 
+// keep in sync with user-plan-features.server
+export const $userPlanFeatures = atom<UserPlanFeatures>({
+  allowShareAdminLinks: false,
+  allowDynamicData: false,
+  maxContactEmails: 0,
+  maxDomainsAllowedPerUser: 1,
+  hasSubscription: false,
+  hasProPlan: false,
+});
+
 const builderModes = ["design", "preview", "content"] as const;
 export type BuilderMode = (typeof builderModes)[number];
 export const isBuilderMode = (mode: string | null): mode is BuilderMode =>
@@ -323,6 +334,54 @@ export const $authTokenPermissions = atom<TokenPermissions>({
 });
 
 export const $authToken = atom<string | undefined>(undefined);
+
+export const $isContentModeAllowed = computed(
+  [$authToken, $userPlanFeatures],
+  (token, userPlanFeatures) => {
+    return (
+      token === undefined ||
+      (token !== undefined && userPlanFeatures.hasProPlan === true)
+    );
+  }
+);
+
+export const $isDesignModeAllowed = computed([$authPermit], (authPermit) => {
+  return authPermit !== "edit";
+});
+
+export const setBuilderMode = (mode: BuilderMode | null) => {
+  const authPermit = $authPermit.get();
+
+  if (mode === "content" && !$isContentModeAllowed.get()) {
+    // This is content link from a non pro user, we don't allow content mode for such links
+    toast.error(
+      "Content mode is not available for this link. The link’s author must have a Pro plan."
+    );
+
+    $builderMode.set("preview");
+    return;
+  }
+
+  if (mode === "design" && !$isDesignModeAllowed.get()) {
+    toast.error("Design mode is not available for content edit links.");
+
+    $builderMode.set("content");
+    return;
+  }
+
+  if (authPermit === "view") {
+    $builderMode.set(mode ?? "preview");
+    return;
+  }
+
+  const defaultMode = $isDesignModeAllowed.get()
+    ? "design"
+    : $isContentModeAllowed.get()
+      ? "content"
+      : "preview";
+
+  $builderMode.set(mode ?? defaultMode);
+};
 
 export const $toastErrors = atom<string[]>([]);
 

--- a/apps/builder/app/shared/nano-states/misc.ts
+++ b/apps/builder/app/shared/nano-states/misc.ts
@@ -338,10 +338,13 @@ export const $authToken = atom<string | undefined>(undefined);
 export const $isContentModeAllowed = computed(
   [$authToken, $userPlanFeatures],
   (token, userPlanFeatures) => {
-    return (
-      token === undefined ||
-      (token !== undefined && userPlanFeatures.hasProPlan === true)
-    );
+    // In own projects, everyone can edit content
+    if (token === undefined) {
+      return true;
+    }
+
+    // In shared projects, only Pro users can share editable links, so check the plan features of the user who shared the link
+    return userPlanFeatures.hasProPlan === true;
   }
 );
 

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -8,7 +8,7 @@ import {
   $selectedPageHash,
   $builderMode,
   isBuilderMode,
-  $isPreviewMode,
+  setBuilderMode,
 } from "~/shared/nano-states";
 import { builderPath } from "~/shared/router-utils";
 import { $selectedPage, selectPage } from "../awareness";
@@ -30,7 +30,7 @@ const setPageStateFromUrl = () => {
     `Invalid search param mode: ${mode}`
   );
 
-  $builderMode.set(isBuilderMode(mode) ? mode : "design");
+  setBuilderMode(mode);
 
   $selectedPageHash.set(searchParams.get("pageHash") ?? "");
   selectPage(pageId);
@@ -49,7 +49,7 @@ export const useSyncPageUrl = () => {
   const navigate = useNavigate();
   const page = useStore($selectedPage);
   const pageHash = useStore($selectedPageHash);
-  const isPreviewMode = useStore($isPreviewMode);
+  const builderMode = useStore($builderMode);
 
   // Get pageId and pageHash from URL
   // once pages are loaded
@@ -82,13 +82,16 @@ export const useSyncPageUrl = () => {
 
     const searchParamsPageId = searchParams.get("pageId") ?? pages.homePage.id;
     const searchParamsPageHash = searchParams.get("pageHash") ?? "";
-    const searchParamsIsPreviewMode = searchParams.get("mode") === "preview";
+    const searParamsModeRaw = searchParams.get("mode");
+    const searParamsMode = isBuilderMode(searParamsModeRaw)
+      ? searParamsModeRaw
+      : undefined;
 
     // Do not navigate on popstate change
     if (
       searchParamsPageId === page.id &&
       searchParamsPageHash === pageHash &&
-      searchParamsIsPreviewMode === isPreviewMode
+      searParamsMode === builderMode
     ) {
       return;
     }
@@ -98,10 +101,10 @@ export const useSyncPageUrl = () => {
         pageId: page.id === pages.homePage.id ? undefined : page.id,
         authToken: $authToken.get(),
         pageHash: pageHash === "" ? undefined : pageHash,
-        mode: isPreviewMode ? "preview" : undefined,
+        mode: builderMode === "design" ? undefined : builderMode,
       })
     );
-  }, [isPreviewMode, navigate, page, pageHash]);
+  }, [builderMode, navigate, page, pageHash]);
 };
 
 /**

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -23,7 +23,7 @@ export const builderPath = ({
   pageId?: string;
   authToken?: string;
   pageHash?: string;
-  mode?: "preview";
+  mode?: "preview" | "content";
 }) => {
   return `/${searchParams({
     pageId,

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -15,7 +15,8 @@
   },
   "devDependencies": {
     "@webstudio-is/tsconfig": "workspace:*",
-    "typescript": "5.6.3"
+    "typescript": "5.6.3",
+    "type-fest": "^4.26.1"
   },
   "exports": {
     ".": {

--- a/packages/authorization-token/src/trpc/authorization-tokens-router.ts
+++ b/packages/authorization-token/src/trpc/authorization-tokens-router.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import { router, procedure } from "@webstudio-is/trpc-interface/index.server";
 import { db } from "../db";
+import type { IsEqual } from "type-fest";
+import type { Database } from "@webstudio-is/postrest/index.server";
+
+type Relation =
+  Database["public"]["Tables"]["AuthorizationToken"]["Row"]["relation"];
 
 const TokenProjectRelation = z.enum([
   "viewers",
@@ -8,6 +13,10 @@ const TokenProjectRelation = z.enum([
   "builders",
   "administrators",
 ]);
+
+// Check DB types are compatible with zod types
+type TokenRelation = z.infer<typeof TokenProjectRelation>;
+true satisfies IsEqual<TokenRelation, Relation>;
 
 export const authorizationTokenRouter = router({
   findMany: procedure

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,6 +1014,9 @@ importers:
       '@webstudio-is/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      type-fest:
+        specifier: ^4.26.1
+        version: 4.26.1
       typescript:
         specifier: 5.6.3
         version: 5.6.3


### PR DESCRIPTION
## Description

Part 2 Of #3994


Hidden under flag

<img width="360" alt="image" src="https://github.com/user-attachments/assets/59cf859a-3325-425b-b06e-31b74bd93df4">


<img width="350" alt="image" src="https://github.com/user-attachments/assets/dca8521c-5e2b-4e4f-893f-df416cea0481">


Links with `?mode=content` from free plan should not work

<img width="626" alt="image" src="https://github.com/user-attachments/assets/d737474d-8110-42a1-98fd-2ab94ed24cde">

Content edit shared links have no design mode

<img width="421" alt="image" src="https://github.com/user-attachments/assets/42ee3d4b-7aab-4e2c-9e28-b5b0fe6c58af">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
