### PR TITLE
chore: Add new template IDs to trpc

### DIFF
--- a/packages/trpc-interface/src/authorize/project.server.ts
+++ b/packages/trpc-interface/src/authorize/project.server.ts
@@ -100,6 +100,10 @@ export const checkProjectPermit = async (
     "94e6e1b8-c6c4-485a-9d7a-8282e11920c0",
     "05954204-fcee-407e-b47f-77a38de74431",
     "afc162c2-6396-41b7-a855-8fc04604a7b1",
+    "3f260731-825b-486a-b534-e747f0ed6106",
+    "400b1bde-def1-49e0-9b64-e26416d326fa",
+    "2e802ad7-ef32-48e6-8706-3a162785ef95",
+    "01f6f1d8-06f5-4a6c-a3b1-89a0448046c7",
     // Staging IDs
     "c236999d-be6b-43fb-9edc-78a2ba59e56d",
     "a1371dce-752c-4ccf-8ea4-88bab577fe50",


### PR DESCRIPTION
**Waiting to merge until other areas are complete.**

## Todo 

- [x] Accept templates into the Marketplace
- [ ] Marketing coms
- [ ] Update .env
- [ ] Anything else?

## Template IDs and names

Craft (Style Guide)
3f260731-825b-486a-b534-e747f0ed6106

Positivus (Agency)
400b1bde-def1-49e0-9b64-e26416d326fa

Visual Designer (Portfolio)
2e802ad7-ef32-48e6-8706-3a162785ef95

Personal (Portfolio)
01f6f1d8-06f5-4a6c-a3b1-89a0448046c7

## Description

Has IDs for 4 new templates including Craft and three landing pages.

Appears they need to be added here as packages don't have access to .env.

*Before release, update .env with the templates so this release triggers .env changes.*

Will wait to merge until other areas of this release are finalized.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
