### PR TITLE
build: bring back nanoid to prisma

### DIFF
--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -95,7 +95,7 @@
     "mdast-util-gfm": "^3.0.0",
     "micromark-extension-gfm": "^3.0.0",
     "nanoevents": "^8.0.0",
-    "nanoid": "^5.0.1",
+    "nanoid": "^5.0.8",
     "nanostores": "^0.9.3",
     "picocolors": "^1.1.0",
     "pretty-bytes": "^6.1.1",

--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -18,7 +18,7 @@
     "fontkit": "^2.0.2",
     "image-size": "^1.1.1",
     "immer": "^10.0.3",
-    "nanoid": "^5.0.1",
+    "nanoid": "^5.0.8",
     "warn-once": "^0.1.1"
   },
   "devDependencies": {

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -14,7 +14,7 @@
     "@webstudio-is/project-build": "workspace:*",
     "@webstudio-is/sdk": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
-    "nanoid": "^5.0.1",
+    "nanoid": "^5.0.8",
     "type-fest": "^4.26.1",
     "zod": "^3.22.4"
   },

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -25,6 +25,7 @@
   "license": "AGPL-3.0-or-later",
   "private": true,
   "dependencies": {
+    "nanoid": "^5.0.8",
     "tinyexec": "^0.3.1",
     "umzug": "^3.2.1"
   },

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -24,7 +24,7 @@
     "@webstudio-is/postrest": "workspace:*",
     "@webstudio-is/sdk": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
-    "nanoid": "^5.0.1",
+    "nanoid": "^5.0.8",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -13,7 +13,7 @@
     "@webstudio-is/asset-uploader": "workspace:*",
     "@webstudio-is/project-build": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
-    "nanoid": "^5.0.1",
+    "nanoid": "^5.0.8",
     "slugify": "^1.6.6",
     "type-fest": "^4.26.1",
     "zod": "^3.22.4"

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -36,7 +36,7 @@
     "@webstudio-is/sdk": "workspace:*",
     "change-case": "^5.4.4",
     "html-tags": "^4.0.0",
-    "nanoid": "^5.0.1",
+    "nanoid": "^5.0.8",
     "title-case": "^4.3.2"
   },
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,8 +353,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       nanoid:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.8
+        version: 5.0.8
       nanostores:
         specifier: ^0.9.3
         version: 0.9.3
@@ -974,8 +974,8 @@ importers:
         specifier: ^10.0.3
         version: 10.0.3
       nanoid:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.8
+        version: 5.0.8
       warn-once:
         specifier: ^0.1.1
         version: 0.1.1
@@ -1449,8 +1449,8 @@ importers:
         specifier: workspace:*
         version: link:../trpc-interface
       nanoid:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.8
+        version: 5.0.8
       type-fest:
         specifier: ^4.26.1
         version: 4.26.1
@@ -1658,6 +1658,9 @@ importers:
 
   packages/prisma-client:
     dependencies:
+      nanoid:
+        specifier: ^5.0.8
+        version: 5.0.8
       tinyexec:
         specifier: ^0.3.1
         version: 0.3.1
@@ -1699,8 +1702,8 @@ importers:
         specifier: workspace:*
         version: link:../trpc-interface
       nanoid:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.8
+        version: 5.0.8
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
@@ -1730,8 +1733,8 @@ importers:
         specifier: workspace:*
         version: link:../trpc-interface
       nanoid:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.8
+        version: 5.0.8
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1773,8 +1776,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       nanoid:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^5.0.8
+        version: 5.0.8
       title-case:
         specifier: ^4.3.2
         version: 4.3.2
@@ -7103,8 +7106,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.0.1:
-    resolution: {integrity: sha512-vWeVtV5Cw68aML/QaZvqN/3QQXc6fBfIieAlu05m7FZW2Dgb+3f0xc0TTxuJW+7u30t7iSDTV/j3kVI0oJqIfQ==}
+  nanoid@5.0.8:
+    resolution: {integrity: sha512-TcJPw+9RV9dibz1hHUzlLVy8N4X9TnwirAjrU08Juo6BNKggzVfP2ZJ/3ZUSq15Xl5i85i+Z89XBO90pB2PghQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -13349,7 +13352,7 @@ snapshots:
   immerhin@0.9.0:
     dependencies:
       immer: 10.0.3
-      nanoid: 5.0.1
+      nanoid: 5.0.8
 
   import-fresh@3.3.0:
     dependencies:
@@ -14495,7 +14498,7 @@ snapshots:
 
   nanoid@3.3.7: {}
 
-  nanoid@5.0.1: {}
+  nanoid@5.0.8: {}
 
   nanostores@0.9.3: {}
 


### PR DESCRIPTION
Nanoid was used in very old migrations. Forgot we need to run them all when setup new db.

Also bumped nanoid version to the latest.