### PR TITLE
fix: stop failing when retrieve mdn url for css variables

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/configs.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/configs.ts
@@ -54,7 +54,8 @@ export const styleConfigByName = (propertyName: StyleProperty): StyleConfig => {
 
   const keywords = keywordValues[property] || [];
   const label = humanizeString(property);
-  const propertyData = properties[property];
+  // property data does not exist for css custom properties
+  const propertyData = properties[property] ?? {};
 
   const result = {
     label,


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/4431