### PR TITLE
feat: Add Editable Block Component

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -93,6 +93,7 @@ const SidePanel = ({
 }: SidePanelProps) => {
   return (
     <Box
+      id="jopa"
       as="aside"
       css={{
         position: "relative",
@@ -104,7 +105,7 @@ const SidePanel = ({
         fg: 0,
         // Left sidebar tabs won't be able to pop out to the right if we set overflowX to auto.
         //overflowY: "auto",
-        bc: theme.colors.backgroundPanel,
+        backgroundColor: theme.colors.backgroundPanel,
         height: "100%",
         ...css,
       }}
@@ -120,7 +121,6 @@ const Main = ({ children }: { children: ReactNode }) => (
     direction="column"
     css={{
       gridArea: "main",
-      overflow: "hidden",
       position: "relative",
     }}
   >
@@ -417,6 +417,9 @@ export const Builder = ({
               />
             }
           />
+          <SidePanel gridArea="sidebar">
+            <SidebarLeft publish={publish} />
+          </SidePanel>
           <Main>
             <Workspace onTransitionEnd={onTransitionEnd}>
               {dataLoadingState === "loaded" && (
@@ -430,9 +433,6 @@ export const Builder = ({
 
             {isDesignMode && <AiCommandBar />}
           </Main>
-          <SidePanel gridArea="sidebar">
-            <SidebarLeft publish={publish} />
-          </SidePanel>
           <SidePanel
             gridArea="inspector"
             isPreviewMode={isPreviewMode}

--- a/apps/builder/app/builder/features/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator-tree.tsx
@@ -33,6 +33,7 @@ import {
 } from "@webstudio-is/icons";
 import {
   $dragAndDropState,
+  $editableBlockChildOutline,
   $editingItemSelector,
   $hoveredInstanceSelector,
   $instances,
@@ -590,8 +591,10 @@ export const NavigatorTree = () => {
                   },
                 }}
                 buttonProps={{
-                  onMouseEnter: () =>
-                    $hoveredInstanceSelector.set(item.selector),
+                  onMouseEnter: () => {
+                    $hoveredInstanceSelector.set(item.selector);
+                    $editableBlockChildOutline.set(undefined);
+                  },
                   onMouseLeave: () => $hoveredInstanceSelector.set(undefined),
                   onClick: () => selectInstance(item.selector),
                   onFocus: () => selectInstance(item.selector),

--- a/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
@@ -66,20 +66,18 @@ export const CanvasTools = () => {
   }
 
   return (
-    <div className={containerStyle()}>
+    <>
       <MediaBadge />
       <ResizeHandles />
       {isPreviewMode === false && (
         <>
-          <div className={containerStyle({ overflow: "hidden" })}>
-            <SelectedInstanceOutline />
-            <HoveredInstanceOutline />
-            <EditableBlockChildHoveredInstanceOutline />
-            <CollaborativeInstanceOutline />
-          </div>
+          <SelectedInstanceOutline />
+          <HoveredInstanceOutline />
+          <EditableBlockChildHoveredInstanceOutline />
+          <CollaborativeInstanceOutline />
           <TextToolbar />
         </>
       )}
-    </div>
+    </>
   );
 };

--- a/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
@@ -19,6 +19,7 @@ import { ResizeHandles } from "./resize-handles";
 import { MediaBadge } from "./media-badge";
 import { applyScale } from "./outline";
 import { $scale } from "~/builder/shared/nano-states";
+import { EditableBlockChildHoveredInstanceOutline } from "./outline/hovered-instance-outline";
 
 const containerStyle = css({
   position: "absolute",
@@ -73,6 +74,7 @@ export const CanvasTools = () => {
           <div className={containerStyle({ overflow: "hidden" })}>
             <SelectedInstanceOutline />
             <HoveredInstanceOutline />
+            <EditableBlockChildHoveredInstanceOutline />
             <CollaborativeInstanceOutline />
           </div>
           <TextToolbar />

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
@@ -15,7 +15,7 @@ import { $scale } from "~/builder/shared/nano-states";
 import { findClosestSlot } from "~/shared/instance-utils";
 import { shallowEqual } from "shallow-equal";
 import type { InstanceSelector } from "~/shared/tree-utils";
-import { IconButton, Tooltip } from "@webstudio-is/design-system";
+import { IconButton, theme, Tooltip } from "@webstudio-is/design-system";
 import { PlusIcon } from "@webstudio-is/icons";
 import { useRef, useState } from "react";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
@@ -54,15 +54,21 @@ export const EditableBlockChildHoveredInstanceOutline = () => {
           variant={"local"}
           // @todo colors
           css={{
-            borderStyle: "dashed",
-            borderColor: `#4f46e5`,
-            color: "#6366f1",
+            borderStyle: "solid",
+            borderColor: `oklch(from ${theme.colors.backgroundPrimary} l c h / 0.7)`,
+            borderRadius: "100%",
             pointerEvents: "all",
-            backgroundColor: `#eef2ff`,
+            // marginTop: 8,
+            /*
+
+
+            color: "#f59e0b",
+            backgroundColor: `#fffbeb`,
             "&:hover": {
               backgroundColor: `#e0e7ff`,
               color: "#4f46e5",
             },
+            */
           }}
           onClick={() => {
             alert("not implemented");

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
@@ -52,23 +52,12 @@ export const EditableBlockChildHoveredInstanceOutline = () => {
       <Tooltip content="Add next block" side="top" disableHoverableContent>
         <IconButton
           variant={"local"}
-          // @todo colors
           css={{
             borderStyle: "solid",
             borderColor: `oklch(from ${theme.colors.backgroundPrimary} l c h / 0.7)`,
             borderRadius: "100%",
             pointerEvents: "all",
-            // marginTop: 8,
-            /*
-
-
-            color: "#f59e0b",
-            backgroundColor: `#fffbeb`,
-            "&:hover": {
-              backgroundColor: `#e0e7ff`,
-              color: "#4f46e5",
-            },
-            */
+            // mr: theme.spacing[12],
           }}
           onClick={() => {
             alert("not implemented");

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
@@ -101,12 +101,13 @@ export const HoveredInstanceOutline = () => {
   const outline = useStore($hoveredInstanceOutlineAndInstance);
   const scale = useStore($scale);
   const textEditingInstanceSelector = useStore($textEditingInstanceSelector);
+  const isContentMode = useStore($isContentMode);
 
   if (outline === undefined || hoveredInstanceSelector === undefined) {
     return;
   }
 
-  if (isFeatureEnabled("contentEditableMode")) {
+  if (isFeatureEnabled("contentEditableMode") && isContentMode) {
     if (
       shallowEqual(editableBlockChildOutline?.selector, hoveredInstanceSelector)
     ) {

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/label.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/label.tsx
@@ -63,13 +63,19 @@ const LabelContainer = styled(
         top: {
           left: -1,
           top: `-${theme.spacing[10]}`,
+          borderTopLeftRadius: theme.borderRadius[4],
+          borderTopRightRadius: theme.borderRadius[4],
         },
         inside: {
           top: 0,
+          borderBottomLeftRadius: theme.borderRadius[4],
+          borderBottomRightRadius: theme.borderRadius[4],
         },
         bottom: {
           left: -1,
           bottom: `-${theme.spacing[10]}`,
+          borderBottomLeftRadius: theme.borderRadius[4],
+          borderBottomRightRadius: theme.borderRadius[4],
         },
       },
       variant: {

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/label.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/label.tsx
@@ -61,12 +61,14 @@ const LabelContainer = styled(
     variants: {
       position: {
         top: {
+          left: -1,
           top: `-${theme.spacing[10]}`,
         },
         inside: {
           top: 0,
         },
         bottom: {
+          left: -1,
           bottom: `-${theme.spacing[10]}`,
         },
       },

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
@@ -23,7 +23,6 @@ const angleKeyframes = keyframes({
 
 const baseOutlineStyle = css({
   borderWidth: 1,
-  // mixBlendMode: "color-burn",
   variants: {
     variant: {
       default: {
@@ -40,43 +39,16 @@ const baseOutlineStyle = css({
         borderStyle: "solid",
         borderColor: theme.colors.foregroundReusable,
       },
-      content: {
-        borderStyle: "solid",
-        // borderColor: `#f59e0b`,
-        borderColor: `oklch(from ${theme.colors.backgroundPrimary} l c h / 0.7)`,
-        // backgroundColor: "oklch(from #eef2ff l c h / 0.5)",
-      },
-    },
-
-    borderBlock: {
-      left: {
-        borderRightWidth: 0,
-      },
-      right: {
-        borderLeftWidth: 0,
-      },
-      center: {
-        borderRightWidth: 0,
-        borderLeftWidth: 0,
-        borderBottomWidth: 0,
-        alignContent: "end",
-      },
-      full: {},
-      none: {
-        borderWidth: 0,
-      },
     },
   },
-  defaultVariants: { variant: "default", borderBlock: "full" },
+  defaultVariants: { variant: "default" },
 });
 
 const baseStyle = css({
   boxSizing: "border-box",
   position: "absolute",
   display: "grid",
-  // gap: 1, // Border dashed looks strange without gap
-  gridTemplateColumns: `1fr auto 1fr`,
-  // pointerEvents: "none",
+  pointerEvents: "none",
   top: 0,
   left: 0,
 });
@@ -107,35 +79,28 @@ export const EditableBlockChildAddButtonOutline = ({
   rect: Rect;
   children: ReactNode;
 }) => {
-  const variant = "content";
   const dynamicStyle = useDynamicStyle(rect);
 
   return (
     <>
       <div
-        className={`${baseStyle()} ${baseOutlineStyle({ borderBlock: "none" })}`}
+        className={`${baseStyle()} ${baseOutlineStyle()}`}
         style={dynamicStyle}
       >
         <div
-          className={baseOutlineStyle({ variant, borderBlock: "left" })}
-        ></div>
+          style={{
+            height: 0,
+            width: 0,
+            display: "grid",
+            alignContent: "center",
+            justifyContent: "center",
 
-        <div className={baseOutlineStyle({ variant, borderBlock: "center" })}>
-          <div
-            style={{
-              height: 0,
-              display: "grid",
-              alignContent: "center",
-              alignSelf: "end",
-            }}
-          >
-            {children}
-          </div>
+            justifySelf: "start",
+            alignSelf: "start",
+          }}
+        >
+          {children}
         </div>
-
-        <div
-          className={baseOutlineStyle({ variant, borderBlock: "right" })}
-        ></div>
       </div>
     </>
   );

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
@@ -23,7 +23,7 @@ const angleKeyframes = keyframes({
 
 const baseOutlineStyle = css({
   borderWidth: 1,
-
+  // mixBlendMode: "color-burn",
   variants: {
     variant: {
       default: {
@@ -39,11 +39,12 @@ const baseOutlineStyle = css({
       slot: {
         borderStyle: "solid",
         borderColor: theme.colors.foregroundReusable,
-        outlineOffset: -1,
       },
       content: {
-        borderStyle: "dashed",
-        borderColor: `#4f46e5`,
+        borderStyle: "solid",
+        // borderColor: `#f59e0b`,
+        borderColor: `oklch(from ${theme.colors.backgroundPrimary} l c h / 0.7)`,
+        // backgroundColor: "oklch(from #eef2ff l c h / 0.5)",
       },
     },
 
@@ -73,7 +74,7 @@ const baseStyle = css({
   boxSizing: "border-box",
   position: "absolute",
   display: "grid",
-  gap: 1, // Border dashed looks strange without gap
+  // gap: 1, // Border dashed looks strange without gap
   gridTemplateColumns: `1fr auto 1fr`,
   // pointerEvents: "none",
   top: 0,

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
@@ -21,33 +21,63 @@ const angleKeyframes = keyframes({
   },
 });
 
-const baseStyle = css({
-  boxSizing: "border-box",
-  position: "absolute",
-  pointerEvents: "none",
-  top: 0,
-  left: 0,
+const baseOutlineStyle = css({
   borderWidth: 1,
+
   variants: {
     variant: {
       default: {
-        // Semi-transparent color allows user to see the carret when outlining content editable
-        outline: `1px solid oklch(from ${theme.colors.backgroundPrimary} l c h / 0.7) `,
-        outlineOffset: -1,
+        borderStyle: "solid",
+        borderColor: `oklch(from ${theme.colors.backgroundPrimary} l c h / 0.7)`,
       },
       collaboration: {
         [angleVar]: `0deg`,
-        border: `1px solid`,
+        borderStyle: "solid",
         borderImage: `conic-gradient(from var(${angleVar}), #39FBBB 0%, #4A4EFA 12.5%, #E63CFE 25%, #FFAE3C 37.5%, #39FBBB 50%, #4A4EFA 62.5%, #E63CFE 75%, #FFAE3C 87.5%) 1`,
         animation: `2s ${angleKeyframes} linear infinite`,
       },
       slot: {
-        outline: `1px solid ${theme.colors.foregroundReusable}`,
+        borderStyle: "solid",
+        borderColor: theme.colors.foregroundReusable,
         outlineOffset: -1,
+      },
+      content: {
+        borderStyle: "dashed",
+        borderColor: `#4f46e5`,
+      },
+    },
+
+    borderBlock: {
+      left: {
+        borderRightWidth: 0,
+      },
+      right: {
+        borderLeftWidth: 0,
+      },
+      center: {
+        borderRightWidth: 0,
+        borderLeftWidth: 0,
+        borderBottomWidth: 0,
+        alignContent: "end",
+      },
+      full: {},
+      none: {
+        borderWidth: 0,
       },
     },
   },
-  defaultVariants: { variant: "default" },
+  defaultVariants: { variant: "default", borderBlock: "full" },
+});
+
+const baseStyle = css({
+  boxSizing: "border-box",
+  position: "absolute",
+  display: "grid",
+  gap: 1, // Border dashed looks strange without gap
+  gridTemplateColumns: `1fr auto 1fr`,
+  // pointerEvents: "none",
+  top: 0,
+  left: 0,
 });
 
 const useDynamicStyle = (rect?: Rect) => {
@@ -69,12 +99,57 @@ type OutlineProps = {
   variant?: "default" | "collaboration" | "slot";
 };
 
+export const EditableBlockChildAddButtonOutline = ({
+  rect,
+  children,
+}: {
+  rect: Rect;
+  children: ReactNode;
+}) => {
+  const variant = "content";
+  const dynamicStyle = useDynamicStyle(rect);
+
+  return (
+    <>
+      <div
+        className={`${baseStyle()} ${baseOutlineStyle({ borderBlock: "none" })}`}
+        style={dynamicStyle}
+      >
+        <div
+          className={baseOutlineStyle({ variant, borderBlock: "left" })}
+        ></div>
+
+        <div className={baseOutlineStyle({ variant, borderBlock: "center" })}>
+          <div
+            style={{
+              height: 0,
+              display: "grid",
+              alignContent: "center",
+              alignSelf: "end",
+            }}
+          >
+            {children}
+          </div>
+        </div>
+
+        <div
+          className={baseOutlineStyle({ variant, borderBlock: "right" })}
+        ></div>
+      </div>
+    </>
+  );
+};
+
 export const Outline = ({ children, rect, variant }: OutlineProps) => {
   const dynamicStyle = useDynamicStyle(rect);
+
   return (
     <>
       {propertyStyle}
-      <div className={baseStyle({ variant })} style={dynamicStyle}>
+      <div
+        className={`${baseStyle()} ${baseOutlineStyle({ variant })}`}
+        style={dynamicStyle}
+      >
         {children}
       </div>
     </>

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -16,7 +16,8 @@ const workspaceStyle = css({
   background: theme.colors.backgroundCanvas,
   position: "relative",
   // Prevent scrollIntoView from scrolling the whole page
-  overflow: "clip",
+  // Commented to see what it will break
+  // overflow: "clip",
 });
 
 const canvasContainerStyle = css({
@@ -104,22 +105,28 @@ export const Workspace = ({ children, onTransitionEnd }: WorkspaceProps) => {
   };
 
   return (
-    <div
-      className={workspaceStyle()}
-      onClick={handleWorkspaceClick}
-      ref={workspaceRef}
-    >
+    <>
       <div
-        className={canvasContainerStyle()}
-        style={canvasStyle}
-        onTransitionEnd={onTransitionEnd}
+        className={workspaceStyle()}
+        onClick={handleWorkspaceClick}
+        ref={workspaceRef}
       >
-        {children}
-      </div>
-      <div className={canvasContainerStyle()} style={outlineStyle}>
-        <CanvasTools />
+        <div
+          className={canvasContainerStyle()}
+          style={canvasStyle}
+          onTransitionEnd={onTransitionEnd}
+        >
+          {children}
+        </div>
+        <div
+          data-name="canvas-tools-wrapper"
+          className={canvasContainerStyle()}
+          style={outlineStyle}
+        >
+          <CanvasTools />
+        </div>
       </div>
       <Toaster />
-    </div>
+    </>
   );
 };

--- a/apps/builder/app/canvas/features/build-mode/editable-block-template.tsx
+++ b/apps/builder/app/canvas/features/build-mode/editable-block-template.tsx
@@ -1,0 +1,12 @@
+import type {
+  AnyComponent,
+  WebstudioComponentSystemProps,
+} from "@webstudio-is/react-sdk";
+import * as React from "react";
+
+export const EditableBlockTemplate = React.forwardRef<
+  HTMLDivElement,
+  WebstudioComponentSystemProps
+>((props, ref) => {
+  return <div ref={ref} {...props} />;
+}) as AnyComponent;

--- a/apps/builder/app/canvas/features/build-mode/editable-block.tsx
+++ b/apps/builder/app/canvas/features/build-mode/editable-block.tsx
@@ -1,0 +1,12 @@
+import type {
+  AnyComponent,
+  WebstudioComponentSystemProps,
+} from "@webstudio-is/react-sdk";
+import * as React from "react";
+
+export const EditableBlock = React.forwardRef<
+  HTMLDivElement,
+  WebstudioComponentSystemProps
+>((props, ref) => {
+  return <div ref={ref} {...props} />;
+}) as AnyComponent;

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -26,6 +26,8 @@ import {
   type AnyComponent,
   textContentAttribute,
   descendantComponent,
+  editableBlockComponent,
+  editableBlockTemplateComponent,
 } from "@webstudio-is/react-sdk";
 import { rawTheme } from "@webstudio-is/design-system";
 import {
@@ -49,6 +51,8 @@ import {
   createInstanceChildrenElements,
   type WebstudioComponentProps,
 } from "~/canvas/elements";
+import { EditableBlock } from "../build-mode/editable-block";
+import { EditableBlockTemplate } from "../build-mode/editable-block-template";
 
 const ContentEditable = ({
   renderComponentWithRef,
@@ -426,6 +430,14 @@ export const WebstudioComponentCanvas = forwardRef<
 
   if (instance.component === descendantComponent) {
     return <></>;
+  }
+
+  if (instance.component === editableBlockComponent) {
+    Component = EditableBlock;
+  }
+
+  if (instance.component === editableBlockTemplateComponent) {
+    Component = EditableBlockTemplate;
   }
 
   const props: {

--- a/apps/builder/app/shared/nano-states/canvas.ts
+++ b/apps/builder/app/shared/nano-states/canvas.ts
@@ -3,6 +3,7 @@ import type { Instance, Instances } from "@webstudio-is/sdk";
 import type { FontWeight } from "@webstudio-is/fonts";
 import { $instances } from "./instances";
 import type { InstanceSelector } from "../tree-utils";
+import { editableBlockComponent } from "@webstudio-is/react-sdk";
 
 export type TextToolbarState = {
   selectionRect: undefined | DOMRect;
@@ -18,6 +19,11 @@ export const $textToolbar = atom<undefined | TextToolbarState>(undefined);
 
 type InstanceOutline = {
   instanceId: Instance["id"];
+  rect: DOMRect;
+};
+
+export type EditableBlockChildOutline = {
+  selector: InstanceSelector;
   rect: DOMRect;
 };
 
@@ -62,6 +68,26 @@ export const $collaborativeInstanceSelector = atom<
 >(undefined);
 
 export const $collaborativeInstanceRect = atom<undefined | DOMRect>(undefined);
+
+export const $editableBlockChildOutline = atom<
+  undefined | EditableBlockChildOutline
+>(undefined);
+
+export const findEditableBlockChildSelector = (
+  instanceSelector: InstanceSelector
+) => {
+  const instances = $instances.get();
+  let editableBlockChildSelector: InstanceSelector | undefined = undefined;
+
+  for (let i = 1; i < instanceSelector.length; ++i) {
+    const instance = instances.get(instanceSelector[i]);
+    if (instance?.component === editableBlockComponent) {
+      editableBlockChildSelector = instanceSelector.slice(i - 1);
+
+      return editableBlockChildSelector;
+    }
+  }
+};
 
 export const $canvasIframeState = atom<"idle" | "ready">("idle");
 

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -41,6 +41,7 @@ import {
   $collaborativeInstanceSelector,
   $hoveredInstanceOutline,
   $selectedInstanceOutline,
+  $editableBlockChildOutline,
   $textToolbar,
   $registeredComponentMetas,
   $registeredComponentPropsMetas,
@@ -137,6 +138,11 @@ const createObjectPool = () => {
       $selectedInstanceOutline
     ),
     new NanostoresSyncObject("hoveredInstanceOutline", $hoveredInstanceOutline),
+    new NanostoresSyncObject(
+      "editableBlockChildOutline",
+      $editableBlockChildOutline
+    ),
+
     new NanostoresSyncObject(
       "collaborativeInstanceSelector",
       $collaborativeInstanceSelector

--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -1,7 +1,9 @@
 import {
+  EditIcon,
   ListViewIcon,
   PaintBrushIcon,
   SettingsIcon,
+  TriggerIcon,
 } from "@webstudio-is/icons/svg";
 import { html } from "@webstudio-is/sdk/normalize.css";
 import type {
@@ -124,16 +126,66 @@ const descendantPropsMeta: WsComponentPropsMeta = {
   initialProps: ["selector"],
 };
 
+export const editableBlockTemplateComponent = "ws:editable-block-template";
+
+export const editableBlockTemplateMeta: WsComponentMeta = {
+  category: "hidden",
+  detachable: false,
+  type: "container",
+  icon: TriggerIcon,
+  stylable: false,
+};
+
+const editableBlockTemplatePropsMeta: WsComponentPropsMeta = {
+  props: {},
+  initialProps: [],
+};
+
+export const editableBlockComponent = "ws:editable-block";
+
+const editableBlockMeta: WsComponentMeta = {
+  category: "data",
+  order: 2,
+  type: "container",
+  label: "Editable Block",
+  icon: EditIcon,
+  stylable: false,
+  template: [
+    {
+      type: "instance",
+      component: editableBlockComponent,
+      props: [],
+      children: [
+        {
+          type: "instance",
+          label: "Templates",
+          component: editableBlockTemplateComponent,
+          children: [],
+        },
+      ],
+    },
+  ],
+};
+
+const editableBlockPropsMeta: WsComponentPropsMeta = {
+  props: {},
+  initialProps: [],
+};
+
 export const coreMetas = {
   [rootComponent]: rootMeta,
   [collectionComponent]: collectionMeta,
   [descendantComponent]: descendantMeta,
+  [editableBlockComponent]: editableBlockMeta,
+  [editableBlockTemplateComponent]: editableBlockTemplateMeta,
 };
 
 export const corePropsMetas = {
   [rootComponent]: rootPropsMeta,
   [collectionComponent]: collectionPropsMeta,
   [descendantComponent]: descendantPropsMeta,
+  [editableBlockComponent]: editableBlockPropsMeta,
+  [editableBlockTemplateComponent]: editableBlockTemplatePropsMeta,
 };
 
 // components with custom implementation
@@ -141,4 +193,6 @@ export const corePropsMetas = {
 export const isCoreComponent = (component: string) =>
   component === rootComponent ||
   component === collectionComponent ||
-  component === descendantComponent;
+  component === descendantComponent ||
+  component === editableBlockComponent ||
+  component === editableBlockTemplateComponent;


### PR DESCRIPTION
## Description

ref #3994 

Outline for content mode Editable Childs

https://p-64ece825-f290-4de0-8dac-223c8e88c258-dot-editable-block.development.webstudio.is/?mode=content

Like in notion if eny keyboard event is occured inside outlined block, we hide it
Also + hovers are only on canvas

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
