### PR TITLE
fix: transition property selection when an exact property matched during search

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
@@ -130,7 +130,7 @@ export const TransitionContent = ({ index }: { index: number }) => {
         <TransitionProperty
           value={property ?? properties.transitionProperty.initial}
           onChange={(value) => {
-            updateIntermediateValue({ duration: value });
+            updateIntermediateValue({ property: value });
             setRepeatedStyleItem(transitionProperty, index, value);
           }}
         />

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -108,14 +108,6 @@ export const TransitionProperty = ({
         keys: [itemToString],
         sorter: (rankedItems) =>
           rankedItems.sort((a, b) => {
-            // Prioritize exact matches
-            if (a.item.name === search) {
-              return -1;
-            }
-            if (b.item.name === search) {
-              return 1;
-            }
-
             // Keep the proeprties on instance at the top
             if (animatableDefinedProperties.has(a.item.name)) {
               return -1;


### PR DESCRIPTION
## Description
fixes #4444 

Fixes a bug related to selecting transition property values that have an exact match. We used to bring up the exact matched values to the top of the list at the time of searching the transition property. But then when we added "properties on the node" feature we need to take care of sorting again. Because these values are always on the top irrespective of the search.
While fixing i noticed another side effect of refactor. We are setting transition property as duration.

## Steps for reproduction

- Add a transition property on node.
- Search for `traisiton`, `border` or any common property with full text.
- Use arrows to move and select the values now.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
