### PR TITLE
refactor: add sync object pool

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -54,7 +54,7 @@ import {
   initCopyPaste,
   initCopyPasteForContentEditMode,
 } from "~/shared/copy-paste/init-copy-paste";
-import { setDataCollapsed, subscribeCollapsedToPubSub } from "./collapsed";
+import { setDataCollapsed, subscribeCollapsed } from "./collapsed";
 import { useWindowResizeDebounced } from "~/shared/dom-hooks";
 import { subscribeInstanceSelection } from "./instance-selection";
 import { subscribeInstanceHovering } from "./instance-hovering";
@@ -294,7 +294,7 @@ export const Canvas = ({ params, imageLoader }: CanvasProps) => {
     }
   });
 
-  useEffect(subscribeCollapsedToPubSub, []);
+  useEffect(subscribeCollapsed, []);
 
   useHashLinkSync();
 

--- a/apps/builder/app/canvas/collapsed.ts
+++ b/apps/builder/app/canvas/collapsed.ts
@@ -1,5 +1,6 @@
 import htmlTags, { voidHtmlTags, type HtmlTags } from "html-tags";
 import { collapsedAttribute, idAttribute } from "@webstudio-is/react-sdk";
+import { compareMedia, StyleValue } from "@webstudio-is/css-engine";
 import {
   $breakpoints,
   $instances,
@@ -7,9 +8,8 @@ import {
   $stylesIndex,
 } from "~/shared/nano-states";
 import { $selectedBreakpoint } from "~/shared/nano-states";
-import { subscribe } from "~/shared/pubsub";
 import { $selectedPage } from "~/shared/awareness";
-import { compareMedia, StyleValue } from "@webstudio-is/css-engine";
+import { serverSyncStore } from "~/shared/sync";
 
 const isHtmlTag = (tag: string): tag is HtmlTags =>
   htmlTags.includes(tag as HtmlTags);
@@ -297,8 +297,8 @@ export const setDataCollapsed = (instanceId: string, syncExec = false) => {
  * For optimisation reasons try to extract instanceId of changed elements from pubsub
  * In that case we just check the subtree of parent/common ancestor of changed elements to find collapsed elements
  **/
-export const subscribeCollapsedToPubSub = () =>
-  subscribe("sendStoreChanges", ({ changes }) => {
+export const subscribeCollapsed = () => {
+  return serverSyncStore.subscribe((_transactionId, changes) => {
     for (const change of changes) {
       if (change.namespace === "styleSourceSelections") {
         for (const patch of change.patches) {
@@ -311,3 +311,4 @@ export const subscribeCollapsedToPubSub = () =>
       }
     }
   });
+};

--- a/apps/builder/app/shared/sync-client.test.ts
+++ b/apps/builder/app/shared/sync-client.test.ts
@@ -192,10 +192,10 @@ test("support pool of objects", () => {
   const store2 = createFollowerStore();
   const leader = new SyncClient({
     role: "leader",
-    object: new SyncObjectPool(
+    object: new SyncObjectPool([
       new ImmerhinSyncObject("store1", store1),
-      new ImmerhinSyncObject("store2", store2)
-    ),
+      new ImmerhinSyncObject("store2", store2),
+    ]),
   });
   leader.connect({ signal: new AbortController().signal });
   store1.createTransaction([store1.containers.get("users")!], (users) => {

--- a/apps/builder/app/shared/sync-client.ts
+++ b/apps/builder/app/shared/sync-client.ts
@@ -54,7 +54,7 @@ export class ImmerhinSyncObject implements SyncObject {
 export class SyncObjectPool implements SyncObject {
   name = "SyncObjectPool";
   objects = new Map<string, SyncObject>();
-  constructor(...objects: SyncObject[]) {
+  constructor(objects: SyncObject[]) {
     for (const object of objects) {
       this.objects.set(object.name, object);
     }

--- a/apps/builder/app/shared/sync-client.ts
+++ b/apps/builder/app/shared/sync-client.ts
@@ -4,14 +4,91 @@ import type { Change, Store } from "immerhin";
 
 type Transaction = {
   id: string;
+  object: string;
   changes: Change[];
 };
+
+type RevertedTransaction = {
+  id: string;
+  object: string;
+};
+
+export class ImmerhinSyncObject implements SyncObject {
+  name: string;
+  store: Store;
+  constructor(name: string, store: Store) {
+    this.name = name;
+    this.store = store;
+  }
+  getState() {
+    const state = new Map<string, unknown>();
+    for (const [namespace, $store] of this.store.containers) {
+      state.set(namespace, $store.get());
+    }
+    return state;
+  }
+  setState(state: Map<string, unknown>) {
+    for (const [namespace, $store] of this.store.containers) {
+      // immer is not able to work with Map instances from another realm
+      // use clone to recreate data with current realm classes
+      $store.set(structuredClone(state.get(namespace)));
+    }
+  }
+  addTransaction(transaction: Transaction) {
+    this.store.addTransaction(transaction.id, transaction.changes, "remote");
+  }
+  revertTransaction(transaction: RevertedTransaction) {
+    this.store.revertTransaction(transaction.id);
+  }
+  subscribe(callback: (transaction: Transaction) => void, signal: AbortSignal) {
+    const unsubscribe = this.store.subscribe((id, changes, source) => {
+      if (source === "remote") {
+        return;
+      }
+      callback({ id, object: this.name, changes });
+    });
+    signal.addEventListener("abort", unsubscribe);
+  }
+}
+
+export class SyncObjectPool implements SyncObject {
+  name = "SyncObjectPool";
+  objects = new Map<string, SyncObject>();
+  constructor(...objects: SyncObject[]) {
+    for (const object of objects) {
+      this.objects.set(object.name, object);
+    }
+  }
+  getState() {
+    const state = new Map<string, unknown>();
+    for (const [name, object] of this.objects) {
+      state.set(name, object.getState());
+    }
+    return state;
+  }
+  setState(state: Map<string, unknown>) {
+    for (const [name, object] of this.objects) {
+      object.setState(state.get(name) as never);
+    }
+  }
+  addTransaction(transaction: Transaction) {
+    this.objects.get(transaction.object)?.addTransaction(transaction);
+  }
+  revertTransaction(transaction: RevertedTransaction) {
+    this.objects.get(transaction.object)?.revertTransaction(transaction);
+  }
+  subscribe(callback: (transaction: Transaction) => void, signal: AbortSignal) {
+    for (const object of this.objects.values()) {
+      object.subscribe(callback, signal);
+    }
+  }
+}
 
 type SyncMessage =
   | { type: "connect"; clientId: string }
   | { type: "state"; clientId: string; state: Map<string, unknown> }
   | { type: "commit"; clientId: string; transaction: Transaction }
-  | { type: "revert"; clientId: string; transactionId: string };
+  | { type: "revert"; clientId: string; transaction: RevertedTransaction };
 
 export type SyncEmitter = Emitter<{
   message: (message: SyncMessage) => void;
@@ -19,38 +96,42 @@ export type SyncEmitter = Emitter<{
 
 type SyncClientOptions = {
   role: "leader" | "follower";
-  store: Store;
+  object: SyncObject;
   emitter?: SyncEmitter;
 };
+
+interface SyncObject {
+  name: string;
+  getState(): Map<string, unknown>;
+  setState(state: Map<string, unknown>): void;
+  addTransaction(transaction: Transaction): void;
+  revertTransaction(transaction: RevertedTransaction): void;
+  subscribe(
+    callback: (transaction: Transaction) => void,
+    signal: AbortSignal
+  ): void;
+}
 
 export class SyncClient {
   clientId = nanoid();
   role: SyncClientOptions["role"];
-  store: Store;
+  object: SyncObject;
   emitter: SyncEmitter;
   connection: "disconnected" | "connecting" | "connected" = "disconnected";
 
   constructor(options: SyncClientOptions) {
     this.role = options.role;
-    this.store = options.store;
+    this.object = options.object;
     this.emitter = options.emitter ?? createNanoEvents();
-  }
-
-  broadcastState() {
-    const state = new Map<string, unknown>();
-    for (const [namespace, $store] of this.store.containers) {
-      state.set(namespace, $store.get());
-    }
-    this.emitter.emit("message", {
-      clientId: this.clientId,
-      type: "state",
-      state,
-    });
   }
 
   lead() {
     this.role = "leader";
-    this.broadcastState();
+    this.emitter.emit("message", {
+      clientId: this.clientId,
+      type: "state",
+      state: this.object.getState(),
+    });
   }
 
   connect({ signal }: { signal: AbortSignal }) {
@@ -63,18 +144,18 @@ export class SyncClient {
         if (this.role !== "leader") {
           return;
         }
-        this.broadcastState();
+        this.emitter.emit("message", {
+          clientId: this.clientId,
+          type: "state",
+          state: this.object.getState(),
+        });
       }
       if (message.type === "state") {
         if (this.connection === "connected") {
           return;
         }
         this.connection = "connected";
-        for (const [namespace, $store] of this.store.containers) {
-          // immer is not able to work with Map instances from another realm
-          // use clone to recreate data with current realm classes
-          $store.set(structuredClone(message.state.get(namespace)));
-        }
+        this.object.setState(message.state);
       }
       if (message.type === "commit") {
         /*
@@ -85,33 +166,21 @@ export class SyncClient {
           return;
         }
         */
-        this.store.addTransaction(
-          message.transaction.id,
-          message.transaction.changes,
-          "remote"
-        );
+        this.object.addTransaction(message.transaction);
       }
       if (message.type === "revert") {
-        this.store.revertTransaction(message.transactionId);
+        this.object.revertTransaction(message.transaction);
       }
     });
+    signal.addEventListener("abort", off);
 
-    const unsubscribe = this.store.subscribe((id, changes, source) => {
-      if (source === "remote") {
-        return;
-      }
-      const transaction: Transaction = { id, changes };
+    this.object.subscribe((transaction) => {
       this.emitter.emit("message", {
         clientId: this.clientId,
         type: "commit",
         transaction,
       });
-    });
-
-    signal.addEventListener("abort", () => {
-      off();
-      unsubscribe();
-    });
+    }, signal);
 
     this.emitter.emit("message", {
       clientId: this.clientId,
@@ -121,7 +190,11 @@ export class SyncClient {
       this.connection = "connecting";
     }
     if (this.role === "leader") {
-      this.broadcastState();
+      this.emitter.emit("message", {
+        clientId: this.clientId,
+        type: "state",
+        state: this.object.getState(),
+      });
     }
   }
 }

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -231,10 +231,10 @@ const sharedSyncEmitter =
     ? undefined
     : window.__webstudioSharedSyncEmitter__;
 
-const objectPool = new SyncObjectPool(
+const objectPool = new SyncObjectPool([
   new ImmerhinSyncObject("server", serverSyncStore),
-  new ImmerhinSyncObject("client", clientSyncStore)
-);
+  new ImmerhinSyncObject("client", clientSyncStore),
+]);
 
 export const useCanvasStore = (publish: Publish) => {
   useEffect(() => {


### PR DESCRIPTION
Sync client is getting some shape. Here I abstracted all immerhin related api into SyncObject and added SyncObjectPool to combine multiple objects. Objects are identified by unique name.