### PR TITLE
refactor: stop importing remix overrides on canvas

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -13,7 +13,6 @@ import * as baseComponents from "@webstudio-is/sdk-components-react";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
 import * as baseComponentPropsMetas from "@webstudio-is/sdk-components-react/props";
 import { hooks as baseComponentHooks } from "@webstudio-is/sdk-components-react/hooks";
-import * as remixComponents from "@webstudio-is/sdk-components-react-remix";
 import * as remixComponentMetas from "@webstudio-is/sdk-components-react-remix/metas";
 import * as remixComponentPropsMetas from "@webstudio-is/sdk-components-react-remix/props";
 import * as radixComponents from "@webstudio-is/sdk-components-react-radix";
@@ -73,6 +72,7 @@ import { subscribeSelected } from "./instance-selected";
 import { subscribeScrollNewInstanceIntoView } from "./shared/scroll-new-instance-into-view";
 import { $selectedPage } from "~/shared/awareness";
 import { createInstanceElement } from "./elements";
+import { Body } from "./shared/body";
 
 registerContainers();
 
@@ -244,7 +244,10 @@ export const Canvas = ({ params, imageLoader }: CanvasProps) => {
       hooks: baseComponentHooks,
     });
     registerComponentLibrary({
-      components: remixComponents,
+      components: {
+        // override only body canvas specific component
+        Body,
+      },
       metas: remixComponentMetas,
       propsMetas: remixComponentPropsMetas,
     });
@@ -310,7 +313,7 @@ export const Canvas = ({ params, imageLoader }: CanvasProps) => {
   }, []);
 
   if (components.size === 0 || instances.size === 0) {
-    return <remixComponents.Body />;
+    return <Body />;
   }
 
   return (

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -245,7 +245,8 @@ export const Canvas = ({ params, imageLoader }: CanvasProps) => {
     });
     registerComponentLibrary({
       components: {
-        // override only body canvas specific component
+        // override only canvas specific body component
+        // not related to sdk-components-react-remix anymore
         Body,
       },
       metas: remixComponentMetas,

--- a/apps/builder/app/canvas/shared/body.tsx
+++ b/apps/builder/app/canvas/shared/body.tsx
@@ -1,0 +1,14 @@
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
+import { Scripts, ScrollRestoration } from "@remix-run/react";
+
+export const Body = forwardRef<ElementRef<"body">, ComponentProps<"body">>(
+  ({ children, ...props }, ref) => (
+    <body {...props} ref={ref}>
+      {children}
+      <Scripts />
+      <ScrollRestoration />
+    </body>
+  )
+);
+
+Body.displayName = "Body";


### PR DESCRIPTION
We want to decouple remix in cli and published sites from remix in builder.

Here I stopped importing remix override components. So now we could migrate CLI to react router without changes in builder.