### PR TITLE
refactor: remove instance selector from component hooks

### DIFF
--- a/apps/builder/app/builder/features/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator-tree.tsx
@@ -57,7 +57,11 @@ import {
 } from "~/shared/instance-utils";
 import { emitCommand } from "~/builder/shared/commands";
 import { useContentEditable } from "~/shared/dom-hooks";
-import { $selectedPage, selectInstance } from "~/shared/awareness";
+import {
+  $selectedPage,
+  getInstanceKey,
+  selectInstance,
+} from "~/shared/awareness";
 
 type TreeItem = {
   level: number;
@@ -112,7 +116,7 @@ const $flatTree = computed(
         return;
       }
       const propValues = propValuesByInstanceSelector.get(
-        JSON.stringify(selector)
+        getInstanceKey(selector)
       );
       const isHidden =
         isParentHidden ||
@@ -519,7 +523,7 @@ export const NavigatorTree = () => {
         {flatTree.map((item) => {
           const key = item.selector.join();
           const propValues = propValuesByInstanceSelector.get(
-            JSON.stringify(item.selector)
+            getInstanceKey(item.selector)
           );
           const show = Boolean(propValues?.get(showAttribute) ?? true);
           const meta = metas.get(item.instance.component);

--- a/apps/builder/app/builder/features/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/pages/page-utils.ts
@@ -23,7 +23,7 @@ import {
   $variableValuesByInstanceSelector,
 } from "~/shared/nano-states";
 import { insertPageCopyMutable } from "~/shared/page-utils";
-import { $selectedPage, selectPage } from "~/shared/awareness";
+import { $selectedPage, getInstanceKey, selectPage } from "~/shared/awareness";
 
 /**
  * When page or folder needs to be deleted or moved to a different parent,
@@ -247,7 +247,7 @@ export const $pageRootScope = computed(
     }
     const values =
       variableValuesByInstanceSelector.get(
-        JSON.stringify([page.rootInstanceId])
+        getInstanceKey([page.rootInstanceId])
       ) ?? new Map<string, unknown>();
     for (const [dataSourceId, value] of values) {
       const dataSource = dataSources.get(dataSourceId);

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -46,7 +46,11 @@ import { setDataCollapsed } from "~/canvas/collapsed";
 import { getIsVisuallyHidden } from "~/shared/visually-hidden";
 import { serverSyncStore } from "~/shared/sync";
 import { TextEditor } from "../text-editor";
-import { $selectedPage, selectInstance } from "~/shared/awareness";
+import {
+  $selectedPage,
+  getInstanceKey,
+  selectInstance,
+} from "~/shared/awareness";
 import {
   createInstanceChildrenElements,
   type WebstudioComponentProps,
@@ -250,7 +254,7 @@ const $indexesWithinAncestors = computed(
 );
 
 const useInstanceProps = (instanceSelector: InstanceSelector) => {
-  const instanceSelectorKey = JSON.stringify(instanceSelector);
+  const instanceKey = getInstanceKey(instanceSelector);
   const [instanceId] = instanceSelector;
   const $instancePropsObject = useMemo(() => {
     return computed(
@@ -261,8 +265,7 @@ const useInstanceProps = (instanceSelector: InstanceSelector) => {
         if (index !== undefined) {
           instancePropsObject[indexAttribute] = index.toString();
         }
-        const instanceProps =
-          propValuesByInstanceSelector.get(instanceSelectorKey);
+        const instanceProps = propValuesByInstanceSelector.get(instanceKey);
         if (instanceProps) {
           for (const [name, value] of instanceProps) {
             instancePropsObject[name] = value;
@@ -271,7 +274,7 @@ const useInstanceProps = (instanceSelector: InstanceSelector) => {
         return instancePropsObject;
       }
     );
-  }, [instanceSelectorKey, instanceId]);
+  }, [instanceKey, instanceId]);
   const instancePropsObject = useStore($instancePropsObject);
   return instancePropsObject;
 };

--- a/apps/builder/app/shared/awareness.ts
+++ b/apps/builder/app/shared/awareness.ts
@@ -58,12 +58,16 @@ export const $selectedInstance = computed(
   }
 );
 
-export const $selectedInstanceKey = computed($awareness, (awareness) => {
-  if (awareness === undefined) {
-    return;
-  }
-  return JSON.stringify(awareness.instanceSelector);
-});
+export const getInstanceKey = <
+  InstanceSelector extends undefined | Instance["id"][],
+>(
+  instanceSelector: InstanceSelector
+): (InstanceSelector extends undefined ? undefined : never) | string =>
+  JSON.stringify(instanceSelector);
+
+export const $selectedInstanceKey = computed($awareness, (awareness) =>
+  getInstanceKey(awareness?.instanceSelector)
+);
 
 export const selectPage = (pageId: Page["id"]) => {
   const pages = $pages.get();

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -47,7 +47,7 @@ import {
 } from "./variables";
 import { uploadingFileDataToAsset } from "~/builder/shared/assets/asset-utils";
 import { fetch } from "~/shared/fetch.client";
-import { $selectedPage } from "../awareness";
+import { $selectedPage, getInstanceKey } from "../awareness";
 
 export const getIndexedInstanceId = (
   instanceId: Instance["id"],
@@ -393,7 +393,7 @@ export const $propValuesByInstanceSelector = computed(
       }
 
       propValuesByInstanceSelector.set(
-        JSON.stringify(instanceSelector),
+        getInstanceKey(instanceSelector),
         propValues
       );
 
@@ -503,7 +503,7 @@ export const $variableValuesByInstanceSelector = computed(
 
       let variableValues = new Map<string, unknown>(parentVariableValues);
       variableValuesByInstanceSelector.set(
-        JSON.stringify(instanceSelector),
+        getInstanceKey(instanceSelector),
         variableValues
       );
       const variables = variablesByInstanceId.get(instanceId);

--- a/packages/react-sdk/src/hook.test.ts
+++ b/packages/react-sdk/src/hook.test.ts
@@ -5,27 +5,27 @@ test("get closest instance", () => {
   const instancePath: InstancePath = [
     {
       id: "4",
-      instanceSelector: ["4", "3", "2", "1", "0"],
+      instanceKey: JSON.stringify(["4", "3", "2", "1", "0"]),
       component: "Content",
     },
     {
       id: "3",
-      instanceSelector: ["3", "2", "1", "0"],
+      instanceKey: JSON.stringify(["3", "2", "1", "0"]),
       component: "Tabs",
     },
     {
       id: "2",
-      instanceSelector: ["2", "1", "0"],
+      instanceKey: JSON.stringify(["2", "1", "0"]),
       component: "Content",
     },
     {
       id: "1",
-      instanceSelector: ["1", "0"],
+      instanceKey: JSON.stringify(["1", "0"]),
       component: "Tabs",
     },
     {
       id: "0",
-      instanceSelector: ["0"],
+      instanceKey: JSON.stringify(["0"]),
       component: "Body",
     },
   ];

--- a/packages/react-sdk/src/hook.test.ts
+++ b/packages/react-sdk/src/hook.test.ts
@@ -3,11 +3,31 @@ import { getClosestInstance, type InstancePath } from "./hook";
 
 test("get closest instance", () => {
   const instancePath: InstancePath = [
-    { type: "instance", id: "4", component: "Content", children: [] },
-    { type: "instance", id: "3", component: "Tabs", children: [] },
-    { type: "instance", id: "2", component: "Content", children: [] },
-    { type: "instance", id: "1", component: "Tabs", children: [] },
-    { type: "instance", id: "0", component: "Body", children: [] },
+    {
+      id: "4",
+      instanceSelector: ["4", "3", "2", "1", "0"],
+      component: "Content",
+    },
+    {
+      id: "3",
+      instanceSelector: ["3", "2", "1", "0"],
+      component: "Tabs",
+    },
+    {
+      id: "2",
+      instanceSelector: ["2", "1", "0"],
+      component: "Content",
+    },
+    {
+      id: "1",
+      instanceSelector: ["1", "0"],
+      component: "Tabs",
+    },
+    {
+      id: "0",
+      instanceSelector: ["0"],
+      component: "Body",
+    },
   ];
   const [content2, tabs2, content1, tabs1, _body] = instancePath;
   expect(getClosestInstance(instancePath, content2, "Tabs")).toBe(tabs2);

--- a/packages/react-sdk/src/hook.ts
+++ b/packages/react-sdk/src/hook.ts
@@ -1,6 +1,12 @@
 import type { Instance, Prop } from "@webstudio-is/sdk";
 import type { IndexesWithinAncestors } from "./instance-utils";
 
+export type InstanceData = {
+  id: Instance["id"];
+  instanceKey: string;
+  component: Instance["component"];
+};
+
 /**
  * Hooks are subscriptions to builder events
  * with limited way to interact with it.
@@ -9,27 +15,21 @@ import type { IndexesWithinAncestors } from "./instance-utils";
 
 export type HookContext = {
   indexesWithinAncestors: IndexesWithinAncestors;
-  getPropValue: (instanceId: Instance["id"], propName: Prop["name"]) => unknown;
-  setPropVariable: (
-    instanceId: Instance["id"],
-    propName: Prop["name"],
-    value: unknown
-  ) => void;
+  getPropValue: (instanceData: InstanceData, propName: Prop["name"]) => unknown;
   setMemoryProp: (
-    instanceId: readonly Instance["id"][],
+    instanceData: InstanceData,
     propName: Prop["name"],
     value: unknown
   ) => void;
 };
 
-export type InstancePath = Instance[];
+export type InstancePath = InstanceData[];
 
 type NavigatorEvent = {
   /**
    * List of instances from selected to the root
    */
   instancePath: InstancePath;
-  instanceSelector: readonly Instance["id"][];
 };
 
 export type Hook = {
@@ -43,8 +43,8 @@ export type Hook = {
  */
 export const getClosestInstance = (
   instancePath: InstancePath,
-  currentInstance: Instance,
-  closestComponent: Instance["component"]
+  currentInstance: InstanceData,
+  closestComponent: InstanceData["component"]
 ) => {
   let matched = false;
   for (const instance of instancePath) {
@@ -55,17 +55,4 @@ export const getClosestInstance = (
       return instance;
     }
   }
-};
-
-export const getInstanceSelectorById = (
-  instanceSelector: readonly Instance["id"][],
-  instanceId: Instance["id"]
-) => {
-  const index = instanceSelector.findIndex(
-    (selector) => selector === instanceId
-  );
-  if (index === -1) {
-    return [];
-  }
-  return instanceSelector.slice(index);
 };

--- a/packages/sdk-components-react-radix/src/accordion.tsx
+++ b/packages/sdk-components-react-radix/src/accordion.tsx
@@ -15,7 +15,6 @@ import {
 import {
   getClosestInstance,
   getIndexWithinAncestorFromComponentProps,
-  getInstanceSelectorById,
   type Hook,
 } from "@webstudio-is/react-sdk/runtime";
 
@@ -75,15 +74,11 @@ export const hooksAccordion: Hook = {
         );
         if (accordion && item) {
           const itemValue =
-            context.getPropValue(item.id, "value") ??
+            context.getPropValue(item, "value") ??
             context.indexesWithinAncestors.get(item.id)?.toString();
 
           if (itemValue) {
-            const instanceSelector = getInstanceSelectorById(
-              event.instanceSelector,
-              accordion.id
-            );
-            context.setMemoryProp(instanceSelector, "value", itemValue);
+            context.setMemoryProp(accordion, "value", itemValue);
           }
         }
       }

--- a/packages/sdk-components-react-radix/src/collapsible.tsx
+++ b/packages/sdk-components-react-radix/src/collapsible.tsx
@@ -7,11 +7,7 @@ import {
   type RefAttributes,
 } from "react";
 import { Root, Trigger, Content } from "@radix-ui/react-collapsible";
-import {
-  type Hook,
-  getClosestInstance,
-  getInstanceSelectorById,
-} from "@webstudio-is/react-sdk/runtime";
+import { type Hook, getClosestInstance } from "@webstudio-is/react-sdk/runtime";
 
 export const Collapsible: ForwardRefExoticComponent<
   Omit<ComponentProps<typeof Root>, "defaultOpen" | "asChild"> &
@@ -58,11 +54,7 @@ export const hooksCollapsible: Hook = {
           `${namespace}:Collapsible`
         );
         if (collapsible) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            collapsible.id
-          );
-          context.setMemoryProp(instanceSelector, "open", true);
+          context.setMemoryProp(collapsible, "open", true);
         }
       }
     }

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -12,7 +12,6 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import {
   ReactSdkContext,
   getClosestInstance,
-  getInstanceSelectorById,
   type Hook,
 } from "@webstudio-is/react-sdk/runtime";
 
@@ -202,11 +201,7 @@ export const hooksDialog: Hook = {
           `${namespace}:Dialog`
         );
         if (dialog) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            dialog.id
-          );
-          context.setMemoryProp(instanceSelector, "open", undefined);
+          context.setMemoryProp(dialog, "open", undefined);
         }
       }
     }
@@ -219,14 +214,8 @@ export const hooksDialog: Hook = {
           instance,
           `${namespace}:Dialog`
         );
-
         if (dialog) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            dialog.id
-          );
-
-          context.setMemoryProp(instanceSelector, "open", true);
+          context.setMemoryProp(dialog, "open", true);
         }
       }
     }

--- a/packages/sdk-components-react-radix/src/navigation-menu.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-menu.tsx
@@ -2,7 +2,6 @@ import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
 import {
   getClosestInstance,
   getIndexWithinAncestorFromComponentProps,
-  getInstanceSelectorById,
   ReactSdkContext,
   type Hook,
 } from "@webstudio-is/react-sdk/runtime";
@@ -90,14 +89,8 @@ export const hooksNavigationMenu: Hook = {
           instance,
           `${namespace}:NavigationMenu`
         );
-
         if (menu) {
-          const menuSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            menu.id
-          );
-
-          context.setMemoryProp(menuSelector, "value", undefined);
+          context.setMemoryProp(menu, "value", undefined);
         }
       }
     }
@@ -110,28 +103,19 @@ export const hooksNavigationMenu: Hook = {
           instance,
           `${namespace}:NavigationMenu`
         );
-
         const menuItem = getClosestInstance(
           event.instancePath,
           instance,
           `${namespace}:NavigationMenuItem`
         );
-
         if (menuItem === undefined || menu === undefined) {
           return;
         }
-
         const contentValue =
-          context.getPropValue(menuItem.id, "value") ??
+          context.getPropValue(menuItem, "value") ??
           context.indexesWithinAncestors.get(menuItem.id)?.toString();
-
         if (contentValue) {
-          const menuSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            menu.id
-          );
-
-          context.setMemoryProp(menuSelector, "value", contentValue);
+          context.setMemoryProp(menu, "value", contentValue);
         }
       }
     }

--- a/packages/sdk-components-react-radix/src/popover.tsx
+++ b/packages/sdk-components-react-radix/src/popover.tsx
@@ -5,11 +5,7 @@ import {
   Children,
 } from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
-import {
-  getClosestInstance,
-  getInstanceSelectorById,
-  type Hook,
-} from "@webstudio-is/react-sdk/runtime";
+import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk/runtime";
 
 // wrap in forwardRef because Root is functional component without ref
 export const Popover = forwardRef<
@@ -75,11 +71,7 @@ export const hooksPopover: Hook = {
           `${namespace}:Popover`
         );
         if (popover) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            popover.id
-          );
-          context.setMemoryProp(instanceSelector, "open", undefined);
+          context.setMemoryProp(popover, "open", undefined);
         }
       }
     }
@@ -93,11 +85,7 @@ export const hooksPopover: Hook = {
           `${namespace}:Popover`
         );
         if (popover) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            popover.id
-          );
-          context.setMemoryProp(instanceSelector, "open", true);
+          context.setMemoryProp(popover, "open", true);
         }
       }
     }

--- a/packages/sdk-components-react-radix/src/select.tsx
+++ b/packages/sdk-components-react-radix/src/select.tsx
@@ -20,7 +20,6 @@ import {
 import {
   type Hook,
   getClosestInstance,
-  getInstanceSelectorById,
   ReactSdkContext,
 } from "@webstudio-is/react-sdk/runtime";
 
@@ -99,11 +98,7 @@ export const hooksSelect: Hook = {
           `${namespace}:Select`
         );
         if (select) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            select.id
-          );
-          context.setMemoryProp(instanceSelector, "open", undefined);
+          context.setMemoryProp(select, "open", undefined);
         }
       }
     }
@@ -117,11 +112,7 @@ export const hooksSelect: Hook = {
           `${namespace}:Select`
         );
         if (select) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            select.id
-          );
-          context.setMemoryProp(instanceSelector, "open", true);
+          context.setMemoryProp(select, "open", true);
         }
       }
     }

--- a/packages/sdk-components-react-radix/src/sheet.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.tsx
@@ -3,11 +3,7 @@ import {
   type ElementRef,
   type ComponentPropsWithoutRef,
 } from "react";
-import {
-  getClosestInstance,
-  getInstanceSelectorById,
-  type Hook,
-} from "@webstudio-is/react-sdk/runtime";
+import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk/runtime";
 import * as Dialog from "./dialog";
 
 export const Sheet = Dialog.Dialog;
@@ -61,11 +57,7 @@ export const hooksSheet: Hook = {
         );
 
         if (sheet) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            sheet.id
-          );
-          context.setMemoryProp(instanceSelector, "open", undefined);
+          context.setMemoryProp(sheet, "open", undefined);
         }
       }
     }
@@ -79,11 +71,7 @@ export const hooksSheet: Hook = {
           `${namespace}:Sheet`
         );
         if (sheet) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            sheet.id
-          );
-          context.setMemoryProp(instanceSelector, "open", true);
+          context.setMemoryProp(sheet, "open", true);
         }
       }
     }

--- a/packages/sdk-components-react-radix/src/tabs.tsx
+++ b/packages/sdk-components-react-radix/src/tabs.tsx
@@ -9,7 +9,6 @@ import { Root, List, Trigger, Content } from "@radix-ui/react-tabs";
 import {
   getClosestInstance,
   getIndexWithinAncestorFromComponentProps,
-  getInstanceSelectorById,
   type Hook,
 } from "@webstudio-is/react-sdk/runtime";
 
@@ -52,14 +51,10 @@ export const hooksTabs: Hook = {
           `${namespace}:Tabs`
         );
         const contentValue =
-          context.getPropValue(instance.id, "value") ??
+          context.getPropValue(instance, "value") ??
           context.indexesWithinAncestors.get(instance.id)?.toString();
         if (tabs && contentValue) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            tabs.id
-          );
-          context.setMemoryProp(instanceSelector, "value", contentValue);
+          context.setMemoryProp(tabs, "value", contentValue);
         }
       }
     }

--- a/packages/sdk-components-react-radix/src/tooltip.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.tsx
@@ -1,9 +1,5 @@
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import {
-  getClosestInstance,
-  getInstanceSelectorById,
-  type Hook,
-} from "@webstudio-is/react-sdk/runtime";
+import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk/runtime";
 
 import {
   forwardRef,
@@ -74,11 +70,7 @@ export const hooksTooltip: Hook = {
           `${namespace}:Tooltip`
         );
         if (tooltip) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            tooltip.id
-          );
-          context.setMemoryProp(instanceSelector, "open", undefined);
+          context.setMemoryProp(tooltip, "open", undefined);
         }
       }
     }
@@ -92,11 +84,7 @@ export const hooksTooltip: Hook = {
           `${namespace}:Tooltip`
         );
         if (tooltip) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            tooltip.id
-          );
-          context.setMemoryProp(instanceSelector, "open", true);
+          context.setMemoryProp(tooltip, "open", true);
         }
       }
     }

--- a/packages/sdk-components-react/src/select.tsx
+++ b/packages/sdk-components-react/src/select.tsx
@@ -1,8 +1,4 @@
-import {
-  getClosestInstance,
-  getInstanceSelectorById,
-  type Hook,
-} from "@webstudio-is/react-sdk/runtime";
+import { type Hook } from "@webstudio-is/react-sdk/runtime";
 import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 export const defaultTag = "select";
@@ -23,36 +19,14 @@ export const hooksSelect: Hook = {
   onNavigatorUnselect: (context, event) => {
     for (const instance of event.instancePath) {
       if (instance.component === `Option`) {
-        const option = getClosestInstance(
-          event.instancePath,
-          instance,
-          `Option`
-        );
-        if (option) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            option.id
-          );
-          context.setMemoryProp(instanceSelector, "selected", undefined);
-        }
+        context.setMemoryProp(instance, "selected", undefined);
       }
     }
   },
   onNavigatorSelect: (context, event) => {
     for (const instance of event.instancePath) {
       if (instance.component === `Option`) {
-        const option = getClosestInstance(
-          event.instancePath,
-          instance,
-          `Option`
-        );
-        if (option) {
-          const instanceSelector = getInstanceSelectorById(
-            event.instanceSelector,
-            option.id
-          );
-          context.setMemoryProp(instanceSelector, "selected", true);
-        }
+        context.setMemoryProp(instance, "selected", true);
       }
     }
   },


### PR DESCRIPTION
We need to remove reliance on instance selector iteration as much as possible. In most cases we need only instance key which is a JSON.stringify or instance selector to access computed props and variables.

Here got rid of instance selector in component hooks and instead made api to accept "instance data" with instance id, key and component inside.