### PR TITLE
refactor: enable isolated declarations in asset uploader

### DIFF
--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
-    "@smithy/signature-v4": "^2.3.0",
+    "@smithy/signature-v4": "^4.2.3",
     "@webstudio-is/fonts": "workspace:*",
     "@webstudio-is/sdk": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
-    "fontkit": "^2.0.2",
+    "fontkit": "^2.0.4",
     "image-size": "^1.1.1",
     "immer": "^10.1.1",
     "nanoid": "^5.0.8",

--- a/packages/asset-uploader/src/clients/fs/upload.ts
+++ b/packages/asset-uploader/src/clients/fs/upload.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { buffer } from "node:stream/consumers";
-import { getAssetData } from "../../utils/get-asset-data";
+import { type AssetData, getAssetData } from "../../utils/get-asset-data";
 import { createSizeLimiter } from "../../utils/size-limiter";
 
 export const uploadToFs = async ({
@@ -16,7 +16,7 @@ export const uploadToFs = async ({
   data: AsyncIterable<Uint8Array>;
   maxSize: number;
   fileDirectory: string;
-}) => {
+}): Promise<AssetData> => {
   const filepath = resolve(fileDirectory, name);
 
   await mkdir(dirname(filepath), { recursive: true }).catch(() => {});

--- a/packages/asset-uploader/src/clients/s3/upload.ts
+++ b/packages/asset-uploader/src/clients/s3/upload.ts
@@ -1,6 +1,6 @@
 import { arrayBuffer } from "node:stream/consumers";
 import type { SignatureV4 } from "@smithy/signature-v4";
-import { getAssetData } from "../../utils/get-asset-data";
+import { type AssetData, getAssetData } from "../../utils/get-asset-data";
 import { createSizeLimiter } from "../../utils/size-limiter";
 import { extendedEncodeURIComponent } from "../../utils/sanitize-s3-key";
 
@@ -22,7 +22,7 @@ export const uploadToS3 = async ({
   endpoint: string;
   bucket: string;
   acl?: string;
-}) => {
+}): Promise<AssetData> => {
   const limitSize = createSizeLimiter(maxSize, name);
 
   // @todo this is going to put the entire file in memory

--- a/packages/asset-uploader/src/delete.ts
+++ b/packages/asset-uploader/src/delete.ts
@@ -11,7 +11,7 @@ export const deleteAssets = async (
     projectId: string;
   },
   context: AppContext
-) => {
+): Promise<void> => {
   const canDelete = await authorizeProject.hasProjectPermit(
     { projectId: props.projectId, permit: "edit" },
     context

--- a/packages/asset-uploader/src/patch.ts
+++ b/packages/asset-uploader/src/patch.ts
@@ -15,7 +15,7 @@ export const patchAssets = async (
   { projectId }: { projectId: string },
   patches: Array<Patch>,
   context: AppContext
-) => {
+): Promise<void> => {
   const canEdit = await authorizeProject.hasProjectPermit(
     { projectId, permit: "edit" },
     context

--- a/packages/asset-uploader/src/schema.ts
+++ b/packages/asset-uploader/src/schema.ts
@@ -2,10 +2,18 @@ import { z } from "zod";
 import { MAX_UPLOAD_SIZE } from "./constants";
 import { toBytes } from "./utils/to-bytes";
 
-export const MaxSize = z
+export const MaxSize: z.ZodEffects<
+  z.ZodDefault<z.ZodString>,
+  number,
+  string | undefined
+> = z
   .string()
   .default(MAX_UPLOAD_SIZE)
   // user inputs the max value in mb and we transform it to bytes
   .transform(toBytes);
 
-export const MaxAssets = z.string().default("50").transform(Number.parseFloat);
+export const MaxAssets: z.ZodEffects<
+  z.ZodDefault<z.ZodString>,
+  number,
+  string | undefined
+> = z.string().default("50").transform(Number.parseFloat);

--- a/packages/asset-uploader/src/upload.ts
+++ b/packages/asset-uploader/src/upload.ts
@@ -7,6 +7,7 @@ import type { AssetClient } from "./client";
 import { getUniqueFilename } from "./utils/get-unique-filename";
 import { sanitizeS3Key } from "./utils/sanitize-s3-key";
 import { formatAsset } from "./utils/format-asset";
+import type { Asset } from "@webstudio-is/sdk";
 
 type UploadData = {
   projectId: string;
@@ -20,7 +21,7 @@ const UPLOADING_STALE_TIMEOUT = 1000 * 60 * 30; // 30 minutes
 export const createUploadName = async (
   data: UploadData,
   context: AppContext
-) => {
+): Promise<string> => {
   const { projectId, maxAssetsPerProject, type, filename } = data;
   const canEdit = await authorizeProject.hasProjectPermit(
     { projectId, permit: "edit" },
@@ -96,7 +97,7 @@ export const uploadFile = async (
   data: ReadableStream<Uint8Array>,
   client: AssetClient,
   context: AppContext
-) => {
+): Promise<Asset> => {
   let file = await context.postgrest.client
     .from("File")
     .select("*")

--- a/packages/asset-uploader/src/utils/font-data.ts
+++ b/packages/asset-uploader/src/utils/font-data.ts
@@ -18,7 +18,9 @@ declare module "fontkit" {
 // same default fontkit uses internally
 const defaultLanguage = "en";
 
-export const parseSubfamily = (subfamily: string) => {
+export const parseSubfamily = (
+  subfamily: string
+): { style: FontStyle; weight: number } => {
   const subfamilyLow = subfamily.toLowerCase();
   let style: FontStyle = "normal";
   for (const possibleStyle of FONT_STYLES) {
@@ -105,4 +107,10 @@ export const getFontData = (data: Uint8Array, fileName: string): FontData => {
   };
 };
 
-export const __testing__ = { normalizeFamily };
+export const __testing__: {
+  normalizeFamily: (
+    family: string,
+    subfamily: string,
+    fileName: string
+  ) => string;
+} = { normalizeFamily };

--- a/packages/asset-uploader/src/utils/get-asset-data.ts
+++ b/packages/asset-uploader/src/utils/get-asset-data.ts
@@ -4,13 +4,17 @@ import { FontMeta } from "@webstudio-is/fonts";
 import { ImageMeta } from "@webstudio-is/sdk";
 import { getFontData } from "./font-data";
 
-export const AssetData = z.object({
+export type AssetData = {
+  size: number;
+  format: string;
+  meta: ImageMeta | FontMeta;
+};
+
+export const AssetData: z.ZodType<AssetData> = z.object({
   size: z.number(),
   format: z.string(),
   meta: z.union([ImageMeta, FontMeta]),
 });
-
-export type AssetData = z.infer<typeof AssetData>;
 
 type BaseAssetOptions = {
   size: number;

--- a/packages/asset-uploader/src/utils/size-limiter.ts
+++ b/packages/asset-uploader/src/utils/size-limiter.ts
@@ -1,5 +1,7 @@
 export const createSizeLimiter = (maxSize: number, name: string) => {
-  return async function* (data: AsyncIterable<ArrayBuffer>) {
+  return async function* (
+    data: AsyncIterable<ArrayBuffer>
+  ): AsyncGenerator<ArrayBuffer> {
     let size = 0;
     for await (const chunk of data) {
       size += chunk.byteLength;

--- a/packages/asset-uploader/src/utils/to-bytes.ts
+++ b/packages/asset-uploader/src/utils/to-bytes.ts
@@ -1,2 +1,3 @@
 // Convert a string value in assumed MB to bytes number
-export const toBytes = (value: string) => Number.parseFloat(value) * 1e6;
+export const toBytes = (value: string): number =>
+  Number.parseFloat(value) * 1e6;

--- a/packages/asset-uploader/tsconfig.json
+++ b/packages/asset-uploader/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json"
+  "extends": "@webstudio-is/tsconfig/base.json",
+  "compilerOptions": {
+    "isolatedDeclarations": true
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,8 +953,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0
       '@smithy/signature-v4':
-        specifier: ^2.3.0
-        version: 2.3.0
+        specifier: ^4.2.3
+        version: 4.2.3
       '@webstudio-is/fonts':
         specifier: workspace:*
         version: link:../fonts
@@ -965,8 +965,8 @@ importers:
         specifier: workspace:*
         version: link:../trpc-interface
       fontkit:
-        specifier: ^2.0.2
-        version: 2.0.2
+        specifier: ^2.0.4
+        version: 2.0.4
       image-size:
         specifier: ^1.1.1
         version: 1.1.1
@@ -2120,9 +2120,9 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/types@3.357.0':
-    resolution: {integrity: sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==}
-    engines: {node: '>=14.0.0'}
+  '@aws-sdk/types@3.696.0':
+    resolution: {integrity: sha512-9rTvUJIAj5d3//U5FDPWGJ1nFJLuWb30vugGOrWk7aNZ6y9tuA3PI7Cc9dP8WEXKVyK1vuuk8rSFP2iqXnlgrw==}
+    engines: {node: '>=16.0.0'}
 
   '@babel/code-frame@7.22.5':
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
@@ -4499,49 +4499,53 @@ packages:
   '@rushstack/ts-command-line@4.12.2':
     resolution: {integrity: sha512-poBtnumLuWmwmhCEkVAgynWgtnF9Kygekxyp4qtQUSbBrkuyPQTL85c8Cva1YfoUpOdOXxezMAkUt0n5SNKGqw==}
 
-  '@smithy/is-array-buffer@2.0.0':
-    resolution: {integrity: sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==}
-    engines: {node: '>=14.0.0'}
-
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/signature-v4@2.3.0':
-    resolution: {integrity: sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==}
-    engines: {node: '>=14.0.0'}
+  '@smithy/is-array-buffer@3.0.0':
+    resolution: {integrity: sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==}
+    engines: {node: '>=16.0.0'}
 
-  '@smithy/types@2.12.0':
-    resolution: {integrity: sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==}
-    engines: {node: '>=14.0.0'}
+  '@smithy/protocol-http@4.1.7':
+    resolution: {integrity: sha512-FP2LepWD0eJeOTm0SjssPcgqAlDFzOmRXqXmGhfIM52G7Lrox/pcpQf6RP4F21k0+O12zaqQt5fCDOeBtqY6Cg==}
+    engines: {node: '>=16.0.0'}
 
-  '@smithy/util-buffer-from@2.0.0':
-    resolution: {integrity: sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==}
-    engines: {node: '>=14.0.0'}
+  '@smithy/signature-v4@4.2.3':
+    resolution: {integrity: sha512-pPSQQ2v2vu9vc8iew7sszLd0O09I5TRc5zhY71KA+Ao0xYazIG+uLeHbTJfIWGO3BGVLiXjUr3EEeCcEQLjpWQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@smithy/types@3.7.1':
+    resolution: {integrity: sha512-XKLcLXZY7sUQgvvWyeaL/qwNPp6V3dWcUjqrQKjSb+tzYiCy340R/c64LV5j+Tnb2GhmunEX0eou+L+m2hJNYA==}
+    engines: {node: '>=16.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
     resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-hex-encoding@2.2.0':
-    resolution: {integrity: sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==}
-    engines: {node: '>=14.0.0'}
+  '@smithy/util-buffer-from@3.0.0':
+    resolution: {integrity: sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==}
+    engines: {node: '>=16.0.0'}
 
-  '@smithy/util-middleware@2.2.0':
-    resolution: {integrity: sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==}
-    engines: {node: '>=14.0.0'}
+  '@smithy/util-hex-encoding@3.0.0':
+    resolution: {integrity: sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==}
+    engines: {node: '>=16.0.0'}
 
-  '@smithy/util-uri-escape@2.2.0':
-    resolution: {integrity: sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==}
-    engines: {node: '>=14.0.0'}
+  '@smithy/util-middleware@3.0.10':
+    resolution: {integrity: sha512-eJO+/+RsrG2RpmY68jZdwQtnfsxjmPxzMlQpnHKjFPwrYqvlcT+fHdT+ZVwcjlWSrByOhGr9Ff2GG17efc192A==}
+    engines: {node: '>=16.0.0'}
 
-  '@smithy/util-utf8@2.0.0':
-    resolution: {integrity: sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==}
-    engines: {node: '>=14.0.0'}
+  '@smithy/util-uri-escape@3.0.0':
+    resolution: {integrity: sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==}
+    engines: {node: '>=16.0.0'}
 
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@3.0.0':
+    resolution: {integrity: sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==}
+    engines: {node: '>=16.0.0'}
 
   '@stitches/react@1.3.1-1':
     resolution: {integrity: sha512-ErptbQehV25Da6LtZuM/51kGNK/UvlRY2da9IhhfXQ9h4bmf2f+lYFiJQ9j43O1kwYr6iYJIBRM47FEbsUWffw==}
@@ -4650,14 +4654,11 @@ packages:
     resolution: {integrity: sha512-0e4B41q+GnS8TI+SWHQw78ziW6V07Li2TMLS8FwbvKOTIJL0ua1Sat1AI0AFAjHlAePz9b+1VtyJzv1516edJw==}
     hasBin: true
 
-  '@swc/helpers@0.4.14':
-    resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
-
-  '@swc/helpers@0.4.36':
-    resolution: {integrity: sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==}
-
   '@swc/helpers@0.5.1':
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@testing-library/dom@9.3.4':
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
@@ -5979,8 +5980,8 @@ packages:
       debug:
         optional: true
 
-  fontkit@2.0.2:
-    resolution: {integrity: sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==}
+  fontkit@2.0.4:
+    resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -8319,6 +8320,9 @@ packages:
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsx@4.19.2:
     resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
     engines: {node: '>=18.0.0'}
@@ -8878,18 +8882,19 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.357.0
-      tslib: 2.6.2
+      '@aws-sdk/types': 3.696.0
+      tslib: 2.8.1
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.357.0
-      '@smithy/util-utf8': 2.0.0
-      tslib: 2.6.2
+      '@aws-sdk/types': 3.696.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
 
-  '@aws-sdk/types@3.357.0':
+  '@aws-sdk/types@3.696.0':
     dependencies:
-      tslib: 2.6.2
+      '@smithy/types': 3.7.1
+      tslib: 2.8.1
 
   '@babel/code-frame@7.22.5':
     dependencies:
@@ -11138,60 +11143,66 @@ snapshots:
       colors: 1.2.5
       string-argv: 0.3.1
 
-  '@smithy/is-array-buffer@2.0.0':
-    dependencies:
-      tslib: 2.6.2
-
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@smithy/signature-v4@2.3.0':
+  '@smithy/is-array-buffer@3.0.0':
     dependencies:
-      '@smithy/is-array-buffer': 2.2.0
-      '@smithy/types': 2.12.0
-      '@smithy/util-hex-encoding': 2.2.0
-      '@smithy/util-middleware': 2.2.0
-      '@smithy/util-uri-escape': 2.2.0
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@smithy/types@2.12.0':
+  '@smithy/protocol-http@4.1.7':
     dependencies:
-      tslib: 2.6.2
+      '@smithy/types': 3.7.1
+      tslib: 2.8.1
 
-  '@smithy/util-buffer-from@2.0.0':
+  '@smithy/signature-v4@4.2.3':
     dependencies:
-      '@smithy/is-array-buffer': 2.0.0
-      tslib: 2.6.2
+      '@smithy/is-array-buffer': 3.0.0
+      '@smithy/protocol-http': 4.1.7
+      '@smithy/types': 3.7.1
+      '@smithy/util-hex-encoding': 3.0.0
+      '@smithy/util-middleware': 3.0.10
+      '@smithy/util-uri-escape': 3.0.0
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.8.1
+
+  '@smithy/types@3.7.1':
+    dependencies:
+      tslib: 2.8.1
 
   '@smithy/util-buffer-from@2.2.0':
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@smithy/util-hex-encoding@2.2.0':
+  '@smithy/util-buffer-from@3.0.0':
     dependencies:
-      tslib: 2.6.2
+      '@smithy/is-array-buffer': 3.0.0
+      tslib: 2.8.1
 
-  '@smithy/util-middleware@2.2.0':
+  '@smithy/util-hex-encoding@3.0.0':
     dependencies:
-      '@smithy/types': 2.12.0
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@smithy/util-uri-escape@2.2.0':
+  '@smithy/util-middleware@3.0.10':
     dependencies:
-      tslib: 2.6.2
+      '@smithy/types': 3.7.1
+      tslib: 2.8.1
 
-  '@smithy/util-utf8@2.0.0':
+  '@smithy/util-uri-escape@3.0.0':
     dependencies:
-      '@smithy/util-buffer-from': 2.0.0
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   '@smithy/util-utf8@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.6.2
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@3.0.0':
+    dependencies:
+      '@smithy/util-buffer-from': 3.0.0
+      tslib: 2.8.1
 
   '@stitches/react@1.3.1-1(patch_hash=knml42mpr6mlzseo3d6gjljiq4)(react@18.3.0-canary-14898b6a9-20240318)':
     dependencies:
@@ -11329,18 +11340,13 @@ snapshots:
       css-tree: 2.3.1(patch_hash=epgcmebti7rfrc2ej4odb3t4jy)
       svgo: 3.0.2
 
-  '@swc/helpers@0.4.14':
-    dependencies:
-      tslib: 2.6.2
-
-  '@swc/helpers@0.4.36':
-    dependencies:
-      legacy-swc-helpers: '@swc/helpers@0.4.14'
-      tslib: 2.6.0
-
   '@swc/helpers@0.5.1':
     dependencies:
       tslib: 2.6.2
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
 
   '@testing-library/dom@9.3.4':
     dependencies:
@@ -12998,9 +13004,9 @@ snapshots:
 
   follow-redirects@1.15.2: {}
 
-  fontkit@2.0.2:
+  fontkit@2.0.4:
     dependencies:
-      '@swc/helpers': 0.4.36
+      '@swc/helpers': 0.5.15
       brotli: 1.3.3
       clone: 2.1.2
       dfa: 1.2.0
@@ -15766,6 +15772,8 @@ snapshots:
   tslib@2.6.0: {}
 
   tslib@2.6.2: {}
+
+  tslib@2.8.1: {}
 
   tsx@4.19.2:
     dependencies:


### PR DESCRIPTION
Simplified types in asset uploader and covered all exports to enable isolated declarations flag which also potentially may improve checking performance.