### PR TITLE
refactor: add server as storage to sync engine

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -7,12 +7,12 @@ import type { Project } from "@webstudio-is/project";
 import { theme, Box, type CSS, Flex, Grid } from "@webstudio-is/design-system";
 import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
 import { createImageLoader } from "@webstudio-is/image";
+import { registerContainers, createObjectPool } from "~/shared/sync";
 import {
-  builderClient,
-  registerContainers,
-  useBuilderStore,
-} from "~/shared/sync";
-import { startProjectSync, useSyncServer } from "./shared/sync/sync-server";
+  ServerSyncStorage,
+  startProjectSync,
+  useSyncServer,
+} from "./shared/sync/sync-server";
 import { SidebarLeft } from "./sidebar-left";
 import { Inspector } from "./features/inspector";
 import { Topbar } from "./features/topbar";
@@ -57,7 +57,6 @@ import {
 import { CloneProjectDialog } from "~/shared/clone-project";
 import type { TokenPermissions } from "@webstudio-is/authorization-token";
 import { useToastErrors } from "~/shared/error/toast-error";
-import { loadBuilderData, setBuilderData } from "~/shared/builder-data";
 import { initBuilderApi } from "~/shared/builder-api";
 import { updateWebstudioData } from "~/shared/instance-utils";
 import { migrateWebstudioDataMutable } from "~/shared/webstudio-data-migrator";
@@ -71,6 +70,7 @@ import {
 } from "~/shared/copy-paste/init-copy-paste";
 import { useInertHandlers } from "./shared/inert-handlers";
 import { TextToolbar } from "./features/workspace/canvas-tools/text-toolbar";
+import { SyncClient } from "~/shared/sync-client";
 
 registerContainers();
 
@@ -206,6 +206,12 @@ const ChromeWrapper = ({
   );
 };
 
+const builderClient = new SyncClient({
+  role: "leader",
+  object: createObjectPool(),
+  storages: [new ServerSyncStorage()],
+});
+
 export type BuilderProps = {
   project: Project;
   publisherHost: string;
@@ -242,9 +248,9 @@ export const Builder = ({
     const controller = new AbortController();
 
     $dataLoadingState.set("loading");
-    loadBuilderData({ projectId: project.id, signal: controller.signal })
-      .then((data) => {
-        setBuilderData(data);
+    builderClient.connect({
+      signal: controller.signal,
+      onReady() {
         startProjectSync({
           projectId: project.id,
           buildId: build.id,
@@ -260,12 +266,10 @@ export const Builder = ({
         // so builder is started listening for connect event
         // when canvas is rendered
         $dataLoadingState.set("loaded");
-      })
-      .catch((error) => {
-        console.error(error);
+
         // @todo make needs error handling and error state? e.g. a toast
-        $dataLoadingState.set("idle");
-      });
+      },
+    });
     return () => {
       $dataLoadingState.set("idle");
       controller.abort("unmount");
@@ -287,7 +291,6 @@ export const Builder = ({
     $publisher.set({ publish });
   }, [publish]);
 
-  useBuilderStore();
   useSyncServer({
     projectId: project.id,
     authPermit,

--- a/apps/builder/app/builder/shared/sync/command-queue.ts
+++ b/apps/builder/app/builder/shared/sync/command-queue.ts
@@ -1,12 +1,13 @@
 import type { Project } from "@webstudio-is/project";
 import type { Build } from "@webstudio-is/project-build";
-import type { SyncItem } from "immerhin";
+import type { Change } from "immerhin";
+import type { Transaction } from "~/shared/sync-client";
 
 type Command =
   | {
       type: "transactions";
       projectId: Project["id"];
-      transactions: SyncItem[];
+      transactions: Transaction<Change[]>[];
     }
   | {
       type: "setDetails";

--- a/apps/builder/app/builder/shared/sync/sync-server.ts
+++ b/apps/builder/app/builder/shared/sync/sync-server.ts
@@ -1,13 +1,16 @@
 import { useEffect } from "react";
 import { atom } from "nanostores";
+import type { Change } from "immerhin";
 import type { Project } from "@webstudio-is/project";
 import type { Build } from "@webstudio-is/project-build";
 import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
 import * as commandQueue from "./command-queue";
 import { restPatchPath } from "~/shared/router-utils";
 import { toast } from "@webstudio-is/design-system";
-import { serverSyncStore } from "~/shared/sync";
 import { fetch } from "~/shared/fetch.client";
+import type { SyncStorage, Transaction } from "~/shared/sync-client";
+import { $project } from "~/shared/nano-states";
+import { loadBuilderData } from "~/shared/builder-data";
 
 // Periodic check for new entries to group them into one job/call in sync queue.
 const NEW_ENTRIES_INTERVAL = 1000;
@@ -37,6 +40,8 @@ export type QueueStatus =
   | { status: "fatal"; error: string };
 
 export const queueStatus = atom<QueueStatus>({ status: "idle" });
+
+const pendingTransactions: Transaction<Change[]>[] = [];
 
 const getRandomBetween = (a: number, b: number) => {
   return Math.random() * (b - a) + a;
@@ -286,10 +291,11 @@ const useSyncProject = ({
     syncServer();
 
     const updateProjectTransactions = () => {
-      const transactions = serverSyncStore.popAll();
-      if (transactions.length === 0) {
+      if (pendingTransactions.length === 0) {
         return;
       }
+      const transactions = [...pendingTransactions];
+      pendingTransactions.splice(0);
       commandQueue.enqueue({ type: "transactions", transactions, projectId });
     };
 
@@ -304,6 +310,22 @@ const useSyncProject = ({
     };
   }, [projectId, authPermit]);
 };
+
+export class ServerSyncStorage implements SyncStorage {
+  name = "server";
+  sendTransaction(transaction: Transaction<Change[]>) {
+    if (transaction.object === "server") {
+      pendingTransactions.push(transaction);
+    }
+  }
+  subscribe(setState: (state: unknown) => void, signal: AbortSignal) {
+    const projectId = $project.get()?.id ?? "";
+    loadBuilderData({ projectId, signal }).then((data) => {
+      const serverData = new Map(Object.entries(data));
+      setState(new Map([["server", serverData]]));
+    });
+  }
+}
 
 type SyncServerProps = {
   projectId: Project["id"];

--- a/apps/builder/app/shared/builder-data.ts
+++ b/apps/builder/app/shared/builder-data.ts
@@ -40,21 +40,6 @@ export const getBuilderData = (): BuilderData => {
   };
 };
 
-export const setBuilderData = (data: BuilderData) => {
-  $assets.set(data.assets);
-  $instances.set(data.instances);
-  $dataSources.set(data.dataSources);
-  $resources.set(data.resources);
-  // props should be after data sources to compute logic
-  $props.set(data.props);
-  $pages.set(data.pages);
-  $styleSources.set(data.styleSources);
-  $styleSourceSelections.set(data.styleSourceSelections);
-  $breakpoints.set(data.breakpoints);
-  $styles.set(data.styles);
-  $marketplaceProduct.set(data.marketplaceProduct);
-};
-
 const getPair = <Item extends { id: string }>(item: Item) =>
   [item.id, item] as const;
 

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -79,7 +79,7 @@ export const registerContainers = () => {
   serverSyncStore.register("marketplaceProduct", $marketplaceProduct);
 };
 
-const createObjectPool = () => {
+export const createObjectPool = () => {
   return new SyncObjectPool([
     new ImmerhinSyncObject("server", serverSyncStore),
     new ImmerhinSyncObject("client", clientSyncStore),
@@ -97,15 +97,15 @@ const createObjectPool = () => {
       $selectedInstanceBrowserStyle
     ),
     new NanostoresSyncObject(
-      "$selectedInstanceIntanceToTag",
+      "selectedInstanceIntanceToTag",
       $selectedInstanceIntanceToTag
     ),
     new NanostoresSyncObject(
-      "$selectedInstanceUnitSizes",
+      "selectedInstanceUnitSizes",
       $selectedInstanceUnitSizes
     ),
     new NanostoresSyncObject(
-      "$selectedInstanceRenderState",
+      "selectedInstanceRenderState",
       $selectedInstanceRenderState
     ),
     new NanostoresSyncObject(
@@ -141,7 +141,6 @@ const createObjectPool = () => {
     new NanostoresSyncObject("hoveredInstanceOutline", $hoveredInstanceOutline),
     new NanostoresSyncObject("blockChildOutline", $blockChildOutline),
     new NanostoresSyncObject("modifierKeys", $modifierKeys),
-
     new NanostoresSyncObject(
       "collaborativeInstanceSelector",
       $collaborativeInstanceSelector
@@ -186,22 +185,6 @@ export const useCanvasStore = () => {
 
     const controller = new AbortController();
     canvasClient.connect({ signal: controller.signal });
-    return () => {
-      controller.abort();
-    };
-  }, []);
-};
-
-export const builderClient = new SyncClient({
-  role: "leader",
-  object: createObjectPool(),
-});
-
-export const useBuilderStore = () => {
-  useEffect(() => {
-    const controller = new AbortController();
-    builderClient.connect({ signal: controller.signal });
-
     return () => {
       controller.abort();
     };

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -174,6 +174,9 @@ const sharedSyncEmitter =
   typeof window === "undefined"
     ? undefined
     : window.__webstudioSharedSyncEmitter__;
+if (typeof window !== "undefined") {
+  delete window.__webstudioSharedSyncEmitter__;
+}
 
 export const useCanvasStore = () => {
   useEffect(() => {


### PR DESCRIPTION
Another layer in sync engine is composable storage.

Now you can specify a chain of storages. Each can listen transactions to update some state. Though subscription for state is invoked one by one until non-undefined is provided.

See tests to understand API.

Here I also migrated our server data loading and synchronization to this storage api.