### PR TITLE
feat: Allow delete/reorder Content Block children in Content mode

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/editable-block-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/editable-block-instance-outline.tsx
@@ -43,7 +43,7 @@ import {
 } from "~/shared/instance-utils";
 import { shallowEqual } from "shallow-equal";
 
-const findEditableBlockSelector = (
+export const findEditableBlockSelector = (
   anchor: InstanceSelector,
   instances: Instances
 ) => {


### PR DESCRIPTION
## Description

In content mode children of the Editable Block can be reordered and deleted now.

ref #3994 

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
