### PR TITLE
feat: Plus button hover polygon and menu icons

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/editable-block-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/editable-block-instance-outline.tsx
@@ -21,6 +21,7 @@ import {
   toast,
   Kbd,
   Text,
+  iconButtonSize,
 } from "@webstudio-is/design-system";
 import { EditableBlockChildAddButtonOutline } from "./outline";
 import { applyScale } from "./apply-scale";
@@ -357,7 +358,7 @@ export const EditableBlockChildHoveredInstanceOutline = () => {
         css={{
           width: "min-content",
           pointerEvents: isMenuOpen ? "none" : "all",
-          clipPath: `polygon(0% 0%, 100% 0%, 100% 100%, 0% 24px)`,
+          clipPath: `polygon(0% 0%, 100% 0%, 100% 100%, 0% ${iconButtonSize})`,
         }}
         onMouseEnter={() => {
           clearTimeout(timeoutRef.current);

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/editable-block-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/editable-block-instance-outline.tsx
@@ -352,8 +352,8 @@ export const EditableBlockChildHoveredInstanceOutline = () => {
       <Flex
         css={{
           width: "min-content",
-          height: "min-content",
           pointerEvents: isMenuOpen ? "none" : "all",
+          clipPath: `polygon(0% 0%, 100% 0%, 100% 100%, 0% 24px)`,
         }}
         onMouseEnter={() => {
           clearTimeout(timeoutRef.current);
@@ -385,6 +385,7 @@ export const EditableBlockChildHoveredInstanceOutline = () => {
           <IconButton
             variant={"local"}
             css={{
+              mr: theme.spacing[4],
               borderStyle: "solid",
               borderColor: `oklch(from ${theme.colors.backgroundPrimary} l c h / 0.7)`,
             }}
@@ -392,13 +393,6 @@ export const EditableBlockChildHoveredInstanceOutline = () => {
             <PlusIcon />
           </IconButton>
         </TemplatesMenu>
-        <Box
-          css={{
-            width: theme.spacing[4],
-            // For easier hover
-            height: theme.spacing[12],
-          }}
-        ></Box>
       </Flex>
     </EditableBlockChildAddButtonOutline>
   );

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/editable-block-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/editable-block-instance-outline.tsx
@@ -3,6 +3,7 @@ import {
   $editableBlockChildOutline,
   $instances,
   $isContentMode,
+  $registeredComponentMetas,
   type EditableBlockChildOutline,
 } from "~/shared/nano-states";
 import {
@@ -24,7 +25,8 @@ import {
 import { EditableBlockChildAddButtonOutline } from "./outline";
 import { applyScale } from "./apply-scale";
 import { $scale } from "~/builder/shared/nano-states";
-import { BoxIcon, PlusIcon } from "@webstudio-is/icons";
+import { PlusIcon } from "@webstudio-is/icons";
+import { BoxIcon } from "@webstudio-is/icons/svg";
 import { useRef, useState } from "react";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import type { DroppableTarget, InstanceSelector } from "~/shared/tree-utils";
@@ -42,6 +44,7 @@ import {
   updateWebstudioData,
 } from "~/shared/instance-utils";
 import { shallowEqual } from "shallow-equal";
+import { MetaIcon } from "~/builder/shared/meta-icon";
 
 const findEditableBlockSelector = (
   anchor: InstanceSelector,
@@ -182,6 +185,7 @@ const TemplatesMenu = ({
   anchor: InstanceSelector;
 }) => {
   const instances = useStore($instances);
+  const metas = useStore($registeredComponentMetas);
 
   const optionPointerDownTime = useRef(0);
   const isMenuOpenedWithOption = useRef(false);
@@ -197,7 +201,7 @@ const TemplatesMenu = ({
 
   const menuItems = templates?.map(([template, templateSelector]) => ({
     id: template.id,
-    icon: <BoxIcon />,
+    icon: <MetaIcon icon={metas.get(template.component)?.icon ?? BoxIcon} />,
     title: template.label ?? template.component,
     value: templateSelector,
   }));

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/outline.tsx
@@ -89,15 +89,11 @@ export const EditableBlockChildAddButtonOutline = ({
       >
         <div
           style={{
-            height: 0,
             width: 0,
             display: "grid",
 
-            alignContent: "start",
+            alignContent: "stretch",
             justifyContent: "end",
-
-            justifySelf: "start",
-            alignSelf: "start",
           }}
         >
           {children}

--- a/packages/design-system/src/components/icon-button.tsx
+++ b/packages/design-system/src/components/icon-button.tsx
@@ -20,6 +20,8 @@ const disabledVariantStyles = {
   },
 };
 
+export const iconButtonSize = theme.spacing[11];
+
 export const IconButton = styled("button", {
   // reset styles
   boxSizing: "border-box",
@@ -33,8 +35,8 @@ export const IconButton = styled("button", {
   alignItems: "center",
   // prevent shrinking inside flex box
   flexShrink: 0,
-  width: theme.spacing[11],
-  height: theme.spacing[11],
+  width: iconButtonSize,
+  height: iconButtonSize,
   borderRadius: theme.borderRadius[3],
   minWidth: 0,
   outline: "none",


### PR DESCRIPTION
## Description

ref #3994

Menu Icons are now from meta

<img width="229" alt="image" src="https://github.com/user-attachments/assets/5e6e0fcd-6c1c-4eab-b493-94d70f2162f7">



Red is hover polygon (used to not lost hover) (small quad before was not enough)

<img width="404" alt="image" src="https://github.com/user-attachments/assets/0395d0db-3ec8-493f-b1b8-b40e117026e6">


<img width="383" alt="image" src="https://github.com/user-attachments/assets/36544e8d-bda5-4a06-bfe4-a92d93247333">

<img width="417" alt="image" src="https://github.com/user-attachments/assets/6ce49c43-cc37-4ba9-94cd-bb0bb6930253">


<img width="372" alt="image" src="https://github.com/user-attachments/assets/8771b051-09a5-43fe-9903-5d8e60dc72a3">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
