### PR TITLE
fix:  flex dropdown items height consistency

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/menu/menu-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/menu/menu-control.tsx
@@ -102,17 +102,19 @@ export const MenuControl = ({
                     setDescriptionValue(undefined);
                   }}
                 >
-                  <Flex
-                    css={{
-                      width: theme.spacing[11],
-                      height: theme.spacing[11],
-                    }}
-                    align="center"
-                    justify="center"
-                  >
-                    <Icon />
+                  <Flex gap="1">
+                    <Flex
+                      css={{
+                        width: theme.spacing[9],
+                        height: theme.spacing[9],
+                      }}
+                      align="center"
+                      justify="center"
+                    >
+                      <Icon />
+                    </Flex>
+                    {label}
                   </Flex>
-                  {label}
                 </DropdownMenuRadioItem>
               );
             })}


### PR DESCRIPTION
## Description

When I migrated to 24px inputs height, I forgot this one.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
