### PR TITLE
refactor: add new insert constraints

### DIFF
--- a/apps/builder/app/shared/instance-utils.test.tsx
+++ b/apps/builder/app/shared/instance-utils.test.tsx
@@ -9,6 +9,7 @@ import type { Project } from "@webstudio-is/project";
 import { createDefaultPages } from "@webstudio-is/project-build";
 import { $, ws, renderJsx, ExpressionValue } from "@webstudio-is/sdk/testing";
 import { parseCss } from "@webstudio-is/css-data";
+import { coreMetas } from "@webstudio-is/react-sdk";
 import * as defaultMetas from "@webstudio-is/sdk-components-react/metas";
 import type {
   Asset,
@@ -66,7 +67,9 @@ registerContainers();
 
 $pages.set(createDefaultPages({ rootInstanceId: "", systemDataSourceId: "" }));
 
-const defaultMetasMap = new Map(Object.entries(defaultMetas));
+const defaultMetasMap = new Map(
+  Object.entries({ ...defaultMetas, ...coreMetas })
+);
 $registeredComponentMetas.set(defaultMetasMap);
 
 const createFragment = (

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -1551,7 +1551,7 @@ export const findClosestInsertable = (
     return;
   }
   // paste to the page root if nothing is selected
-  let instanceSelector = awareness?.instanceSelector ?? [
+  const instanceSelector = awareness?.instanceSelector ?? [
     selectedPage.rootInstanceId,
   ];
   if (instanceSelector[0] === ROOT_INSTANCE_ID) {

--- a/apps/builder/app/shared/matcher.test.tsx
+++ b/apps/builder/app/shared/matcher.test.tsx
@@ -1,0 +1,586 @@
+import { describe, expect, test } from "vitest";
+import { renderJsx, $, ExpressionValue } from "@webstudio-is/sdk/testing";
+import { coreMetas } from "@webstudio-is/react-sdk";
+import * as baseMetas from "@webstudio-is/sdk-components-react/metas";
+import type { WsComponentMeta } from "@webstudio-is/react-sdk";
+import type { WebstudioFragment } from "@webstudio-is/sdk";
+import {
+  findClosestContainer,
+  findClosestInstanceMatchingFragment,
+  isInstanceMatching,
+  isTreeMatching,
+} from "./matcher";
+
+const metas = new Map(Object.entries({ ...coreMetas, ...baseMetas }));
+
+describe("is instance matching", () => {
+  test("matches self with self matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "list", "body"],
+        query: {
+          relation: "self",
+          component: { $eq: "ListItem" },
+        },
+      })
+    ).toBeTruthy();
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "list", "body"],
+        query: {
+          relation: "self",
+          component: { $in: ["ListItem", "ListBox"] },
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  test("matches self with negated self matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "list", "body"],
+        query: {
+          relation: "self",
+          component: { $neq: "Box" },
+        },
+      })
+    ).toBeTruthy();
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "list", "body"],
+        query: {
+          relation: "self",
+          component: { $nin: ["Box", "List"] },
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  test("matches parent with parent matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "list", "body"],
+        query: {
+          relation: "parent",
+          component: { $eq: "List" },
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  test("not matches ancestor with parent matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.Box ws:id="box">
+                <$.ListItem ws:id="listitem"></$.ListItem>
+              </$.Box>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "box", "list", "body"],
+        query: {
+          relation: "parent",
+          component: { $eq: "List" },
+        },
+      })
+    ).toBeFalsy();
+  });
+
+  test("not matches another parent with parent matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.ListItem ws:id="listitem"></$.ListItem>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "body"],
+        query: {
+          relation: "parent",
+          component: { $eq: "List" },
+        },
+      })
+    ).toBeFalsy();
+  });
+
+  test("matches parent with negated parent matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.ListItem ws:id="listitem"></$.ListItem>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "body"],
+        query: {
+          relation: "parent",
+          component: { $neq: "List" },
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  test("not matches parent with negated parent matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "list", "body"],
+        query: {
+          relation: "parent",
+          component: { $neq: "List" },
+        },
+      })
+    ).toBeFalsy();
+  });
+
+  test("matches parent with ancestor matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "list", "body"],
+        query: {
+          relation: "ancestor",
+          component: { $eq: "List" },
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  test("matches parent with ancestor matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.Box ws:id="box">
+                <$.ListItem ws:id="listitem"></$.ListItem>
+              </$.Box>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "box", "list", "body"],
+        query: {
+          relation: "ancestor",
+          component: { $eq: "List" },
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  test("not matches another ancestor with ancestor matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Box ws:id="box">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.Box>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "box", "body"],
+        query: {
+          relation: "ancestor",
+          component: { $eq: "List" },
+        },
+      })
+    ).toBeFalsy();
+  });
+
+  test("matches ancestor with negated ancestor matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Box ws:id="box">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.Box>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "box", "body"],
+        query: {
+          relation: "ancestor",
+          component: { $neq: "List" },
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  test("not matches ancestor with negated ancestor matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "list", "body"],
+        query: {
+          relation: "ancestor",
+          component: { $neq: "List" },
+        },
+      })
+    ).toBeFalsy();
+  });
+
+  test("combines self, parent and ancestor matchers", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "list", "body"],
+        query: [
+          {
+            relation: "self",
+            component: { $eq: "ListItem" },
+          },
+          {
+            relation: "parent",
+            component: { $eq: "List" },
+          },
+          {
+            relation: "ancestor",
+            component: { $eq: "Body" },
+          },
+        ],
+      })
+    ).toBeTruthy();
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Box ws:id="box">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.Box>
+          </$.Body>
+        ),
+        instanceSelector: ["listitem", "box", "body"],
+        query: [
+          {
+            relation: "self",
+            component: { $eq: "ListItem" },
+          },
+          {
+            relation: "parent",
+            component: { $eq: "List" },
+          },
+          {
+            relation: "ancestor",
+            component: { $eq: "Body" },
+          },
+        ],
+      })
+    ).toBeFalsy();
+  });
+
+  test("negated ancestor matcher should not interfere with self relation", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list"></$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query: {
+          relation: "ancestor",
+          component: { $neq: "List" },
+        },
+      })
+    ).toBeTruthy();
+  });
+});
+
+describe("is tree matching", () => {
+  const metas = new Map<string, WsComponentMeta>([
+    [
+      "ListItem",
+      {
+        type: "container",
+        icon: "",
+        constraints: {
+          relation: "parent",
+          component: { $eq: "List" },
+        },
+      },
+    ],
+  ]);
+
+  test("match selected instance", () => {
+    expect(
+      isTreeMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["listitem", "list", "body"],
+      })
+    ).toBeTruthy();
+    expect(
+      isTreeMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.ListItem ws:id="listitem"></$.ListItem>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["listitem", "body"],
+      })
+    ).toBeFalsy();
+  });
+
+  test("match all descendants", () => {
+    expect(
+      isTreeMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["list", "body"],
+      })
+    ).toBeTruthy();
+    expect(
+      isTreeMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.ListItem ws:id="listitem"></$.ListItem>
+            <$.Box ws:id="box"></$.Box>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["body"],
+      })
+    ).toBeFalsy();
+  });
+});
+
+describe("find closest instance matching fragment", () => {
+  const createFragment = (element: JSX.Element): WebstudioFragment => {
+    const { instances } = renderJsx(element);
+    const instancesArray = Array.from(instances.values());
+    return {
+      children: instancesArray[0].children,
+      instances: instancesArray,
+      styleSourceSelections: [],
+      styleSources: [],
+      breakpoints: [],
+      styles: [],
+      dataSources: [],
+      resources: [],
+      props: [],
+      assets: [],
+    };
+  };
+
+  test("finds closest list with list item fragment", () => {
+    const { instances } = renderJsx(
+      <$.Body ws:id="body">
+        <$.List ws:id="list">
+          <$.ListItem ws:id="listitem"></$.ListItem>
+        </$.List>
+      </$.Body>
+    );
+    const fragment = createFragment(
+      // only children are tested
+      <>
+        <$.ListItem ws:id="new"></$.ListItem>
+      </>
+    );
+    expect(
+      findClosestInstanceMatchingFragment({
+        metas,
+        instances,
+        instanceSelector: ["list", "body"],
+        fragment,
+      })
+    ).toEqual(0);
+    expect(
+      findClosestInstanceMatchingFragment({
+        metas,
+        instances,
+        // looks up until list parent is reached
+        instanceSelector: ["listitem", "list", "body"],
+        fragment,
+      })
+    ).toEqual(1);
+    expect(
+      findClosestInstanceMatchingFragment({
+        metas,
+        instances,
+        instanceSelector: ["body"],
+        fragment,
+      })
+    ).toEqual(-1);
+  });
+
+  test("finds button parent with button fragment", () => {
+    const { instances } = renderJsx(
+      <$.Body ws:id="body">
+        <$.Button ws:id="button"></$.Button>
+      </$.Body>
+    );
+    const fragment = createFragment(
+      // only children are tested
+      <>
+        <$.Button ws:id="new"></$.Button>
+      </>
+    );
+    expect(
+      findClosestInstanceMatchingFragment({
+        metas,
+        instances,
+        instanceSelector: ["button", "body"],
+        fragment,
+      })
+    ).toEqual(1);
+  });
+
+  test("finds button parent with button+span fragment", () => {
+    const { instances } = renderJsx(
+      <$.Body ws:id="body">
+        <$.Button ws:id="button"></$.Button>
+      </$.Body>
+    );
+    const fragment = createFragment(
+      // only children are tested
+      <>
+        <$.Button ws:id="new-button"></$.Button>
+        <$.Text ws:id="new-text"></$.Text>
+      </>
+    );
+    expect(
+      findClosestInstanceMatchingFragment({
+        metas,
+        instances,
+        instanceSelector: ["button", "body"],
+        fragment,
+      })
+    ).toEqual(1);
+  });
+});
+
+describe("find closest container", () => {
+  test("skips non-container instances", () => {
+    expect(
+      findClosestContainer({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Box ws:id="box">
+              <$.Image ws:id="image" />
+            </$.Box>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["image", "box", "body"],
+      })
+    ).toEqual(1);
+  });
+
+  test("skips containers with text", () => {
+    expect(
+      findClosestContainer({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Box ws:id="box">
+              <$.Box ws:id="box-with-text">text</$.Box>
+            </$.Box>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["box-with-text", "box", "body"],
+      })
+    ).toEqual(1);
+  });
+
+  test("skips containers with expression", () => {
+    expect(
+      findClosestContainer({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Box ws:id="box">
+              <$.Box ws:id="box-with-expr">
+                {new ExpressionValue("1 + 1")}
+              </$.Box>
+            </$.Box>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["box-with-expr", "box", "body"],
+      })
+    ).toEqual(1);
+  });
+
+  test("allow root with text", () => {
+    expect(
+      findClosestContainer({
+        ...renderJsx(<$.Body ws:id="body">text</$.Body>),
+        metas,
+        instanceSelector: ["body"],
+      })
+    ).toEqual(0);
+  });
+});

--- a/apps/builder/app/shared/matcher.test.tsx
+++ b/apps/builder/app/shared/matcher.test.tsx
@@ -3,7 +3,7 @@ import { renderJsx, $, ExpressionValue } from "@webstudio-is/sdk/testing";
 import { coreMetas } from "@webstudio-is/react-sdk";
 import * as baseMetas from "@webstudio-is/sdk-components-react/metas";
 import type { WsComponentMeta } from "@webstudio-is/react-sdk";
-import type { WebstudioFragment } from "@webstudio-is/sdk";
+import type { Matcher, WebstudioFragment } from "@webstudio-is/sdk";
 import {
   findClosestContainer,
   findClosestInstanceMatchingFragment,
@@ -344,6 +344,43 @@ describe("is instance matching", () => {
         },
       })
     ).toBeTruthy();
+  });
+
+  test("combines multiple ancestor matchers", () => {
+    const query: Matcher[] = [
+      {
+        relation: "ancestor",
+        component: { $eq: "Body" },
+      },
+      {
+        relation: "ancestor",
+        component: { $in: ["Box"] },
+      },
+    ];
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Box ws:id="box">
+              <$.List ws:id="list"></$.List>
+            </$.Box>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "box", "body"],
+        query,
+      })
+    ).toBeTruthy();
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list"></$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query,
+      })
+    ).toBeFalsy();
   });
 });
 

--- a/apps/builder/app/shared/matcher.ts
+++ b/apps/builder/app/shared/matcher.ts
@@ -1,0 +1,222 @@
+import type {
+  Instances,
+  Matcher,
+  MatcherOperation,
+  MatcherRelation,
+  WebstudioFragment,
+} from "@webstudio-is/sdk";
+import type { InstanceSelector } from "./tree-utils";
+import type { WsComponentMeta } from "@webstudio-is/react-sdk";
+
+const isNegated = (operation?: MatcherOperation) => {
+  return operation?.$neq !== undefined || operation?.$nin !== undefined;
+};
+
+const isMatching = (
+  value: undefined | string,
+  operation: undefined | MatcherOperation
+) => {
+  if (operation?.$eq) {
+    return operation.$eq === value;
+  }
+  if (operation?.$neq) {
+    return operation.$neq === value;
+  }
+  if (operation?.$in && value) {
+    return operation.$in.includes(value);
+  }
+  if (operation?.$nin && value) {
+    return operation.$nin.includes(value);
+  }
+  return false;
+};
+
+const isRelationMatching = (index: number, relation: MatcherRelation) => {
+  return (
+    (relation === "self" && index === 0) ||
+    (relation === "parent" && index === 1) ||
+    (relation === "ancestor" && index >= 1)
+  );
+};
+
+/**
+ * @todo following features are missing
+ * - child matcher
+ * - descendant matcher
+ * - tag matcher
+ */
+export const isInstanceMatching = ({
+  instances,
+  instanceSelector,
+  query,
+}: {
+  instances: Instances;
+  instanceSelector: InstanceSelector;
+  query: undefined | Matcher | Matcher[];
+}): boolean => {
+  // fast path to the lack of constraints
+  if (query === undefined) {
+    return true;
+  }
+  const queries = Array.isArray(query) ? query : [query];
+  let selfMatches: undefined | boolean;
+  let parentMatches: undefined | boolean;
+  let ancestorMatches: undefined | boolean;
+  let index = 0;
+  for (const instanceId of instanceSelector) {
+    const instance = instances.get(instanceId);
+    for (const { relation, component } of queries) {
+      if (isRelationMatching(index, relation)) {
+        let matches = isMatching(instance?.component, component);
+        if (isNegated(component)) {
+          if (matches) {
+            return false;
+          }
+          // inverse negated match
+          matches = true;
+        }
+        if (relation === "self") {
+          selfMatches ??= false;
+          selfMatches = selfMatches || matches;
+        }
+        if (relation === "parent") {
+          parentMatches ??= false;
+          parentMatches = parentMatches || matches;
+        }
+        if (relation === "ancestor") {
+          ancestorMatches ??= false;
+          ancestorMatches = ancestorMatches || matches;
+        }
+      }
+    }
+    index += 1;
+  }
+  // relations without matchers always match
+  return (
+    (selfMatches ?? true) &&
+    (parentMatches ?? true) &&
+    (ancestorMatches ?? true)
+  );
+};
+
+export const isTreeMatching = ({
+  instances,
+  metas,
+  instanceSelector,
+}: {
+  instances: Instances;
+  metas: Map<string, WsComponentMeta>;
+  instanceSelector: InstanceSelector;
+}): boolean => {
+  const [instanceId] = instanceSelector;
+  const instance = instances.get(instanceId);
+  // collection item can be undefined
+  if (instance === undefined) {
+    return true;
+  }
+  const meta = metas.get(instance.component);
+  let matches = isInstanceMatching({
+    instances,
+    instanceSelector,
+    query: meta?.constraints,
+  });
+  if (matches === false) {
+    return false;
+  }
+  for (const child of instance.children) {
+    if (child.type === "id") {
+      matches = isTreeMatching({
+        instances,
+        metas,
+        instanceSelector: [child.value, ...instanceSelector],
+      });
+      if (matches === false) {
+        return false;
+      }
+    }
+  }
+  return matches;
+};
+
+export const findClosestInstanceMatchingFragment = ({
+  instances,
+  metas,
+  instanceSelector,
+  fragment,
+}: {
+  instances: Instances;
+  metas: Map<string, WsComponentMeta>;
+  instanceSelector: InstanceSelector;
+  fragment: WebstudioFragment;
+}) => {
+  const mergedInstances = new Map(instances);
+  for (const instance of fragment.instances) {
+    mergedInstances.set(instance.id, instance);
+  }
+  for (let index = 0; index < instanceSelector.length; index += 1) {
+    const instanceId = instanceSelector[index];
+    const instance = instances.get(instanceId);
+    // collection item can be undefined
+    if (instance === undefined) {
+      continue;
+    }
+    const meta = metas.get(instance.component);
+    if (meta === undefined) {
+      continue;
+    }
+    let matches = true;
+    for (const child of fragment.children) {
+      if (child.type === "id") {
+        matches &&= isTreeMatching({
+          instances: mergedInstances,
+          metas,
+          instanceSelector: [child.value, ...instanceSelector.slice(index)],
+        });
+      }
+    }
+    if (matches) {
+      return index;
+    }
+  }
+  return -1;
+};
+
+export const findClosestContainer = ({
+  metas,
+  instances,
+  instanceSelector,
+}: {
+  metas: Map<string, WsComponentMeta>;
+  instances: Instances;
+  instanceSelector: InstanceSelector;
+}) => {
+  // page root with text can be used as container
+  if (instanceSelector.length === 1) {
+    return 0;
+  }
+  for (let index = 0; index < instanceSelector.length; index += 1) {
+    const instanceId = instanceSelector[index];
+    const instance = instances.get(instanceId);
+    // collection item can be undefined
+    if (instance === undefined) {
+      continue;
+    }
+    const meta = metas.get(instance.component);
+    if (meta === undefined) {
+      continue;
+    }
+    let hasText = false;
+    for (const child of instance.children) {
+      if (child.type === "text" || child.type === "expression") {
+        hasText = true;
+      }
+    }
+    if (hasText) {
+      continue;
+    }
+    if (meta.type === "container") {
+      return index;
+    }
+  }
+  return -1;
+};

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
-import { PropMeta } from "../prop-meta";
 import type { HtmlTags } from "html-tags";
+import { Matchers } from "@webstudio-is/sdk";
+import { PropMeta } from "../prop-meta";
 import { EmbedTemplateStyleDecl, WsEmbedTemplate } from "../embed-template";
 
 export type PresetStyle<Tag extends HtmlTags = HtmlTags> = Partial<
@@ -61,6 +62,7 @@ export const WsComponentMeta = z.object({
   type: z.enum(["container", "control", "embed", "rich-text-child"]),
   requiredAncestors: z.optional(z.array(z.string())),
   invalidAncestors: z.optional(z.array(z.string())),
+  constraints: Matchers.optional(),
   // when this field is specified component receives
   // prop with index of same components withiin specified ancestor
   // important to automatically enumerate collections without

--- a/packages/react-sdk/src/embed-template.test.tsx
+++ b/packages/react-sdk/src/embed-template.test.tsx
@@ -768,6 +768,10 @@ test("add namespace to selected components in embed template", () => {
         icon: "",
         requiredAncestors: ["Button", "Box"],
         invalidAncestors: ["Tooltip"],
+        constraints: {
+          relation: "ancestor",
+          component: { $nin: ["Button", "Box"] },
+        },
         indexWithinAncestor: "Tooltip",
         presetTokens: {
           base: { styles: [] },
@@ -805,6 +809,10 @@ test("add namespace to selected components in embed template", () => {
     icon: "",
     requiredAncestors: ["my-namespace:Button", "Box"],
     invalidAncestors: ["my-namespace:Tooltip"],
+    constraints: {
+      relation: "ancestor",
+      component: { $nin: ["my-namespace:Button", "my-namespace:Box"] },
+    },
     indexWithinAncestor: "my-namespace:Tooltip",
     presetTokens: {
       base: { styles: [] },

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -12,6 +12,7 @@ import type {
   Breakpoint,
   DataSource,
   WebstudioFragment,
+  Matcher,
 } from "@webstudio-is/sdk";
 import {
   encodeDataSourceVariable,
@@ -451,6 +452,27 @@ const namespaceEmbedTemplateComponents = (
   });
 };
 
+const namespaceMatcher = (namespace: string, matcher: Matcher) => {
+  const newMatcher = structuredClone(matcher);
+  if (newMatcher.component?.$eq) {
+    newMatcher.component.$eq = `${namespace}:${newMatcher.component.$eq}`;
+  }
+  if (newMatcher.component?.$neq) {
+    newMatcher.component.$neq = `${namespace}:${newMatcher.component.$neq}`;
+  }
+  if (newMatcher.component?.$in) {
+    newMatcher.component.$in = newMatcher.component.$in.map(
+      (component) => `${namespace}:${component}`
+    );
+  }
+  if (newMatcher.component?.$nin) {
+    newMatcher.component.$nin = newMatcher.component.$nin.map(
+      (component) => `${namespace}:${component}`
+    );
+  }
+  return newMatcher;
+};
+
 export const namespaceMeta = (
   meta: WsComponentMeta,
   namespace: string,
@@ -466,6 +488,15 @@ export const namespaceMeta = (
     newMeta.invalidAncestors = newMeta.invalidAncestors.map((component) =>
       components.has(component) ? `${namespace}:${component}` : component
     );
+  }
+  if (newMeta.constraints) {
+    if (Array.isArray(newMeta.constraints)) {
+      newMeta.constraints = newMeta.constraints.map((matcher) =>
+        namespaceMatcher(namespace, matcher)
+      );
+    } else {
+      newMeta.constraints = namespaceMatcher(namespace, newMeta.constraints);
+    }
   }
   if (newMeta.indexWithinAncestor) {
     newMeta.indexWithinAncestor = components.has(newMeta.indexWithinAncestor)

--- a/packages/sdk-components-react-radix/src/accordion.ws.ts
+++ b/packages/sdk-components-react-radix/src/accordion.ws.ts
@@ -223,6 +223,10 @@ export const metaAccordionItem: WsComponentMeta = {
   label: "Item",
   icon: ItemIcon,
   requiredAncestors: ["Accordion"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Accordion" },
+  },
   indexWithinAncestor: "Accordion",
   presetStyle,
 };
@@ -233,6 +237,10 @@ export const metaAccordionHeader: WsComponentMeta = {
   label: "Item Header",
   icon: HeaderIcon,
   requiredAncestors: ["AccordionItem"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "AccordionItem" },
+  },
   detachable: false,
   presetStyle: {
     h3: [h3, tc.my(0)].flat(),
@@ -245,6 +253,10 @@ export const metaAccordionTrigger: WsComponentMeta = {
   label: "Item Trigger",
   icon: TriggerIcon,
   requiredAncestors: ["AccordionHeader"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "AccordionHeader" },
+  },
   detachable: false,
   states: [
     ...defaultStates,
@@ -265,6 +277,10 @@ export const metaAccordionContent: WsComponentMeta = {
   label: "Item Content",
   icon: ContentIcon,
   requiredAncestors: ["AccordionItem"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "AccordionItem" },
+  },
   detachable: false,
   presetStyle,
 };

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -432,6 +432,10 @@ export const metaNavigationMenuList: WsComponentMeta = {
   type: "container",
   icon: ListIcon,
   requiredAncestors: ["NavigationMenu"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "NavigationMenu" },
+  },
   presetStyle,
   label: "Menu List",
 };
@@ -441,6 +445,10 @@ export const metaNavigationMenuItem: WsComponentMeta = {
   type: "container",
   icon: ListItemIcon,
   requiredAncestors: ["NavigationMenu"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "NavigationMenu" },
+  },
   presetStyle,
   indexWithinAncestor: "NavigationMenu",
   label: "Menu Item",
@@ -452,6 +460,10 @@ export const metaNavigationMenuTrigger: WsComponentMeta = {
   type: "container",
   icon: TriggerIcon,
   requiredAncestors: ["NavigationMenuItem"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "NavigationMenuItem" },
+  },
   presetStyle,
   label: "Menu Trigger",
 };
@@ -461,6 +473,10 @@ export const metaNavigationMenuContent: WsComponentMeta = {
   type: "container",
   icon: ContentIcon,
   requiredAncestors: ["NavigationMenuItem"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "NavigationMenuItem" },
+  },
   indexWithinAncestor: "NavigationMenu",
   presetStyle,
   label: "Menu Content",
@@ -476,6 +492,10 @@ export const metaNavigationMenuLink: WsComponentMeta = {
   // requiredAncestors: ["NavigationMenuContent", "NavigationMenuItem"],
   // Temporary restrict to NavigationMenu
   requiredAncestors: ["NavigationMenu"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "NavigationMenu" },
+  },
   presetStyle,
   label: "Accessible Link Wrapper",
 };
@@ -486,6 +506,10 @@ export const metaNavigationMenuViewport: WsComponentMeta = {
   type: "container",
   icon: ViewportIcon,
   requiredAncestors: ["NavigationMenu"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "NavigationMenu" },
+  },
   presetStyle,
   label: "Menu Viewport",
 };

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -488,14 +488,17 @@ export const metaNavigationMenuLink: WsComponentMeta = {
   type: "container",
   stylable: false,
   icon: BoxIcon,
-  // https://github.com/webstudio-is/webstudio/issues/2193
-  // requiredAncestors: ["NavigationMenuContent", "NavigationMenuItem"],
-  // Temporary restrict to NavigationMenu
   requiredAncestors: ["NavigationMenu"],
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: "NavigationMenu" },
-  },
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "NavigationMenu" },
+    },
+    {
+      relation: "ancestor",
+      component: { $in: ["NavigationMenuContent", "NavigationMenuItem"] },
+    },
+  ],
   presetStyle,
   label: "Accessible Link Wrapper",
 };

--- a/packages/sdk-components-react-radix/src/radio-group.ws.ts
+++ b/packages/sdk-components-react-radix/src/radio-group.ws.ts
@@ -145,6 +145,10 @@ export const metaRadioGroupItem: WsComponentMeta = {
   category: "hidden",
   type: "container",
   requiredAncestors: ["RadioGroup"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "RadioGroup" },
+  },
   icon: ItemIcon,
   states: defaultStates,
   presetStyle: {

--- a/packages/sdk-components-react-radix/src/select.ws.ts
+++ b/packages/sdk-components-react-radix/src/select.ws.ts
@@ -279,6 +279,10 @@ export const metaSelectItem: WsComponentMeta = {
   type: "container",
   icon: ItemIcon,
   requiredAncestors: ["SelectViewport"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "SelectViewport" },
+  },
   presetStyle,
 };
 
@@ -289,6 +293,10 @@ export const metaSelectItemIndicator: WsComponentMeta = {
   icon: CheckMarkIcon,
   detachable: false,
   requiredAncestors: ["SelectItem"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "SelectItem" },
+  },
   presetStyle: {
     span,
   },
@@ -301,6 +309,10 @@ export const metaSelectItemText: WsComponentMeta = {
   icon: TextIcon,
   detachable: false,
   requiredAncestors: ["SelectItem"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "SelectItem" },
+  },
   presetStyle: {
     span,
   },

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -147,6 +147,10 @@ export const metaTabsList: WsComponentMeta = {
   type: "container",
   icon: HeaderIcon,
   requiredAncestors: ["Tabs"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Tabs" },
+  },
   presetStyle,
 };
 
@@ -156,6 +160,16 @@ export const metaTabsTrigger: WsComponentMeta = {
   icon: TriggerIcon,
   requiredAncestors: ["TabsList"],
   invalidAncestors: ["TabsTrigger"],
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "TabsList" },
+    },
+    {
+      relation: "ancestor",
+      component: { $neq: "TabsTrigger" },
+    },
+  ],
   indexWithinAncestor: "Tabs",
   label: "Tab Trigger",
   states: [
@@ -177,6 +191,10 @@ export const metaTabsContent: WsComponentMeta = {
   label: "Tab Content",
   icon: ContentIcon,
   requiredAncestors: ["Tabs"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Tabs" },
+  },
   indexWithinAncestor: "Tabs",
   presetStyle,
 };

--- a/packages/sdk-components-react/src/button.ws.ts
+++ b/packages/sdk-components-react/src/button.ws.ts
@@ -17,6 +17,10 @@ export const meta: WsComponentMeta = {
   category: "forms",
   type: "container",
   invalidAncestors: ["Button", "Link"],
+  constraints: {
+    relation: "ancestor",
+    component: { $nin: ["Button", "Link"] },
+  },
   description:
     "Use a button to submit forms or trigger actions within a page. Do not use a button to navigate users to another resource or another page - that’s what a link is used for.",
   icon: ButtonElementIcon,

--- a/packages/sdk-components-react/src/checkbox.ws.ts
+++ b/packages/sdk-components-react/src/checkbox.ws.ts
@@ -22,6 +22,10 @@ const presetStyle = {
 export const meta: WsComponentMeta = {
   category: "forms",
   invalidAncestors: ["Button", "Link"],
+  constraints: {
+    relation: "ancestor",
+    component: { $nin: ["Button", "Link"] },
+  },
   type: "control",
   description:
     "Use within a form to allow your users to toggle between checked and not checked. Group checkboxes by matching their “Name” properties. Unlike radios, any number of checkboxes in a group can be checked.",

--- a/packages/sdk-components-react/src/code-text.ws.ts
+++ b/packages/sdk-components-react/src/code-text.ws.ts
@@ -46,6 +46,10 @@ export const meta: WsComponentMeta = {
     "Use this component when you want to display code as text on the page.",
   icon: CodeTextIcon,
   invalidAncestors: ["CodeText"],
+  constraints: {
+    relation: "ancestor",
+    component: { $neq: "CodeText" },
+  },
   states: defaultStates,
   presetStyle,
   order: 9,

--- a/packages/sdk-components-react/src/form.ws.ts
+++ b/packages/sdk-components-react/src/form.ws.ts
@@ -21,6 +21,10 @@ export const meta: WsComponentMeta = {
   type: "container",
   label: "Form",
   invalidAncestors: ["Form", "Button", "Link"],
+  constraints: {
+    relation: "ancestor",
+    component: { $nin: ["Form", "Button", "Link"] },
+  },
   description: "Create filters, surveys, searches and more.",
   icon: FormIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/heading.ws.ts
+++ b/packages/sdk-components-react/src/heading.ws.ts
@@ -28,6 +28,10 @@ export const meta: WsComponentMeta = {
     "Use HTML headings to structure and organize content. Use the Tag property in settings to change the heading level (h1-h6).",
   icon: HeadingIcon,
   invalidAncestors: ["Heading"],
+  constraints: {
+    relation: "ancestor",
+    component: { $neq: "Heading" },
+  },
   states: defaultStates,
   presetStyle,
   order: 1,

--- a/packages/sdk-components-react/src/input.ws.ts
+++ b/packages/sdk-components-react/src/input.ws.ts
@@ -22,6 +22,10 @@ const presetStyle = {
 export const meta: WsComponentMeta = {
   category: "forms",
   invalidAncestors: ["Button", "Link"],
+  constraints: {
+    relation: "ancestor",
+    component: { $nin: ["Button", "Link"] },
+  },
   type: "control",
   label: "Text Input",
   description:

--- a/packages/sdk-components-react/src/label.ws.ts
+++ b/packages/sdk-components-react/src/label.ws.ts
@@ -19,6 +19,10 @@ const presetStyle = {
 export const meta: WsComponentMeta = {
   category: "forms",
   invalidAncestors: ["Button", "Label"],
+  constraints: {
+    relation: "ancestor",
+    component: { $nin: ["Button", "Link"] },
+  },
   type: "container",
   label: "Input Label",
   icon: LabelIcon,

--- a/packages/sdk-components-react/src/link.ws.ts
+++ b/packages/sdk-components-react/src/link.ws.ts
@@ -30,6 +30,10 @@ export const meta: WsComponentMeta = {
     "Use a link to send your users to another page, section, or resource. Configure links in the Settings panel.",
   icon: LinkIcon,
   invalidAncestors: ["Link", "Button"],
+  constraints: {
+    relation: "ancestor",
+    component: { $nin: ["Button", "Link"] },
+  },
   presetStyle,
   order: 1,
   states: [

--- a/packages/sdk-components-react/src/list-item.ws.ts
+++ b/packages/sdk-components-react/src/list-item.ws.ts
@@ -17,6 +17,10 @@ export const meta: WsComponentMeta = {
   category: "general",
   type: "container",
   requiredAncestors: ["List"],
+  constraints: {
+    relation: "parent",
+    component: { $eq: "List" },
+  },
   description: "Adds a new item to an existing list.",
   icon: ListItemIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/option.ws.ts
+++ b/packages/sdk-components-react/src/option.ws.ts
@@ -28,6 +28,10 @@ export const meta: WsComponentMeta = {
   category: "hidden",
   // @todo: requiredAncestors should be ["Select", "Optgroup", "Datalist"] but that gives unreadable error when adding Select onto Canvas
   requiredAncestors: ["Select"],
+  constraints: {
+    relation: "parent",
+    component: { $eq: "Select" },
+  },
   type: "control",
   description:
     "An item within a drop-down menu that users can select as their chosen value.",

--- a/packages/sdk-components-react/src/paragraph.ws.ts
+++ b/packages/sdk-components-react/src/paragraph.ws.ts
@@ -19,6 +19,10 @@ export const meta: WsComponentMeta = {
   description: "A container for multi-line text.",
   icon: TextAlignLeftIcon,
   invalidAncestors: ["Paragraph"],
+  constraints: {
+    relation: "ancestor",
+    component: { $neq: "Paragraph" },
+  },
   states: defaultStates,
   presetStyle,
   order: 2,

--- a/packages/sdk-components-react/src/radio-button.ws.ts
+++ b/packages/sdk-components-react/src/radio-button.ws.ts
@@ -22,6 +22,10 @@ const presetStyle = {
 export const meta: WsComponentMeta = {
   category: "forms",
   invalidAncestors: ["Button", "Link"],
+  constraints: {
+    relation: "ancestor",
+    component: { $nin: ["Button", "Link"] },
+  },
   type: "control",
   label: "Radio",
   description:

--- a/packages/sdk-components-react/src/select.ws.ts
+++ b/packages/sdk-components-react/src/select.ws.ts
@@ -22,6 +22,10 @@ const presetStyle = {
 export const meta: WsComponentMeta = {
   category: "forms",
   invalidAncestors: ["Button", "Link"],
+  constraints: {
+    relation: "ancestor",
+    component: { $nin: ["Button", "Link"] },
+  },
   type: "container",
   description:
     "A drop-down menu for users to select a single option from a predefined list.",

--- a/packages/sdk-components-react/src/textarea.ws.ts
+++ b/packages/sdk-components-react/src/textarea.ws.ts
@@ -31,6 +31,10 @@ export const meta: WsComponentMeta = {
   presetStyle,
   order: 4,
   invalidAncestors: ["Button", "Link"],
+  constraints: {
+    relation: "ancestor",
+    component: { $nin: ["Button", "Link"] },
+  },
   states: [
     ...defaultStates,
     { selector: "::placeholder", label: "Placeholder" },

--- a/packages/sdk-components-react/src/vimeo-play-button.ws.ts
+++ b/packages/sdk-components-react/src/vimeo-play-button.ws.ts
@@ -18,6 +18,16 @@ export const meta: WsComponentMeta = {
   type: "container",
   invalidAncestors: ["Button"],
   requiredAncestors: ["Vimeo"],
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "Vimeo" },
+    },
+    {
+      relation: "ancestor",
+      component: { $neq: "Button" },
+    },
+  ],
   label: "Play Button",
   icon: ButtonElementIcon,
   presetStyle,

--- a/packages/sdk-components-react/src/vimeo-preview-image.ws.ts
+++ b/packages/sdk-components-react/src/vimeo-preview-image.ws.ts
@@ -14,6 +14,10 @@ export const meta: WsComponentMeta = {
   category: "hidden",
   label: "Preview Image",
   requiredAncestors: ["Vimeo"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Vimeo" },
+  },
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/vimeo-spinner.ws.ts
+++ b/packages/sdk-components-react/src/vimeo-spinner.ws.ts
@@ -14,12 +14,16 @@ const presetStyle = {
 
 export const meta: WsComponentMeta = {
   type: "container",
+  requiredAncestors: ["Vimeo"],
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Vimeo" },
+  },
   icon: BoxIcon,
   states: defaultStates,
   presetStyle,
   category: "hidden",
   label: "Spinner",
-  requiredAncestors: ["Vimeo"],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/vimeo.ws.ts
+++ b/packages/sdk-components-react/src/vimeo.ws.ts
@@ -24,6 +24,10 @@ export const meta: WsComponentMeta = {
   states: defaultStates,
   presetStyle,
   invalidAncestors: ["Button", "Heading", "Link"],
+  constraints: {
+    relation: "ancestor",
+    component: { $nin: ["Button", "Link", "Heading"] },
+  },
   template: [
     {
       type: "instance",

--- a/packages/sdk/src/schema/instances.ts
+++ b/packages/sdk/src/schema/instances.ts
@@ -37,3 +37,34 @@ export type Instance = z.infer<typeof Instance>;
 export const Instances = z.map(InstanceId, Instance);
 
 export type Instances = z.infer<typeof Instances>;
+
+export const MatcherRelation = z.union([
+  z.literal("ancestor"),
+  z.literal("parent"),
+  z.literal("self"),
+  z.literal("child"),
+  z.literal("descendant"),
+]);
+
+export type MatcherRelation = z.infer<typeof MatcherRelation>;
+
+export const MatcherOperation = z.object({
+  $eq: z.string().optional(),
+  $neq: z.string().optional(),
+  $in: z.array(z.string()).optional(),
+  $nin: z.array(z.string()).optional(),
+});
+
+export type MatcherOperation = z.infer<typeof MatcherOperation>;
+
+export const Matcher = z.object({
+  relation: MatcherRelation,
+  component: MatcherOperation.optional(),
+  tag: MatcherOperation.optional(),
+});
+
+export type Matcher = z.infer<typeof Matcher>;
+
+export const Matchers = z.union([Matcher, z.array(Matcher)]);
+
+export type Matchers = z.infer<typeof Matchers>;


### PR DESCRIPTION
Here added new constraints format which will allow us build more expressive lookups and matchers for internal logic and components constraints.

For now added only ancestor, parent and self matchers with $eq, $neq, $in, $nin operations.

Closes https://github.com/webstudio-is/webstudio/issues/2193 "$in" operation works like "or".