### PR TITLE
feat: Allow select link selector during text edit

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
@@ -5,12 +5,19 @@ import {
   $selectedInstanceSelector,
 } from "~/shared/nano-states";
 import { $textEditingInstanceSelector } from "~/shared/nano-states";
-import { areInstanceSelectorsEqual } from "~/shared/tree-utils";
+import { type InstanceSelector } from "~/shared/tree-utils";
 import { Outline } from "./outline";
 import { applyScale } from "./apply-scale";
 import { $scale } from "~/builder/shared/nano-states";
 import { findClosestSlot } from "~/shared/instance-utils";
 import { $ephemeralStyles } from "~/canvas/stores";
+
+const isDescendantOrSelf = (
+  descendant: InstanceSelector,
+  self: InstanceSelector
+) => {
+  return descendant.join(",").endsWith(self.join(","));
+};
 
 export const SelectedInstanceOutline = () => {
   const instances = useStore($instances);
@@ -20,17 +27,20 @@ export const SelectedInstanceOutline = () => {
   const scale = useStore($scale);
   const ephemeralStyles = useStore($ephemeralStyles);
 
+  if (selectedInstanceSelector === undefined) {
+    return;
+  }
+
   const isEditingCurrentInstance =
     textEditingInstanceSelector !== undefined &&
-    areInstanceSelectorsEqual(
-      textEditingInstanceSelector.selector,
-      selectedInstanceSelector
+    isDescendantOrSelf(
+      selectedInstanceSelector,
+      textEditingInstanceSelector.selector
     );
 
   if (
     isEditingCurrentInstance ||
     outline === undefined ||
-    selectedInstanceSelector === undefined ||
     ephemeralStyles.length !== 0
   ) {
     return;


### PR DESCRIPTION
## Description

Before, there was no way to select a link inside the text on the canvas in content mode (it was only possible through the navigation menu).
Now, when the cursor is over a link, it is displayed in the settings panel.

This does not work with newly created links. Will do in the following PR.


https://github.com/user-attachments/assets/7472bfd1-3cf7-4ad5-9d39-1bd2effdab26



## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
