### PR TITLE
experimental: show only block and ts children in navigator

### DIFF
--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -149,6 +149,10 @@ const blockMeta: WsComponentMeta = {
   type: "container",
   label: "Content Block",
   icon: EditIcon,
+  constraints: {
+    relation: "ancestor",
+    component: { $neq: collectionComponent },
+  },
   stylable: false,
   template: [
     {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3994

<img width="279" alt="Screenshot 2024-12-04 at 17 32 32" src="https://github.com/user-attachments/assets/277c7fbc-537a-459d-bab0-fbcb56c990b4">
<img width="284" alt="Screenshot 2024-12-04 at 17 32 41" src="https://github.com/user-attachments/assets/8e1d870f-7751-441f-bb49-3da5180109cd">
