### PR TITLE
fix: Prevent focus when selecting form label in builder

### DIFF
--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -71,12 +71,12 @@ const switchPageAndUpdateSystem = (href: string, formData?: FormData) => {
 export const subscribeInterceptedEvents = () => {
   const handleClick = (event: MouseEvent) => {
     // Prevent forwarding the click event on an input element when the associated label has a "for" attribute
-    if (event.target instanceof Element) {
-      if (event.target.closest("label[for]")) {
-        if (!$isPreviewMode.get()) {
-          event.preventDefault();
-        }
-      }
+    if (
+      event.target instanceof Element &&
+      event.target.closest("label[for]") &&
+      !$isPreviewMode.get()
+    ) {
+      event.preventDefault();
     }
 
     if (

--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -70,6 +70,15 @@ const switchPageAndUpdateSystem = (href: string, formData?: FormData) => {
 
 export const subscribeInterceptedEvents = () => {
   const handleClick = (event: MouseEvent) => {
+    // Prevent forwarding the click event on an input element when the associated label has a "for" attribute
+    if (event.target instanceof Element) {
+      if (event.target.closest("label[for]")) {
+        if (!$isPreviewMode.get()) {
+          event.preventDefault();
+        }
+      }
+    }
+
     if (
       event.target instanceof HTMLElement ||
       event.target instanceof SVGElement


### PR DESCRIPTION
## Description

Prevent forwarding the click event on an input element when the associated label has a "for" attribute

In real browser emulates click event on input when label is clicked.

closes #4513

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
