### PR TITLE
fix: Scroll to display contents elements.

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/block-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/block-instance-outline.tsx
@@ -53,6 +53,7 @@ import {
 import { shallowEqual } from "shallow-equal";
 import { MetaIcon } from "~/builder/shared/meta-icon";
 import { skipInertHandlersAttribute } from "~/builder/shared/inert-handlers";
+import { selectInstance } from "~/shared/awareness";
 
 export const findBlockSelector = (
   anchor: InstanceSelector,
@@ -274,6 +275,8 @@ const TemplatesMenu = ({
                   { type: "id", value: newRootInstanceId },
                 ];
                 insertInstanceChildrenMutable(data, children, target);
+
+                selectInstance([newRootInstanceId, ...target.parentSelector]);
               });
             }}
           >

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -125,7 +125,7 @@ const subscribeSelectedInstance = (
 
   const bbox = getAllElementsBoundingBox(visibleElements);
 
-  // To have a little bit of space above the element after scrolling
+  // Adds a small amount of space around the element after scrolling
   const topScrollMargin = 16;
 
   if (bbox.top < 0 || bbox.bottom > window.innerHeight) {

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -123,27 +123,29 @@ const subscribeSelectedInstance = (
     selectedInstanceSelector
   );
 
-  const bbox = getAllElementsBoundingBox(visibleElements);
+  const updateScroll = () => {
+    const bbox = getAllElementsBoundingBox(visibleElements);
 
-  // Adds a small amount of space around the element after scrolling
-  const topScrollMargin = 16;
+    // Adds a small amount of space around the element after scrolling
+    const topScrollMargin = 16;
 
-  if (bbox.top < 0 || bbox.bottom > window.innerHeight) {
-    const moveToTopDelta = bbox.top - topScrollMargin;
-    const moveToBottomDelta =
-      bbox.bottom - window.innerHeight + topScrollMargin;
+    if (bbox.top < 0 || bbox.bottom > window.innerHeight) {
+      const moveToTopDelta = bbox.top - topScrollMargin;
+      const moveToBottomDelta =
+        bbox.bottom - window.innerHeight + topScrollMargin;
 
-    // scrollTo is used because scrollIntoView does not work with elements that have display:contents, etc.
-    // Here, we can be confident that if the outline can be calculated, we can scroll to it.
-    window.scrollTo({
-      top:
-        window.scrollY +
-        (Math.abs(moveToTopDelta) < Math.abs(moveToBottomDelta)
-          ? moveToTopDelta
-          : moveToBottomDelta),
-      behavior: "smooth",
-    });
-  }
+      // scrollTo is used because scrollIntoView does not work with elements that have display:contents, etc.
+      // Here, we can be confident that if the outline can be calculated, we can scroll to it.
+      window.scrollTo({
+        top:
+          window.scrollY +
+          (Math.abs(moveToTopDelta) < Math.abs(moveToBottomDelta)
+            ? moveToTopDelta
+            : moveToBottomDelta),
+        behavior: "smooth",
+      });
+    }
+  };
 
   const updateElements = () => {
     visibleElements = getVisibleElementsByInstanceSelector(
@@ -253,6 +255,9 @@ const subscribeSelectedInstance = (
 
       // Having that elements can be changed (i.e. div => address tag change, observe again)
       updateObservers();
+
+      // update scroll state
+      updateScroll();
     });
   };
 

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -123,10 +123,27 @@ const subscribeSelectedInstance = (
     selectedInstanceSelector
   );
 
-  visibleElements[0]?.scrollIntoView({
-    behavior: "smooth",
-    block: "nearest",
-  });
+  const bbox = getAllElementsBoundingBox(visibleElements);
+
+  // To have a little bit of space above the element after scrolling
+  const topScrollMargin = 16;
+
+  if (bbox.top < 0 || bbox.bottom > window.innerHeight) {
+    const moveToTopDelta = bbox.top - topScrollMargin;
+    const moveToBottomDelta =
+      bbox.bottom - window.innerHeight + topScrollMargin;
+
+    // scrollTo is used because scrollIntoView does not work with elements that have display:contents, etc.
+    // Here, we can be confident that if the outline can be calculated, we can scroll to it.
+    window.scrollTo({
+      top:
+        window.scrollY +
+        (Math.abs(moveToTopDelta) < Math.abs(moveToBottomDelta)
+          ? moveToTopDelta
+          : moveToBottomDelta),
+      behavior: "smooth",
+    });
+  }
 
   const updateElements = () => {
     visibleElements = getVisibleElementsByInstanceSelector(


### PR DESCRIPTION
## Description

ref #3994

Scroll is seriously changed so need to be carefully tested.

As side effect this fixes "When clicking "Content Block" in the navigator, nothing is scrolled into view."

`+` fixed: When inserting a template instance, it should be selected automatically.


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
