### PR TITLE
refactor: add child and descendant matchers

### DIFF
--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -18,7 +18,6 @@ import {
   findAvailableDataSources,
   extractWebstudioFragment,
   insertWebstudioFragmentCopy,
-  isInstanceDetachable,
   updateWebstudioData,
 } from "~/shared/instance-utils";
 import type { InstanceSelector } from "~/shared/tree-utils";
@@ -285,13 +284,6 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
 
         const instanceSelector = $selectedInstanceSelector.get();
         if (instanceSelector === undefined) {
-          return;
-        }
-        const instances = $instances.get();
-        if (isInstanceDetachable(instances, instanceSelector) === false) {
-          builderApi.toast.error(
-            "This instance can not be moved outside of its parent component."
-          );
           return;
         }
         // @todo tell user they can't copy or cut root

--- a/apps/builder/app/shared/matcher.test.tsx
+++ b/apps/builder/app/shared/matcher.test.tsx
@@ -382,6 +382,187 @@ describe("is instance matching", () => {
       })
     ).toBeFalsy();
   });
+
+  test("matches a child with child matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query: {
+          relation: "child",
+          component: { $eq: "ListItem" },
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  test("matches a child with negated child matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list"></$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query: {
+          relation: "child",
+          component: { $neq: "ListItem" },
+        },
+      })
+    ).toBeTruthy();
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.Box ws:id="box"></$.Box>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query: {
+          relation: "child",
+          component: { $neq: "ListItem" },
+        },
+      })
+    ).toBeTruthy();
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query: {
+          relation: "child",
+          component: { $neq: "ListItem" },
+        },
+      })
+    ).toBeFalsy();
+  });
+
+  test("not matches a parent without a child with child matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list"></$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query: {
+          relation: "child",
+          component: { $eq: "ListItem" },
+        },
+      })
+    ).toBeFalsy();
+  });
+
+  test("not matches a parent with different child with child matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.Box ws:id="box"></$.Box>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query: {
+          relation: "child",
+          component: { $eq: "ListItem" },
+        },
+      })
+    ).toBeFalsy();
+  });
+
+  test("matches a child with descendant matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.ListItem ws:id="listitem"></$.ListItem>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query: {
+          relation: "descendant",
+          component: { $eq: "ListItem" },
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  test("matches a descendant with descendant matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.Box ws:id="box">
+                <$.ListItem ws:id="listitem"></$.ListItem>
+              </$.Box>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query: {
+          relation: "descendant",
+          component: { $eq: "ListItem" },
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  test("matches a descendant with negated descendant matcher", () => {
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.Box ws:id="box"></$.Box>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query: {
+          relation: "descendant",
+          component: { $neq: "ListItem" },
+        },
+      })
+    ).toBeTruthy();
+    expect(
+      isInstanceMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.List ws:id="list">
+              <$.Box ws:id="box">
+                <$.ListItem ws:id="listitem"></$.ListItem>
+              </$.Box>
+            </$.List>
+          </$.Body>
+        ),
+        instanceSelector: ["list", "body"],
+        query: {
+          relation: "descendant",
+          component: { $neq: "ListItem" },
+        },
+      })
+    ).toBeFalsy();
+  });
 });
 
 describe("is tree matching", () => {
@@ -394,6 +575,17 @@ describe("is tree matching", () => {
         constraints: {
           relation: "parent",
           component: { $eq: "List" },
+        },
+      },
+    ],
+    [
+      "Tabs",
+      {
+        type: "container",
+        icon: "",
+        constraints: {
+          relation: "descendant",
+          component: { $eq: "TabsTrigger" },
         },
       },
     ],
@@ -450,6 +642,37 @@ describe("is tree matching", () => {
         ),
         metas,
         instanceSelector: ["body"],
+      })
+    ).toBeFalsy();
+  });
+
+  test("match ancestors", () => {
+    expect(
+      isTreeMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Tabs ws:id="tabs">
+              <$.Box ws:id="box">
+                <$.TabsTrigger ws:id="trigger"></$.TabsTrigger>
+              </$.Box>
+            </$.Tabs>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["trigger", "box", "tabs", "body"],
+      })
+    ).toBeTruthy();
+    expect(
+      isTreeMatching({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Tabs ws:id="tabs">
+              <$.Box ws:id="box"></$.Box>
+            </$.Tabs>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["box", "tabs", "body"],
       })
     ).toBeFalsy();
   });

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -72,6 +72,20 @@ export const metaTabs: WsComponentMeta = {
   order: 2,
   type: "container",
   icon: TabsIcon,
+  constraints: [
+    {
+      relation: "descendant",
+      component: { $eq: "TabsTrigger" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "TabsList" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "TabsContent" },
+    },
+  ],
   presetStyle,
   description:
     "A set of panels with content that are displayed one at a time. Duplicate both a tab trigger and tab content to add more tabs. Triggers and content are connected according to their order in the Navigator.",
@@ -143,7 +157,6 @@ export const metaTabs: WsComponentMeta = {
 
 export const metaTabsList: WsComponentMeta = {
   category: "hidden",
-  detachable: false,
   type: "container",
   icon: HeaderIcon,
   requiredAncestors: ["Tabs"],


### PR DESCRIPTION
Now we have two more matcher for direct children and descendants. Eventually they will replace "detachable" flag in meta.

Here used new matchers to prevent user from deleting last tab trigger or last tab content which cannot be readded from components panel.

Added matchers check to "delete" and "cut"