### PR TITLE
refactor: remove variable fallback on autocomplete

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -478,9 +478,16 @@ export const CssValueInput = ({
     }
 
     if (value.type !== "intermediate" && value.type !== "invalid") {
+      // variables fallback is used for preview value while autocompleting
+      // removed fallback when select variable to not pollute values
+      let newValue = value;
+      if (value.type === "var") {
+        newValue = { ...value };
+        delete newValue.fallback;
+      }
       // The value might be valid but not selected from the combo menu. Close the menu.
       closeMenu();
-      props.onChangeComplete({ ...defaultProps, ...event, value });
+      props.onChangeComplete({ ...defaultProps, ...event, value: newValue });
       return;
     }
 


### PR DESCRIPTION
Forgot to clear fallback after variable values preview.

<img width="335" alt="Screenshot 2024-12-06 at 13 40 03" src="https://github.com/user-attachments/assets/0d35bcbe-f890-4082-9da1-e194645ad1bb">
