### PR TITLE
build: automatically publish CLI along with release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,34 @@ jobs:
             name: tag_name,
             body: changelog,
           })
+
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }} # tag name
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: bump version to ${{ github.ref }}
+        run: pnpx replace-in-files-cli --string="0.191.0" --replacement="${{ github.ref }}" "**/package.json"
+
+      - name: pnpm instal
+        run: pnpm install --ignore-scripts
+      - run: pnpm -r build
+      - run: pnpm -r dts
+
+      - name: Creating .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: pnpm -r publish --access public --no-git-checks


### PR DESCRIPTION
We often forget to publish CLI packages after release and get some bug reports from users because of it.

Here invoked publishing along with release generation when tag is pushed.

The version is taken from release name and
will no longer be committed to repo.

Gonna test it once merged.