### PR TITLE
fix: hide chevron consistently when there are no items in the style panel section

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/style-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/style-section.tsx
@@ -85,7 +85,7 @@ export const RepeatedStyleSection = (props: {
       trigger={
         <SectionTitle
           inactive={dots.length === 0}
-          collapsible={collapsible}
+          collapsible={collapsible ?? dots.length !== 0}
           dots={getDots(styles)}
           suffix={
             <SectionTitleButton


### PR DESCRIPTION
## Description

Forgot to set the default  for chevron to be hidden when there are no items and no colapsible property passed explicitely

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
