### PR TITLE
fix: When a mode like "Content" is selected in share links, it's odd that clone and copy are checked and blue

### DIFF
--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -194,14 +194,17 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
               }}
             >
               <Checkbox
-                disabled={hasProPlan !== true}
+                disabled={hasProPlan !== true || value.relation !== "viewers"}
                 checked={value.canClone}
                 onCheckedChange={(canClone) => {
                   onChange({ ...value, canClone: Boolean(canClone) });
                 }}
                 id={ids.canClone}
               />
-              <Label htmlFor={ids.canClone} disabled={hasProPlan !== true}>
+              <Label
+                htmlFor={ids.canClone}
+                disabled={hasProPlan !== true || value.relation !== "viewers"}
+              >
                 Can clone
               </Label>
             </Grid>
@@ -214,14 +217,17 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
               }}
             >
               <Checkbox
-                disabled={hasProPlan !== true}
+                disabled={hasProPlan !== true || value.relation !== "viewers"}
                 checked={value.canCopy}
                 onCheckedChange={(canCopy) => {
                   onChange({ ...value, canCopy: Boolean(canCopy) });
                 }}
                 id={ids.canCopy}
               />
-              <Label htmlFor={ids.canCopy} disabled={hasProPlan !== true}>
+              <Label
+                htmlFor={ids.canCopy}
+                disabled={hasProPlan !== true || value.relation !== "viewers"}
+              >
                 Can copy
               </Label>
             </Grid>


### PR DESCRIPTION
## Description

ref #3994

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
