### PR TITLE
fix: Do not show empty content blocks in preview mode

### DIFF
--- a/apps/builder/app/canvas/features/build-mode/block.tsx
+++ b/apps/builder/app/canvas/features/build-mode/block.tsx
@@ -11,6 +11,7 @@ import * as React from "react";
 import {
   $instances,
   $isDesignMode,
+  $isPreviewMode,
   $selectedInstanceSelector,
 } from "~/shared/nano-states";
 
@@ -20,6 +21,7 @@ export const Block = React.forwardRef<
 >(({ children, ...props }, ref) => {
   const instances = useStore($instances);
   const isDesignMode = useStore($isDesignMode);
+  const isPreviewMode = useStore($isPreviewMode);
   const instanceId = props[idAttribute];
   const instance = instances.get(instanceId);
   const selectedInstanceSelector = useStore($selectedInstanceSelector);
@@ -81,7 +83,9 @@ export const Block = React.forwardRef<
   return (
     <div ref={ref} style={editableBlockStyle} {...props}>
       {childArray}
-      {hasContent ? null : <div>Editable block you can edit</div>}
+      {hasContent || isPreviewMode ? null : (
+        <div>Editable block you can edit</div>
+      )}
     </div>
   );
 }) as AnyComponent;


### PR DESCRIPTION
## Description

ref #3994

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
