### PR TITLE
refactor: replace detachable: false with constraints

### DIFF
--- a/apps/builder/app/builder/features/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator-tree.tsx
@@ -444,13 +444,16 @@ const canDrag = (instance: Instance, instanceSelector: InstanceSelector) => {
       return false;
     }
   }
+  // prevent moving block template out of first position
+  if (instance.component === blockTemplateComponent) {
+    return false;
+  }
 
   const meta = $registeredComponentMetas.get().get(instance.component);
   if (meta === undefined) {
     return true;
   }
-  const detachable =
-    meta.type !== "rich-text-child" && (meta.detachable ?? true);
+  const detachable = meta.type !== "rich-text-child";
   if (detachable === false) {
     toast.error(
       "This instance can not be moved outside of its parent component."

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -255,28 +255,6 @@ export const findClosestEditableInstanceSelector = (
   }
 };
 
-export const findClosestDetachableInstanceSelector = (
-  instanceSelector: InstanceSelector,
-  instances: Instances,
-  metas: Map<string, WsComponentMeta>
-) => {
-  for (const instanceId of instanceSelector) {
-    const instance = instances.get(instanceId);
-    if (instance === undefined) {
-      return;
-    }
-    const meta = metas.get(instance.component);
-    if (meta === undefined) {
-      return;
-    }
-    const detachable = meta.detachable ?? true;
-    if (meta.type === "rich-text-child" || detachable === false) {
-      continue;
-    }
-    return getAncestorInstanceSelector(instanceSelector, instanceId);
-  }
-};
-
 export const isInstanceDetachable = (
   instances: Instances,
   instanceSelector: InstanceSelector
@@ -296,17 +274,11 @@ export const isInstanceDetachable = (
     newInstances.set(parentInstance.id, parentInstance);
   }
   // check parent can follow constraints without selected instance
-  const matches = isTreeMatching({
+  return isTreeMatching({
     instances: newInstances,
     metas,
     instanceSelector: instanceSelector.slice(1),
   });
-  const instance = instances.get(instanceId);
-  if (instance === undefined) {
-    return false;
-  }
-  const meta = metas.get(instance.component);
-  return (meta?.detachable ?? true) && matches;
 };
 
 export const insertInstanceChildrenMutable = (

--- a/apps/builder/app/shared/matcher.ts
+++ b/apps/builder/app/shared/matcher.ts
@@ -1,10 +1,11 @@
-import type {
-  Instance,
-  Instances,
-  Matcher,
-  MatcherOperation,
-  MatcherRelation,
-  WebstudioFragment,
+import {
+  parseComponentName,
+  type Instance,
+  type Instances,
+  type Matcher,
+  type MatcherOperation,
+  type MatcherRelation,
+  type WebstudioFragment,
 } from "@webstudio-is/sdk";
 import type { InstanceSelector } from "./tree-utils";
 import type { WsComponentMeta } from "@webstudio-is/react-sdk";
@@ -65,7 +66,12 @@ const formatList = (operation: MatcherOperation) => {
   if (operation.$nin) {
     list.push(...operation.$nin);
   }
-  return listFormat.format(list);
+  return listFormat.format(
+    list.map((component) => {
+      const [_namespace, name] = parseComponentName(component);
+      return name;
+    })
+  );
 };
 
 /**

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -67,10 +67,6 @@ export const WsComponentMeta = z.object({
   // naming every item manually
   indexWithinAncestor: z.optional(z.string()),
   stylable: z.optional(z.boolean()),
-  // specifies whether the instance can be deleted,
-  // copied or dragged out of its parent instance
-  // true by default
-  detachable: z.optional(z.boolean()),
   label: z.optional(z.string()),
   description: z.string().optional(),
   icon: z.string(),

--- a/packages/react-sdk/src/core-components.ts
+++ b/packages/react-sdk/src/core-components.ts
@@ -94,7 +94,10 @@ const descendantMeta: WsComponentMeta = {
   type: "control",
   label: "Descendant",
   icon: PaintBrushIcon,
-  detachable: false,
+  constraints: {
+    relation: "parent",
+    component: { $eq: "HtmlEmbed" },
+  },
 };
 
 const descendantPropsMeta: WsComponentPropsMeta = {
@@ -126,14 +129,19 @@ const descendantPropsMeta: WsComponentPropsMeta = {
   initialProps: ["selector"],
 };
 
+export const blockComponent = "ws:block";
+
 export const blockTemplateComponent = "ws:block-template";
 
 export const blockTemplateMeta: WsComponentMeta = {
   category: "hidden",
-  detachable: false,
   type: "container",
   icon: AddTemplateInstanceIcon,
   stylable: false,
+  constraints: {
+    relation: "parent",
+    component: { $eq: blockComponent },
+  },
 };
 
 const blockTemplatePropsMeta: WsComponentPropsMeta = {
@@ -141,18 +149,22 @@ const blockTemplatePropsMeta: WsComponentPropsMeta = {
   initialProps: [],
 };
 
-export const blockComponent = "ws:block";
-
 const blockMeta: WsComponentMeta = {
   category: "data",
   order: 2,
   type: "container",
   label: "Content Block",
   icon: EditIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $nin: [collectionComponent, blockComponent] },
-  },
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $nin: [collectionComponent, blockComponent] },
+    },
+    {
+      relation: "child",
+      component: { $eq: blockTemplateComponent },
+    },
+  ],
   stylable: false,
   template: [
     {

--- a/packages/sdk-components-react-radix/src/accordion.ws.ts
+++ b/packages/sdk-components-react-radix/src/accordion.ws.ts
@@ -127,6 +127,12 @@ export const metaAccordion: WsComponentMeta = {
   presetStyle,
   description:
     "A vertically stacked set of interactive headings that each reveal an associated section of content. Clicking on the heading will open the item and close other items.",
+  constraints: [
+    {
+      relation: "descendant",
+      component: { $eq: "AccordionItem" },
+    },
+  ],
   template: [
     {
       type: "instance",
@@ -222,10 +228,20 @@ export const metaAccordionItem: WsComponentMeta = {
   type: "container",
   label: "Item",
   icon: ItemIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: "Accordion" },
-  },
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "Accordion" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "AccordionHeader" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "AccordionContent" },
+    },
+  ],
   indexWithinAncestor: "Accordion",
   presetStyle,
 };
@@ -235,11 +251,16 @@ export const metaAccordionHeader: WsComponentMeta = {
   type: "container",
   label: "Item Header",
   icon: HeaderIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: "AccordionItem" },
-  },
-  detachable: false,
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "AccordionItem" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "AccordionTrigger" },
+    },
+  ],
   presetStyle: {
     h3: [h3, tc.my(0)].flat(),
   },
@@ -254,7 +275,6 @@ export const metaAccordionTrigger: WsComponentMeta = {
     relation: "ancestor",
     component: { $eq: "AccordionHeader" },
   },
-  detachable: false,
   states: [
     ...defaultStates,
     {
@@ -277,7 +297,6 @@ export const metaAccordionContent: WsComponentMeta = {
     relation: "ancestor",
     component: { $eq: "AccordionItem" },
   },
-  detachable: false,
   presetStyle,
 };
 

--- a/packages/sdk-components-react-radix/src/checkbox.ws.ts
+++ b/packages/sdk-components-react-radix/src/checkbox.ws.ts
@@ -20,6 +20,10 @@ export const metaCheckbox: WsComponentMeta = {
   category: "radix",
   order: 101,
   type: "container",
+  constraints: {
+    relation: "descendant",
+    component: { $eq: "CheckboxIndicator" },
+  },
   icon: CheckboxCheckedIcon,
   description:
     "Use within a form to allow your users to toggle between checked and not checked. Group checkboxes by matching their “Name” properties. Unlike radios, any number of checkboxes in a group can be checked.",
@@ -136,7 +140,10 @@ export const metaCheckbox: WsComponentMeta = {
 export const metaCheckboxIndicator: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  detachable: false,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Checkbox" },
+  },
   icon: TriggerIcon,
   states: defaultStates,
   presetStyle: {

--- a/packages/sdk-components-react-radix/src/collapsible.ws.ts
+++ b/packages/sdk-components-react-radix/src/collapsible.ws.ts
@@ -24,6 +24,16 @@ export const metaCollapsible: WsComponentMeta = {
   category: "radix",
   order: 5,
   type: "container",
+  constraints: [
+    {
+      relation: "descendant",
+      component: { $eq: "CollapsibleTrigger" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "CollapsibleContent" },
+    },
+  ],
   presetStyle,
   icon: CollapsibleIcon,
   description:
@@ -79,7 +89,10 @@ export const metaCollapsibleTrigger: WsComponentMeta = {
   type: "container",
   icon: TriggerIcon,
   stylable: false,
-  detachable: false,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Collapsible" },
+  },
 };
 
 export const metaCollapsibleContent: WsComponentMeta = {
@@ -87,7 +100,10 @@ export const metaCollapsibleContent: WsComponentMeta = {
   type: "container",
   presetStyle,
   icon: ContentIcon,
-  detachable: false,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Collapsible" },
+  },
 };
 
 export const propsMetaCollapsible: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/dialog.ws.ts
+++ b/packages/sdk-components-react-radix/src/dialog.ws.ts
@@ -45,15 +45,10 @@ export const metaDialogTrigger: WsComponentMeta = {
   type: "container",
   icon: TriggerIcon,
   stylable: false,
-  detachable: false,
-};
-
-export const metaDialogContent: WsComponentMeta = {
-  category: "hidden",
-  type: "container",
-  presetStyle,
-  icon: ContentIcon,
-  detachable: false,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Dialog" },
+  },
 };
 
 export const metaDialogOverlay: WsComponentMeta = {
@@ -61,7 +56,41 @@ export const metaDialogOverlay: WsComponentMeta = {
   type: "container",
   presetStyle,
   icon: OverlayIcon,
-  detachable: false,
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "Dialog" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "DialogContent" },
+    },
+  ],
+};
+
+export const metaDialogContent: WsComponentMeta = {
+  category: "hidden",
+  type: "container",
+  presetStyle,
+  icon: ContentIcon,
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "DialogOverlay" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "DialogTitle" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "DialogDescription" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "DialogClose" },
+    },
+  ],
 };
 
 export const metaDialogTitle: WsComponentMeta = {
@@ -69,6 +98,10 @@ export const metaDialogTitle: WsComponentMeta = {
   type: "container",
   presetStyle: titlePresetStyle,
   icon: HeadingIcon,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "DialogContent" },
+  },
 };
 
 export const metaDialogDescription: WsComponentMeta = {
@@ -76,6 +109,10 @@ export const metaDialogDescription: WsComponentMeta = {
   type: "container",
   presetStyle: descriptionPresetStyle,
   icon: TextIcon,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "DialogContent" },
+  },
 };
 
 export const metaDialogClose: WsComponentMeta = {
@@ -87,6 +124,10 @@ export const metaDialogClose: WsComponentMeta = {
   states: defaultStates,
   icon: ButtonElementIcon,
   label: "Close Button",
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "DialogContent" },
+  },
 };
 
 /**
@@ -101,6 +142,16 @@ export const metaDialog: WsComponentMeta = {
   category: "radix",
   order: 4,
   type: "container",
+  constraints: [
+    {
+      relation: "descendant",
+      component: { $eq: "DialogTrigger" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "DialogOverlay" },
+    },
+  ],
   icon: DialogIcon,
   stylable: false,
   description:

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -313,7 +313,16 @@ export const metaNavigationMenu: WsComponentMeta = {
   description: "A collection of links for navigating websites.",
   icon: NavigationMenuIcon,
   presetStyle,
-
+  constraints: [
+    {
+      relation: "descendant",
+      component: { $eq: "NavigationMenuList" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "NavigationMenuViewport" },
+    },
+  ],
   template: [
     {
       type: "instance",
@@ -428,13 +437,18 @@ export const metaNavigationMenu: WsComponentMeta = {
 
 export const metaNavigationMenuList: WsComponentMeta = {
   category: "hidden",
-  detachable: false,
   type: "container",
   icon: ListIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: "NavigationMenu" },
-  },
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "NavigationMenu" },
+    },
+    {
+      relation: "child",
+      component: { $eq: "NavigationMenuItem" },
+    },
+  ],
   presetStyle,
   label: "Menu List",
 };
@@ -444,16 +458,16 @@ export const metaNavigationMenuItem: WsComponentMeta = {
   type: "container",
   icon: ListItemIcon,
   constraints: {
-    relation: "ancestor",
-    component: { $eq: "NavigationMenu" },
+    relation: "parent",
+    component: { $eq: "NavigationMenuList" },
   },
   presetStyle,
   indexWithinAncestor: "NavigationMenu",
   label: "Menu Item",
 };
+
 export const metaNavigationMenuTrigger: WsComponentMeta = {
   category: "hidden",
-  detachable: false,
   stylable: false,
   type: "container",
   icon: TriggerIcon,
@@ -464,9 +478,9 @@ export const metaNavigationMenuTrigger: WsComponentMeta = {
   presetStyle,
   label: "Menu Trigger",
 };
+
 export const metaNavigationMenuContent: WsComponentMeta = {
   category: "hidden",
-  detachable: false,
   type: "container",
   icon: ContentIcon,
   constraints: {
@@ -480,7 +494,6 @@ export const metaNavigationMenuContent: WsComponentMeta = {
 
 export const metaNavigationMenuLink: WsComponentMeta = {
   category: "hidden",
-  detachable: true,
   type: "container",
   stylable: false,
   icon: BoxIcon,
@@ -500,7 +513,6 @@ export const metaNavigationMenuLink: WsComponentMeta = {
 
 export const metaNavigationMenuViewport: WsComponentMeta = {
   category: "hidden",
-  detachable: true,
   type: "container",
   icon: ViewportIcon,
   constraints: {

--- a/packages/sdk-components-react-radix/src/popover.ws.ts
+++ b/packages/sdk-components-react-radix/src/popover.ws.ts
@@ -23,7 +23,10 @@ export const metaPopoverTrigger: WsComponentMeta = {
   type: "container",
   icon: TriggerIcon,
   stylable: false,
-  detachable: false,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Popover" },
+  },
 };
 
 export const metaPopoverContent: WsComponentMeta = {
@@ -31,7 +34,10 @@ export const metaPopoverContent: WsComponentMeta = {
   type: "container",
   presetStyle,
   icon: ContentIcon,
-  detachable: false,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Popover" },
+  },
 };
 
 /**
@@ -46,6 +52,16 @@ export const metaPopover: WsComponentMeta = {
   category: "radix",
   order: 6,
   type: "container",
+  constraints: [
+    {
+      relation: "descendant",
+      component: { $eq: "PopoverTrigger" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "PopoverContent" },
+    },
+  ],
   icon: PopoverIcon,
   stylable: false,
   description: "Displays rich content in a portal, triggered by a button.",

--- a/packages/sdk-components-react-radix/src/radio-group.ws.ts
+++ b/packages/sdk-components-react-radix/src/radio-group.ws.ts
@@ -86,6 +86,10 @@ export const metaRadioGroup: WsComponentMeta = {
   category: "radix",
   order: 100,
   type: "container",
+  constraints: {
+    relation: "descendant",
+    component: { $eq: "RadioGroupItem" },
+  },
   description:
     "A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.",
   icon: RadioCheckedIcon,
@@ -144,10 +148,16 @@ export const metaRadioGroup: WsComponentMeta = {
 export const metaRadioGroupItem: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: "RadioGroup" },
-  },
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "RadioGroup" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "RadioGroupIndicator" },
+    },
+  ],
   icon: ItemIcon,
   states: defaultStates,
   presetStyle: {
@@ -158,8 +168,11 @@ export const metaRadioGroupItem: WsComponentMeta = {
 export const metaRadioGroupIndicator: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  detachable: false,
   icon: TriggerIcon,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "RadioGroupItem" },
+  },
   states: defaultStates,
   presetStyle: {
     span,

--- a/packages/sdk-components-react-radix/src/select.ws.ts
+++ b/packages/sdk-components-react-radix/src/select.ws.ts
@@ -106,6 +106,16 @@ export const metaSelect: WsComponentMeta = {
   category: "radix",
   order: 10,
   type: "container",
+  constraints: [
+    {
+      relation: "descendant",
+      component: { $eq: "SelectTrigger" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "SelectContent" },
+    },
+  ],
   icon: SelectIcon,
   stylable: false,
   description:
@@ -241,10 +251,19 @@ export const metaSelectTrigger: WsComponentMeta = {
   category: "hidden",
   type: "container",
   icon: TriggerIcon,
-  detachable: false,
   presetStyle: {
     button,
   },
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "Select" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "SelectValue" },
+    },
+  ],
 };
 
 export const metaSelectValue: WsComponentMeta = {
@@ -252,9 +271,12 @@ export const metaSelectValue: WsComponentMeta = {
   type: "container",
   label: "Value",
   icon: FormTextFieldIcon,
-  detachable: false,
   presetStyle: {
     span,
+  },
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "SelectTrigger" },
   },
 };
 
@@ -262,26 +284,54 @@ export const metaSelectContent: WsComponentMeta = {
   category: "hidden",
   type: "container",
   icon: ContentIcon,
-  detachable: false,
   presetStyle,
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "Select" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "SelectViewport" },
+    },
+  ],
 };
 
 export const metaSelectViewport: WsComponentMeta = {
   category: "hidden",
   type: "container",
   icon: ViewportIcon,
-  detachable: false,
   presetStyle,
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "SelectContent" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "SelectItem" },
+    },
+  ],
 };
 
 export const metaSelectItem: WsComponentMeta = {
   category: "hidden",
   type: "container",
   icon: ItemIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: "SelectViewport" },
-  },
+  constraints: [
+    {
+      relation: "ancestor",
+      component: { $eq: "SelectViewport" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "SelectItemIndicator" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "SelectItemText" },
+    },
+  ],
   presetStyle,
 };
 
@@ -290,7 +340,6 @@ export const metaSelectItemIndicator: WsComponentMeta = {
   type: "container",
   label: "Indicator",
   icon: CheckMarkIcon,
-  detachable: false,
   constraints: {
     relation: "ancestor",
     component: { $eq: "SelectItem" },
@@ -305,7 +354,6 @@ export const metaSelectItemText: WsComponentMeta = {
   type: "container",
   label: "Item Text",
   icon: TextIcon,
-  detachable: false,
   constraints: {
     relation: "ancestor",
     component: { $eq: "SelectItem" },

--- a/packages/sdk-components-react-radix/src/switch.ws.ts
+++ b/packages/sdk-components-react-radix/src/switch.ws.ts
@@ -13,6 +13,10 @@ export const metaSwitch: WsComponentMeta = {
   category: "radix",
   order: 11,
   type: "container",
+  constraints: {
+    relation: "descendant",
+    component: { $eq: "SwitchThumb" },
+  },
   description:
     "A control that allows the user to toggle between checked and not checked.",
   icon: SwitchIcon,
@@ -116,7 +120,10 @@ export const metaSwitch: WsComponentMeta = {
 export const metaSwitchThumb: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  detachable: false,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Switch" },
+  },
   icon: TriggerIcon,
   states: [
     ...defaultStates,

--- a/packages/sdk-components-react-radix/src/tooltip.ws.ts
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.ts
@@ -20,18 +20,24 @@ const presetStyle = {
 // @todo add [data-state] to button and link
 export const metaTooltipTrigger: WsComponentMeta = {
   category: "hidden",
-  detachable: false,
   type: "container",
   icon: TriggerIcon,
   stylable: false,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Tooltip" },
+  },
 };
 
 export const metaTooltipContent: WsComponentMeta = {
   category: "hidden",
-  detachable: false,
   type: "container",
-  presetStyle,
   icon: ContentIcon,
+  presetStyle,
+  constraints: {
+    relation: "ancestor",
+    component: { $eq: "Tooltip" },
+  },
 };
 
 /**
@@ -46,6 +52,16 @@ export const metaTooltip: WsComponentMeta = {
   category: "radix",
   order: 7,
   type: "container",
+  constraints: [
+    {
+      relation: "descendant",
+      component: { $eq: "TooltipTrigger" },
+    },
+    {
+      relation: "descendant",
+      component: { $eq: "TooltipContent" },
+    },
+  ],
   icon: TooltipIcon,
   stylable: false,
   description:

--- a/packages/sdk-components-react/src/body.ws.ts
+++ b/packages/sdk-components-react/src/body.ws.ts
@@ -28,7 +28,6 @@ export const meta: WsComponentMeta = {
   icon: BodyIcon,
   states: defaultStates,
   presetStyle,
-  detachable: false,
 };
 
 export const propsMeta: WsComponentPropsMeta = {


### PR DESCRIPTION
Here got rid of detachable flag in favor of more universal constraints queries.

Despite of detachable constraints allow to drag such nodes but limits drop target more precisely.

Try any radix component.