### PR TITLE
fix: relax list item constraint

### DIFF
--- a/packages/sdk-components-react/src/list-item.ws.ts
+++ b/packages/sdk-components-react/src/list-item.ws.ts
@@ -17,7 +17,7 @@ export const meta: WsComponentMeta = {
   category: "general",
   type: "container",
   constraints: {
-    relation: "parent",
+    relation: "ancestor",
     component: { $eq: "List" },
   },
   description: "Adds a new item to an existing list.",


### PR DESCRIPTION
Latest constraints improvements let us support direct child constraints. Which can be useful for very coupled components. Though in case of list and list item should be avoided because list item can be used inside of slot and collection.