### PR TITLE
refactor: drop image base url from builder

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -214,7 +214,6 @@ const builderClient = new SyncClient({
 export type BuilderProps = {
   project: Project;
   publisherHost: string;
-  imageBaseUrl: string;
   build: Pick<Build, "id" | "version">;
   authToken?: string;
   authPermit: AuthPermit;
@@ -225,7 +224,6 @@ export type BuilderProps = {
 export const Builder = ({
   project,
   publisherHost,
-  imageBaseUrl,
   build,
   authToken,
   authPermit,
@@ -238,7 +236,7 @@ export const Builder = ({
     // additional data stores
     $project.set(project);
     $publisherHost.set(publisherHost);
-    $imageLoader.set(createImageLoader({ imageBaseUrl }));
+    $imageLoader.set(createImageLoader({}));
     $authPermit.set(authPermit);
     $authToken.set(authToken);
     $userPlanFeatures.set(userPlanFeatures);

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -61,7 +61,7 @@ import { subscribeInstanceHovering } from "./instance-hovering";
 import { useHashLinkSync } from "~/shared/pages";
 import { useMount } from "~/shared/hook-utils/use-mount";
 import { subscribeInterceptedEvents } from "./interceptor";
-import type { ImageLoader } from "@webstudio-is/image";
+import { createImageLoader } from "@webstudio-is/image";
 import { subscribeCommands } from "~/canvas/shared/commands";
 import { updateCollaborativeInstanceRect } from "./collaborative-instance";
 import { $params } from "./stores";
@@ -97,12 +97,12 @@ const FallbackComponent = ({ error, resetErrorBoundary }: FallbackProps) => {
 const useElementsTree = (
   components: Components,
   instances: Instances,
-  params: Params,
-  imageLoader: ImageLoader
+  params: Params
 ) => {
   const page = useStore($selectedPage);
   const isPreviewMode = useStore($isPreviewMode);
   const rootInstanceId = page?.rootInstanceId ?? "";
+  const imageLoader = useMemo(() => createImageLoader({}), []);
 
   if (typeof window === "undefined") {
     // @todo remove after https://github.com/webstudio-is/webstudio/issues/1313 now its needed to be sure that no leaks exists
@@ -119,7 +119,7 @@ const useElementsTree = (
       <ReactSdkContext.Provider
         value={{
           renderer: isPreviewMode ? "preview" : "canvas",
-          imageBaseUrl: params.imageBaseUrl,
+          imageBaseUrl: "/cgi/image/",
           assetBaseUrl: params.assetBaseUrl,
           imageLoader,
           resources: {},
@@ -223,10 +223,9 @@ const ContentEditMode = () => {
 
 type CanvasProps = {
   params: Params;
-  imageLoader: ImageLoader;
 };
 
-export const Canvas = ({ params, imageLoader }: CanvasProps) => {
+export const Canvas = ({ params }: CanvasProps) => {
   useCanvasStore();
   const isDesignMode = useStore($isDesignMode);
   const isContentMode = useStore($isContentMode);
@@ -306,7 +305,7 @@ export const Canvas = ({ params, imageLoader }: CanvasProps) => {
 
   const components = useStore($registeredComponents);
   const instances = useStore($instances);
-  const elements = useElementsTree(components, instances, params, imageLoader);
+  const elements = useElementsTree(components, instances, params);
 
   const [isInitialized, setInitialized] = useState(false);
   useEffect(() => {

--- a/apps/builder/app/dashboard/dashboard.stories.tsx
+++ b/apps/builder/app/dashboard/dashboard.stories.tsx
@@ -45,7 +45,6 @@ export const Empty: StoryFn<typeof Dashboard> = () => {
       projectTemplates={[]}
       userPlanFeatures={userPlanFeatures}
       publisherHost={"https://wstd.work"}
-      imageBaseUrl=""
     />
   );
   return <RouterProvider router={router} />;
@@ -75,7 +74,6 @@ export const WithProjects: StoryFn<typeof Dashboard> = () => {
       projectTemplates={projects}
       userPlanFeatures={userPlanFeatures}
       publisherHost={"https://wstd.work"}
-      imageBaseUrl=""
     />
   );
   return <RouterProvider router={router} />;

--- a/apps/builder/app/dashboard/dashboard.tsx
+++ b/apps/builder/app/dashboard/dashboard.tsx
@@ -51,7 +51,6 @@ export type DashboardProps = {
   projectTemplates: Array<DashboardProject>;
   userPlanFeatures: UserPlanFeatures;
   publisherHost: string;
-  imageBaseUrl: string;
   projectToClone?: {
     authToken: string;
     id: string;
@@ -102,7 +101,6 @@ export const Dashboard = ({
   projectTemplates,
   userPlanFeatures,
   publisherHost,
-  imageBaseUrl,
   projectToClone,
 }: DashboardProps) => {
   globalStyles();
@@ -120,7 +118,6 @@ export const Dashboard = ({
             projectTemplates={projectTemplates}
             hasProPlan={userPlanFeatures.hasProPlan}
             publisherHost={publisherHost}
-            imageBaseUrl={imageBaseUrl}
           />
         </Section>
       </Main>

--- a/apps/builder/app/dashboard/projects/project-card.tsx
+++ b/apps/builder/app/dashboard/projects/project-card.tsx
@@ -17,7 +17,6 @@ import {
 } from "@webstudio-is/design-system";
 import { InfoCircleIcon, EllipsesIcon } from "@webstudio-is/icons";
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
-import type { ImageLoader } from "@webstudio-is/image";
 import { builderUrl } from "~/shared/router-utils";
 import {
   RenameProjectDialog,
@@ -152,7 +151,6 @@ type ProjectCardProps = {
   project: DashboardProject;
   hasProPlan: boolean;
   publisherHost: string;
-  imageLoader: ImageLoader;
 };
 
 export const ProjectCard = ({
@@ -167,7 +165,6 @@ export const ProjectCard = ({
   },
   hasProPlan,
   publisherHost,
-  imageLoader,
 }: ProjectCardProps) => {
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -229,7 +226,6 @@ export const ProjectCard = ({
             to={linkPath}
             name={previewImageAsset.name}
             ref={thumbnailRef}
-            imageLoader={imageLoader}
           />
         ) : (
           <ThumbnailLinkWithAbbr
@@ -322,7 +318,6 @@ export const ProjectCard = ({
 export const ProjectTemplateCard = ({
   project,
   publisherHost,
-  imageLoader,
 }: Omit<ProjectCardProps, "hasProPlan">) => {
   const { thumbnailRef, handleKeyDown } = useProjectCard();
   const [isDuplicateDialogOpen, setIsDuplicateDialogOpen] = useState(false);
@@ -339,7 +334,6 @@ export const ProjectTemplateCard = ({
             onClick={() => {
               setIsDuplicateDialogOpen(true);
             }}
-            imageLoader={imageLoader}
           />
         ) : (
           <ThumbnailWithAbbr

--- a/apps/builder/app/dashboard/projects/projects.tsx
+++ b/apps/builder/app/dashboard/projects/projects.tsx
@@ -1,7 +1,5 @@
-import { useMemo } from "react";
 import { Flex, Grid, Text, rawTheme } from "@webstudio-is/design-system";
 import type { DashboardProject } from "@webstudio-is/dashboard";
-import { createImageLoader } from "@webstudio-is/image";
 import { EmptyState } from "./empty-state";
 import { Panel } from "../shared/panel";
 import { ProjectCard, ProjectTemplateCard } from "./project-card";
@@ -12,7 +10,6 @@ type ProjectsProps = {
   projectTemplates: Array<DashboardProject>;
   hasProPlan: boolean;
   publisherHost: string;
-  imageBaseUrl: string;
 };
 
 export const Projects = ({
@@ -20,12 +17,7 @@ export const Projects = ({
   projectTemplates,
   hasProPlan,
   publisherHost,
-  imageBaseUrl,
 }: ProjectsProps) => {
-  const imageLoader = useMemo(
-    () => createImageLoader({ imageBaseUrl }),
-    [imageBaseUrl]
-  );
   return (
     <Panel>
       <Flex direction="column" gap="3">
@@ -49,7 +41,6 @@ export const Projects = ({
                 key={project.id}
                 hasProPlan={hasProPlan}
                 publisherHost={publisherHost}
-                imageLoader={imageLoader}
               />
             );
           })}
@@ -75,7 +66,6 @@ export const Projects = ({
                   project={project}
                   publisherHost={publisherHost}
                   key={project.id}
-                  imageLoader={imageLoader}
                 />
               );
             })}

--- a/apps/builder/app/dashboard/projects/thumbnail.tsx
+++ b/apps/builder/app/dashboard/projects/thumbnail.tsx
@@ -1,5 +1,5 @@
-import { forwardRef } from "react";
-import { Image, type ImageLoader } from "@webstudio-is/image";
+import { forwardRef, useMemo } from "react";
+import { createImageLoader, Image } from "@webstudio-is/image";
 import { css, theme, textVariants } from "@webstudio-is/design-system";
 
 const abbrStyle = css(textVariants.brandThumbnailLargeDefault, {
@@ -72,8 +72,9 @@ const imageStyle = css({
 
 export const ThumbnailLinkWithImage = forwardRef<
   HTMLAnchorElement,
-  { name: string; to: string; imageLoader: ImageLoader }
->(({ name, to, imageLoader }, ref) => {
+  { name: string; to: string }
+>(({ name, to }, ref) => {
+  const imageLoader = useMemo(() => createImageLoader({}), []);
   return (
     <a ref={ref} href={to} className={imageContainerStyle()} tabIndex={-1}>
       <Image src={name} loader={imageLoader} className={imageStyle()} />
@@ -87,9 +88,9 @@ export const ThumbnailWithImage = forwardRef<
   {
     name: string;
     onClick: React.MouseEventHandler<HTMLDivElement>;
-    imageLoader: ImageLoader;
   }
->(({ name, onClick, imageLoader }, ref) => {
+>(({ name, onClick }, ref) => {
+  const imageLoader = useMemo(() => createImageLoader({}), []);
   return (
     <div
       ref={ref}

--- a/apps/builder/app/env/env.server.ts
+++ b/apps/builder/app/env/env.server.ts
@@ -24,14 +24,6 @@ const env = {
   MAX_UPLOAD_SIZE: process.env.MAX_UPLOAD_SIZE,
   MAX_ASSETS_PER_PROJECT: process.env.MAX_ASSETS_PER_PROJECT,
   /**
-   * Base url ir base path for images with ending slash.
-   * Possible values are
-   * /asset/image/
-   * https://image-transform.wstd.io/cdn-cgi/image/
-   * https://webstudio.is/cdn-cgi/image/
-   */
-  IMAGE_BASE_URL: process.env.IMAGE_BASE_URL ?? "/cgi/image/",
-  /**
    * Base url or base path for any asset with ending slash.
    * Possible values are
    * /s/uploads/

--- a/apps/builder/app/routes/_canvas.canvas.tsx
+++ b/apps/builder/app/routes/_canvas.canvas.tsx
@@ -3,7 +3,6 @@ import { type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { useLoaderData } from "@remix-run/react";
 import type { Params } from "@webstudio-is/react-sdk";
 import { Body } from "@webstudio-is/sdk-components-react-remix";
-import { createImageLoader } from "@webstudio-is/image";
 import env from "~/env/env.server";
 import { isCanvas } from "~/shared/router-utils";
 import { ClientOnly } from "~/shared/client-only";
@@ -17,7 +16,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   }
 
   const params: Params = {
-    imageBaseUrl: env.IMAGE_BASE_URL,
+    imageBaseUrl: "/cgi/image/",
     assetBaseUrl: env.ASSET_BASE_URL,
   };
 
@@ -31,12 +30,9 @@ const Canvas = lazy(async () => {
 
 const CanvasRoute = () => {
   const { params } = useLoaderData<typeof loader>();
-  const imageLoader = createImageLoader({
-    imageBaseUrl: params.imageBaseUrl,
-  });
   return (
     <ClientOnly fallback={<Body />}>
-      <Canvas params={params} imageLoader={imageLoader} />
+      <Canvas params={params} />
     </ClientOnly>
   );
 };

--- a/apps/builder/app/routes/_ui.(builder).tsx
+++ b/apps/builder/app/routes/_ui.(builder).tsx
@@ -211,7 +211,6 @@ export const loader = async (loaderArgs: LoaderFunctionArgs) => {
       {
         project,
         publisherHost,
-        imageBaseUrl: env.IMAGE_BASE_URL,
         build: {
           id: devBuild.id,
           version: devBuild.version,

--- a/apps/builder/app/routes/_ui.dashboard.tsx
+++ b/apps/builder/app/routes/_ui.dashboard.tsx
@@ -118,7 +118,6 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     projectTemplates,
     userPlanFeatures,
     publisherHost: env.PUBLISHER_HOST,
-    imageBaseUrl: env.IMAGE_BASE_URL,
     origin: sourceOrigin,
     projectToClone,
   });

--- a/apps/builder/app/routes/cgi.image.$.ts
+++ b/apps/builder/app/routes/cgi.image.$.ts
@@ -72,9 +72,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   }
 
   if (env.RESIZE_ORIGIN !== undefined) {
-    const imageLoader = createImageLoader({
-      imageBaseUrl: `${env.RESIZE_ORIGIN}/cgi/image/`,
-    });
+    const imageLoader = createImageLoader({});
 
     const imgHref = imageLoader({
       src: name,
@@ -82,7 +80,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       format: "auto",
     });
 
-    const imgUrl = new URL(imgHref);
+    const imgUrl = new URL(env.RESIZE_ORIGIN + imgHref);
     imgUrl.search = url.search;
 
     const response = await fetch(imgUrl.href, {
@@ -107,6 +105,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
   if (env.FILE_UPLOAD_PATH === undefined) {
     throw Error("FILE_UPLOAD_PATH is not provided");
+  }
+  // support absolute urls locally
+  if (URL.canParse(name)) {
+    return fetch(name);
   }
   const fileUploadPath = env.FILE_UPLOAD_PATH;
   const filePath = join(process.cwd(), fileUploadPath, name);

--- a/apps/builder/app/shared/nano-states/misc.ts
+++ b/apps/builder/app/shared/nano-states/misc.ts
@@ -35,9 +35,7 @@ export const $project = atom<Project | undefined>();
 
 export const $publisherHost = atom<string>("wstd.work");
 
-export const $imageLoader = atom<ImageLoader>(
-  createImageLoader({ imageBaseUrl: "" })
-);
+export const $imageLoader = atom<ImageLoader>(createImageLoader({}));
 
 export const $publishedOrigin = computed(
   [$project, $publisherHost],

--- a/packages/image/src/image-loaders.ts
+++ b/packages/image/src/image-loaders.ts
@@ -2,7 +2,7 @@ import warnOnce from "warn-once";
 import { allSizes, type ImageLoader } from "./image-optimize";
 
 export type ImageLoaderOptions = {
-  imageBaseUrl: string;
+  imageBaseUrl?: string;
 };
 
 const NON_EXISTING_DOMAIN = "https://a3cbcbec-cdb1-4ea4-ad60-43c795308ddc.ddc";
@@ -39,7 +39,7 @@ export const createImageLoader =
 
     let resultUrl;
     try {
-      resultUrl = new URL(imageBaseUrl, NON_EXISTING_DOMAIN);
+      resultUrl = new URL(imageBaseUrl ?? "/cgi/image/", NON_EXISTING_DOMAIN);
     } catch {
       return src;
     }


### PR DESCRIPTION
Builder rely on cloud based image resolution which does not require additional configuration. Here I dropped IMAGE_BASE_URL env and replaced bypassing it to loader with loader default.