### PR TITLE
fix: Don't allow outline to go outside of the workspace,

### DIFF
--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -27,6 +27,7 @@ const canvasContainerStyle = css({
   transformOrigin: "0 0",
   // We had a case where some Windows 10 + Chrome 129 users couldn't scroll iframe canvas.
   willChange: "transform",
+  overflow: "clip",
 });
 
 const useMeasureWorkspace = () => {


### PR DESCRIPTION
## Description

Don't allow outline to go outside of the workspace, because it will cover any builder UI

![image](https://github.com/user-attachments/assets/f609b1db-33b2-4f54-8509-8d12c1e247e5)
<img width="599" alt="image" src="https://github.com/user-attachments/assets/593b7377-e284-4c3d-a34f-945c281c9d6e" />


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
