### PR TITLE
refactor: drop image base url from cli and templates

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -119,7 +119,6 @@ const useElementsTree = (
       <ReactSdkContext.Provider
         value={{
           renderer: isPreviewMode ? "preview" : "canvas",
-          imageBaseUrl: "/cgi/image/",
           assetBaseUrl: params.assetBaseUrl,
           imageLoader,
           resources: {},

--- a/apps/builder/app/routes/_canvas.canvas.tsx
+++ b/apps/builder/app/routes/_canvas.canvas.tsx
@@ -16,7 +16,6 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   }
 
   const params: Params = {
-    imageBaseUrl: "/cgi/image/",
     assetBaseUrl: env.ASSET_BASE_URL,
   };
 

--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -243,7 +243,6 @@ test("resolve asset prop values when params is provided", () => {
 
   $params.set({
     assetBaseUrl: "/asset/",
-    imageBaseUrl: "/image/",
   });
   expect(
     $propValuesByInstanceSelector.get().get(JSON.stringify(["box"]))
@@ -279,7 +278,6 @@ test("resolve page prop values when params is provided", () => {
 
   $params.set({
     assetBaseUrl: "/asset/",
-    imageBaseUrl: "/image/",
   });
   expect(
     $propValuesByInstanceSelector.get().get(JSON.stringify(["box"]))

--- a/fixtures/ssg-netlify-by-project-id/app/constants.mjs
+++ b/fixtures/ssg-netlify-by-project-id/app/constants.mjs
@@ -16,17 +16,17 @@ export const imageLoader = (props) => {
   }
 
   if (process.env.NODE_ENV !== "production") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   if (props.format === "raw") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   // https://docs.netlify.com/image-cdn/overview/
   return (
     "/.netlify/images?url=" +
-    encodeURIComponent(imageBaseUrl + props.src) +
+    encodeURIComponent(assetBaseUrl + props.src) +
     "&w=" +
     props.width +
     "&q=" +

--- a/fixtures/ssg-netlify-by-project-id/pages/index/+Page.tsx
+++ b/fixtures/ssg-netlify-by-project-id/pages/index/+Page.tsx
@@ -1,10 +1,6 @@
 import type { PageContext } from "vike/types";
 import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
-import {
-  assetBaseUrl,
-  imageBaseUrl,
-  imageLoader,
-} from "../../app/constants.mjs";
+import { assetBaseUrl, imageLoader } from "../../app/constants.mjs";
 import { Page } from "../../app/__generated__/_index";
 
 const PageComponent = ({ data }: { data: PageContext["data"] }) => {
@@ -14,7 +10,6 @@ const PageComponent = ({ data }: { data: PageContext["data"] }) => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/ssg/app/constants.mjs
+++ b/fixtures/ssg/app/constants.mjs
@@ -15,5 +15,5 @@ export const imageLoader = ({ src }) => {
     return src;
   }
 
-  return imageBaseUrl + src;
+  return assetBaseUrl + src;
 };

--- a/fixtures/ssg/pages/another-page/+Page.tsx
+++ b/fixtures/ssg/pages/another-page/+Page.tsx
@@ -1,10 +1,6 @@
 import type { PageContext } from "vike/types";
 import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
-import {
-  assetBaseUrl,
-  imageBaseUrl,
-  imageLoader,
-} from "../../app/constants.mjs";
+import { assetBaseUrl, imageLoader } from "../../app/constants.mjs";
 import { Page } from "../../app/__generated__/[another-page]._index";
 
 const PageComponent = ({ data }: { data: PageContext["data"] }) => {
@@ -14,7 +10,6 @@ const PageComponent = ({ data }: { data: PageContext["data"] }) => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/ssg/pages/index/+Page.tsx
+++ b/fixtures/ssg/pages/index/+Page.tsx
@@ -1,10 +1,6 @@
 import type { PageContext } from "vike/types";
 import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
-import {
-  assetBaseUrl,
-  imageBaseUrl,
-  imageLoader,
-} from "../../app/constants.mjs";
+import { assetBaseUrl, imageLoader } from "../../app/constants.mjs";
 import { Page } from "../../app/__generated__/_index";
 
 const PageComponent = ({ data }: { data: PageContext["data"] }) => {
@@ -14,7 +10,6 @@ const PageComponent = ({ data }: { data: PageContext["data"] }) => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-cloudflare-template/app/constants.mjs
+++ b/fixtures/webstudio-cloudflare-template/app/constants.mjs
@@ -9,5 +9,5 @@ export const imageBaseUrl = "/assets/";
  * @type {import("@webstudio-is/image").ImageLoader}
  */
 export const imageLoader = ({ src }) => {
-  return imageBaseUrl + src;
+  return assetBaseUrl + src;
 };

--- a/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[another-page]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/_index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-custom-template/app/constants.mjs
+++ b/fixtures/webstudio-custom-template/app/constants.mjs
@@ -9,5 +9,5 @@ export const imageBaseUrl = "/custom-folder/";
  * @type {import("@webstudio-is/image").ImageLoader}
  */
 export const imageLoader = ({ src }) => {
-  return imageBaseUrl + src;
+  return assetBaseUrl + src;
 };

--- a/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[script-test]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[script-test]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-custom-template/app/routes/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[sitemap.xml]._index.tsx
@@ -8,7 +8,7 @@ import {
   getRemixParams,
   getResources,
 } from "../__generated__/[sitemap.xml]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
@@ -65,7 +65,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/[world]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[world]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-custom-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/routes/_index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/_index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-custom-template/custom-template/app/constants.mjs
+++ b/fixtures/webstudio-custom-template/custom-template/app/constants.mjs
@@ -9,5 +9,5 @@ export const imageBaseUrl = "/custom-folder/";
  * @type {import("@webstudio-is/image").ImageLoader}
  */
 export const imageLoader = ({ src }) => {
-  return imageBaseUrl + src;
+  return assetBaseUrl + src;
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/constants.mjs
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/constants.mjs
@@ -10,17 +10,17 @@ export const imageBaseUrl = "/assets/";
  */
 export const imageLoader = (props) => {
   if (process.env.NODE_ENV !== "production") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   if (props.format === "raw") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   // https://docs.netlify.com/image-cdn/overview/
   return (
     "/.netlify/images?url=" +
-    encodeURIComponent(imageBaseUrl + props.src) +
+    encodeURIComponent(assetBaseUrl + props.src) +
     "&w=" +
     props.width +
     "&q=" +

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/[another-page]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[another-page]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/routes/_index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/_index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-netlify-functions/app/constants.mjs
+++ b/fixtures/webstudio-remix-netlify-functions/app/constants.mjs
@@ -10,17 +10,17 @@ export const imageBaseUrl = "/assets/";
  */
 export const imageLoader = (props) => {
   if (process.env.NODE_ENV !== "production") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   if (props.format === "raw") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   // https://docs.netlify.com/image-cdn/overview/
   return (
     "/.netlify/images?url=" +
-    encodeURIComponent(imageBaseUrl + props.src) +
+    encodeURIComponent(assetBaseUrl + props.src) +
     "&w=" +
     props.width +
     "&q=" +

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/[another-page]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[another-page]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/routes/_index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/_index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/constants.mjs
+++ b/fixtures/webstudio-remix-vercel/app/constants.mjs
@@ -10,17 +10,17 @@ export const imageBaseUrl = "/assets/";
  */
 export const imageLoader = (props) => {
   if (process.env.NODE_ENV !== "production") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   if (props.format === "raw") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   // https://vercel.com/blog/build-your-own-web-framework#automatic-image-optimization
   return (
     "/_vercel/image?url=" +
-    encodeURIComponent(imageBaseUrl + props.src) +
+    encodeURIComponent(assetBaseUrl + props.src) +
     "&w=" +
     props.width +
     "&q=" +

--- a/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[_route_with_symbols_]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[_route_with_symbols_]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[class-names]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[class-names]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[class-names]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[content-block]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[content-block]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[content-block]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[expressions]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[expressions]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[expressions]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[form]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[form]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[heading-with-id]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[heading-with-id]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[nested].[nested-page]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[nested].[nested-page]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[radix]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[radix]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[resources]._index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/[resources]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/[sitemap.xml]._index.tsx
@@ -8,7 +8,7 @@ import {
   getRemixParams,
   getResources,
 } from "../__generated__/[sitemap.xml]._index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
@@ -65,7 +65,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/routes/_index.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "../__generated__/_index.server";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "../constants.mjs";
+import { assetBaseUrl, imageLoader } from "../constants.mjs";
 import css from "../__generated__/index.css?url";
 import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -49,7 +49,6 @@ import {
   replaceFormActionsWithResources,
 } from "@webstudio-is/sdk";
 import type { Data } from "@webstudio-is/http-client";
-import { createImageLoader } from "@webstudio-is/image";
 import { LOCAL_DATA_FILE } from "./config";
 import {
   createFileIfNotExists,
@@ -448,19 +447,16 @@ export const prebuild = async (options: {
 
     const assetBuildUrl = `https://${domain}.${appDomain}/cgi/asset/`;
 
-    const imageLoader = createImageLoader({
-      imageBaseUrl: assetBuildUrl,
-    });
-
     for (const asset of siteData.assets) {
       if (asset.type === "image") {
-        const imageSrc = imageLoader({
-          src: asset.name,
-          format: "raw",
-        });
-
         assetsToDownload.push(
-          limit(() => downloadAsset(imageSrc, asset.name, assetBaseUrl))
+          limit(() =>
+            downloadAsset(
+              `${assetBuildUrl}${asset.name}`,
+              asset.name,
+              assetBaseUrl
+            )
+          )
         );
       }
 

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -49,6 +49,7 @@ import {
   replaceFormActionsWithResources,
 } from "@webstudio-is/sdk";
 import type { Data } from "@webstudio-is/http-client";
+import { createImageLoader } from "@webstudio-is/image";
 import { LOCAL_DATA_FILE } from "./config";
 import {
   createFileIfNotExists,
@@ -445,14 +446,19 @@ export const prebuild = async (options: {
       throw new Error(`Project domain is missing from the project data`);
     }
 
-    const assetBuildUrl = `https://${domain}.${appDomain}/cgi/asset/`;
+    const assetOrigin = `https://${domain}.${appDomain}`;
+    const imageLoader = createImageLoader({});
 
     for (const asset of siteData.assets) {
       if (asset.type === "image") {
+        const imagePath = imageLoader({
+          src: asset.name,
+          format: "raw",
+        });
         assetsToDownload.push(
           limit(() =>
             downloadAsset(
-              `${assetBuildUrl}${asset.name}`,
+              `${assetOrigin}${imagePath}`,
               asset.name,
               assetBaseUrl
             )
@@ -464,7 +470,7 @@ export const prebuild = async (options: {
         assetsToDownload.push(
           limit(() =>
             downloadAsset(
-              `${assetBuildUrl}${asset.name}`,
+              `${assetOrigin}/cgi/asset/${asset.name}`,
               asset.name,
               assetBaseUrl
             )

--- a/packages/cli/templates/defaults/app/constants.mjs
+++ b/packages/cli/templates/defaults/app/constants.mjs
@@ -9,5 +9,5 @@ export const imageBaseUrl = "/assets/";
  * @type {import("@webstudio-is/image").ImageLoader}
  */
 export const imageLoader = ({ src }) => {
-  return imageBaseUrl + src;
+  return assetBaseUrl + src;
 };

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -31,7 +31,7 @@ import {
   projectId,
   contactEmail,
 } from "__SERVER__";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "__CONSTANTS__";
+import { assetBaseUrl, imageLoader } from "__CONSTANTS__";
 import css from "__CSS__?url";
 import { sitemap } from "__SITEMAP__";
 
@@ -329,7 +329,6 @@ const Outlet = () => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/packages/cli/templates/defaults/app/route-templates/xml.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/xml.tsx
@@ -4,7 +4,7 @@ import { isLocalResource, loadResources } from "@webstudio-is/sdk/runtime";
 import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import { Page } from "__CLIENT__";
 import { getPageMeta, getRemixParams, getResources } from "__SERVER__";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "__CONSTANTS__";
+import { assetBaseUrl, imageLoader } from "__CONSTANTS__";
 import { sitemap } from "__SITEMAP__";
 
 const customFetch: typeof fetch = (input, init) => {
@@ -61,7 +61,6 @@ export const loader = async (arg: LoaderFunctionArgs) => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/packages/cli/templates/netlify-edge-functions/app/constants.mjs
+++ b/packages/cli/templates/netlify-edge-functions/app/constants.mjs
@@ -10,17 +10,17 @@ export const imageBaseUrl = "/assets/";
  */
 export const imageLoader = (props) => {
   if (process.env.NODE_ENV !== "production") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   if (props.format === "raw") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   // https://docs.netlify.com/image-cdn/overview/
   return (
     "/.netlify/images?url=" +
-    encodeURIComponent(imageBaseUrl + props.src) +
+    encodeURIComponent(assetBaseUrl + props.src) +
     "&w=" +
     props.width +
     "&q=" +

--- a/packages/cli/templates/netlify-functions/app/constants.mjs
+++ b/packages/cli/templates/netlify-functions/app/constants.mjs
@@ -10,17 +10,17 @@ export const imageBaseUrl = "/assets/";
  */
 export const imageLoader = (props) => {
   if (process.env.NODE_ENV !== "production") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   if (props.format === "raw") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   // https://docs.netlify.com/image-cdn/overview/
   return (
     "/.netlify/images?url=" +
-    encodeURIComponent(imageBaseUrl + props.src) +
+    encodeURIComponent(assetBaseUrl + props.src) +
     "&w=" +
     props.width +
     "&q=" +

--- a/packages/cli/templates/ssg-netlify/app/constants.mjs
+++ b/packages/cli/templates/ssg-netlify/app/constants.mjs
@@ -16,17 +16,17 @@ export const imageLoader = (props) => {
   }
 
   if (process.env.NODE_ENV !== "production") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   if (props.format === "raw") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   // https://docs.netlify.com/image-cdn/overview/
   return (
     "/.netlify/images?url=" +
-    encodeURIComponent(imageBaseUrl + props.src) +
+    encodeURIComponent(assetBaseUrl + props.src) +
     "&w=" +
     props.width +
     "&q=" +

--- a/packages/cli/templates/ssg-vercel/app/constants.mjs
+++ b/packages/cli/templates/ssg-vercel/app/constants.mjs
@@ -16,17 +16,17 @@ export const imageLoader = (props) => {
   }
 
   if (process.env.NODE_ENV !== "production") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   if (props.format === "raw") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   // https://vercel.com/blog/build-your-own-web-framework#automatic-image-optimization
   return (
     "/_vercel/image?url=" +
-    encodeURIComponent(imageBaseUrl + props.src) +
+    encodeURIComponent(assetBaseUrl + props.src) +
     "&w=" +
     props.width +
     "&q=" +

--- a/packages/cli/templates/ssg/app/constants.mjs
+++ b/packages/cli/templates/ssg/app/constants.mjs
@@ -15,5 +15,5 @@ export const imageLoader = ({ src }) => {
     return src;
   }
 
-  return imageBaseUrl + src;
+  return assetBaseUrl + src;
 };

--- a/packages/cli/templates/ssg/app/route-templates/html/+Page.tsx
+++ b/packages/cli/templates/ssg/app/route-templates/html/+Page.tsx
@@ -1,6 +1,6 @@
 import type { PageContext } from "vike/types";
 import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
-import { assetBaseUrl, imageBaseUrl, imageLoader } from "__CONSTANTS__";
+import { assetBaseUrl, imageLoader } from "__CONSTANTS__";
 import { Page } from "__CLIENT__";
 
 const PageComponent = ({ data }: { data: PageContext["data"] }) => {
@@ -10,7 +10,6 @@ const PageComponent = ({ data }: { data: PageContext["data"] }) => {
       value={{
         imageLoader,
         assetBaseUrl,
-        imageBaseUrl,
         resources,
       }}
     >

--- a/packages/cli/templates/vercel/app/constants.mjs
+++ b/packages/cli/templates/vercel/app/constants.mjs
@@ -10,17 +10,17 @@ export const imageBaseUrl = "/assets/";
  */
 export const imageLoader = (props) => {
   if (process.env.NODE_ENV !== "production") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   if (props.format === "raw") {
-    return imageBaseUrl + props.src;
+    return assetBaseUrl + props.src;
   }
 
   // https://vercel.com/blog/build-your-own-web-framework#automatic-image-optimization
   return (
     "/_vercel/image?url=" +
-    encodeURIComponent(imageBaseUrl + props.src) +
+    encodeURIComponent(assetBaseUrl + props.src) +
     "&w=" +
     props.width +
     "&q=" +

--- a/packages/image/src/image-loader.test.ts
+++ b/packages/image/src/image-loader.test.ts
@@ -11,8 +11,8 @@ const encodePathFragment = (fragment: string) => {
 
 describe("Asset image transforms", () => {
   test("width is number", () => {
-    const imageBaseUrl = "/asset/image/";
-    const loader = createImageLoader({ imageBaseUrl });
+    const imageBaseUrl = "/cgi/image/";
+    const loader = createImageLoader({});
 
     const assetName = "Привет_Мир__2F__BQNEuP8O9N79eVwPfbBJg.webp";
     const result = loader({
@@ -24,35 +24,19 @@ describe("Asset image transforms", () => {
     const resultUrl = new URL(result, "https://any-domain.any");
 
     expect(result).toMatchInlineSnapshot(
-      `"/asset/image/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82_%D0%9C%D0%B8%D1%80__2F__BQNEuP8O9N79eVwPfbBJg.webp?width=128&quality=100&format=auto"`
+      `"/cgi/image/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82_%D0%9C%D0%B8%D1%80__2F__BQNEuP8O9N79eVwPfbBJg.webp?width=128&quality=100&format=auto"`
     );
 
     expect(
       decodePathFragment(resultUrl.pathname.slice(imageBaseUrl.length))
     ).toBe(assetName);
   });
-
-  test("imageBaseUrl is remote", () => {
-    const loader = createImageLoader({
-      imageBaseUrl: "https://remote-transform-server.xx/asset/image/",
-    });
-
-    const result = loader({
-      width: 128,
-      src: "logo.webp",
-      quality: 100,
-    });
-
-    expect(result).toMatchInlineSnapshot(
-      `"https://remote-transform-server.xx/asset/image/logo.webp?width=128&quality=100&format=auto"`
-    );
-  });
 });
 
 describe("Remote src image transforms", () => {
   test("width is number", () => {
-    const imageBaseUrl = "/asset/image/";
-    const loader = createImageLoader({ imageBaseUrl });
+    const imageBaseUrl = "/cgi/image/";
+    const loader = createImageLoader({});
 
     const remoteSrc = "https://example.com/lo%3Fgo.webp?a=1";
 
@@ -71,13 +55,13 @@ describe("Remote src image transforms", () => {
     expect(resultUrl.searchParams.get("width")).toBe("128");
 
     expect(result).toMatchInlineSnapshot(
-      `"/asset/image/https%3A//example.com/lo%253Fgo.webp%3Fa%3D1?width=128&quality=100&format=auto"`
+      `"/cgi/image/https%3A//example.com/lo%253Fgo.webp%3Fa%3D1?width=128&quality=100&format=auto"`
     );
   });
 
   test("Double encoded fragment", () => {
-    const imageBaseUrl = "/asset/image/";
-    const loader = createImageLoader({ imageBaseUrl });
+    const imageBaseUrl = "/cgi/image/";
+    const loader = createImageLoader({});
 
     const remoteSrc = encodePathFragment(
       "https://ex%2Fample.com/lo%3Fgo.webp?a=1"

--- a/packages/image/src/image-loaders.ts
+++ b/packages/image/src/image-loaders.ts
@@ -23,7 +23,7 @@ const encodePathFragment = (fragment: string) => {
  * https://developers.cloudflare.com/images/image-resizing/url-format/
  **/
 export const createImageLoader =
-  (loaderOptions: ImageLoaderOptions): ImageLoader =>
+  (_loaderOptions: ImageLoaderOptions): ImageLoader =>
   (props) => {
     const width = props.format === "raw" ? 16 : props.width;
     const quality = props.format === "raw" ? 100 : props.quality;
@@ -35,14 +35,8 @@ export const createImageLoader =
         "Width must be only from allowed values"
       );
     }
-    const { imageBaseUrl } = loaderOptions;
 
-    let resultUrl;
-    try {
-      resultUrl = new URL(imageBaseUrl ?? "/cgi/image/", NON_EXISTING_DOMAIN);
-    } catch {
-      return src;
-    }
+    const resultUrl = new URL("/cgi/image/", NON_EXISTING_DOMAIN);
 
     if (format !== "raw") {
       resultUrl.searchParams.set("width", width.toString());

--- a/packages/image/src/image-optimize.test.ts
+++ b/packages/image/src/image-optimize.test.ts
@@ -11,14 +11,14 @@ describe("Image optimizations applied", () => {
       srcSet: undefined,
       sizes: undefined,
       quality: 100,
-      loader: createImageLoader({ imageBaseUrl: "/asset/image/" }),
+      loader: createImageLoader({}),
     });
 
     expect(imgAttr).toMatchInlineSnapshot(`
       {
         "sizes": "100vw",
-        "src": "/asset/image/logo.webp?width=256&quality=100&format=auto",
-        "srcSet": "/asset/image/logo.webp?width=16&quality=100&format=auto 16w, /asset/image/logo.webp?width=32&quality=100&format=auto 32w, /asset/image/logo.webp?width=48&quality=100&format=auto 48w, /asset/image/logo.webp?width=64&quality=100&format=auto 64w, /asset/image/logo.webp?width=96&quality=100&format=auto 96w, /asset/image/logo.webp?width=128&quality=100&format=auto 128w, /asset/image/logo.webp?width=256&quality=100&format=auto 256w",
+        "src": "/cgi/image/logo.webp?width=256&quality=100&format=auto",
+        "srcSet": "/cgi/image/logo.webp?width=16&quality=100&format=auto 16w, /cgi/image/logo.webp?width=32&quality=100&format=auto 32w, /cgi/image/logo.webp?width=48&quality=100&format=auto 48w, /cgi/image/logo.webp?width=64&quality=100&format=auto 64w, /cgi/image/logo.webp?width=96&quality=100&format=auto 96w, /cgi/image/logo.webp?width=128&quality=100&format=auto 128w, /cgi/image/logo.webp?width=256&quality=100&format=auto 256w",
       }
     `);
   });
@@ -31,14 +31,14 @@ describe("Image optimizations applied", () => {
       srcSet: undefined,
       sizes: undefined,
       quality: 100,
-      loader: createImageLoader({ imageBaseUrl: "/asset/image/" }),
+      loader: createImageLoader({}),
     });
 
     expect(imgAttr).toMatchInlineSnapshot(`
       {
         "sizes": "100vw",
-        "src": "/asset/image/https%3A//webstudio.is/logo.webp?width=256&quality=100&format=auto",
-        "srcSet": "/asset/image/https%3A//webstudio.is/logo.webp?width=16&quality=100&format=auto 16w, /asset/image/https%3A//webstudio.is/logo.webp?width=32&quality=100&format=auto 32w, /asset/image/https%3A//webstudio.is/logo.webp?width=48&quality=100&format=auto 48w, /asset/image/https%3A//webstudio.is/logo.webp?width=64&quality=100&format=auto 64w, /asset/image/https%3A//webstudio.is/logo.webp?width=96&quality=100&format=auto 96w, /asset/image/https%3A//webstudio.is/logo.webp?width=128&quality=100&format=auto 128w, /asset/image/https%3A//webstudio.is/logo.webp?width=256&quality=100&format=auto 256w",
+        "src": "/cgi/image/https%3A//webstudio.is/logo.webp?width=256&quality=100&format=auto",
+        "srcSet": "/cgi/image/https%3A//webstudio.is/logo.webp?width=16&quality=100&format=auto 16w, /cgi/image/https%3A//webstudio.is/logo.webp?width=32&quality=100&format=auto 32w, /cgi/image/https%3A//webstudio.is/logo.webp?width=48&quality=100&format=auto 48w, /cgi/image/https%3A//webstudio.is/logo.webp?width=64&quality=100&format=auto 64w, /cgi/image/https%3A//webstudio.is/logo.webp?width=96&quality=100&format=auto 96w, /cgi/image/https%3A//webstudio.is/logo.webp?width=128&quality=100&format=auto 128w, /cgi/image/https%3A//webstudio.is/logo.webp?width=256&quality=100&format=auto 256w",
       }
     `);
   });
@@ -51,14 +51,14 @@ describe("Image optimizations applied", () => {
       srcSet: undefined,
       sizes: undefined,
       quality: 90,
-      loader: createImageLoader({ imageBaseUrl: "/asset/image/" }),
+      loader: createImageLoader({}),
     });
 
     expect(imgAttr).toMatchInlineSnapshot(`
       {
         "sizes": "(min-width: 1280px) 50vw, 100vw",
-        "src": "/asset/image/logo.webp?width=3840&quality=90&format=auto",
-        "srcSet": "/asset/image/logo.webp?width=384&quality=90&format=auto 384w, /asset/image/logo.webp?width=640&quality=90&format=auto 640w, /asset/image/logo.webp?width=750&quality=90&format=auto 750w, /asset/image/logo.webp?width=828&quality=90&format=auto 828w, /asset/image/logo.webp?width=1080&quality=90&format=auto 1080w, /asset/image/logo.webp?width=1200&quality=90&format=auto 1200w, /asset/image/logo.webp?width=1920&quality=90&format=auto 1920w, /asset/image/logo.webp?width=2048&quality=90&format=auto 2048w, /asset/image/logo.webp?width=3840&quality=90&format=auto 3840w",
+        "src": "/cgi/image/logo.webp?width=3840&quality=90&format=auto",
+        "srcSet": "/cgi/image/logo.webp?width=384&quality=90&format=auto 384w, /cgi/image/logo.webp?width=640&quality=90&format=auto 640w, /cgi/image/logo.webp?width=750&quality=90&format=auto 750w, /cgi/image/logo.webp?width=828&quality=90&format=auto 828w, /cgi/image/logo.webp?width=1080&quality=90&format=auto 1080w, /cgi/image/logo.webp?width=1200&quality=90&format=auto 1200w, /cgi/image/logo.webp?width=1920&quality=90&format=auto 1920w, /cgi/image/logo.webp?width=2048&quality=90&format=auto 2048w, /cgi/image/logo.webp?width=3840&quality=90&format=auto 3840w",
       }
     `);
   });
@@ -71,14 +71,14 @@ describe("Image optimizations applied", () => {
       srcSet: undefined,
       sizes: "100vw",
       quality: 70,
-      loader: createImageLoader({ imageBaseUrl: "/asset/image/" }),
+      loader: createImageLoader({}),
     });
 
     expect(imgAttr).toMatchInlineSnapshot(`
       {
         "sizes": "100vw",
-        "src": "/asset/image/logo.webp?width=3840&quality=70&format=auto",
-        "srcSet": "/asset/image/logo.webp?width=640&quality=70&format=auto 640w, /asset/image/logo.webp?width=750&quality=70&format=auto 750w, /asset/image/logo.webp?width=828&quality=70&format=auto 828w, /asset/image/logo.webp?width=1080&quality=70&format=auto 1080w, /asset/image/logo.webp?width=1200&quality=70&format=auto 1200w, /asset/image/logo.webp?width=1920&quality=70&format=auto 1920w, /asset/image/logo.webp?width=2048&quality=70&format=auto 2048w, /asset/image/logo.webp?width=3840&quality=70&format=auto 3840w",
+        "src": "/cgi/image/logo.webp?width=3840&quality=70&format=auto",
+        "srcSet": "/cgi/image/logo.webp?width=640&quality=70&format=auto 640w, /cgi/image/logo.webp?width=750&quality=70&format=auto 750w, /cgi/image/logo.webp?width=828&quality=70&format=auto 828w, /cgi/image/logo.webp?width=1080&quality=70&format=auto 1080w, /cgi/image/logo.webp?width=1200&quality=70&format=auto 1200w, /cgi/image/logo.webp?width=1920&quality=70&format=auto 1920w, /cgi/image/logo.webp?width=2048&quality=70&format=auto 2048w, /cgi/image/logo.webp?width=3840&quality=70&format=auto 3840w",
       }
     `);
   });
@@ -91,16 +91,14 @@ describe("Image optimizations applied", () => {
       srcSet: undefined,
       sizes: "100vw",
       quality: 70,
-      loader: createImageLoader({
-        imageBaseUrl: "https://resize-origin.is/asset/image/",
-      }),
+      loader: createImageLoader({}),
     });
 
     expect(imgAttr).toMatchInlineSnapshot(`
       {
         "sizes": "100vw",
-        "src": "https://resize-origin.is/asset/image/logo.webp?width=3840&quality=70&format=auto",
-        "srcSet": "https://resize-origin.is/asset/image/logo.webp?width=640&quality=70&format=auto 640w, https://resize-origin.is/asset/image/logo.webp?width=750&quality=70&format=auto 750w, https://resize-origin.is/asset/image/logo.webp?width=828&quality=70&format=auto 828w, https://resize-origin.is/asset/image/logo.webp?width=1080&quality=70&format=auto 1080w, https://resize-origin.is/asset/image/logo.webp?width=1200&quality=70&format=auto 1200w, https://resize-origin.is/asset/image/logo.webp?width=1920&quality=70&format=auto 1920w, https://resize-origin.is/asset/image/logo.webp?width=2048&quality=70&format=auto 2048w, https://resize-origin.is/asset/image/logo.webp?width=3840&quality=70&format=auto 3840w",
+        "src": "/cgi/image/logo.webp?width=3840&quality=70&format=auto",
+        "srcSet": "/cgi/image/logo.webp?width=640&quality=70&format=auto 640w, /cgi/image/logo.webp?width=750&quality=70&format=auto 750w, /cgi/image/logo.webp?width=828&quality=70&format=auto 828w, /cgi/image/logo.webp?width=1080&quality=70&format=auto 1080w, /cgi/image/logo.webp?width=1200&quality=70&format=auto 1200w, /cgi/image/logo.webp?width=1920&quality=70&format=auto 1920w, /cgi/image/logo.webp?width=2048&quality=70&format=auto 2048w, /cgi/image/logo.webp?width=3840&quality=70&format=auto 3840w",
       }
     `);
   });
@@ -138,12 +136,12 @@ describe("Image optimizations not applied", () => {
       srcSet: undefined,
       sizes: undefined,
       quality: 100,
-      loader: createImageLoader({ imageBaseUrl: "/asset/image/" }),
+      loader: createImageLoader({}),
     });
 
     expect(imgAttr).toMatchInlineSnapshot(`
       {
-        "src": "/asset/image/logo.webp?format=raw",
+        "src": "/cgi/image/logo.webp?format=raw",
       }
     `);
   });
@@ -156,7 +154,7 @@ describe("Image optimizations not applied", () => {
       srcSet: undefined,
       sizes: undefined,
       quality: 100,
-      loader: createImageLoader({ imageBaseUrl: "/asset/image/" }),
+      loader: createImageLoader({}),
     });
 
     expect(imgAttr).toMatchInlineSnapshot(`
@@ -174,7 +172,7 @@ describe("Image optimizations not applied", () => {
       srcSet: "user-defined-srcset",
       sizes: undefined,
       quality: 100,
-      loader: createImageLoader({ imageBaseUrl: "/asset/image/" }),
+      loader: createImageLoader({}),
     });
 
     expect(imgAttr).toMatchInlineSnapshot(`
@@ -193,7 +191,7 @@ describe("Image optimizations not applied", () => {
       srcSet: undefined,
       sizes: undefined,
       quality: 100,
-      loader: createImageLoader({ imageBaseUrl: "/asset/image/" }),
+      loader: createImageLoader({}),
     });
 
     expect(imgAttr).toMatchInlineSnapshot(`undefined`);
@@ -207,7 +205,7 @@ describe("Image optimizations not applied", () => {
       srcSet: undefined,
       sizes: undefined,
       quality: 100,
-      loader: createImageLoader({ imageBaseUrl: "/asset/image/" }),
+      loader: createImageLoader({}),
     });
 
     expect(imgAttr).toMatchInlineSnapshot(`undefined`);

--- a/packages/react-sdk/src/context.tsx
+++ b/packages/react-sdk/src/context.tsx
@@ -13,17 +13,6 @@ export type Params = {
    */
   renderer?: "canvas" | "preview";
   /**
-   * Base url ir base path for images with ending slash.
-   * Used for configuring image with different sizes.
-   * Concatinated with "name?width=&quality=&format=".
-   *
-   * For example
-   * /asset/image/ used by default in builder
-   * https://image-transform.wstd.io/cdn-cgi/image/
-   * https://webstudio.is/cdn-cgi/image/
-   */
-  imageBaseUrl: string;
-  /**
    * Base url or base path for any asset with ending slash.
    * Used to load assets like fonts or images in styles
    * Concatinated with "name".
@@ -46,7 +35,6 @@ export const ReactSdkContext = createContext<
   }
 >({
   assetBaseUrl: "/",
-  imageBaseUrl: "/",
   imageLoader: ({ src }) => src,
   resources: {},
 });

--- a/packages/sdk-components-react/src/html-embed.test.tsx
+++ b/packages/sdk-components-react/src/html-embed.test.tsx
@@ -32,7 +32,6 @@ const App = (props: {
     <ReactSdkContext.Provider
       value={{
         assetBaseUrl: "",
-        imageBaseUrl: "",
         imageLoader: () => "",
         renderer: props.renderer,
         resources: {},
@@ -279,7 +278,6 @@ describe("Builder renderer= canvas | preview", () => {
         <ReactSdkContext.Provider
           value={{
             assetBaseUrl: "",
-            imageBaseUrl: "",
             imageLoader: () => "",
             renderer: "canvas",
             resources: {},


### PR DESCRIPTION
In all cli templates asset base url and image base url are the same so we can safely switch.

Removed image loader from prebuild.ts.

Dropped imageBaseUrl from sdk react context.