### PR TITLE
feat: Allow maximizing CSS value for complex values

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -157,7 +157,7 @@ const getChromeLayout = ({
 
   if (navigatorLayout === "undocked" && activeSidebarPanel !== "none") {
     return {
-      gridTemplateColumns: `auto ${theme.spacing[30]} 1fr ${theme.spacing[30]}`,
+      gridTemplateColumns: `auto ${theme.sizes.sidebarWidth} 1fr ${theme.sizes.sidebarWidth}`,
       gridTemplateAreas: `
             "header header header header"
             "sidebar navigator main inspector"
@@ -167,7 +167,7 @@ const getChromeLayout = ({
   }
 
   return {
-    gridTemplateColumns: `auto 1fr ${theme.spacing[30]}`,
+    gridTemplateColumns: `auto 1fr ${theme.sizes.sidebarWidth}`,
     gridTemplateAreas: `
           "header header header"
           "sidebar main inspector"

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -157,7 +157,7 @@ const getChromeLayout = ({
 
   if (navigatorLayout === "undocked" && activeSidebarPanel !== "none") {
     return {
-      gridTemplateColumns: `auto ${theme.sizes.sidebarWidth} 1fr ${theme.sizes.sidebarWidth}`,
+      gridTemplateColumns: `auto ${theme.spacing[30]} 1fr ${theme.spacing[30]}`,
       gridTemplateAreas: `
             "header header header header"
             "sidebar navigator main inspector"
@@ -167,7 +167,7 @@ const getChromeLayout = ({
   }
 
   return {
-    gridTemplateColumns: `auto 1fr ${theme.sizes.sidebarWidth}`,
+    gridTemplateColumns: `auto 1fr ${theme.spacing[30]}`,
     gridTemplateAreas: `
           "header header header"
           "sidebar main inspector"

--- a/apps/builder/app/builder/features/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings.tsx
@@ -677,7 +677,7 @@ const MarketplaceSection = ({
             justifySelf: "start",
           }}
         >
-          <Grid gap={1} css={{ width: theme.sizes.sidebarWidth }}>
+          <Grid gap={1} css={{ width: theme.spacing[30] }}>
             {category && <Label text="title">{category}</Label>}
             <Card
               title={values.name}

--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -196,6 +196,7 @@ export const SectionGeneral = () => {
           lang="html"
           value={meta.code ?? ""}
           onChange={handleSave("code")}
+          onChangeComplete={handleSave("code")}
         />
       </Grid>
     </Grid>

--- a/apps/builder/app/builder/features/settings-panel/controls/code.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/code.tsx
@@ -173,7 +173,7 @@ export const CodeControl = ({
             setError(undefined);
             localValue.set(value);
           }}
-          onBlur={localValue.save}
+          onChangeComplete={localValue.save}
         />
         <BindingPopover
           scope={scope}

--- a/apps/builder/app/builder/features/settings-panel/controls/json.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/json.tsx
@@ -74,7 +74,7 @@ export const JsonControl = ({
           readOnly={overwritable === false}
           value={localValue.value}
           onChange={localValue.set}
-          onBlur={localValue.save}
+          onChangeComplete={localValue.save}
         />
         <BindingPopover
           scope={scope}

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -515,7 +515,7 @@ const BodyField = ({
                       ) ?? "")
                 }
                 onChange={onChange}
-                onBlur={() => bodyRef.current?.checkValidity()}
+                onChangeComplete={() => bodyRef.current?.checkValidity()}
               />
             </div>
           ) : (
@@ -943,7 +943,7 @@ export const GraphqlResourceForm = forwardRef<
                       ) ?? "")
                 }
                 onChange={setVariables}
-                onBlur={() => variablesRef.current?.checkValidity()}
+                onChangeComplete={() => variablesRef.current?.checkValidity()}
               />
             </div>
           </InputErrorsTooltip>

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -470,7 +470,7 @@ const JsonForm = forwardRef<
           color={valueError ? "error" : undefined}
           value={value}
           onChange={setValue}
-          onBlur={() => valueRef.current?.checkValidity()}
+          onChangeComplete={() => valueRef.current?.checkValidity()}
         />
       </Flex>
     </>

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -667,7 +667,7 @@ export const VariablePopoverTrigger = forwardRef<
             // flex fixes content overflowing artificial scroll area
             display: "flex",
             flexDirection: "column",
-            width: theme.sizes.sidebarWidth,
+            width: theme.spacing[30],
           }}
         >
           <Flex

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -147,13 +147,7 @@ export const BackgroundGradient = ({ index }: { index: number }) => {
             autoFocus={styleValue.type === "var"}
             value={textAreaValue ?? ""}
             onChange={handleChange}
-            onBlur={handleOnComplete}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") {
-                handleOnComplete();
-                event.preventDefault();
-              }
-            }}
+            onChangeComplete={handleOnComplete}
           />
         }
       />

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -13,7 +13,11 @@ import {
   editRepeatedStyleItem,
   setRepeatedStyleItem,
 } from "../../shared/repeated-style";
-import { parseCssFragment, CssFragmentEditor } from "../../shared/css-fragment";
+import {
+  parseCssFragment,
+  CssFragmentEditor,
+  CssFragmentEditorContent,
+} from "../../shared/css-fragment";
 
 type IntermediateValue = {
   type: "intermediate";
@@ -137,17 +141,21 @@ export const BackgroundGradient = ({ index }: { index: number }) => {
         </Flex>
       </Label>
       <CssFragmentEditor
-        invalid={intermediateValue?.type === "invalid"}
-        autoFocus={styleValue.type === "var"}
-        value={textAreaValue ?? ""}
-        onChange={handleChange}
-        onBlur={handleOnComplete}
-        onKeyDown={(event) => {
-          if (event.key === "Enter") {
-            handleOnComplete();
-            event.preventDefault();
-          }
-        }}
+        content={
+          <CssFragmentEditorContent
+            invalid={intermediateValue?.type === "invalid"}
+            autoFocus={styleValue.type === "var"}
+            value={textAreaValue ?? ""}
+            onChange={handleChange}
+            onBlur={handleOnComplete}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                handleOnComplete();
+                event.preventDefault();
+              }
+            }}
+          />
+        }
       />
     </Flex>
   );

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
@@ -52,7 +52,7 @@ $awareness.set({
 });
 
 const Panel = styled("div", {
-  width: theme.sizes.sidebarWidth,
+  width: theme.spacing[30],
 });
 
 export const Backgrounds = () => {

--- a/apps/builder/app/builder/features/style-panel/sections/borders/borders.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/borders.stories.tsx
@@ -2,7 +2,7 @@ import { styled, theme } from "@webstudio-is/design-system";
 import { Section } from "./borders";
 
 const Panel = styled("div", {
-  width: theme.sizes.sidebarWidth,
+  width: theme.spacing[30],
   boxSizing: "border-box",
 });
 

--- a/apps/builder/app/builder/features/style-panel/sections/shared/input-popover.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/shared/input-popover.tsx
@@ -79,7 +79,7 @@ const Input = ({
         batch.setProperty(property)(styleValue);
         batch.publish({ isEphemeral: true });
       }}
-      onChangeComplete={({ value, altKey, shiftKey }) => {
+      onChangeComplete={({ value, close = true, altKey, shiftKey }) => {
         const activeProperties = getActiveProperties({
           altKey,
           shiftKey,
@@ -93,7 +93,9 @@ const Input = ({
           batch.setProperty(property)(value);
         }
         batch.publish();
-        onClosePopover();
+        if (close) {
+          onClosePopover();
+        }
       }}
       onAbort={() => {
         const batch = createBatchUpdate();

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
@@ -231,7 +231,7 @@ export const TransitionContent = ({ index }: { index: number }) => {
         css={{
           padding: theme.panel.padding,
           gap: theme.spacing[3],
-          minWidth: theme.sizes.sidebarWidth,
+          minWidth: theme.spacing[30],
         }}
       >
         <Label>

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.stories.tsx
@@ -12,7 +12,7 @@ import { Section } from "./transitions";
 import { $awareness } from "~/shared/awareness";
 
 const Panel = styled("div", {
-  width: theme.sizes.sidebarWidth,
+  width: theme.spacing[30],
   boxShadow: theme.shadows.panelSectionDropShadow,
 });
 

--- a/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
@@ -283,7 +283,7 @@ const TypographySectionAdvancedPopover = () => {
           css={{
             padding: theme.panel.padding,
             gap: theme.spacing[9],
-            width: theme.sizes.sidebarWidth,
+            width: theme.spacing[30],
           }}
         >
           <Grid css={{ gridTemplateColumns: "5fr 5fr" }} gap={2}>

--- a/apps/builder/app/builder/features/style-panel/shared/css-fragment.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-fragment.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, type ComponentProps } from "react";
+import { useMemo, useRef, type ComponentProps, type ReactNode } from "react";
 import { matchSorter, type RankingInfo } from "match-sorter";
 import { EditorView, keymap, tooltips } from "@codemirror/view";
 import { css } from "@codemirror/lang-css";
@@ -10,8 +10,10 @@ import {
 import { parseCss } from "@webstudio-is/css-data";
 import { css as style } from "@webstudio-is/design-system";
 import {
-  CodeEditorBase,
   EditorContent,
+  EditorDialog,
+  EditorDialogButton,
+  EditorDialogControl,
   getMinMaxHeightVars,
 } from "~/builder/shared/code-editor-base";
 import { $availableVariables } from "./model";
@@ -95,12 +97,30 @@ export const CssFragmentEditorContent = ({
   return <EditorContent extensions={extensions} {...props} />;
 };
 
-export const CssFragmentEditor = (
-  props: ComponentProps<typeof CodeEditorBase>
-) => {
+export const CssFragmentEditor = ({
+  title,
+  open,
+  content,
+  onOpenChange,
+}: {
+  title?: ReactNode;
+  open?: boolean;
+  content: ReactNode;
+  onOpenChange?: (newOpen: boolean) => void;
+}) => {
   return (
     <div className={wrapperStyle()}>
-      <CodeEditorBase {...props} />
+      <EditorDialogControl>
+        {content}
+        <EditorDialog
+          open={open}
+          onOpenChange={onOpenChange}
+          title={title}
+          content={content}
+        >
+          <EditorDialogButton />
+        </EditorDialog>
+      </EditorDialogControl>
     </div>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/shared/css-fragment.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-fragment.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, type ComponentProps } from "react";
 import { matchSorter, type RankingInfo } from "match-sorter";
 import { EditorView, keymap, tooltips } from "@codemirror/view";
 import { css } from "@codemirror/lang-css";
@@ -11,6 +11,7 @@ import { parseCss } from "@webstudio-is/css-data";
 import { css as style } from "@webstudio-is/design-system";
 import {
   CodeEditorBase,
+  EditorContent,
   getMinMaxHeightVars,
 } from "~/builder/shared/code-editor-base";
 import { $availableVariables } from "./model";
@@ -65,15 +66,10 @@ const wrapperStyle = style({
   ...getMinMaxHeightVars({ minHeight: "40px", maxHeight: "80px" }),
 });
 
-export const CssFragmentEditor = ({
+export const CssFragmentEditorContent = ({
   onKeyDown,
   ...props
-}: {
-  invalid?: boolean;
-  autoFocus?: boolean;
-  value: string;
-  onChange: (newValue: string) => void;
-  onBlur?: (event: FocusEvent) => void;
+}: ComponentProps<typeof EditorContent> & {
   onKeyDown?: (event: KeyboardEvent) => void;
 }) => {
   const onKeyDownRef = useRef(onKeyDown);
@@ -96,10 +92,15 @@ export const CssFragmentEditor = ({
       }),
     ];
   }, []);
+  return <EditorContent extensions={extensions} {...props} />;
+};
 
+export const CssFragmentEditor = (
+  props: ComponentProps<typeof CodeEditorBase>
+) => {
   return (
     <div className={wrapperStyle()}>
-      <CodeEditorBase {...props} extensions={extensions} />
+      <CodeEditorBase {...props} />
     </div>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.stories.tsx
@@ -158,7 +158,7 @@ export const WithUnits = () => {
   );
 };
 
-export const AutoScroll = () => {
+export const Oversized = () => {
   const [value, setValue] = React.useState<StyleValue>({
     type: "var",
     value: "start-test-test-test-test-test-test-test-end",

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -53,7 +53,7 @@ import { mergeRefs } from "@react-aria/utils";
 import { composeEventHandlers } from "~/shared/event-utils";
 import type { StyleValueSourceColor } from "~/shared/style-object-model";
 import { ColorThumb } from "../color-thumb";
-import { ValueEditorDialog } from "./value-editor-dialog";
+import { cssButtonDisplay, ValueEditorDialog } from "./value-editor-dialog";
 
 // We need to enable scrub on properties that can have numeric value.
 const canBeNumber = (property: StyleProperty, value: CssValueInputValue) => {
@@ -870,7 +870,14 @@ export const CssValueInput = ({
                 </Flex>
               )
             }
-            css={{ cursor: "default", minWidth: "2em" }}
+            css={{
+              cursor: "default",
+              minWidth: "2em",
+              position: "relative",
+              "&:hover": {
+                [cssButtonDisplay]: "block",
+              },
+            }}
             text={text}
           />
         </ComboboxAnchor>

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -828,9 +828,10 @@ export const CssValueInput = ({
   );
 
   const suffixRef = useRef<HTMLDivElement | null>(null);
-  const suffixElement = unitSelectElement ?? keywordButtonElement ?? (
-    <ValueEditorDialog />
-  );
+  const valueEditorElement =
+    value.type === "keyword" ? undefined : <ValueEditorDialog />;
+  const suffixElement =
+    unitSelectElement ?? keywordButtonElement ?? valueEditorElement;
 
   return (
     <ComboboxRoot open={isOpen}>

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -653,11 +653,10 @@ export const CssValueInput = ({
 
   const menuProps = getMenuProps();
 
-  const isFocused = () => document.activeElement === inputRef.current;
-
   const getInputValue = () => {
+    const isFocused = document.activeElement === inputRef.current;
     // When input is not focused, we are removing var() to fit more into the small inputs.
-    return value.type === "var" && isFocused() === false
+    return value.type === "var" && isFocused === false
       ? `--${value.value}`
       : inputProps.value;
   };
@@ -665,8 +664,9 @@ export const CssValueInput = ({
     inputProps.onBlur(event);
 
     // Restore the value without var()
-    event.target.value = getInputValue();
-
+    if (event.target instanceof HTMLInputElement) {
+      event.target.value = getInputValue();
+    }
     // When unit select is open, onBlur is triggered,though we don't want a change event in this case.
     if (isUnitsOpen) {
       return;
@@ -847,12 +847,12 @@ export const CssValueInput = ({
             {...inputProps}
             {...autoScrollProps}
             value={getInputValue()}
-            onFocus={() => {
-              if (isFocused()) {
+            onFocus={(event) => {
+              if (event.target instanceof HTMLInputElement) {
                 // We are setting the value on focus because we might have removed the var() from the value,
                 // but once focused, we need to show the full value
-                inputRef.current.value = itemToString(value);
-                inputRef.current?.select();
+                event.target.value = itemToString(value);
+                event.target.select();
               }
             }}
             autoFocus={autoFocus}

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -17,7 +17,6 @@ import {
   Flex,
   styled,
   Text,
-  TextArea,
 } from "@webstudio-is/design-system";
 import type {
   KeywordValue,
@@ -36,7 +35,6 @@ import {
   useState,
   useMemo,
   type ComponentProps,
-  useId,
 } from "react";
 import { useUnitSelect } from "./unit-select";
 import { parseIntermediateOrInvalidValue } from "./parse-intermediate-or-invalid-value";
@@ -55,8 +53,7 @@ import { mergeRefs } from "@react-aria/utils";
 import { composeEventHandlers } from "~/shared/event-utils";
 import type { StyleValueSourceColor } from "~/shared/style-object-model";
 import { ColorThumb } from "../color-thumb";
-import { MaximizeIcon } from "@webstudio-is/icons";
-import { EditorDialog } from "~/builder/shared/code-editor-base";
+import { ValueEditorDialog } from "./value-editor-dialog";
 
 // We need to enable scrub on properties that can have numeric value.
 const canBeNumber = (property: StyleProperty, value: CssValueInputValue) => {
@@ -387,36 +384,6 @@ const getAutoScrollProps = () => {
 };
 
 const Description = styled(Box, { width: theme.spacing[27] });
-
-const ValueEditorDialog = ({
-  value,
-  onChangeComplete,
-}: {
-  value: string;
-  onChangeComplete: (value: string) => void;
-}) => {
-  const valueId = useId();
-  const [input, setInput] = useState(value);
-
-  return (
-    <EditorDialog
-      title="CSS Value"
-      content={
-        <TextArea grow={true} id={valueId} value={input} onChange={setInput} />
-      }
-      onOpenChange={(isOpen) => {
-        if (isOpen) {
-          return;
-        }
-        onChangeComplete(input);
-      }}
-    >
-      <NestedInputButton tabIndex={-1}>
-        <MaximizeIcon size={12} />
-      </NestedInputButton>
-    </EditorDialog>
-  );
-};
 
 /**
  * Common:
@@ -843,11 +810,12 @@ export const CssValueInput = ({
   const valueEditorElement =
     value.type === "keyword" ? undefined : (
       <ValueEditorDialog
+        property={property}
         value={inputProps.value}
         onChangeComplete={(value) => {
           onChangeComplete({
             type: "dialog-close",
-            value: { type: "intermediate", value },
+            value,
           });
         }}
       />

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -242,8 +242,9 @@ type ChangeCompleteEvent = {
     | "unit-select"
     | "keyword-select"
     | "delta"
-    | "dialog-close";
+    | "dialog-change-complete";
   value: StyleValue;
+  close?: boolean;
 } & Modifiers;
 
 type CssValueInputProps = Pick<
@@ -462,6 +463,7 @@ export const CssValueInput = ({
     event: {
       type: ChangeCompleteEvent["type"];
       value: CssValueInputValue;
+      close?: boolean;
     } & Partial<Modifiers>
   ) => {
     const { value } = event;
@@ -684,6 +686,7 @@ export const CssValueInput = ({
       onAbort();
       return;
     }
+
     onChangeComplete({ value, type: "blur" });
   };
 
@@ -826,8 +829,9 @@ export const CssValueInput = ({
         value={inputProps.value}
         onChangeComplete={(value) => {
           onChangeComplete({
-            type: "dialog-close",
+            type: "dialog-change-complete",
             value,
+            close: false,
           });
         }}
       />

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -873,7 +873,6 @@ export const CssValueInput = ({
             css={{
               cursor: "default",
               minWidth: "2em",
-              position: "relative",
               "&:hover": {
                 [cssButtonDisplay]: "block",
               },

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -653,8 +653,20 @@ export const CssValueInput = ({
 
   const menuProps = getMenuProps();
 
+  const isFocused = () => document.activeElement === inputRef.current;
+
+  const getInputValue = () => {
+    // When input is not focused, we are removing var() to fit more into the small inputs.
+    return value.type === "var" && isFocused() === false
+      ? `--${value.value}`
+      : inputProps.value;
+  };
   const handleOnBlur: KeyboardEventHandler = (event) => {
     inputProps.onBlur(event);
+
+    // Restore the value without var()
+    event.target.value = getInputValue();
+
     // When unit select is open, onBlur is triggered,though we don't want a change event in this case.
     if (isUnitsOpen) {
       return;
@@ -834,9 +846,12 @@ export const CssValueInput = ({
             fieldSizing={fieldSizing}
             {...inputProps}
             {...autoScrollProps}
+            value={getInputValue()}
             onFocus={() => {
-              const isFocused = document.activeElement === inputRef.current;
-              if (isFocused) {
+              if (isFocused()) {
+                // We are setting the value on focus because we might have removed the var() from the value,
+                // but once focused, we need to show the full value
+                inputRef.current.value = itemToString(value);
                 inputRef.current?.select();
               }
             }}

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -688,30 +688,17 @@ export const CssValueInput = ({
       </NestedIconLabel>
     ));
 
-  const keywordButtonElement = (
-    <NestedInputButton
-      {...getToggleButtonProps()}
-      data-state={isOpen ? "open" : "closed"}
-      tabIndex={-1}
-    />
-  );
+  const keywordButtonElement =
+    value.type === "keyword" && items.length !== 0 ? (
+      <NestedInputButton
+        {...getToggleButtonProps()}
+        data-state={isOpen ? "open" : "closed"}
+        tabIndex={-1}
+      />
+    ) : undefined;
 
-  const isUnitValue = unitSelectElement !== null;
-
-  const hasItems = items.length !== 0;
-  const isKeywordValue = value.type === "keyword" && hasItems;
   const suffixRef = useRef<HTMLDivElement | null>(null);
-
-  const suffix =
-    showSuffix === false ? null : (
-      <Flex align="center" ref={suffixRef}>
-        {isUnitValue
-          ? unitSelectElement
-          : isKeywordValue
-            ? keywordButtonElement
-            : null}
-      </Flex>
-    );
+  const suffixElement = unitSelectElement ?? keywordButtonElement;
 
   let description;
   // When user hovers or focuses an item in the combobox list we want to show the description of the item and otherwise show the description of the current value
@@ -848,7 +835,13 @@ export const CssValueInput = ({
             name={property}
             color={value.type === "invalid" ? "error" : undefined}
             prefix={finalPrefix}
-            suffix={suffix}
+            suffix={
+              suffixElement && (
+                <Flex align="center" ref={suffixRef}>
+                  {suffixElement}
+                </Flex>
+              )
+            }
             css={{ cursor: "default", minWidth: "2em" }}
             text={text}
           />

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -868,11 +868,9 @@ export const CssValueInput = ({
             color={value.type === "invalid" ? "error" : undefined}
             prefix={finalPrefix}
             suffix={
-              suffixElement && (
-                <Flex align="center" ref={suffixRef}>
-                  {suffixElement}
-                </Flex>
-              )
+              <Flex align="center" ref={suffixRef}>
+                {suffixElement}
+              </Flex>
             }
             css={{
               cursor: "default",

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -819,7 +819,7 @@ export const CssValueInput = ({
   );
 
   const suffixRef = useRef<HTMLDivElement | null>(null);
-  const valueEditorElement =
+  const valueEditorButtonElement =
     value.type === "keyword" ? undefined : (
       <ValueEditorDialog
         property={property}
@@ -832,8 +832,12 @@ export const CssValueInput = ({
         }}
       />
     );
+  const invalidValueElement = value.type === "invalid" ? <></> : undefined;
   const suffixElement =
-    unitSelectElement ?? keywordButtonElement ?? valueEditorElement;
+    invalidValueElement ??
+    unitSelectElement ??
+    keywordButtonElement ??
+    valueEditorButtonElement;
 
   return (
     <ComboboxRoot open={isOpen}>

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -820,7 +820,7 @@ export const CssValueInput = ({
 
   const suffixRef = useRef<HTMLDivElement | null>(null);
   const valueEditorButtonElement =
-    value.type === "keyword" ? undefined : (
+    value.type === "unparsed" ? (
       <ValueEditorDialog
         property={property}
         value={inputProps.value}
@@ -831,7 +831,7 @@ export const CssValueInput = ({
           });
         }}
       />
-    );
+    ) : undefined;
   const invalidValueElement = value.type === "invalid" ? <></> : undefined;
   const suffixElement =
     invalidValueElement ??

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
@@ -47,7 +47,8 @@ export const useUnitSelect = ({
   if (
     options.length === 0 ||
     value.type === "var" ||
-    value.type === "unparsed"
+    value.type === "unparsed" ||
+    value.type === "invalid"
   ) {
     return [isOpen, undefined];
   }

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
@@ -44,26 +44,23 @@ export const useUnitSelect = ({
     [property, value]
   );
 
-  if (
-    options.length === 0 ||
-    value.type === "var" ||
-    value.type === "unparsed" ||
-    value.type === "invalid"
-  ) {
-    return [isOpen, undefined];
-  }
-
-  const unitOrKeywordValue: string | undefined =
-    value.type === "unit"
-      ? value.unit
-      : value.type === "keyword"
-        ? value.value
-        : undefined;
-
   const unit =
     value.type === "unit" || value.type === "intermediate"
       ? value.unit
       : undefined;
+
+  const unitOrKeywordValue: string | undefined =
+    unit ?? (value.type === "keyword" ? value.value : undefined);
+
+  if (
+    options.length === 0 ||
+    value.type === "var" ||
+    value.type === "unparsed" ||
+    value.type === "invalid" ||
+    unitOrKeywordValue === undefined
+  ) {
+    return [isOpen, undefined];
+  }
 
   const select = (
     <UnitSelect

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
@@ -36,41 +36,49 @@ export const useUnitSelect = ({
   value,
   onChange,
   onCloseAutoFocus,
-}: UseUnitSelectType): [boolean, JSX.Element | null] => {
+}: UseUnitSelectType): [boolean, JSX.Element | undefined] => {
   const [isOpen, setIsOpen] = useState(false);
-
-  const unit =
-    value.type === "unit" || value.type === "intermediate"
-      ? value.unit
-      : undefined;
 
   const options = useMemo(
     () => buildOptions(property, value, nestedSelectButtonUnitless),
     [property, value]
   );
 
-  if (options.length === 0) {
-    return [isOpen, null];
+  if (
+    options.length === 0 ||
+    value.type === "var" ||
+    value.type === "unparsed"
+  ) {
+    return [isOpen, undefined];
   }
 
-  const unitOrKeyword: string | undefined =
-    unit ?? (value.type === "keyword" ? value.value : undefined);
+  const unitOrKeywordValue: string | undefined =
+    value.type === "unit"
+      ? value.unit
+      : value.type === "keyword"
+        ? value.value
+        : undefined;
+
+  const unit =
+    value.type === "unit" || value.type === "intermediate"
+      ? value.unit
+      : undefined;
 
   const select = (
     <UnitSelect
-      value={unitOrKeyword}
+      value={unitOrKeywordValue}
       label={unit ?? nestedSelectButtonUnitless}
       options={options}
       open={isOpen}
       onCloseAutoFocus={onCloseAutoFocus}
       onOpenChange={setIsOpen}
-      onChange={(unitOption) => {
-        if (unitOption.type === "keyword") {
-          onChange({ type: "keyword", value: unitOption.id });
+      onChange={(option) => {
+        if (option.type === "keyword") {
+          onChange({ type: "keyword", value: option.id });
           return;
         }
 
-        onChange({ type: "unit", value: unitOption.id });
+        onChange({ type: "unit", value: option.id });
       }}
     />
   );

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -45,6 +45,16 @@ export const ValueEditorDialog = ({
     y: 0,
   }));
 
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen && triggerRef.current) {
+      const triggerRect = triggerRef.current.getBoundingClientRect();
+      setRect({
+        ...rect,
+        y: triggerRect.y - rect.width / 2,
+      });
+    }
+  };
+
   const handleChange = (value: string) => {
     setIntermediateValue({
       type: "intermediate",
@@ -74,15 +84,7 @@ export const ValueEditorDialog = ({
   return (
     <EditorDialog
       title="CSS Value"
-      onOpenChange={(isOpen) => {
-        if (isOpen && triggerRef.current) {
-          const triggerRect = triggerRef.current.getBoundingClientRect();
-          setRect({
-            ...rect,
-            y: triggerRect.y - rect.width / 2,
-          });
-        }
-      }}
+      onOpenChange={handleOpenChange}
       {...rect}
       content={
         <CssFragmentEditorContent

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -1,4 +1,4 @@
-import { NestedInputButton } from "@webstudio-is/design-system";
+import { NestedInputButton, theme } from "@webstudio-is/design-system";
 import { MaximizeIcon } from "@webstudio-is/icons";
 import { useEffect, useState } from "react";
 import { EditorDialog } from "~/builder/shared/code-editor-base";
@@ -10,6 +10,8 @@ import {
   type StyleValue,
 } from "@webstudio-is/css-engine";
 import { parseIntermediateOrInvalidValue } from "./parse-intermediate-or-invalid-value";
+
+export const cssButtonDisplay = "--ws-css-value-input-maximize-button-display";
 
 export const ValueEditorDialog = ({
   property,
@@ -73,7 +75,15 @@ export const ValueEditorDialog = ({
         />
       }
     >
-      <NestedInputButton tabIndex={-1}>
+      <NestedInputButton
+        tabIndex={-1}
+        css={{
+          display: `var(${cssButtonDisplay}, none)`,
+          position: "absolute",
+          right: 1,
+          background: theme.colors.backgroundControls,
+        }}
+      >
         <MaximizeIcon size={12} />
       </NestedInputButton>
     </EditorDialog>

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -1,4 +1,8 @@
-import { NestedInputButton, theme } from "@webstudio-is/design-system";
+import {
+  NestedInputButton,
+  rawTheme,
+  theme,
+} from "@webstudio-is/design-system";
 import { MaximizeIcon } from "@webstudio-is/icons";
 import { useEffect, useRef, useState } from "react";
 import {
@@ -15,6 +19,8 @@ import {
 import { parseIntermediateOrInvalidValue } from "./parse-intermediate-or-invalid-value";
 
 export const cssButtonDisplay = "--ws-css-value-input-maximize-button-display";
+
+const width = parseFloat(rawTheme.spacing[30]);
 
 export const ValueEditorDialog = ({
   property,
@@ -62,19 +68,26 @@ export const ValueEditorDialog = ({
   const editorApiRef = useRef<EditorApi>();
   const triggerRef = useRef<HTMLButtonElement>(null);
 
-  const rectRef = useRef({
-    height: 300,
-    width: 240,
-    x: window.innerWidth - 240,
+  const [rect, setRect] = useState(() => ({
+    height: 200,
+    width,
+    x: window.innerWidth - width,
     y: 0,
-  });
-  const [isOpen, setIsOpen] = useState(false);
+  }));
 
   return (
     <EditorDialog
       title="CSS Value"
-      open={isOpen}
-      {...rectRef.current}
+      onOpenChange={(isOpen) => {
+        if (isOpen && triggerRef.current) {
+          const triggerRect = triggerRef.current.getBoundingClientRect();
+          setRect({
+            ...rect,
+            y: triggerRect.y - rect.width / 2,
+          });
+        }
+      }}
+      {...rect}
       content={
         <CssFragmentEditorContent
           autoFocus
@@ -97,14 +110,6 @@ export const ValueEditorDialog = ({
           },
         }}
         ref={triggerRef}
-        onClick={(event) => {
-          if (event.currentTarget instanceof HTMLButtonElement === false) {
-            return;
-          }
-          const triggerRect = event.currentTarget.getBoundingClientRect();
-          rectRef.current.y = triggerRect.y - rectRef.current.width / 2;
-          setIsOpen(true);
-        }}
       >
         <MaximizeIcon size={12} />
       </NestedInputButton>

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -17,7 +17,7 @@ import { parseIntermediateOrInvalidValue } from "./parse-intermediate-or-invalid
 
 export const cssButtonDisplay = "--ws-css-value-input-maximize-button-display";
 
-const width = parseFloat(rawTheme.spacing[30]);
+const width = parseFloat(rawTheme.sizes.sidebarWidth);
 
 export const ValueEditorDialog = ({
   property,

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -60,24 +60,28 @@ export const ValueEditorDialog = ({
   };
 
   const editorApiRef = useRef<EditorApi>();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const rectRef = useRef({
+    height: 300,
+    width: 240,
+    x: window.innerWidth - 240,
+    y: 0,
+  });
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <EditorDialog
       title="CSS Value"
-      onOpenChange={(isOpen) => {
-        if (isOpen) {
-          // Workaround, we need to wait a frame before we can get the focus,
-          // otherwise we will loose it again to CssValueInput popover
-          requestAnimationFrame(() => {
-            editorApiRef.current?.focus();
-          });
-        }
-      }}
+      open={isOpen}
+      {...rectRef.current}
       content={
         <CssFragmentEditorContent
+          autoFocus
           editorApiRef={editorApiRef}
           value={intermediateValue?.value ?? value ?? ""}
           invalid={intermediateValue?.type === "invalid"}
+          showShortcuts
           onChange={handleChange}
           onChangeComplete={handleComplete}
         />
@@ -91,6 +95,15 @@ export const ValueEditorDialog = ({
           '&[data-state="open"]': {
             display: "block",
           },
+        }}
+        ref={triggerRef}
+        onClick={(event) => {
+          if (event.currentTarget instanceof HTMLButtonElement === false) {
+            return;
+          }
+          const triggerRect = event.currentTarget.getBoundingClientRect();
+          rectRef.current.y = triggerRect.y - rectRef.current.width / 2;
+          setIsOpen(true);
         }}
       >
         <MaximizeIcon size={12} />

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -50,7 +50,7 @@ export const ValueEditorDialog = ({
       const triggerRect = triggerRef.current.getBoundingClientRect();
       setRect({
         ...rect,
-        y: triggerRect.y - rect.width / 2,
+        y: triggerRect.y,
       });
     }
   };

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -28,7 +28,6 @@ export const ValueEditorDialog = ({
   const [intermediateValue, setIntermediateValue] = useState<
     IntermediateStyleValue | InvalidValue | undefined
   >({ type: "intermediate", value });
-  const editorDialogOpenStateRef = useRef(false);
 
   useEffect(() => {
     setIntermediateValue({ type: "intermediate", value });
@@ -80,13 +79,7 @@ export const ValueEditorDialog = ({
           value={intermediateValue?.value ?? value ?? ""}
           invalid={intermediateValue?.type === "invalid"}
           onChange={handleChange}
-          onBlur={handleComplete}
-          onKeyDown={(event) => {
-            if (event.key === "Enter") {
-              handleComplete();
-              event.preventDefault();
-            }
-          }}
+          onChangeComplete={handleComplete}
         />
       }
     >
@@ -95,6 +88,9 @@ export const ValueEditorDialog = ({
         css={{
           display: `var(${cssButtonDisplay}, none)`,
           background: theme.colors.backgroundControls,
+          '&[data-state="open"]': {
+            display: "block",
+          },
         }}
       >
         <MaximizeIcon size={12} />

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -17,7 +17,7 @@ import { parseIntermediateOrInvalidValue } from "./parse-intermediate-or-invalid
 
 export const cssButtonDisplay = "--ws-css-value-input-maximize-button-display";
 
-const width = parseFloat(rawTheme.sizes.sidebarWidth);
+const width = parseFloat(rawTheme.spacing[30]);
 
 export const ValueEditorDialog = ({
   property,

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -66,6 +66,12 @@ export const ValueEditorDialog = ({
           invalid={intermediateValue?.type === "invalid"}
           onChange={handleChange}
           onBlur={handleComplete}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              handleComplete();
+              event.preventDefault();
+            }
+          }}
         />
       }
     >

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -1,0 +1,81 @@
+import { NestedInputButton } from "@webstudio-is/design-system";
+import { MaximizeIcon } from "@webstudio-is/icons";
+import { useEffect, useState } from "react";
+import { EditorDialog } from "~/builder/shared/code-editor-base";
+import { CssFragmentEditor } from "../css-fragment";
+import type { IntermediateStyleValue } from "./css-value-input";
+import {
+  type InvalidValue,
+  type StyleProperty,
+  type StyleValue,
+} from "@webstudio-is/css-engine";
+import { parseIntermediateOrInvalidValue } from "./parse-intermediate-or-invalid-value";
+
+export const ValueEditorDialog = ({
+  property,
+  value,
+  onChangeComplete,
+}: {
+  property: StyleProperty;
+  value: string;
+  onChangeComplete: (value: StyleValue) => void;
+}) => {
+  const [intermediateValue, setIntermediateValue] = useState<
+    IntermediateStyleValue | InvalidValue | undefined
+  >({ type: "intermediate", value });
+
+  useEffect(() => {
+    setIntermediateValue({ type: "intermediate", value });
+  }, [value]);
+
+  const handleChange = (value: string) => {
+    setIntermediateValue({
+      type: "intermediate",
+      value,
+    });
+  };
+
+  const handleComplete = () => {
+    if (intermediateValue === undefined) {
+      return;
+    }
+    const parsedValue = parseIntermediateOrInvalidValue(
+      property,
+      intermediateValue
+    );
+
+    if (parsedValue?.type === "invalid") {
+      setIntermediateValue({
+        type: "invalid",
+        value: intermediateValue.value,
+      });
+      return;
+    }
+    onChangeComplete(parsedValue);
+  };
+
+  return (
+    <EditorDialog
+      title="CSS Value"
+      content={
+        <CssFragmentEditor
+          invalid={intermediateValue?.type === "invalid"}
+          autoFocus
+          value={intermediateValue?.value ?? value ?? ""}
+          onChange={handleChange}
+          onBlur={handleComplete}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              handleComplete();
+              event.preventDefault();
+            }
+          }}
+        />
+      }
+    >
+      <NestedInputButton tabIndex={-1}>
+        <MaximizeIcon size={12} />
+      </NestedInputButton>
+    </EditorDialog>
+  );
+};

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -1,7 +1,10 @@
 import { NestedInputButton, theme } from "@webstudio-is/design-system";
 import { MaximizeIcon } from "@webstudio-is/icons";
-import { useEffect, useState } from "react";
-import { EditorDialog } from "~/builder/shared/code-editor-base";
+import { useEffect, useRef, useState } from "react";
+import {
+  EditorDialog,
+  type EditorApi,
+} from "~/builder/shared/code-editor-base";
 import { CssFragmentEditorContent } from "../css-fragment";
 import type { IntermediateStyleValue } from "./css-value-input";
 import {
@@ -25,6 +28,7 @@ export const ValueEditorDialog = ({
   const [intermediateValue, setIntermediateValue] = useState<
     IntermediateStyleValue | InvalidValue | undefined
   >({ type: "intermediate", value });
+  const editorDialogOpenStateRef = useRef(false);
 
   useEffect(() => {
     setIntermediateValue({ type: "intermediate", value });
@@ -56,12 +60,23 @@ export const ValueEditorDialog = ({
     onChangeComplete(parsedValue);
   };
 
+  const editorApiRef = useRef<EditorApi>();
+
   return (
     <EditorDialog
       title="CSS Value"
+      onOpenChange={(isOpen) => {
+        if (isOpen) {
+          // Workaround, we need to wait a frame before we can get the focus,
+          // otherwise we will loose it again to CssValueInput popover
+          requestAnimationFrame(() => {
+            editorApiRef.current?.focus();
+          });
+        }
+      }}
       content={
         <CssFragmentEditorContent
-          autoFocus
+          editorApiRef={editorApiRef}
           value={intermediateValue?.value ?? value ?? ""}
           invalid={intermediateValue?.type === "invalid"}
           onChange={handleChange}

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -2,7 +2,7 @@ import { NestedInputButton, theme } from "@webstudio-is/design-system";
 import { MaximizeIcon } from "@webstudio-is/icons";
 import { useEffect, useState } from "react";
 import { EditorDialog } from "~/builder/shared/code-editor-base";
-import { CssFragmentEditor } from "../css-fragment";
+import { CssFragmentEditorContent } from "../css-fragment";
 import type { IntermediateStyleValue } from "./css-value-input";
 import {
   type InvalidValue,
@@ -60,18 +60,12 @@ export const ValueEditorDialog = ({
     <EditorDialog
       title="CSS Value"
       content={
-        <CssFragmentEditor
-          invalid={intermediateValue?.type === "invalid"}
+        <CssFragmentEditorContent
           autoFocus
           value={intermediateValue?.value ?? value ?? ""}
+          invalid={intermediateValue?.type === "invalid"}
           onChange={handleChange}
           onBlur={handleComplete}
-          onKeyDown={(event) => {
-            if (event.key === "Enter") {
-              handleComplete();
-              event.preventDefault();
-            }
-          }}
         />
       }
     >

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -79,8 +79,6 @@ export const ValueEditorDialog = ({
         tabIndex={-1}
         css={{
           display: `var(${cssButtonDisplay}, none)`,
-          position: "absolute",
-          right: 1,
           background: theme.colors.backgroundControls,
         }}
       >

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -56,29 +56,34 @@ export const ValueEditorDialog = ({
   };
 
   const handleChange = (value: string) => {
-    setIntermediateValue({
+    const parsedValue = parseIntermediateOrInvalidValue(property, {
       type: "intermediate",
       value,
     });
-  };
 
-  const handleComplete = () => {
-    if (intermediateValue === undefined) {
-      return;
-    }
-    const parsedValue = parseIntermediateOrInvalidValue(
-      property,
-      intermediateValue
-    );
-
-    if (parsedValue?.type === "invalid") {
+    if (parsedValue.type === "invalid") {
       setIntermediateValue({
         type: "invalid",
-        value: intermediateValue.value,
+        value,
       });
       return;
     }
-    onChangeComplete(parsedValue);
+
+    if (parsedValue) {
+      setIntermediateValue({
+        type: "intermediate",
+        value,
+      });
+    }
+
+    return parsedValue;
+  };
+
+  const handleChangeComplete = (value: string) => {
+    const parsedValue = handleChange(value);
+    if (parsedValue) {
+      onChangeComplete(parsedValue);
+    }
   };
 
   return (
@@ -93,7 +98,7 @@ export const ValueEditorDialog = ({
           invalid={intermediateValue?.type === "invalid"}
           showShortcuts
           onChange={handleChange}
-          onChangeComplete={handleComplete}
+          onChangeComplete={handleChangeComplete}
         />
       }
     >

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/value-editor-dialog.tsx
@@ -5,10 +5,7 @@ import {
 } from "@webstudio-is/design-system";
 import { MaximizeIcon } from "@webstudio-is/icons";
 import { useEffect, useRef, useState } from "react";
-import {
-  EditorDialog,
-  type EditorApi,
-} from "~/builder/shared/code-editor-base";
+import { EditorDialog } from "~/builder/shared/code-editor-base";
 import { CssFragmentEditorContent } from "../css-fragment";
 import type { IntermediateStyleValue } from "./css-value-input";
 import {
@@ -39,6 +36,15 @@ export const ValueEditorDialog = ({
     setIntermediateValue({ type: "intermediate", value });
   }, [value]);
 
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const [rect, setRect] = useState(() => ({
+    height: 200,
+    width,
+    x: window.innerWidth - width,
+    y: 0,
+  }));
+
   const handleChange = (value: string) => {
     setIntermediateValue({
       type: "intermediate",
@@ -65,16 +71,6 @@ export const ValueEditorDialog = ({
     onChangeComplete(parsedValue);
   };
 
-  const editorApiRef = useRef<EditorApi>();
-  const triggerRef = useRef<HTMLButtonElement>(null);
-
-  const [rect, setRect] = useState(() => ({
-    height: 200,
-    width,
-    x: window.innerWidth - width,
-    y: 0,
-  }));
-
   return (
     <EditorDialog
       title="CSS Value"
@@ -91,7 +87,6 @@ export const ValueEditorDialog = ({
       content={
         <CssFragmentEditorContent
           autoFocus
-          editorApiRef={editorApiRef}
           value={intermediateValue?.value ?? value ?? ""}
           invalid={intermediateValue?.type === "invalid"}
           showShortcuts

--- a/apps/builder/app/builder/features/style-panel/shared/filter-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/filter-content.tsx
@@ -240,7 +240,7 @@ export const FilterSectionContent = ({
         css={{
           padding: theme.panel.padding,
           gap: theme.spacing[3],
-          minWidth: theme.sizes.sidebarWidth,
+          minWidth: theme.spacing[30],
         }}
       >
         <Label>

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -417,13 +417,7 @@ export const ShadowContent = ({
                   autoFocus={layer.type === "var"}
                   value={intermediateValue?.value ?? propertyValue ?? ""}
                   onChange={handleChange}
-                  onBlur={handleComplete}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      handleComplete();
-                      event.preventDefault();
-                    }
-                  }}
+                  onChangeComplete={handleComplete}
                 />
               }
             />

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -387,7 +387,7 @@ export const ShadowContent = ({
             css={{
               padding: theme.panel.padding,
               gap: theme.spacing[3],
-              minWidth: theme.sizes.sidebarWidth,
+              minWidth: theme.spacing[30],
             }}
           >
             <Label>

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -35,7 +35,11 @@ import type { IntermediateStyleValue } from "../shared/css-value-input";
 import { CssValueInputContainer } from "../shared/css-value-input";
 import { toPascalCase } from "../shared/keyword-utils";
 import type { StyleUpdateOptions } from "../shared/use-style-data";
-import { CssFragmentEditor, parseCssFragment } from "./css-fragment";
+import {
+  CssFragmentEditor,
+  CssFragmentEditorContent,
+  parseCssFragment,
+} from "./css-fragment";
 import { PropertyInlineLabel } from "../property-label";
 import { styleConfigByName } from "./configs";
 import { ColorPicker } from "./color-picker";
@@ -407,17 +411,21 @@ export const ShadowContent = ({
               </Flex>
             </Label>
             <CssFragmentEditor
-              invalid={intermediateValue?.type === "invalid"}
-              autoFocus={layer.type === "var"}
-              value={intermediateValue?.value ?? propertyValue ?? ""}
-              onChange={handleChange}
-              onBlur={handleComplete}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  handleComplete();
-                  event.preventDefault();
-                }
-              }}
+              content={
+                <CssFragmentEditorContent
+                  invalid={intermediateValue?.type === "invalid"}
+                  autoFocus={layer.type === "var"}
+                  value={intermediateValue?.value ?? propertyValue ?? ""}
+                  onChange={handleChange}
+                  onBlur={handleComplete}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      handleComplete();
+                      event.preventDefault();
+                    }
+                  }}
+                />
+              }
             />
           </Flex>
         </>

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -119,7 +119,7 @@ export const Topbar = ({ project, hasProPlan, css, loading }: TopbarProps) => {
             isolation: "isolate",
             justifyContent: "flex-end",
             gap: theme.spacing[5],
-            width: theme.sizes.sidebarWidth,
+            width: theme.spacing[30],
           }}
         >
           <ViewMode />

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -196,7 +196,7 @@ const BindingPanel = ({
             updateExpression(value);
             setTouched(false);
           }}
-          onBlur={() => {
+          onChangeComplete={() => {
             onSave(expression, errorsCount > 0);
             setTouched(true);
           }}

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -111,7 +111,7 @@ const BindingPanel = ({
       css={{
         display: "flex",
         flexDirection: "column",
-        width: theme.sizes.sidebarWidth,
+        width: theme.spacing[30],
       }}
     >
       <Box css={{ paddingBottom: theme.spacing[5] }}>

--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -416,29 +416,3 @@ export const EditorDialog = ({
     </Dialog>
   );
 };
-
-export const CodeEditorBase = ({
-  title,
-  open,
-  content,
-  onOpenChange,
-}: {
-  title?: ReactNode;
-  open?: boolean;
-  content: ReactNode;
-  onOpenChange?: (newOpen: boolean) => void;
-}) => {
-  return (
-    <EditorDialogControl>
-      {content}
-      <EditorDialog
-        open={open}
-        onOpenChange={onOpenChange}
-        title={title}
-        content={content}
-      >
-        <EditorDialogButton />
-      </EditorDialog>
-    </EditorDialogControl>
-  );
-};

--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -42,6 +42,8 @@ import {
   Flex,
   rawTheme,
   globalCss,
+  Kbd,
+  Text,
 } from "@webstudio-is/design-system";
 import { CrossIcon, MaximizeIcon, MinimizeIcon } from "@webstudio-is/icons";
 import { solarizedLight } from "./code-highlight";
@@ -56,6 +58,8 @@ const ExternalChange = Annotation.define<boolean>();
 
 const minHeightVar = "--ws-code-editor-min-height";
 const maxHeightVar = "--ws-code-editor-max-height";
+const maximizeIconVisibilityVar = "--ws-code-editor-maximize-icon-visibility";
+const keyboardShortcutDisplayVar = "--ws-code-editor-keyboard-shortcut-display";
 
 export const getMinMaxHeightVars = ({
   minHeight,
@@ -78,6 +82,7 @@ const editorContentStyle = css({
   ...textVariants.mono,
   // fit editor into parent if stretched
   display: "flex",
+  position: "relative",
   minHeight: 0,
   boxSizing: "border-box",
   color: theme.colors.foregroundMain,
@@ -90,6 +95,9 @@ const editorContentStyle = css({
   paddingLeft: theme.spacing[3],
   // required to support copying selected text
   userSelect: "text",
+  "&:hover": {
+    [keyboardShortcutDisplayVar]: "flex",
+  },
   "&:focus-within": {
     borderColor: theme.colors.borderFocus,
   },
@@ -123,6 +131,18 @@ const editorContentStyle = css({
     textDecoration: "underline wavy red",
     backgroundColor: "rgba(255, 0, 0, 0.1)",
   },
+});
+
+const shortcutStyle = css({
+  position: "absolute",
+  left: 0,
+  bottom: 0,
+  width: "100%",
+  paddingInline: theme.spacing[3],
+  display: `var(${keyboardShortcutDisplayVar}, none)`,
+  background: "oklch(100% 0 0 / 50%)",
+  zIndex: 1,
+  pointerEvents: "none",
 });
 
 const autocompletionTooltipTheme = EditorView.theme({
@@ -337,14 +357,19 @@ export const EditorContent = ({
       className={editorContentStyle()}
       data-invalid={invalid}
       ref={editorRef}
-    />
+    >
+      <Flex justify="end" gap="1" className={shortcutStyle()}>
+        <Text variant="labelsSentenceCase">Save</Text>
+        <Kbd value={["cmd", "enter"]} />
+      </Flex>
+    </div>
   );
 };
 
 const editorDialogControlStyle = css({
   position: "relative",
   "&:hover": {
-    "--ws-code-editor-maximize-icon-visibility": "visible",
+    [maximizeIconVisibilityVar]: "visible",
   },
 });
 
@@ -363,9 +388,10 @@ export const EditorDialogButton = forwardRef<
       icon={<MaximizeIcon />}
       css={{
         position: "absolute",
-        top: 6,
+        top: 4,
         right: 4,
-        visibility: `var(--ws-code-editor-maximize-icon-visibility, hidden)`,
+        visibility: `var(${maximizeIconVisibilityVar}, hidden)`,
+        background: "oklch(100% 0 0 / 50%)",
       }}
     />
   );

--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -172,6 +172,7 @@ const autocompletionTooltipTheme = EditorView.theme({
 
 export type EditorApi = {
   replaceSelection: (string: string) => void;
+  focus: () => void;
 };
 
 type EditorContentProps = {
@@ -216,7 +217,9 @@ export const EditorContent = ({
       parent: editorRef.current,
     });
     if (autoFocus) {
-      view.focus();
+      requestAnimationFrame(() => {
+        view.focus();
+      });
     }
     viewRef.current = view;
     return () => {
@@ -300,6 +303,9 @@ export const EditorContent = ({
       }
       view.dispatch(view.state.replaceSelection(string));
       view.focus();
+    },
+    focus() {
+      viewRef.current?.focus();
     },
   }));
 

--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -59,7 +59,6 @@ const ExternalChange = Annotation.define<boolean>();
 const minHeightVar = "--ws-code-editor-min-height";
 const maxHeightVar = "--ws-code-editor-max-height";
 const maximizeIconVisibilityVar = "--ws-code-editor-maximize-icon-visibility";
-const keyboardShortcutDisplayVar = "--ws-code-editor-keyboard-shortcut-display";
 
 export const getMinMaxHeightVars = ({
   minHeight,
@@ -89,15 +88,12 @@ const editorContentStyle = css({
   borderRadius: theme.borderRadius[4],
   border: `1px solid ${theme.colors.borderMain}`,
   background: theme.colors.backgroundControls,
-  paddingTop: 6,
-  paddingBottom: 4,
+  paddingTop: 4,
+  paddingBottom: 2,
   paddingRight: theme.spacing[2],
   paddingLeft: theme.spacing[3],
   // required to support copying selected text
   userSelect: "text",
-  "&:hover": {
-    [keyboardShortcutDisplayVar]: "flex",
-  },
   "&:focus-within": {
     borderColor: theme.colors.borderFocus,
   },
@@ -139,7 +135,6 @@ const shortcutStyle = css({
   bottom: 0,
   width: "100%",
   paddingInline: theme.spacing[3],
-  display: `var(${keyboardShortcutDisplayVar}, none)`,
   background: "oklch(100% 0 0 / 50%)",
   zIndex: 1,
   pointerEvents: "none",
@@ -210,6 +205,7 @@ type EditorContentProps = {
   readOnly?: boolean;
   autoFocus?: boolean;
   invalid?: boolean;
+  showShortcuts?: boolean;
   value: string;
   onChange: (value: string) => void;
   onChangeComplete: (value: string) => void;
@@ -221,6 +217,7 @@ export const EditorContent = ({
   readOnly = false,
   autoFocus = false,
   invalid = false,
+  showShortcuts = false,
   value,
   onChange,
   onChangeComplete,
@@ -358,10 +355,12 @@ export const EditorContent = ({
       data-invalid={invalid}
       ref={editorRef}
     >
-      <Flex justify="end" gap="1" className={shortcutStyle()}>
-        <Text variant="labelsSentenceCase">Save</Text>
-        <Kbd value={["cmd", "enter"]} />
-      </Flex>
+      {showShortcuts && (
+        <Flex align="center" justify="end" gap="1" className={shortcutStyle()}>
+          <Text variant="small">Submit</Text>
+          <Kbd value={["cmd", "enter"]} />
+        </Flex>
+      )}
     </div>
   );
 };
@@ -404,12 +403,20 @@ export const EditorDialog = ({
   title,
   content,
   children,
+  width = 640,
+  height = 480,
+  x,
+  y,
 }: {
   open?: boolean;
   onOpenChange?: (newOpen: boolean) => void;
   title?: ReactNode;
   content: ReactNode;
   children: ReactNode;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
 }) => {
   const [isMaximized, setIsMaximized] = useState(false);
   return (
@@ -417,8 +424,10 @@ export const EditorDialog = ({
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
         resize="auto"
-        width={640}
-        height={480}
+        width={width}
+        height={height}
+        x={x}
+        y={y}
         minHeight={240}
         isMaximized={isMaximized}
         onInteractOutside={(event) => {

--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -182,7 +182,8 @@ type EditorContentProps = {
   autoFocus?: boolean;
   invalid?: boolean;
   value: string;
-  onChange: (newValue: string) => void;
+  onChange: (value: string) => void;
+  onChangeComplete: (value: string) => void;
   onBlur?: (event: FocusEvent) => void;
 };
 
@@ -195,6 +196,7 @@ export const EditorContent = ({
   value,
   onChange,
   onBlur,
+  onChangeComplete,
 }: EditorContentProps) => {
   globalStyles();
 
@@ -203,6 +205,8 @@ export const EditorContent = ({
 
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+  const onChangeCompleteRef = useRef(onChangeComplete);
+  onChangeCompleteRef.current = onChangeComplete;
   const onBlurRef = useRef(onBlur);
   onBlurRef.current = onBlur;
 
@@ -266,11 +270,18 @@ export const EditorContent = ({
         EditorView.domEventHandlers({
           blur(event) {
             onBlurRef.current?.(event);
+            onChangeCompleteRef.current(view.state.doc.toString());
           },
           cut(event) {
             // prevent catching cut by global copy paste
             // with target outside of contenteditable
             event.stopPropagation();
+          },
+          keydown(event) {
+            if (event.key === "s" && (event.ctrlKey || event.metaKey)) {
+              event.preventDefault();
+              onChangeCompleteRef.current(view.state.doc.toString());
+            }
           },
         }),
       ]),

--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -420,14 +420,14 @@ export const EditorDialog = ({
 export const CodeEditorBase = ({
   title,
   open,
+  content,
   onOpenChange,
-  ...editorContentProps
-}: EditorContentProps & {
+}: {
   title?: ReactNode;
   open?: boolean;
+  content: ReactNode;
   onOpenChange?: (newOpen: boolean) => void;
 }) => {
-  const content = <EditorContent {...editorContentProps} />;
   return (
     <EditorDialogControl>
       {content}

--- a/apps/builder/app/builder/shared/code-editor.stories.tsx
+++ b/apps/builder/app/builder/shared/code-editor.stories.tsx
@@ -18,10 +18,23 @@ const initialHtml = `
 
 export const BaseEditor = () => {
   const [value, setValue] = useState(initialHtml);
-  return <CodeEditorComponent value={value} onChange={setValue} />;
+  return (
+    <CodeEditorComponent
+      value={value}
+      onChange={setValue}
+      onChangeComplete={setValue}
+    />
+  );
 };
 
 export const HtmlEditor = () => {
   const [value, setValue] = useState(initialHtml);
-  return <CodeEditorComponent value={value} onChange={setValue} lang="html" />;
+  return (
+    <CodeEditorComponent
+      value={value}
+      onChange={setValue}
+      onChangeComplete={setValue}
+      lang="html"
+    />
+  );
 };

--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, useMemo, type ComponentProps, useEffect } from "react";
+import {
+  forwardRef,
+  useMemo,
+  type ComponentProps,
+  useEffect,
+  type ReactNode,
+} from "react";
 import { styleTags, tags } from "@lezer/highlight";
 import {
   keymap,
@@ -17,8 +23,10 @@ import { html } from "@codemirror/lang-html";
 import { markdown } from "@codemirror/lang-markdown";
 import { css } from "@webstudio-is/design-system";
 import {
-  CodeEditorBase,
   EditorContent,
+  EditorDialog,
+  EditorDialogButton,
+  EditorDialogControl,
   getMinMaxHeightVars,
 } from "./code-editor-base";
 
@@ -73,11 +81,11 @@ const getMarkdownExtensions = () => [
 
 export const CodeEditor = forwardRef<
   HTMLDivElement,
-  Omit<ComponentProps<typeof CodeEditorBase>, "content"> &
-    Omit<ComponentProps<typeof EditorContent>, "extensions"> & {
-      lang?: "html" | "markdown";
-    }
->(({ lang, ...props }, ref) => {
+  Omit<ComponentProps<typeof EditorContent>, "extensions"> & {
+    lang?: "html" | "markdown";
+    title?: ReactNode;
+  }
+>(({ lang, title, ...editorContentProps }, ref) => {
   const extensions = useMemo(() => {
     if (lang === "html") {
       return getHtmlExtensions();
@@ -105,12 +113,17 @@ export const CodeEditor = forwardRef<
       document.removeEventListener("pointerdown", handlePointerDown, options);
     };
   }, []);
-
+  const content = (
+    <EditorContent {...editorContentProps} extensions={extensions} />
+  );
   return (
     <div className={wrapperStyle()} ref={ref}>
-      <CodeEditorBase
-        content={<EditorContent {...props} extensions={extensions} />}
-      />
+      <EditorDialogControl>
+        {content}
+        <EditorDialog title={title} content={content}>
+          <EditorDialogButton />
+        </EditorDialog>
+      </EditorDialogControl>
     </div>
   );
 });

--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -16,7 +16,11 @@ import {
 import { html } from "@codemirror/lang-html";
 import { markdown } from "@codemirror/lang-markdown";
 import { css } from "@webstudio-is/design-system";
-import { CodeEditorBase, getMinMaxHeightVars } from "./code-editor-base";
+import {
+  CodeEditorBase,
+  EditorContent,
+  getMinMaxHeightVars,
+} from "./code-editor-base";
 
 const wrapperStyle = css({
   position: "relative",
@@ -69,9 +73,10 @@ const getMarkdownExtensions = () => [
 
 export const CodeEditor = forwardRef<
   HTMLDivElement,
-  Omit<ComponentProps<typeof CodeEditorBase>, "extensions"> & {
-    lang?: "html" | "markdown";
-  }
+  Omit<ComponentProps<typeof CodeEditorBase>, "content"> &
+    Omit<ComponentProps<typeof EditorContent>, "extensions"> & {
+      lang?: "html" | "markdown";
+    }
 >(({ lang, ...props }, ref) => {
   const extensions = useMemo(() => {
     if (lang === "html") {
@@ -103,7 +108,9 @@ export const CodeEditor = forwardRef<
 
   return (
     <div className={wrapperStyle()} ref={ref}>
-      <CodeEditorBase {...props} extensions={extensions} />
+      <CodeEditorBase
+        content={<EditorContent {...props} extensions={extensions} />}
+      />
     </div>
   );
 });

--- a/apps/builder/app/builder/shared/expression-editor.stories.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.stories.tsx
@@ -46,6 +46,7 @@ const ExpressionStory = () => {
       aliases={aliases}
       value={value}
       onChange={setValue}
+      onChangeComplete={setValue}
     />
   );
 };

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -431,7 +431,7 @@ export const ExpressionEditor = ({
   readOnly = false,
   value,
   onChange,
-  onBlur,
+  onChangeComplete,
 }: {
   editorApiRef?: RefObject<undefined | EditorApi>;
   /**
@@ -446,8 +446,8 @@ export const ExpressionEditor = ({
   autoFocus?: boolean;
   readOnly?: boolean;
   value: string;
-  onChange: (newValue: string) => void;
-  onBlur?: () => void;
+  onChange: (value: string) => void;
+  onChangeComplete: (value: string) => void;
 }) => {
   const extensions = useMemo(
     () => [
@@ -498,7 +498,7 @@ export const ExpressionEditor = ({
       autoFocus={autoFocus}
       value={value}
       onChange={onChange}
-      onBlur={onBlur}
+      onChangeComplete={onChangeComplete}
     />
   );
 
@@ -525,6 +525,7 @@ const ValuePreviewEditor = ({ value }: { value: unknown }) => {
       extensions={extensions}
       value={JSON.stringify(value, null, 2)}
       onChange={() => {}}
+      onChangeComplete={() => {}}
     />
   );
 };

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -491,14 +491,18 @@ export const ExpressionEditor = ({
   return (
     <div className={wrapperStyle.toString()}>
       <CodeEditorBase
-        editorApiRef={editorApiRef}
-        extensions={extensions}
-        invalid={color === "error"}
-        readOnly={readOnly}
-        autoFocus={autoFocus}
-        value={value}
-        onChange={onChange}
-        onBlur={onBlur}
+        content={
+          <EditorContent
+            editorApiRef={editorApiRef}
+            extensions={extensions}
+            invalid={color === "error"}
+            readOnly={readOnly}
+            autoFocus={autoFocus}
+            value={value}
+            onChange={onChange}
+            onBlur={onBlur}
+          />
+        }
       />
     </div>
   );

--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -35,9 +35,10 @@ import {
 } from "@webstudio-is/sdk";
 import { mapGroupBy } from "~/shared/shim";
 import {
-  CodeEditorBase,
   EditorContent,
   EditorDialog,
+  EditorDialogButton,
+  EditorDialogControl,
   type EditorApi,
 } from "./code-editor-base";
 
@@ -488,22 +489,27 @@ export const ExpressionEditor = ({
     };
   }, []);
 
+  const content = (
+    <EditorContent
+      editorApiRef={editorApiRef}
+      extensions={extensions}
+      invalid={color === "error"}
+      readOnly={readOnly}
+      autoFocus={autoFocus}
+      value={value}
+      onChange={onChange}
+      onBlur={onBlur}
+    />
+  );
+
   return (
     <div className={wrapperStyle.toString()}>
-      <CodeEditorBase
-        content={
-          <EditorContent
-            editorApiRef={editorApiRef}
-            extensions={extensions}
-            invalid={color === "error"}
-            readOnly={readOnly}
-            autoFocus={autoFocus}
-            value={value}
-            onChange={onChange}
-            onBlur={onBlur}
-          />
-        }
-      />
+      <EditorDialogControl>
+        {content}
+        <EditorDialog content={content}>
+          <EditorDialogButton />
+        </EditorDialog>
+      </EditorDialogControl>
     </div>
   );
 };

--- a/apps/builder/app/builder/shared/floating-panel.tsx
+++ b/apps/builder/app/builder/shared/floating-panel.tsx
@@ -89,7 +89,7 @@ type FloatingPanelProps = {
 };
 
 const contentStyle = css({
-  width: theme.spacing[30],
+  width: theme.sizes.sidebarWidth,
 });
 
 export const FloatingPanel = ({

--- a/apps/builder/app/builder/shared/floating-panel.tsx
+++ b/apps/builder/app/builder/shared/floating-panel.tsx
@@ -89,7 +89,7 @@ type FloatingPanelProps = {
 };
 
 const contentStyle = css({
-  width: theme.sizes.sidebarWidth,
+  width: theme.spacing[30],
 });
 
 export const FloatingPanel = ({

--- a/apps/builder/app/builder/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/sidebar-left/sidebar-left.tsx
@@ -278,7 +278,7 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
           }
         }}
         css={{
-          width: theme.sizes.sidebarWidth,
+          width: theme.spacing[30],
           // We need the node to be rendered but hidden
           // to keep receiving the drag events.
           visibility:

--- a/packages/design-system/src/components/button.tsx
+++ b/packages/design-system/src/components/button.tsx
@@ -116,7 +116,7 @@ export const buttonStyle = css({
   alignItems: "center",
   justifyContent: "center",
   gap: theme.spacing[2],
-  padding: `0 ${theme.spacing[4]}`,
+  padding: `0 ${theme.spacing[3]}`,
   height: theme.spacing[11],
   borderRadius: theme.borderRadius[4],
   whiteSpace: "nowrap",

--- a/packages/design-system/src/components/card.tsx
+++ b/packages/design-system/src/components/card.tsx
@@ -35,7 +35,7 @@ export const Card = styled("div", {
   variants: {
     size: {
       1: {
-        width: theme.sizes.sidebarWidth,
+        width: theme.spacing[30],
         padding: theme.spacing[11],
       },
     },

--- a/packages/design-system/src/components/css-value-list-item.stories.tsx
+++ b/packages/design-system/src/components/css-value-list-item.stories.tsx
@@ -41,7 +41,7 @@ const Thumbnail = styled("div", {
 });
 
 const Panel = styled("div", {
-  width: theme.sizes.sidebarWidth,
+  width: theme.spacing[30],
 });
 
 const ListItem = (props: {

--- a/packages/design-system/src/components/dialog.tsx
+++ b/packages/design-system/src/components/dialog.tsx
@@ -34,9 +34,9 @@ if (placeholderImage) {
     "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==";
 }
 
-type Position = { x: number; y: number };
+type Point = { x: number; y: number };
 type Size = { width: number; height: number };
-export type Rect = Position & Size;
+type Rect = Point & Size;
 
 type UseDraggableProps = {
   isMaximized?: boolean;
@@ -56,7 +56,7 @@ const useDraggable = ({
   const initialDataRef = useRef<
     | undefined
     | {
-        point: Position;
+        point: Point;
         rect: Rect;
       }
   >(undefined);

--- a/packages/design-system/src/components/dialog.tsx
+++ b/packages/design-system/src/components/dialog.tsx
@@ -250,7 +250,7 @@ const centeredContent: CSSProperties = {
 const contentStyle = css(floatingPanelStyle, {
   position: "fixed",
   width: "min-content",
-  minWidth: theme.sizes.sidebarWidth,
+  minWidth: theme.spacing[30],
   maxWidth: "calc(100vw - 40px)",
   maxHeight: "calc(100vh - 40px)",
   userSelect: "none",

--- a/packages/design-system/src/components/dialog.tsx
+++ b/packages/design-system/src/components/dialog.tsx
@@ -125,13 +125,15 @@ const useDraggable = ({
   if (minHeight !== undefined) {
     style.minHeight = minHeight;
   }
-  if (x !== undefined) {
-    style.left = x;
-    delete style.transform;
-  }
-  if (y !== undefined) {
-    style.top = y;
-    delete style.transform;
+  if (isMaximized === false) {
+    if (x !== undefined) {
+      style.left = x;
+      delete style.transform;
+    }
+    if (y !== undefined) {
+      style.top = y;
+      delete style.transform;
+    }
   }
   return {
     onDragStart: handleDragStart,

--- a/packages/design-system/src/components/dialog.tsx
+++ b/packages/design-system/src/components/dialog.tsx
@@ -7,7 +7,7 @@ import {
   type DragEventHandler,
 } from "react";
 import * as Primitive from "@radix-ui/react-dialog";
-import { css, theme, keyframes, type CSS } from "../stitches.config";
+import { css, theme, type CSS } from "../stitches.config";
 import { PanelTitle } from "./panel-title";
 import { floatingPanelStyle, CloseButton, TitleSlot } from "./floating-panel";
 import { Flex } from "./flex";
@@ -34,16 +34,20 @@ if (placeholderImage) {
     "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==";
 }
 
+type Position = { x: number; y: number };
+type Size = { width: number; height: number };
+export type Rect = Position & Size;
+
 type UseDraggableProps = {
   isMaximized?: boolean;
-  width?: number;
-  height?: number;
   minWidth?: number;
   minHeight?: number;
-};
+} & Partial<Rect>;
 
 const useDraggable = ({
   isMaximized = false,
+  x,
+  y,
   width,
   height,
   minHeight,
@@ -52,8 +56,8 @@ const useDraggable = ({
   const initialDataRef = useRef<
     | undefined
     | {
-        point: { x: number; y: number };
-        rect: DOMRect;
+        point: Position;
+        rect: Rect;
       }
   >(undefined);
   const { enableCanvasPointerEvents, disableCanvasPointerEvents } =
@@ -69,9 +73,10 @@ const useDraggable = ({
     if (placeholderImage) {
       event.dataTransfer.setDragImage(placeholderImage, 0, 0);
     }
+
     const rect = target.getBoundingClientRect();
-    target.style.left = `${rect.left}px`;
-    target.style.top = `${rect.top}px`;
+    target.style.left = `${rect.x}px`;
+    target.style.top = `${rect.y}px`;
     target.style.transform = "none";
     initialDataRef.current = {
       point: { x: event.pageX, y: event.pageY },
@@ -109,6 +114,7 @@ const useDraggable = ({
         height: "100vh",
       }
     : {
+        ...centeredContent,
         width,
         height,
       };
@@ -119,7 +125,14 @@ const useDraggable = ({
   if (minHeight !== undefined) {
     style.minHeight = minHeight;
   }
-
+  if (x !== undefined) {
+    style.left = x;
+    delete style.transform;
+  }
+  if (y !== undefined) {
+    style.top = y;
+    delete style.transform;
+  }
   return {
     onDragStart: handleDragStart,
     onDrag: handleDrag,
@@ -139,6 +152,8 @@ export const DialogContent = forwardRef(
       isMaximized,
       width,
       height,
+      x,
+      y,
       minWidth,
       minHeight,
       ...props
@@ -152,10 +167,13 @@ export const DialogContent = forwardRef(
     const { draggableRef, ...draggableProps } = useDraggable({
       width,
       height,
+      x,
+      y,
       minWidth,
       minHeight,
       isMaximized,
     });
+
     return (
       <Primitive.Portal>
         <Primitive.Overlay className={overlayStyle()} />
@@ -215,21 +233,10 @@ export const DialogActions = ({ children }: { children: ReactNode }) => {
 
 // Styles specific to dialog
 // (as opposed to be common for all floating panels)
-
-const overlayShow = keyframes({
-  from: { opacity: 0 },
-  to: { opacity: 1 },
-});
 const overlayStyle = css({
   backgroundColor: "rgba(17, 24, 28, 0.66)",
   position: "fixed",
   inset: 0,
-  animation: `${overlayShow} 150ms ${theme.easing.easeOut}`,
-});
-
-const contentShow = keyframes({
-  from: { opacity: 0, transform: "translate(-50%, -48%) scale(0.96)" },
-  to: { opacity: 1, transform: "translate(-50%, -50%) scale(1)" },
 });
 
 const centeredContent: CSSProperties = {
@@ -239,14 +246,12 @@ const centeredContent: CSSProperties = {
 };
 
 const contentStyle = css(floatingPanelStyle, {
-  ...centeredContent,
   position: "fixed",
   width: "min-content",
   minWidth: theme.sizes.sidebarWidth,
   maxWidth: "calc(100vw - 40px)",
   maxHeight: "calc(100vh - 40px)",
   userSelect: "none",
-  animation: `${contentShow} 150ms ${theme.easing.easeOut}`,
 
   overflow: "hidden",
   variants: {

--- a/packages/design-system/src/components/dialog.tsx
+++ b/packages/design-system/src/components/dialog.tsx
@@ -250,7 +250,7 @@ const centeredContent: CSSProperties = {
 const contentStyle = css(floatingPanelStyle, {
   position: "fixed",
   width: "min-content",
-  minWidth: theme.spacing[30],
+  minWidth: theme.sizes.sidebarWidth,
   maxWidth: "calc(100vw - 40px)",
   maxHeight: "calc(100vh - 40px)",
   userSelect: "none",

--- a/packages/design-system/src/components/nested-input-button.tsx
+++ b/packages/design-system/src/components/nested-input-button.tsx
@@ -45,7 +45,7 @@ const style = css({
     hasChildren: {
       true: {
         "&:where(:has(svg))": {
-          width: theme.spacing[11],
+          paddingInline: theme.spacing[2],
         },
       },
     },

--- a/packages/design-system/src/stitches.config.ts
+++ b/packages/design-system/src/stitches.config.ts
@@ -56,7 +56,9 @@ const { styled, css, getCssText, globalCss, keyframes, config, reset } =
         1: "0.4",
       },
       spacing,
-
+      sizes: {
+        sidebarWidth: spacing[30],
+      },
       /**
        * Use instead: textVariants / textStyles / <Text />
        */

--- a/packages/design-system/src/stitches.config.ts
+++ b/packages/design-system/src/stitches.config.ts
@@ -56,9 +56,7 @@ const { styled, css, getCssText, globalCss, keyframes, config, reset } =
         1: "0.4",
       },
       spacing,
-      sizes: {
-        sidebarWidth: spacing[30],
-      },
+
       /**
        * Use instead: textVariants / textStyles / <Text />
        */


### PR DESCRIPTION
## Description

When the value is not a simple keyword or unit, we now show a maximize button in the css value input and that lets you edit comfortably a long value.

When dialog gets closed, value gets applied.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
