### PR TITLE
fix: Code Mirror autocomplete click closes popovers and dialogs

### DIFF
--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -205,6 +205,25 @@ export const EditorContent = ({
   const onBlurRef = useRef(onBlur);
   onBlurRef.current = onBlur;
 
+  useEffect(() => {
+    document.addEventListener(
+      // https://github.com/radix-ui/primitives/blob/dac4fd8ab0c1974020e316c865db258ab10d2279/packages/react/dismissable-layer/src/DismissableLayer.tsx#L14
+      "dismissableLayer.pointerDownOutside",
+      (event) => {
+        if (
+          event.target instanceof Element &&
+          // Prevent radix dialogs and popups from closing when clicking on the editor's autocomplete items
+          event.target.closest(".cm-tooltip.cm-tooltip-autocomplete")
+        ) {
+          event.preventDefault();
+        }
+      },
+      {
+        capture: true,
+      }
+    );
+  }, []);
+
   // setup editor
 
   useEffect(() => {

--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -206,6 +206,8 @@ export const EditorContent = ({
   onBlurRef.current = onBlur;
 
   useEffect(() => {
+    const abortController = new AbortController();
+
     document.addEventListener(
       // https://github.com/radix-ui/primitives/blob/dac4fd8ab0c1974020e316c865db258ab10d2279/packages/react/dismissable-layer/src/DismissableLayer.tsx#L14
       "dismissableLayer.pointerDownOutside",
@@ -220,8 +222,12 @@ export const EditorContent = ({
       },
       {
         capture: true,
+        signal: abortController.signal,
       }
     );
+    return () => {
+      abortController.abort();
+    };
   }, []);
 
   // setup editor


### PR DESCRIPTION
## Description

closes #4573

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
