### PR TITLE
fix: multiple property reset when using shortcuts on toggle groups

### DIFF
--- a/apps/builder/app/builder/features/style-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/style-panel/property-label.tsx
@@ -263,6 +263,10 @@ export const PropertyLabel = ({
           onClick: (event) => {
             if (event.altKey) {
               event.preventDefault();
+              // If not, when mixed with ToogleGroupControl.
+              // The will trigger the reset of the toggle group.
+              // And resets all of the properties in the toggle group.
+              event.stopPropagation();
               resetProperty();
               return;
             }


### PR DESCRIPTION
## Description

fixes #4411 
When `PropertyLabel` is used inside `ToggleGroupControl` if we don't stop after handling the reset. The event keeps bubbling up and effect the reset shortcut handler of `ToggleGroupControl` and ends up resetting the whole group.

## Steps for reproduction

- Add a `div` and make the parent's display as `flex`
- And now add some values for `sizing` under the `flex-child`. 
- Click on advanced option, and use `Alt + click` on any of the property label.

More details about reproducing are here #4411 

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")
