### PR TITLE
chore: Use sidebarWidth variable everywhere

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -157,7 +157,7 @@ const getChromeLayout = ({
 
   if (navigatorLayout === "undocked" && activeSidebarPanel !== "none") {
     return {
-      gridTemplateColumns: `auto ${theme.spacing[30]} 1fr ${theme.spacing[30]}`,
+      gridTemplateColumns: `auto ${theme.sizes.sidebarWidth} 1fr ${theme.sizes.sidebarWidth}`,
       gridTemplateAreas: `
             "header header header header"
             "sidebar navigator main inspector"
@@ -167,7 +167,7 @@ const getChromeLayout = ({
   }
 
   return {
-    gridTemplateColumns: `auto 1fr ${theme.spacing[30]}`,
+    gridTemplateColumns: `auto 1fr ${theme.sizes.sidebarWidth}`,
     gridTemplateAreas: `
           "header header header"
           "sidebar main inspector"

--- a/apps/builder/app/builder/features/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings.tsx
@@ -677,7 +677,7 @@ const MarketplaceSection = ({
             justifySelf: "start",
           }}
         >
-          <Grid gap={1} css={{ width: theme.spacing[30] }}>
+          <Grid gap={1} css={{ width: theme.sizes.sidebarWidth }}>
             {category && <Label text="title">{category}</Label>}
             <Card
               title={values.name}

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -667,7 +667,7 @@ export const VariablePopoverTrigger = forwardRef<
             // flex fixes content overflowing artificial scroll area
             display: "flex",
             flexDirection: "column",
-            width: theme.spacing[30],
+            width: theme.sizes.sidebarWidth,
           }}
         >
           <Flex

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
@@ -52,7 +52,7 @@ $awareness.set({
 });
 
 const Panel = styled("div", {
-  width: theme.spacing[30],
+  width: theme.sizes.sidebarWidth,
 });
 
 export const Backgrounds = () => {

--- a/apps/builder/app/builder/features/style-panel/sections/borders/borders.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/borders.stories.tsx
@@ -2,7 +2,7 @@ import { styled, theme } from "@webstudio-is/design-system";
 import { Section } from "./borders";
 
 const Panel = styled("div", {
-  width: theme.spacing[30],
+  width: theme.sizes.sidebarWidth,
   boxSizing: "border-box",
 });
 

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
@@ -231,7 +231,7 @@ export const TransitionContent = ({ index }: { index: number }) => {
         css={{
           padding: theme.panel.padding,
           gap: theme.spacing[3],
-          minWidth: theme.spacing[30],
+          minWidth: theme.sizes.sidebarWidth,
         }}
       >
         <Label>

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.stories.tsx
@@ -12,7 +12,7 @@ import { Section } from "./transitions";
 import { $awareness } from "~/shared/awareness";
 
 const Panel = styled("div", {
-  width: theme.spacing[30],
+  width: theme.sizes.sidebarWidth,
   boxShadow: theme.shadows.panelSectionDropShadow,
 });
 

--- a/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
@@ -283,7 +283,7 @@ const TypographySectionAdvancedPopover = () => {
           css={{
             padding: theme.panel.padding,
             gap: theme.spacing[9],
-            width: theme.spacing[30],
+            width: theme.sizes.sidebarWidth,
           }}
         >
           <Grid css={{ gridTemplateColumns: "5fr 5fr" }} gap={2}>

--- a/apps/builder/app/builder/features/style-panel/shared/filter-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/filter-content.tsx
@@ -240,7 +240,7 @@ export const FilterSectionContent = ({
         css={{
           padding: theme.panel.padding,
           gap: theme.spacing[3],
-          minWidth: theme.spacing[30],
+          minWidth: theme.sizes.sidebarWidth,
         }}
       >
         <Label>

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -383,7 +383,7 @@ export const ShadowContent = ({
             css={{
               padding: theme.panel.padding,
               gap: theme.spacing[3],
-              minWidth: theme.spacing[30],
+              minWidth: theme.sizes.sidebarWidth,
             }}
           >
             <Label>

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -119,7 +119,7 @@ export const Topbar = ({ project, hasProPlan, css, loading }: TopbarProps) => {
             isolation: "isolate",
             justifyContent: "flex-end",
             gap: theme.spacing[5],
-            width: theme.spacing[30],
+            width: theme.sizes.sidebarWidth,
           }}
         >
           <ViewMode />

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -111,7 +111,7 @@ const BindingPanel = ({
       css={{
         display: "flex",
         flexDirection: "column",
-        width: theme.spacing[30],
+        width: theme.sizes.sidebarWidth,
       }}
     >
       <Box css={{ paddingBottom: theme.spacing[5] }}>

--- a/apps/builder/app/builder/shared/floating-panel.tsx
+++ b/apps/builder/app/builder/shared/floating-panel.tsx
@@ -89,7 +89,7 @@ type FloatingPanelProps = {
 };
 
 const contentStyle = css({
-  width: theme.spacing[30],
+  width: theme.sizes.sidebarWidth,
 });
 
 export const FloatingPanel = ({

--- a/apps/builder/app/builder/sidebar-left/sidebar-left.tsx
+++ b/apps/builder/app/builder/sidebar-left/sidebar-left.tsx
@@ -278,7 +278,7 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
           }
         }}
         css={{
-          width: theme.spacing[30],
+          width: theme.sizes.sidebarWidth,
           // We need the node to be rendered but hidden
           // to keep receiving the drag events.
           visibility:

--- a/packages/design-system/src/components/card.tsx
+++ b/packages/design-system/src/components/card.tsx
@@ -35,7 +35,7 @@ export const Card = styled("div", {
   variants: {
     size: {
       1: {
-        width: theme.spacing[30],
+        width: theme.sizes.sidebarWidth,
         padding: theme.spacing[11],
       },
     },

--- a/packages/design-system/src/components/css-value-list-item.stories.tsx
+++ b/packages/design-system/src/components/css-value-list-item.stories.tsx
@@ -41,7 +41,7 @@ const Thumbnail = styled("div", {
 });
 
 const Panel = styled("div", {
-  width: theme.spacing[30],
+  width: theme.sizes.sidebarWidth,
 });
 
 const ListItem = (props: {

--- a/packages/design-system/src/components/dialog.tsx
+++ b/packages/design-system/src/components/dialog.tsx
@@ -242,7 +242,7 @@ const contentStyle = css(floatingPanelStyle, {
   ...centeredContent,
   position: "fixed",
   width: "min-content",
-  minWidth: theme.spacing[33],
+  minWidth: theme.sizes.sidebarWidth,
   maxWidth: "calc(100vw - 40px)",
   maxHeight: "calc(100vh - 40px)",
   userSelect: "none",

--- a/packages/design-system/src/stitches.config.ts
+++ b/packages/design-system/src/stitches.config.ts
@@ -56,7 +56,9 @@ const { styled, css, getCssText, globalCss, keyframes, config, reset } =
         1: "0.4",
       },
       spacing,
-
+      sizes: {
+        sidebarWidth: spacing[30],
+      },
       /**
        * Use instead: textVariants / textStyles / <Text />
        */


### PR DESCRIPTION
## Description

We need to make the dependency on 240px size more clear, its the sidebar width

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
