### PR TITLE
fix: Empty description space for color-inputs in the combobox

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -920,10 +920,11 @@ export const CssValueInput = ({
                   </ComboboxListboxItem>
                 ))}
               </ComboboxScrollArea>
-
-              <ComboboxItemDescription descriptions={descriptions}>
-                <Description>{description}</Description>
-              </ComboboxItemDescription>
+              {descriptions.length > 0 && (
+                <ComboboxItemDescription descriptions={descriptions}>
+                  <Description>{description}</Description>
+                </ComboboxItemDescription>
+              )}
             </ComboboxListbox>
           </ComboboxContent>
         )}


### PR DESCRIPTION
## Description

closes #4585

Do not show description panel if zero descriptions are available

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
