### PR TITLE
refactor: fallback missing pages to home page

### DIFF
--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -12,6 +12,7 @@ import {
 } from "~/shared/nano-states";
 import { builderPath } from "~/shared/router-utils";
 import { $selectedPage, selectPage } from "../awareness";
+import { findPageByIdOrPath } from "@webstudio-is/sdk";
 
 const setPageStateFromUrl = () => {
   const searchParams = new URLSearchParams(window.location.search);
@@ -19,7 +20,6 @@ const setPageStateFromUrl = () => {
   if (pages === undefined) {
     return;
   }
-  const pageId = searchParams.get("pageId") ?? pages.homePage.id;
 
   let mode = searchParams.get("mode");
 
@@ -29,6 +29,12 @@ const setPageStateFromUrl = () => {
   }
 
   setBuilderMode(mode);
+
+  // check the page actually exists
+  // to avoid confusing the user with broken state
+  const pageId =
+    findPageByIdOrPath(searchParams.get("pageId") ?? "", pages)?.id ??
+    pages.homePage.id;
 
   $selectedPageHash.set(searchParams.get("pageHash") ?? "");
   selectPage(pageId);


### PR DESCRIPTION
See https://discord.com/channels/955905230107738152/1318274135679438959/1318274135679438959

With undo current selected pages can be deleted
though we do not have a logic reverting selected page or instance.

So here is quick fix to always fallback to home page if pageId in url references missing page.