### PR TITLE
feat: Add export dialog to the menu, add shortcuts shift+P and shift+E

### DIFF
--- a/apps/builder/app/builder/features/topbar/menu/menu.tsx
+++ b/apps/builder/app/builder/features/topbar/menu/menu.tsx
@@ -18,7 +18,7 @@ import {
 import {
   $isCloneDialogOpen,
   $isShareDialogOpen,
-  $isPublishDialogOpen,
+  $publishDialog,
 } from "~/builder/shared/nano-states";
 import { cloneProjectUrl, dashboardUrl } from "~/shared/router-utils";
 import {
@@ -174,11 +174,32 @@ export const Menu = () => {
           >
             <DropdownMenuItem
               onSelect={() => {
-                $isPublishDialogOpen.set(true);
+                $publishDialog.set("publish");
               }}
               disabled={isPublishEnabled === false}
             >
               Publish
+              <DropdownMenuItemRightSlot>
+                <Kbd value={["shift", "P"]} />
+              </DropdownMenuItemRightSlot>
+            </DropdownMenuItem>
+          </Tooltip>
+
+          <Tooltip
+            side="right"
+            sideOffset={10}
+            content={disabledPublishTooltipContent}
+          >
+            <DropdownMenuItem
+              onSelect={() => {
+                $publishDialog.set("export");
+              }}
+              disabled={isPublishEnabled === false}
+            >
+              Export
+              <DropdownMenuItemRightSlot>
+                <Kbd value={["shift", "E"]} />
+              </DropdownMenuItemRightSlot>
             </DropdownMenuItem>
           </Tooltip>
 

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -35,7 +35,7 @@ import {
   RadioGroup,
 } from "@webstudio-is/design-system";
 import stripIndent from "strip-indent";
-import { $isPublishDialogOpen } from "../../shared/nano-states";
+import { $publishDialog } from "../../shared/nano-states";
 import { validateProjectDomain, type Project } from "@webstudio-is/project";
 import {
   $authTokenPermissions,
@@ -836,12 +836,8 @@ type PublishProps = {
 };
 
 export const PublishButton = ({ projectId }: PublishProps) => {
-  const isPublishDialogOpen = useStore($isPublishDialogOpen);
+  const publishDialog = useStore($publishDialog);
   const authTokenPermissions = useStore($authTokenPermissions);
-  const [dialogContentType, setDialogContentType] = useState<
-    "publish" | "export"
-  >("publish");
-
   const isPublishEnabled = authTokenPermissions.canPublish;
 
   const tooltipContent = isPublishEnabled
@@ -849,20 +845,17 @@ export const PublishButton = ({ projectId }: PublishProps) => {
     : "Only the owner, an admin, or content editors with publish permissions can publish projects";
 
   const handleExportClick = () => {
-    setDialogContentType("export");
+    $publishDialog.set("export");
   };
 
   const handleOpenChange = (isOpen: boolean) => {
-    if (isOpen === false) {
-      setDialogContentType("publish");
-    }
-    $isPublishDialogOpen.set(isOpen);
+    $publishDialog.set(isOpen ? "publish" : "none");
   };
 
   return (
     <FloatingPanelPopover
       modal
-      open={isPublishDialogOpen}
+      open={publishDialog !== "none"}
       onOpenChange={handleOpenChange}
     >
       <FloatingPanelAnchor>
@@ -891,14 +884,14 @@ export const PublishButton = ({ projectId }: PublishProps) => {
           marginRight: theme.spacing[3],
         }}
       >
-        {dialogContentType === "export" && (
+        {publishDialog === "export" && (
           <>
             <FloatingPanelPopoverTitle>Export</FloatingPanelPopoverTitle>
             <ExportContent projectId={projectId} />
           </>
         )}
 
-        {dialogContentType === "publish" && (
+        {publishDialog === "publish" && (
           <>
             <FloatingPanelPopoverTitle
               actions={

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -31,6 +31,7 @@ import { serverSyncStore } from "~/shared/sync";
 import { $publisher } from "~/shared/pubsub";
 import {
   $activeInspectorPanel,
+  $publishDialog,
   setActiveSidebarPanel,
   toggleActiveSidebarPanel,
 } from "./nano-states";
@@ -308,6 +309,20 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "openBreakpointsMenu",
       handler: () => {
         $breakpointsMenuView.set("initial");
+      },
+    },
+    {
+      name: "openPublishDialog",
+      defaultHotkeys: ["shift+P"],
+      handler: () => {
+        $publishDialog.set("publish");
+      },
+    },
+    {
+      name: "openExportDialog",
+      defaultHotkeys: ["shift+E"],
+      handler: () => {
+        $publishDialog.set("export");
       },
     },
     {

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -8,7 +8,7 @@ import { $settings, getSetting } from "../client-settings";
 
 export const $isShareDialogOpen = atom<boolean>(false);
 
-export const $isPublishDialogOpen = atom<boolean>(false);
+export const $publishDialog = atom<"none" | "publish" | "export">("none");
 
 export const $canvasWidth = atom<number | undefined>();
 


### PR DESCRIPTION
## Description

- More discoverable export dialog access from the menu
- shift+P and shift+E shortcuts, same es webflow 

## Todo

- [ ] add the shortcuts to the docs

<img width="210" alt="image" src="https://github.com/user-attachments/assets/e35c1725-067b-4ea1-8b6d-bb4afe5c9e66" />


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
