### PR TITLE
refactor: add instance path

### DIFF
--- a/apps/builder/app/builder/features/footer/breadcrumbs.tsx
+++ b/apps/builder/app/builder/features/footer/breadcrumbs.tsx
@@ -2,35 +2,24 @@ import { Fragment } from "react";
 import { useStore } from "@nanostores/react";
 import { ChevronRightIcon } from "@webstudio-is/icons";
 import { theme, Button, Flex, Text } from "@webstudio-is/design-system";
-import {
-  $instances,
-  $registeredComponentMetas,
-  $selectedInstanceSelector,
-} from "~/shared/nano-states";
-import { getAncestorInstanceSelector } from "~/shared/tree-utils";
+import { $registeredComponentMetas } from "~/shared/nano-states";
 import { $textEditingInstanceSelector } from "~/shared/nano-states";
 import { getInstanceLabel } from "~/shared/instance-utils";
-import { selectInstance } from "~/shared/awareness";
+import { $selectedInstancePath, selectInstance } from "~/shared/awareness";
 
 export const Breadcrumbs = () => {
-  const instances = useStore($instances);
-  const selectedInstanceSelector = useStore($selectedInstanceSelector);
+  const instancePath = useStore($selectedInstancePath);
   const metas = useStore($registeredComponentMetas);
-
   return (
     <Flex align="center" css={{ height: "100%", px: theme.spacing[3] }}>
-      {selectedInstanceSelector === undefined ? (
+      {instancePath === undefined ? (
         <Text>No instance selected</Text>
       ) : (
-        selectedInstanceSelector
+        instancePath
           // start breadcrumbs from the root
           .slice()
           .reverse()
-          .map((instanceId, index) => {
-            const instance = instances.get(instanceId);
-            if (instance === undefined) {
-              return;
-            }
+          .map(({ instance, instanceSelector }, index) => {
             const meta = metas.get(instance.component);
             if (meta === undefined) {
               return;
@@ -42,20 +31,14 @@ export const Breadcrumbs = () => {
                   css={{ color: "inherit" }}
                   key={instance.id}
                   onClick={() => {
-                    selectInstance(
-                      getAncestorInstanceSelector(
-                        selectedInstanceSelector,
-                        instance.id
-                      )
-                    );
+                    selectInstance(instanceSelector);
                     $textEditingInstanceSelector.set(undefined);
                   }}
                 >
                   {getInstanceLabel(instance, meta)}
                 </Button>
-                {index < selectedInstanceSelector.length - 1 ? (
-                  <ChevronRightIcon />
-                ) : null}
+                {/* hide the last one */}
+                {index < instancePath.length - 1 && <ChevronRightIcon />}
               </Fragment>
             );
           })


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/4364

The new $selecedInstancePath is a list of co-located instance and its selector from selection until the root. It allows to skip the knowledge about missing collection item and removes boilerplate of resolving "instance" from selector.