### PR TITLE
experimental: Enter support

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/block-editor-context-menu.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/block-editor-context-menu.tsx
@@ -18,7 +18,6 @@ import { useEffectEvent } from "~/shared/hook-utils/effect-event";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import type { Instance } from "@webstudio-is/sdk";
 import { shallowEqual } from "shallow-equal";
-import { emitCommand } from "~/builder/shared/commands";
 
 const TriggerButton = styled("button", {
   position: "absolute",
@@ -84,7 +83,6 @@ const Menu = ({
     (templateSelector: InstanceSelector) => {
       const insertBefore = modifierKeys.altKey;
       insertTemplateAt(templateSelector, anchor, insertBefore);
-      emitCommand("newInstanceText");
     },
     [anchor, modifierKeys.altKey]
   );

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/block-utils.ts
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/block-utils.ts
@@ -138,6 +138,8 @@ export const insertTemplateAt = (
         selector: editableInstanceSelector,
         reason: "new",
       });
+    } else {
+      $textEditingInstanceSelector.set(undefined);
     }
 
     selectInstance([newRootInstanceId, ...target.parentSelector]);

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/block-utils.ts
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/block-utils.ts
@@ -4,6 +4,7 @@ import { shallowEqual } from "shallow-equal";
 import { selectInstance } from "~/shared/awareness";
 import {
   extractWebstudioFragment,
+  findAllEditableInstanceSelector,
   findAvailableDataSources,
   getWebstudioData,
   insertInstanceChildrenMutable,
@@ -12,6 +13,8 @@ import {
 } from "~/shared/instance-utils";
 import {
   $instances,
+  $registeredComponentMetas,
+  $textEditingInstanceSelector,
   findBlockChildSelector,
   findBlockSelector,
 } from "~/shared/nano-states";
@@ -111,7 +114,31 @@ export const insertTemplateAt = (
     const children: Instance["children"] = [
       { type: "id", value: newRootInstanceId },
     ];
+
     insertInstanceChildrenMutable(data, children, target);
+
+    const selectedInstanceSelector = [
+      newRootInstanceId,
+      ...target.parentSelector,
+    ];
+
+    const selectors: InstanceSelector[] = [];
+
+    findAllEditableInstanceSelector(
+      selectedInstanceSelector,
+      data.instances,
+      $registeredComponentMetas.get(),
+      selectors
+    );
+
+    const editableInstanceSelector = selectors[0];
+
+    if (editableInstanceSelector) {
+      $textEditingInstanceSelector.set({
+        selector: editableInstanceSelector,
+        reason: "new",
+      });
+    }
 
     selectInstance([newRootInstanceId, ...target.parentSelector]);
   });

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -230,7 +230,6 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
   source: "builder",
   externalCommands: [
     "editInstanceText",
-    "newInstanceText",
     "formatBold",
     "formatItalic",
     "formatSuperscript",

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -39,6 +39,7 @@ import {
   type NodeKey,
   $getNodeByKey,
   SELECTION_CHANGE_COMMAND,
+  $selectAll,
 } from "lexical";
 import { LinkNode } from "@lexical/link";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
@@ -714,6 +715,10 @@ const InitCursorPlugin = () => {
           }
         }
 
+        return;
+      }
+      if (reason === "new") {
+        $selectAll();
         return;
       }
 

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -1070,7 +1070,7 @@ const ContextMenuPluginInternal = ({
         }
 
         if (menuState === "closed") {
-          if (event.key === "Enter") {
+          if (event.key === "Enter" && !event.shiftKey) {
             // Check if it pressed on the last line, last symbol
 
             const allowedComponents = ["Paragraph", "Text", "Heading"];

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -93,7 +93,6 @@ import {
 } from "~/shared/awareness";
 import { shallowEqual } from "shallow-equal";
 import { insertTemplateAt } from "~/builder/features/workspace/canvas-tools/outline/block-utils";
-import { emitCommand } from "~/canvas/shared/commands";
 
 const BindInstanceToNodePlugin = ({
   refs,
@@ -1127,7 +1126,6 @@ const ContextMenuPluginInternal = ({
               */
 
               insertTemplateAt(templateSelector, rootInstanceSelector, false);
-              emitCommand("newInstanceText");
 
               event.preventDefault();
               return true;

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -947,6 +947,7 @@ const ContextMenuPlugin = (props: ContextMenuPluginProps) => {
   const [templates] = useState(() =>
     findTemplates(props.rootInstanceSelector, $instances.get())
   );
+
   if (templates === undefined) {
     return;
   }
@@ -1352,13 +1353,14 @@ const AnyKeyDownPlugin = ({
 };
 
 export const TextEditor = ({
-  rootInstanceSelector,
+  rootInstanceSelector: rootInstanceSelectorUnstable,
   instances,
   contentEditable,
   editable,
   onChange,
   onSelectInstance,
 }: TextEditorProps) => {
+  const [rootInstanceSelector] = useState(() => rootInstanceSelectorUnstable);
   // class names must be started with letter so we add a prefix
   const [paragraphClassName] = useState(() => `a${nanoid()}`);
   const [italicClassName] = useState(() => `a${nanoid()}`);

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -1262,7 +1262,7 @@ const ContextMenuPluginInternal = ({
       unsubscibeSelectionChange();
       unsubscribeBlurListener();
     };
-  }, [editor, handleOpen, preservedSelection]);
+  }, [editor, handleOpen, preservedSelection, rootInstanceSelector, templates]);
 
   return null;
 };

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -1473,7 +1473,7 @@ export const TextEditor = ({
     onError,
   };
 
-  const handleNext = useCallback(
+  const handleNext = useEffectEvent(
     (state: EditorState, args: HandleNextParams) => {
       const rootInstanceId = $selectedPage.get()?.rootInstanceId;
 
@@ -1554,8 +1554,7 @@ export const TextEditor = ({
 
         break;
       }
-    },
-    [handleChange, instances, rootInstanceSelector]
+    }
   );
 
   const handleAnyKeydown = useCallback((event: KeyboardEvent) => {

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -76,6 +76,7 @@ import {
   $textEditingInstanceSelector,
   $textEditorContextMenu,
   execTextEditorContextMenuCommand,
+  findBlockChildSelector,
   findTemplates,
 } from "~/shared/nano-states";
 import {
@@ -1011,9 +1012,14 @@ const ContextMenuPluginInternal = ({
         const rootNodeContent = $getRoot().getTextContent().trim();
         // Delete current
         if (rootNodeContent.length === 0) {
-          updateWebstudioData((data) => {
-            deleteInstanceMutable(data, rootInstanceSelector);
-          });
+          const blockChildSelector =
+            findBlockChildSelector(rootInstanceSelector);
+
+          if (blockChildSelector) {
+            updateWebstudioData((data) => {
+              deleteInstanceMutable(data, rootInstanceSelector);
+            });
+          }
         }
       }
 
@@ -1035,10 +1041,10 @@ const ContextMenuPluginInternal = ({
           return false;
         }
 
-        if (!isSingleCursorSelection()) {
-          closeMenu();
-          return false;
-        }
+        //if (!isSingleCursorSelection()) {
+        //  closeMenu();
+        //  return false;
+        //}
 
         const selection = $getSelection();
 
@@ -1060,10 +1066,6 @@ const ContextMenuPluginInternal = ({
     const unsubscibeKeyDown = editor.registerCommand(
       KEY_DOWN_COMMAND,
       (event) => {
-        if (!isSingleCursorSelection()) {
-          return false;
-        }
-
         const selection = $getSelection();
 
         if (!$isRangeSelection(selection)) {
@@ -1386,6 +1388,15 @@ export const TextEditor = ({
 
       setDataCollapsed(rootInstanceSelector[0], false);
     });
+
+    const textEditingSelector = $textEditingInstanceSelector.get()?.selector;
+    if (textEditingSelector === undefined) {
+      return;
+    }
+
+    if (shallowEqual(textEditingSelector, rootInstanceSelector)) {
+      $textEditingInstanceSelector.set(undefined);
+    }
   });
 
   useLayoutEffect(() => {

--- a/apps/builder/app/canvas/instance-hovering.ts
+++ b/apps/builder/app/canvas/instance-hovering.ts
@@ -46,40 +46,46 @@ export const subscribeInstanceHovering = ({
     },
     eventOptions
   );
-  window.addEventListener(
-    "mousemove",
-    () => {
-      // We want the hover outline to appear only if a mouse or trackpad action caused it, not from keyboard navigation.
-      // Otherwise, when we leave the Lexical editor using the keyboard,
-      // the mouseover event triggers on elements created after Lexical loses focus.
-      // This causes an outline to appear on the element under the now-invisible mouse pointer
-      // (as the browser hides the pointer on blur), creating some visual distraction.
-      if (hoveredElement !== undefined) {
-        const instanceSelector = getInstanceSelectorFromElement(hoveredElement);
-        if (instanceSelector) {
-          if (updateOnMouseMove) {
-            $hoveredInstanceSelector.set(instanceSelector);
-            updateEditableChildOutline(instanceSelector);
-          } else {
-            const textSelector = $textEditingInstanceSelector.get()?.selector;
 
-            // We need to update the editable child's outline even if the mouseover event is not triggered.
-            // This can happen if the user enters text editing mode, presses any key, and then moves the mouse.
-            // In this case, the mouseover event does not occur, but we still need to show the editable child's outline.
-            if (
-              textSelector &&
-              isDescendantOrSelf(instanceSelector, textSelector) && // optimisation
-              $blockChildOutline.get() === undefined
-            ) {
-              updateEditableChildOutline(instanceSelector);
-            }
+  const updateEditableOutline = () => {
+    // We want the hover outline to appear only if a mouse or trackpad action caused it, not from keyboard navigation.
+    // Otherwise, when we leave the Lexical editor using the keyboard,
+    // the mouseover event triggers on elements created after Lexical loses focus.
+    // This causes an outline to appear on the element under the now-invisible mouse pointer
+    // (as the browser hides the pointer on blur), creating some visual distraction.
+    if (hoveredElement !== undefined) {
+      const instanceSelector = getInstanceSelectorFromElement(hoveredElement);
+      if (instanceSelector) {
+        if (updateOnMouseMove) {
+          $hoveredInstanceSelector.set(instanceSelector);
+          updateEditableChildOutline(instanceSelector);
+        } else {
+          const textSelector = $textEditingInstanceSelector.get()?.selector;
+
+          // We need to update the editable child's outline even if the mouseover event is not triggered.
+          // This can happen if the user enters text editing mode, presses any key, and then moves the mouse.
+          // In this case, the mouseover event does not occur, but we still need to show the editable child's outline.
+          if (
+            textSelector &&
+            isDescendantOrSelf(instanceSelector, textSelector) && // optimisation
+            $blockChildOutline.get() === undefined
+          ) {
+            updateEditableChildOutline(instanceSelector);
           }
         }
       }
-      updateOnMouseMove = false;
-    },
-    eventOptions
+    }
+    updateOnMouseMove = false;
+  };
+
+  const unsubscribeTextEditingInstance = $textEditingInstanceSelector.listen(
+    () => {
+      // Fixes the bug if initial editable instance is empty and has collapsed paddings
+      setTimeout(updateEditableOutline, 0);
+    }
   );
+
+  window.addEventListener("mousemove", updateEditableOutline, eventOptions);
 
   window.addEventListener(
     "mouseout",
@@ -210,5 +216,6 @@ export const subscribeInstanceHovering = ({
     clearTimeout(mouseOutTimeoutId);
     unsubscribeHoveredInstanceId();
     usubscribeSelectedInstanceSelector();
+    unsubscribeTextEditingInstance();
   });
 };

--- a/apps/builder/app/canvas/shared/commands.ts
+++ b/apps/builder/app/canvas/shared/commands.ts
@@ -73,7 +73,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
 
         $textEditingInstanceSelector.set({
           selector: editableInstanceSelector,
-          reason: "enter",
+          reason: "new",
         });
       },
     },

--- a/apps/builder/app/canvas/shared/commands.ts
+++ b/apps/builder/app/canvas/shared/commands.ts
@@ -146,6 +146,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "escapeSelection",
       hidden: true,
       defaultHotkeys: ["escape"],
+      disableHotkeyOnContentEditable: true,
       // reset selection for canvas, but not for the builder
       disableHotkeyOutsideApp: true,
       handler: () => {

--- a/apps/builder/app/canvas/shared/commands.ts
+++ b/apps/builder/app/canvas/shared/commands.ts
@@ -27,58 +27,6 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
   externalCommands: ["clickCanvas"],
   commands: [
     {
-      name: "newInstanceText",
-      hidden: true,
-      disableHotkeyOutsideApp: true,
-      handler: () => {
-        const selectedInstanceSelector = $selectedInstanceSelector.get();
-        if (selectedInstanceSelector === undefined) {
-          return;
-        }
-
-        if (
-          isDescendantOrSelf(
-            $textEditingInstanceSelector.get()?.selector ?? [],
-            selectedInstanceSelector
-          )
-        ) {
-          // already in text editing mode
-          return;
-        }
-
-        const selectors: InstanceSelector[] = [];
-
-        findAllEditableInstanceSelector(
-          selectedInstanceSelector,
-          $instances.get(),
-          $registeredComponentMetas.get(),
-          selectors
-        );
-
-        if (selectors.length === 0) {
-          $textEditingInstanceSelector.set(undefined);
-          return;
-        }
-
-        const editableInstanceSelector = selectors[0];
-
-        const element = getElementByInstanceSelector(editableInstanceSelector);
-        if (element === undefined) {
-          return;
-        }
-        // When an event is triggered from the Builder,
-        // the canvas element may be unfocused, so it's important to focus the element on the canvas.
-        element.focus();
-        selectInstance(editableInstanceSelector);
-
-        $textEditingInstanceSelector.set({
-          selector: editableInstanceSelector,
-          reason: "new",
-        });
-      },
-    },
-
-    {
       name: "editInstanceText",
       hidden: true,
       defaultHotkeys: ["enter"],

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -20,6 +20,10 @@ export const $textEditingInstanceSelector = atom<
     }
   | {
       selector: InstanceSelector;
+      reason: "new";
+    }
+  | {
+      selector: InstanceSelector;
       reason: "click";
       mouseX: number;
       mouseY: number;


### PR DESCRIPTION
## Description

ref #4595 

- Enter on block creates new paragraph, text or h1 block if any exists in templates
- New text added through `/` command is fully selected
- If after command block is empty it's replaced with another block
- esc now closes the `/` menu
- backspace on empty now deletes block


Play here

https://p-0b40acbe-34df-4475-8f52-120d5b97da4e-dot-enter.development.webstudio.is/?mode=content

- [x] - Bug (Next PR)
<img width="325" alt="image" src="https://github.com/user-attachments/assets/0dfa447b-dbfd-4c60-b553-ca041da23a4f" />
to reproduce
`Enter`, `/` select Heading, type `blabla`, then `/`, then `Enter`



## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
