### PR TITLE
refactor: migrate curl parse to args-tokenizer

### DIFF
--- a/@types/arrgv.d.ts
+++ b/@types/arrgv.d.ts
@@ -1,3 +1,0 @@
-declare module "arrgv" {
-  export default function arrgv(input: string): string[];
-}

--- a/apps/builder/app/builder/features/settings-panel/curl.ts
+++ b/apps/builder/app/builder/features/settings-panel/curl.ts
@@ -1,5 +1,5 @@
 import type { ResourceRequest } from "@webstudio-is/sdk";
-import arrgv from "arrgv";
+import { tokenizeArgs } from "args-tokenizer";
 import { parse as parseArgs } from "ultraflag";
 
 /*
@@ -30,15 +30,7 @@ export type CurlRequest = Pick<
 >;
 
 export const parseCurl = (curl: string): undefined | CurlRequest => {
-  // remove backslash followed by newline
-  // https://github.com/astur/arrgv/issues/3
-  curl = curl.replaceAll(/\\(?=\s)/g, "");
-  let argv;
-  try {
-    argv = arrgv(curl);
-  } catch {
-    return;
-  }
+  const argv = tokenizeArgs(curl);
   if (argv.length === 0) {
     return;
   }

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -75,7 +75,7 @@
     "@webstudio-is/sdk-components-react-radix": "workspace:*",
     "@webstudio-is/template": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
-    "arrgv": "^1.0.2",
+    "args-tokenizer": "^0.1.0",
     "bcp-47": "^2.1.0",
     "change-case": "^5.4.4",
     "colord": "^2.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,9 +292,9 @@ importers:
       '@webstudio-is/trpc-interface':
         specifier: workspace:*
         version: link:../../packages/trpc-interface
-      arrgv:
-        specifier: ^1.0.2
-        version: 1.0.2
+      args-tokenizer:
+        specifier: ^0.1.0
+        version: 0.1.0
       bcp-47:
         specifier: ^2.1.0
         version: 2.1.0
@@ -5111,6 +5111,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  args-tokenizer@0.1.0:
+    resolution: {integrity: sha512-9yDBBeg+2WTmWXJMfdO3efV+VknAL2UlxS7Yxt5e/aYjMW3yDiQhGPuFg+wEuTGN3JxsRL/wjCg0qBDFklyXjw==}
+
   aria-hidden@1.1.3:
     resolution: {integrity: sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==}
     engines: {node: '>=8.5.0'}
@@ -5126,10 +5129,6 @@ packages:
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
-
-  arrgv@1.0.2:
-    resolution: {integrity: sha512-a4eg4yhp7mmruZDQFqVMlxNRFGi/i1r87pt8SDHy0/I8PqSXoUTlWZRdAZo0VXgvEARcujbtTk8kiZRi1uDGRw==}
-    engines: {node: '>=8.0.0'}
 
   as-table@1.0.55:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
@@ -12008,6 +12007,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  args-tokenizer@0.1.0: {}
+
   aria-hidden@1.1.3:
     dependencies:
       tslib: 1.14.1
@@ -12026,8 +12027,6 @@ snapshots:
       is-array-buffer: 3.0.2
 
   array-flatten@1.1.1: {}
-
-  arrgv@1.0.2: {}
 
   as-table@1.0.55:
     dependencies:


### PR DESCRIPTION
Created new package https://github.com/TrySound/args-tokenizer for curl parser. Might be useful in combination with tinyexec.