### PR TITLE
fix: remove parent/child constraints from navigation menu

### DIFF
--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -445,7 +445,7 @@ export const metaNavigationMenuList: WsComponentMeta = {
       component: { $eq: "NavigationMenu" },
     },
     {
-      relation: "child",
+      relation: "descendant",
       component: { $eq: "NavigationMenuItem" },
     },
   ],
@@ -458,7 +458,7 @@ export const metaNavigationMenuItem: WsComponentMeta = {
   type: "container",
   icon: ListItemIcon,
   constraints: {
-    relation: "parent",
+    relation: "ancestor",
     component: { $eq: "NavigationMenuList" },
   },
   presetStyle,


### PR DESCRIPTION
Looks like parent/child constraints will work only for tags and not for components.