### PR TITLE
fix: Fix CSS fragment editor dialog title

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-fragment.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-fragment.tsx
@@ -98,11 +98,9 @@ export const CssFragmentEditorContent = ({
 };
 
 export const CssFragmentEditor = ({
-  title,
   content,
   onOpenChange,
 }: {
-  title?: ReactNode;
   content: ReactNode;
   onOpenChange?: (newOpen: boolean) => void;
 }) => {
@@ -112,7 +110,7 @@ export const CssFragmentEditor = ({
         {content}
         <EditorDialog
           onOpenChange={onOpenChange}
-          title={title}
+          title="CSS Value"
           content={content}
         >
           <EditorDialogButton />


### PR DESCRIPTION
## Description

Title for css fragment was forgotten 

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
