### PR TITLE
chore: remove increased target size for scroll thumbs

### DIFF
--- a/packages/design-system/src/components/scroll-area.tsx
+++ b/packages/design-system/src/components/scroll-area.tsx
@@ -11,40 +11,10 @@ const ScrollAreaRoot = styled(Root, {
 });
 
 const ScrollAreaThumb = styled(Thumb, {
+  position: "relative",
   boxSizing: "border-box",
   background: theme.colors.foregroundScrollBar,
   borderRadius: theme.spacing[4],
-  // increase target size for touch devices https://www.w3.org/WAI/WCAG21/Understanding/target-size.html
-
-  position: "relative",
-
-  "&::before": {
-    content: '""',
-    position: "absolute",
-    top: "50%",
-    left: "50%",
-    transform: "translate(-50%, -50%)",
-    width: "100%",
-    height: "100%",
-  },
-
-  variants: {
-    orientation: {
-      vertical: {
-        "&::before": {
-          minWidth: 16,
-          minHeight: 44,
-        },
-      },
-      horizontal: {
-        minHeight: "100%",
-        "&::before": {
-          minWidth: 44,
-          minHeight: 16,
-        },
-      },
-    },
-  },
 });
 
 const ScrollAreaScrollbar = styled(Scrollbar, {
@@ -124,12 +94,12 @@ export const ScrollArea = forwardRef(
         </Viewport>
         {(direction === "vertical" || direction === "both") && (
           <ScrollAreaScrollbar orientation="vertical" direction={direction}>
-            <ScrollAreaThumb orientation="vertical" />
+            <ScrollAreaThumb />
           </ScrollAreaScrollbar>
         )}
         {(direction === "horizontal" || direction === "both") && (
           <ScrollAreaScrollbar orientation="horizontal" direction={direction}>
-            <ScrollAreaThumb orientation="horizontal" />
+            <ScrollAreaThumb />
           </ScrollAreaScrollbar>
         )}
       </ScrollAreaRoot>


### PR DESCRIPTION
Because we don't have enough space and  touch device user scrolls the entire area directly anyways

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
