### PR TITLE
refactor: add templates meta support

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.stories.tsx
@@ -206,6 +206,7 @@ const checkProp = (options = defaultOptions, label?: string): PropMeta => ({
 registerComponentLibrary({
   components: {},
   metas: {},
+  templates: {},
   propsMetas: {
     Box: {
       props: {

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -13,6 +13,7 @@ import * as baseComponents from "@webstudio-is/sdk-components-react";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
 import * as baseComponentPropsMetas from "@webstudio-is/sdk-components-react/props";
 import { hooks as baseComponentHooks } from "@webstudio-is/sdk-components-react/hooks";
+import * as baseComponentTemplates from "@webstudio-is/sdk-components-react/templates";
 import * as radixComponents from "@webstudio-is/sdk-components-react-radix";
 import * as radixComponentMetas from "@webstudio-is/sdk-components-react-radix/metas";
 import * as radixComponentPropsMetas from "@webstudio-is/sdk-components-react-radix/props";
@@ -218,12 +219,14 @@ export const Canvas = () => {
       components: {},
       metas: coreMetas,
       propsMetas: corePropsMetas,
+      templates: {},
     });
     registerComponentLibrary({
       components: baseComponents,
       metas: baseComponentMetas,
       propsMetas: baseComponentPropsMetas,
       hooks: baseComponentHooks,
+      templates: baseComponentTemplates,
     });
     registerComponentLibrary({
       components: {
@@ -233,6 +236,7 @@ export const Canvas = () => {
       },
       metas: {},
       propsMetas: {},
+      templates: {},
     });
     registerComponentLibrary({
       namespace: "@webstudio-is/sdk-components-react-radix",
@@ -240,6 +244,7 @@ export const Canvas = () => {
       metas: radixComponentMetas,
       propsMetas: radixComponentPropsMetas,
       hooks: radixComponentHooks,
+      templates: {},
     });
   });
 

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -45,6 +45,7 @@ import {
   $breakpoints,
   $pages,
   $resources,
+  $registeredTemplates,
 } from "./nano-states";
 import {
   type DroppableTarget,
@@ -341,14 +342,21 @@ export const insertWebstudioFragmentAt = (
   }
 };
 
-export const getComponentTemplateData = (component: string) => {
+export const getComponentTemplateData = (
+  componentOrTemplate: string
+): WebstudioFragment => {
+  const templates = $registeredTemplates.get();
+  const templateMeta = templates.get(componentOrTemplate);
+  if (templateMeta) {
+    return templateMeta.template;
+  }
   const metas = $registeredComponentMetas.get();
-  const componentMeta = metas.get(component);
+  const componentMeta = metas.get(componentOrTemplate);
   // when template not specified fallback to template with the component
   const template = componentMeta?.template ?? [
     {
       type: "instance",
-      component,
+      component: componentOrTemplate,
       children: [],
     },
   ];

--- a/apps/builder/app/shared/nano-states/components.ts
+++ b/apps/builder/app/shared/nano-states/components.ts
@@ -221,7 +221,6 @@ export const registerComponentLibrary = ({
   const nextTemplates = new Map(prevTemplates);
   for (const [componentName, meta] of Object.entries(templates)) {
     const { template, ...generatedMeta } = meta;
-    console.log(renderTemplate(template));
     nextTemplates.set(`${prefix}${componentName}`, {
       ...generatedMeta,
       template: renderTemplate(template),

--- a/apps/builder/app/shared/nano-states/components.ts
+++ b/apps/builder/app/shared/nano-states/components.ts
@@ -17,6 +17,11 @@ import type { InstanceSelector } from "../tree-utils";
 import { $memoryProps, $props } from "./misc";
 import { $instances } from "./instances";
 import { $awareness, $selectedPage, getInstanceKey } from "../awareness";
+import {
+  renderTemplate,
+  type GeneratedTemplateMeta,
+  type TemplateMeta,
+} from "@webstudio-is/template";
 
 const createHookContext = (): HookContext => {
   const metas = $registeredComponentMetas.get();
@@ -166,6 +171,10 @@ export const $registeredComponentMetas = atom(
   new Map<string, WsComponentMeta>()
 );
 
+export const $registeredTemplates = atom(
+  new Map<string, GeneratedTemplateMeta>()
+);
+
 export const $registeredComponentPropsMetas = atom(
   new Map<string, WsComponentPropsMeta>()
 );
@@ -176,6 +185,7 @@ export const registerComponentLibrary = ({
   metas,
   propsMetas,
   hooks,
+  templates,
 }: {
   namespace?: string;
   // simplify adding component libraries
@@ -184,6 +194,7 @@ export const registerComponentLibrary = ({
   metas: Record<Instance["component"], WsComponentMeta>;
   propsMetas: Record<Instance["component"], WsComponentPropsMeta>;
   hooks?: Hook[];
+  templates: Record<Instance["component"], TemplateMeta>;
 }) => {
   const prefix = namespace === undefined ? "" : `${namespace}:`;
 
@@ -205,6 +216,18 @@ export const registerComponentLibrary = ({
     );
   }
   $registeredComponentMetas.set(nextMetas);
+
+  const prevTemplates = $registeredTemplates.get();
+  const nextTemplates = new Map(prevTemplates);
+  for (const [componentName, meta] of Object.entries(templates)) {
+    const { template, ...generatedMeta } = meta;
+    console.log(renderTemplate(template));
+    nextTemplates.set(`${prefix}${componentName}`, {
+      ...generatedMeta,
+      template: renderTemplate(template),
+    });
+  }
+  $registeredTemplates.set(nextTemplates);
 
   if (hooks) {
     const prevHooks = $registeredComponentHooks.get();

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -47,6 +47,7 @@ import {
   $textToolbar,
   $registeredComponentMetas,
   $registeredComponentPropsMetas,
+  $registeredTemplates,
   $modifierKeys,
 } from "~/shared/nano-states";
 import { $ephemeralStyles } from "~/canvas/stores";
@@ -167,6 +168,7 @@ export const createObjectPool = () => {
       "registeredComponentPropsMetas",
       $registeredComponentPropsMetas
     ),
+    new NanostoresSyncObject("registeredTemplates", $registeredTemplates),
     new NanostoresSyncObject("canvasScrollbarWidth", $canvasScrollbarSize),
   ]);
 };

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -32,6 +32,11 @@
       "webstudio": "./src/hooks.ts",
       "types": "./lib/types/hooks.d.ts",
       "import": "./lib/hooks.js"
+    },
+    "./templates": {
+      "webstudio": "./src/templates.ts",
+      "types": "./lib/types/templates.d.ts",
+      "import": "./lib/templates.js"
     }
   },
   "scripts": {
@@ -42,8 +47,14 @@
     "typecheck": "tsc"
   },
   "peerDependencies": {
+    "@webstudio-is/template": "workspace:*",
     "react": "18.3.0-canary-14898b6a9-20240318",
     "react-dom": "18.3.0-canary-14898b6a9-20240318"
+  },
+  "peerDependenciesMeta": {
+    "@webstudio-is/template": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@react-aria/utils": "^3.25.3",
@@ -60,6 +71,7 @@
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
     "@webstudio-is/generate-arg-types": "workspace:*",
+    "@webstudio-is/template": "workspace:*",
     "@webstudio-is/tsconfig": "workspace:*",
     "react": "18.3.0-canary-14898b6a9-20240318",
     "react-dom": "18.3.0-canary-14898b6a9-20240318",

--- a/packages/sdk-components-react/src/button.template.tsx
+++ b/packages/sdk-components-react/src/button.template.tsx
@@ -1,0 +1,11 @@
+import { type TemplateMeta, $, PlaceholderValue } from "@webstudio-is/template";
+
+export const meta: TemplateMeta = {
+  category: "forms",
+  order: 2,
+  description:
+    "Use a button to submit forms or trigger actions within a page. Do not use a button to navigate users to another resource or another page - that’s what a link is used for.",
+  template: (
+    <$.Button>{new PlaceholderValue("Button text you can edit")}</$.Button>
+  ),
+};

--- a/packages/sdk-components-react/src/button.ws.ts
+++ b/packages/sdk-components-react/src/button.ws.ts
@@ -14,34 +14,18 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  category: "forms",
+  category: "hidden",
+  icon: ButtonElementIcon,
   type: "container",
   constraints: {
     relation: "ancestor",
     component: { $nin: ["Button", "Link"] },
   },
-  description:
-    "Use a button to submit forms or trigger actions within a page. Do not use a button to navigate users to another resource or another page - that’s what a link is used for.",
-  icon: ButtonElementIcon,
   presetStyle,
   states: [
     ...defaultStates,
     { selector: ":disabled", label: "Disabled" },
     { selector: ":enabled", label: "Enabled" },
-  ],
-  order: 2,
-  template: [
-    {
-      type: "instance",
-      component: "Button",
-      children: [
-        {
-          type: "text",
-          value: "Button text you can edit",
-          placeholder: true,
-        },
-      ],
-    },
   ],
 };
 

--- a/packages/sdk-components-react/src/button.ws.ts
+++ b/packages/sdk-components-react/src/button.ws.ts
@@ -14,7 +14,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  category: "hidden",
   icon: ButtonElementIcon,
   type: "container",
   constraints: {

--- a/packages/sdk-components-react/src/list.template.tsx
+++ b/packages/sdk-components-react/src/list.template.tsx
@@ -1,0 +1,20 @@
+import { type TemplateMeta, $, PlaceholderValue } from "@webstudio-is/template";
+
+export const meta: TemplateMeta = {
+  category: "typography",
+  description: "Groups content, like links in a menu or steps in a recipe.",
+  order: 4,
+  template: (
+    <$.List>
+      <$.ListItem>
+        {new PlaceholderValue("List Item text you can edit")}
+      </$.ListItem>
+      <$.ListItem>
+        {new PlaceholderValue("List Item text you can edit")}
+      </$.ListItem>
+      <$.ListItem>
+        {new PlaceholderValue("List Item text you can edit")}
+      </$.ListItem>
+    </$.List>
+  ),
+};

--- a/packages/sdk-components-react/src/list.ws.ts
+++ b/packages/sdk-components-react/src/list.ws.ts
@@ -43,7 +43,6 @@ const presetStyle = {
 } satisfies PresetStyle<ListTag>;
 
 export const meta: WsComponentMeta = {
-  category: "hidden",
   type: "container",
   icon: ListIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/list.ws.ts
+++ b/packages/sdk-components-react/src/list.ws.ts
@@ -43,54 +43,11 @@ const presetStyle = {
 } satisfies PresetStyle<ListTag>;
 
 export const meta: WsComponentMeta = {
-  category: "typography",
+  category: "hidden",
   type: "container",
-  description: "Groups content, like links in a menu or steps in a recipe.",
   icon: ListIcon,
   states: defaultStates,
   presetStyle,
-  order: 4,
-  template: [
-    {
-      type: "instance",
-      component: "List",
-      children: [
-        {
-          type: "instance",
-          component: "ListItem",
-          children: [
-            {
-              type: "text",
-              value: "List Item text you can edit",
-              placeholder: true,
-            },
-          ],
-        },
-        {
-          type: "instance",
-          component: "ListItem",
-          children: [
-            {
-              type: "text",
-              value: "List Item text you can edit",
-              placeholder: true,
-            },
-          ],
-        },
-        {
-          type: "instance",
-          component: "ListItem",
-          children: [
-            {
-              type: "text",
-              value: "List Item text you can edit",
-              placeholder: true,
-            },
-          ],
-        },
-      ],
-    },
-  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/templates.ts
+++ b/packages/sdk-components-react/src/templates.ts
@@ -1,0 +1,2 @@
+export { meta as Button } from "./button.template";
+export { meta as List } from "./list.template";

--- a/packages/template/src/index.ts
+++ b/packages/template/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./jsx";
+export * from "./template";

--- a/packages/template/src/jsx.test.tsx
+++ b/packages/template/src/jsx.test.tsx
@@ -5,6 +5,7 @@ import {
   ExpressionValue,
   PageValue,
   ParameterValue,
+  PlaceholderValue,
   renderTemplate,
 } from "./jsx";
 
@@ -193,6 +194,22 @@ test("render defined props", () => {
       name: "data-instance",
       type: "page",
       value: { pageId: "pageId", instanceId: "instanceId" },
+    },
+  ]);
+});
+
+test("render placeholder value", () => {
+  const { instances } = renderTemplate(
+    <$.Body>{new PlaceholderValue("Placeholder text")}</$.Body>
+  );
+  expect(instances).toEqual([
+    {
+      type: "instance",
+      id: "0",
+      component: "Body",
+      children: [
+        { type: "text", value: "Placeholder text", placeholder: true },
+      ],
     },
   ]);
 });

--- a/packages/template/src/template.ts
+++ b/packages/template/src/template.ts
@@ -1,0 +1,27 @@
+import type { JSX } from "react";
+import type { WebstudioFragment } from "@webstudio-is/sdk";
+
+export const templateCategories = [
+  "general",
+  "typography",
+  "data",
+  "media",
+  "forms",
+  "radix",
+  "xml",
+  "hidden",
+  "internal",
+] as const;
+
+export type TemplateMeta = {
+  category: (typeof templateCategories)[number];
+  label?: string;
+  description?: string;
+  icon?: string;
+  order?: number;
+  template: JSX.Element;
+};
+
+export type GeneratedTemplateMeta = Omit<TemplateMeta, "template"> & {
+  template: WebstudioFragment;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1860,6 +1860,9 @@ importers:
       '@webstudio-is/generate-arg-types':
         specifier: workspace:*
         version: link:../generate-arg-types
+      '@webstudio-is/template':
+        specifier: workspace:*
+        version: link:../template
       '@webstudio-is/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig

--- a/vite.sdk-components.config.ts
+++ b/vite.sdk-components.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
         "src/metas.ts",
         "src/props.ts",
         "src/hooks.ts",
+        "src/templates.ts",
       ],
       formats: ["es"],
     },


### PR DESCRIPTION
Here added one more description file for components `*.template.tsx`.

It is decoupled from component meta to fix the issue with some templates like Sheet being treated as components though we don't have actual components with this name.

Another reason is have it separately to not include builder specific code and dependencies into CLI and published websites. Template package is defined as optional in peer dependencies meta.

In this PR migrated only Button and List as examples. There is still not support for data sources and styles.

Added support for text placeholders in children