### PR TITLE
fix: avoid cli installing private template package

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
+    "@webstudio-is/template": "workspace:*",
     "@webstudio-is/tsconfig": "workspace:*",
     "react": "18.3.0-canary-14898b6a9-20240318",
     "react-dom": "18.3.0-canary-14898b6a9-20240318",
@@ -33,7 +34,6 @@
     "@webstudio-is/icons": "workspace:^",
     "@webstudio-is/image": "workspace:*",
     "@webstudio-is/sdk": "workspace:*",
-    "@webstudio-is/template": "workspace:*",
     "change-case": "^5.4.4",
     "html-tags": "^4.0.0",
     "nanoid": "^5.0.8"

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -47,14 +47,8 @@
     "typecheck": "tsc"
   },
   "peerDependencies": {
-    "@webstudio-is/template": "workspace:*",
     "react": "18.3.0-canary-14898b6a9-20240318",
     "react-dom": "18.3.0-canary-14898b6a9-20240318"
-  },
-  "peerDependenciesMeta": {
-    "@webstudio-is/template": {
-      "optional": true
-    }
   },
   "dependencies": {
     "@react-aria/utils": "^3.25.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1715,9 +1715,6 @@ importers:
       '@webstudio-is/sdk':
         specifier: workspace:*
         version: link:../sdk
-      '@webstudio-is/template':
-        specifier: workspace:*
-        version: link:../template
       change-case:
         specifier: ^5.4.4
         version: 5.4.4
@@ -1734,6 +1731,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.25
         version: 18.2.25
+      '@webstudio-is/template':
+        specifier: workspace:*
+        version: link:../template
       '@webstudio-is/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/4654

template package is private for now so better move it into dev dependencies.