### PR TITLE
refactor: rewrite radix tabs template with jsx

### DIFF
--- a/packages/css-data/src/parse-css.test.ts
+++ b/packages/css-data/src/parse-css.test.ts
@@ -714,6 +714,40 @@ test("ignore unsupported at rules", () => {
   ]);
 });
 
+test("parse &:pseudo-classes as state", () => {
+  expect(
+    parseCss(`
+      &:hover {
+        color: red;
+      }
+   `)
+  ).toEqual([
+    {
+      selector: "",
+      state: ":hover",
+      property: "color",
+      value: { type: "keyword", value: "red" },
+    },
+  ]);
+});
+
+test("parse &[attribute=selector] as state", () => {
+  expect(
+    parseCss(`
+      &[data-state=active] {
+        color: red;
+      }
+   `)
+  ).toEqual([
+    {
+      selector: "",
+      state: "[data-state=active]",
+      property: "color",
+      value: { type: "keyword", value: "red" },
+    },
+  ]);
+});
+
 test("parse media query", () => {
   expect(parseMediaQuery(`(min-width: 768px)`)).toEqual({
     minWidth: 768,

--- a/packages/css-data/src/parse-css.ts
+++ b/packages/css-data/src/parse-css.ts
@@ -168,7 +168,11 @@ export const parseCss = (css: string): ParsedStyleDecl[] => {
         continue;
       }
       let selector: Selector | undefined = undefined;
-      for (const childNode of node.children) {
+      const children = node.children.toArray();
+      // @ts-ignore
+      let startsWithNesting = children[0]?.type === "NestingSelector";
+      for (let index = 0; index < children.length; index += 1) {
+        const childNode = children[index];
         let name: string = "";
         let state: string | undefined;
         switch (childNode.type) {
@@ -179,7 +183,12 @@ export const parseCss = (css: string): ParsedStyleDecl[] => {
             name = `.${childNode.name}`;
             break;
           case "AttributeSelector":
-            name = csstree.generate(childNode);
+            // for example &[data-state=active]
+            if (startsWithNesting && index === 1 && children.length === 2) {
+              state = csstree.generate(childNode);
+            } else {
+              name = csstree.generate(childNode);
+            }
             break;
           case "PseudoClassSelector": {
             // First pseudo selector is not a state but an element selector, e.g. :root

--- a/packages/css-data/src/parse-css.ts
+++ b/packages/css-data/src/parse-css.ts
@@ -169,8 +169,8 @@ export const parseCss = (css: string): ParsedStyleDecl[] => {
       }
       let selector: Selector | undefined = undefined;
       const children = node.children.toArray();
-      // @ts-ignore
-      let startsWithNesting = children[0]?.type === "NestingSelector";
+      // @ts-expect-error NestingSelector is not defined in type definitions
+      const startsWithNesting = children[0]?.type === "NestingSelector";
       for (let index = 0; index < children.length; index += 1) {
         const childNode = children[index];
         let name: string = "";

--- a/packages/sdk-components-react-radix/src/shared/theme.ts
+++ b/packages/sdk-components-react-radix/src/shared/theme.ts
@@ -58,3 +58,157 @@ export const weights = {
   extrabold: "800",
   black: "900",
 } as const;
+
+export const spacing = {
+  "0": "0px",
+  "1": "0.25rem",
+  "2": "0.5rem",
+  "3": "0.75rem",
+  "4": "1rem",
+  "5": "1.25rem",
+  "6": "1.5rem",
+  "7": "1.75rem",
+  "8": "2rem",
+  "9": "2.25rem",
+  "10": "2.5rem",
+  "11": "2.75rem",
+  "12": "3rem",
+  "14": "3.5rem",
+  "16": "4rem",
+  "20": "5rem",
+  "24": "6rem",
+  "28": "7rem",
+  "32": "8rem",
+  "36": "9rem",
+  "40": "10rem",
+  "44": "11rem",
+  "48": "12rem",
+  "52": "13rem",
+  "56": "14rem",
+  "60": "15rem",
+  "64": "16rem",
+  "72": "18rem",
+  "80": "20rem",
+  "96": "24rem",
+  px: "1px",
+  "0.5": "0.125rem",
+  "1.5": "0.375rem",
+  "2.5": "0.625rem",
+  "3.5": "0.875rem",
+} as const;
+
+export const height = {
+  ...spacing,
+  auto: "auto",
+  "1/2": "50%",
+  "1/3": "33.333333%",
+  "2/3": "66.666667%",
+  "1/4": "25%",
+  "2/4": "50%",
+  "3/4": "75%",
+  "1/5": "20%",
+  "2/5": "40%",
+  "3/5": "60%",
+  "4/5": "80%",
+  "1/6": "16.666667%",
+  "2/6": "33.333333%",
+  "3/6": "50%",
+  "4/6": "66.666667%",
+  "5/6": "83.333333%",
+  full: "100%",
+  screen: "100vh",
+  min: "min-content",
+  max: "max-content",
+  fit: "fit-content",
+} as const;
+
+export const borderRadius = {
+  none: "0px",
+  sm: "0.125rem",
+  DEFAULT: "0.5rem",
+  md: "0.375rem",
+  lg: "0.5rem",
+  xl: "0.75rem",
+  "2xl": "1rem",
+  "3xl": "1.5rem",
+  full: "9999px",
+} as const;
+
+export const colors = {
+  transparent: "transparent",
+  current: "currentColor",
+  inherit: "inherit",
+  popover: "rgb(255, 255, 255)",
+  popoverForeground: "rgb(2, 8, 23)",
+  border: "rgb(226, 232, 240)",
+  background: "rgb(255, 255, 255)",
+  foreground: "hsl(222.2 84% 4.9%)",
+  ring: "rgb(148, 163, 184)",
+  mutedForeground: "rgb(100, 116, 139)",
+  muted: "hsl(210 40% 96.1%)",
+  primary: "rgb(15, 23, 42)",
+  primaryForeground: "hsl(210 40% 98%)",
+  destructive: "rgb(239, 68, 68)",
+  destructiveForeground: "rgb(248, 250, 252)",
+  accent: "rgb(241, 245, 249)",
+  accentForeground: "rgb(15, 23, 42)",
+  input: "rgb(226, 232, 240)",
+  secondary: "rgb(241, 245, 249)",
+  secondaryForeground: "rgb(15, 23, 42)",
+} as const;
+
+export const transition = {
+  all: "all 150ms cubic-bezier(0.4, 0, 0.2, 1)",
+  transform: "transform 150ms cubic-bezier(0.4, 0, 0.2, 1)",
+} as const;
+
+export const opacity = {
+  "0": "0",
+  "5": "0.05",
+  "10": "0.1",
+  "20": "0.2",
+  "25": "0.25",
+  "30": "0.3",
+  "40": "0.4",
+  "50": "0.5",
+  "60": "0.6",
+  "70": "0.7",
+  "75": "0.75",
+  "80": "0.8",
+  "90": "0.9",
+  "95": "0.95",
+  "100": "1",
+} as const;
+
+const ringWidth = {
+  "0": "0px",
+  "1": "1px",
+  "2": "2px",
+  "4": "4px",
+  "8": "8px",
+  DEFAULT: "3px",
+} as const;
+
+const ringOffsetWidth = {
+  "0": "0px",
+  "1": "1px",
+  "2": "2px",
+  "4": "4px",
+  "8": "8px",
+} as const;
+
+export const boxShadow = {
+  sm: "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+  DEFAULT: "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)",
+  md: "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+  lg: "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+  xl: "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)",
+  "2xl": "0 25px 50px -12px rgb(0 0 0 / 0.25)",
+  inner: "inset 0 2px 4px 0 rgb(0 0 0 / 0.05)",
+  none: "none",
+  // 0 0 0 ringOffsetWidth ringOffsetColor
+  // 0 0 0 ringWidth + ringOffsetWidth ringColor
+  ring:
+    `0 0 0 ${ringOffsetWidth[2]} ${colors.background}, ` +
+    `0 0 0 calc(${ringWidth[2]} + ${ringOffsetWidth[2]}) ${colors.ring}`,
+} as const;

--- a/packages/sdk-components-react-radix/src/tabs.template.tsx
+++ b/packages/sdk-components-react-radix/src/tabs.template.tsx
@@ -1,0 +1,104 @@
+import {
+  css,
+  PlaceholderValue,
+  type TemplateMeta,
+} from "@webstudio-is/template";
+import { radix } from "./shared/proxy";
+import {
+  borderRadius,
+  colors,
+  fontSize,
+  fontSizeLineHeight,
+  height,
+  weights,
+  transition,
+  opacity,
+  boxShadow,
+  spacing,
+} from "./shared/theme";
+
+/**
+ * Styles source without animations:
+ * https://github.com/shadcn-ui/ui/blob/main/apps/www/registry/default/ui/tabs.tsx
+ *
+ * Attributions
+ * MIT License
+ * Copyright (c) 2023 shadcn
+ **/
+
+// inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all
+// focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+// disabled:pointer-events-none disabled:opacity-50
+// data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm
+
+const tabsTriggerStyle = css`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: ${borderRadius.md};
+  padding: ${spacing[1.5]} ${spacing[3]};
+  font-size: ${fontSize.sm};
+  line-height: ${fontSizeLineHeight.sm};
+  font-weight: ${weights.medium};
+  transition: ${transition.all};
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${boxShadow.ring};
+  }
+  &:disabled {
+    pointer-events: none;
+    opacity: ${opacity[50]};
+  }
+  &[data-state="active"] {
+    background-color: ${colors.background};
+    color: ${colors.foreground};
+    box-shadow: ${boxShadow.sm};
+  }
+`;
+
+// mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+const tabsContentStyle = css`
+  margin-top: ${spacing[2]};
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${boxShadow.ring};
+  }
+`;
+
+export const meta: TemplateMeta = {
+  category: "radix",
+  description:
+    "A set of panels with content that are displayed one at a time. Duplicate both a tab trigger and tab content to add more tabs. Triggers and content are connected according to their order in the Navigator.",
+  order: 2,
+  template: (
+    <radix.Tabs defaultValue="0">
+      <radix.TabsList
+        // inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground
+        ws:style={css`
+          display: inline-flex;
+          height: ${height[10]};
+          align-items: center;
+          justify-content: center;
+          border-radius: ${borderRadius.md};
+          background-color: ${colors.muted};
+          padding: ${spacing[1]};
+          color: ${colors.mutedForeground};
+        `}
+      >
+        <radix.TabsTrigger ws:style={tabsTriggerStyle}>
+          {new PlaceholderValue("Account")}
+        </radix.TabsTrigger>
+        <radix.TabsTrigger ws:style={tabsTriggerStyle}>
+          {new PlaceholderValue("Password")}
+        </radix.TabsTrigger>
+      </radix.TabsList>
+      <radix.TabsContent ws:style={tabsContentStyle}>
+        {new PlaceholderValue("Make changes to your account here.")}
+      </radix.TabsContent>
+      <radix.TabsContent ws:style={tabsContentStyle}>
+        {new PlaceholderValue("Change your password here.")}
+      </radix.TabsContent>
+    </radix.Tabs>
+  ),
+};

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -6,13 +6,11 @@ import {
 } from "@webstudio-is/icons/svg";
 import {
   defaultStates,
-  type EmbedTemplateStyleDecl,
   type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/react-sdk";
 import { button, div } from "@webstudio-is/sdk/normalize.css";
-import * as tc from "./theme/tailwind-classes";
 import { buttonReset } from "./theme/styles";
 import {
   propsTabs,
@@ -25,51 +23,7 @@ const presetStyle = {
   div,
 } satisfies PresetStyle<"div">;
 
-/**
- * Styles source without animations:
- * https://github.com/shadcn-ui/ui/blob/main/apps/www/registry/default/ui/tabs.tsx
- *
- * Attributions
- * MIT License
- * Copyright (c) 2023 shadcn
- **/
-
-// inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all
-// focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
-// disabled:pointer-events-none disabled:opacity-50
-// data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm
-const tabsTriggerStyles = [
-  tc.inlineFlex(),
-  tc.items("center"),
-  tc.justify("center"),
-  tc.whitespace("nowrap"),
-  tc.rounded("md"),
-  tc.px(3),
-  tc.py(1.5),
-  tc.text("sm"),
-  tc.font("medium"),
-  tc.transition("all"),
-  tc.focusVisible(
-    [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
-  ),
-  tc.disabled([tc.pointerEvents("none"), tc.opacity(50)].flat()),
-  tc.state(
-    [tc.bg("background"), tc.text("foreground"), tc.shadow("sm")].flat(),
-    "[data-state=active]"
-  ),
-].flat();
-
-// mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
-const tabsContentStyles: EmbedTemplateStyleDecl[] = [
-  tc.mt(2),
-  tc.focusVisible(
-    [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
-  ),
-].flat();
-
 export const metaTabs: WsComponentMeta = {
-  category: "radix",
-  order: 2,
   type: "container",
   icon: TabsIcon,
   constraints: [
@@ -87,76 +41,9 @@ export const metaTabs: WsComponentMeta = {
     },
   ],
   presetStyle,
-  description:
-    "A set of panels with content that are displayed one at a time. Duplicate both a tab trigger and tab content to add more tabs. Triggers and content are connected according to their order in the Navigator.",
-  template: [
-    {
-      type: "instance",
-      component: "Tabs",
-      props: [{ type: "string", name: "defaultValue", value: "0" }],
-      children: [
-        {
-          type: "instance",
-          component: "TabsList",
-          // inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground
-          styles: [
-            tc.inlineFlex(),
-            tc.h(10),
-            tc.items("center"),
-            tc.justify("center"),
-            tc.rounded("md"),
-            tc.bg("muted"),
-            tc.p(1),
-            tc.text("mutedForeground"),
-          ].flat(),
-          children: [
-            {
-              type: "instance",
-              component: "TabsTrigger",
-              styles: tabsTriggerStyles,
-              children: [{ type: "text", value: "Account", placeholder: true }],
-            },
-            {
-              type: "instance",
-              component: "TabsTrigger",
-              styles: tabsTriggerStyles,
-              children: [
-                { type: "text", value: "Password", placeholder: true },
-              ],
-            },
-          ],
-        },
-        {
-          type: "instance",
-          component: "TabsContent",
-          styles: tabsContentStyles,
-          children: [
-            {
-              type: "text",
-              value: "Make changes to your account here.",
-              placeholder: true,
-            },
-          ],
-        },
-        {
-          type: "instance",
-          component: "TabsContent",
-          styles: tabsContentStyles,
-          children: [
-            {
-              type: "text",
-              value: "Change your password here.",
-              placeholder: true,
-            },
-          ],
-        },
-      ],
-    },
-  ],
 };
 
 export const metaTabsList: WsComponentMeta = {
-  category: "hidden",
   type: "container",
   icon: HeaderIcon,
   constraints: {
@@ -167,7 +54,6 @@ export const metaTabsList: WsComponentMeta = {
 };
 
 export const metaTabsTrigger: WsComponentMeta = {
-  category: "hidden",
   type: "container",
   icon: TriggerIcon,
   constraints: [
@@ -196,7 +82,6 @@ export const metaTabsTrigger: WsComponentMeta = {
 };
 
 export const metaTabsContent: WsComponentMeta = {
-  category: "hidden",
   type: "container",
   label: "Tab Content",
   icon: ContentIcon,

--- a/packages/sdk-components-react-radix/src/templates.ts
+++ b/packages/sdk-components-react-radix/src/templates.ts
@@ -1,1 +1,2 @@
 export { meta as Label } from "./label.template";
+export { meta as Tabs } from "./tabs.template";


### PR DESCRIPTION
- support `&[data-state=active]` as state in css parser
- added more theme values
- migrated radix tabs to jsx templates