### PR TITLE
fix: relax detaching constraint

### DIFF
--- a/apps/builder/app/builder/features/ai/apply-operations.ts
+++ b/apps/builder/app/builder/features/ai/apply-operations.ts
@@ -7,7 +7,6 @@ import { isBaseBreakpoint } from "~/shared/breakpoints";
 import {
   deleteInstanceMutable,
   insertWebstudioFragmentAt,
-  isInstanceDetachable,
   updateWebstudioData,
   type Insertable,
 } from "~/shared/instance-utils";
@@ -22,6 +21,7 @@ import {
 } from "~/shared/nano-states";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { $selectedInstance } from "~/shared/awareness";
+import { isInstanceDetachable } from "~/shared/matcher";
 
 export const applyOperations = (operations: operations.WsOperations) => {
   for (const operation of operations) {
@@ -96,8 +96,15 @@ const deleteInstanceByOp = (
     if (instanceSelector.length === 1) {
       return;
     }
+    const metas = $registeredComponentMetas.get();
     updateWebstudioData((data) => {
-      if (isInstanceDetachable(data.instances, instanceSelector) === false) {
+      if (
+        isInstanceDetachable({
+          metas,
+          instances: data.instances,
+          instanceSelector,
+        }) === false
+      ) {
         return;
       }
       deleteInstanceMutable(data, instanceSelector);

--- a/apps/builder/app/builder/features/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator-tree.tsx
@@ -440,6 +440,10 @@ const getBuilderDropTarget = (
 };
 
 const canDrag = (instance: Instance, instanceSelector: InstanceSelector) => {
+  // forbid moving root instance
+  if (instanceSelector.length === 1) {
+    return false;
+  }
   if ($isContentMode.get()) {
     const parentId = instanceSelector[1];
     const parentInstance = $instances.get().get(parentId);

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -24,7 +24,6 @@ import {
   extractWebstudioFragment,
   insertWebstudioFragmentCopy,
   updateWebstudioData,
-  isInstanceDetachable,
 } from "~/shared/instance-utils";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { serverSyncStore } from "~/shared/sync";
@@ -41,6 +40,7 @@ import { builderApi } from "~/shared/builder-api";
 
 import {
   findClosestNonTextualContainer,
+  isInstanceDetachable,
   isTreeMatching,
 } from "~/shared/matcher";
 
@@ -73,7 +73,14 @@ export const deleteSelectedInstance = () => {
   const [selectedItem, parentItem] = instancePath;
   const selectedInstanceSelector = selectedItem.instanceSelector;
   const instances = $instances.get();
-  if (isInstanceDetachable(instances, selectedInstanceSelector) === false) {
+  const metas = $registeredComponentMetas.get();
+  if (
+    isInstanceDetachable({
+      metas,
+      instances,
+      instanceSelector: selectedInstanceSelector,
+    }) === false
+  ) {
     toast.error(
       "This instance can not be moved outside of its parent component."
     );

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -368,13 +368,12 @@ const getTextContent = (instanceProps: Record<string, unknown>) => {
 };
 
 const getEditableComponentPlaceholder = (
+  instance: Instance,
   instanceSelector: InstanceSelector,
   instances: Instances,
   metas: Map<string, WsComponentMeta>,
   mode: "editing" | "editable"
 ) => {
-  const instance = instances.get(instanceSelector[0])!;
-
   if (!editablePlaceholderComponents.includes(instance.component)) {
     return;
   }
@@ -498,6 +497,7 @@ export const WebstudioComponentCanvas = forwardRef<
   }
 
   const placeholder = getEditableComponentPlaceholder(
+    instance,
     instanceSelector,
     instances,
     metas,
@@ -558,6 +558,7 @@ export const WebstudioComponentCanvas = forwardRef<
       contentEditable={
         <ContentEditable
           placeholder={getEditableComponentPlaceholder(
+            instance,
             instanceSelector,
             instances,
             metas,

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -8,19 +8,23 @@ import {
   WebstudioFragment,
   findTreeInstanceIdsExcludingSlotDescendants,
 } from "@webstudio-is/sdk";
-import { $selectedInstanceSelector, $instances } from "../nano-states";
+import {
+  $selectedInstanceSelector,
+  $instances,
+  $registeredComponentMetas,
+} from "../nano-states";
 import type { InstanceSelector, DroppableTarget } from "../tree-utils";
 import {
   deleteInstanceMutable,
   findAvailableDataSources,
   extractWebstudioFragment,
   insertWebstudioFragmentCopy,
-  isInstanceDetachable,
   updateWebstudioData,
   getWebstudioData,
   insertInstanceChildrenMutable,
   findClosestInsertable,
 } from "../instance-utils";
+import { isInstanceDetachable } from "../matcher";
 
 const version = "@webstudio/instance/v0.1";
 
@@ -30,9 +34,10 @@ const InstanceData = WebstudioFragment.extend({
 
 type InstanceData = z.infer<typeof InstanceData>;
 
-const getTreeData = (targetInstanceSelector: InstanceSelector) => {
+const getTreeData = (instanceSelector: InstanceSelector) => {
   const instances = $instances.get();
-  if (isInstanceDetachable(instances, targetInstanceSelector) === false) {
+  const metas = $registeredComponentMetas.get();
+  if (isInstanceDetachable({ metas, instances, instanceSelector }) === false) {
     toast.error(
       "This instance can not be moved outside of its parent component."
     );
@@ -40,14 +45,14 @@ const getTreeData = (targetInstanceSelector: InstanceSelector) => {
   }
 
   // @todo tell user they can't copy or cut root
-  if (targetInstanceSelector.length === 1) {
+  if (instanceSelector.length === 1) {
     return;
   }
 
-  const [targetInstanceId] = targetInstanceSelector;
+  const [targetInstanceId] = instanceSelector;
 
   return {
-    instanceSelector: targetInstanceSelector,
+    instanceSelector,
     ...extractWebstudioFragment(getWebstudioData(), targetInstanceId),
   };
 };

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -65,7 +65,6 @@ import { $awareness, $selectedPage, selectInstance } from "./awareness";
 import {
   findClosestNonTextualContainer,
   findClosestInstanceMatchingFragment,
-  isTreeMatching,
 } from "./matcher";
 
 export const updateWebstudioData = (mutate: (data: WebstudioData) => void) => {
@@ -256,32 +255,6 @@ export const findClosestEditableInstanceSelector = (
       return getAncestorInstanceSelector(instanceSelector, instanceId);
     }
   }
-};
-
-export const isInstanceDetachable = (
-  instances: Instances,
-  instanceSelector: InstanceSelector
-) => {
-  const metas = $registeredComponentMetas.get();
-  const [instanceId, parentId] = instanceSelector;
-  const newInstances = new Map(instances);
-  // replace parent with the one without selected instance
-  let parentInstance = newInstances.get(parentId);
-  if (parentInstance) {
-    parentInstance = {
-      ...parentInstance,
-      children: parentInstance.children.filter(
-        (child) => child.type === "id" && child.value !== instanceId
-      ),
-    };
-    newInstances.set(parentInstance.id, parentInstance);
-  }
-  // check parent can follow constraints without selected instance
-  return isTreeMatching({
-    instances: newInstances,
-    metas,
-    instanceSelector: instanceSelector.slice(1),
-  });
 };
 
 export const insertInstanceChildrenMutable = (

--- a/apps/builder/app/shared/matcher.test.tsx
+++ b/apps/builder/app/shared/matcher.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@webstudio-is/template";
 import { coreMetas } from "@webstudio-is/react-sdk";
 import * as baseMetas from "@webstudio-is/sdk-components-react/metas";
+import * as radixMetas from "@webstudio-is/sdk-components-react-radix/metas";
 import type { Matcher, WsComponentMeta } from "@webstudio-is/sdk";
 import {
   findClosestNonTextualContainer,
@@ -14,6 +15,7 @@ import {
   isInstanceMatching,
   isTreeMatching,
   findClosestContainer,
+  isInstanceDetachable,
 } from "./matcher";
 
 const metas = new Map(Object.entries({ ...coreMetas, ...baseMetas }));
@@ -753,6 +755,65 @@ describe("is tree matching", () => {
         instanceSelector: ["box", "tabs", "body"],
       })
     ).toBeFalsy();
+  });
+});
+
+describe("is instance detachable", () => {
+  const metas = new Map(Object.entries({ ...baseMetas, ...radixMetas }));
+
+  test("allow deleting one of matching instances", () => {
+    expect(
+      isInstanceDetachable({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Tabs ws:id="tabs">
+              <$.TabsList ws:id="list">
+                <$.TabsTrigger ws:id="trigger1"></$.TabsTrigger>
+                <$.TabsTrigger ws:id="trigger2"></$.TabsTrigger>
+              </$.TabsList>
+              <$.TabsContent ws:id="content1"></$.TabsContent>
+              <$.TabsContent ws:id="content2"></$.TabsContent>
+            </$.Tabs>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["trigger1", "list", "tabs", "body"],
+      })
+    ).toBeTruthy();
+  });
+
+  test("prevent deleting last matching instance", () => {
+    expect(
+      isInstanceDetachable({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Tabs ws:id="tabs">
+              <$.TabsList ws:id="list">
+                <$.TabsTrigger ws:id="trigger1"></$.TabsTrigger>
+              </$.TabsList>
+              <$.TabsContent ws:id="content1"></$.TabsContent>
+            </$.Tabs>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["trigger1", "list", "tabs", "body"],
+      })
+    ).toBeFalsy();
+  });
+
+  test("allow deleting when siblings not matching", () => {
+    expect(
+      isInstanceDetachable({
+        ...renderJsx(
+          <$.Body ws:id="body">
+            <$.Tabs ws:id="tabs"></$.Tabs>
+            <$.Box ws:id="box"></$.Box>
+          </$.Body>
+        ),
+        metas,
+        instanceSelector: ["box", "body"],
+      })
+    ).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
Every time somebody is facing invalid constraint issue whole tree is blocked from deleting instances except the problematic one with actual issue.

Here rewrote detachability check to validate only ancestors and avoid traversing potentially problematic siblings.