### PR TITLE
refactor: rewrite radix switch and checkbox templates with jsx

### DIFF
--- a/packages/sdk-components-react-radix/src/checkbox.template.tsx
+++ b/packages/sdk-components-react-radix/src/checkbox.template.tsx
@@ -1,0 +1,77 @@
+import { CheckMarkIcon } from "@webstudio-is/icons/svg";
+import {
+  type TemplateMeta,
+  $,
+  css,
+  PlaceholderValue,
+} from "@webstudio-is/template";
+import { radix } from "./shared/proxy";
+import {
+  borderRadius,
+  borderWidth,
+  boxShadow,
+  colors,
+  height,
+  opacity,
+  spacing,
+  width,
+} from "./shared/theme";
+
+export const meta: TemplateMeta = {
+  category: "radix",
+  description:
+    "Use within a form to allow your users to toggle between checked and not checked. Group checkboxes by matching their “Name” properties. Unlike radios, any number of checkboxes in a group can be checked.",
+  order: 101,
+  template: (
+    <$.Label
+      ws:label="Checkbox Field"
+      ws:style={css`
+        display: flex;
+        gap: ${spacing[2]};
+        align-items: center;
+      `}
+    >
+      <radix.Checkbox
+        // peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background
+        // focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+        // disabled:cursor-not-allowed disabled:opacity-50
+        // data-[state=checked]:bg-primary
+        // data-[state=checked]:text-primary-foreground",
+        ws:style={css`
+          height: ${height[4]};
+          width: ${width[4]};
+          flex-shrink: 0;
+          border-radius: ${borderRadius.sm};
+          border: ${borderWidth.DEFAULT} solid ${colors.primary};
+          &:focus-visible {
+            outline: none;
+            box-shadow: ${boxShadow.ring};
+          }
+          &:disabled {
+            cursor: not-allowed;
+            opacity: ${opacity[50]};
+          }
+          &[data-state="checked"] {
+            background-color: ${colors.primary};
+            color: ${colors.primaryForeground};
+          }
+        `}
+      >
+        <radix.CheckboxIndicator
+          // flex items-center justify-center text-current
+          ws:style={css`
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: currentColor;
+          `}
+        >
+          <$.HtmlEmbed ws:label="Indicator Icon" code={CheckMarkIcon} />
+        </radix.CheckboxIndicator>
+      </radix.Checkbox>
+      <$.Text ws:label="Checkbox Label" tag="span">
+        {new PlaceholderValue("Checkbox")}
+      </$.Text>
+    </$.Label>
+  ),
+};

--- a/packages/sdk-components-react-radix/src/checkbox.ws.ts
+++ b/packages/sdk-components-react-radix/src/checkbox.ws.ts
@@ -1,15 +1,10 @@
-import {
-  CheckMarkIcon,
-  CheckboxCheckedIcon,
-  TriggerIcon,
-} from "@webstudio-is/icons/svg";
+import { CheckboxCheckedIcon, TriggerIcon } from "@webstudio-is/icons/svg";
 import {
   defaultStates,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/react-sdk";
 import { button, span } from "@webstudio-is/sdk/normalize.css";
-import * as tc from "./theme/tailwind-classes";
 import { buttonReset } from "./theme/styles";
 import {
   propsCheckbox,
@@ -17,16 +12,12 @@ import {
 } from "./__generated__/checkbox.props";
 
 export const metaCheckbox: WsComponentMeta = {
-  category: "radix",
-  order: 101,
   type: "container",
   constraints: {
     relation: "descendant",
     component: { $eq: "CheckboxIndicator" },
   },
   icon: CheckboxCheckedIcon,
-  description:
-    "Use within a form to allow your users to toggle between checked and not checked. Group checkboxes by matching their “Name” properties. Unlike radios, any number of checkboxes in a group can be checked.",
   states: [
     ...defaultStates,
     {
@@ -43,102 +34,9 @@ export const metaCheckbox: WsComponentMeta = {
   presetStyle: {
     button: [button, buttonReset].flat(),
   },
-  template: [
-    {
-      type: "instance",
-      component: "Label",
-      label: "Checkbox Field",
-      styles: [tc.flex(), tc.gap(2), tc.items("center")].flat(),
-      children: [
-        {
-          type: "instance",
-          component: "Checkbox",
-          variables: {
-            checkboxChecked: { initialValue: false },
-          },
-          props: [
-            {
-              name: "checked",
-              type: "expression",
-              code: "checkboxChecked",
-            },
-            {
-              name: "onCheckedChange",
-              type: "action",
-              value: [
-                {
-                  type: "execute",
-                  args: ["checked"],
-                  code: `checkboxChecked = checked`,
-                },
-              ],
-            },
-          ],
-          // peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background
-          // focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
-          // disabled:cursor-not-allowed disabled:opacity-50
-          // data-[state=checked]:bg-primary
-          // data-[state=checked]:text-primary-foreground",
-          styles: [
-            // We are not supporting peer like styles yet
-            tc.h(4),
-            tc.w(4),
-            tc.shrink(0),
-            tc.rounded("sm"),
-            tc.border(),
-            tc.border("primary"),
-            tc.focusVisible(
-              [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
-            ),
-            tc.disabled([tc.cursor("not-allowed"), tc.opacity(50)].flat()),
-            tc.state(
-              [tc.bg("primary"), tc.text("primaryForeground")].flat(),
-              "[data-state=checked]"
-            ),
-          ].flat(),
-          children: [
-            {
-              type: "instance",
-              component: "CheckboxIndicator",
-              // flex items-center justify-center text-current
-              styles: [
-                tc.flex(),
-                tc.items("center"),
-                tc.justify("center"),
-                tc.text("current"),
-              ].flat(),
-              children: [
-                {
-                  type: "instance",
-                  component: "HtmlEmbed",
-                  label: "Indicator Icon",
-                  props: [
-                    {
-                      type: "string",
-                      name: "code",
-                      value: CheckMarkIcon,
-                    },
-                  ],
-                  children: [],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          type: "instance",
-          component: "Text",
-          label: "Checkbox Label",
-          props: [{ name: "tag", type: "string", value: "span" }],
-          children: [{ type: "text", value: "Checkbox", placeholder: true }],
-        },
-      ],
-    },
-  ],
 };
 
 export const metaCheckboxIndicator: WsComponentMeta = {
-  category: "hidden",
   type: "container",
   constraints: {
     relation: "ancestor",

--- a/packages/sdk-components-react-radix/src/switch.template.tsx
+++ b/packages/sdk-components-react-radix/src/switch.template.tsx
@@ -1,0 +1,75 @@
+import { css, type TemplateMeta } from "@webstudio-is/template";
+import { radix } from "./shared/proxy";
+import {
+  borderRadius,
+  borderWidth,
+  boxShadow,
+  colors,
+  height,
+  opacity,
+  transition,
+  width,
+} from "./shared/theme";
+
+export const meta: TemplateMeta = {
+  category: "radix",
+  description:
+    "A control that allows the user to toggle between checked and not checked.",
+  order: 11,
+  template: (
+    <radix.Switch
+      // peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors
+      // focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background
+      // disabled:cursor-not-allowed disabled:opacity-50
+      // data-[state=checked]:bg-primary
+      // data-[state=unchecked]:bg-input
+      ws:style={css`
+        display: inline-flex;
+        height: 24px;
+        width: 44px;
+        flex-shrink: 0;
+        cursor: pointer;
+        align-items: center;
+        border-radius: ${borderRadius.full};
+        border: ${borderWidth[2]} solid transparent;
+        transition: ${transition.all};
+        &:focus-visible {
+          outline: none;
+          box-shadow: ${boxShadow.ring};
+        }
+        &:disabled {
+          cursor: not-allowed;
+          opacity: ${opacity[50]};
+        }
+        &[data-state="checked"] {
+          background-color: ${colors.primary};
+        }
+        &[data-state="unchecked"] {
+          background-color: ${colors.input};
+        }
+      `}
+    >
+      <radix.SwitchThumb
+        // pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform
+        // data-[state=checked]:translate-x-5
+        // data-[state=unchecked]:translate-x-0
+        ws:style={css`
+          pointer-events: none;
+          display: block;
+          height: ${height[5]};
+          width: ${width[5]};
+          border-radius: ${borderRadius.full};
+          background-color: ${colors.background};
+          box-shadow: ${boxShadow.lg};
+          transition: ${transition.transform};
+          &[data-state="checked"] {
+            transform: translateX(20px);
+          }
+          &[data-state="unchecked"] {
+            transform: translateX(0px);
+          }
+        `}
+      />
+    </radix.Switch>
+  ),
+};

--- a/packages/sdk-components-react-radix/src/switch.tsx
+++ b/packages/sdk-components-react-radix/src/switch.tsx
@@ -9,7 +9,7 @@ import { Root, Thumb } from "@radix-ui/react-switch";
 export const Switch = forwardRef<
   HTMLButtonElement,
   ComponentProps<typeof Root>
->(({ checked, defaultChecked, ...props }, ref) => {
+>(({ defaultChecked, checked, ...props }, ref) => {
   return (
     <Root {...props} ref={ref} defaultChecked={checked ?? defaultChecked} />
   );

--- a/packages/sdk-components-react-radix/src/switch.ws.ts
+++ b/packages/sdk-components-react-radix/src/switch.ws.ts
@@ -5,20 +5,15 @@ import {
   type WsComponentPropsMeta,
 } from "@webstudio-is/react-sdk";
 import { button, span } from "@webstudio-is/sdk/normalize.css";
-import * as tc from "./theme/tailwind-classes";
 import { buttonReset } from "./theme/styles";
 import { propsSwitch, propsSwitchThumb } from "./__generated__/switch.props";
 
 export const metaSwitch: WsComponentMeta = {
-  category: "radix",
-  order: 11,
   type: "container",
   constraints: {
     relation: "descendant",
     component: { $eq: "SwitchThumb" },
   },
-  description:
-    "A control that allows the user to toggle between checked and not checked.",
   icon: SwitchIcon,
   states: [
     ...defaultStates,
@@ -36,89 +31,9 @@ export const metaSwitch: WsComponentMeta = {
   presetStyle: {
     button: [button, buttonReset].flat(),
   },
-  template: [
-    {
-      type: "instance",
-      component: "Switch",
-      variables: {
-        switchChecked: { initialValue: false },
-      },
-      props: [
-        {
-          name: "checked",
-          type: "expression",
-          code: "switchChecked",
-        },
-        {
-          name: "onCheckedChange",
-          type: "action",
-          value: [
-            {
-              type: "execute",
-              args: ["checked"],
-              code: `switchChecked = checked`,
-            },
-          ],
-        },
-      ],
-      // peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors
-      // focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background
-      // disabled:cursor-not-allowed disabled:opacity-50
-      // data-[state=checked]:bg-primary
-      // data-[state=unchecked]:bg-input
-      styles: [
-        // We are not supporting peer like styles yet
-        tc.inlineFlex(),
-        tc.property("height", "24px"),
-        tc.property("width", "44px"),
-        tc.shrink(0),
-        tc.cursor("pointer"),
-        tc.items("center"),
-        tc.rounded("full"),
-        tc.border(2),
-        tc.border("transparent"),
-        tc.transition("all"),
-        tc.focusVisible(
-          [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
-        ),
-        tc.disabled([tc.cursor("not-allowed"), tc.opacity(50)].flat()),
-        tc.state([tc.bg("primary")].flat(), "[data-state=checked]"),
-        tc.state([tc.bg("input")].flat(), "[data-state=unchecked]"),
-      ].flat(),
-      children: [
-        {
-          type: "instance",
-          component: "SwitchThumb",
-          // pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform
-          // data-[state=checked]:translate-x-5
-          // data-[state=unchecked]:translate-x-0
-          styles: [
-            tc.pointerEvents("none"),
-            tc.block(),
-            tc.h(5),
-            tc.w(5),
-            tc.rounded("full"),
-            tc.bg("background"),
-            tc.shadow("lg"),
-            tc.transition("transform"),
-            tc.state(
-              [tc.property("transform", "translateX(20px)")].flat(),
-              "[data-state=checked]"
-            ),
-            tc.state(
-              [tc.property("transform", "translateX(0px)")].flat(),
-              "[data-state=unchecked]"
-            ),
-          ].flat(),
-          children: [],
-        },
-      ],
-    },
-  ],
 };
 
 export const metaSwitchThumb: WsComponentMeta = {
-  category: "hidden",
   type: "container",
   constraints: {
     relation: "ancestor",

--- a/packages/sdk-components-react-radix/src/templates.ts
+++ b/packages/sdk-components-react-radix/src/templates.ts
@@ -2,3 +2,5 @@ export { meta as Label } from "./label.template";
 export { meta as Tabs } from "./tabs.template";
 export { meta as Sheet } from "./sheet.template";
 export { meta as Dialog } from "./dialog.template";
+export { meta as Switch } from "./switch.template";
+export { meta as Checkbox } from "./checkbox.template";


### PR DESCRIPTION
Here avoided using variables and instead made Switch uncontrolled which should cover most use cases where variables just complicates everything.

Checkbox already works this way.

Both checkbox and switch templates are migrated to jsx.