### PR TITLE
fix: Scroll into view doesn't work any more for scrollable divs 

### DIFF
--- a/apps/builder/app/canvas/instance-hovering.ts
+++ b/apps/builder/app/canvas/instance-hovering.ts
@@ -92,10 +92,10 @@ export const subscribeInstanceHovering = ({
   window.addEventListener(
     "mouseout",
     () => {
-      mouseOutTimeoutId = setTimeout(() => {
-        updateOnMouseMove = false;
-        hoveredElement = undefined;
+      updateOnMouseMove = false;
+      hoveredElement = undefined;
 
+      mouseOutTimeoutId = setTimeout(() => {
         $blockChildOutline.set(undefined);
         $hoveredInstanceSelector.set(undefined);
         $hoveredInstanceOutline.set(undefined);

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -129,6 +129,9 @@ const subscribeSelectedInstance = (
 
   const updateScroll = () => {
     const bbox = getAllElementsBoundingBox(visibleElements);
+    if (visibleElements.length === 0) {
+      return;
+    }
     scrollIntoView(visibleElements[0], bbox);
   };
 

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -20,6 +20,8 @@ import {
   getAllElementsBoundingBox,
   getVisibleElementsByInstanceSelector,
   getAllElementsByInstanceSelector,
+  scrollIntoView,
+  hasDoNotTrackMutationRecord,
 } from "~/shared/dom-utils";
 import { subscribeScrollState } from "~/canvas/shared/scroll-state";
 import { $selectedInstanceOutline } from "~/shared/nano-states";
@@ -127,26 +129,7 @@ const subscribeSelectedInstance = (
 
   const updateScroll = () => {
     const bbox = getAllElementsBoundingBox(visibleElements);
-
-    // Adds a small amount of space around the element after scrolling
-    const topScrollMargin = 16;
-
-    if (bbox.top < 0 || bbox.bottom > window.innerHeight) {
-      const moveToTopDelta = bbox.top - topScrollMargin;
-      const moveToBottomDelta =
-        bbox.bottom - window.innerHeight + topScrollMargin;
-
-      // scrollTo is used because scrollIntoView does not work with elements that have display:contents, etc.
-      // Here, we can be confident that if the outline can be calculated, we can scroll to it.
-      window.scrollTo({
-        top:
-          window.scrollY +
-          (Math.abs(moveToTopDelta) < Math.abs(moveToBottomDelta)
-            ? moveToTopDelta
-            : moveToBottomDelta),
-        behavior: "smooth",
-      });
-    }
+    scrollIntoView(visibleElements[0], bbox);
   };
 
   const updateElements = () => {
@@ -285,6 +268,10 @@ const subscribeSelectedInstance = (
   const resizeObserver = new ResizeObserver(update);
 
   const mutationHandler: MutationCallback = (mutationRecords) => {
+    if (hasDoNotTrackMutationRecord(mutationRecords)) {
+      return;
+    }
+
     if (hasCollapsedMutationRecord(mutationRecords)) {
       return;
     }

--- a/apps/builder/app/services/csrf-session.server.ts
+++ b/apps/builder/app/services/csrf-session.server.ts
@@ -78,15 +78,13 @@ export const getCsrfTokenAndCookie = async (
     const csrfTokenLength = 16;
     const array = new Uint8Array(csrfTokenLength);
     crypto.getRandomValues(array);
-    const token = toBase64Url(array.buffer);
+    const token = toBase64Url(array);
 
     csrfSession.set("hash", hash);
     csrfSession.set("token", token);
     sessionCreateCookieValue =
       await csrfSessionStorage.commitSession(csrfSession);
   }
-
-  console.log("sessionCreateCookieValue", sessionCreateCookieValue);
 
   return [csrfSession.get("token"), sessionCreateCookieValue];
 };

--- a/apps/builder/app/services/csrf-session.server.ts
+++ b/apps/builder/app/services/csrf-session.server.ts
@@ -78,13 +78,15 @@ export const getCsrfTokenAndCookie = async (
     const csrfTokenLength = 16;
     const array = new Uint8Array(csrfTokenLength);
     crypto.getRandomValues(array);
-    const token = toBase64Url(array);
+    const token = toBase64Url(array.buffer);
 
     csrfSession.set("hash", hash);
     csrfSession.set("token", token);
     sessionCreateCookieValue =
       await csrfSessionStorage.commitSession(csrfSession);
   }
+
+  console.log("sessionCreateCookieValue", sessionCreateCookieValue);
 
   return [csrfSession.get("token"), sessionCreateCookieValue];
 };

--- a/apps/builder/app/shared/dom-utils.stories.tsx
+++ b/apps/builder/app/shared/dom-utils.stories.tsx
@@ -7,7 +7,16 @@ export default {
 const handleClick = (selector: string) => {
   const elements = document.querySelectorAll(selector);
 
-  scrollIntoView(elements[0], elements[0].getBoundingClientRect());
+  const element = elements[0];
+  if (element === undefined) {
+    return;
+  }
+
+  if (false === element instanceof HTMLElement) {
+    return;
+  }
+
+  scrollIntoView(element, element.getBoundingClientRect());
 };
 
 const ToolbarStory = () => {

--- a/apps/builder/app/shared/dom-utils.stories.tsx
+++ b/apps/builder/app/shared/dom-utils.stories.tsx
@@ -1,0 +1,54 @@
+import { scrollIntoView } from "./dom-utils";
+
+export default {
+  title: "DomUtile/ScrollIntoView",
+};
+
+const handleClick = (selector: string) => {
+  const elements = document.querySelectorAll(selector);
+
+  scrollIntoView(elements[0], elements[0].getBoundingClientRect());
+};
+
+const ToolbarStory = () => {
+  return (
+    <div>
+      <button onClick={() => handleClick(".element")}>
+        Test Scroll Into Scrollable
+      </button>
+      <button onClick={() => handleClick(".viewport")}>
+        Test Scroll Into Viewport
+      </button>
+      <h1
+        style={{
+          marginTop: "1000px",
+        }}
+      >
+        Viewport Matrix Fiztures
+      </h1>
+      <div
+        style={{
+          marginTop: "20px",
+          width: "200px",
+          height: "200px",
+          overflow: "auto",
+        }}
+      >
+        <h1 style={{ marginTop: "2400px" }} className="element">
+          Inside scrollable
+        </h1>
+        <div style={{ height: "1000px" }}></div>
+      </div>
+      <h2 className="viewport">Inside viewport</h2>
+      <div style={{ height: "1000px" }}></div>
+      <button onClick={() => handleClick(".element")}>
+        Test Scroll Into Scrollable
+      </button>
+      <button onClick={() => handleClick(".viewport")}>
+        Test Scroll Into Viewport
+      </button>
+    </div>
+  );
+};
+
+export { ToolbarStory as Toolbar };

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -276,7 +276,6 @@ const getLocalToViewportMatrix = (container: Element): DOMMatrix => {
   const e = x1;
   const f = y1;
 
-  // Return a DOMMatrix
   return new DOMMatrix([a, b, c, d, e, f]);
 };
 
@@ -285,7 +284,6 @@ const getViewportToLocalMatrix = (container: Element): DOMMatrix => {
 };
 
 const transformDOMRect = (rect: DOMRect, matrix: DOMMatrix) => {
-  // Corners
   const topLeft = new DOMPoint(rect.x, rect.y).matrixTransform(matrix);
   const topRight = new DOMPoint(rect.x + rect.width, rect.y).matrixTransform(
     matrix
@@ -298,7 +296,6 @@ const transformDOMRect = (rect: DOMRect, matrix: DOMMatrix) => {
     rect.y + rect.height
   ).matrixTransform(matrix);
 
-  // Find min/max in each axis
   const xs = [topLeft.x, topRight.x, bottomLeft.x, bottomRight.x];
   const ys = [topLeft.y, topRight.y, bottomLeft.y, bottomRight.y];
   const minX = Math.min(...xs);
@@ -306,7 +303,6 @@ const transformDOMRect = (rect: DOMRect, matrix: DOMMatrix) => {
   const minY = Math.min(...ys);
   const maxY = Math.max(...ys);
 
-  // Return the new bounding box as a DOMRect
   return new DOMRect(minX, minY, maxX - minX, maxY - minY);
 };
 

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -262,12 +262,12 @@ const getLocalToViewportMatrix = (container: Element): DOMMatrix => {
   const { left, top, width, height } = testDiv.getBoundingClientRect();
   container.removeChild(testDiv);
 
-  const x1 = left,
-    y1 = top;
-  const x2 = left + width,
-    y2 = top;
-  const x3 = left,
-    y3 = top + height;
+  const x1 = left;
+  const y1 = top;
+  const x2 = left + width;
+  const y2 = top;
+  const x3 = left;
+  const y3 = top + height;
 
   const a = (x2 - x1) / rectSize;
   const b = (y2 - y1) / rectSize;

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -310,6 +310,13 @@ const transformDOMRect = (rect: DOMRect, matrix: DOMMatrix) => {
   return new DOMRect(minX, minY, maxX - minX, maxY - minY);
 };
 
+/**
+ * We scroll using rectangle and anchor calculations because `scrollIntoView` does not work
+ * reliably for certain elements, such as those with `display: contents`.
+ * For these elements, we display a selected or hovered outline on the canvas using the
+ * bounding rectangles of their children or the selection range.
+ * Here, we ensure scrolling works for these elements as well.
+ */
 export const scrollIntoView = (anchor: Element, rect: DOMRect) => {
   const scrollParent = getScrollParent(anchor, true);
 

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -218,7 +218,7 @@ export const getAllElementsBoundingBox = (
   });
 };
 
-const doNotTrackMutationAttribute = "data-do-not-track-mutation";
+const doNotTrackMutationAttribute = "data-ws-do-not-track-mutation";
 
 export const hasDoNotTrackMutationAttribute = (element: Element) => {
   return element.hasAttribute(doNotTrackMutationAttribute);


### PR DESCRIPTION
## Description

closes  #4631

tested in Safari, FF, Chrome

## TODO:

- [x] - Menu content cause
<img width="914" alt="image" src="https://github.com/user-attachments/assets/45567d6b-b9b4-493d-80b8-596f5c0ac650" />


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
