### PR TITLE
feat: support tables in content and markdown embed

### DIFF
--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -122,7 +122,7 @@ export const CodeEditor = forwardRef<
   return (
     <div className={wrapperStyle()} ref={ref}>
       <EditorDialogControl>
-        {<EditorContent {...editorContentProps} extensions={extensions} />}
+        <EditorContent {...editorContentProps} extensions={extensions} />
         <EditorDialog
           title={title}
           content={

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -90,7 +90,7 @@
     "isbot": "^5.1.19",
     "lexical": "^0.21.0",
     "match-sorter": "^8.0.0",
-    "mdast-util-from-markdown": "^2.0.1",
+    "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-gfm": "^3.0.0",
     "micromark-extension-gfm": "^3.0.0",
     "nanoevents": "^9.1.0",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -31,7 +31,7 @@
     "@webstudio-is/sdk": "workspace:*",
     "ai": "^2.2.12",
     "escape-string-regexp": "^5.0.0",
-    "mdast-util-from-markdown": "^2.0.1",
+    "mdast-util-from-markdown": "^2.0.2",
     "openai": "^4.8.0",
     "unist-util-visit-parents": "^6.0.1",
     "zod": "^3.22.4",

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -56,9 +56,10 @@
     "@webstudio-is/image": "workspace:*",
     "@webstudio-is/react-sdk": "workspace:*",
     "@webstudio-is/sdk": "workspace:*",
+    "await-interaction-response": "^0.0.2",
     "colord": "^2.9.3",
-    "micromark": "^4.0.0",
-    "await-interaction-response": "^0.0.2"
+    "micromark": "^4.0.1",
+    "micromark-extension-gfm-table": "^2.1.0"
   },
   "devDependencies": {
     "@testing-library/react": "^14.2.2",

--- a/packages/sdk-components-react/src/content-embed.template.tsx
+++ b/packages/sdk-components-react/src/content-embed.template.tsx
@@ -28,6 +28,28 @@ const htmlSample = `
 <img src="${imagePlaceholderDataUrl}">
 <blockquote>Capture attention with a powerful quote.</blockquote>
 <p>Using <code>console.log("Hello World");</code> will log to the console.</p>
+<table>
+  <tr>
+    <th>Header 1</th>
+    <th>Header 2</th>
+    <th>Header 3</th>
+  </tr>
+  <tr>
+    <td>Cell 1.1</td>
+    <td>Cell 1.2</td>
+    <td>Cell 1.3</td>
+  </tr>
+  <tr>
+    <td>Cell 2.1</td>
+    <td>Cell 2.2</td>
+    <td>Cell 2.3</td>
+  </tr>
+  <tr>
+    <td>Cell 3.1</td>
+    <td>Cell 3.2</td>
+    <td>Cell 3.3</td>
+  </tr>
+</table>
 `.trim();
 
 export const meta: TemplateMeta = {

--- a/packages/sdk-components-react/src/content-embed.template.tsx
+++ b/packages/sdk-components-react/src/content-embed.template.tsx
@@ -54,6 +54,10 @@ export const meta: TemplateMeta = {
       <ws.descendant ws:label="List" selector=" :where(ul, ol)" />
       <ws.descendant ws:label="List Item" selector=" li" />
       <ws.descendant ws:label="Separator" selector=" hr" />
+      <ws.descendant ws:label="Table" selector=" table" />
+      <ws.descendant ws:label="Table Row" selector=" tr" />
+      <ws.descendant ws:label="Table Header Cell" selector=" th" />
+      <ws.descendant ws:label="Table Cell" selector=" td" />
     </$.HtmlEmbed>
   ),
 };

--- a/packages/sdk-components-react/src/markdown-embed.template.tsx
+++ b/packages/sdk-components-react/src/markdown-embed.template.tsx
@@ -37,6 +37,12 @@ Any elements that were not used above are used below.
 > Capture attention with a powerful quote.
 
 Using \`console.log("Hello World");\` will log to the console.
+
+| Header 1   | Header 2   | Header 3   |
+|------------|------------|------------|
+| Cell 1.1   | Cell 1.2   | Cell 1.3   |
+| Cell 2.1   | Cell 2.2   | Cell 2.3   |
+| Cell 3.1   | Cell 3.2   | Cell 3.3   |
 `.trim();
 
 export const meta: TemplateMeta = {

--- a/packages/sdk-components-react/src/markdown-embed.template.tsx
+++ b/packages/sdk-components-react/src/markdown-embed.template.tsx
@@ -61,6 +61,10 @@ export const meta: TemplateMeta = {
       <ws.descendant ws:label="List" selector=" :where(ul, ol)" />
       <ws.descendant ws:label="List Item" selector=" li" />
       <ws.descendant ws:label="Separator" selector=" hr" />
+      <ws.descendant ws:label="Table" selector=" table" />
+      <ws.descendant ws:label="Table Row" selector=" tr" />
+      <ws.descendant ws:label="Table Header Cell" selector=" th" />
+      <ws.descendant ws:label="Table Cell" selector=" td" />
     </$.MarkdownEmbed>
   ),
 };

--- a/packages/sdk-components-react/src/markdown-embed.tsx
+++ b/packages/sdk-components-react/src/markdown-embed.tsx
@@ -1,4 +1,5 @@
 import { micromark } from "micromark";
+import { gfmTable, gfmTableHtml } from "micromark-extension-gfm-table";
 import { forwardRef, useMemo } from "react";
 
 type MarkdownEmbedProps = {
@@ -15,7 +16,12 @@ export const MarkdownEmbed = /* @__PURE__ */ forwardRef<
   const { code, children, ...rest } = props;
   const html = useMemo(
     // support data uri protocol in images
-    () => micromark(code ?? "", { allowDangerousProtocol: true }),
+    () =>
+      micromark(code ?? "", {
+        allowDangerousProtocol: true,
+        extensions: [gfmTable()],
+        htmlExtensions: [gfmTableHtml()],
+      }),
     [code]
   );
   return <div {...rest} ref={ref} dangerouslySetInnerHTML={{ __html: html }} />;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,8 +338,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       mdast-util-from-markdown:
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.2
+        version: 2.0.2
       mdast-util-gfm:
         specifier: ^3.0.0
         version: 3.0.0
@@ -916,8 +916,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       mdast-util-from-markdown:
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.2
+        version: 2.0.2
       openai:
         specifier: ^4.8.0
         version: 4.8.0
@@ -1809,8 +1809,11 @@ importers:
         specifier: ^2.9.3
         version: 2.9.3
       micromark:
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^4.0.1
+        version: 4.0.1
+      micromark-extension-gfm-table:
+        specifier: ^2.1.0
+        version: 2.1.0
     devDependencies:
       '@testing-library/react':
         specifier: ^14.2.2
@@ -4640,9 +4643,6 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
-  '@types/debug@4.1.7':
-    resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
-
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
@@ -6574,14 +6574,14 @@ packages:
   mdast-util-from-markdown@1.3.1:
     resolution: {integrity: sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==}
 
-  mdast-util-from-markdown@2.0.1:
-    resolution: {integrity: sha512-aJEUyzZ6TzlsX2s5B4Of7lN7EQtAxvtradMMglCQDyaTFgse6CmtmdJ15ElnVRlCg1vpNyVtbem0PWzlNieZsA==}
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
 
   mdast-util-frontmatter@1.0.1:
     resolution: {integrity: sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==}
 
-  mdast-util-gfm-autolink-literal@2.0.0:
-    resolution: {integrity: sha512-FyzMsduZZHSc3i0Px3PQcBT4WJY/X/RCtEJKuybiC6sjPqLv7h1yqAkmILZtuxMSsUyaLUWNp71+vQH2zqp5cg==}
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
   mdast-util-gfm-footnote@2.0.0:
     resolution: {integrity: sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==}
@@ -6622,8 +6622,8 @@ packages:
   mdast-util-to-markdown@1.5.0:
     resolution: {integrity: sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==}
 
-  mdast-util-to-markdown@2.1.0:
-    resolution: {integrity: sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==}
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
 
   mdast-util-to-string@3.2.0:
     resolution: {integrity: sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==}
@@ -6836,8 +6836,8 @@ packages:
   micromark@3.2.0:
     resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
 
-  micromark@4.0.0:
-    resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
+  micromark@4.0.1:
+    resolution: {integrity: sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==}
 
   micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -11327,10 +11327,6 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.31
 
-  '@types/debug@4.1.7':
-    dependencies:
-      '@types/ms': 0.7.31
-
   '@types/doctrine@0.0.9': {}
 
   '@types/dom-navigation@1.0.4': {}
@@ -13616,14 +13612,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-from-markdown@2.0.1:
+  mdast-util-from-markdown@2.0.2:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.0
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.0
+      micromark: 4.0.1
       micromark-util-decode-numeric-character-reference: 2.0.1
       micromark-util-decode-string: 2.0.0
       micromark-util-normalize-identifier: 2.0.0
@@ -13639,7 +13635,7 @@ snapshots:
       mdast-util-to-markdown: 1.5.0
       micromark-extension-frontmatter: 1.1.1
 
-  mdast-util-gfm-autolink-literal@2.0.0:
+  mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
       ccount: 2.0.1
@@ -13651,8 +13647,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.1
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -13660,8 +13656,8 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.1
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13670,8 +13666,8 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.3
-      mdast-util-from-markdown: 2.0.1
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13679,20 +13675,20 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.1
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.1
-      mdast-util-gfm-autolink-literal: 2.0.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.0.0
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0
       mdast-util-gfm-task-list-item: 2.0.0
-      mdast-util-to-markdown: 2.1.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13775,13 +13771,14 @@ snapshots:
       unist-util-visit: 4.1.2
       zwitch: 2.0.4
 
-  mdast-util-to-markdown@2.1.0:
+  mdast-util-to-markdown@2.1.2:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.0
       longest-streak: 3.1.0
       mdast-util-phrasing: 4.1.0
       mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.0
       micromark-util-decode-string: 2.0.0
       unist-util-visit: 5.0.0
       zwitch: 2.0.4
@@ -14204,9 +14201,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  micromark@4.0.0:
+  micromark@4.0.1:
     dependencies:
-      '@types/debug': 4.1.7
+      '@types/debug': 4.1.12
       debug: 4.3.7
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0


### PR DESCRIPTION
Markdown embed now can convert tables like this into html

```
| Month    | Savings |
| -------- | ------- |
| January  | $250    |
| February | $80     |
| March    | $420    |
```

Both markdown embed and content embed have descendants to style tables. Added table, row, header and cell.