### PR TITLE
experimental: 2x speedup of StylePanel rendering on selection change

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -44,10 +44,6 @@ import {
   isValidDeclaration,
   properties,
 } from "@webstudio-is/css-data";
-import {
-  $selectedInstanceBrowserStyle,
-  $selectedInstanceUnitSizes,
-} from "~/shared/nano-states";
 import { convertUnits } from "./convert-units";
 import { mergeRefs } from "@react-aria/utils";
 import { composeEventHandlers } from "~/shared/event-utils";
@@ -58,6 +54,8 @@ import {
   isComplexValue,
   ValueEditorDialog,
 } from "./value-editor-dialog";
+import { canvasApi } from "~/shared/canvas-api";
+import { $selectedInstanceSelector } from "~/shared/nano-states";
 
 // We need to enable scrub on properties that can have numeric value.
 const canBeNumber = (property: StyleProperty, value: CssValueInputValue) => {
@@ -569,7 +567,8 @@ export const CssValueInput = ({
         return;
       }
 
-      const unitSizes = $selectedInstanceUnitSizes.get();
+      const selectedInstanceSelector = $selectedInstanceSelector.get();
+      const unitSizes = canvasApi.calculateUnitSizes(selectedInstanceSelector);
 
       // Value not edited by the user, we need to convert it to the new unit
       if (value.type === "unit") {
@@ -592,7 +591,10 @@ export const CssValueInput = ({
 
       // value is a keyword or non numeric, try get browser style value and convert it
       if (value.type === "keyword" || value.type === "intermediate") {
-        const browserStyle = $selectedInstanceBrowserStyle.get();
+        const browserStyle = canvasApi.getBrowserStyle(
+          selectedInstanceSelector
+        );
+
         const browserPropertyValue = browserStyle?.[property];
         const propertyValue =
           browserPropertyValue?.type === "unit"

--- a/apps/builder/app/builder/features/style-panel/style-panel.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-panel.tsx
@@ -32,8 +32,6 @@ export const StylePanel = () => {
   const display = useParentComputedStyleDecl("display");
   const displayValue = toValue(display.computedValue);
 
-  console.log("render");
-
   // If selected instance is not rendered on the canvas,
   // style panel will not work, because it needs the element in DOM in order to work.
   // See <SelectedInstanceConnector> for more details.

--- a/apps/builder/app/builder/features/style-panel/style-panel.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-panel.tsx
@@ -32,6 +32,8 @@ export const StylePanel = () => {
   const display = useParentComputedStyleDecl("display");
   const displayValue = toValue(display.computedValue);
 
+  console.log("render");
+
   // If selected instance is not rendered on the canvas,
   // style panel will not work, because it needs the element in DOM in order to work.
   // See <SelectedInstanceConnector> for more details.

--- a/apps/builder/app/canvas/features/webstudio-component/get-browser-style.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/get-browser-style.ts
@@ -66,6 +66,10 @@ export const getBrowserStyle = (
 ): Style => {
   const browserStyle: Style = {};
 
+  if (process.env.NODE_ENV === "test") {
+    return browserStyle;
+  }
+
   if (instanceSelector === undefined) {
     return browserStyle;
   }
@@ -107,6 +111,10 @@ const defaultUnitSizes: UnitSizes = {
 export const calculateUnitSizes = (
   instanceSelector: InstanceSelector | undefined
 ): UnitSizes => {
+  if (process.env.NODE_ENV === "test") {
+    return defaultUnitSizes;
+  }
+
   if (instanceSelector === undefined) {
     return defaultUnitSizes;
   }
@@ -159,21 +167,26 @@ export const calculateUnitSizes = (
 export const getElementAndAncestorInstanceTags = (
   instanceSelector: Readonly<InstanceSelector> | undefined
 ) => {
+  const instanceToTag = new Map<Instance["id"], HtmlTags>([
+    [ROOT_INSTANCE_ID, "html"],
+  ]);
+
+  if (process.env.NODE_ENV === "test") {
+    return instanceToTag;
+  }
+
   if (instanceSelector === undefined) {
-    return;
+    return instanceToTag;
   }
 
   const elements = getAllElementsByInstanceSelector(instanceSelector);
 
   if (elements.length === 0) {
-    return;
+    return instanceToTag;
   }
 
   const [element] = elements;
 
-  const instanceToTag = new Map<Instance["id"], HtmlTags>([
-    [ROOT_INSTANCE_ID, "html"],
-  ]);
   for (
     let ancestorOrSelf: HTMLElement | null = element;
     ancestorOrSelf !== null;

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -3,9 +3,7 @@ import { idAttribute, selectorIdAttribute } from "@webstudio-is/react-sdk";
 import { subscribeWindowResize } from "~/shared/dom-hooks";
 import {
   $isResizingCanvas,
-  $selectedInstanceBrowserStyle,
   $selectedInstanceIntanceToTag,
-  $selectedInstanceUnitSizes,
   $selectedInstanceRenderState,
   $stylesIndex,
   $instances,
@@ -25,12 +23,10 @@ import {
 } from "~/shared/dom-utils";
 import { subscribeScrollState } from "~/canvas/shared/scroll-state";
 import { $selectedInstanceOutline } from "~/shared/nano-states";
-import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
 import {
   hasCollapsedMutationRecord,
   setDataCollapsed,
 } from "~/canvas/collapsed";
-import { getBrowserStyle } from "./features/webstudio-component/get-browser-style";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { shallowEqual } from "shallow-equal";
 import warnOnce from "warn-once";
@@ -47,40 +43,6 @@ const setOutline = (instanceId: Instance["id"], elements: HTMLElement[]) => {
 
 const hideOutline = () => {
   $selectedInstanceOutline.set(undefined);
-};
-
-const calculateUnitSizes = (element: HTMLElement): UnitSizes => {
-  // Based on this https://stackoverflow.com/questions/1248081/how-to-get-the-browser-viewport-dimensions/8876069#8876069
-  // this is crossbrowser way to get viewport sizes vw vh in px
-  const vw =
-    Math.max(document.documentElement.clientWidth, window.innerWidth) / 100;
-  const vh =
-    Math.max(document.documentElement.clientHeight, window.innerHeight) / 100;
-
-  // em in px is equal to current computed style for font size
-  const em = Number.parseFloat(getComputedStyle(element).fontSize);
-
-  // rem in px is equal to root computed style for font size
-  const rem = Number.parseFloat(
-    getComputedStyle(document.documentElement).fontSize
-  );
-
-  // we create a node with 1ch width, measure it in px and remove it
-  const node = document.createElement("div");
-  node.style.width = "1ch";
-  node.style.position = "absolute";
-  element.appendChild(node);
-  const ch = Number.parseFloat(getComputedStyle(node).width);
-  element.removeChild(node);
-
-  return {
-    ch, // 1ch in pixels
-    vw, // 1vw in pixels
-    vh, // 1vh in pixels
-    em, // 1em in pixels
-    rem, // 1rem in pixels
-    px: 1, // always 1, simplifies conversions and types, i.e valueTo = valueFrom * unitSizes[from] / unitSizes[to]
-  };
 };
 
 export const getElementAndAncestorInstanceTags = (
@@ -186,7 +148,6 @@ const subscribeSelectedInstance = (
 
     const [element] = elements;
     // trigger style recomputing every time instance styles are changed
-    $selectedInstanceBrowserStyle.set(getBrowserStyle(element));
 
     // Map self and ancestor instance ids to tag names
     const instanceToTag = getElementAndAncestorInstanceTags(
@@ -199,11 +160,8 @@ const subscribeSelectedInstance = (
         [...(instanceToTag?.entries() ?? [])].flat()
       )
     ) {
-      $selectedInstanceIntanceToTag.set(instanceToTag);
+      // $selectedInstanceIntanceToTag.set(instanceToTag);
     }
-
-    const unitSizes = calculateUnitSizes(element);
-    $selectedInstanceUnitSizes.set(unitSizes);
 
     const availableStates = new Set<string>();
     const instanceStyleSourceIds = new Set(

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -1,9 +1,8 @@
-import { ROOT_INSTANCE_ID, type Instance } from "@webstudio-is/sdk";
-import { idAttribute, selectorIdAttribute } from "@webstudio-is/react-sdk";
+import { type Instance } from "@webstudio-is/sdk";
+import { selectorIdAttribute } from "@webstudio-is/react-sdk";
 import { subscribeWindowResize } from "~/shared/dom-hooks";
 import {
   $isResizingCanvas,
-  $selectedInstanceIntanceToTag,
   $selectedInstanceRenderState,
   $stylesIndex,
   $instances,
@@ -13,7 +12,6 @@ import {
   $selectedInstanceStates,
   $styleSourceSelections,
 } from "~/shared/nano-states";
-import htmlTags, { type HtmlTags } from "html-tags";
 import {
   getAllElementsBoundingBox,
   getVisibleElementsByInstanceSelector,
@@ -31,9 +29,6 @@ import type { InstanceSelector } from "~/shared/tree-utils";
 import { shallowEqual } from "shallow-equal";
 import warnOnce from "warn-once";
 
-const isHtmlTag = (tag: string): tag is HtmlTags =>
-  htmlTags.includes(tag as HtmlTags);
-
 const setOutline = (instanceId: Instance["id"], elements: HTMLElement[]) => {
   $selectedInstanceOutline.set({
     instanceId,
@@ -43,36 +38,6 @@ const setOutline = (instanceId: Instance["id"], elements: HTMLElement[]) => {
 
 const hideOutline = () => {
   $selectedInstanceOutline.set(undefined);
-};
-
-export const getElementAndAncestorInstanceTags = (
-  instanceSelector: Readonly<InstanceSelector>
-) => {
-  const elements = getAllElementsByInstanceSelector(instanceSelector);
-
-  if (elements.length === 0) {
-    return;
-  }
-
-  const [element] = elements;
-
-  const instanceToTag = new Map<Instance["id"], HtmlTags>([
-    [ROOT_INSTANCE_ID, "html"],
-  ]);
-  for (
-    let ancestorOrSelf: HTMLElement | null = element;
-    ancestorOrSelf !== null;
-    ancestorOrSelf = ancestorOrSelf.parentElement
-  ) {
-    const tagName = ancestorOrSelf.tagName.toLowerCase();
-    const instanceId = ancestorOrSelf.getAttribute(idAttribute);
-
-    if (isHtmlTag(tagName) && instanceId !== null) {
-      instanceToTag.set(instanceId, tagName);
-    }
-  }
-
-  return instanceToTag;
 };
 
 const subscribeSelectedInstance = (
@@ -147,21 +112,6 @@ const subscribeSelectedInstance = (
     }
 
     const [element] = elements;
-    // trigger style recomputing every time instance styles are changed
-
-    // Map self and ancestor instance ids to tag names
-    const instanceToTag = getElementAndAncestorInstanceTags(
-      selectedInstanceSelector
-    );
-
-    if (
-      !shallowEqual(
-        [...($selectedInstanceIntanceToTag.get()?.entries() ?? [])].flat(),
-        [...(instanceToTag?.entries() ?? [])].flat()
-      )
-    ) {
-      // $selectedInstanceIntanceToTag.set(instanceToTag);
-    }
 
     const availableStates = new Set<string>();
     const instanceStyleSourceIds = new Set(

--- a/apps/builder/app/shared/awareness.ts
+++ b/apps/builder/app/shared/awareness.ts
@@ -9,6 +9,8 @@ import {
 import { rootComponent } from "@webstudio-is/react-sdk";
 import { $pages } from "./nano-states/pages";
 import { $instances, $selectedInstanceSelector } from "./nano-states/instances";
+import { canvasApi } from "./canvas-api";
+import { $selectedInstanceIntanceToTag } from "./nano-states";
 
 type Awareness = {
   pageId: Page["id"];
@@ -139,6 +141,11 @@ export const selectInstance = (
 ) => {
   const awareness = $awareness.get();
   if (awareness) {
+    const instanceToTag =
+      canvasApi.getElementAndAncestorInstanceTags(instanceSelector);
+
+    $selectedInstanceIntanceToTag.set(instanceToTag);
+
     $awareness.set({
       pageId: awareness.pageId,
       instanceSelector,

--- a/apps/builder/app/shared/canvas-api.ts
+++ b/apps/builder/app/shared/canvas-api.ts
@@ -6,6 +6,10 @@ import invariant from "tiny-invariant";
 import { $canvasIframeState } from "./nano-states";
 import { getElementAndAncestorInstanceTags } from "~/canvas/instance-selected";
 import { detectSupportedFontWeights } from "~/canvas/shared/font-weight-support";
+import {
+  getBrowserStyle,
+  calculateUnitSizes,
+} from "~/canvas/features/webstudio-component/get-browser-style";
 
 const apiWindowNamespace = "__webstudio__$__canvasApi";
 
@@ -17,6 +21,8 @@ const _canvasApi = {
   monitorForExternal,
   getElementAndAncestorInstanceTags,
   detectSupportedFontWeights,
+  getBrowserStyle,
+  calculateUnitSizes,
 };
 
 declare global {

--- a/apps/builder/app/shared/canvas-api.ts
+++ b/apps/builder/app/shared/canvas-api.ts
@@ -4,11 +4,11 @@ import { monitorForExternal } from "@atlaskit/pragmatic-drag-and-drop/external/a
 import { createRecursiveProxy } from "@trpc/server/shared";
 import invariant from "tiny-invariant";
 import { $canvasIframeState } from "./nano-states";
-import { getElementAndAncestorInstanceTags } from "~/canvas/instance-selected";
 import { detectSupportedFontWeights } from "~/canvas/shared/font-weight-support";
 import {
   getBrowserStyle,
   calculateUnitSizes,
+  getElementAndAncestorInstanceTags,
 } from "~/canvas/features/webstudio-component/get-browser-style";
 
 const apiWindowNamespace = "__webstudio__$__canvasApi";

--- a/apps/builder/app/shared/nano-states/misc.ts
+++ b/apps/builder/app/shared/nano-states/misc.ts
@@ -15,7 +15,6 @@ import type {
   StyleSources,
   StyleSourceSelections,
 } from "@webstudio-is/sdk";
-import type { Style } from "@webstudio-is/css-engine";
 import type { Project } from "@webstudio-is/project";
 import type { MarketplaceProduct } from "@webstudio-is/project-build";
 import type { TokenPermissions } from "@webstudio-is/authorization-token";
@@ -23,7 +22,6 @@ import type { DragStartPayload } from "~/canvas/shared/use-drag-drop";
 import { type InstanceSelector } from "../tree-utils";
 import type { HtmlTags } from "html-tags";
 import { $selectedInstanceSelector } from "./instances";
-import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
 import type { Simplify } from "type-fest";
 import type { AssetType } from "@webstudio-is/asset-uploader";
 import type { ChildrenOrientation } from "node_modules/@webstudio-is/design-system/src/components/primitives/dnd/geometry-utils";
@@ -146,18 +144,6 @@ export type UploadingFileData = Simplify<
 >;
 
 export const $uploadingFilesDataStore = atom<UploadingFileData[]>([]);
-
-export const $selectedInstanceBrowserStyle = atom<undefined | Style>();
-
-// Init with some defaults to avoid undefined
-export const $selectedInstanceUnitSizes = atom<UnitSizes>({
-  ch: 8,
-  vw: 3.2,
-  vh: 4.8,
-  em: 16,
-  rem: 16,
-  px: 1,
-});
 
 /**
  * instanceId => tagName store for selected instance and its ancestors

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -14,8 +14,6 @@ import {
   $assets,
   $selectedPageHash,
   $selectedInstanceSelector,
-  $selectedInstanceBrowserStyle,
-  $selectedInstanceUnitSizes,
   $selectedInstanceIntanceToTag,
   $selectedInstanceRenderState,
   $hoveredInstanceSelector,
@@ -99,16 +97,8 @@ export const createObjectPool = () => {
     new NanostoresSyncObject("resourceValues", $resourceValues),
     new NanostoresSyncObject("selectedPageHash", $selectedPageHash),
     new NanostoresSyncObject(
-      "selectedInstanceBrowserStyle",
-      $selectedInstanceBrowserStyle
-    ),
-    new NanostoresSyncObject(
       "selectedInstanceIntanceToTag",
       $selectedInstanceIntanceToTag
-    ),
-    new NanostoresSyncObject(
-      "selectedInstanceUnitSizes",
-      $selectedInstanceUnitSizes
     ),
     new NanostoresSyncObject(
       "selectedInstanceRenderState",


### PR DESCRIPTION
## Description

Open this
https://p-cfc5b051-3b7a-4a59-a994-44d8d2f8b836-dot-prf.development.webstudio.is/

Start edit, and hold down button.
On my machine edit inputs are switching without serious perf issues in this PR

https://github.com/user-attachments/assets/58902844-a267-4439-9793-93348d1d0528

On my machine on Main https://p-cfc5b051-3b7a-4a59-a994-44d8d2f8b836-dot-main.development.webstudio.is/  it's very slow and finally hangs for a 10+ seconds

https://github.com/user-attachments/assets/b4647e65-4d51-4e48-855c-330ec2a0682c


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
