### PR TITLE
perf: compute tags statically

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-panel.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-panel.tsx
@@ -10,19 +10,18 @@ import { useStore } from "@nanostores/react";
 import { computed } from "nanostores";
 import { StyleSourcesSection } from "./style-source-section";
 import { $selectedInstanceRenderState } from "~/shared/nano-states";
-import { $selectedInstanceIntanceToTag } from "~/shared/nano-states";
 import { sections } from "./sections";
 import { toValue } from "@webstudio-is/css-engine";
-import { useParentComputedStyleDecl } from "./shared/model";
+import { $instanceTags, useParentComputedStyleDecl } from "./shared/model";
 import { $selectedInstance } from "~/shared/awareness";
 
 const $selectedInstanceTag = computed(
-  [$selectedInstance, $selectedInstanceIntanceToTag],
-  (selectedInstance, instanceToTag) => {
-    if (selectedInstance === undefined || instanceToTag === undefined) {
+  [$selectedInstance, $instanceTags],
+  (selectedInstance, instanceTags) => {
+    if (selectedInstance === undefined) {
       return;
     }
-    return instanceToTag.get(selectedInstance.id);
+    return instanceTags.get(selectedInstance.id);
   }
 );
 

--- a/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar.tsx
@@ -12,13 +12,11 @@ import {
   LinkIcon,
   PaintBrushIcon,
 } from "@webstudio-is/icons";
-import {
-  $selectedInstanceIntanceToTag,
-  $selectedInstanceSelector,
-} from "~/shared/nano-states";
+import { $selectedInstanceSelector } from "~/shared/nano-states";
 import { type TextToolbarState, $textToolbar } from "~/shared/nano-states";
 import { $scale } from "~/builder/shared/nano-states";
 import { emitCommand } from "~/builder/shared/commands";
+import { $instanceTags } from "../../style-panel/shared/model";
 
 const getRectForRelativeRect = (
   parent: DOMRect,
@@ -39,16 +37,13 @@ const getRectForRelativeRect = (
 };
 
 const $isWithinLink = computed(
-  [$selectedInstanceSelector, $selectedInstanceIntanceToTag],
-  (selectedInstanceSelector, selectedInstanceIntanceToTag) => {
-    if (
-      selectedInstanceSelector === undefined ||
-      selectedInstanceIntanceToTag === undefined
-    ) {
+  [$selectedInstanceSelector, $instanceTags],
+  (selectedInstanceSelector, instanceTags) => {
+    if (selectedInstanceSelector === undefined) {
       return false;
     }
     for (const instanceId of selectedInstanceSelector) {
-      const tag = selectedInstanceIntanceToTag.get(instanceId);
+      const tag = instanceTags.get(instanceId);
       if (tag === "a") {
         return true;
       }

--- a/apps/builder/app/shared/canvas-api.ts
+++ b/apps/builder/app/shared/canvas-api.ts
@@ -4,7 +4,6 @@ import { monitorForExternal } from "@atlaskit/pragmatic-drag-and-drop/external/a
 import { createRecursiveProxy } from "@trpc/server/shared";
 import invariant from "tiny-invariant";
 import { $canvasIframeState } from "./nano-states";
-import { getElementAndAncestorInstanceTags } from "~/canvas/instance-selected";
 import { detectSupportedFontWeights } from "~/canvas/shared/font-weight-support";
 
 const apiWindowNamespace = "__webstudio__$__canvasApi";
@@ -15,7 +14,6 @@ const _canvasApi = {
   resetInert,
   preventUnhandled,
   monitorForExternal,
-  getElementAndAncestorInstanceTags,
   detectSupportedFontWeights,
 };
 

--- a/apps/builder/app/shared/nano-states/misc.ts
+++ b/apps/builder/app/shared/nano-states/misc.ts
@@ -21,7 +21,6 @@ import type { MarketplaceProduct } from "@webstudio-is/project-build";
 import type { TokenPermissions } from "@webstudio-is/authorization-token";
 import type { DragStartPayload } from "~/canvas/shared/use-drag-drop";
 import { type InstanceSelector } from "../tree-utils";
-import type { HtmlTags } from "html-tags";
 import { $selectedInstanceSelector } from "./instances";
 import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
 import type { Simplify } from "type-fest";
@@ -158,13 +157,6 @@ export const $selectedInstanceUnitSizes = atom<UnitSizes>({
   rem: 16,
   px: 1,
 });
-
-/**
- * instanceId => tagName store for selected instance and its ancestors
- */
-export const $selectedInstanceIntanceToTag = atom<
-  undefined | Map<Instance["id"], HtmlTags>
->();
 
 /**
  * pending means: previous selected instance unmounted,

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -16,7 +16,6 @@ import {
   $selectedInstanceSelector,
   $selectedInstanceBrowserStyle,
   $selectedInstanceUnitSizes,
-  $selectedInstanceIntanceToTag,
   $selectedInstanceRenderState,
   $hoveredInstanceSelector,
   $authTokenPermissions,
@@ -101,10 +100,6 @@ export const createObjectPool = () => {
     new NanostoresSyncObject(
       "selectedInstanceBrowserStyle",
       $selectedInstanceBrowserStyle
-    ),
-    new NanostoresSyncObject(
-      "selectedInstanceIntanceToTag",
-      $selectedInstanceIntanceToTag
     ),
     new NanostoresSyncObject(
       "selectedInstanceUnitSizes",


### PR DESCRIPTION
Got rid of computing tags from dom in canvas. Now tags are computed from possible preset styles and tag prop if available.