### PR TITLE
fix: restore missing components in command panel

### DIFF
--- a/packages/template/src/template.ts
+++ b/packages/template/src/template.ts
@@ -4,9 +4,10 @@ import type { WebstudioFragment } from "@webstudio-is/sdk";
 export const templateCategories = [
   "general",
   "typography",
-  "data",
   "media",
+  "data",
   "forms",
+  "localization",
   "radix",
   "xml",
   "hidden",


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/4689

While refactoring with new component templates
forgot to register them in command panel.

Looks like the prod is affected a little too