### PR TITLE
fix: Fixes hotkeys on radix select, dropdown etc

### DIFF
--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -51,8 +51,7 @@ const makeBreakpointCommand = <CommandName extends string>(
   name,
   hidden: true,
   defaultHotkeys: [`${number}`],
-  disableHotkeyOnFormTags: true,
-  disableHotkeyOnContentEditable: true,
+  disableOnInputLikeControls: true,
   handler: () => {
     selectBreakpointByOrder(number);
   },
@@ -299,8 +298,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       handler: () => {
         $publishDialog.set("publish");
       },
-      disableHotkeyOnFormTags: true,
-      disableHotkeyOnContentEditable: true,
+      disableOnInputLikeControls: true,
     },
     {
       name: "openExportDialog",
@@ -308,8 +306,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       handler: () => {
         $publishDialog.set("export");
       },
-      disableHotkeyOnFormTags: true,
-      disableHotkeyOnContentEditable: true,
+      disableOnInputLikeControls: true,
     },
     {
       name: "toggleComponentsPanel",
@@ -323,8 +320,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
         }
         toggleActiveSidebarPanel("components");
       },
-      disableHotkeyOnFormTags: true,
-      disableHotkeyOnContentEditable: true,
+      disableOnInputLikeControls: true,
     },
     {
       name: "toggleNavigatorPanel",
@@ -332,8 +328,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       handler: () => {
         toggleActiveSidebarPanel("navigator");
       },
-      disableHotkeyOnFormTags: true,
-      disableHotkeyOnContentEditable: true,
+      disableOnInputLikeControls: true,
     },
     {
       name: "openStylePanel",
@@ -347,8 +342,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
         }
         $activeInspectorPanel.set("style");
       },
-      disableHotkeyOnFormTags: true,
-      disableHotkeyOnContentEditable: true,
+      disableOnInputLikeControls: true,
     },
     {
       name: "openSettingsPanel",
@@ -356,8 +350,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       handler: () => {
         $activeInspectorPanel.set("settings");
       },
-      disableHotkeyOnFormTags: true,
-      disableHotkeyOnContentEditable: true,
+      disableOnInputLikeControls: true,
     },
     makeBreakpointCommand("selectBreakpoint1", 1),
     makeBreakpointCommand("selectBreakpoint2", 2),
@@ -373,10 +366,9 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
     {
       name: "toggleAiCommandBar",
       defaultHotkeys: ["space"],
-      disableHotkeyOnContentEditable: true,
       // this disables hotkey for inputs on style panel
       // but still work for input on canvas which call event.preventDefault() in keydown handler
-      disableHotkeyOnFormTags: true,
+      disableOnInputLikeControls: true,
       handler: () => {
         $isAiCommandBarVisible.set($isAiCommandBarVisible.get() === false);
       },
@@ -388,10 +380,9 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
     {
       name: "deleteInstance",
       defaultHotkeys: ["backspace", "delete"],
-      disableHotkeyOnContentEditable: true,
       // this disables hotkey for inputs on style panel
       // but still work for input on canvas which call event.preventDefault() in keydown handler
-      disableHotkeyOnFormTags: true,
+      disableOnInputLikeControls: true,
       handler: deleteSelectedInstance,
     },
     {
@@ -479,8 +470,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "undo",
       // safari use cmd+z to reopen closed tabs, here added ctrl as alternative
       defaultHotkeys: ["meta+z", "ctrl+z"],
-      disableHotkeyOnContentEditable: true,
-      disableHotkeyOnFormTags: true,
+      disableOnInputLikeControls: true,
       handler: () => {
         serverSyncStore.undo();
       },
@@ -489,8 +479,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "redo",
       // safari use cmd+z to reopen closed tabs, here added ctrl as alternative
       defaultHotkeys: ["meta+shift+z", "ctrl+shift+z"],
-      disableHotkeyOnContentEditable: true,
-      disableHotkeyOnFormTags: true,
+      disableOnInputLikeControls: true,
       handler: () => {
         serverSyncStore.redo();
       },

--- a/apps/builder/app/canvas/shared/commands.ts
+++ b/apps/builder/app/canvas/shared/commands.ts
@@ -30,7 +30,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "editInstanceText",
       hidden: true,
       defaultHotkeys: ["enter"],
-      disableHotkeyOnContentEditable: true,
+      disableOnInputLikeControls: true,
       // builder invokes command with custom hotkey setup
       disableHotkeyOutsideApp: true,
       handler: () => {
@@ -94,7 +94,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       name: "escapeSelection",
       hidden: true,
       defaultHotkeys: ["escape"],
-      disableHotkeyOnContentEditable: true,
+      disableOnInputLikeControls: true,
       // reset selection for canvas, but not for the builder
       disableHotkeyOutsideApp: true,
       handler: () => {


### PR DESCRIPTION
closes https://github.com/webstudio-is/webstudio/issues/4550

## Description

1. Detect radix dropdown,select and co as part of the form controls that also implement keyboard shortcuts and don't use global shortcuts on these
2. Simplify shortcut settings by having just one setting that works for everything: form tags, content editable, radix

## Steps for reproduction

1. click button
3. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
