### PR TITLE
fix: Gradient code with var goes away after clicking out

### DIFF
--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -268,7 +268,6 @@ export const EditorContent = ({
   }, []);
 
   // setup editor
-
   useEffect(() => {
     if (editorRef.current === null) {
       return;
@@ -277,13 +276,17 @@ export const EditorContent = ({
       doc: "",
       parent: editorRef.current,
     });
-    if (autoFocus) {
-      view.focus();
-    }
+
     viewRef.current = view;
     return () => {
       view.destroy();
     };
+  }, []);
+
+  useEffect(() => {
+    if (autoFocus) {
+      viewRef.current?.focus();
+    }
   }, [autoFocus]);
 
   // update extensions whenever variables data is changed
@@ -364,6 +367,7 @@ export const EditorContent = ({
     if (value === view.state.doc.toString()) {
       return;
     }
+
     view.dispatch({
       changes: { from: 0, to: view.state.doc.length, insert: value },
       annotations: [ExternalChange.of(true)],
@@ -376,6 +380,7 @@ export const EditorContent = ({
       if (view === undefined) {
         return;
       }
+
       view.dispatch(view.state.replaceSelection(string));
       view.focus();
     },


### PR DESCRIPTION
## Description

closes #4573

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
