### PR TITLE
refactor: drop --preview flag from CLI

### DIFF
--- a/.github/workflows/cli-r2-static.yaml
+++ b/.github/workflows/cli-r2-static.yaml
@@ -96,7 +96,7 @@ jobs:
         run: tar --use-compress-program="zstd -d" -xf ssg-template.tar.zst -C .
 
       - name: Webstudio Build
-        run: pnpm webstudio build --template ssg --template internal --preview
+        run: pnpm webstudio build --template ssg --template internal
         working-directory: ${{ github.workspace }}/ssg-template
 
       - name: Build

--- a/fixtures/ssg-netlify-by-project-id/.webstudio/data.json
+++ b/fixtures/ssg-netlify-by-project-id/.webstudio/data.json
@@ -136,5 +136,6 @@
     "email": "hello@webstudio.is"
   },
   "projectDomain": "fixture-client-do-not-touch-wsmel",
-  "projectTitle": "FIXTURE-CLIENT-DO-NOT-TOUCH"
+  "projectTitle": "FIXTURE-CLIENT-DO-NOT-TOUCH",
+  "origin": "https://main.development.webstudio.is"
 }

--- a/fixtures/ssg-netlify-by-project-id/package.json
+++ b/fixtures/ssg-netlify-by-project-id/package.json
@@ -10,7 +10,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link https://p-8a7358b1-7de3-459d-b7b1-56dddfb6ce1e-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=f55154e6-36b9-4920-bc81-3095cc88f8ff'",
     "fixtures:sync": "pnpm cli sync && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "rm -rf pages && pnpm cli build --template ssg-netlify --template internal --preview && prettier --write ."
+    "fixtures:build": "rm -rf pages && pnpm cli build --template ssg-netlify --template internal && prettier --write ."
   },
   "engines": {
     "node": ">=20.0.0"

--- a/fixtures/ssg/.webstudio/data.json
+++ b/fixtures/ssg/.webstudio/data.json
@@ -493,5 +493,6 @@
     "email": "hello@webstudio.is"
   },
   "projectDomain": "cli-basic-test-d0osr",
-  "projectTitle": "cli-basic-test"
+  "projectTitle": "cli-basic-test",
+  "origin": "https://main.development.webstudio.is"
 }

--- a/fixtures/ssg/package.json
+++ b/fixtures/ssg/package.json
@@ -10,7 +10,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link ${BUILDER_URL_DEPRECATED:-https://main.development.webstudio.is}'/builder/d845c167-ea07-4875-b08d-83e97c09dcce?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
     "fixtures:sync": "pnpm cli sync --buildId a2e8de30-03d5-4514-a3a6-406b3266a3af && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "rm -rf pages && pnpm cli build --template ssg --template internal --preview && prettier --write ."
+    "fixtures:build": "rm -rf pages && pnpm cli build --template ssg --template internal && prettier --write ."
   },
   "engines": {
     "node": ">=20.0.0"

--- a/fixtures/webstudio-cloudflare-template/.webstudio/data.json
+++ b/fixtures/webstudio-cloudflare-template/.webstudio/data.json
@@ -493,5 +493,6 @@
     "email": "hello@webstudio.is"
   },
   "projectDomain": "cli-basic-test-d0osr",
-  "projectTitle": "cli-basic-test"
+  "projectTitle": "cli-basic-test",
+  "origin": "https://main.development.webstudio.is"
 }

--- a/fixtures/webstudio-cloudflare-template/package.json
+++ b/fixtures/webstudio-cloudflare-template/package.json
@@ -4,7 +4,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link https://p-d845c167-ea07-4875-b08d-83e97c09dcce-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
     "fixtures:sync": "pnpm cli sync --buildId a2e8de30-03d5-4514-a3a6-406b3266a3af && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "pnpm cli build --template cloudflare --template saas-helpers --template internal --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json",
+    "fixtures:build": "pnpm cli build --template cloudflare --template saas-helpers --template internal && pnpm prettier --write ./app/ ./package.json ./tsconfig.json",
     "build": "remix vite:build",
     "dev": "remix vite:dev",
     "typecheck": "tsc",

--- a/fixtures/webstudio-custom-template/.webstudio/data.json
+++ b/fixtures/webstudio-custom-template/.webstudio/data.json
@@ -2331,5 +2331,6 @@
     "email": "hello@webstudio.is"
   },
   "projectDomain": "webstudio-custom-template-cochj",
-  "projectTitle": "webstudio-custom-template"
+  "projectTitle": "webstudio-custom-template",
+  "origin": "https://main.development.webstudio.is"
 }

--- a/fixtures/webstudio-custom-template/package.json
+++ b/fixtures/webstudio-custom-template/package.json
@@ -7,7 +7,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link https://p-0d856812-61d8-4014-a20a-82e01c0eb8ee-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=d225fafb-4f20-4340-9359-c21df7c49a3f'",
     "fixtures:sync": "pnpm cli sync --buildId d48c7c5e-fdd3-4ef6-9173-ff2eaaf851d9 && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "pnpm cli build --template defaults --template ./custom-template --template ./custom-template-stage --template internal --preview --assets false && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
+    "fixtures:build": "pnpm cli build --template defaults --template ./custom-template --template ./custom-template-stage --template internal --assets false && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },
   "private": true,
   "sideEffects": false,

--- a/fixtures/webstudio-remix-netlify-edge-functions/.webstudio/data.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/.webstudio/data.json
@@ -493,5 +493,6 @@
     "email": "hello@webstudio.is"
   },
   "projectDomain": "cli-basic-test-d0osr",
-  "projectTitle": "cli-basic-test"
+  "projectTitle": "cli-basic-test",
+  "origin": "https://main.development.webstudio.is"
 }

--- a/fixtures/webstudio-remix-netlify-edge-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-edge-functions/package.json
@@ -8,7 +8,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link https://p-d845c167-ea07-4875-b08d-83e97c09dcce-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
     "fixtures:sync": "pnpm cli sync --buildId a2e8de30-03d5-4514-a3a6-406b3266a3af && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "pnpm cli build --template netlify-edge-functions --template internal --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
+    "fixtures:build": "pnpm cli build --template netlify-edge-functions --template internal && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },
   "dependencies": {
     "@netlify/edge-functions": "^2.11.1",

--- a/fixtures/webstudio-remix-netlify-functions/.webstudio/data.json
+++ b/fixtures/webstudio-remix-netlify-functions/.webstudio/data.json
@@ -493,5 +493,6 @@
     "email": "hello@webstudio.is"
   },
   "projectDomain": "cli-basic-test-d0osr",
-  "projectTitle": "cli-basic-test"
+  "projectTitle": "cli-basic-test",
+  "origin": "https://main.development.webstudio.is"
 }

--- a/fixtures/webstudio-remix-netlify-functions/package.json
+++ b/fixtures/webstudio-remix-netlify-functions/package.json
@@ -7,7 +7,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link https://p-d845c167-ea07-4875-b08d-83e97c09dcce-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=e9d1343f-9298-4fd3-a66e-f89a5af2dd93'",
     "fixtures:sync": "pnpm cli sync --buildId a2e8de30-03d5-4514-a3a6-406b3266a3af && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "pnpm cli build --template netlify-functions --template internal --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
+    "fixtures:build": "pnpm cli build --template netlify-functions --template internal && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },
   "dependencies": {
     "@netlify/functions": "^2.8.2",

--- a/fixtures/webstudio-remix-vercel/.webstudio/data.json
+++ b/fixtures/webstudio-remix-vercel/.webstudio/data.json
@@ -5110,5 +5110,6 @@
     "email": "hello@webstudio.is"
   },
   "projectDomain": "webstudio-fixture-project-a-0su3o",
-  "projectTitle": "webstudio-fixture-project-a"
+  "projectTitle": "webstudio-fixture-project-a",
+  "origin": "https://main.development.webstudio.is"
 }

--- a/fixtures/webstudio-remix-vercel/package.json
+++ b/fixtures/webstudio-remix-vercel/package.json
@@ -7,7 +7,7 @@
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link https://p-cddc1d44-af37-4cb6-a430-d300cf6f932d-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d'",
     "fixtures:sync": "pnpm cli sync --buildId 0ff71ecc-db91-41d0-ba52-26d2fc6c196d && pnpm prettier --write ./.webstudio/",
-    "fixtures:build": "pnpm cli build --template vercel --template internal --preview && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
+    "fixtures:build": "pnpm cli build --template vercel --template internal && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },
   "private": true,
   "sideEffects": false,

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -16,11 +16,6 @@ export const buildOptions = (yargs: CommonYargsArgv) =>
       default: true,
       describe: "[Experimental] Download assets",
     })
-    .option("preview", {
-      type: "boolean",
-      default: false,
-      describe: "[Experimental] Use preview version of the project",
-    })
     .option("template", {
       type: "array",
       string: true,

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -55,6 +55,7 @@ export const sync = async (
       seviceToken: options.authToken,
       origin: options.origin,
     });
+    project.origin = options.origin;
   } else {
     const globalConfigText = await readFile(GLOBAL_CONFIG_FILE, "utf-8");
     const globalConfig = jsonToGlobalConfig(JSON.parse(globalConfigText));
@@ -100,6 +101,7 @@ export const sync = async (
               authToken: token,
               origin,
             });
+      project.origin = origin;
     } catch (error) {
       // catch errors about unpublished project
       syncing.stop((error as Error).message, 2);

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -212,10 +212,6 @@ const importFrom = (importee: string, importer: string) => {
 
 export const prebuild = async (options: {
   /**
-   * Use preview (opensource) version of the project
-   **/
-  preview: boolean;
-  /**
    * Do we need download assets
    **/
   assets: boolean;
@@ -434,19 +430,7 @@ export const prebuild = async (options: {
   const assetsToDownload: Promise<void>[] = [];
 
   if (options.assets === true) {
-    const appDomain = options.preview ? "wstd.work" : "wstd.io";
-    const domain =
-      siteData.build.deployment?.assetsDomain ??
-      // fallback to project domain should not be used since 2025-01-01 (for now is used for backward compatibility)
-      (siteData.build.deployment?.destination !== "static"
-        ? siteData.build.deployment?.projectDomain
-        : undefined);
-
-    if (domain === undefined) {
-      throw new Error(`Project domain is missing from the project data`);
-    }
-
-    const assetOrigin = `https://${domain}.${appDomain}`;
+    const assetOrigin = siteData.origin;
 
     for (const asset of siteData.assets) {
       if (asset.type === "image") {

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -35,6 +35,7 @@ export type Data = {
     deployment?: Deployment | undefined;
   };
   assets: Array<Asset>;
+  origin?: string;
 };
 
 // @todo: broken as expects non 200 code


### PR DESCRIPTION
We figured assets can be loaded from shared url without additional manipulation. Here got rid of asset origin detection and dropped excessive --preview flag. Now local, staging and prod will work automatically.