### PR TITLE
fix: Rate limit on shared link clicks

### DIFF
--- a/apps/builder/app/root.tsx
+++ b/apps/builder/app/root.tsx
@@ -1,5 +1,10 @@
 // Our root outlet doesn't contain a layout because we have 2 types of documents: canvas and builder and we need to decide down the line which one to render, thre is no single root document.
-import { Outlet, json, useLoaderData } from "@remix-run/react";
+import {
+  Outlet,
+  json,
+  useLoaderData,
+  type ShouldRevalidateFunction,
+} from "@remix-run/react";
 import { setEnv } from "@webstudio-is/feature-flags";
 import env from "./env/env.server";
 import { useSetFeatures } from "./shared/use-set-features";
@@ -17,3 +22,7 @@ export default function App() {
 
   return <Outlet />;
 }
+
+export const shouldRevalidate: ShouldRevalidateFunction = () => {
+  return false;
+};

--- a/apps/builder/app/routes/_ui.tsx
+++ b/apps/builder/app/routes/_ui.tsx
@@ -5,6 +5,7 @@ import {
   Scripts,
   ScrollRestoration,
   type ClientLoaderFunctionArgs,
+  type ShouldRevalidateFunction,
 } from "@remix-run/react";
 import interFont from "@fontsource-variable/inter/index.css?url";
 import manropeVariableFont from "@fontsource-variable/manrope/index.css?url";
@@ -106,3 +107,7 @@ export default function Layout() {
     </Document>
   );
 }
+
+export const shouldRevalidate: ShouldRevalidateFunction = () => {
+  return false;
+};

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -723,7 +723,7 @@ export const subscribeResources = () => {
         return;
       }
 
-      const result = await loadResources(Array.from(missing.values()));
+      const result = await loadResources(missingValues);
       const newResourceValues = new Map();
       for (const request of computedResources) {
         const cacheKey = JSON.stringify(request);

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -718,6 +718,11 @@ export const subscribeResources = () => {
         cacheByKeys.set(cacheKey, undefined);
       }
 
+      const missingValues = Array.from(missing.values());
+      if (missingValues.length === 0) {
+        return;
+      }
+
       const result = await loadResources(Array.from(missing.values()));
       const newResourceValues = new Map();
       for (const request of computedResources) {


### PR DESCRIPTION
## Description

closes #4403

We have no way to show good errors on naviagation errors (remix does not support this)

Here I reduced amount of reloads on link clicks on preview

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
