### PR TITLE
fix: When toggling undock navigator, outlines show above navigato

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -351,7 +351,6 @@ export const Builder = ({
 
   const inertHandlers = useInertHandlers();
 
-  console.log("navigatorLayout", navigatorLayout);
   return (
     <TooltipProvider>
       <div

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -351,6 +351,7 @@ export const Builder = ({
 
   const inertHandlers = useInertHandlers();
 
+  console.log("navigatorLayout", navigatorLayout);
   return (
     <TooltipProvider>
       <div
@@ -376,7 +377,12 @@ export const Builder = ({
             </Workspace>
           </Main>
 
-          <SidePanel gridArea="sidebar">
+          <SidePanel
+            gridArea="sidebar"
+            css={{
+              order: navigatorLayout === "docked" ? 1 : undefined,
+            }}
+          >
             <SidebarLeft publish={publish} />
           </SidePanel>
           <SidePanel


### PR DESCRIPTION
## Description

closes #4690

<img width="792" alt="image" src="https://github.com/user-attachments/assets/35e774c9-3a56-4137-b9d5-f1727ca3f471" />


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
