### PR TITLE
fix: Various Scrub bugs and issues

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -212,8 +212,12 @@ const useScrub = ({
 
         // Returning focus that we've moved above
         scrubRef.current?.removeAttribute("tabindex");
-        inputRef.current?.focus();
-        inputRef.current?.select();
+
+        // Otherwise selectionchange event can be triggered after 300-1000ms after focus
+        requestAnimationFrame(() => {
+          inputRef.current?.focus();
+          inputRef.current?.select();
+        });
       },
       shouldHandleEvent,
     });
@@ -832,7 +836,7 @@ export const CssValueInput = ({
     inputRef.current.addEventListener(
       "selectionchange",
       () => {
-        if (Date.now() - focusTime < 50) {
+        if (Date.now() - focusTime < 150) {
           inputRef.current?.select();
         }
       },

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -817,6 +817,73 @@ export const CssValueInput = ({
     return () => abort("unmount");
   }, [abort]);
 
+  useEffect(() => {
+    if (inputRef.current === null) {
+      return;
+    }
+
+    const abortController = new AbortController();
+
+    const options = {
+      signal: abortController.signal,
+    };
+
+    let focusValue = null;
+    let focusTime = 0;
+    inputRef.current.addEventListener(
+      "selectionchange",
+      () => {
+        if (Date.now() - focusTime < 50) {
+          console.log("select");
+          inputRef.current?.select();
+        }
+      },
+      options
+    );
+    inputRef.current.addEventListener(
+      "focus",
+      () => {
+        if (inputRef.current === null) {
+          return;
+        }
+        focusValue = inputRef.current.value;
+        focusTime = Date.now();
+      },
+      options
+    );
+    /*
+    inputRef.current.addEventListener(
+      "pointermove",
+      () => {
+        if (Date.now() - focusTime < 200) {
+          console.log("move");
+          inputRef.current?.select();
+          requestAnimationFrame(() => {
+            inputRef.current?.select();
+          });
+        }
+      },
+      options
+    );
+    inputRef.current.addEventListener(
+      "pointerup",
+      () => {
+        if (Date.now() - focusTime < 200) {
+          inputRef.current?.select();
+          requestAnimationFrame(() => {
+            inputRef.current?.select();
+          });
+        }
+      },
+      options
+    );
+    */
+
+    return () => {
+      abortController.abort();
+    };
+  }, [inputRef]);
+
   const inputPropsHandleKeyDown = composeEventHandlers(
     composeEventHandlers(handleUpDownNumeric, inputProps.onKeyDown, {
       // Pass prevented events to the combobox (e.g., the Escape key doesn't work otherwise, as it's blocked by Radix)
@@ -863,7 +930,7 @@ export const CssValueInput = ({
                 // We are setting the value on focus because we might have removed the var() from the value,
                 // but once focused, we need to show the full value
                 event.target.value = itemToString(value);
-                event.target.select();
+                // event.target.select();
               }
             }}
             autoFocus={autoFocus}

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -828,13 +828,11 @@ export const CssValueInput = ({
       signal: abortController.signal,
     };
 
-    let focusValue = null;
     let focusTime = 0;
     inputRef.current.addEventListener(
       "selectionchange",
       () => {
         if (Date.now() - focusTime < 50) {
-          console.log("select");
           inputRef.current?.select();
         }
       },
@@ -846,38 +844,11 @@ export const CssValueInput = ({
         if (inputRef.current === null) {
           return;
         }
-        focusValue = inputRef.current.value;
+
         focusTime = Date.now();
       },
       options
     );
-    /*
-    inputRef.current.addEventListener(
-      "pointermove",
-      () => {
-        if (Date.now() - focusTime < 200) {
-          console.log("move");
-          inputRef.current?.select();
-          requestAnimationFrame(() => {
-            inputRef.current?.select();
-          });
-        }
-      },
-      options
-    );
-    inputRef.current.addEventListener(
-      "pointerup",
-      () => {
-        if (Date.now() - focusTime < 200) {
-          inputRef.current?.select();
-          requestAnimationFrame(() => {
-            inputRef.current?.select();
-          });
-        }
-      },
-      options
-    );
-    */
 
     return () => {
       abortController.abort();
@@ -930,7 +901,6 @@ export const CssValueInput = ({
                 // We are setting the value on focus because we might have removed the var() from the value,
                 // but once focused, we need to show the full value
                 event.target.value = itemToString(value);
-                // event.target.select();
               }
             }}
             autoFocus={autoFocus}

--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -92,13 +92,14 @@ const initPlugins = ({
   plugins: Array<Plugin>;
   signal: AbortSignal;
 }) => {
-  const handleCopy = async (event: ClipboardEvent) => {
+  const handleCopy = (event: ClipboardEvent) => {
     if (validateClipboardEvent(event) === false) {
       return;
     }
 
     for (const { mimeType = defaultMimeType, onCopy } of plugins) {
-      const data = await onCopy?.();
+      const data = onCopy?.();
+
       if (data) {
         // must prevent default, otherwise setData() will not work
         event.preventDefault();

--- a/packages/design-system/src/components/input-field.tsx
+++ b/packages/design-system/src/components/input-field.tsx
@@ -89,6 +89,7 @@ const containerStyle = css({
   },
   "&:focus-within": {
     borderColor: theme.colors.borderFocus,
+    outline: "none",
   },
   "&:has([data-input-field-input][data-color=error])": {
     borderColor: theme.colors.borderDestructiveMain,
@@ -99,6 +100,7 @@ const containerStyle = css({
   "&:has([data-input-field-input]:is(:disabled, [aria-disabled=true]))": {
     backgroundColor: theme.colors.backgroundInputDisabled,
   },
+
   variants: {
     variant: {
       chromeless: {

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -429,18 +429,21 @@ const requestPointerLock = (
       const timerId = window.setTimeout(() => {
         requestPointerLockSafe(targetNode)
           .then(() => {
-            // do nothing
-
-            const cursorNode = (targetNode.ownerDocument.querySelector(
-              "#numeric-guesture-control-cursor"
-            ) ||
-              new Range().createContextualFragment(`
+            const cursorNode =
+              (targetNode.ownerDocument.querySelector(
+                "#numeric-guesture-control-cursor"
+              ) as SVGElement) ||
+              (new DOMParser().parseFromString(
+                `
               <svg id="numeric-guesture-control-cursor" version="1.1" xmlns="http://www.w3.org/2000/svg" width="46" height="15">
                <g transform="translate(2 3)">
                  <path d="M 15 4.5L 15 2L 11.5 5.5L 15 9L 15 6.5L 31 6.5L 31 9L 34.5 5.5L 31 2L 31 4.5Z" fill="#111" fill-rule="evenodd" stroke="#FFF" stroke-width="2"></path>
                   <path d="M 15 4.5L 15 2L 11.5 5.5L 15 9L 15 6.5L 31 6.5L 31 9L 34.5 5.5L 31 2L 31 4.5Z" fill="#111" fill-rule="evenodd"></path>
                 </g>
-              </svg>`).firstElementChild) as SVGElement;
+              </svg>`,
+                "application/xml"
+              ).documentElement as unknown as SVGElement);
+
             cursorNode.style.filter = `drop-shadow(${
               state.direction === "horizontal" ? "0 1px" : "1px 0"
             } 1.1px rgba(0,0,0,.4))`;

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -25,8 +25,19 @@ const scrubUI = css({
 });
 
 const cursorUI = css({
-  "*": {
-    cursor: "ew-resize!important",
+  variants: {
+    direction: {
+      horizontal: {
+        "*": {
+          cursor: "ew-resize!important",
+        },
+      },
+      vertical: {
+        "*": {
+          cursor: "ns-resize!important",
+        },
+      },
+    },
   },
 });
 
@@ -67,7 +78,6 @@ type NumericScrubState = {
   value: number;
   cursor?: SVGElement;
   direction: NumericScrubDirection;
-  timerId?: ReturnType<typeof window.setTimeout>;
   status: "idle" | "scrubbing";
 };
 
@@ -96,19 +106,27 @@ const preventContextMenu = () => {
   };
 };
 
-const addScrubUi = () => {
+const scrubTimeout = 300;
+
+const addScrubUi = (direction: NumericScrubDirection) => {
   const className = scrubUI();
-  const cursorClassName = cursorUI();
+
+  const cursorClassNames = cursorUI({ direction }).toString().split(" ");
+
   const timerId = setTimeout(() => {
-    window.document.documentElement.classList.add(cursorClassName);
-  }, 300);
+    for (const cursorClassName of cursorClassNames) {
+      window.document.documentElement.classList.add(cursorClassName);
+    }
+  }, scrubTimeout);
 
   window.document.documentElement.classList.add(className);
 
   return () => {
     window.document.documentElement.classList.remove(className);
+    for (const cursorClassName of cursorClassNames) {
+      window.document.documentElement.classList.remove(cursorClassName);
+    }
     clearTimeout(timerId);
-    window.document.documentElement.classList.remove(cursorClassName);
   };
 };
 
@@ -128,34 +146,42 @@ export const numericScrubControl = (
     shouldHandleEvent,
   } = options;
 
+  const cleanupTasks: Array<() => void> = [];
+  const disposeOnCleanup = (fn: () => () => void) => cleanupTasks.push(fn());
+
   const state: NumericScrubState = {
     // We will read value lazyly in a moment it will be used to avoid having outdated value
     value: -1,
     cursor: undefined,
     direction,
-    timerId: undefined,
     status: "idle",
   };
 
-  let exitPointerLock: (() => void) | undefined = undefined;
-  let restoreContextMenu: (() => void) | undefined = undefined;
-  let restoreUi: (() => void) | undefined = undefined;
+  // The appearance of the custom cursor is delayed, so we need to track the mouse position
+  // for its initial placement.
+  const mouseState = {
+    x: 0,
+    y: 0,
+  };
 
   const cleanup = () => {
-    targetNode.removeEventListener("pointermove", handleEvent);
+    requestAnimationFrame(() => {
+      for (const task of [...cleanupTasks.reverse()]) {
+        task();
+      }
 
-    if (state.status === "scrubbing") {
-      state.status = "idle";
-      onStatusChange?.("idle");
+      if (state.status === "scrubbing") {
+        state.status = "idle";
+        onStatusChange?.("idle");
+      }
+    });
+  };
+
+  // Called on ESC key press or in cases of third-party pointer lock exit.
+  const handlePointerLockChange = () => {
+    if (document.pointerLockElement !== targetNode) {
+      cleanup();
     }
-
-    clearTimeout(state.timerId);
-    exitPointerLock?.();
-    exitPointerLock = undefined;
-    restoreContextMenu?.();
-    restoreContextMenu = undefined;
-    restoreUi?.();
-    restoreUi = undefined;
   };
 
   // Cannot define `event:` as PointerEvent,
@@ -173,7 +199,6 @@ export const numericScrubControl = (
     switch (type) {
       case "pointerup": {
         const shouldComponentUpdate = state.status === "scrubbing";
-        console.log("pointerup");
 
         cleanup();
 
@@ -200,26 +225,46 @@ export const numericScrubControl = (
           break;
         }
 
-        console.log("pointerdown");
+        mouseState.x = event.clientX;
+        mouseState.y = event.clientY;
 
         onStart?.();
         state.value = getInitialValue();
-        // state.timerId = setTimeout(async () => {
-        exitPointerLock?.();
-        exitPointerLock = requestPointerLock(state, event, targetNode);
-        // }, 150);
+        disposeOnCleanup(() =>
+          requestPointerLock(state, mouseState, event, targetNode)
+        );
 
-        targetNode.addEventListener("pointermove", handleEvent);
-        restoreUi = addScrubUi();
+        disposeOnCleanup(() => {
+          const abortController = new AbortController();
+          const eventOptions = {
+            signal: abortController.signal,
+          };
+
+          targetNode.addEventListener("pointermove", handleEvent, eventOptions);
+
+          document.addEventListener(
+            "pointerlockchange",
+            handlePointerLockChange,
+            eventOptions
+          );
+          return () => {
+            abortController.abort();
+          };
+        });
+
+        disposeOnCleanup(() => addScrubUi(options.direction ?? "horizontal"));
 
         // Pointer event will stop firing on touch after ~300ms because browser starts scrolling the page.
         // restoreUserSelect = setRootStyle(targetNode, "user-select", "none");
         // In chrome mobile touch simulation, you will get the context menu because tapping and holding
         // results in a right click.
-        restoreContextMenu = preventContextMenu();
+        disposeOnCleanup(preventContextMenu);
         break;
       }
       case "pointermove": {
+        mouseState.x = event.clientX;
+        mouseState.y = event.clientY;
+
         const nextValue = getValue(state, movement, options);
         if (nextValue === state.value) {
           break;
@@ -267,17 +312,13 @@ export const numericScrubControl = (
         break;
       }
       case "pointercancel": {
-        console.log("pointercancel");
         cleanup();
-        break;
-      }
-      case "gotpointercapture": {
-        console.log("gotpointercapture");
         break;
       }
       case "lostpointercapture": {
-        console.log("lostpointercapture");
-        cleanup();
+        if (document.pointerLockElement === null) {
+          cleanup();
+        }
         break;
       }
     }
@@ -290,7 +331,6 @@ export const numericScrubControl = (
     "pointerup",
     "pointerdown",
     "pontercancel",
-    "gotpointercapture",
     "lostpointercapture",
   ] as const;
   eventNames.forEach((eventName) =>
@@ -313,93 +353,103 @@ export const numericScrubControl = (
   };
 };
 
-// If the same property was set while its already in a temporal state, something is wrong with
-// the logic on call-site and we need to inform the developer.
-// const rootStyleTracker = new Map<string, boolean>();
+const requestPointerLockSafe = async (targetNode: HTMLElement | SVGElement) => {
+  try {
+    return await targetNode.requestPointerLock({
+      unadjustedMovement: true,
+    });
+  } catch {
+    // Some platforms may not support unadjusted movement.
+    return await targetNode.requestPointerLock();
+  }
+};
 
 const requestPointerLock = (
   state: NumericScrubState,
+  mouseState: { x: number; y: number },
   event: PointerEvent,
   targetNode: HTMLElement | SVGElement
 ) => {
-  // After ~0.3 seconds starts touch events as page scrolling.
-  // const restoreTouchAction = setRootStyle(targetNode, "touch-action", "none");
-
-  // The pointer lock api nukes the cursor on requestng a pointer lock,
-  // creating and managing the visual que of the cursor is thus left to the author
-  // we create and append an svg that serves as the visual que of where the cursor currently is
-  // taking into account horizontal/vertical orientation of the cursor itself, and update its position on move.
-  // we only use pointerLock api on chromium based browsers, because they feature an unobtrusive ux when activating it
-  // other browsers show a warning banner, making the use of it in this scenario subpar: in which case we fallback to using non-pointerLock means:
-  // albeit without an infinite cursor ux.
-  if (shouldUsePointerLock) {
-    // based on https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock is async
-    try {
-      // unadjustedMovement is a chromium only feature, fixes random movementX|Y jumps on windows
-      //await targetNode.requestPointerLock({ unadjustedMovement: true });
-    } catch {
-      // Some platforms may not support unadjusted movement.
-      // await targetNode.requestPointerLock();
-    }
-
-    const cursorNode = (targetNode.ownerDocument.querySelector(
-      "#numeric-guesture-control-cursor"
-    ) ||
-      new Range().createContextualFragment(`
-      <svg id="numeric-guesture-control-cursor" version="1.1" xmlns="http://www.w3.org/2000/svg" width="46" height="15">
-       <g transform="translate(2 3)">
-         <path d="M 15 4.5L 15 2L 11.5 5.5L 15 9L 15 6.5L 31 6.5L 31 9L 34.5 5.5L 31 2L 31 4.5Z" fill="#111" fill-rule="evenodd" stroke="#FFF" stroke-width="2"></path>
-          <path d="M 15 4.5L 15 2L 11.5 5.5L 15 9L 15 6.5L 31 6.5L 31 9L 34.5 5.5L 31 2L 31 4.5Z" fill="#111" fill-rule="evenodd"></path>
-        </g>
-      </svg>`).firstElementChild) as SVGElement;
-    cursorNode.style.filter = `drop-shadow(${
-      state.direction === "horizontal" ? "0 1px" : "1px 0"
-    } 1.1px rgba(0,0,0,.4))`;
-    cursorNode.style.position = "fixed";
-    cursorNode.style.zIndex = Number.MAX_SAFE_INTEGER.toString();
-    cursorNode.style.left = `${event.clientX}px`;
-    cursorNode.style.top = `${event.clientY}px`;
-    cursorNode.style.transform = `translate(-50%, -50%) ${
-      state.direction === "horizontal" ? "rotate(0deg)" : "rotate(90deg)"
-    }`;
-    state.cursor = cursorNode;
-    if (state.cursor) {
-      targetNode.ownerDocument.documentElement.appendChild(state.cursor);
-    }
-    return () => {
-      if (state.cursor) {
-        state.cursor.remove();
-        state.cursor = undefined;
-      }
-      // restoreTouchAction();
-      targetNode.ownerDocument.exitPointerLock();
-    };
-  }
+  const cleanupTasks: Array<() => void> = [];
+  const disposeOnCleanup = (fn: () => () => void) => cleanupTasks.push(fn());
 
   const { pointerId } = event;
-  /*
-  const restoreCursor = setRootStyle(
-    targetNode,
-    "cursor",
-    state.direction === "horizontal" ? "ew-resize" : "ns-resize"
-  );
-  */
 
   // Fixes an issue where setPointerCapture disrupts the input cursor if the input has a selection.
   // To reproduce: click into the input and observe that everything is selected.
   // Then click again and notice the cursor is not placed correctly.
   window.getSelection()?.removeAllRanges();
-  targetNode.setPointerCapture(pointerId);
-  console.log("setPointerCapture", targetNode.hasPointerCapture(pointerId));
+
+  disposeOnCleanup(() => {
+    targetNode.setPointerCapture(pointerId);
+    return () => {
+      targetNode.releasePointerCapture(pointerId);
+    };
+  });
+
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  // Safari supports pointer lock well, but the issue lies with the pointer lock banner.
+  // It shifts the entire page down, which creates a poor user experience.
+  if (!isSafari) {
+    disposeOnCleanup(() => {
+      const timerId = window.setTimeout(() => {
+        requestPointerLockSafe(targetNode)
+          .then(() => {
+            // do nothing
+
+            const cursorNode = (targetNode.ownerDocument.querySelector(
+              "#numeric-guesture-control-cursor"
+            ) ||
+              new Range().createContextualFragment(`
+              <svg id="numeric-guesture-control-cursor" version="1.1" xmlns="http://www.w3.org/2000/svg" width="46" height="15">
+               <g transform="translate(2 3)">
+                 <path d="M 15 4.5L 15 2L 11.5 5.5L 15 9L 15 6.5L 31 6.5L 31 9L 34.5 5.5L 31 2L 31 4.5Z" fill="#111" fill-rule="evenodd" stroke="#FFF" stroke-width="2"></path>
+                  <path d="M 15 4.5L 15 2L 11.5 5.5L 15 9L 15 6.5L 31 6.5L 31 9L 34.5 5.5L 31 2L 31 4.5Z" fill="#111" fill-rule="evenodd"></path>
+                </g>
+              </svg>`).firstElementChild) as SVGElement;
+            cursorNode.style.filter = `drop-shadow(${
+              state.direction === "horizontal" ? "0 1px" : "1px 0"
+            } 1.1px rgba(0,0,0,.4))`;
+            cursorNode.style.position = "fixed";
+            cursorNode.style.zIndex = Number.MAX_SAFE_INTEGER.toString();
+
+            cursorNode.style.left = `${mouseState.x}px`;
+            cursorNode.style.top = `${mouseState.y}px`;
+
+            cursorNode.style.transform = `translate(-50%, -50%) ${
+              state.direction === "horizontal"
+                ? "rotate(0deg)"
+                : "rotate(90deg)"
+            }`;
+            state.cursor = cursorNode;
+            if (state.cursor) {
+              targetNode.ownerDocument.documentElement.appendChild(
+                state.cursor
+              );
+            }
+          })
+          .catch((error) => {
+            console.error("requestPointerLock", error);
+          });
+      }, scrubTimeout);
+
+      return () => {
+        if (state.cursor) {
+          state.cursor.remove();
+          state.cursor = undefined;
+        }
+        targetNode.ownerDocument.exitPointerLock();
+        clearTimeout(timerId);
+      };
+    });
+  }
 
   return () => {
-    // restoreCursor();
-    // restoreTouchAction();
-    targetNode.releasePointerCapture(pointerId);
+    for (const task of [...cleanupTasks.reverse()]) {
+      task();
+    }
   };
 };
-
-const shouldUsePointerLock = false; //  "chrome" in globalThis;
 
 // When the value is outside of the range make it come back to the range from the other side
 //   |        | . -> | .      |

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -442,7 +442,7 @@ const requestPointerLock = (
                 </g>
               </svg>`,
                 "application/xml"
-              ).documentElement as unknown as SVGElement);
+              ).documentElement as Element as SVGElement);
 
             cursorNode.style.filter = `drop-shadow(${
               state.direction === "horizontal" ? "0 1px" : "1px 0"


### PR DESCRIPTION
## Description

Need to be heavily tested

closes #4511 

Fixes:
- [x] - Resize cursor wasn't removed after scrub on some cases <img width="262" alt="image" src="https://github.com/user-attachments/assets/acacbef1-61d8-477d-bb5e-ba3565cc8fd1" />
- [x] - Esc now works as expected.
- [x] - Selection https://github.com/webstudio-is/webstudio/issues/4511 
- [ ]  - Works in Safari and FF
- [ ]  - Should work in case if pointer lock permission is not provided (hard to test as can't revoke chrome permission)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
