### PR TITLE
feat: add a project id to project settings dialog

### DIFF
--- a/apps/builder/app/builder/features/project-settings/project-settings.stories.tsx
+++ b/apps/builder/app/builder/features/project-settings/project-settings.stories.tsx
@@ -1,7 +1,8 @@
 import type { JSX } from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { ProjectSettingsView } from "./project-settings";
-import { $pages } from "~/shared/nano-states";
+import { $pages, $project } from "~/shared/nano-states";
+import type { Project } from "@webstudio-is/project";
 
 export default {
   component: ProjectSettingsView,
@@ -15,6 +16,8 @@ const createRouter = (element: JSX.Element) =>
       loader: () => null,
     },
   ]);
+
+$project.set({ id: "projectId" } as Project);
 
 export const General = () => {
   const router = createRouter(<ProjectSettingsView currentSection="general" />);

--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -122,9 +122,7 @@ export const SectionGeneral = () => {
       <Grid gap={1} css={sectionSpacing}>
         <Flex gap={1} align="center">
           <Text variant="labelsSentenceCase">Project ID:</Text>
-          <Text variant="mono" userSelect="text">
-            {project.id}
-          </Text>
+          <Text userSelect="text">{project.id}</Text>
           <CopyToClipboard text={project.id} copyText="Copy ID">
             <IconButton aria-label="Copy ID">
               <CopyIcon aria-hidden />

--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -98,6 +98,7 @@ export const SectionGeneral = () => {
   const assets = useStore($assets);
   const asset = assets.get(meta.faviconAssetId ?? "");
   const favIconUrl = asset ? `${asset.name}` : undefined;
+  const project = $project.get();
 
   const handleSave = <Name extends keyof ProjectMeta>(
     name: keyof ProjectMeta
@@ -107,6 +108,10 @@ export const SectionGeneral = () => {
       saveSetting(name, value);
     };
   };
+
+  if (project === undefined) {
+    return;
+  }
 
   return (
     <Grid gap={2}>
@@ -118,9 +123,9 @@ export const SectionGeneral = () => {
         <Flex gap={1} align="center">
           <Text variant="labelsSentenceCase">Project ID:</Text>
           <Text variant="mono" userSelect="text">
-            {$project.get()?.id}
+            {project.id}
           </Text>
-          <CopyToClipboard text={$project.get()?.id} copyText="Copy ID">
+          <CopyToClipboard text={project.id} copyText="Copy ID">
             <IconButton aria-label="Copy ID">
               <CopyIcon aria-hidden />
             </IconButton>

--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -98,8 +98,8 @@ export const SectionGeneral = () => {
   const assets = useStore($assets);
   const asset = assets.get(meta.faviconAssetId ?? "");
   const favIconUrl = asset ? `${asset.name}` : undefined;
-  const project = useStore($project);
-  console.log(project);
+  const project = $project.get();
+
   if (project === undefined) {
     return;
   }

--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -15,15 +15,22 @@ import {
   InputErrorsTooltip,
   ProBadge,
   TextArea,
+  IconButton,
 } from "@webstudio-is/design-system";
-import { InfoCircleIcon } from "@webstudio-is/icons";
+import { CopyIcon, InfoCircleIcon } from "@webstudio-is/icons";
 import { Image, wsImageLoader } from "@webstudio-is/image";
 import type { ProjectMeta } from "@webstudio-is/sdk";
 import { ImageControl } from "./image-control";
-import { $assets, $pages, $userPlanFeatures } from "~/shared/nano-states";
+import {
+  $assets,
+  $pages,
+  $project,
+  $userPlanFeatures,
+} from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
 import { sectionSpacing } from "./utils";
 import { CodeEditor } from "~/builder/shared/code-editor";
+import { CopyToClipboard } from "~/builder/shared/copy-to-clipboard";
 
 const imgStyle = css({
   objectFit: "contain",
@@ -106,6 +113,20 @@ export const SectionGeneral = () => {
       <Text variant="titles" css={sectionSpacing}>
         General
       </Text>
+
+      <Grid gap={1} css={sectionSpacing}>
+        <Flex gap={1} align="center">
+          <Text variant="labelsSentenceCase">Project ID:</Text>
+          <Text variant="mono" userSelect="text">
+            {$project.get()?.id}
+          </Text>
+          <CopyToClipboard text={$project.get()?.id} copyText="Copy ID">
+            <IconButton aria-label="Copy ID">
+              <CopyIcon aria-hidden />
+            </IconButton>
+          </CopyToClipboard>
+        </Flex>
+      </Grid>
 
       <Grid gap={1} css={sectionSpacing}>
         <Flex gap={1} align="center">

--- a/apps/builder/app/builder/features/project-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-general.tsx
@@ -98,7 +98,11 @@ export const SectionGeneral = () => {
   const assets = useStore($assets);
   const asset = assets.get(meta.faviconAssetId ?? "");
   const favIconUrl = asset ? `${asset.name}` : undefined;
-  const project = $project.get();
+  const project = useStore($project);
+  console.log(project);
+  if (project === undefined) {
+    return;
+  }
 
   const handleSave = <Name extends keyof ProjectMeta>(
     name: keyof ProjectMeta
@@ -108,10 +112,6 @@ export const SectionGeneral = () => {
       saveSetting(name, value);
     };
   };
-
-  if (project === undefined) {
-    return;
-  }
 
   return (
     <Grid gap={2}>


### PR DESCRIPTION
## Description

Now there is an official place where to find the project id, besides the URL where user can't know

<img width="639" alt="image" src="https://github.com/user-attachments/assets/d6bb08af-ff87-42a1-ab0c-a6ca4395acdb" />


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
