### PR TITLE
fix: fix vimeo and youtube player crash in the builder

### DIFF
--- a/packages/sdk-components-react/src/vimeo.template.tsx
+++ b/packages/sdk-components-react/src/vimeo.template.tsx
@@ -18,7 +18,7 @@ export const meta: TemplateMeta = {
         ws:style={css`
           position: absolute;
           object-fit: cover;
-          object-position: cover;
+          object-position: center;
           width: 100%;
           height: 100%;
           border-radius: 20px;

--- a/packages/sdk-components-react/src/youtube.template.tsx
+++ b/packages/sdk-components-react/src/youtube.template.tsx
@@ -21,12 +21,12 @@ export const meta: TemplateMeta = {
         ws:style={css`
           position: absolute;
           object-fit: cover;
-          object-position: cover;
+          object-position: center;
           width: 100%;
           height: 100%;
           border-radius: 20px;
         `}
-        alt="Vimeo video preview image"
+        alt="YouTube video preview image"
         sizes="100vw"
         optimize={true}
       />


### PR DESCRIPTION
## Description

When clicking on object position on image preview in the style panel builder crashes because object-position: cover doesn't exist

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
