### PR TITLE
fix: merge generated classes and class prop properly

### DIFF
--- a/fixtures/ssg-netlify-by-project-id/app/__generated__/_index.tsx
+++ b/fixtures/ssg-netlify-by-project-id/app/__generated__/_index.tsx
@@ -24,8 +24,8 @@ export const CustomCode = () => {
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body"}>
-      <Heading className={"w-heading"}>{"FIXTURE-CLIENT-DO-NOT-TOUCH"}</Heading>
+    <Body className={`w-body`}>
+      <Heading className={`w-heading`}>{"FIXTURE-CLIENT-DO-NOT-TOUCH"}</Heading>
     </Body>
   );
 };

--- a/fixtures/ssg/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/ssg/app/__generated__/[another-page]._index.tsx
@@ -20,8 +20,8 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body"}>
-      <Heading className={"w-heading"}>{"Another page"}</Heading>
+    <Body className={`w-body`}>
+      <Heading className={`w-heading`}>{"Another page"}</Heading>
     </Body>
   );
 };

--- a/fixtures/ssg/app/__generated__/_index.tsx
+++ b/fixtures/ssg/app/__generated__/_index.tsx
@@ -27,23 +27,23 @@ export const CustomCode = () => {
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body c1jaw2zx cbipm55 ctniqj4 ctgx88l"}>
-      <Heading className={"w-heading"}>{"Simple Project to test CLI"}</Heading>
-      <Text className={"w-text cn3rfux"}>
+    <Body className={`w-body c1jaw2zx cbipm55 ctniqj4 ctgx88l`}>
+      <Heading className={`w-heading`}>{"Simple Project to test CLI"}</Heading>
+      <Text className={`w-text cn3rfux`}>
         {"Please don't change directly in the fixture"}
       </Text>
-      <Link href={"/another-page"} className={"w-link"}>
+      <Link href={"/another-page"} className={`w-link`}>
         {"Test another page link"}
       </Link>
       <Image
         src={"/assets/iconly_svg_converted-converted_zMaMiAAutUl8XrITgz7d1.svg"}
         width={14}
         height={16}
-        className={"w-image c161qeci"}
+        className={`w-image c161qeci`}
       />
       <Image
         src={"https://picsum.photos/id/237/100/100.jpg?blur=4&grayscale"}
-        className={"w-image"}
+        className={`w-image`}
       />
     </Body>
   );

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/[another-page]._index.tsx
@@ -18,8 +18,8 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body"}>
-      <Heading className={"w-heading"}>{"Another page"}</Heading>
+    <Body className={`w-body`}>
+      <Heading className={`w-heading`}>{"Another page"}</Heading>
     </Body>
   );
 };

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
@@ -29,23 +29,23 @@ export const CustomCode = () => {
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body c1jaw2zx cbipm55 ctniqj4 ctgx88l"}>
-      <Heading className={"w-heading"}>{"Simple Project to test CLI"}</Heading>
-      <Text className={"w-text cn3rfux"}>
+    <Body className={`w-body c1jaw2zx cbipm55 ctniqj4 ctgx88l`}>
+      <Heading className={`w-heading`}>{"Simple Project to test CLI"}</Heading>
+      <Text className={`w-text cn3rfux`}>
         {"Please don't change directly in the fixture"}
       </Text>
-      <Link href={"/another-page"} className={"w-link"}>
+      <Link href={"/another-page"} className={`w-link`}>
         {"Test another page link"}
       </Link>
       <Image
         src={"/assets/iconly_svg_converted-converted_zMaMiAAutUl8XrITgz7d1.svg"}
         width={14}
         height={16}
-        className={"w-image c161qeci"}
+        className={`w-image c161qeci`}
       />
       <Image
         src={"https://picsum.photos/id/237/100/100.jpg?blur=4&grayscale"}
-        className={"w-image"}
+        className={`w-image`}
       />
     </Body>
   );

--- a/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[script-test]._index.tsx
@@ -34,23 +34,23 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body cjrgi00"}>
-      <Heading className={"w-heading"}>{"Script Test"}</Heading>
-      <Link href={"/"} className={"w-link"}>
+    <Body className={`w-body cjrgi00`}>
+      <Heading className={`w-heading`}>{"Script Test"}</Heading>
+      <Link href={"/"} className={`w-link`}>
         {"Go Home"}
       </Link>
       <HtmlEmbed
         code={
           "<br>\n<script>console.log('SCRIPT TEST SSR')</script>\n<script>console.log('SCRIPT TEST SSR 2')</script>\nSCRIPTS ARE HERE 2<br>"
         }
-        className={"w-html-embed"}
+        className={`w-html-embed`}
       />
       <HtmlEmbed
         code={
           "<script>console.log('SCRIPTS TEST Client')</script>\n<script>console.log('SCRIPTS TEST 2 Client')</script>\nSCRIPTS ARE HERE <br>"
         }
         clientOnly={true}
-        className={"w-html-embed"}
+        className={`w-html-embed`}
       />
     </Body>
   );

--- a/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[sitemap.xml]._index.tsx
@@ -30,7 +30,7 @@ const Body = (props: any) => <svg>{props.children}</svg>;
 const Page = ({ system: system }: { system: any }) => {
   let sitemapxml = useResource("sitemapxml_1");
   return (
-    <Body className={"w-body"}>
+    <Body className={`w-body`}>
       <XmlNode
         tag={"urlset"}
         xmlns={"http://www.sitemaps.org/schemas/sitemap/0.9"}

--- a/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/[world]._index.tsx
@@ -28,8 +28,8 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body"}>
-      <Heading className={"w-heading"}>{"Привет Мир"}</Heading>
+    <Body className={`w-body`}>
+      <Heading className={`w-heading`}>{"Привет Мир"}</Heading>
     </Body>
   );
 };

--- a/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-custom-template/app/__generated__/_index.tsx
@@ -88,80 +88,72 @@ export const CustomCode = () => {
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body cjrgi00"}>
+    <Body className={`w-body cjrgi00`}>
       <Heading
-        className={
-          "w-heading ce7mxws cd0g70b c1ku1ozg c1kbs9xq c1m6kmmg crjoqt7 c1n5sjmn c1hqh3e6 cwdggon c4o64du"
-        }
+        className={`w-heading ce7mxws cd0g70b c1ku1ozg c1kbs9xq c1m6kmmg crjoqt7 c1n5sjmn c1hqh3e6 cwdggon c4o64du`}
       >
         {"DO NOT TOUCH THIS PROJECT, IT'S USED FOR FIXTURES"}
       </Heading>
-      <Box className={"w-box cxb89wn c12qr5j7 c111rqf8 cp8i2p0 cwfevk3"}>
+      <Box className={`w-box cxb89wn c12qr5j7 c111rqf8 cp8i2p0 cwfevk3`}>
         <Image
           src={
             "/custom-folder/_937084ed-a798-49fe-8664-df93a2af605e_1JqSy_0Wy9fY5mXNZSLJ0.jpeg"
           }
           width={1024}
           height={1024}
-          className={"w-image ccgiojm cv4f3rn cer5re4 c9lz7ss"}
+          className={`w-image ccgiojm cv4f3rn cer5re4 c9lz7ss`}
         />
-        <Box className={"w-box ccgiojm cv4f3rn cer5re4 c9lz7ss"} />
+        <Box className={`w-box ccgiojm cv4f3rn cer5re4 c9lz7ss`} />
       </Box>
-      <Heading className={"w-heading"}>{"Below Image"}</Heading>
+      <Heading className={`w-heading`}>{"Below Image"}</Heading>
       <HtmlEmbed
         code={
           "<script>console.log('PAGE MAIN Client')</script>\n<script>console.log('PAGE MAIN 2 Client')</script>\nSCRIPTS ARE HERE <br>"
         }
         clientOnly={true}
-        className={"w-html-embed"}
+        className={`w-html-embed`}
       />
       <HtmlEmbed
         code={
           "<script>console.log('PAGE MAIN SSR')</script>\n<script>console.log('PAGE MAIN 2 SSR')</script>\nSCRIPTS ARE HERE <br>"
         }
-        className={"w-html-embed"}
+        className={`w-html-embed`}
       />
-      <Link href={"/script-test"} className={"w-link"}>
+      <Link href={"/script-test"} className={`w-link`}>
         {"Goto Scr"}
       </Link>
       <Vimeo
         url={"https://player.vimeo.com/video/831343124"}
         showPreview={true}
-        className={"w-vimeo c17osjft c5kxibo c8mrdqb"}
+        className={`w-vimeo c17osjft c5kxibo c8mrdqb`}
       >
         <VimeoPreviewImage
           alt={"Vimeo video preview image"}
           sizes={"100vw"}
           src={"/custom-folder/home_wsKvRSqvkajPPBeycZ-C8.svg"}
-          className={
-            "w-preview-image c13adha2 c19kjzjn c8mrdqb chv0hit c1vw7ut7 c64vnj4 cow7xo6 cddunt6 cqjhyu2"
-          }
+          className={`w-preview-image c13adha2 c19kjzjn c8mrdqb chv0hit c1vw7ut7 c64vnj4 cow7xo6 cddunt6 cqjhyu2`}
         />
         <VimeoSpinner
-          className={
-            "w-spinner c13adha2 c1ifzo79 c1ljqvnn c10zke2u cplzsl2 c1ardg8l ces5mo3"
-          }
+          className={`w-spinner c13adha2 c1ifzo79 c1ljqvnn c10zke2u cplzsl2 c1ardg8l ces5mo3`}
         >
           <HtmlEmbed
             code={
               '<svg xmlns="http://www.w3.org/2000/svg" id="e2CRglijn891" shape-rendering="geometricPrecision" text-rendering="geometricPrecision" viewBox="0 0 128 128" fill="currentColor" width="100%" height="100%" style="display: block;"><style>@keyframes e2CRglijn892_tr__tr{0%{transform:translate(64px,64px) rotate(90deg);animation-timing-function:cubic-bezier(.42,0,.58,1)}50%{transform:translate(64px,64px) rotate(810deg);animation-timing-function:cubic-bezier(.42,0,.58,1)}to{transform:translate(64px,64px) rotate(1530deg)}}@keyframes e2CRglijn892_s_p{0%,to{stroke:#39fbbb}25%{stroke:#4a4efa}50%{stroke:#e63cfe}75%{stroke:#ffae3c}}@keyframes e2CRglijn892_s_do{0%{stroke-dashoffset:251.89}2.5%,52.5%{stroke-dashoffset:263.88;animation-timing-function:cubic-bezier(.42,0,.58,1)}25%,75%{stroke-dashoffset:131.945}to{stroke-dashoffset:251.885909}}#e2CRglijn892_tr{animation:e2CRglijn892_tr__tr 3000ms linear infinite normal forwards}#e2CRglijn892{animation-name:e2CRglijn892_s_p,e2CRglijn892_s_do;animation-duration:3000ms;animation-fill-mode:forwards;animation-timing-function:linear;animation-direction:normal;animation-iteration-count:infinite}</style><g id="e2CRglijn892_tr" transform="translate(64,64) rotate(90)"><circle id="e2CRglijn892" r="42" fill="none" stroke="#39fbbb" stroke-dasharray="263.89" stroke-dashoffset="251.89" stroke-linecap="round" stroke-width="16" transform="scale(-1,1) translate(0,0)"/></g></svg>'
             }
             executeScriptOnCanvas={false}
-            className={"w-html-embed"}
+            className={`w-html-embed`}
           />
         </VimeoSpinner>
         <VimeoPlayButton
           aria-label={"Play button"}
-          className={
-            "w-play-button c13adha2 c1t88ri8 ca7kf99 c1ifzo79 c1ljqvnn c1bld9op ctly9e6 cxb89wn cwcnvqs cvchf4 c1y7dyx c1bnrgjg c1joowif c120xed6 c2eug5n cvwgylz c1f0qcby c1syyj1x cil01r8 c11087u4 coba2o7 c82nx6d"
-          }
+          className={`w-play-button c13adha2 c1t88ri8 ca7kf99 c1ifzo79 c1ljqvnn c1bld9op ctly9e6 cxb89wn cwcnvqs cvchf4 c1y7dyx c1bnrgjg c1joowif c120xed6 c2eug5n cvwgylz c1f0qcby c1syyj1x cil01r8 c11087u4 coba2o7 c82nx6d`}
         >
-          <Box aria-hidden={"true"} className={"w-box c1cccshn c1eyznz"}>
+          <Box aria-hidden={"true"} className={`w-box c1cccshn c1eyznz`}>
             <HtmlEmbed
               code={
                 '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.766 5.765c0-.725 0-1.088.178-1.288a.93.93 0 0 1 .648-.294c.294-.015.65.186 1.359.588l9.234 5.235c.586.332.88.498.982.708.09.183.09.389 0 .572-.102.21-.396.376-.982.708l-9.234 5.235c-.71.402-1.065.603-1.359.588a.93.93 0 0 1-.648-.294c-.178-.2-.178-.563-.178-1.288V5.765Z"/></svg>'
               }
-              className={"w-html-embed"}
+              className={`w-html-embed`}
             />
           </Box>
         </VimeoPlayButton>

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/[another-page]._index.tsx
@@ -18,8 +18,8 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body"}>
-      <Heading className={"w-heading"}>{"Another page"}</Heading>
+    <Body className={`w-body`}>
+      <Heading className={`w-heading`}>{"Another page"}</Heading>
     </Body>
   );
 };

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/__generated__/_index.tsx
@@ -29,23 +29,23 @@ export const CustomCode = () => {
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body c1jaw2zx cbipm55 ctniqj4 ctgx88l"}>
-      <Heading className={"w-heading"}>{"Simple Project to test CLI"}</Heading>
-      <Text className={"w-text cn3rfux"}>
+    <Body className={`w-body c1jaw2zx cbipm55 ctniqj4 ctgx88l`}>
+      <Heading className={`w-heading`}>{"Simple Project to test CLI"}</Heading>
+      <Text className={`w-text cn3rfux`}>
         {"Please don't change directly in the fixture"}
       </Text>
-      <Link href={"/another-page"} className={"w-link"}>
+      <Link href={"/another-page"} className={`w-link`}>
         {"Test another page link"}
       </Link>
       <Image
         src={"/assets/iconly_svg_converted-converted_zMaMiAAutUl8XrITgz7d1.svg"}
         width={14}
         height={16}
-        className={"w-image c161qeci"}
+        className={`w-image c161qeci`}
       />
       <Image
         src={"https://picsum.photos/id/237/100/100.jpg?blur=4&grayscale"}
-        className={"w-image"}
+        className={`w-image`}
       />
     </Body>
   );

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/[another-page]._index.tsx
@@ -28,8 +28,8 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body"}>
-      <Heading className={"w-heading"}>{"Another page"}</Heading>
+    <Body className={`w-body`}>
+      <Heading className={`w-heading`}>{"Another page"}</Heading>
     </Body>
   );
 };

--- a/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-netlify-functions/app/__generated__/_index.tsx
@@ -39,23 +39,23 @@ export const CustomCode = () => {
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body c1jaw2zx cbipm55 ctniqj4 ctgx88l"}>
-      <Heading className={"w-heading"}>{"Simple Project to test CLI"}</Heading>
-      <Text className={"w-text cn3rfux"}>
+    <Body className={`w-body c1jaw2zx cbipm55 ctniqj4 ctgx88l`}>
+      <Heading className={`w-heading`}>{"Simple Project to test CLI"}</Heading>
+      <Text className={`w-text cn3rfux`}>
         {"Please don't change directly in the fixture"}
       </Text>
-      <Link href={"/another-page"} className={"w-link"}>
+      <Link href={"/another-page"} className={`w-link`}>
         {"Test another page link"}
       </Link>
       <Image
         src={"/assets/iconly_svg_converted-converted_zMaMiAAutUl8XrITgz7d1.svg"}
         width={14}
         height={16}
-        className={"w-image c161qeci"}
+        className={`w-image c161qeci`}
       />
       <Image
         src={"https://picsum.photos/id/237/100/100.jpg?blur=4&grayscale"}
-        className={"w-image"}
+        className={`w-image`}
       />
     </Body>
   );

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -28,10 +28,10 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body"}>
+    <Body className={`w-body`}>
       <Image
         src={"/assets/small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp"}
-        className={"w-image c1czoo99"}
+        className={`w-image c1czoo99`}
       />
     </Body>
   );

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[class-names]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[class-names]._index.tsx
@@ -29,14 +29,12 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 const Page = ({}: { system: any }) => {
   let [classVar, set$classVar] = useVariableState<any>("varClass");
   return (
-    <Body className={"w-body"}>
+    <Body className={`w-body`}>
       <Box
         id={"\"broken'with`symbols"}
-        className={
-          "w-box cm16yxw" + " " + "custom-class \"broken 'with `symbols"
-        }
+        className={`w-box cm16yxw ${"custom-class \"broken 'with `symbols"}`}
       />
-      <Box className={"w-box ctm310" + " " + `${classVar} class_3`} />
+      <Box className={`w-box ctm310 ${`${classVar} class_3`}`} />
     </Body>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[content-block]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[content-block]._index.tsx
@@ -32,26 +32,26 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body"}>
-      <Box className={"w-box coklr1z"}>
-        <Heading className={"w-heading cc5h0no"}>
+    <Body className={`w-body`}>
+      <Box className={`w-box coklr1z`}>
+        <Heading className={`w-heading cc5h0no`}>
           {"Content Block With Templates And Content"}
         </Heading>
-        <Heading className={"w-heading"}>{"H1"}</Heading>
-        <Paragraph className={"w-paragraph"}>{"Paragraph"}</Paragraph>
+        <Heading className={`w-heading`}>{"H1"}</Heading>
+        <Paragraph className={`w-paragraph`}>{"Paragraph"}</Paragraph>
       </Box>
-      <Box className={"w-box c1cqkpk9"}>
-        <Heading className={"w-heading cc5h0no"}>
+      <Box className={`w-box c1cqkpk9`}>
+        <Heading className={`w-heading cc5h0no`}>
           {"Content Block With Templates Only"}
         </Heading>
       </Box>
-      <Box className={"w-box ccxj65f"}>
-        <Heading className={"w-heading cc5h0no"}>{"With Content Only"}</Heading>
-        <Heading className={"w-heading"}>{"H1"}</Heading>
-        <Paragraph className={"w-paragraph"}>{"Paragraph"}</Paragraph>
+      <Box className={`w-box ccxj65f`}>
+        <Heading className={`w-heading cc5h0no`}>{"With Content Only"}</Heading>
+        <Heading className={`w-heading`}>{"H1"}</Heading>
+        <Paragraph className={`w-paragraph`}>{"Paragraph"}</Paragraph>
       </Box>
-      <Box className={"w-box c1a2hnxl"}>
-        <Heading className={"w-heading cc5h0no"}>{"Empty"}</Heading>
+      <Box className={`w-box c1a2hnxl`}>
+        <Heading className={`w-heading cc5h0no`}>{"Empty"}</Heading>
       </Box>
     </Body>
   );

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[expressions]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[expressions]._index.tsx
@@ -33,8 +33,8 @@ const Page = ({}: { system: any }) => {
   let jsonResourceVariable = useResource("jsonResourceVariable_1");
   let [jsonVar, set$jsonVar] = useVariableState<any>({ hello: "world" });
   return (
-    <Body className={"w-body"}>
-      <Heading className={"w-heading"}>
+    <Body className={`w-body`}>
+      <Heading className={`w-heading`}>
         {`${jsonResourceVariable?.data?.args}`}
       </Heading>
       <HtmlEmbed
@@ -45,7 +45,7 @@ const b = ${jsonVar}
 
 console.log(a, b);
 </script>`}
-        className={"w-html-embed"}
+        className={`w-html-embed`}
       />
     </Body>
   );

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[form]._index.tsx
@@ -39,32 +39,32 @@ const Page = ({}: { system: any }) => {
   let [formState, set$formState] = useVariableState<any>("initial");
   let [formState_1, set$formState_1] = useVariableState<any>("initial");
   return (
-    <Body className={"w-body"}>
+    <Body className={`w-body`}>
       <Form
         state={formState}
         onStateChange={(state: any) => {
           formState = state;
           set$formState(formState);
         }}
-        className={"w-webhook-form"}
+        className={`w-webhook-form`}
       >
         {(formState === "initial" || formState === "error") && (
-          <Box className={"w-box"}>
-            <Heading tag={"h3"} className={"w-heading"}>
+          <Box className={`w-box`}>
+            <Heading tag={"h3"} className={`w-heading`}>
               {"Default form"}
             </Heading>
-            <Label className={"w-input-label"}>{"Name"}</Label>
-            <Input name={"name"} className={"w-text-input"} />
-            <Label className={"w-input-label"}>{"Email"}</Label>
-            <Input name={"email"} className={"w-text-input"} />
-            <Button className={"w-button"}>{"Submit"}</Button>
+            <Label className={`w-input-label`}>{"Name"}</Label>
+            <Input name={"name"} className={`w-text-input`} />
+            <Label className={`w-input-label`}>{"Email"}</Label>
+            <Input name={"email"} className={`w-text-input`} />
+            <Button className={`w-button`}>{"Submit"}</Button>
           </Box>
         )}
         {formState === "success" && (
-          <Box className={"w-box"}>{"Thank you for getting in touch!"}</Box>
+          <Box className={`w-box`}>{"Thank you for getting in touch!"}</Box>
         )}
         {formState === "error" && (
-          <Box className={"w-box"}>{"Sorry, something went wrong."}</Box>
+          <Box className={`w-box`}>{"Sorry, something went wrong."}</Box>
         )}
       </Form>
       <Form
@@ -74,25 +74,25 @@ const Page = ({}: { system: any }) => {
           set$formState_1(formState_1);
         }}
         action={"action"}
-        className={"w-webhook-form"}
+        className={`w-webhook-form`}
       >
         {(formState_1 === "initial" || formState_1 === "error") && (
-          <Box className={"w-box"}>
-            <Heading tag={"h3"} className={"w-heading"}>
+          <Box className={`w-box`}>
+            <Heading tag={"h3"} className={`w-heading`}>
               {"Form with custom action and method"}
             </Heading>
-            <Label className={"w-input-label"}>{"Name"}</Label>
-            <Input name={"name"} className={"w-text-input"} />
-            <Label className={"w-input-label"}>{"Email"}</Label>
-            <Input name={"email"} className={"w-text-input"} />
-            <Button className={"w-button"}>{"Submit"}</Button>
+            <Label className={`w-input-label`}>{"Name"}</Label>
+            <Input name={"name"} className={`w-text-input`} />
+            <Label className={`w-input-label`}>{"Email"}</Label>
+            <Input name={"email"} className={`w-text-input`} />
+            <Button className={`w-button`}>{"Submit"}</Button>
           </Box>
         )}
         {formState_1 === "success" && (
-          <Box className={"w-box"}>{"Thank you for getting in touch!"}</Box>
+          <Box className={`w-box`}>{"Thank you for getting in touch!"}</Box>
         )}
         {formState_1 === "error" && (
-          <Box className={"w-box"}>{"Sorry, something went wrong."}</Box>
+          <Box className={`w-box`}>{"Sorry, something went wrong."}</Box>
         )}
       </Form>
     </Body>

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[heading-with-id]._index.tsx
@@ -28,8 +28,8 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body"}>
-      <Heading id={"my-heading"} className={"w-heading"}>
+    <Body className={`w-body`}>
+      <Heading id={"my-heading"} className={`w-heading`}>
         {"Heading you can edit"}
       </Heading>
     </Body>

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[nested].[nested-page]._index.tsx
@@ -28,8 +28,8 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body"}>
-      <Heading className={"w-heading"}>{"Nested page"}</Heading>
+    <Body className={`w-body`}>
+      <Heading className={`w-heading`}>{"Nested page"}</Heading>
     </Body>
   );
 };

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[radix]._index.tsx
@@ -40,7 +40,7 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 const Page = ({}: { system: any }) => {
   let [accordionValue, set$accordionValue] = useVariableState<any>("0");
   return (
-    <Body className={"w-body"}>
+    <Body className={`w-body`}>
       <Accordion
         collapsible={true}
         value={accordionValue}
@@ -48,96 +48,78 @@ const Page = ({}: { system: any }) => {
           accordionValue = value;
           set$accordionValue(accordionValue);
         }}
-        className={"w-accordion"}
+        className={`w-accordion`}
       >
-        <AccordionItem data-ws-index="0" className={"w-item c2onvcp"}>
-          <AccordionHeader className={"w-item-header c13v7j50"}>
+        <AccordionItem data-ws-index="0" className={`w-item c2onvcp`}>
+          <AccordionHeader className={`w-item-header c13v7j50`}>
             <AccordionTrigger
-              className={
-                "w-item-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc"
-              }
+              className={`w-item-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc`}
             >
-              <Text className={"w-text"}>{"Is it accessible?"}</Text>
+              <Text className={`w-text`}>{"Is it accessible?"}</Text>
               <Box
-                className={
-                  "w-box c14hansb c6d2sb5 cwwiftc c16vb2zi c1hl6g8z c1xm49r0 c1vri55v"
-                }
+                className={`w-box c14hansb c6d2sb5 cwwiftc c16vb2zi c1hl6g8z c1xm49r0 c1vri55v`}
               >
                 <HtmlEmbed
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
                   }
-                  className={"w-html-embed"}
+                  className={`w-html-embed`}
                 />
               </Box>
             </AccordionTrigger>
           </AccordionHeader>
           <AccordionContent
-            className={
-              "w-item-content c1j0j9ep c1gl2i2 c44srea c1xcxvc0 c12ct49k"
-            }
+            className={`w-item-content c1j0j9ep c1gl2i2 c44srea c1xcxvc0 c12ct49k`}
           >
             {"Yes. It adheres to the WAI-ARIA design pattern."}
           </AccordionContent>
         </AccordionItem>
-        <AccordionItem data-ws-index="1" className={"w-item c2onvcp"}>
-          <AccordionHeader className={"w-item-header c13v7j50"}>
+        <AccordionItem data-ws-index="1" className={`w-item c2onvcp`}>
+          <AccordionHeader className={`w-item-header c13v7j50`}>
             <AccordionTrigger
-              className={
-                "w-item-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc"
-              }
+              className={`w-item-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc`}
             >
-              <Text className={"w-text"}>{"Is it styled?"}</Text>
+              <Text className={`w-text`}>{"Is it styled?"}</Text>
               <Box
-                className={
-                  "w-box c14hansb c6d2sb5 cwwiftc c16vb2zi c1hl6g8z c1xm49r0 c1vri55v"
-                }
+                className={`w-box c14hansb c6d2sb5 cwwiftc c16vb2zi c1hl6g8z c1xm49r0 c1vri55v`}
               >
                 <HtmlEmbed
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
                   }
-                  className={"w-html-embed"}
+                  className={`w-html-embed`}
                 />
               </Box>
             </AccordionTrigger>
           </AccordionHeader>
           <AccordionContent
-            className={
-              "w-item-content c1j0j9ep c1gl2i2 c44srea c1xcxvc0 c12ct49k"
-            }
+            className={`w-item-content c1j0j9ep c1gl2i2 c44srea c1xcxvc0 c12ct49k`}
           >
             {
               "Yes. It comes with default styles that matches the other components' aesthetic."
             }
           </AccordionContent>
         </AccordionItem>
-        <AccordionItem data-ws-index="2" className={"w-item c2onvcp"}>
-          <AccordionHeader className={"w-item-header c13v7j50"}>
+        <AccordionItem data-ws-index="2" className={`w-item c2onvcp`}>
+          <AccordionHeader className={`w-item-header c13v7j50`}>
             <AccordionTrigger
-              className={
-                "w-item-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc"
-              }
+              className={`w-item-trigger c13v7j50 c1qxdkbn chhejm9 c13bviim cpjvam0 c1tw5o2 cqw88jp c44srea c14kxsax cg783j6 c1ad236a c1s4llbc`}
             >
-              <Text className={"w-text"}>{"Is it animated?"}</Text>
+              <Text className={`w-text`}>{"Is it animated?"}</Text>
               <Box
-                className={
-                  "w-box c14hansb c6d2sb5 cwwiftc c16vb2zi c1hl6g8z c1xm49r0 c1vri55v"
-                }
+                className={`w-box c14hansb c6d2sb5 cwwiftc c16vb2zi c1hl6g8z c1xm49r0 c1vri55v`}
               >
                 <HtmlEmbed
                   code={
                     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%" style="display: block;"><path d="M4.04 6.284a.65.65 0 0 1 .92.001L8 9.335l3.04-3.05a.65.65 0 1 1 .921.918l-3.5 3.512a.65.65 0 0 1-.921 0L4.039 7.203a.65.65 0 0 1 .001-.92Z"/></svg>'
                   }
-                  className={"w-html-embed"}
+                  className={`w-html-embed`}
                 />
               </Box>
             </AccordionTrigger>
           </AccordionHeader>
           <AccordionContent
-            className={
-              "w-item-content c1j0j9ep c1gl2i2 c44srea c1xcxvc0 c12ct49k"
-            }
+            className={`w-item-content c1j0j9ep c1gl2i2 c44srea c1xcxvc0 c12ct49k`}
           >
             {
               "Yes. It's animated by default, but you can disable it if you prefer."

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[resources]._index.tsx
@@ -32,11 +32,11 @@ export const pageBackgroundImageAssets: ImageAsset[] = [];
 const Page = ({}: { system: any }) => {
   let list = useResource("list_1");
   return (
-    <Body className={"w-body"}>
+    <Body className={`w-body`}>
       {list?.data?.map((collectionItem: any, index: number) => (
         <Fragment key={index}>
-          <Box className={"w-box"}>
-            <HtmlEmbed code={collectionItem?.name} className={"w-html-embed"} />
+          <Box className={`w-box`}>
+            <HtmlEmbed code={collectionItem?.name} className={`w-html-embed`} />
           </Box>
         </Fragment>
       ))}

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[sitemap.xml]._index.tsx
@@ -30,7 +30,7 @@ const Heading = (props: any) => null;
 
 const Page = ({ system: system }: { system: any }) => {
   return (
-    <Body className={"w-body"}>
+    <Body className={`w-body`}>
       <XmlNode
         tag={"urlset"}
         xmlns={"http://www.sitemaps.org/schemas/sitemap/0.9"}
@@ -61,7 +61,7 @@ const Page = ({ system: system }: { system: any }) => {
             </XmlNode>
           </Fragment>
         ))}
-        <Heading tag={"h3"} className={"w-heading c1jumvji cvdtpev"}>
+        <Heading tag={"h3"} className={`w-heading c1jumvji cvdtpev`}>
           {"Below is custom section"}
         </Heading>
         <XmlNode tag={"url"}>

--- a/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/_index.tsx
@@ -60,47 +60,47 @@ export const CustomCode = () => {
 
 const Page = ({}: { system: any }) => {
   return (
-    <Body className={"w-body cielobv"}>
-      <Heading className={"w-heading ceva767"}>
+    <Body className={`w-body cielobv`}>
+      <Heading className={`w-heading ceva767`}>
         {"DO NOT TOUCH THIS PROJECT, IT'S USED FOR FIXTURES"}
       </Heading>
-      <Box className={"w-box c13v7j50 cqkqnmd cv6wa71"}>
-        <Box className={"w-box c1t3ybra c1qxdkbn c1ogzcge cv3kvac"}>
-          <Heading className={"w-heading"}>{"Heading"}</Heading>
-          <Paragraph className={"w-paragraph"}>
+      <Box className={`w-box c13v7j50 cqkqnmd cv6wa71`}>
+        <Box className={`w-box c1t3ybra c1qxdkbn c1ogzcge cv3kvac`}>
+          <Heading className={`w-heading`}>{"Heading"}</Heading>
+          <Paragraph className={`w-paragraph`}>
             {
               "a little kitten painted in black and white gouache with a thick brush"
             }
           </Paragraph>
-          <Link href={"https://github.com/"} className={"w-link"}>
+          <Link href={"https://github.com/"} className={`w-link`}>
             {"Click here to adore more kittens"}
           </Link>
-          <Text tag={"span"} className={"w-text"}>
+          <Text tag={"span"} className={`w-text`}>
             {" or "}
           </Text>
           <Link
             href={"/assets/small-avif-kitty_FnabJsioMWpBtXZSGf4DR.webp"}
-            className={"w-link"}
+            className={`w-link`}
           >
             {"go download this little kitten"}
           </Link>
-          <Box className={"w-box"} />
-          <Link href={"/_route_with_symbols_"} className={"w-link ch2exr5"}>
+          <Box className={`w-box`} />
+          <Link href={"/_route_with_symbols_"} className={`w-link ch2exr5`}>
             {"Symbols in path"}
           </Link>
           <Link
             href={"/heading-with-id#my-heading"}
-            className={"w-link ch2exr5"}
+            className={`w-link ch2exr5`}
           >
             {"Link to instance"}
           </Link>
         </Box>
-        <Box className={"w-box c1t3ybra c1qxdkbn c1ogzcge cv3kvac"}>
+        <Box className={`w-box c1t3ybra c1qxdkbn c1ogzcge cv3kvac`}>
           <Image
             src={
               "/assets/_937084ed-a798-49fe-8664-df93a2af605e_uiBk3o6UWdqolyakMvQJ9.jpeg"
             }
-            className={"w-image c1czoo99"}
+            className={`w-image c1czoo99`}
           />
         </Box>
       </Box>

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -174,12 +174,7 @@ export const generateJsxElement = ({
   let conditionValue: undefined | string;
   let collectionDataValue: undefined | string;
   let collectionItemValue: undefined | string;
-
-  const classMapArray = classesMap?.get(instance.id);
-  const classes =
-    classMapArray !== undefined
-      ? [JSON.stringify(classMapArray.join(" "))]
-      : [];
+  let classNameValue: undefined | string;
 
   for (const prop of props.values()) {
     if (prop.instanceId !== instance.id) {
@@ -222,8 +217,7 @@ export const generateJsxElement = ({
     }
     // We need to merge atomic classes with user-defined className prop.
     if (prop.name === "className" && propValue !== undefined) {
-      classes.push(propValue);
-
+      classNameValue = propValue;
       continue;
     }
     if (propValue !== undefined) {
@@ -231,8 +225,18 @@ export const generateJsxElement = ({
     }
   }
 
-  if (classes.length !== 0) {
-    generatedProps += `\nclassName={${classes.join(` + " " + `)}}`;
+  const classMapArray = classesMap?.get(instance.id);
+  if (classMapArray || classNameValue) {
+    let classNameTemplate = classMapArray ? classMapArray.join(" ") : "";
+    if (classNameValue) {
+      if (classNameTemplate) {
+        classNameTemplate += " ";
+      }
+      classNameTemplate += "${" + classNameValue + "}";
+    }
+    // wrap class expression with template literal to properly group
+    // for exaple expressions
+    generatedProps += "\nclassName={`" + classNameTemplate + "`}";
   }
 
   let generatedElement = "";


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/4749

Classes were merged without considering ternaries like this

```js
"cls1" + " " + condition ? "cls2" : ""
```

which made condition part always truthy

Fixed by generating template literal instead of concatenation operator.