### PR TITLE
feat: Do not filter out empty props

### DIFF
--- a/fixtures/webstudio-remix-vercel/.webstudio/data.json
+++ b/fixtures/webstudio-remix-vercel/.webstudio/data.json
@@ -1,10 +1,10 @@
 {
   "build": {
-    "id": "0d43a990-f5cd-43c3-ab26-863ebe71eb27",
+    "id": "1bd755a0-9c8a-416b-b373-2123f3568393",
     "projectId": "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    "version": 463,
-    "createdAt": "2025-01-18T19:56:10.675+00:00",
-    "updatedAt": "2025-01-18T19:56:10.675+00:00",
+    "version": 464,
+    "createdAt": "2025-01-19T14:02:13.405+00:00",
+    "updatedAt": "2025-01-19T14:02:13.405+00:00",
     "pages": {
       "meta": {
         "siteName": "KittyGuardedZone",
@@ -2948,16 +2948,6 @@
           "name": "href",
           "type": "page",
           "value": "7Db64ZXgYiRqKSQNR-qTQ"
-        }
-      ],
-      [
-        "oCeOjUq5kg_g-0dq5iApN",
-        {
-          "id": "oCeOjUq5kg_g-0dq5iApN",
-          "instanceId": "EveN4Skg9xb8Lj1QJcW52",
-          "name": "name",
-          "type": "string",
-          "value": ""
         }
       ],
       [

--- a/fixtures/webstudio-remix-vercel/app/__generated__/$resources.sitemap.xml.ts
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/$resources.sitemap.xml.ts
@@ -1,26 +1,26 @@
 export const sitemap = [
   {
     path: "/",
-    lastModified: "2025-01-18",
+    lastModified: "2025-01-19",
   },
   {
     path: "/_route_with_symbols_",
-    lastModified: "2025-01-18",
+    lastModified: "2025-01-19",
   },
   {
     path: "/form",
-    lastModified: "2025-01-18",
+    lastModified: "2025-01-19",
   },
   {
     path: "/heading-with-id",
-    lastModified: "2025-01-18",
+    lastModified: "2025-01-19",
   },
   {
     path: "/resources",
-    lastModified: "2025-01-18",
+    lastModified: "2025-01-19",
   },
   {
     path: "/nested/nested-page",
-    lastModified: "2025-01-18",
+    lastModified: "2025-01-19",
   },
 ];

--- a/fixtures/webstudio-remix-vercel/app/__generated__/[head-tag]._index.tsx
+++ b/fixtures/webstudio-remix-vercel/app/__generated__/[head-tag]._index.tsx
@@ -42,11 +42,7 @@ const Page = ({}: { system: any }) => {
         <HeadTitle>{"Head Slot Title"}</HeadTitle>
         <HeadLink rel={"help"} href={"/help-head-slot"} />
         <HeadMeta name={"keywords"} content={"Head Slot Content"} />
-        <HeadMeta
-          name={""}
-          content={"Head Slot Content"}
-          property={"og:title"}
-        />
+        <HeadMeta content={"Head Slot Content"} property={"og:title"} />
       </HeadSlot>
       <Heading className={`w-heading`}>{"Test Head Slot"}</Heading>
       <Link href={"/"} className={`w-link`}>

--- a/fixtures/webstudio-remix-vercel/package.json
+++ b/fixtures/webstudio-remix-vercel/package.json
@@ -6,7 +6,7 @@
     "typecheck": "tsc",
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link https://p-cddc1d44-af37-4cb6-a430-d300cf6f932d-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d'",
-    "fixtures:sync": "pnpm cli sync --buildId 0d43a990-f5cd-43c3-ab26-863ebe71eb27 && pnpm prettier --write ./.webstudio/",
+    "fixtures:sync": "pnpm cli sync --buildId 1bd755a0-9c8a-416b-b373-2123f3568393 && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "pnpm cli build --template vercel --template internal --template ./.template && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },
   "private": true,

--- a/packages/sdk-components-react/src/head-link.tsx
+++ b/packages/sdk-components-react/src/head-link.tsx
@@ -62,9 +62,7 @@ export const HeadLink = forwardRef<
   const cleanOrderedProps: Record<string, unknown> = {};
 
   for (const prop of propsSet) {
-    // Boolean check is not a mistake; it excludes empty values.
-    // Empty properties must be excluded because there is no UI to reset them to undefined.
-    if (prop in props && Boolean(props[prop])) {
+    if (prop in props && props[prop] !== undefined) {
       cleanOrderedProps[prop] = props[prop];
     }
   }

--- a/packages/sdk-components-react/src/head-meta.tsx
+++ b/packages/sdk-components-react/src/head-meta.tsx
@@ -24,10 +24,7 @@ export const HeadMeta = forwardRef<
   const cleanOrderedProps: Record<string, unknown> = {};
 
   for (const prop of propsSet) {
-    // Boolean check is not a mistake; it excludes empty values.
-    // Empty properties must be excluded because there is no UI to reset them to undefined.
-    // Additionally, <meta property="" name="someName" content="someContent" /> is invalid.
-    if (prop in props && Boolean(props[prop])) {
+    if (prop in props && props[prop] !== undefined) {
       cleanOrderedProps[prop] = props[prop];
     }
   }

--- a/packages/sdk-components-react/src/head-title.tsx
+++ b/packages/sdk-components-react/src/head-title.tsx
@@ -24,9 +24,7 @@ export const HeadTitle = forwardRef<
   const cleanOrderedProps: Record<string, unknown> = {};
 
   for (const prop of propsSet) {
-    // Boolean check is not a mistake; it excludes empty values.
-    // Empty properties must be excluded because there is no UI to reset them to undefined.
-    if (prop in props && Boolean(props[prop])) {
+    if (prop in props && props[prop] !== undefined) {
       cleanOrderedProps[prop] = props[prop];
     }
   }

--- a/packages/sdk-components-react/src/xml-node.tsx
+++ b/packages/sdk-components-react/src/xml-node.tsx
@@ -33,7 +33,7 @@ export const XmlNode = forwardRef<ElementRef<"div">, Props>(
         ([key]) =>
           key.startsWith("data-") === false && key.startsWith("aria-") === false
       )
-      .filter(([key]) => key !== "tabIndex")
+      .filter(([key]) => key.toLowerCase() !== "tabindex")
       .filter(([, value]) => typeof value !== "function");
 
     const elementName = tag


### PR DESCRIPTION
## Description

This #4759 allows to not filter out empty props

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
