### PR TITLE
fix: avoid imports of not installed packages when setup SSG

### DIFF
--- a/fixtures/ssg-netlify-by-project-id/app/constants.mjs
+++ b/fixtures/ssg-netlify-by-project-id/app/constants.mjs
@@ -2,7 +2,6 @@
  * We use mjs extension as constants in this file is shared with the build script
  * and we use `node --eval` to extract the constants.
  */
-import { UrlCanParse } from "@webstudio-is/image";
 
 export const assetBaseUrl = "/assets/";
 export const imageBaseUrl = "/assets/";
@@ -11,10 +10,6 @@ export const imageBaseUrl = "/assets/";
  * @type {import("@webstudio-is/image").ImageLoader}
  */
 export const imageLoader = (props) => {
-  if (UrlCanParse(props.src)) {
-    return props.src;
-  }
-
   if (process.env.NODE_ENV !== "production") {
     return props.src;
   }

--- a/packages/cli/templates/ssg-netlify/app/constants.mjs
+++ b/packages/cli/templates/ssg-netlify/app/constants.mjs
@@ -2,7 +2,6 @@
  * We use mjs extension as constants in this file is shared with the build script
  * and we use `node --eval` to extract the constants.
  */
-import { UrlCanParse } from "@webstudio-is/image";
 
 export const assetBaseUrl = "/assets/";
 export const imageBaseUrl = "/assets/";
@@ -11,10 +10,6 @@ export const imageBaseUrl = "/assets/";
  * @type {import("@webstudio-is/image").ImageLoader}
  */
 export const imageLoader = (props) => {
-  if (UrlCanParse(props.src)) {
-    return props.src;
-  }
-
   if (process.env.NODE_ENV !== "production") {
     return props.src;
   }

--- a/packages/cli/templates/ssg-vercel/app/constants.mjs
+++ b/packages/cli/templates/ssg-vercel/app/constants.mjs
@@ -2,7 +2,6 @@
  * We use mjs extension as constants in this file is shared with the build script
  * and we use `node --eval` to extract the constants.
  */
-import { UrlCanParse } from "@webstudio-is/image";
 
 export const assetBaseUrl = "/assets/";
 export const imageBaseUrl = "/assets/";
@@ -11,10 +10,6 @@ export const imageBaseUrl = "/assets/";
  * @type {import("@webstudio-is/image").ImageLoader}
  */
 export const imageLoader = (props) => {
-  if (UrlCanParse(props.src)) {
-    return props.src;
-  }
-
   if (process.env.NODE_ENV !== "production") {
     return props.src;
   }

--- a/packages/image/src/image-optimize.ts
+++ b/packages/image/src/image-optimize.ts
@@ -235,7 +235,7 @@ const DEFAULT_QUALITY = 80;
 /**
  * URL.canParse(props.src)
  */
-export const UrlCanParse = (url: string): boolean => {
+const UrlCanParse = (url: string): boolean => {
   try {
     new URL(url);
     return true;


### PR DESCRIPTION
SSG templates have @webstudio-is/image imports which is not installed when prebuild.ts imports constants.mjs.

Here removed URL.canParse checks in favor of netlify and vercel domains configuration.