### PR TITLE
refactor: drop imageBaseUrl from constants.mjs

### DIFF
--- a/fixtures/react-router-docker/app/constants.mjs
+++ b/fixtures/react-router-docker/app/constants.mjs
@@ -3,7 +3,6 @@
  * and we use `node --eval` to extract the constants.
  */
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/fixtures/ssg-netlify-by-project-id/app/constants.mjs
+++ b/fixtures/ssg-netlify-by-project-id/app/constants.mjs
@@ -4,7 +4,6 @@
  */
 
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/fixtures/ssg-netlify-by-project-id/vike.d.ts
+++ b/fixtures/ssg-netlify-by-project-id/vike.d.ts
@@ -11,7 +11,6 @@ declare global {
     interface PageContext {
       constants: {
         assetBaseUrl: string;
-        imageBaseUrl: string;
         imageLoader: ImageLoader;
       };
       data: {

--- a/fixtures/ssg/app/constants.mjs
+++ b/fixtures/ssg/app/constants.mjs
@@ -4,7 +4,6 @@
  */
 
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/fixtures/ssg/vike.d.ts
+++ b/fixtures/ssg/vike.d.ts
@@ -11,7 +11,6 @@ declare global {
     interface PageContext {
       constants: {
         assetBaseUrl: string;
-        imageBaseUrl: string;
         imageLoader: ImageLoader;
       };
       data: {

--- a/fixtures/webstudio-cloudflare-template/app/constants.mjs
+++ b/fixtures/webstudio-cloudflare-template/app/constants.mjs
@@ -3,7 +3,6 @@
  * and we use `node --eval` to extract the constants.
  */
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/fixtures/webstudio-remix-netlify-edge-functions/app/constants.mjs
+++ b/fixtures/webstudio-remix-netlify-edge-functions/app/constants.mjs
@@ -3,7 +3,6 @@
  * and we use `node --eval` to extract the constants.
  */
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/fixtures/webstudio-remix-netlify-functions/app/constants.mjs
+++ b/fixtures/webstudio-remix-netlify-functions/app/constants.mjs
@@ -3,7 +3,6 @@
  * and we use `node --eval` to extract the constants.
  */
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/fixtures/webstudio-remix-vercel/app/constants.mjs
+++ b/fixtures/webstudio-remix-vercel/app/constants.mjs
@@ -3,7 +3,6 @@
  * and we use `node --eval` to extract the constants.
  */
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/packages/cli/templates/defaults/app/constants.mjs
+++ b/packages/cli/templates/defaults/app/constants.mjs
@@ -3,7 +3,6 @@
  * and we use `node --eval` to extract the constants.
  */
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/packages/cli/templates/netlify-edge-functions/app/constants.mjs
+++ b/packages/cli/templates/netlify-edge-functions/app/constants.mjs
@@ -3,7 +3,6 @@
  * and we use `node --eval` to extract the constants.
  */
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/packages/cli/templates/netlify-functions/app/constants.mjs
+++ b/packages/cli/templates/netlify-functions/app/constants.mjs
@@ -3,7 +3,6 @@
  * and we use `node --eval` to extract the constants.
  */
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/packages/cli/templates/react-router-docker/app/constants.mjs
+++ b/packages/cli/templates/react-router-docker/app/constants.mjs
@@ -3,7 +3,6 @@
  * and we use `node --eval` to extract the constants.
  */
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/packages/cli/templates/ssg-netlify/app/constants.mjs
+++ b/packages/cli/templates/ssg-netlify/app/constants.mjs
@@ -4,7 +4,6 @@
  */
 
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/packages/cli/templates/ssg-vercel/app/constants.mjs
+++ b/packages/cli/templates/ssg-vercel/app/constants.mjs
@@ -4,7 +4,6 @@
  */
 
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/packages/cli/templates/ssg/app/constants.mjs
+++ b/packages/cli/templates/ssg/app/constants.mjs
@@ -4,7 +4,6 @@
  */
 
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/packages/cli/templates/ssg/vike.d.ts
+++ b/packages/cli/templates/ssg/vike.d.ts
@@ -11,7 +11,6 @@ declare global {
     interface PageContext {
       constants: {
         assetBaseUrl: string;
-        imageBaseUrl: string;
         imageLoader: ImageLoader;
       };
       data: {

--- a/packages/cli/templates/vercel/app/constants.mjs
+++ b/packages/cli/templates/vercel/app/constants.mjs
@@ -3,7 +3,6 @@
  * and we use `node --eval` to extract the constants.
  */
 export const assetBaseUrl = "/assets/";
-export const imageBaseUrl = "/assets/";
 
 /**
  * @type {import("@webstudio-is/image").ImageLoader}

--- a/packages/image/src/image-loaders.ts
+++ b/packages/image/src/image-loaders.ts
@@ -60,11 +60,3 @@ export const wsImageLoader: ImageLoader = (props) => {
   // Cloudflare docs say that we don't need to urlencode the path params
   return resultUrl.href;
 };
-
-type ImageLoaderOptions = {
-  imageBaseUrl?: string;
-};
-
-export const createImageLoader = (
-  _loaderOptions: ImageLoaderOptions
-): ImageLoader => wsImageLoader;

--- a/packages/react-sdk/placeholder.d.ts
+++ b/packages/react-sdk/placeholder.d.ts
@@ -1,7 +1,6 @@
 declare module "__CONSTANTS__" {
   import type { ImageLoader } from "@webstudio-is/image";
   export const assetBaseUrl: string;
-  export const imageBaseUrl: string;
   export const imageLoader: ImageLoader;
 }
 


### PR DESCRIPTION
It is no longer configurable and always dictated by image loader.