### PR TITLE
feat: show inherited data variables

### DIFF
--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -8,6 +8,7 @@ import {
   createContext,
   type ReactNode,
 } from "react";
+import { useStore } from "@nanostores/react";
 import {
   DotIcon,
   InfoCircleIcon,
@@ -47,7 +48,6 @@ import {
   $isDesignMode,
   computeExpression,
 } from "~/shared/nano-states";
-import { useStore } from "@nanostores/react";
 
 export const evaluateExpressionWithinScope = (
   expression: string,

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -1087,14 +1087,16 @@ export const insertWebstudioFragmentCopy = ({
         dataSources.set(newDataSourceId, {
           ...dataSource,
           id: newDataSourceId,
-          scopeInstanceId: newInstanceIds.get(scopeInstanceId),
+          scopeInstanceId:
+            newInstanceIds.get(scopeInstanceId) ?? scopeInstanceId,
           resourceId: newResourceId,
         });
       } else {
         dataSources.set(newDataSourceId, {
           ...dataSource,
           id: newDataSourceId,
-          scopeInstanceId: newInstanceIds.get(scopeInstanceId),
+          scopeInstanceId:
+            newInstanceIds.get(scopeInstanceId) ?? scopeInstanceId,
         });
       }
     }

--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -93,12 +93,14 @@ test("compute expression prop values", () => {
     toMap([
       {
         id: "var1",
+        scopeInstanceId: "box",
         type: "variable",
         name: "",
         value: { type: "number", value: 1 },
       },
       {
         id: "var2",
+        scopeInstanceId: "box",
         type: "variable",
         name: "",
         value: { type: "string", value: "Hello" },
@@ -162,6 +164,7 @@ test("generate action prop callbacks", () => {
     toMap([
       {
         id: "var",
+        scopeInstanceId: "box",
         type: "variable",
         name: "",
         value: { type: "number", value: 1 },
@@ -292,6 +295,7 @@ test("compute expression from collection items", () => {
     toMap([
       {
         id: "itemId",
+        scopeInstanceId: "list",
         type: "parameter",
         name: "item",
       },
@@ -362,6 +366,7 @@ test("access parameter value from variables values", () => {
     toMap([
       {
         id: "parameterId",
+        scopeInstanceId: "body",
         type: "parameter",
         name: "paramName",
       },
@@ -400,6 +405,7 @@ test("compute props bound to resource variables", () => {
     toMap([
       {
         id: "resourceVariableId",
+        scopeInstanceId: "body",
         type: "resource",
         name: "paramName",
         resourceId: "resourceId",

--- a/packages/design-system/src/components/css-value-list-item.tsx
+++ b/packages/design-system/src/components/css-value-list-item.tsx
@@ -180,7 +180,7 @@ export const CssValueListItem = forwardRef(
               {...listItemAttributes}
               {...rest}
               hidden={hidden}
-              disabled={hidden === true}
+              disabled={hidden === true || rest.disabled}
             >
               <DragHandleIconStyled />
 

--- a/packages/sdk/src/schema/data-sources.ts
+++ b/packages/sdk/src/schema/data-sources.ts
@@ -30,20 +30,20 @@ export const DataSource = z.union([
   z.object({
     type: z.literal("variable"),
     id: DataSourceId,
-    scopeInstanceId: z.optional(z.string()),
+    scopeInstanceId: z.string(),
     name: z.string(),
     value: DataSourceVariableValue,
   }),
   z.object({
     type: z.literal("parameter"),
     id: DataSourceId,
-    scopeInstanceId: z.optional(z.string()),
+    scopeInstanceId: z.string(),
     name: z.string(),
   }),
   z.object({
     type: z.literal("resource"),
     id: DataSourceId,
-    scopeInstanceId: z.optional(z.string()),
+    scopeInstanceId: z.string(),
     name: z.string(),
     resourceId: z.string(),
   }),


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/4768

Here made a few changes to align data variables with css variables.

1. inherited variables are also shown in "Data Variables" section in Settings
2. local and remote variables have blue and orange labels
3. local variables with the same name "mask" inherited variables in the list
4. inherited variables can only be inspected

<img width="244" alt="image" src="https://github.com/user-attachments/assets/bf4648e6-b5fc-48cb-a6c3-a6d5e8b234cd" />
