### PR TITLE
refactor: drop stylable flag in component meta

### DIFF
--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -102,7 +102,13 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
   type PanelName = "style" | "settings";
 
   const availablePanels = new Set<PanelName>();
-  if (documentType === "html" && (meta?.stylable ?? true) && isDesignMode) {
+  if (
+    // forbid styling body in xml document
+    documentType === "html" &&
+    // forbid styling components without preset
+    meta?.presetStyle !== undefined &&
+    isDesignMode
+  ) {
     availablePanels.add("style");
   }
   // @todo hide root component settings until

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -38,7 +38,6 @@ import {
   properties as propertiesData,
   propertyDescriptions,
 } from "@webstudio-is/css-data";
-import { ROOT_INSTANCE_ID } from "@webstudio-is/sdk";
 import {
   hyphenateProperty,
   toValue,
@@ -67,13 +66,12 @@ import { PropertyInfo } from "../../property-label";
 import { sections } from "../sections";
 import { ColorPopover } from "../../shared/color-picker";
 import {
-  $instances,
   $registeredComponentMetas,
-  $selectedInstanceSelector,
   $styles,
   $styleSourceSelections,
 } from "~/shared/nano-states";
 import { useClientSupports } from "~/shared/client-supports";
+import { $selectedInstancePath } from "~/shared/awareness";
 
 // Only here to keep the same section module interface
 export const properties = [];
@@ -376,33 +374,20 @@ const initialProperties = new Set<StyleProperty>([
 
 const $advancedProperties = computed(
   [
-    $selectedInstanceSelector,
-    $instances,
+    // prevent showing properties inherited from root
+    // to not bloat advanced panel
+    $selectedInstancePath,
     $registeredComponentMetas,
     $styleSourceSelections,
     $matchingBreakpoints,
     $styles,
   ],
-  (
-    instanceSelector,
-    instances,
-    metas,
-    styleSourceSelections,
-    matchingBreakpoints,
-    styles
-  ) => {
-    if (instanceSelector === undefined) {
+  (instancePath, metas, styleSourceSelections, matchingBreakpoints, styles) => {
+    if (instancePath === undefined) {
       return [];
     }
-    const instanceAndRootSelector =
-      instanceSelector[0] === ROOT_INSTANCE_ID
-        ? instanceSelector
-        : // prevent showing properties inherited from root
-          // to not bloat advanced panel
-          instanceSelector;
     const definedStyles = getDefinedStyles({
-      instanceSelector: instanceAndRootSelector,
-      instances,
+      instancePath,
       metas,
       matchingBreakpoints,
       styleSourceSelections,

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.stories.tsx
@@ -4,8 +4,10 @@ import {
   FloatingPanel,
   FloatingPanelProvider,
 } from "@webstudio-is/design-system";
+import { createDefaultPages } from "@webstudio-is/project-build";
 import {
   $breakpoints,
+  $pages,
   $selectedBreakpointId,
   $styles,
   $styleSourceSelections,
@@ -31,8 +33,15 @@ $styles.set(new Map([[getStyleDeclKey(backgroundImage), backgroundImage]]));
 $styleSourceSelections.set(
   new Map([["box", { instanceId: "box", values: ["local"] }]])
 );
+$pages.set(
+  createDefaultPages({
+    homePageId: "homePageId",
+    rootInstanceId: "box",
+    systemDataSourceId: "systemId",
+  })
+);
 $awareness.set({
-  pageId: "",
+  pageId: "homePageId",
   instanceSelector: ["box"],
 });
 

--- a/apps/builder/app/builder/features/style-panel/sections/position/inset-control.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/position/inset-control.stories.tsx
@@ -1,10 +1,12 @@
 import type { Meta } from "@storybook/react";
 import { Box } from "@webstudio-is/design-system";
 import { getStyleDeclKey, StyleDecl } from "@webstudio-is/sdk";
+import { createDefaultPages } from "@webstudio-is/project-build";
 import { InsetControl } from "./inset-control";
 import { registerContainers } from "~/shared/sync";
 import {
   $breakpoints,
+  $pages,
   $selectedBreakpointId,
   $styles,
   $styleSources,
@@ -41,8 +43,15 @@ $styles.set(new Map([[getStyleDeclKey(right), right]]));
 $styleSourceSelections.set(
   new Map([["box", { instanceId: "box", values: ["local"] }]])
 );
+$pages.set(
+  createDefaultPages({
+    homePageId: "homePageId",
+    rootInstanceId: "box",
+    systemDataSourceId: "systemId",
+  })
+);
 $awareness.set({
-  pageId: "",
+  pageId: "homePageId",
   instanceSelector: ["box"],
 });
 

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.stories.tsx
@@ -2,6 +2,7 @@ import { styled, theme } from "@webstudio-is/design-system";
 import { getStyleDeclKey, StyleDecl } from "@webstudio-is/sdk";
 import {
   $breakpoints,
+  $pages,
   $selectedBreakpointId,
   $styles,
   $styleSources,
@@ -10,6 +11,7 @@ import {
 import { registerContainers } from "~/shared/sync";
 import { Section } from "./transitions";
 import { $awareness } from "~/shared/awareness";
+import { createDefaultPages } from "@webstudio-is/project-build";
 
 const Panel = styled("div", {
   width: theme.spacing[30],
@@ -50,8 +52,15 @@ $styles.set(
 $styleSourceSelections.set(
   new Map([["box", { instanceId: "box", values: ["local"] }]])
 );
+$pages.set(
+  createDefaultPages({
+    homePageId: "homePageId",
+    rootInstanceId: "box",
+    systemDataSourceId: "systemId",
+  })
+);
 $awareness.set({
-  pageId: "",
+  pageId: "homePageId",
   instanceSelector: ["box"],
 });
 

--- a/apps/builder/app/shared/awareness.ts
+++ b/apps/builder/app/shared/awareness.ts
@@ -76,7 +76,7 @@ export const $selectedInstanceKey = computed($awareness, (awareness) =>
   getInstanceKey(awareness?.instanceSelector)
 );
 
-type InstancePath = Array<{
+export type InstancePath = Array<{
   instance: Instance;
   instanceSelector: string[];
 }>;
@@ -112,6 +112,26 @@ export const $selectedInstancePath = computed(
     const instanceSelector = awareness?.instanceSelector;
     if (instanceSelector === undefined) {
       return;
+    }
+    return getInstancePath(
+      instances,
+      virtualInstances,
+      temporaryInstances,
+      instanceSelector
+    );
+  }
+);
+
+export const $selectedInstancePathWithRoot = computed(
+  [$instances, $virtualInstances, $temporaryInstances, $awareness],
+  (instances, virtualInstances, temporaryInstances, awareness) => {
+    let instanceSelector = awareness?.instanceSelector;
+    if (instanceSelector === undefined) {
+      return;
+    }
+    // add root as ancestor when root is not selected
+    if (instanceSelector[0] !== ROOT_INSTANCE_ID) {
+      instanceSelector = [...instanceSelector, ROOT_INSTANCE_ID];
     }
     return getInstancePath(
       instances,

--- a/packages/sdk-components-react-radix/src/collapsible.ws.ts
+++ b/packages/sdk-components-react-radix/src/collapsible.ws.ts
@@ -3,21 +3,13 @@ import {
   TriggerIcon,
   ContentIcon,
 } from "@webstudio-is/icons/svg";
-import type {
-  PresetStyle,
-  WsComponentMeta,
-  WsComponentPropsMeta,
-} from "@webstudio-is/sdk";
+import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { div } from "@webstudio-is/sdk/normalize.css";
 import {
   propsCollapsible,
   propsCollapsibleContent,
   propsCollapsibleTrigger,
 } from "./__generated__/collapsible.props";
-
-const presetStyle = {
-  div,
-} satisfies PresetStyle<"div">;
 
 export const metaCollapsible: WsComponentMeta = {
   type: "container",
@@ -31,14 +23,15 @@ export const metaCollapsible: WsComponentMeta = {
       component: { $eq: "CollapsibleContent" },
     },
   ],
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   icon: CollapsibleIcon,
 };
 
 export const metaCollapsibleTrigger: WsComponentMeta = {
   type: "container",
   icon: TriggerIcon,
-  stylable: false,
   constraints: {
     relation: "ancestor",
     component: { $eq: "Collapsible" },
@@ -47,7 +40,9 @@ export const metaCollapsibleTrigger: WsComponentMeta = {
 
 export const metaCollapsibleContent: WsComponentMeta = {
   type: "container",
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   icon: ContentIcon,
   constraints: {
     relation: "ancestor",

--- a/packages/sdk-components-react-radix/src/dialog.ws.ts
+++ b/packages/sdk-components-react-radix/src/dialog.ws.ts
@@ -9,7 +9,6 @@ import {
 } from "@webstudio-is/icons/svg";
 import {
   defaultStates,
-  type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
@@ -25,23 +24,10 @@ import {
 } from "./__generated__/dialog.props";
 import { buttonReset } from "./shared/preset-styles";
 
-const presetStyle = {
-  div,
-} satisfies PresetStyle<"div">;
-
-const titlePresetStyle = {
-  h2,
-} satisfies PresetStyle<"h2">;
-
-const descriptionPresetStyle = {
-  p,
-} satisfies PresetStyle<"p">;
-
 // @todo add [data-state] to button and link
 export const metaDialogTrigger: WsComponentMeta = {
   type: "container",
   icon: TriggerIcon,
-  stylable: false,
   constraints: {
     relation: "ancestor",
     component: { $eq: "Dialog" },
@@ -50,7 +36,9 @@ export const metaDialogTrigger: WsComponentMeta = {
 
 export const metaDialogOverlay: WsComponentMeta = {
   type: "container",
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   icon: OverlayIcon,
   constraints: [
     {
@@ -66,7 +54,9 @@ export const metaDialogOverlay: WsComponentMeta = {
 
 export const metaDialogContent: WsComponentMeta = {
   type: "container",
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   icon: ContentIcon,
   constraints: [
     {
@@ -94,7 +84,9 @@ export const metaDialogContent: WsComponentMeta = {
 
 export const metaDialogTitle: WsComponentMeta = {
   type: "container",
-  presetStyle: titlePresetStyle,
+  presetStyle: {
+    h2,
+  },
   icon: HeadingIcon,
   constraints: {
     relation: "ancestor",
@@ -104,7 +96,9 @@ export const metaDialogTitle: WsComponentMeta = {
 
 export const metaDialogDescription: WsComponentMeta = {
   type: "container",
-  presetStyle: descriptionPresetStyle,
+  presetStyle: {
+    p,
+  },
   icon: TextIcon,
   constraints: {
     relation: "ancestor",
@@ -128,6 +122,7 @@ export const metaDialogClose: WsComponentMeta = {
 
 export const metaDialog: WsComponentMeta = {
   type: "container",
+  icon: DialogIcon,
   constraints: [
     {
       relation: "descendant",
@@ -138,8 +133,6 @@ export const metaDialog: WsComponentMeta = {
       component: { $eq: "DialogOverlay" },
     },
   ],
-  icon: DialogIcon,
-  stylable: false,
 };
 
 export const propsMetaDialog: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -7,11 +7,7 @@ import {
   ViewportIcon,
   NavigationMenuIcon,
 } from "@webstudio-is/icons/svg";
-import type {
-  PresetStyle,
-  WsComponentMeta,
-  WsComponentPropsMeta,
-} from "@webstudio-is/sdk";
+import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { div } from "@webstudio-is/sdk/normalize.css";
 import {
   propsNavigationMenu,
@@ -23,14 +19,12 @@ import {
   propsNavigationMenuViewport,
 } from "./__generated__/navigation-menu.props";
 
-const presetStyle = {
-  div,
-} satisfies PresetStyle<"div">;
-
 export const metaNavigationMenu: WsComponentMeta = {
   type: "container",
   icon: NavigationMenuIcon,
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   constraints: [
     {
       relation: "descendant",
@@ -56,7 +50,9 @@ export const metaNavigationMenuList: WsComponentMeta = {
       component: { $eq: "NavigationMenuItem" },
     },
   ],
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   label: "Menu List",
 };
 
@@ -67,20 +63,20 @@ export const metaNavigationMenuItem: WsComponentMeta = {
     relation: "ancestor",
     component: { $eq: "NavigationMenuList" },
   },
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   indexWithinAncestor: "NavigationMenu",
   label: "Menu Item",
 };
 
 export const metaNavigationMenuTrigger: WsComponentMeta = {
-  stylable: false,
   type: "container",
   icon: TriggerIcon,
   constraints: {
     relation: "ancestor",
     component: { $eq: "NavigationMenuItem" },
   },
-  presetStyle,
   label: "Menu Trigger",
 };
 
@@ -92,13 +88,14 @@ export const metaNavigationMenuContent: WsComponentMeta = {
     component: { $eq: "NavigationMenuItem" },
   },
   indexWithinAncestor: "NavigationMenu",
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   label: "Menu Content",
 };
 
 export const metaNavigationMenuLink: WsComponentMeta = {
   type: "container",
-  stylable: false,
   icon: BoxIcon,
   constraints: [
     {
@@ -110,7 +107,6 @@ export const metaNavigationMenuLink: WsComponentMeta = {
       component: { $in: ["NavigationMenuContent", "NavigationMenuItem"] },
     },
   ],
-  presetStyle,
   label: "Accessible Link Wrapper",
 };
 
@@ -121,7 +117,9 @@ export const metaNavigationMenuViewport: WsComponentMeta = {
     relation: "ancestor",
     component: { $eq: "NavigationMenu" },
   },
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   label: "Menu Viewport",
 };
 

--- a/packages/sdk-components-react-radix/src/popover.ws.ts
+++ b/packages/sdk-components-react-radix/src/popover.ws.ts
@@ -1,9 +1,5 @@
 import { PopoverIcon, TriggerIcon, ContentIcon } from "@webstudio-is/icons/svg";
-import type {
-  PresetStyle,
-  WsComponentMeta,
-  WsComponentPropsMeta,
-} from "@webstudio-is/sdk";
+import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { div } from "@webstudio-is/sdk/normalize.css";
 import {
   propsPopover,
@@ -11,15 +7,10 @@ import {
   propsPopoverTrigger,
 } from "./__generated__/popover.props";
 
-const presetStyle = {
-  div,
-} satisfies PresetStyle<"div">;
-
 // @todo add [data-state] to button and link
 export const metaPopoverTrigger: WsComponentMeta = {
   type: "container",
   icon: TriggerIcon,
-  stylable: false,
   constraints: {
     relation: "ancestor",
     component: { $eq: "Popover" },
@@ -28,7 +19,9 @@ export const metaPopoverTrigger: WsComponentMeta = {
 
 export const metaPopoverContent: WsComponentMeta = {
   type: "container",
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   icon: ContentIcon,
   constraints: {
     relation: "ancestor",
@@ -38,6 +31,7 @@ export const metaPopoverContent: WsComponentMeta = {
 
 export const metaPopover: WsComponentMeta = {
   type: "container",
+  icon: PopoverIcon,
   constraints: [
     {
       relation: "descendant",
@@ -48,8 +42,6 @@ export const metaPopover: WsComponentMeta = {
       component: { $eq: "PopoverContent" },
     },
   ],
-  icon: PopoverIcon,
-  stylable: false,
 };
 
 export const propsMetaPopover: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/select.ws.ts
+++ b/packages/sdk-components-react-radix/src/select.ws.ts
@@ -8,11 +8,7 @@ import {
   TextIcon,
   CheckMarkIcon,
 } from "@webstudio-is/icons/svg";
-import type {
-  PresetStyle,
-  WsComponentMeta,
-  WsComponentPropsMeta,
-} from "@webstudio-is/sdk";
+import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { button, div, span } from "@webstudio-is/sdk/normalize.css";
 import {
   propsSelect,
@@ -25,12 +21,9 @@ import {
   propsSelectViewport,
 } from "./__generated__/select.props";
 
-const presetStyle = {
-  div,
-} satisfies PresetStyle<"div">;
-
 export const metaSelect: WsComponentMeta = {
   type: "container",
+  icon: SelectIcon,
   constraints: [
     {
       relation: "descendant",
@@ -41,8 +34,6 @@ export const metaSelect: WsComponentMeta = {
       component: { $eq: "SelectContent" },
     },
   ],
-  icon: SelectIcon,
-  stylable: false,
 };
 
 export const metaSelectTrigger: WsComponentMeta = {
@@ -79,7 +70,9 @@ export const metaSelectValue: WsComponentMeta = {
 export const metaSelectContent: WsComponentMeta = {
   type: "container",
   icon: ContentIcon,
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   constraints: [
     {
       relation: "ancestor",
@@ -95,7 +88,9 @@ export const metaSelectContent: WsComponentMeta = {
 export const metaSelectViewport: WsComponentMeta = {
   type: "container",
   icon: ViewportIcon,
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   constraints: [
     {
       relation: "ancestor",
@@ -125,7 +120,9 @@ export const metaSelectItem: WsComponentMeta = {
       component: { $eq: "SelectItemText" },
     },
   ],
-  presetStyle,
+  presetStyle: {
+    div,
+  },
 };
 
 export const metaSelectItemIndicator: WsComponentMeta = {

--- a/packages/sdk-components-react-radix/src/tooltip.ws.ts
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.ts
@@ -1,9 +1,5 @@
 import { TooltipIcon, TriggerIcon, ContentIcon } from "@webstudio-is/icons/svg";
-import {
-  type PresetStyle,
-  type WsComponentMeta,
-  type WsComponentPropsMeta,
-} from "@webstudio-is/sdk";
+import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { div } from "@webstudio-is/sdk/normalize.css";
 import {
   propsTooltip,
@@ -11,15 +7,10 @@ import {
   propsTooltipTrigger,
 } from "./__generated__/tooltip.props";
 
-const presetStyle = {
-  div,
-} satisfies PresetStyle<"div">;
-
 // @todo add [data-state] to button and link
 export const metaTooltipTrigger: WsComponentMeta = {
   type: "container",
   icon: TriggerIcon,
-  stylable: false,
   constraints: {
     relation: "ancestor",
     component: { $eq: "Tooltip" },
@@ -29,7 +20,9 @@ export const metaTooltipTrigger: WsComponentMeta = {
 export const metaTooltipContent: WsComponentMeta = {
   type: "container",
   icon: ContentIcon,
-  presetStyle,
+  presetStyle: {
+    div,
+  },
   constraints: {
     relation: "ancestor",
     component: { $eq: "Tooltip" },
@@ -49,7 +42,6 @@ export const metaTooltip: WsComponentMeta = {
     },
   ],
   icon: TooltipIcon,
-  stylable: false,
 };
 
 export const propsMetaTooltip: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/fragment.ws.ts
+++ b/packages/sdk-components-react/src/fragment.ws.ts
@@ -3,7 +3,6 @@ import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 export const meta: WsComponentMeta = {
   type: "container",
   icon: "",
-  stylable: false,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/head-link.ws.ts
+++ b/packages/sdk-components-react/src/head-link.ws.ts
@@ -10,7 +10,6 @@ export const meta: WsComponentMeta = {
   category: "hidden",
   icon: ResourceIcon,
   type: "container",
-  stylable: false,
   constraints: {
     relation: "parent",
     component: { $eq: "HeadSlot" },

--- a/packages/sdk-components-react/src/head-meta.ws.ts
+++ b/packages/sdk-components-react/src/head-meta.ws.ts
@@ -10,7 +10,6 @@ export const meta: WsComponentMeta = {
   category: "hidden",
   icon: WindowInfoIcon,
   type: "container",
-  stylable: false,
   constraints: {
     relation: "parent",
     component: { $eq: "HeadSlot" },

--- a/packages/sdk-components-react/src/head-slot.ws.ts
+++ b/packages/sdk-components-react/src/head-slot.ws.ts
@@ -9,7 +9,6 @@ import { props } from "./__generated__/head.props";
 export const meta: WsComponentMeta = {
   icon: HeaderIcon,
   type: "container",
-  stylable: false,
   description: "Inserts children into the head of the document",
   constraints: [
     {

--- a/packages/sdk-components-react/src/head-title.ws.ts
+++ b/packages/sdk-components-react/src/head-title.ws.ts
@@ -10,7 +10,6 @@ export const meta: WsComponentMeta = {
   category: "hidden",
   icon: WindowTitleIcon,
   type: "container",
-  stylable: false,
   constraints: {
     relation: "parent",
     component: { $eq: "HeadSlot" },

--- a/packages/sdk-components-react/src/slot.ws.ts
+++ b/packages/sdk-components-react/src/slot.ws.ts
@@ -7,7 +7,6 @@ export const meta: WsComponentMeta = {
   description:
     "Slot is a container for content that you want to reference across the project. Changes made to a Slot's children will be reflected in all other instances of that Slot.",
   icon: SlotComponentIcon,
-  stylable: false,
   order: 5,
 };
 

--- a/packages/sdk-components-react/src/xml-node.ws.ts
+++ b/packages/sdk-components-react/src/xml-node.ws.ts
@@ -7,7 +7,6 @@ export const meta: WsComponentMeta = {
   order: 6,
   type: "container",
   icon: XmlIcon,
-  stylable: false,
   description: "XML Node",
 };
 

--- a/packages/sdk-components-react/src/xml-time.ws.ts
+++ b/packages/sdk-components-react/src/xml-time.ws.ts
@@ -7,7 +7,6 @@ export const meta: WsComponentMeta = {
   type: "container",
   description: "Converts machine-readable date and time to ISO format.",
   icon: CalendarIcon,
-  stylable: false,
   order: 7,
 };
 

--- a/packages/sdk/src/core-metas.ts
+++ b/packages/sdk/src/core-metas.ts
@@ -34,7 +34,6 @@ const collectionMeta: WsComponentMeta = {
   type: "container",
   label: "Collection",
   icon: ListViewIcon,
-  stylable: false,
 };
 
 const collectionPropsMeta: WsComponentPropsMeta = {
@@ -54,6 +53,8 @@ const descendantMeta: WsComponentMeta = {
   type: "control",
   label: "Descendant",
   icon: PaintBrushIcon,
+  // @todo infer possible presets
+  presetStyle: {},
   constraints: {
     relation: "parent",
     component: { $in: ["HtmlEmbed", "MarkdownEmbed"] },
@@ -96,7 +97,6 @@ export const blockTemplateComponent = "ws:block-template";
 export const blockTemplateMeta: WsComponentMeta = {
   type: "container",
   icon: AddTemplateInstanceIcon,
-  stylable: false,
   constraints: {
     relation: "parent",
     component: { $eq: blockComponent },
@@ -121,7 +121,6 @@ const blockMeta: WsComponentMeta = {
       component: { $eq: blockTemplateComponent },
     },
   ],
-  stylable: false,
 };
 
 const blockPropsMeta: WsComponentPropsMeta = {

--- a/packages/sdk/src/schema/component-meta.ts
+++ b/packages/sdk/src/schema/component-meta.ts
@@ -62,7 +62,6 @@ export const WsComponentMeta = z.object({
   // important to automatically enumerate collections without
   // naming every item manually
   indexWithinAncestor: z.optional(z.string()),
-  stylable: z.optional(z.boolean()),
   label: z.optional(z.string()),
   description: z.string().optional(),
   icon: z.string(),


### PR DESCRIPTION
There is no need in additional flag if we add preset style to every stylable component already.