### PR TITLE
build: fix publishing beta version of packages

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -42,11 +42,15 @@ jobs:
       - id: tag
         run: echo "value=$(echo ${{ github.event.label.name }} | cut -d ':' -f2)" >> $GITHUB_OUTPUT
 
-      - name: Creating version using ${{ steps.short_sha.outputs.value }} sha
-        run: pnpm -r exec pnpm version prepatch --preid ${{ steps.short_sha.outputs.value }}
+      - name: bump version to 0.0.0-${{ steps.short_sha.outputs.value }}
+        run: |
+          pnpx replace-in-files-cli \
+            --string="0.0.0-webstudio-version" \
+            --replacement="0.0.0-${{ steps.short_sha.outputs.value }}" \
+            "**/package.json"
 
-      - run: pnpm -r build
-      - run: pnpm -r dts
+      - run: pnpm --filter="webstudio..." build
+      - run: pnpm --filter="webstudio..." dts
 
       - name: Publishing ${{ steps.tag.outputs.value }} tag with sha ${{ steps.short_sha.outputs.value }}
         run: pnpm -r publish --tag "${{ steps.tag.outputs.value }}" --no-git-checks --access public


### PR DESCRIPTION
Beta version is published without replacing packages version in templates. Reused the code from release action.
