### PR TITLE
feat: Support youtube list embed URL

### DIFF
--- a/packages/sdk-components-react/src/youtube.tsx
+++ b/packages/sdk-components-react/src/youtube.tsx
@@ -207,10 +207,6 @@ const getVideoUrl = (options: YouTubePlayerOptions, videoUrlOrigin: string) => {
     }
   }
 
-  if (!url) {
-    return;
-  }
-
   const optionsKeys = Object.keys(options) as (keyof YouTubePlayerParameters)[];
 
   const parameters: Record<string, string | undefined> = {};


### PR DESCRIPTION
## Description

With this PR user can paste an embed url like this https://youtube.com/embed?listType=playlist&list=UUjk2nKmHzgH5Xy-C5qYRd5A and we will still be able to render it

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
