### PR TITLE
feat: allow saving expressions with unset variables

### DIFF
--- a/apps/builder/app/builder/features/pages/custom-metadata.tsx
+++ b/apps/builder/app/builder/features/pages/custom-metadata.tsx
@@ -13,11 +13,11 @@ import {
 import { TrashIcon, PlusIcon } from "@webstudio-is/icons";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { isLiteralExpression } from "@webstudio-is/sdk";
+import { computeExpression } from "~/shared/data-variables";
 import {
   BindingControl,
   BindingPopover,
 } from "~/builder/shared/binding-popover";
-import { computeExpression } from "~/shared/nano-states";
 import { $pageRootScope } from "./page-utils";
 
 type Meta = {

--- a/apps/builder/app/builder/features/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings.tsx
@@ -74,7 +74,6 @@ import {
   $instances,
   $pages,
   $dataSources,
-  computeExpression,
   $dataSourceVariables,
   $publishedOrigin,
   $project,
@@ -112,6 +111,7 @@ import type { UserPlanFeatures } from "~/shared/db/user-plan-features.server";
 import { useUnmount } from "~/shared/hook-utils/use-mount";
 import { Card } from "../marketplace/card";
 import { selectInstance } from "~/shared/awareness";
+import { computeExpression } from "~/shared/data-variables";
 
 const fieldDefaultValues = {
   name: "Untitled",

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -442,6 +442,7 @@ BooleanForm.displayName = "BooleanForm";
 
 const validateJsonValue = (expression: string) => {
   const diagnostics = lintExpression({ expression });
+  // prevent saving with any message including unset variable
   return diagnostics.length > 0 ? "error" : "";
 };
 

--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -220,8 +220,10 @@ const VariablesItem = ({
         id={variable.id}
         index={index}
         label={
-          <Flex align="center" css={{}}>
-            <Label color={source}>{variable.name}</Label>
+          <Flex align="center">
+            <Label tag="label" color={source}>
+              {variable.name}
+            </Label>
             {value !== undefined && (
               <span className={variableLabelStyle.toString()}>
                 &nbsp;

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -38,16 +38,13 @@ import {
   getExpressionIdentifiers,
   lintExpression,
 } from "@webstudio-is/sdk";
+import { $dataSourceVariables, $isDesignMode } from "~/shared/nano-states";
+import { computeExpression } from "~/shared/data-variables";
 import {
   ExpressionEditor,
   formatValuePreview,
   type EditorApi,
 } from "./expression-editor";
-import {
-  $dataSourceVariables,
-  $isDesignMode,
-  computeExpression,
-} from "~/shared/nano-states";
 
 export const evaluateExpressionWithinScope = (
   expression: string,
@@ -94,7 +91,9 @@ const BindingPanel = ({
       expression,
       availableVariables: new Set(aliases.keys()),
     });
-    setErrorsCount(diagnostics.length);
+    // prevent saving expression only with syntax error
+    const errors = diagnostics.filter((item) => item.severity === "error");
+    setErrorsCount(errors.length);
   };
 
   const updateExpression = (newExpression: string) => {

--- a/apps/builder/app/builder/shared/code-editor-base.tsx
+++ b/apps/builder/app/builder/shared/code-editor-base.tsx
@@ -122,6 +122,10 @@ const editorContentStyle = css({
     textDecoration: "underline wavy red",
     backgroundColor: "rgba(255, 0, 0, 0.1)",
   },
+  ".cm-lintRange-warning": {
+    textDecoration: "underline wavy orange",
+    backgroundColor: "rgba(255, 0, 0, 0.1)",
+  },
   ".cm-gutters": {
     backgroundColor: "transparent",
     border: 0,

--- a/apps/builder/app/shared/data-variables.ts
+++ b/apps/builder/app/shared/data-variables.ts
@@ -4,6 +4,10 @@ import {
   encodeDataVariableId,
   transpileExpression,
 } from "@webstudio-is/sdk";
+import {
+  createJsonStringifyProxy,
+  isPlainObject,
+} from "@webstudio-is/sdk/runtime";
 
 const allowedJsChars = /[A-Za-z_]/;
 
@@ -90,5 +94,82 @@ export const restoreExpressionVariables = ({
     });
   } catch {
     return expression;
+  }
+};
+
+export const computeExpression = (
+  expression: string,
+  variables: Map<DataSource["name"], unknown>
+) => {
+  try {
+    const usedVariables = new Map();
+    const transpiled = transpileExpression({
+      expression,
+      executable: true,
+      replaceVariable: (identifier) => {
+        const id = decodeDataVariableId(identifier);
+        if (id) {
+          usedVariables.set(identifier, id);
+        } else {
+          // access all variable values from specified map
+          const name = decodeDataVariableName(identifier);
+          usedVariables.set(identifier, name);
+        }
+      },
+    });
+    let code = "";
+    // add only used variables in expression and get values
+    // from variables map without additional serializing of these values
+    for (const [identifier, name] of usedVariables) {
+      code += `let ${identifier} = _variables.get(${JSON.stringify(name)});\n`;
+    }
+    code += `return (${transpiled})`;
+
+    /**
+     *
+     * We are using structuredClone on frozen values because, for some reason,
+     * the Proxy example below throws a cryptic error:
+     * TypeError: 'get' on proxy: property 'data' is a read-only and non-configurable
+     * data property on the proxy target, but the proxy did not return its actual value
+     * (expected '[object Array]' but got '[object Array]').
+     *
+     * ```
+     * const createJsonStringifyProxy = (target) => {
+     *   return new Proxy(target, {
+     *     get(target, prop, receiver) {
+     *
+     *       console.log((prop in target), prop)
+     *
+     *       const value = Reflect.get(target, prop, receiver);
+     *
+     *       if (typeof value === "object" && value !== null) {
+     *         return createJsonStringifyProxy(value);
+     *       }
+     *
+     *       return value;
+     *     },
+     *   });
+     * };
+     * const obj = Object.freeze({ data: [1, 2, 3, 4] });
+     * const proxy = createJsonStringifyProxy(obj)
+     * proxy.data
+     *
+     * ```
+     */
+    const proxiedVariables = new Map(
+      [...variables.entries()].map(([key, value]) => [
+        key,
+        isPlainObject(value)
+          ? createJsonStringifyProxy(
+              Object.isFrozen(value) ? structuredClone(value) : value
+            )
+          : value,
+      ])
+    );
+
+    const result = new Function("_variables", code)(proxiedVariables);
+    return result;
+  } catch (error) {
+    console.error(error);
   }
 };

--- a/apps/builder/app/shared/nano-states/props.test.ts
+++ b/apps/builder/app/shared/nano-states/props.test.ts
@@ -2,17 +2,12 @@ import { beforeEach, expect, test } from "vitest";
 import { cleanStores } from "nanostores";
 import { createDefaultPages } from "@webstudio-is/project-build";
 import { setEnv } from "@webstudio-is/feature-flags";
-import {
-  type Instance,
-  encodeDataSourceVariable,
-  collectionComponent,
-} from "@webstudio-is/sdk";
+import { type Instance, collectionComponent } from "@webstudio-is/sdk";
 import { textContentAttribute } from "@webstudio-is/react-sdk";
 import { $instances } from "./instances";
 import {
   $propValuesByInstanceSelector,
   $variableValuesByInstanceSelector,
-  computeExpression,
 } from "./props";
 import { $pages } from "./pages";
 import { $assets, $dataSources, $props, $resources } from "./misc";
@@ -977,25 +972,4 @@ test("prefill default system variable value", () => {
   );
 
   cleanStores($variableValuesByInstanceSelector);
-});
-
-test("compute expression when invalid syntax", () => {
-  expect(computeExpression("https://github.com", new Map())).toEqual(undefined);
-});
-
-test("compute literal expression when variable is json object", () => {
-  const variableName = "jsonVariable";
-  const encVariableName = encodeDataSourceVariable(variableName);
-  const jsonObject = { hello: "world", subObject: { world: "hello" } };
-  const variables = new Map([[variableName, jsonObject]]);
-  const expression = "`${" + encVariableName + "}`";
-
-  expect(computeExpression(expression, variables)).toEqual(
-    JSON.stringify(jsonObject)
-  );
-
-  const subObjectExpression = "`${" + encVariableName + ".subObject}`";
-  expect(computeExpression(subObjectExpression, variables)).toEqual(
-    JSON.stringify(jsonObject.subObject)
-  );
 });

--- a/packages/design-system/src/components/floating-panel.tsx
+++ b/packages/design-system/src/components/floating-panel.tsx
@@ -127,8 +127,8 @@ export const FloatingPanel = ({
         placement === "bottom" && flip(),
         offset(offsetProp),
       ],
-    }).then((position) => {
-      setPosition(position);
+    }).then(({ x, y }) => {
+      setPosition({ x, y });
       positionIsSetRef.current = true;
     });
   }, [

--- a/packages/design-system/src/components/label.tsx
+++ b/packages/design-system/src/components/label.tsx
@@ -127,6 +127,7 @@ const StyledLabel = styled(RadixLabel, {
 });
 
 type Props = {
+  tag?: "button" | "label";
   color?: (typeof labelColors)[number];
   text?: "title" | "sentence" | "mono";
   disabled?: boolean;
@@ -137,13 +138,16 @@ type Props = {
 export const isLabelButton = (color: Props["color"]) => color !== undefined;
 
 export const Label = forwardRef((props: Props, ref: Ref<HTMLLabelElement>) => {
-  const { disabled, children, ...rest } = props;
+  const { tag = "label", disabled, children, ...rest } = props;
 
   // To enable keyboard accessibility for users who rely on the spacebar to activate the radix
   // when using a preset, locala, overwritten or remote color, we need to wrap the label with
   // a button that has a "label" role.
   // (Radix adds role="button" to the label)
-  const isButton = isLabelButton(props.color);
+  let isButton = isLabelButton(props.color) || tag === "button";
+  if (tag === "label") {
+    isButton = false;
+  }
 
   return (
     <StyledLabel

--- a/packages/design-system/src/components/label.tsx
+++ b/packages/design-system/src/components/label.tsx
@@ -138,13 +138,14 @@ type Props = {
 export const isLabelButton = (color: Props["color"]) => color !== undefined;
 
 export const Label = forwardRef((props: Props, ref: Ref<HTMLLabelElement>) => {
-  const { tag = "label", disabled, children, ...rest } = props;
+  const { tag, disabled, children, ...rest } = props;
 
   // To enable keyboard accessibility for users who rely on the spacebar to activate the radix
   // when using a preset, locala, overwritten or remote color, we need to wrap the label with
   // a button that has a "label" role.
   // (Radix adds role="button" to the label)
   let isButton = isLabelButton(props.color) || tag === "button";
+  // when explicit label
   if (tag === "label") {
     isButton = false;
   }

--- a/packages/react-sdk/src/component-generator.test.tsx
+++ b/packages/react-sdk/src/component-generator.test.tsx
@@ -997,7 +997,7 @@ test("variable names can be js identifiers", () => {
   );
 });
 
-test("Renders nothing if only templates are present in block", () => {
+test("renders nothing if only templates are present in block", () => {
   const BlockTemplate = ws["block-template"];
   expect(
     generateWebstudioComponent({
@@ -1029,8 +1029,8 @@ test("Renders nothing if only templates are present in block", () => {
   );
 });
 
-test("Renders only block children", () => {
-  const Bt = ws["block-template"];
+test("renders only block children", () => {
+  const BlockTemplate = ws["block-template"];
 
   expect(
     generateWebstudioComponent({
@@ -1043,9 +1043,9 @@ test("Renders only block children", () => {
       ...renderData(
         <$.Body ws:id="body">
           <ws.block ws:id="block">
-            <Bt>
+            <BlockTemplate>
               <$.Box>Test</$.Box>
-            </Bt>
+            </BlockTemplate>
             <$.Box>Child0</$.Box>
           </ws.block>
         </$.Body>
@@ -1058,6 +1058,36 @@ test("Renders only block children", () => {
       return <Body>
       <Box>
       {"Child0"}
+      </Box>
+      </Body>
+      }
+    `)
+    )
+  );
+});
+
+test("generate unset variables as undefined", () => {
+  expect(
+    generateWebstudioComponent({
+      classesMap: new Map(),
+      scope: createScope(),
+      name: "Page",
+      rootInstanceId: "body",
+      parameters: [],
+      indexesWithinAncestors: new Map(),
+      ...renderData(
+        <$.Body ws:id="body">
+          <$.Box>{expression`a + b`}</$.Box>
+        </$.Body>
+      ),
+    })
+  ).toEqual(
+    validateJSX(
+      clear(`
+      const Page = () => {
+      return <Body>
+      <Box>
+      {undefined + undefined}
       </Box>
       </Body>
       }

--- a/packages/sdk/src/expression.test.ts
+++ b/packages/sdk/src/expression.test.ts
@@ -20,6 +20,13 @@ describe("lint expression", () => {
     message,
   });
 
+  const warn = (from: number, to: number, message: string): Diagnostic => ({
+    from,
+    to,
+    severity: "warning",
+    message,
+  });
+
   test("forbid empty expression", () => {
     expect(lintExpression({ expression: `` })).toEqual([
       error(0, 0, `Expression cannot be empty`),
@@ -119,8 +126,8 @@ describe("lint expression", () => {
     expect(
       lintExpression({ expression: ` a = b + 1`, allowAssignment: true })
     ).toEqual([
-      error(5, 6, `"b" is not defined in the scope`),
-      error(1, 2, `"a" is not defined in the scope`),
+      warn(5, 6, `"b" is not defined in the scope`),
+      warn(1, 2, `"a" is not defined in the scope`),
     ]);
     expect(
       lintExpression({

--- a/packages/sdk/src/expression.ts
+++ b/packages/sdk/src/expression.ts
@@ -85,7 +85,10 @@ export const lintExpression = ({
         simple(node.left, {
           Identifier(node) {
             if (availableVariables.has(node.name) === false) {
-              addMessage(`"${node.name}" is not defined in the scope`)(node);
+              addMessage(
+                `"${node.name}" is not defined in the scope`,
+                "warning"
+              )(node);
             }
           },
         });


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/4768 https://github.com/webstudio-is/webstudio/issues/4753

User can paste expression with not defined variable and should get it saved in case of accidental closing popover.

Now such expressions can be executed in builder and will be compiled with undefined instead of variables in published sites.

In the future we need to add global diagnostics to let users find such places faster.

Also fixed a couple of ui issues
- react error about using button inside of button in data variables list
- react error about using unknown middlewareData prop from floating-ui

<img width="307" alt="Screenshot 2025-01-27 at 16 30 58" src="https://github.com/user-attachments/assets/2ddc9ead-33a2-4438-b641-6943d7472f7e" />

