### PR TITLE
refactor: drop react and warn-once from CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,10 +42,8 @@
     "p-limit": "^6.2.0",
     "parse5": "7.2.1",
     "picocolors": "^1.1.1",
-    "react": "18.3.0-canary-14898b6a9-20240318",
     "reserved-identifiers": "^1.0.0",
     "tinyexec": "^0.3.2",
-    "warn-once": "^0.1.1",
     "yargs": "^17.7.2",
     "zod": "^3.22.4"
   },
@@ -77,6 +75,7 @@
     "h3": "^1.14.0",
     "ipx": "^3.0.1",
     "prettier": "3.4.2",
+    "react": "18.3.0-canary-14898b6a9-20240318",
     "react-dom": "18.3.0-canary-14898b6a9-20240318",
     "react-router": "^7.1.3",
     "ts-expect": "^1.3.0",

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -49,7 +49,6 @@ import {
   coreMetas,
 } from "@webstudio-is/sdk";
 import type { Data } from "@webstudio-is/http-client";
-import { wsImageLoader } from "@webstudio-is/image";
 import { LOCAL_DATA_FILE } from "./config";
 import {
   createFileIfNotExists,
@@ -443,14 +442,10 @@ export const prebuild = async (options: {
 
     for (const asset of siteData.assets) {
       if (asset.type === "image") {
-        const imagePath = wsImageLoader({
-          src: asset.name,
-          format: "raw",
-        });
         assetsToDownload.push(
           limit(() =>
             downloadAsset(
-              `${assetOrigin}${imagePath}`,
+              `${assetOrigin}/cgi/image/${asset.name}?format=auto`,
               asset.name,
               assetBaseUrl
             )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1135,18 +1135,12 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
-      react:
-        specifier: 18.3.0-canary-14898b6a9-20240318
-        version: 18.3.0-canary-14898b6a9-20240318
       reserved-identifiers:
         specifier: ^1.0.0
         version: 1.0.0
       tinyexec:
         specifier: ^0.3.2
         version: 0.3.2
-      warn-once:
-        specifier: ^0.1.1
-        version: 0.1.1
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -1235,6 +1229,9 @@ importers:
       prettier:
         specifier: 3.4.2
         version: 3.4.2
+      react:
+        specifier: 18.3.0-canary-14898b6a9-20240318
+        version: 18.3.0-canary-14898b6a9-20240318
       react-dom:
         specifier: 18.3.0-canary-14898b6a9-20240318
         version: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)


### PR DESCRIPTION
Here removed image package from CLI which depends on react and warn-once. CLI can be a little smaller without it.