### PR TITLE
fix: validate unexpected closing paren in expressions

### DIFF
--- a/packages/sdk/src/expression.test.ts
+++ b/packages/sdk/src/expression.test.ts
@@ -40,6 +40,9 @@ describe("lint expression", () => {
     expect(lintExpression({ expression: `a + ` })).toEqual([
       error(4, 4, "Unexpected token"),
     ]);
+    expect(lintExpression({ expression: `"string" + a)` })).toEqual([
+      error(13, 13, "Unexpected token"),
+    ]);
   });
 
   test("restrict expression syntax", () => {

--- a/packages/sdk/src/expression.ts
+++ b/packages/sdk/src/expression.ts
@@ -1,4 +1,9 @@
-import { type Expression, type Identifier, parseExpressionAt } from "acorn";
+import {
+  type Expression,
+  type Identifier,
+  parse,
+  parseExpressionAt,
+} from "acorn";
 import { simple } from "acorn-walk";
 import type { DataSources } from "./schema/data-sources";
 import type { Scope } from "./scope";
@@ -51,8 +56,7 @@ export const lintExpression = ({
   try {
     // wrap expression with parentheses to force acorn parse whole expression
     // instead of just first valid part
-    // https://github.com/acornjs/acorn/tree/master/acorn
-    const root = parseExpressionAt(`(${expression})`, 0, {
+    const root = parse(`(${expression})`, {
       ecmaVersion: "latest",
       // support parsing import to forbid explicitly
       sourceType: "module",


### PR DESCRIPTION
User found syntax error which was accepted by linter. Turns out parseExpressionAt allows something like this
```js
(a + b))
```

Switched back to `parse` which actually gives proper result when expression is wrapped with parens.