### PR TITLE
fix: forbid text content in head meta and link

### DIFF
--- a/packages/sdk-components-react/src/head-link.ws.ts
+++ b/packages/sdk-components-react/src/head-link.ws.ts
@@ -9,7 +9,7 @@ import { props } from "./__generated__/head-link.props";
 export const meta: WsComponentMeta = {
   category: "hidden",
   icon: ResourceIcon,
-  type: "container",
+  type: "embed",
   constraints: {
     relation: "parent",
     component: { $eq: "HeadSlot" },

--- a/packages/sdk-components-react/src/head-meta.ws.ts
+++ b/packages/sdk-components-react/src/head-meta.ws.ts
@@ -9,7 +9,7 @@ import { props } from "./__generated__/head-meta.props";
 export const meta: WsComponentMeta = {
   category: "hidden",
   icon: WindowInfoIcon,
-  type: "container",
+  type: "embed",
   constraints: {
     relation: "parent",
     component: { $eq: "HeadSlot" },


### PR DESCRIPTION
Users should not be able to add children in meta and link elements.