### PR TITLE
refactor: use text field for devlogin

### DIFF
--- a/apps/builder/app/auth/secret-login.tsx
+++ b/apps/builder/app/auth/secret-login.tsx
@@ -14,7 +14,7 @@ export const SecretLogin = () => {
         <Flex gap="2">
           <InputField
             name="secret"
-            type="password"
+            type="text"
             minLength={2}
             required
             autoFocus


### PR DESCRIPTION
Password field makes it harder to enter email for new user. Since thew feature is dev only there is no need to protect it as password.