### PR TITLE
fix: Scrub on windows

### DIFF
--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -450,10 +450,6 @@ const requestPointerLock = (
         state.pointerCaptureRequested = true;
         requestPointerLockSafe(targetNode)
           .then(() => {
-            if (targetNode.hasPointerCapture(pointerId)) {
-              targetNode.releasePointerCapture(pointerId);
-            }
-
             state.pointerCaptureRequested = false;
             const cursorNode =
               (targetNode.ownerDocument.querySelector(

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -439,6 +439,11 @@ const requestPointerLock = (
     };
   });
 
+  let isDisposed = false;
+  disposeOnCleanup(() => () => {
+    isDisposed = true;
+  });
+
   const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
   // Safari supports pointer lock well, but the issue lies with the pointer lock banner.
@@ -450,6 +455,14 @@ const requestPointerLock = (
         requestPointerLockSafe(targetNode)
           .then(() => {
             state.pointerCaptureRequested = false;
+
+            if (isDisposed) {
+              if (targetNode.ownerDocument.pointerLockElement === targetNode) {
+                targetNode.ownerDocument.exitPointerLock();
+              }
+              return;
+            }
+
             const cursorNode =
               (targetNode.ownerDocument.querySelector(
                 "#numeric-guesture-control-cursor"

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -214,6 +214,7 @@ export const numericScrubControl = (
     if (!(event instanceof PointerEvent)) {
       return;
     }
+
     const { type } = event;
 
     switch (type) {
@@ -404,8 +405,6 @@ export const numericScrubControl = (
 
 const requestPointerLockSafe = async (targetNode: HTMLElement | SVGElement) => {
   try {
-    // await targetNode.requestPointerLock();
-
     return await targetNode.requestPointerLock({
       unadjustedMovement: true,
     });

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -148,6 +148,14 @@ const addCursorUI = (direction: NumericScrubDirection) => {
   };
 };
 
+const isWindows = () => {
+  if (typeof window !== "undefined") {
+    return navigator.platform.toLowerCase().includes("win");
+  }
+
+  return false;
+};
+
 export const numericScrubControl = (
   targetNode: HTMLElement | SVGElement,
   options: NumericScrubOptions
@@ -187,6 +195,8 @@ export const numericScrubControl = (
     for (const task of [...cleanupTasks.reverse()]) {
       task();
     }
+
+    cleanupTasks.length = 0;
 
     if (state.status === "scrubbing") {
       state.status = "idle";
@@ -235,6 +245,8 @@ export const numericScrubControl = (
         break;
       }
       case "pointerdown": {
+        cleanup();
+
         if (
           event.target &&
           shouldHandleEvent?.(event.target as Node) === false
@@ -362,8 +374,12 @@ export const numericScrubControl = (
       }
 
       case "lostpointercapture": {
-        if (state.pointerCaptureRequested) {
-          break;
+        // On Mac if this happens it's near 100% probability that pointerup event will not fire
+        if (isWindows()) {
+          // This Windows fix cause other bug, in some cases pointerup event will not fire
+          if (state.pointerCaptureRequested) {
+            break;
+          }
         }
 
         if (document.pointerLockElement === null) {

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -82,8 +82,8 @@ type NumericScrubState = {
   direction: NumericScrubDirection;
   status: "idle" | "scrubbing";
   /**
-   * On windows it's possible that requestPointerLock is already called,
-   * but document.pointerLockElement is not updated yet.
+   * On Windows, requestPointerLock might already be called,
+   * but document.pointerLockElement may not have been updated yet.
    */
   pointerCaptureRequested: boolean;
 };


### PR DESCRIPTION
## Description

https://discord.com/channels/955905230107738152/1337534586707644416


There are other bugs I see on Windows on my machine - `requestPointerLock` seems too buggy.  

1. In my case, wrap-around is not working.  
2. Fast clicks and movements can cause `pointerup` to not be intercepted (because of the fix above).  

Here’s how I see the issue:  

- `requestPointerLock` is asynchronous.  
- During `requestPointerLock`, we might get a `lostpointercapture` event.  
- This has a very low probability of happening on Mac.  
- On Windows, the probability is very high _(it can be caused by calling `requestPointerLock` itself, depending on the machine)_.  
- On Mac, if this happens, the `pointerup` event will most likely be lost.  
- On Windows, the `pointerup` event is usually preserved but can be lost as well.  

Currently, on Windows, instead of cleanup, we assume everything will be fine.  
On Mac, we perform cleanup on the `lostpointercapture` event.  

Windows' behavior is buggy, but I haven’t found a proper way to fix it.  
There's no way to detect `event.buttons` on move, and this happens independently of the `pointerleave` event.  
Using body as lock target etc doesn't work too. 

My suggestion - if this causes new bugs - is to remove `requestPointerLock` entirely on Windows.


## Steps for reproduction

1. click button
3. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
