### PR TITLE
feat: Suggest a variable when user forgets -- in advanced panel

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -33,6 +33,7 @@ import {
   Text,
   theme,
   Tooltip,
+  truncate,
   useCombobox,
 } from "@webstudio-is/design-system";
 import {
@@ -135,6 +136,13 @@ const matchOrSuggestToCreate = (
     matched.unshift({
       value: propertyName,
       label: `Create "${propertyName}"`,
+    });
+  }
+  // When there is no match we suggest to create a custom property.
+  if (matched.length === 0) {
+    matched.unshift({
+      value: `--${propertyName}`,
+      label: `--${propertyName}`,
     });
   }
   return matched;
@@ -257,8 +265,15 @@ const AddProperty = forwardRef<
                 <ComboboxListboxItem
                   {...combobox.getItemProps({ item, index })}
                   key={index}
+                  asChild
                 >
-                  {item.label}
+                  <Text
+                    variant="labelsSentenceCase"
+                    truncate
+                    css={{ maxWidth: "25ch" }}
+                  >
+                    {item.label}
+                  </Text>
                 </ComboboxListboxItem>
               ))}
             </ComboboxScrollArea>

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -33,7 +33,6 @@ import {
   Text,
   theme,
   Tooltip,
-  truncate,
   useCombobox,
 } from "@webstudio-is/design-system";
 import {

--- a/packages/design-system/src/utilities.ts
+++ b/packages/design-system/src/utilities.ts
@@ -145,5 +145,5 @@ export const useResize = ({
 export const truncate = (): CSS => ({
   whiteSpace: "nowrap",
   textOverflow: "ellipsis",
-  overflow: "hidden",
+  overflow: "clip",
 });


### PR DESCRIPTION
https://github.com/webstudio-is/webstudio/issues/4804

## Description

When user is trying to create a variable but forgot to add --, we can help

<img width="258" alt="image" src="https://github.com/user-attachments/assets/689b33a3-5044-461b-bafa-6cac9bbcc3b2" />


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
