### PR TITLE
experimental: Validate the guessed variable

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -137,11 +137,15 @@ const matchOrSuggestToCreate = (
       label: `Create "${propertyName}"`,
     });
   }
+
   // When there is no match we suggest to create a custom property.
-  if (matched.length === 0) {
+  if (
+    matched.length === 0 &&
+    lexer.match("<custom-ident>", `--${propertyName}`).matched
+  ) {
     matched.unshift({
       value: `--${propertyName}`,
-      label: `--${propertyName}`,
+      label: `--${propertyName}: unset;`,
     });
   }
   return matched;


### PR DESCRIPTION
## Description

Currently you can create a css variable  `bla` and it will bypass validation. With this PR it will validate

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
