### PR TITLE
feat: Autocomplete values in advanced panel 

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -40,6 +40,7 @@ import {
   properties as propertiesData,
   keywordValues,
   propertyDescriptions,
+  parseCssValue,
 } from "@webstudio-is/css-data";
 import {
   cssWideKeywords,
@@ -241,6 +242,7 @@ const AddProperty = forwardRef<
     property: "",
     label: "",
   });
+  const highlightedItemRef = useRef<SearchItem>();
 
   const combobox = useCombobox<SearchItem>({
     getItems: getAutocompleteItems,
@@ -253,6 +255,24 @@ const AddProperty = forwardRef<
     onItemSelect: (item) => {
       clear();
       onSubmit(`${item.property}: ${item.value ?? "unset"}`);
+    },
+    onItemHighlight: (item) => {
+      const previousHighlightedItem = highlightedItemRef.current;
+      if (item?.value === undefined && previousHighlightedItem) {
+        deleteProperty(previousHighlightedItem.property as StyleProperty, {
+          isEphemeral: true,
+        });
+        highlightedItemRef.current = undefined;
+        return;
+      }
+
+      if (item?.value) {
+        const value = parseCssValue(item.property as StyleProperty, item.value);
+        setProperty(item.property as StyleProperty)(value, {
+          isEphemeral: true,
+        });
+        highlightedItemRef.current = item;
+      }
     },
   });
 

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -133,10 +133,15 @@ const getAutocompleteItems = () => {
     });
   });
 
+  const ignoreValues = ["inherit", "initial", "unset", ...keywordValues.color];
+
   (Object.keys(keywordValues) as Array<keyof typeof keywordValues>).forEach(
     (property) => {
       const values = keywordValues[property];
       for (const value of values) {
+        if (ignoreValues.includes(value)) {
+          continue;
+        }
         autoCompleteItems.push({
           property,
           value,

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -117,7 +117,7 @@ const AdvancedStyleSection = (props: {
   );
 };
 
-type SearchItem = { value: string; label: string };
+type SearchItem = { property: string; label: string };
 
 const matchOrSuggestToCreate = (
   search: string,
@@ -127,21 +127,21 @@ const matchOrSuggestToCreate = (
   const matched = matchSorter(items, search, {
     keys: [itemToString],
   });
-  const propertyName = search.trim();
+  const property = search.trim();
   if (
-    propertyName.startsWith("--") &&
-    lexer.match("<custom-ident>", propertyName).matched
+    property.startsWith("--") &&
+    lexer.match("<custom-ident>", property).matched
   ) {
     matched.unshift({
-      value: propertyName,
-      label: `Create "${propertyName}"`,
+      property,
+      label: `Create "${property}"`,
     });
   }
   // When there is no match we suggest to create a custom property.
   if (matched.length === 0) {
     matched.unshift({
-      value: `--${propertyName}`,
-      label: `--${propertyName}`,
+      property: `--${property}`,
+      label: `--${property}`,
     });
   }
   return matched;
@@ -149,8 +149,8 @@ const matchOrSuggestToCreate = (
 
 const getNewPropertyDescription = (item: null | SearchItem) => {
   let description: string | undefined = `Create CSS variable.`;
-  if (item && item.value in propertyDescriptions) {
-    description = propertyDescriptions[item.value];
+  if (item && item.property in propertyDescriptions) {
+    description = propertyDescriptions[item.property];
   }
   return <Box css={{ width: theme.spacing[28] }}>{description}</Box>;
 };
@@ -171,7 +171,7 @@ const insertStyles = (text: string) => {
 const sortedProperties = Object.keys(propertiesData)
   .sort(Intl.Collator().compare)
   .map((property) => ({
-    value: property,
+    property,
     label: hyphenateProperty(property),
   }));
 
@@ -190,12 +190,12 @@ const AddProperty = forwardRef<
   {
     onSelect: (value: StyleProperty) => void;
     onClose: () => void;
-    onSubmit: (value: string) => void;
+    onSubmit: (property: string) => void;
     onFocus: () => void;
   }
 >(({ onSelect, onClose, onSubmit, onFocus }, forwardedRef) => {
   const [item, setItem] = useState<SearchItem>({
-    value: "",
+    property: "",
     label: "",
   });
 
@@ -206,10 +206,11 @@ const AddProperty = forwardRef<
     defaultHighlightedIndex: 0,
     getItemProps: () => ({ text: "sentence" }),
     match: matchOrSuggestToCreate,
-    onChange: (value) => setItem({ value: value ?? "", label: value ?? "" }),
+    onChange: (property) =>
+      setItem({ property: property ?? "", label: property ?? "" }),
     onItemSelect: (item) => {
       clear();
-      onSelect(item.value as StyleProperty);
+      onSelect(item.property as StyleProperty);
     },
   });
 
@@ -219,7 +220,7 @@ const AddProperty = forwardRef<
   const inputProps = combobox.getInputProps();
 
   const clear = () => {
-    setItem({ value: "", label: "" });
+    setItem({ property: "", label: "" });
   };
 
   const handleKeys = (event: KeyboardEvent) => {
@@ -229,7 +230,7 @@ const AddProperty = forwardRef<
     }
     if (event.key === "Enter") {
       clear();
-      onSubmit(item.value);
+      onSubmit(item.property);
       return;
     }
     if (event.key === "Escape") {

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -42,6 +42,7 @@ import {
   propertyDescriptions,
 } from "@webstudio-is/css-data";
 import {
+  cssWideKeywords,
   hyphenateProperty,
   toValue,
   type StyleProperty,
@@ -126,30 +127,28 @@ const getAutocompleteItems = () => {
   if (autoCompleteItems.length > 0) {
     return autoCompleteItems;
   }
-  Object.keys(propertiesData).forEach((property) => {
+  for (const property in propertiesData) {
     autoCompleteItems.push({
       property,
       label: hyphenateProperty(property),
     });
-  });
+  }
 
-  const ignoreValues = ["inherit", "initial", "unset", ...keywordValues.color];
+  const ignoreValues = new Set([...cssWideKeywords, ...keywordValues.color]);
 
-  (Object.keys(keywordValues) as Array<keyof typeof keywordValues>).forEach(
-    (property) => {
-      const values = keywordValues[property];
-      for (const value of values) {
-        if (ignoreValues.includes(value)) {
-          continue;
-        }
-        autoCompleteItems.push({
-          property,
-          value,
-          label: `${hyphenateProperty(property)}: ${value}`,
-        });
+  for (const property in keywordValues) {
+    const values = keywordValues[property as keyof typeof keywordValues];
+    for (const value of values) {
+      if (ignoreValues.has(value)) {
+        continue;
       }
+      autoCompleteItems.push({
+        property,
+        value,
+        label: `${hyphenateProperty(property)}: ${value}`,
+      });
     }
-  );
+  }
 
   autoCompleteItems.sort((a, b) =>
     Intl.Collator().compare(a.property, b.property)
@@ -253,7 +252,7 @@ const AddProperty = forwardRef<
     onChange: (value) => setItem({ property: value ?? "", label: value ?? "" }),
     onItemSelect: (item) => {
       clear();
-      return onSubmit(`${item.property}: ${item.value ?? "unset"}`);
+      onSubmit(`${item.property}: ${item.value ?? "unset"}`);
     },
   });
 
@@ -273,7 +272,7 @@ const AddProperty = forwardRef<
     }
     if (event.key === "Enter") {
       clear();
-      onSubmit(`${item.property}`);
+      onSubmit(item.property);
       return;
     }
     if (event.key === "Escape") {


### PR DESCRIPTION
https://github.com/webstudio-is/webstudio/issues/4816

## Description

- When adding a new property, you sometimes don't know the property name, e.g. you know you want to "center" it but you don't remember if its align-items, align-content or any other and you need to see the list.
- Currently you can create a css variable "bla" and it will bypass validation, now it will validate
- also try "color" esc autocomplete, enter
- or "color:red" esc autocomplete enter


Try typing "center"

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
