### PR TITLE
fix: remove masked duplicates in binding popover

### DIFF
--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -422,7 +422,7 @@ export const $variableValuesByInstanceSelector = computed(
       const [instanceId] = instanceSelector;
       const instance = instances.get(instanceId);
 
-      let variableNames = new Map(parentVariableNames);
+      const variableNames = new Map(parentVariableNames);
       let variableValues = new Map<string, unknown>(parentVariableValues);
       variableValuesByInstanceSelector.set(
         getInstanceKey(instanceSelector),


### PR DESCRIPTION
Here improved computing variables logic to exclude masked variables from bindings popover list.

Also rewrote related tests with jsx template.

<img width="550" alt="Screenshot 2025-02-11 at 17 49 00" src="https://github.com/user-attachments/assets/4a4995c6-90f2-4ec4-aa08-ff66e682e90d" />
