### PR TITLE
fix: Fix copy instance if no text is selected 

### DIFF
--- a/apps/builder/app/builder/features/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator-tree.tsx
@@ -542,6 +542,13 @@ export const NavigatorTree = () => {
     }
   }, [selectedInstanceSelector]);
 
+  const selectInstanceAndClearSelection = (
+    instanceSelector: undefined | Instance["id"][]
+  ) => {
+    window.getSelection()?.removeAllRanges();
+    selectInstance(instanceSelector);
+  };
+
   return (
     <ScrollArea
       direction="both"
@@ -558,8 +565,10 @@ export const NavigatorTree = () => {
             level={0}
             isSelected={selectedKey === ROOT_INSTANCE_ID}
             buttonProps={{
-              onClick: () => selectInstance([ROOT_INSTANCE_ID]),
-              onFocus: () => selectInstance([ROOT_INSTANCE_ID]),
+              onClick: () =>
+                selectInstanceAndClearSelection([ROOT_INSTANCE_ID]),
+              onFocus: () =>
+                selectInstanceAndClearSelection([ROOT_INSTANCE_ID]),
             }}
             action={
               <Tooltip
@@ -664,8 +673,8 @@ export const NavigatorTree = () => {
                     $blockChildOutline.set(undefined);
                   },
                   onMouseLeave: () => $hoveredInstanceSelector.set(undefined),
-                  onClick: () => selectInstance(item.selector),
-                  onFocus: () => selectInstance(item.selector),
+                  onClick: () => selectInstanceAndClearSelection(item.selector),
+                  onFocus: () => selectInstanceAndClearSelection(item.selector),
                   onKeyDown: (event) => {
                     if (event.key === "Enter") {
                       emitCommand("editInstanceText");

--- a/apps/builder/app/builder/features/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator-tree.tsx
@@ -545,6 +545,8 @@ export const NavigatorTree = () => {
   const selectInstanceAndClearSelection = (
     instanceSelector: undefined | Instance["id"][]
   ) => {
+    // If text is selected, it needs to be unselected before selecting the instance.
+    // Otherwise user will cmd+c the text instead of copying the instance.
     window.getSelection()?.removeAllRanges();
     selectInstance(instanceSelector);
   };

--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -49,23 +49,10 @@ const validateClipboardEvent = (event: ClipboardEvent) => {
   // Allows native selection of text in the Builder panels, such as CSS Preview.
   if (event.type === "copy") {
     const isInBuilderContext = window.self === window.top;
+    const selection = window.getSelection();
 
-    if (isInBuilderContext) {
-      // Note on event.target:
-      //
-      //   The spec (https://w3c.github.io/clipboard-apis/#to-fire-a-clipboard-event)
-      //   says that if the context is not editable, the target should be the focused node.
-      //
-      //   But in practice it seems that the target is based
-      //   on where the cursor is, rather than which element has focus.
-      //   For example, if a <button> has focus, the target is the <body> element.
-      //   If some text is selected, the target is a wrapping element of the text.
-      //   (at least in Chrome).
-
-      // We are using the behavior described above: if some text is selected, the target is usually (at least in the cases we need) not the body.
-      if (event.target !== window.document.body) {
-        return false;
-      }
+    if (isInBuilderContext && selection && selection.isCollapsed === false) {
+      return false;
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/4856

## Description

Current logic broke in Chrome 133

1. Select instance in navigator
2. Copy
3. Paste
4. Should still allow selecting text and copying it

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
