### PR TITLE
fix: cleanup parent children when delete instances

### DIFF
--- a/apps/builder/app/shared/instance-utils.test.tsx
+++ b/apps/builder/app/shared/instance-utils.test.tsx
@@ -740,7 +740,8 @@ describe("delete instance", () => {
     expect(data.instances.get("bodyId")?.children.length).toEqual(2);
     deleteInstanceMutable(
       data,
-      getInstancePath(["boxId", "bodyId"], data.instances)
+      // clone to make sure data is mutated instead of instance path
+      structuredClone(getInstancePath(["boxId", "bodyId"], data.instances))
     );
     expect(data.instances.size).toEqual(2);
     expect(data.instances.get("bodyId")?.children.length).toEqual(1);

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -443,6 +443,8 @@ export const deleteInstanceMutable = (
     instanceIds
   );
 
+  // mutate instances from data instead of instance path
+  parentInstance = data.instances.get(parentInstance?.id as string);
   // may not exist when delete root
   if (parentInstance) {
     removeByMutable(


### PR DESCRIPTION
Was missed while refactoring. Wrong data was mutated.