### PR TITLE
feat: allow deleting variables used in expressions

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -278,13 +278,14 @@ const VariablesItem = ({
               onOpenChange={setIsDeleteDialogOpen}
             >
               <DialogContent>
-                <DialogTitle>Do you want to delete this variable?</DialogTitle>
+                <DialogTitle>Delete Variable?</DialogTitle>
                 <DialogDescription
                   className={css({
                     paddingInline: theme.panel.paddingInline,
+                    textWrap: "nowrap",
                   }).toString()}
                 >
-                  This variable is used in {usageCount}&nbsp;
+                  Variable "{variable.name}" is used in {usageCount}&nbsp;
                   {usageCount === 1 ? "expression" : "expressions"}.
                 </DialogDescription>
                 <DialogActions>

--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -8,7 +8,6 @@ import {
   CssValueListItem,
   Dialog,
   DialogActions,
-  DialogClose,
   DialogContent,
   DialogDescription,
   DialogTitle,
@@ -285,7 +284,7 @@ const VariablesItem = ({
                     paddingInline: theme.panel.paddingInline,
                   }).toString()}
                 >
-                  This variable is used in {usageCount}{" "}
+                  This variable is used in {usageCount}&nbsp;
                   {usageCount === 1 ? "expression" : "expressions"}.
                 </DialogDescription>
                 <DialogActions>


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/4768

Before we disabled deleting variables which are used in expressions. Now we will ask confirmation and unset this variable. This way user will not be locked if variable is lost and we will show diagnostics (in the future) where all unset variables are.

<img width="908" alt="Screenshot 2025-02-12 at 15 38 14" src="https://github.com/user-attachments/assets/ea9eea58-c276-4251-8b95-1214e9380621" />
