### PR TITLE
feat: drop legacy CLI templates

### DIFF
--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -643,25 +643,28 @@ const Content = (props: {
 
 const deployTargets = {
   vanilla: {
+    label: "Docker",
+    docs: "https://reactrouter.com/",
     command: `
-      npm install
-      npm run dev
+      docker build -t my-image .
+      docker run my-image
     `,
-    docs: "https://remix.run/",
     ssgTemplates: ["ssg"],
   },
   vercel: {
-    command: "npx vercel@latest",
+    label: "Vercel",
     docs: "https://vercel.com/docs/cli",
+    command: "npx vercel@latest",
     ssgTemplates: ["ssg-vercel"],
   },
   netlify: {
+    label: "Netlify",
+    docs: "https://docs.netlify.com/cli/get-started/",
     command: `
 npx netlify-cli@latest login
 npx netlify-cli sites:create
 npx netlify-cli build
 npx netlify-cli deploy`,
-    docs: "https://docs.netlify.com/cli/get-started/",
     ssgTemplates: ["ssg-netlify"],
   },
 } as const;
@@ -803,7 +806,7 @@ const ExportContent = (props: { projectId: Project["id"] }) => {
               target="_blank"
               rel="noreferrer"
             >
-              {humanizeString(deployTarget)}
+              {humanizeString(deployTargets[deployTarget].label)}
             </Link>{" "}
           </Text>
         </Grid>

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -54,11 +54,6 @@ export type GlobalConfig = z.infer<typeof zGlobalConfig>;
 
 export const PROJECT_TEMPLATES = [
   {
-    value: "vanilla" as const,
-    label: "Vanilla",
-    expand: ["defaults"],
-  },
-  {
     value: "docker" as const,
     label: "Docker",
     expand: ["react-router", "react-router-docker"],
@@ -67,11 +62,6 @@ export const PROJECT_TEMPLATES = [
     value: "vercel" as const,
     label: "Vercel",
     expand: ["react-router", "react-router-vercel"],
-  },
-  {
-    value: "vercel-legacy" as const,
-    label: "Vercel (legacy)",
-    expand: ["defaults", "vercel"],
   },
   {
     value: "netlify" as const,

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -5,7 +5,6 @@ export const aiRadixComponents = false;
 export const cms = false;
 export const filters = false;
 export const xmlElement = false;
-export const staticExport = false;
 export const contentEditableMode = false;
 export const command = false;
 export const headSlotComponent = false;

--- a/packages/sdk/src/schema/deployment.ts
+++ b/packages/sdk/src/schema/deployment.ts
@@ -1,10 +1,8 @@
 import { z } from "zod";
 
 export const Templates = z.enum([
-  "vanilla",
   "docker",
   "vercel",
-  "vercel-legacy",
   "netlify",
   "ssg",
   "ssg-netlify",


### PR DESCRIPTION
Here dropped vanilla and legacy vercel templates.
Replaced vanilla with docker in publish dialog.

<img width="360" alt="Screenshot 2025-02-13 at 18 34 53" src="https://github.com/user-attachments/assets/c84cdae1-d1f8-4a91-b03c-1e13e95bcbf2" />
