### PR TITLE
feat: support global data variables

### DIFF
--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -2,7 +2,6 @@ import { useRef } from "react";
 import { computed } from "nanostores";
 import { useStore } from "@nanostores/react";
 import type { Instance } from "@webstudio-is/sdk";
-import { rootComponent } from "@webstudio-is/sdk";
 import {
   theme,
   PanelTabs,
@@ -20,7 +19,7 @@ import {
   FloatingPanelProvider,
 } from "@webstudio-is/design-system";
 import { ModeMenu, StylePanel } from "~/builder/features/style-panel";
-import { SettingsPanelContainer } from "~/builder/features/settings-panel";
+import { SettingsPanel } from "~/builder/features/settings-panel";
 import {
   $registeredComponentMetas,
   $dragAndDropState,
@@ -93,6 +92,7 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
   type PanelName = "style" | "settings";
 
   const availablePanels = new Set<PanelName>();
+  availablePanels.add("settings");
   if (
     // forbid styling body in xml document
     documentType === "html" &&
@@ -101,11 +101,6 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
     isDesignMode
   ) {
     availablePanels.add("style");
-  }
-  // @todo hide root component settings until
-  // global data sources are implemented
-  if (selectedInstance.component !== rootComponent) {
-    availablePanels.add("settings");
   }
 
   return (
@@ -197,7 +192,7 @@ export const Inspector = ({ navigatorLayout }: InspectorProps) => {
                   >
                     <InstanceInfo instance={selectedInstance} />
                   </Flex>
-                  <SettingsPanelContainer
+                  <SettingsPanel
                     // Re-render when instance changes
                     key={selectedInstance.id}
                     selectedInstance={selectedInstance}

--- a/apps/builder/app/builder/features/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/pages/page-utils.ts
@@ -11,6 +11,7 @@ import {
   encodeDataSourceVariable,
   ROOT_FOLDER_ID,
   isRootFolder,
+  ROOT_INSTANCE_ID,
 } from "@webstudio-is/sdk";
 import { removeByMutable } from "~/shared/array-utils";
 import {
@@ -255,7 +256,7 @@ export const $pageRootScope = computed(
     }
     const values =
       variableValuesByInstanceSelector.get(
-        getInstanceKey([page.rootInstanceId])
+        getInstanceKey([page.rootInstanceId, ROOT_INSTANCE_ID])
       ) ?? new Map<string, unknown>();
     for (const [dataSourceId, value] of values) {
       const dataSource = dataSources.get(dataSourceId);

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -55,7 +55,7 @@ import {
 import { parseCurl, type CurlRequest } from "./curl";
 import {
   $selectedInstance,
-  $selectedInstanceKey,
+  $selectedInstanceKeyWithRoot,
   $selectedPage,
 } from "~/shared/awareness";
 import { updateWebstudioData } from "~/shared/instance-utils";
@@ -384,7 +384,7 @@ const $hiddenDataSourceIds = computed(
 
 const $selectedInstanceScope = computed(
   [
-    $selectedInstanceKey,
+    $selectedInstanceKeyWithRoot,
     $variableValuesByInstanceSelector,
     $dataSources,
     $hiddenDataSourceIds,

--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -16,7 +16,7 @@ import { useStore } from "@nanostores/react";
 import cmsUpgradeBanner from "./cms-upgrade-banner.svg?url";
 import { $isDesignMode, $userPlanFeatures } from "~/shared/nano-states";
 
-export const SettingsPanelContainer = ({
+export const SettingsPanel = ({
   selectedInstance,
 }: {
   selectedInstance: Instance;

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -36,7 +36,7 @@ import {
 } from "~/shared/nano-states";
 import type { BindingVariant } from "~/builder/shared/binding-popover";
 import { humanizeString } from "~/shared/string-utils";
-import { $selectedInstanceKey } from "~/shared/awareness";
+import { $selectedInstanceKeyWithRoot } from "~/shared/awareness";
 
 export type PropValue =
   | { type: "number"; value: number }
@@ -314,7 +314,11 @@ export const Row = ({
 );
 
 export const $selectedInstanceScope = computed(
-  [$selectedInstanceKey, $variableValuesByInstanceSelector, $dataSources],
+  [
+    $selectedInstanceKeyWithRoot,
+    $variableValuesByInstanceSelector,
+    $dataSources,
+  ],
   (instanceKey, variableValuesByInstanceSelector, dataSources) => {
     const scope: Record<string, unknown> = {};
     const aliases = new Map<string, string>();

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/block-utils.ts
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/block-utils.ts
@@ -2,10 +2,10 @@ import type { Instance, Instances } from "@webstudio-is/sdk";
 import { blockTemplateComponent } from "@webstudio-is/sdk";
 import { shallowEqual } from "shallow-equal";
 import { selectInstance } from "~/shared/awareness";
+import { findAvailableVariables } from "~/shared/data-variables";
 import {
   extractWebstudioFragment,
   findAllEditableInstanceSelector,
-  findAvailableDataSources,
   getWebstudioData,
   insertInstanceChildrenMutable,
   insertWebstudioFragmentCopy,
@@ -107,11 +107,10 @@ export const insertListItemAt = (listItemSelector: InstanceSelector) => {
     const { newInstanceIds } = insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: findAvailableDataSources(
-        data.dataSources,
-        data.instances,
-        target.parentSelector
-      ),
+      availableVariables: findAvailableVariables({
+        ...data,
+        startingInstanceId: target.parentSelector[0],
+      }),
     });
     const newRootInstanceId = newInstanceIds.get(fragment.instances[0].id);
     if (newRootInstanceId === undefined) {
@@ -170,11 +169,10 @@ export const insertTemplateAt = (
     const { newInstanceIds } = insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: findAvailableDataSources(
-        data.dataSources,
-        data.instances,
-        target.parentSelector
-      ),
+      availableVariables: findAvailableVariables({
+        ...data,
+        startingInstanceId: target.parentSelector[0],
+      }),
     });
     const newRootInstanceId = newInstanceIds.get(fragment.instances[0].id);
     if (newRootInstanceId === undefined) {

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -20,7 +20,6 @@ import {
 } from "~/shared/breakpoints";
 import {
   deleteInstanceMutable,
-  findAvailableDataSources,
   extractWebstudioFragment,
   insertWebstudioFragmentCopy,
   updateWebstudioData,
@@ -44,6 +43,7 @@ import {
   isTreeMatching,
 } from "~/shared/matcher";
 import { getSetting, setSetting } from "./client-settings";
+import { findAvailableVariables } from "~/shared/data-variables";
 
 const makeBreakpointCommand = <CommandName extends string>(
   name: CommandName,
@@ -424,11 +424,10 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
           const { newInstanceIds } = insertWebstudioFragmentCopy({
             data,
             fragment,
-            availableDataSources: findAvailableDataSources(
-              data.dataSources,
-              data.instances,
-              parentItem.instanceSelector
-            ),
+            availableVariables: findAvailableVariables({
+              ...data,
+              startingInstanceId: parentItem.instanceSelector[0],
+            }),
           });
           const newRootInstanceId = newInstanceIds.get(
             selectedItem.instance.id

--- a/apps/builder/app/shared/awareness.ts
+++ b/apps/builder/app/shared/awareness.ts
@@ -72,6 +72,19 @@ export const getInstanceKey = <
 ): (InstanceSelector extends undefined ? undefined : never) | string =>
   JSON.stringify(instanceSelector);
 
+export const $selectedInstanceKeyWithRoot = computed(
+  $awareness,
+  (awareness) => {
+    const instanceSelector = awareness?.instanceSelector;
+    if (instanceSelector) {
+      if (instanceSelector[0] === ROOT_INSTANCE_ID) {
+        return getInstanceKey(instanceSelector);
+      }
+      return getInstanceKey([...instanceSelector, ROOT_INSTANCE_ID]);
+    }
+  }
+);
+
 export const $selectedInstanceKey = computed($awareness, (awareness) =>
   getInstanceKey(awareness?.instanceSelector)
 );

--- a/apps/builder/app/shared/copy-paste.test.tsx
+++ b/apps/builder/app/shared/copy-paste.test.tsx
@@ -24,10 +24,10 @@ import {
 import type { Project } from "@webstudio-is/project";
 import {
   extractWebstudioFragment,
-  findAvailableDataSources,
   insertWebstudioFragmentCopy,
 } from "./instance-utils";
 import { $project } from "./nano-states";
+import { findAvailableVariables } from "./data-variables";
 
 $project.set({ id: "current_project" } as Project);
 
@@ -121,13 +121,13 @@ test("insert instances with slots", () => {
   insertWebstudioFragmentCopy({
     data,
     fragment,
-    availableDataSources: new Set(),
+    availableVariables: [],
   });
   expect(data.instances.size).toEqual(4);
   insertWebstudioFragmentCopy({
     data,
     fragment,
-    availableDataSources: new Set(),
+    availableVariables: [],
   });
   expect(data.instances.size).toEqual(5);
   expect(Array.from(data.instances.values())).toEqual([
@@ -156,7 +156,7 @@ test("insert instances with multiple roots", () => {
   insertWebstudioFragmentCopy({
     data,
     fragment,
-    availableDataSources: new Set(),
+    availableVariables: [],
   });
   expect(data.instances.size).toEqual(5);
 });
@@ -177,7 +177,7 @@ test("should add :root local styles", () => {
   insertWebstudioFragmentCopy({
     data: newProject,
     fragment,
-    availableDataSources: new Set(),
+    availableVariables: [],
   });
   expect(toCss(newProject)).toEqual(
     stripIndent(`
@@ -215,7 +215,7 @@ test("should merge :root local styles", () => {
   insertWebstudioFragmentCopy({
     data: newProject,
     fragment,
-    availableDataSources: new Set(),
+    availableVariables: [],
   });
   expect(toCss(newProject)).toEqual(
     stripIndent(`
@@ -244,7 +244,7 @@ test("should copy local styles of duplicated instance", () => {
   insertWebstudioFragmentCopy({
     data: project,
     fragment,
-    availableDataSources: new Set(),
+    availableVariables: [],
   });
   const newInstanceId = Array.from(project.instances.keys()).at(-1);
   expect(toCss(project)).toEqual(
@@ -309,7 +309,7 @@ describe("props", () => {
     insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     expect(Array.from(data.props.values())).toEqual([
       expect.objectContaining({
@@ -337,7 +337,7 @@ describe("props", () => {
     insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     expect(Array.from(data.props.values())).toEqual([
       expect.objectContaining({
@@ -429,7 +429,7 @@ describe("variables", () => {
     insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     const [newDataSourceId] = data.dataSources.keys();
     expect(Array.from(data.dataSources.values())).toEqual([
@@ -480,7 +480,7 @@ describe("variables", () => {
     insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     expect(Array.from(data.dataSources.values())).toEqual([
       expect.objectContaining({
@@ -529,11 +529,10 @@ describe("variables", () => {
     insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: findAvailableDataSources(
-        data.dataSources,
-        data.instances,
-        ["bodyId"]
-      ),
+      availableVariables: findAvailableVariables({
+        ...data,
+        startingInstanceId: "bodyId",
+      }),
     });
     const newInstanceId = Array.from(data.instances.keys()).at(-1) ?? "";
     expect(newInstanceId).not.toEqual("boxId");
@@ -626,11 +625,10 @@ describe("resources", () => {
     insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: findAvailableDataSources(
-        data.dataSources,
-        data.instances,
-        ["bodyId"]
-      ),
+      availableVariables: findAvailableVariables({
+        ...data,
+        startingInstanceId: "bodyId",
+      }),
     });
     const newInstanceId = Array.from(data.instances.keys()).at(-1);
     expect(newInstanceId).not.toEqual("boxId");
@@ -715,11 +713,10 @@ describe("resources", () => {
     insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: findAvailableDataSources(
-        data.dataSources,
-        data.instances,
-        ["bodyId"]
-      ),
+      availableVariables: findAvailableVariables({
+        ...data,
+        startingInstanceId: "bodyId",
+      }),
     });
     const newInstanceId = Array.from(data.instances.keys()).at(-1);
     expect(newInstanceId).not.toEqual("boxId");
@@ -762,7 +759,7 @@ describe("resources", () => {
     insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     const [newPropResourceId, newVariableResourceId] = data.resources.keys();
     const [newBoxVariableId] = data.dataSources.keys();
@@ -828,7 +825,7 @@ describe("resources", () => {
     insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     expect(Array.from(data.dataSources.values())).toEqual([
       expect.objectContaining({

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -16,7 +16,6 @@ import {
 import type { InstanceSelector, DroppableTarget } from "../tree-utils";
 import {
   deleteInstanceMutable,
-  findAvailableDataSources,
   extractWebstudioFragment,
   insertWebstudioFragmentCopy,
   updateWebstudioData,
@@ -26,6 +25,7 @@ import {
 } from "../instance-utils";
 import { isInstanceDetachable } from "../matcher";
 import { $selectedInstancePath } from "../awareness";
+import { findAvailableVariables } from "../data-variables";
 
 const version = "@webstudio/instance/v0.1";
 
@@ -172,11 +172,10 @@ export const onPaste = (clipboardData: string) => {
     const { newInstanceIds } = insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: findAvailableDataSources(
-        data.dataSources,
-        data.instances,
-        pasteTarget.parentSelector
-      ),
+      availableVariables: findAvailableVariables({
+        ...data,
+        startingInstanceId: pasteTarget.parentSelector[0],
+      }),
     });
     const newRootInstanceId = newInstanceIds.get(fragment.instances[0].id);
     if (newRootInstanceId === undefined) {

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
@@ -1,6 +1,5 @@
 import type { Instance, WebstudioFragment } from "@webstudio-is/sdk";
 import {
-  findAvailableDataSources,
   findClosestInsertable,
   insertInstanceChildrenMutable,
   insertWebstudioFragmentCopy,
@@ -19,6 +18,7 @@ import { addStyles } from "./styles";
 import { builderApi } from "~/shared/builder-api";
 import { denormalizeSrcProps } from "../asset-upload";
 import { nanoHash } from "~/shared/nano-hash";
+import { findAvailableVariables } from "~/shared/data-variables";
 
 const { toast } = builderApi;
 
@@ -186,11 +186,10 @@ export const onPaste = async (clipboardData: string) => {
     const { newInstanceIds } = insertWebstudioFragmentCopy({
       data,
       fragment,
-      availableDataSources: findAvailableDataSources(
-        data.dataSources,
-        data.instances,
-        insertable.parentSelector
-      ),
+      availableVariables: findAvailableVariables({
+        ...data,
+        startingInstanceId: insertable.parentSelector[0],
+      }),
     });
 
     const children = fragment.children

--- a/apps/builder/app/shared/data-variables.ts
+++ b/apps/builder/app/shared/data-variables.ts
@@ -7,6 +7,7 @@ import {
   type Resource,
   type Resources,
   type WebstudioData,
+  ROOT_INSTANCE_ID,
   decodeDataVariableId,
   encodeDataVariableId,
   findTreeInstanceIdsExcludingSlotDescendants,
@@ -209,6 +210,8 @@ const findMaskedVariablesByInstanceId = ({
     instanceIdsPath.push(currentId);
     currentId = parentInstanceById.get(currentId);
   }
+  // allow accessing global variables everywhere
+  instanceIdsPath.push(ROOT_INSTANCE_ID);
   const maskedVariables = new Map<DataSource["name"], DataSource["id"]>();
   // start from the root to descendant
   // so child variables override parent variables
@@ -220,6 +223,30 @@ const findMaskedVariablesByInstanceId = ({
     }
   }
   return maskedVariables;
+};
+
+export const findAvailableVariables = ({
+  startingInstanceId,
+  instances,
+  dataSources,
+}: {
+  startingInstanceId: Instance["id"];
+  instances: Instances;
+  dataSources: DataSources;
+}) => {
+  const maskedVariables = findMaskedVariablesByInstanceId({
+    startingInstanceId,
+    instances,
+    dataSources,
+  });
+  const availableVariables: DataSource[] = [];
+  for (const dataSourceId of maskedVariables.values()) {
+    const dataSource = dataSources.get(dataSourceId);
+    if (dataSource) {
+      availableVariables.push(dataSource);
+    }
+  }
+  return availableVariables;
 };
 
 const traverseExpressions = ({

--- a/apps/builder/app/shared/instance-utils.test.tsx
+++ b/apps/builder/app/shared/instance-utils.test.tsx
@@ -1065,7 +1065,7 @@ describe("insert webstudio fragment copy", () => {
         ...emptyFragment,
         assets: [createImageAsset("asset1", "name", "another_project")],
       },
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     expect(Array.from(data.assets.values())).toEqual([
       createImageAsset("asset1", "name", "current_project"),
@@ -1083,7 +1083,7 @@ describe("insert webstudio fragment copy", () => {
           createImageAsset("asset2", "another_name", "another_project"),
         ],
       },
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     expect(Array.from(data.assets.values())).toEqual([
       // preserve any user changes
@@ -1117,7 +1117,7 @@ describe("insert webstudio fragment copy", () => {
           },
         ],
       },
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     expect(Array.from(data.breakpoints.values())).toEqual([
       { id: "existing_base", label: "base" },
@@ -1156,7 +1156,7 @@ describe("insert webstudio fragment copy", () => {
           },
         ],
       },
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     expect(Array.from(data.styleSources.values())).toEqual([
       { id: "token1", type: "token", name: "oldLabel" },
@@ -1208,7 +1208,7 @@ describe("insert webstudio fragment copy", () => {
           },
         ],
       },
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     expect(Array.from(data.styleSourceSelections.values())).toEqual([
       {
@@ -1273,7 +1273,7 @@ describe("insert webstudio fragment copy", () => {
           },
         ],
       },
-      availableDataSources: new Set(),
+      availableVariables: [],
     });
     expect(Array.from(data.styleSourceSelections.values())).toEqual([
       { instanceId: "fragment", values: ["localId", "tokenId"] },

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -423,7 +423,7 @@ export const $variableValuesByInstanceSelector = computed(
     ) => {
       const [instanceId] = instanceSelector;
       const variableNames = new Map(parentVariableNames);
-      let variableValues = new Map<string, unknown>(parentVariableValues);
+      const variableValues = new Map<string, unknown>(parentVariableValues);
       variableValuesByInstanceSelector.set(
         getInstanceKey(instanceSelector),
         variableValues
@@ -543,7 +543,7 @@ export const $variableValuesByInstanceSelector = computed(
         }
       }
     };
-    let {
+    const {
       variableValues: globalVariableValues,
       variableNames: globalVariableNames,
     } = collectVariables([ROOT_INSTANCE_ID]);

--- a/apps/builder/app/shared/page-utils.ts
+++ b/apps/builder/app/shared/page-utils.ts
@@ -16,6 +16,7 @@ import {
   extractWebstudioFragment,
   insertWebstudioFragmentCopy,
 } from "./instance-utils";
+import { findAvailableVariables } from "./data-variables";
 
 const deduplicateName = (
   pages: Pages,
@@ -99,13 +100,19 @@ export const insertPageCopyMutable = ({
   insertWebstudioFragmentCopy({
     data: target.data,
     fragment: extractWebstudioFragment(source.data, ROOT_INSTANCE_ID),
-    availableDataSources: new Set(),
+    availableVariables: findAvailableVariables({
+      ...target.data,
+      startingInstanceId: ROOT_INSTANCE_ID,
+    }),
   });
   // copy paste page body
   const { newInstanceIds, newDataSourceIds } = insertWebstudioFragmentCopy({
     data: target.data,
     fragment: extractWebstudioFragment(source.data, page.rootInstanceId),
-    availableDataSources: new Set(),
+    availableVariables: findAvailableVariables({
+      ...target.data,
+      startingInstanceId: ROOT_INSTANCE_ID,
+    }),
   });
   const newPageId = nanoid();
   const newRootInstanceId =


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/4166 https://github.com/webstudio-is/webstudio/issues/3686

Added "Settings" section to global root. Now users can create data variables which are available for all pages and inside slots.


https://github.com/user-attachments/assets/be2cf862-08ec-427e-aea3-076fa03a4437

