### PR TITLE
fix: preserve global variables when duplicate page

### DIFF
--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -959,7 +959,10 @@ export const insertWebstudioFragmentCopy = ({
     const { scopeInstanceId } = dataSource;
     if (scopeInstanceId === ROOT_INSTANCE_ID) {
       // add global variable only if not exist already
-      if (dataSources.has(dataSource.id) === false) {
+      if (
+        dataSources.has(dataSource.id) === false &&
+        maskedIdByName.has(dataSource.name) === false
+      ) {
         dataSources.set(dataSource.id, dataSource);
       }
       continue;

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -770,11 +770,6 @@ export const insertWebstudioFragmentCopy = ({
     }
   }
 
-  const fragmentDataSources: DataSources = new Map();
-  for (const dataSource of fragment.dataSources) {
-    fragmentDataSources.set(dataSource.id, dataSource);
-  }
-
   const {
     assets,
     instances,
@@ -962,6 +957,13 @@ export const insertWebstudioFragmentCopy = ({
   const newResourceIds = new Map<Resource["id"], Resource["id"]>();
   for (let dataSource of fragment.dataSources) {
     const { scopeInstanceId } = dataSource;
+    if (scopeInstanceId === ROOT_INSTANCE_ID) {
+      // add global variable only if not exist already
+      if (dataSources.has(dataSource.id) === false) {
+        dataSources.set(dataSource.id, dataSource);
+      }
+      continue;
+    }
     // insert only data sources within portal content
     if (fragmentInstanceIds.has(scopeInstanceId)) {
       const newDataSourceId = nanoid();

--- a/packages/template/src/jsx.ts
+++ b/packages/template/src/jsx.ts
@@ -142,7 +142,10 @@ const traverseJsx = (
   return result;
 };
 
-export const renderTemplate = (root: JSX.Element): WebstudioFragment => {
+export const renderTemplate = (
+  root: JSX.Element,
+  generateId?: () => string
+): WebstudioFragment => {
   let lastId = -1;
   const instances: Instance[] = [];
   const props: Prop[] = [];
@@ -157,7 +160,7 @@ export const renderTemplate = (root: JSX.Element): WebstudioFragment => {
     let id = ids.get(key);
     if (id === undefined) {
       lastId += 1;
-      id = lastId.toString();
+      id = generateId?.() ?? lastId.toString();
       ids.set(key, id);
     }
     return id;
@@ -370,7 +373,10 @@ export const renderTemplate = (root: JSX.Element): WebstudioFragment => {
   };
 };
 
-export const renderData = (root: JSX.Element): Omit<WebstudioData, "pages"> => {
+export const renderData = (
+  root: JSX.Element,
+  generateId?: () => string
+): Omit<WebstudioData, "pages"> => {
   const {
     instances,
     props,
@@ -381,7 +387,7 @@ export const renderData = (root: JSX.Element): Omit<WebstudioData, "pages"> => {
     dataSources,
     resources,
     assets,
-  } = renderTemplate(root);
+  } = renderTemplate(root, generateId);
   return {
     instances: new Map(instances.map((item) => [item.id, item])),
     props: new Map(props.map((item) => [item.id, item])),


### PR DESCRIPTION
Missed the case. Global variables were recreated and got invalid state. Now global variables are reused or added without changes.