### PR TITLE
feat: Context menu for advanced style panel

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/advanced/add-styles-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/add-styles-input.tsx
@@ -188,9 +188,14 @@ export const AddStylesInput = forwardRef<
       onSubmit(item.property);
       return;
     }
-    if (event.key === "Escape") {
+    // When user hits backspace and there is nothing in the input - we hide the input
+    const abortByBackspace =
+      event.key === "Backspace" && combobox.inputValue === "";
+
+    if (event.key === "Escape" || abortByBackspace) {
       clear();
       onClose();
+      event.preventDefault();
     }
   };
 

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/add-styles-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/add-styles-input.tsx
@@ -1,0 +1,249 @@
+import { lexer } from "css-tree";
+import { forwardRef, useRef, useState, type KeyboardEvent } from "react";
+import { matchSorter } from "match-sorter";
+import {
+  Box,
+  ComboboxAnchor,
+  ComboboxContent,
+  ComboboxItemDescription,
+  ComboboxListbox,
+  ComboboxListboxItem,
+  ComboboxRoot,
+  ComboboxScrollArea,
+  InputField,
+  NestedInputButton,
+  Text,
+  theme,
+  useCombobox,
+} from "@webstudio-is/design-system";
+import {
+  properties as propertiesData,
+  keywordValues,
+  propertyDescriptions,
+  parseCssValue,
+} from "@webstudio-is/css-data";
+import {
+  cssWideKeywords,
+  hyphenateProperty,
+  type StyleProperty,
+} from "@webstudio-is/css-engine";
+import { deleteProperty, setProperty } from "../../shared/use-style-data";
+import { composeEventHandlers } from "~/shared/event-utils";
+
+type SearchItem = { property: string; label: string; value?: string };
+
+const autoCompleteItems: Array<SearchItem> = [];
+
+const getNewPropertyDescription = (item: null | SearchItem) => {
+  let description: string | undefined = `Create CSS variable.`;
+  if (item && item.property in propertyDescriptions) {
+    description = propertyDescriptions[item.property];
+  }
+  return <Box css={{ width: theme.spacing[28] }}>{description}</Box>;
+};
+
+const getAutocompleteItems = () => {
+  if (autoCompleteItems.length > 0) {
+    return autoCompleteItems;
+  }
+  for (const property in propertiesData) {
+    autoCompleteItems.push({
+      property,
+      label: hyphenateProperty(property),
+    });
+  }
+
+  const ignoreValues = new Set([...cssWideKeywords, ...keywordValues.color]);
+
+  for (const property in keywordValues) {
+    const values = keywordValues[property as keyof typeof keywordValues];
+    for (const value of values) {
+      if (ignoreValues.has(value)) {
+        continue;
+      }
+      autoCompleteItems.push({
+        property,
+        value,
+        label: `${hyphenateProperty(property)}: ${value}`,
+      });
+    }
+  }
+
+  autoCompleteItems.sort((a, b) =>
+    Intl.Collator().compare(a.property, b.property)
+  );
+
+  return autoCompleteItems;
+};
+
+const matchOrSuggestToCreate = (
+  search: string,
+  items: Array<SearchItem>,
+  itemToString: (item: SearchItem) => string
+) => {
+  const matched = matchSorter(items, search, {
+    keys: [itemToString],
+  });
+
+  // Limit the array to 100 elements
+  matched.length = Math.min(matched.length, 100);
+
+  const property = search.trim();
+  if (
+    property.startsWith("--") &&
+    lexer.match("<custom-ident>", property).matched
+  ) {
+    matched.unshift({
+      property,
+      label: `Create "${property}"`,
+    });
+  }
+  // When there is no match we suggest to create a custom property.
+  if (
+    matched.length === 0 &&
+    lexer.match("<custom-ident>", `--${property}`).matched
+  ) {
+    matched.unshift({
+      property: `--${property}`,
+      label: `--${property}: unset;`,
+    });
+  }
+
+  return matched;
+};
+
+/**
+ *
+ * Advanced search control supports following interactions
+ *
+ * find property
+ * create custom property
+ * submit css declarations
+ * paste css declarations
+ *
+ */
+export const AddStylesInput = forwardRef<
+  HTMLInputElement,
+  {
+    onClose: () => void;
+    onSubmit: (css: string) => void;
+    onFocus: () => void;
+    onBlur: () => void;
+  }
+>(({ onClose, onSubmit, onFocus, onBlur }, forwardedRef) => {
+  const [item, setItem] = useState<SearchItem>({
+    property: "",
+    label: "",
+  });
+  const highlightedItemRef = useRef<SearchItem>();
+
+  const combobox = useCombobox<SearchItem>({
+    getItems: getAutocompleteItems,
+    itemToString: (item) => item?.label ?? "",
+    value: item,
+    defaultHighlightedIndex: 0,
+    getItemProps: () => ({ text: "sentence" }),
+    match: matchOrSuggestToCreate,
+    onChange: (value) => setItem({ property: value ?? "", label: value ?? "" }),
+    onItemSelect: (item) => {
+      clear();
+      onSubmit(`${item.property}: ${item.value ?? "unset"}`);
+    },
+    onItemHighlight: (item) => {
+      const previousHighlightedItem = highlightedItemRef.current;
+      if (item?.value === undefined && previousHighlightedItem) {
+        deleteProperty(previousHighlightedItem.property as StyleProperty, {
+          isEphemeral: true,
+        });
+        highlightedItemRef.current = undefined;
+        return;
+      }
+
+      if (item?.value) {
+        const value = parseCssValue(item.property as StyleProperty, item.value);
+        setProperty(item.property as StyleProperty)(value, {
+          isEphemeral: true,
+        });
+        highlightedItemRef.current = item;
+      }
+    },
+  });
+
+  const descriptionItem = combobox.items[combobox.highlightedIndex];
+  const description = getNewPropertyDescription(descriptionItem);
+  const descriptions = combobox.items.map(getNewPropertyDescription);
+  const inputProps = combobox.getInputProps();
+
+  const clear = () => {
+    setItem({ property: "", label: "" });
+  };
+
+  const handleKeys = (event: KeyboardEvent) => {
+    // Dropdown might handle enter or escape.
+    if (event.defaultPrevented) {
+      return;
+    }
+    if (event.key === "Enter") {
+      clear();
+      onSubmit(item.property);
+      return;
+    }
+    if (event.key === "Escape") {
+      clear();
+      onClose();
+    }
+  };
+
+  const handleKeyDown = composeEventHandlers(inputProps.onKeyDown, handleKeys, {
+    // Pass prevented events to the combobox (e.g., the Escape key doesn't work otherwise, as it's blocked by Radix)
+    checkForDefaultPrevented: false,
+  });
+
+  return (
+    <ComboboxRoot open={combobox.isOpen}>
+      <div {...combobox.getComboboxProps()}>
+        <ComboboxAnchor>
+          <InputField
+            {...inputProps}
+            autoFocus
+            onFocus={onFocus}
+            onBlur={(event) => {
+              inputProps.onBlur(event);
+              onBlur();
+            }}
+            inputRef={forwardedRef}
+            onKeyDown={handleKeyDown}
+            placeholder="Add styles"
+            suffix={<NestedInputButton {...combobox.getToggleButtonProps()} />}
+          />
+        </ComboboxAnchor>
+        <ComboboxContent>
+          <ComboboxListbox {...combobox.getMenuProps()}>
+            <ComboboxScrollArea>
+              {combobox.items.map((item, index) => (
+                <ComboboxListboxItem
+                  {...combobox.getItemProps({ item, index })}
+                  key={index}
+                  asChild
+                >
+                  <Text
+                    variant="labelsSentenceCase"
+                    truncate
+                    css={{ maxWidth: "25ch" }}
+                  >
+                    {item.label}
+                  </Text>
+                </ComboboxListboxItem>
+              ))}
+            </ComboboxScrollArea>
+            {description && (
+              <ComboboxItemDescription descriptions={descriptions}>
+                {description}
+              </ComboboxItemDescription>
+            )}
+          </ComboboxListbox>
+        </ComboboxContent>
+      </div>
+    </ComboboxRoot>
+  );
+});

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -662,7 +662,10 @@ export const Section = () => {
           onAbort={handleAbortSearch}
         />
       </Box>
-      <CopyPasteMenu onPaste={handleInsertStyles}>
+      <CopyPasteMenu
+        onPaste={handleInsertStyles}
+        properties={currentProperties}
+      >
         <Flex gap="2" direction="column">
           <Box css={{ paddingInline: theme.panel.paddingInline }}>
             {showRecentProperties &&

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -73,7 +73,7 @@ import { PropertyInfo } from "../../property-label";
 import { ColorPopover } from "../../shared/color-picker";
 import { useClientSupports } from "~/shared/client-supports";
 import { composeEventHandlers } from "~/shared/event-utils";
-import { CopyPasteMenu } from "./copy-paste-menu";
+import { CopyPasteMenu, propertyContainerAttribute } from "./copy-paste-menu";
 import { $advancedStyles } from "./stores";
 
 // Only here to keep the same section module interface
@@ -557,6 +557,7 @@ const AdvancedProperty = memo(
         wrap="wrap"
         align="center"
         justify="start"
+        {...{ [propertyContainerAttribute]: property }}
       >
         {isVisible && (
           <>

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -637,8 +637,17 @@ export const Section = () => {
       return handleAbortSearch();
     }
     memorizeMinHeight();
-    const matched = matchSorter(advancedProperties, search);
-    setSearchProperties(matched);
+
+    const styles = [];
+    for (const [property, value] of advancedStyles) {
+      styles.push({ property, value: toValue(value) });
+    }
+
+    const matched = matchSorter(styles, search, {
+      keys: ["property", "value"],
+    }).map(({ property }) => property);
+
+    setSearchProperties(matched as StyleProperty[]);
   };
 
   const handleAbortAddStyles = () => {

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -75,6 +75,7 @@ import { useClientSupports } from "~/shared/client-supports";
 import { composeEventHandlers } from "~/shared/event-utils";
 import { CopyPasteMenu, propertyContainerAttribute } from "./copy-paste-menu";
 import { $advancedStyles } from "./stores";
+import { $settings } from "~/builder/shared/client-settings";
 
 // Only here to keep the same section module interface
 export const properties = [];
@@ -636,7 +637,10 @@ export const Section = () => {
     if (search === "") {
       return handleAbortSearch();
     }
-    memorizeMinHeight();
+    // This is not needed in advanced mode because the input won't jump there as it is on top
+    if ($settings.get().stylePanelMode !== "advanced") {
+      memorizeMinHeight();
+    }
 
     const styles = [];
     for (const [property, value] of advancedStyles) {

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -708,7 +708,7 @@ export const Section = () => {
               })}
             {(showRecentProperties || isAdding) && (
               <Box
-                style={
+                css={
                   isAdding
                     ? { paddingTop: theme.spacing[3] }
                     : // We hide it visually so you can tab into it to get shown.

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
@@ -1,0 +1,46 @@
+import { type ReactNode } from "react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+  theme,
+} from "@webstudio-is/design-system";
+import { generateStyleMap, mergeStyles } from "@webstudio-is/css-engine";
+import { useStore } from "@nanostores/react";
+import { $advancedStyles } from "./stores";
+
+export const CopyPasteMenu = ({
+  children,
+  onPaste,
+}: {
+  children: ReactNode;
+  onPaste: (cssText: string) => void;
+}) => {
+  const advancedStyles = useStore($advancedStyles);
+
+  const handlePaste = () => {
+    navigator.clipboard.readText().then(onPaste);
+  };
+
+  const handleCopyAll = () => {
+    const css = generateStyleMap({ style: mergeStyles(advancedStyles) });
+    navigator.clipboard.writeText(css);
+    return css;
+  };
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent css={{ width: theme.spacing[25] }}>
+        <ContextMenuItem onSelect={handleCopyAll}>
+          Copy all declarations
+        </ContextMenuItem>
+        <ContextMenuItem>Copy declaration</ContextMenuItem>
+        <ContextMenuItem onSelect={handlePaste}>
+          Paste declarations
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+};

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
@@ -72,11 +72,11 @@ export const CopyPasteMenu = ({
         {children}
       </ContextMenuTrigger>
       <ContextMenuContent css={{ width: theme.spacing[25] }}>
-        <ContextMenuItem onSelect={handleCopyAll}>
-          Copy all declarations
-        </ContextMenuItem>
         <ContextMenuItem onSelect={handleCopy}>
           Copy declaration
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={handleCopyAll}>
+          Copy all declarations
         </ContextMenuItem>
         <ContextMenuItem onSelect={handlePaste}>
           Paste declarations

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
@@ -67,7 +67,7 @@ export const CopyPasteMenu = ({
           if (!(event.target instanceof HTMLElement)) {
             return;
           }
-          const property = event.target.closest(
+          const property = event.target.closest<HTMLElement>(
             `[${propertyContainerAttribute}]`
           )?.dataset.property;
           lastClickedProperty.current = property;

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
@@ -8,6 +8,7 @@ import {
 } from "@webstudio-is/design-system";
 import {
   generateStyleMap,
+  hyphenateProperty,
   mergeStyles,
   type StyleMap,
 } from "@webstudio-is/css-engine";
@@ -38,9 +39,10 @@ export const CopyPasteMenu = ({
     const currentStyleMap: StyleMap = new Map();
     for (const [property, value] of advancedStyles) {
       if (properties.includes(property)) {
-        currentStyleMap.set(property, value);
+        currentStyleMap.set(hyphenateProperty(property), value);
       }
     }
+
     const css = generateStyleMap({ style: mergeStyles(currentStyleMap) });
     navigator.clipboard.writeText(css);
   };

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
@@ -6,7 +6,11 @@ import {
   ContextMenuTrigger,
   theme,
 } from "@webstudio-is/design-system";
-import { generateStyleMap, mergeStyles } from "@webstudio-is/css-engine";
+import {
+  generateStyleMap,
+  mergeStyles,
+  type StyleMap,
+} from "@webstudio-is/css-engine";
 import { useStore } from "@nanostores/react";
 import { $advancedStyles } from "./stores";
 
@@ -31,7 +35,7 @@ export const CopyPasteMenu = ({
   const handleCopyAll = () => {
     // We want to only copy properties that are currently in front of the user.
     // That includes search or any future filters.
-    const currentStyleMap = new Map();
+    const currentStyleMap: StyleMap = new Map();
     for (const [property, value] of advancedStyles) {
       if (properties.includes(property)) {
         currentStyleMap.set(property, value);

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
@@ -12,9 +12,11 @@ import { $advancedStyles } from "./stores";
 
 export const CopyPasteMenu = ({
   children,
+  properties,
   onPaste,
 }: {
   children: ReactNode;
+  properties: Array<string>;
   onPaste: (cssText: string) => void;
 }) => {
   const advancedStyles = useStore($advancedStyles);
@@ -24,7 +26,15 @@ export const CopyPasteMenu = ({
   };
 
   const handleCopyAll = () => {
-    const css = generateStyleMap({ style: mergeStyles(advancedStyles) });
+    // We want to only copy properties that are currently in front of the user.
+    // That includes search or any future filters.
+    const currentStyleMap = new Map();
+    for (const [property, value] of advancedStyles) {
+      if (properties.includes(property)) {
+        currentStyleMap.set(property, value);
+      }
+    }
+    const css = generateStyleMap({ style: mergeStyles(currentStyleMap) });
     navigator.clipboard.writeText(css);
     return css;
   };

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -10,6 +10,8 @@ import { generateStyleMap, mergeStyles } from "@webstudio-is/css-engine";
 import { useStore } from "@nanostores/react";
 import { $advancedStyles } from "./stores";
 
+export const propertyContainerAttribute = "data-property";
+
 export const CopyPasteMenu = ({
   children,
   properties,
@@ -20,6 +22,7 @@ export const CopyPasteMenu = ({
   onPaste: (cssText: string) => void;
 }) => {
   const advancedStyles = useStore($advancedStyles);
+  const lastClickedProperty = useRef<string>();
 
   const handlePaste = () => {
     navigator.clipboard.readText().then(onPaste);
@@ -36,17 +39,45 @@ export const CopyPasteMenu = ({
     }
     const css = generateStyleMap({ style: mergeStyles(currentStyleMap) });
     navigator.clipboard.writeText(css);
-    return css;
+  };
+
+  const handleCopy = () => {
+    const property = lastClickedProperty.current;
+    if (property === undefined) {
+      return;
+    }
+    const value = advancedStyles.get(property);
+    if (value === undefined) {
+      return;
+    }
+    const style = new Map([[property, value]]);
+    const css = generateStyleMap({ style });
+    navigator.clipboard.writeText(css);
   };
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuTrigger
+        asChild
+        onPointerDown={(event) => {
+          if (!(event.target instanceof HTMLElement)) {
+            return;
+          }
+          const property = event.target.closest(
+            `[${propertyContainerAttribute}]`
+          )?.dataset.property;
+          lastClickedProperty.current = property;
+        }}
+      >
+        {children}
+      </ContextMenuTrigger>
       <ContextMenuContent css={{ width: theme.spacing[25] }}>
         <ContextMenuItem onSelect={handleCopyAll}>
           Copy all declarations
         </ContextMenuItem>
-        <ContextMenuItem>Copy declaration</ContextMenuItem>
+        <ContextMenuItem onSelect={handleCopy}>
+          Copy declaration
+        </ContextMenuItem>
         <ContextMenuItem onSelect={handlePaste}>
           Paste declarations
         </ContextMenuItem>

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
@@ -10,6 +10,7 @@ import {
   generateStyleMap,
   hyphenateProperty,
   mergeStyles,
+  toValue,
   type StyleMap,
 } from "@webstudio-is/css-engine";
 import { useStore } from "@nanostores/react";
@@ -38,7 +39,8 @@ export const CopyPasteMenu = ({
     // That includes search or any future filters.
     const currentStyleMap: StyleMap = new Map();
     for (const [property, value] of advancedStyles) {
-      if (properties.includes(property)) {
+      const isEmpty = toValue(value) === "";
+      if (properties.includes(property) && isEmpty === false) {
         currentStyleMap.set(hyphenateProperty(property), value);
       }
     }

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/stores.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/stores.ts
@@ -1,0 +1,86 @@
+import { computed } from "nanostores";
+import {
+  StyleValue,
+  type StyleMap,
+  type StyleProperty,
+} from "@webstudio-is/css-engine";
+import { $matchingBreakpoints, getDefinedStyles } from "../../shared/model";
+import { sections } from "../sections";
+import {
+  $registeredComponentMetas,
+  $styles,
+  $styleSourceSelections,
+} from "~/shared/nano-states";
+import { $selectedInstancePath } from "~/shared/awareness";
+import { $settings } from "~/builder/shared/client-settings";
+
+const initialProperties = new Set<StyleProperty>([
+  "cursor",
+  "mixBlendMode",
+  "opacity",
+  "pointerEvents",
+  "userSelect",
+]);
+
+export const $advancedStyles = computed(
+  [
+    // prevent showing properties inherited from root
+    // to not bloat advanced panel
+    $selectedInstancePath,
+    $registeredComponentMetas,
+    $styleSourceSelections,
+    $matchingBreakpoints,
+    $styles,
+    $settings,
+  ],
+  (
+    instancePath,
+    metas,
+    styleSourceSelections,
+    matchingBreakpoints,
+    styles,
+    settings
+  ) => {
+    const advancedStyles: StyleMap = new Map();
+
+    if (instancePath === undefined) {
+      return advancedStyles;
+    }
+
+    const definedStyles = getDefinedStyles({
+      instancePath,
+      metas,
+      matchingBreakpoints,
+      styleSourceSelections,
+      styles,
+    });
+    // All properties used by the panels except the advanced panel
+    const baseProperties = new Set<StyleProperty>([]);
+    for (const { properties } of sections.values()) {
+      for (const property of properties) {
+        baseProperties.add(property);
+      }
+    }
+    for (const { property, listed, value } of definedStyles) {
+      if (baseProperties.has(property) === false) {
+        // When property is listed, it was added from advanced panel.
+        // If we are in advanced mode, we show them all.
+        if (listed || settings.stylePanelMode === "advanced") {
+          advancedStyles.set(property, value);
+        }
+      }
+    }
+    // In advanced mode we assume user knows the properties they need, so we don't need to show these.
+    // @todo we need to find a better place for them in any case
+    if (settings.stylePanelMode !== "advanced") {
+      for (const initialProperty of initialProperties) {
+        for (const { property, value } of definedStyles) {
+          if (property === initialProperty) {
+            advancedStyles.set(property, value);
+          }
+        }
+      }
+    }
+    return advancedStyles;
+  }
+);

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/stores.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/stores.ts
@@ -50,31 +50,27 @@ export const $advancedStyles = computed(
       styleSourceSelections,
       styles,
     });
+
     // All properties used by the panels except the advanced panel
-    const baseProperties = new Set<StyleProperty>([]);
+    const visualProperties = new Set<StyleProperty>([]);
     for (const { properties } of sections.values()) {
       for (const property of properties) {
-        baseProperties.add(property);
+        visualProperties.add(property);
       }
     }
-    for (const { property, listed, value } of definedStyles) {
-      if (baseProperties.has(property) === false) {
-        // When property is listed, it was added from advanced panel.
-        // If we are in advanced mode, we show them all.
-        if (listed || settings.stylePanelMode === "advanced") {
-          advancedStyles.set(property, value);
-        }
+    for (const style of definedStyles) {
+      const { property, value, listed } = style;
+      // When property is listed, it was added from advanced panel.
+      // If we are in advanced mode, we show them all.
+      if (listed || settings.stylePanelMode === "advanced") {
+        advancedStyles.set(property, value);
       }
     }
     // In advanced mode we assume user knows the properties they need, so we don't need to show these.
     // @todo we need to find a better place for them in any case
     if (settings.stylePanelMode !== "advanced") {
       for (const initialProperty of initialProperties) {
-        for (const { property, value } of definedStyles) {
-          if (property === initialProperty) {
-            advancedStyles.set(property, value);
-          }
-        }
+        advancedStyles.set(initialProperty, { type: "unset", value: "" });
       }
     }
     return advancedStyles;

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/stores.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/stores.ts
@@ -1,9 +1,5 @@
 import { computed } from "nanostores";
-import {
-  StyleValue,
-  type StyleMap,
-  type StyleProperty,
-} from "@webstudio-is/css-engine";
+import { type StyleMap, type StyleProperty } from "@webstudio-is/css-engine";
 import { $matchingBreakpoints, getDefinedStyles } from "../../shared/model";
 import { sections } from "../sections";
 import {

--- a/apps/builder/app/builder/features/style-panel/shared/model.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/model.tsx
@@ -144,7 +144,7 @@ export const getDefinedStyles = ({
   const matchingBreakpoints = new Set(matchingBreakpointsArray);
   const startingInstanceSelector = instancePath[0].instanceSelector;
 
-  type StyleDeclSubset = Pick<StyleDecl, "property" | "listed">;
+  type StyleDeclSubset = Pick<StyleDecl, "property" | "listed" | "value">;
 
   const instanceStyles = new Set<StyleDeclSubset>();
   const inheritedStyles = new Set<StyleDeclSubset>();

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -34,6 +34,7 @@
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-collapsible": "^1.1.3",
+    "@radix-ui/react-context-menu": "^2.2.6",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.2",

--- a/packages/design-system/src/components/context-menu.tsx
+++ b/packages/design-system/src/components/context-menu.tsx
@@ -54,7 +54,7 @@ export const ContextMenuSeparator = styled(
 
 export const ContextMenuLabel = styled(ContextMenuPrimitive.Label, labelCss);
 
-export const StyledMenuItem = styled(ContextMenuPrimitive.Item, menuItemCss, {
+const StyledMenuItem = styled(ContextMenuPrimitive.Item, menuItemCss, {
   defaultVariants: { withIndicator: true },
 });
 export const ContextMenuItem = forwardRef<

--- a/packages/design-system/src/components/context-menu.tsx
+++ b/packages/design-system/src/components/context-menu.tsx
@@ -1,0 +1,149 @@
+import {
+  forwardRef,
+  type ComponentProps,
+  type ElementRef,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { ChevronRightIcon } from "@webstudio-is/icons";
+import { styled } from "../stitches.config";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import {
+  menuCss,
+  subMenuCss,
+  separatorCss,
+  menuItemCss,
+  labelCss,
+  menuItemIndicatorCss,
+  subContentProps,
+  MenuCheckedIcon,
+} from "./menu";
+export { DropdownMenuArrow } from "./menu";
+
+export const ContextMenu = ContextMenuPrimitive.Root;
+
+export const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+
+export const ContextMenuSub = ContextMenuPrimitive.Sub;
+
+const ContextMenuContentStyled = styled(ContextMenuPrimitive.Content, menuCss);
+export const ContextMenuContent = forwardRef<
+  ElementRef<typeof ContextMenuContentStyled>,
+  ComponentProps<typeof ContextMenuContentStyled>
+>((props, ref) => {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuContentStyled {...props} ref={ref} />
+    </ContextMenuPrimitive.Portal>
+  );
+});
+
+const SubContentStyled = styled(ContextMenuPrimitive.SubContent, subMenuCss);
+export const ContextMenuSubContent = forwardRef<
+  ElementRef<typeof SubContentStyled>,
+  ComponentProps<typeof SubContentStyled>
+>((props, forwardedRef) => (
+  <SubContentStyled {...subContentProps} {...props} ref={forwardedRef} />
+));
+ContextMenuSubContent.displayName = "ContextMenuSubContent";
+
+export const ContextMenuSeparator = styled(
+  ContextMenuPrimitive.Separator,
+  separatorCss
+);
+
+export const ContextMenuLabel = styled(ContextMenuPrimitive.Label, labelCss);
+
+export const StyledMenuItem = styled(ContextMenuPrimitive.Item, menuItemCss, {
+  defaultVariants: { withIndicator: true },
+});
+export const ContextMenuItem = forwardRef<
+  ElementRef<typeof StyledMenuItem>,
+  ComponentProps<typeof StyledMenuItem> & { icon?: ReactNode }
+>(({ icon, children, withIndicator, ...props }, forwardedRef) =>
+  icon ? (
+    <StyledMenuItem
+      withIndicator={withIndicator || Boolean(icon)}
+      {...props}
+      ref={forwardedRef}
+    >
+      <div className={menuItemIndicatorCss()}>{icon}</div>
+      {children}
+    </StyledMenuItem>
+  ) : (
+    <StyledMenuItem
+      withIndicator={withIndicator || Boolean(icon)}
+      {...props}
+      ref={forwardedRef}
+    >
+      {children}
+    </StyledMenuItem>
+  )
+);
+ContextMenuItem.displayName = "ContextMenuItem";
+
+export const ContextMenuItemRightSlot = styled("span", {
+  marginLeft: "auto",
+  display: "flex",
+});
+
+const SubTriggerStyled = styled(ContextMenuPrimitive.SubTrigger, menuItemCss, {
+  defaultVariants: { withIndicator: true },
+});
+export const ContextMenuSubTrigger = forwardRef<
+  ElementRef<typeof SubTriggerStyled>,
+  ComponentProps<typeof SubTriggerStyled> & { icon?: ReactNode }
+>(({ children, withIndicator, icon, ...props }, forwardedRef) => (
+  <SubTriggerStyled
+    withIndicator={withIndicator || Boolean(icon)}
+    {...props}
+    ref={forwardedRef}
+  >
+    {icon && <div className={menuItemIndicatorCss()}>{icon}</div>}
+    {children}
+    <ContextMenuItemRightSlot>
+      <ChevronRightIcon />
+    </ContextMenuItemRightSlot>
+  </SubTriggerStyled>
+));
+ContextMenuSubTrigger.displayName = "ContextMenuSubTrigger";
+
+const Indicator = styled(
+  ContextMenuPrimitive.ItemIndicator,
+  menuItemIndicatorCss
+);
+
+const StyledRadioItem = styled(ContextMenuPrimitive.RadioItem, menuItemCss);
+export const ContextMenuRadioItem = forwardRef<
+  ElementRef<typeof StyledRadioItem>,
+  ComponentProps<typeof StyledRadioItem> & { icon?: ReactElement }
+>(({ children, icon, ...props }, forwardedRef) => (
+  <StyledRadioItem
+    withIndicator={icon !== undefined}
+    {...props}
+    ref={forwardedRef}
+  >
+    {icon !== undefined && <Indicator>{icon}</Indicator>}
+    {children}
+  </StyledRadioItem>
+));
+ContextMenuRadioItem.displayName = "ContextMenuRadioItem";
+
+const StyledCheckboxItem = styled(
+  ContextMenuPrimitive.CheckboxItem,
+  menuItemCss
+);
+export const ContextMenuCheckboxItem = forwardRef<
+  ElementRef<typeof StyledCheckboxItem>,
+  ComponentProps<typeof StyledCheckboxItem> & { icon?: ReactNode }
+>(({ children, icon = <MenuCheckedIcon />, ...props }, forwardedRef) => (
+  <StyledCheckboxItem withIndicator {...props} ref={forwardedRef}>
+    <Indicator>{icon}</Indicator>
+    {children}
+  </StyledCheckboxItem>
+));
+ContextMenuCheckboxItem.displayName = "ContextMenuCheckboxItem";
+
+export const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
+
+export const ContextMenuGroup = ContextMenuPrimitive.Group;

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -13,6 +13,7 @@ export * from "./components/label";
 export * from "./components/select";
 export * from "./components/combobox";
 export * from "./components/dropdown-menu";
+export * from "./components/context-menu";
 export * from "./components/icon-button"; // mostly aligned, but needs a demo and to use tokens
 export * from "./components/toggle-button";
 export * from "./components/dialog";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1321,6 +1321,9 @@ importers:
       '@radix-ui/react-collapsible':
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-context-menu':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       '@radix-ui/react-dialog':
         specifier: ^1.1.6
         version: 1.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
@@ -4052,6 +4055,19 @@ packages:
       react: 18.3.0-canary-14898b6a9-20240318
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.6':
+    resolution: {integrity: sha512-aUP99QZ3VU84NPsHeaFt4cQUNgJqFsLLOt/RbbWXszZ6MP0DpDyjkFZORr4RpAEx3sUBk+Kc8h13yGtC5Qw8dg==}
+    peerDependencies:
+      '@types/react': ^18.2.70
+      '@types/react-dom': ^18.2.25
+      react: 18.3.0-canary-14898b6a9-20240318
+      react-dom: 18.3.0-canary-14898b6a9-20240318
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.0.1':
@@ -11177,6 +11193,20 @@ snapshots:
       react: 18.3.0-canary-14898b6a9-20240318
     optionalDependencies:
       '@types/react': 18.2.79
+
+  '@radix-ui/react-context-menu@2.2.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@18.2.79)(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-menu': 2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.79)(react@18.3.0-canary-14898b6a9-20240318)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.79)(react@18.3.0-canary-14898b6a9-20240318)
+      react: 18.3.0-canary-14898b6a9-20240318
+      react-dom: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
 
   '@radix-ui/react-context@1.0.1(@types/react@18.2.79)(react@18.3.0-canary-14898b6a9-20240318)':
     dependencies:


### PR DESCRIPTION
https://github.com/webstudio-is/webstudio/issues/4816

## Description

1. right click in advanced 
2. copy all
3. copy one
4. paste
5. search now works for properties AND values
6. backspace in add styles input when its empty now also closes the input same as esc

## Steps for reproduction

1. click button
7. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
