### PR TITLE
fix: Space in navigation menu button trigger exits text editing

### DIFF
--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -109,7 +109,7 @@ const ContentEditable = ({
     // Issue: <button> with contentEditable does not allow pressing space.
     // Solution: Add space on space keydown.
     const abortController = new AbortController();
-    if (rootElement.tagName === "BUTTON") {
+    if (rootElement.closest("button")) {
       rootElement.addEventListener(
         "keydown",
         (event) => {


### PR DESCRIPTION
## Description

closes #4879

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
