### PR TITLE
update the message on mode selection dropdown.

### DIFF
--- a/apps/builder/app/builder/features/topbar/builder-mode.tsx
+++ b/apps/builder/app/builder/features/topbar/builder-mode.tsx
@@ -69,6 +69,18 @@ export const BuilderModeDropDown = () => {
     setActiveMode(undefined);
   };
 
+  const getDefaultMessage = () => {
+    if (
+      isContentModeAllowed &&
+      isFeatureEnabled("contentEditableMode") &&
+      isDesignModeAllowed
+    ) {
+      return "Select Design or Content mode";
+    }
+
+    return !isDesignModeAllowed ? "Select Content mode" : "Select Design mode";
+  };
+
   return (
     <Flex align="center">
       <Tooltip
@@ -145,7 +157,7 @@ export const BuilderModeDropDown = () => {
             <Box css={{ width: theme.spacing[25] }}>
               {activeMode
                 ? menuItems[activeMode].description
-                : "Select Design or Content mode"}
+                : getDefaultMessage()}
             </Box>
           </div>
         </DropdownMenuContent>


### PR DESCRIPTION
## Description

fixes issue  #4626 

added a function that returns the default message after checking what all modes are enabled, if both the content mode and design mode is enabled then we display "Select Design or Content mode", if content mode is disabled then we display "Select Design mode" ie in the share page where links generated by free users has the content mode disabled.

but the function doesn't handle a case where both the content and design mode are disabled, since there didn't seem to be any scenario where both are disabled. in such a scenario we should probably just hide the drop down menu that let users select content or design mode.


## Steps for reproduction

1. set USER_PLAN to empty string in env.
2. then generate a share link on the builder page.
3. open the share link and you can the see message is "Select Design mode" in mode selection dropdown, since only design mode is enabled and content mode is disabled.


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review ( feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
