### PR TITLE
chore: Unreleased bugs with advanced section

### DIFF
--- a/apps/builder/app/builder/features/navigator/css-preview.tsx
+++ b/apps/builder/app/builder/features/navigator/css-preview.tsx
@@ -65,7 +65,7 @@ const getCssText = (
       return;
     }
     result.push(`/* ${comment} */`);
-    result.push(generateStyleMap({ style: mergeStyles(style) }));
+    result.push(generateStyleMap(mergeStyles(style)));
   };
 
   add("Style Sources", sourceStyles);

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/add-style-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/add-style-input.tsx
@@ -25,6 +25,7 @@ import {
   cssWideKeywords,
   generateStyleMap,
   hyphenateProperty,
+  toValue,
   type StyleProperty,
 } from "@webstudio-is/css-engine";
 import { deleteProperty, setProperty } from "../../shared/use-style-data";
@@ -94,6 +95,7 @@ const matchOrSuggestToCreate = (
     for (const style of parsedStyles) {
       matched.push({
         property: style.property,
+        value: toValue(style.value),
         label: `Create "${generateStyleMap(new Map([[style.property, style.value]]))}"`,
       });
     }

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/add-style-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/add-style-input.tsx
@@ -92,6 +92,15 @@ const matchOrSuggestToCreate = (
 
   if (matched.length === 0) {
     const parsedStyles = parseStyleInput(search);
+    // When parsedStyles is more than one, user entered a shorthand.
+    // We will suggest to insert their shorthand first.
+    if (parsedStyles.length > 1) {
+      matched.push({
+        property: search,
+        label: `Create "${search}"`,
+      });
+    }
+    // Now we will suggest to insert each longhand separately.
     for (const style of parsedStyles) {
       matched.push({
         property: style.property,

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/add-style-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/add-style-input.tsx
@@ -148,7 +148,11 @@ export const AddStyleInput = forwardRef<
     onChange: (value) => setItem({ property: value ?? "", label: value ?? "" }),
     onItemSelect: (item) => {
       clear();
-      onSubmit(`${item.property}: ${item.value ?? "unset"}`);
+      // When there is no value, it is either a property or a declaration(s)
+      if (item.value === undefined) {
+        return onSubmit(item.property);
+      }
+      onSubmit(`${item.property}: ${item.value}`);
     },
     onItemHighlight: (item) => {
       const previousHighlightedItem = highlightedItemRef.current;

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/add-style-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/add-style-input.tsx
@@ -148,7 +148,10 @@ export const AddStyleInput = forwardRef<
     onChange: (value) => setItem({ property: value ?? "", label: value ?? "" }),
     onItemSelect: (item) => {
       clear();
-      // When there is no value, it is either a property or a declaration(s)
+      // When there is no value, property can be:
+      // - property without value: gap
+      // - declaration with value: gap: 10px
+      // - block: gap: 10px; margin: 20px;
       if (item.value === undefined) {
         return onSubmit(item.property);
       }

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/add-styles-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/add-styles-input.tsx
@@ -1,5 +1,11 @@
 import { lexer } from "css-tree";
-import { forwardRef, useRef, useState, type KeyboardEvent } from "react";
+import {
+  forwardRef,
+  useRef,
+  useState,
+  type FocusEvent,
+  type KeyboardEvent,
+} from "react";
 import { matchSorter } from "match-sorter";
 import {
   Box,
@@ -207,6 +213,17 @@ export const AddStylesInput = forwardRef<
     handleDelete,
   ]);
 
+  const handleBlur = composeEventHandlers([
+    inputProps.onBlur,
+    () => {
+      // When user clicks on a combobox item, input will receive blur event,
+      // but we don't want that to be handled upstream because input may get hidden without click getting handled.
+      if (combobox.isOpen === false) {
+        onBlur();
+      }
+    },
+  ]);
+
   return (
     <ComboboxRoot open={combobox.isOpen}>
       <div {...combobox.getComboboxProps()}>
@@ -215,10 +232,7 @@ export const AddStylesInput = forwardRef<
             {...inputProps}
             autoFocus
             onFocus={onFocus}
-            onBlur={(event) => {
-              inputProps.onBlur(event);
-              onBlur();
-            }}
+            onBlur={handleBlur}
             inputRef={forwardedRef}
             onKeyDown={handleKeyDown}
             placeholder="Add styles"

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/copy-paste-menu.tsx
@@ -45,7 +45,7 @@ export const CopyPasteMenu = ({
       }
     }
 
-    const css = generateStyleMap({ style: mergeStyles(currentStyleMap) });
+    const css = generateStyleMap(mergeStyles(currentStyleMap));
     navigator.clipboard.writeText(css);
   };
 
@@ -59,7 +59,7 @@ export const CopyPasteMenu = ({
       return;
     }
     const style = new Map([[property, value]]);
-    const css = generateStyleMap({ style });
+    const css = generateStyleMap(style);
     navigator.clipboard.writeText(css);
   };
 

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect } from "vitest";
+import { parseStyleInput } from "./parse-style-input";
+
+describe("parseStyleInput", () => {
+  test("parses custom property", () => {
+    const result = parseStyleInput("--custom-color");
+    expect(result).toEqual([
+      {
+        selector: "selector",
+        property: "--custom-color",
+        value: { type: "unset", value: "" },
+      },
+    ]);
+  });
+
+  test("parses regular property", () => {
+    const result = parseStyleInput("color");
+    expect(result).toEqual([
+      {
+        selector: "selector",
+        property: "color",
+        value: { type: "unset", value: "" },
+      },
+    ]);
+  });
+
+  test("trims whitespace", () => {
+    const result = parseStyleInput("  color  ");
+    expect(result).toEqual([
+      {
+        selector: "selector",
+        property: "color",
+        value: { type: "unset", value: "" },
+      },
+    ]);
+  });
+
+  test("handles invalid regular property", () => {
+    const result = parseStyleInput("notapro perty");
+    expect(result).toEqual([]);
+  });
+
+  test("converts unknown property to custom property assuming user forgot to add --", () => {
+    const result = parseStyleInput("notaproperty");
+    expect(result).toEqual([
+      {
+        selector: "selector",
+        property: "--notaproperty",
+        value: { type: "unset", value: "" },
+      },
+    ]);
+  });
+
+  test("parses single property-value pair", () => {
+    const result = parseStyleInput("color: red");
+    expect(result).toEqual([
+      {
+        selector: "selector",
+        property: "color",
+        value: { type: "keyword", value: "red" },
+      },
+    ]);
+  });
+
+  test("parses multiple property-value pairs", () => {
+    const result = parseStyleInput("color: red; display: block");
+    expect(result).toEqual([
+      {
+        selector: "selector",
+        property: "color",
+        value: { type: "keyword", value: "red" },
+      },
+      {
+        selector: "selector",
+        property: "display",
+        value: { type: "keyword", value: "block" },
+      },
+    ]);
+  });
+
+  test("parses custom property with value", () => {
+    const result = parseStyleInput("--custom-color: red");
+    expect(result).toEqual([
+      {
+        selector: "selector",
+        property: "--custom-color",
+        value: { type: "unparsed", value: "red" },
+      },
+    ]);
+  });
+
+  test("handles malformed style block", () => {
+    const result = parseStyleInput("color: red; invalid;");
+    expect(result).toEqual([
+      {
+        selector: "selector",
+        property: "color",
+        value: { type: "keyword", value: "red" },
+      },
+    ]);
+  });
+});

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.test.ts
@@ -78,6 +78,22 @@ describe("parseStyleInput", () => {
     ]);
   });
 
+  test("parses multiple property-value pairs, one is invalid", () => {
+    const result = parseStyleInput("color: red; somethinginvalid: block");
+    expect(result).toEqual([
+      {
+        selector: "selector",
+        property: "color",
+        value: { type: "keyword", value: "red" },
+      },
+      {
+        selector: "selector",
+        property: "--somethinginvalid",
+        value: { type: "unparsed", value: "block" },
+      },
+    ]);
+  });
+
   test("parses custom property with value", () => {
     const result = parseStyleInput("--custom-color: red");
     expect(result).toEqual([

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.test.ts
@@ -35,7 +35,7 @@ describe("parseStyleInput", () => {
     ]);
   });
 
-  test("handles invalid regular property", () => {
+  test("handles unparsable regular property", () => {
     const result = parseStyleInput("notapro perty");
     expect(result).toEqual([]);
   });

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.ts
@@ -1,0 +1,56 @@
+import {
+  properties,
+  parseCss,
+  type ParsedStyleDecl,
+} from "@webstudio-is/css-data";
+import { type StyleProperty } from "@webstudio-is/css-engine";
+import { camelCase } from "change-case";
+import { lexer } from "css-tree";
+
+/**
+ * Does several attempts to parse:
+ * - Custom property "--foo"
+ * - Known regular property "color"
+ * - Custom property without -- (user forgot to add)
+ * - Custom property and value: --foo: red
+ * - Property and value: color: red
+ * - Multiple properties: color: red; background: blue
+ */
+export const parseStyleInput = (css: string): Array<ParsedStyleDecl> => {
+  css = css.trim();
+  // Is it a custom property "--foo"?
+  if (css.startsWith("--") && lexer.match("<custom-ident>", css).matched) {
+    return [
+      {
+        selector: "selector",
+        property: css as StyleProperty,
+        value: { type: "unset", value: "" },
+      },
+    ];
+  }
+
+  // Is it a known regular property?
+  const camelCasedProperty = camelCase(css);
+  if (camelCasedProperty in properties) {
+    return [
+      {
+        selector: "selector",
+        property: css as StyleProperty,
+        value: { type: "unset", value: "" },
+      },
+    ];
+  }
+
+  // Is it a custom property "--foo"?
+  if (lexer.match("<custom-ident>", `--${css}`).matched) {
+    return [
+      {
+        selector: "selector",
+        property: `--${css}`,
+        value: { type: "unset", value: "" },
+      },
+    ];
+  }
+
+  return parseCss(`selector{${css}}`);
+};

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.ts
@@ -6,6 +6,7 @@ import {
 import { type StyleProperty } from "@webstudio-is/css-engine";
 import { camelCase } from "change-case";
 import { lexer } from "css-tree";
+import { styleConfigByName } from "../../shared/configs";
 
 /**
  * Does several attempts to parse:
@@ -52,5 +53,17 @@ export const parseStyleInput = (css: string): Array<ParsedStyleDecl> => {
     ];
   }
 
-  return parseCss(`selector{${css}}`);
+  const styles = parseCss(`selector{${css}}`);
+
+  for (const style of styles) {
+    // somethingunknown: red; -> --somethingunknown: red;
+    if (
+      style.value.type === "unparsed" &&
+      style.property.startsWith("--") === false
+    ) {
+      style.property = `--${style.property}`;
+    }
+  }
+
+  return styles;
 };

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.ts
@@ -6,7 +6,6 @@ import {
 import { type StyleProperty } from "@webstudio-is/css-engine";
 import { camelCase } from "change-case";
 import { lexer } from "css-tree";
-import { styleConfigByName } from "../../shared/configs";
 
 /**
  * Does several attempts to parse:

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.ts
@@ -57,6 +57,8 @@ export const parseStyleInput = (css: string): Array<ParsedStyleDecl> => {
   for (const style of styles) {
     // somethingunknown: red; -> --somethingunknown: red;
     if (
+      // Note: currently in tests it returns unparsed, but in the client it returns invalid,
+      // because we use native APIs when available in parseCss.
       style.value.type === "invalid" ||
       (style.value.type === "unparsed" &&
         style.property.startsWith("--") === false)

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/parse-style-input.ts
@@ -57,8 +57,9 @@ export const parseStyleInput = (css: string): Array<ParsedStyleDecl> => {
   for (const style of styles) {
     // somethingunknown: red; -> --somethingunknown: red;
     if (
-      style.value.type === "unparsed" &&
-      style.property.startsWith("--") === false
+      style.value.type === "invalid" ||
+      (style.value.type === "unparsed" &&
+        style.property.startsWith("--") === false)
     ) {
       style.property = `--${style.property}`;
     }

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -820,7 +820,7 @@ export const CssValueInput = ({
       // - allows to close the menu
       // - prevents baspace from deleting the value AFTER its already reseted to default, e.g. we get "aut" instead of "auto"
       event.preventDefault();
-      //closeMenu();
+      closeMenu();
       onReset();
     }
   };

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -52,15 +52,16 @@ const mergeDeclarations = (declarations: Iterable<Declaration>) => {
 
 export type StyleMap = Map<string, StyleValue>;
 
-export const generateStyleMap = ({
-  style,
-  indent = 0,
-  transformValue,
-}: {
-  style: StyleMap;
-  indent?: number;
-  transformValue?: TransformValue;
-}) => {
+export const generateStyleMap = (
+  style: StyleMap,
+  {
+    indent = 0,
+    transformValue,
+  }: {
+    indent?: number;
+    transformValue?: TransformValue;
+  } = {}
+) => {
   const spaces = " ".repeat(indent);
   let lines = "";
   for (const [property, value] of style) {
@@ -269,8 +270,7 @@ export class NestingRule {
         leftSelector.localeCompare(rightSelector)
       )
       .map(([selector, style]) => {
-        const content = generateStyleMap({
-          style: prefixStyles(style),
+        const content = generateStyleMap(prefixStyles(style), {
           indent: indent + 2,
           transformValue,
         });


### PR DESCRIPTION
## Description

- [x] Can't click a property on main in advanced
    https://github.com/user-attachments/assets/a2446685-e7dc-4c01-bf03-4ee64b8f5e16
- [x] looks like property name validation is broken. I add "dispaaayyy" and it accepeted


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
