### PR TITLE
fix(devcontainer): Fix pnpm installation issue in postinstall.sh

### DIFF
--- a/.devcontainer/postinstall.sh
+++ b/.devcontainer/postinstall.sh
@@ -1,20 +1,38 @@
 #!/bin/bash
 
+echo "Running postinstall.sh"
+
+# Configure FZF and bash history
 echo 'eval "$(fzf --bash)"' >> /home/node/.bashrc
-
-mkdir -p /home/node/.local/fzf
-
+sudo mkdir -p /home/node/.local/fzf
 touch /home/node/.local/fzf/.bash_history
-
 echo 'export HISTFILE=/home/node/.local/fzf/.bash_history' >> "/home/node/.bashrc"
 
-cd /workspaces/webstudio
-sudo corepack enable
-corepack install
+# Aggressively clean npm and corepack caches
+npm cache clean -f
+sudo rm -rf /tmp/corepack-cache
+sudo rm -rf /usr/local/lib/node_modules/corepack # Manually remove global corepack
 
+# Reinstall corepack globally via npm
+npm install -g corepack@latest # Install latest corepack version
+sudo corepack enable # Re-enable corepack
+
+# Check corepack version after reinstall
+echo "--- Corepack version after reinstall ---"
+corepack --version
+echo "--- End corepack version check ---"
+
+
+# Prepare pnpm (again, after corepack reinstall)
+sudo corepack prepare pnpm@9.14.4 --activate
+
+# Go to workspace directory
+cd /workspaces/webstudio
+
+# Configure pnpm store directory
 pnpm config set store-dir $HOME/.pnpm-store
 
-
+# Clean up directories (optional)
 find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +
 find . -name 'lib' -type d -prune -exec rm -rf '{}' +
 find . -name 'build' -type d -prune -exec rm -rf '{}' +
@@ -22,15 +40,16 @@ find . -name 'dist' -type d -prune -exec rm -rf '{}' +
 find . -name '.cache' -type d -prune -exec rm -rf '{}' +
 find . -name '.pnpm-store' -type d -prune -exec rm -rf '{}' +
 
+# Install dependencies, build, and migrate
 pnpm install
 pnpm run build
 pnpm migrations migrate
 
-
+# Add git aliases
 cat << 'EOF' >> /home/node/.bashrc
-
 alias gitclean="(git remote | xargs git remote prune) && git branch -vv | egrep '('\$(git remote | xargs | sed -e 's/ /|/g')')/.*: gone]' | awk '{print \$1}'  | xargs -r git branch -D"
 alias gitrebase="git rebase --interactive main"
 EOF
 
 
+echo "postinstall.sh finished"


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)
    * This PR fixes an issue where `pnpm` was not being correctly installed or configured within the Devcontainer environment when using `postinstall.sh`.
    * This was causing errors during container startup and when running `pnpm` commands inside the Devcontainer.
    * The fix ensures `pnpm` is properly set up in `postinstall.sh`, resolving the Devcontainer setup issue.

## Steps for reproduction

1. Start the Webstudio Devcontainer.
2. Expect the Devcontainer to start successfully without `pnpm` related errors.
3. Verify that `pnpm` commands can be executed correctly within the Devcontainer terminal (e.g., `pnpm --version`).

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file