### PR TITLE
fix: remove trim from onchange event and trim the value onBlur (#4729)

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/settings-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-section.tsx
@@ -50,8 +50,11 @@ export const SettingsSection = () => {
           key={selectedInstance.id}
           placeholder={placeholder}
           value={localValue.value}
-          onChange={(event) => localValue.set(event.target.value.trim())}
-          onBlur={localValue.save}
+          onChange={(event) => localValue.set(event.target.value)}
+          onBlur={(event) => {
+            localValue.set((event.target as HTMLInputElement).value.trim());
+            localValue.save;
+          }}
         />
       </HorizontalLayout>
     </Row>


### PR DESCRIPTION
## Description

fixes issue #4729 
the issues was happening since the value during onchange event had a trim in the end that removed the space from the end and beginning.

we removed the trim from onchange event and moved it to onBlur, so while typing we can enter space at the end and beginning, but when the element looses focus we trim the value.

## Steps for reproduction

1. select an instance
2. click on settings in right side panel
3. edit the name and you can add a space at the end and beginning.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
