### PR TITLE
feat: add global system variable in builder

### DIFF
--- a/apps/builder/app/builder/features/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings.tsx
@@ -1365,36 +1365,26 @@ const NewPageSettingsView = ({
 
 const createPage = (pageId: Page["id"], values: Values) => {
   serverSyncStore.createTransaction(
-    [$pages, $instances, $dataSources],
-    (pages, instances, dataSources) => {
+    [$pages, $instances],
+    (pages, instances) => {
       if (pages === undefined) {
         return;
       }
       const rootInstanceId = nanoid();
-      const systemDataSourceId = nanoid();
       pages.pages.push({
         id: pageId,
         name: values.name,
         path: values.path,
         title: values.title,
         rootInstanceId,
-        systemDataSourceId,
         meta: {},
       });
-
       instances.set(rootInstanceId, {
         type: "instance",
         id: rootInstanceId,
         component: "Body",
         children: [],
       });
-      dataSources.set(systemDataSourceId, {
-        id: systemDataSourceId,
-        scopeInstanceId: rootInstanceId,
-        name: "system",
-        type: "parameter",
-      });
-
       registerFolderChildMutable(pages.folders, pageId, values.parentFolderId);
       selectInstance(undefined);
     }

--- a/apps/builder/app/builder/features/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings.tsx
@@ -71,7 +71,6 @@ import {
   $assets,
   $instances,
   $pages,
-  $dataSources,
   $publishedOrigin,
   $project,
   $userPlanFeatures,

--- a/apps/builder/app/builder/features/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/pages/page-utils.ts
@@ -12,6 +12,8 @@ import {
   ROOT_FOLDER_ID,
   isRootFolder,
   ROOT_INSTANCE_ID,
+  systemParameter,
+  SYSTEM_VARIABLE_ID,
 } from "@webstudio-is/sdk";
 import { removeByMutable } from "~/shared/array-utils";
 import {
@@ -259,7 +261,10 @@ export const $pageRootScope = computed(
         getInstanceKey([page.rootInstanceId, ROOT_INSTANCE_ID])
       ) ?? new Map<string, unknown>();
     for (const [dataSourceId, value] of values) {
-      const dataSource = dataSources.get(dataSourceId);
+      let dataSource = dataSources.get(dataSourceId);
+      if (dataSourceId === SYSTEM_VARIABLE_ID) {
+        dataSource = systemParameter;
+      }
       if (dataSource === undefined) {
         continue;
       }

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -17,6 +17,8 @@ import {
   generateObjectExpression,
   isLiteralExpression,
   parseObjectExpression,
+  SYSTEM_VARIABLE_ID,
+  systemParameter,
 } from "@webstudio-is/sdk";
 import { sitemapResourceUrl } from "@webstudio-is/sdk/runtime";
 import {
@@ -34,7 +36,6 @@ import {
   theme,
 } from "@webstudio-is/design-system";
 import { TrashIcon, InfoCircleIcon, PlusIcon } from "@webstudio-is/icons";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { humanizeString } from "~/shared/string-utils";
 import {
   $dataSources,
@@ -375,7 +376,7 @@ const $hiddenDataSourceIds = computed(
         dataSourceIds.add(dataSource.id);
       }
     }
-    if (page?.systemDataSourceId && isFeatureEnabled("filters")) {
+    if (page?.systemDataSourceId) {
       dataSourceIds.delete(page.systemDataSourceId);
     }
     return dataSourceIds;
@@ -406,7 +407,10 @@ const $selectedInstanceScope = computed(
         if (hiddenDataSourceIds.has(dataSourceId)) {
           continue;
         }
-        const dataSource = dataSources.get(dataSourceId);
+        let dataSource = dataSources.get(dataSourceId);
+        if (dataSourceId === SYSTEM_VARIABLE_ID) {
+          dataSource = systemParameter;
+        }
         if (dataSource === undefined) {
           continue;
         }

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -14,6 +14,8 @@ import equal from "fast-deep-equal";
 import {
   decodeDataSourceVariable,
   encodeDataSourceVariable,
+  SYSTEM_VARIABLE_ID,
+  systemParameter,
 } from "@webstudio-is/sdk";
 import type { PropMeta, Prop, Asset } from "@webstudio-is/sdk";
 import { InfoCircleIcon, MinusIcon } from "@webstudio-is/icons";
@@ -328,7 +330,10 @@ export const $selectedInstanceScope = computed(
     const values = variableValuesByInstanceSelector.get(instanceKey);
     if (values) {
       for (const [dataSourceId, value] of values) {
-        const dataSource = dataSources.get(dataSourceId);
+        let dataSource = dataSources.get(dataSourceId);
+        if (dataSourceId === SYSTEM_VARIABLE_ID) {
+          dataSource = systemParameter;
+        }
         if (dataSource === undefined) {
           continue;
         }

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -44,6 +44,7 @@ import {
   type DataSource,
   transpileExpression,
   lintExpression,
+  SYSTEM_VARIABLE_ID,
 } from "@webstudio-is/sdk";
 import {
   ExpressionEditor,
@@ -735,6 +736,7 @@ export const VariablePopoverTrigger = ({
   const { allowDynamicData } = useStore($userPlanFeatures);
   const [isResource, setIsResource] = useState(variable?.type === "resource");
   const requiresUpgrade = allowDynamicData === false && isResource;
+  const isSystemVariable = variable?.id === SYSTEM_VARIABLE_ID;
 
   return (
     <FloatingPanel
@@ -856,7 +858,7 @@ export const VariablePopoverTrigger = ({
               }}
               onSubmit={(event) => {
                 event.preventDefault();
-                if (requiresUpgrade) {
+                if (requiresUpgrade || isSystemVariable) {
                   return;
                 }
                 const nameElement =
@@ -879,11 +881,17 @@ export const VariablePopoverTrigger = ({
             >
               {/* submit is not triggered when press enter on input without submit button */}
               <button hidden></button>
-              <BindingPopoverProvider
-                value={{ containerRef: bindingPopoverContainerRef }}
+              <fieldset
+                style={{ display: "contents" }}
+                // forbid editing system variable
+                disabled={isSystemVariable}
               >
-                <VariablePanel ref={panelRef} variable={variable} />
-              </BindingPopoverProvider>
+                <BindingPopoverProvider
+                  value={{ containerRef: bindingPopoverContainerRef }}
+                >
+                  <VariablePanel ref={panelRef} variable={variable} />
+                </BindingPopoverProvider>
+              </fieldset>
             </form>
           </Flex>
         </ScrollArea>

--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -281,7 +281,7 @@ const VariablesItem = ({
                         });
                       }}
                     >
-                      Delete legacy system variable
+                      Delete
                     </DropdownMenuItem>
                   )}
               </DropdownMenuContent>

--- a/apps/builder/app/builder/features/settings-panel/variables-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variables-section.tsx
@@ -28,6 +28,7 @@ import { EllipsesIcon, PlusIcon } from "@webstudio-is/icons";
 import type { DataSource } from "@webstudio-is/sdk";
 import {
   decodeDataSourceVariable,
+  findPageByIdOrPath,
   getExpressionIdentifiers,
 } from "@webstudio-is/sdk";
 import {
@@ -196,6 +197,7 @@ const VariablesItem = ({
   value: unknown;
   usageCount: number;
 }) => {
+  const selectedPage = useStore($selectedPage);
   const [inspectDialogOpen, setInspectDialogOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -265,6 +267,23 @@ const VariablesItem = ({
                     Delete {usageCount > 0 && `(${usageCount} bindings)`}
                   </DropdownMenuItem>
                 )}
+                {source === "local" &&
+                  variable.id === selectedPage?.systemDataSourceId && (
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        updateWebstudioData((data) => {
+                          const page = findPageByIdOrPath(
+                            selectedPage.id,
+                            data.pages
+                          );
+                          delete page?.systemDataSourceId;
+                          deleteVariableMutable(data, variable.id);
+                        });
+                      }}
+                    >
+                      Delete legacy system variable
+                    </DropdownMenuItem>
+                  )}
               </DropdownMenuContent>
             </DropdownMenu>
 

--- a/apps/builder/app/shared/data-variables.test.tsx
+++ b/apps/builder/app/shared/data-variables.test.tsx
@@ -8,7 +8,11 @@ import {
   Variable,
   ws,
 } from "@webstudio-is/template";
-import { encodeDataVariableId, ROOT_INSTANCE_ID } from "@webstudio-is/sdk";
+import {
+  encodeDataVariableId,
+  ROOT_INSTANCE_ID,
+  SYSTEM_VARIABLE_ID,
+} from "@webstudio-is/sdk";
 import {
   computeExpression,
   decodeDataVariableName,
@@ -56,6 +60,7 @@ test("find available variables", () => {
   expect(
     findAvailableVariables({ ...data, startingInstanceId: "boxId" })
   ).toEqual([
+    expect.objectContaining({ name: "system", id: SYSTEM_VARIABLE_ID }),
     expect.objectContaining({ name: "bodyVariable" }),
     expect.objectContaining({ name: "boxVariable" }),
   ]);
@@ -72,6 +77,7 @@ test("find masked variables", () => {
   expect(
     findAvailableVariables({ ...data, startingInstanceId: "boxId" })
   ).toEqual([
+    expect.objectContaining({ name: "system", id: SYSTEM_VARIABLE_ID }),
     expect.objectContaining({ scopeInstanceId: "boxId", name: "myVariable" }),
   ]);
 });
@@ -90,6 +96,7 @@ test("find global variables", () => {
   expect(
     findAvailableVariables({ ...data, startingInstanceId: "boxId" })
   ).toEqual([
+    expect.objectContaining({ name: "system", id: SYSTEM_VARIABLE_ID }),
     expect.objectContaining({ name: "globalVariable" }),
     expect.objectContaining({ name: "boxVariable" }),
   ]);
@@ -114,6 +121,7 @@ test("find global variables in slots", () => {
   expect(
     findAvailableVariables({ ...data, startingInstanceId: "boxId" })
   ).toEqual([
+    expect.objectContaining({ name: "system", id: SYSTEM_VARIABLE_ID }),
     expect.objectContaining({ name: "globalVariable" }),
     expect.objectContaining({ name: "boxVariable" }),
   ]);

--- a/apps/builder/app/shared/data-variables.ts
+++ b/apps/builder/app/shared/data-variables.ts
@@ -8,9 +8,11 @@ import {
   type Resources,
   type WebstudioData,
   ROOT_INSTANCE_ID,
+  SYSTEM_VARIABLE_ID,
   decodeDataVariableId,
   encodeDataVariableId,
   findTreeInstanceIdsExcludingSlotDescendants,
+  systemParameter,
   transpileExpression,
 } from "@webstudio-is/sdk";
 import {
@@ -213,6 +215,8 @@ const findMaskedVariablesByInstanceId = ({
   // allow accessing global variables everywhere
   instanceIdsPath.push(ROOT_INSTANCE_ID);
   const maskedVariables = new Map<DataSource["name"], DataSource["id"]>();
+  // global system variable always present
+  maskedVariables.set("system", SYSTEM_VARIABLE_ID);
   // start from the root to descendant
   // so child variables override parent variables
   for (const instanceId of instanceIdsPath.reverse()) {
@@ -244,6 +248,9 @@ export const findAvailableVariables = ({
     const dataSource = dataSources.get(dataSourceId);
     if (dataSource) {
       availableVariables.push(dataSource);
+    }
+    if (dataSourceId === SYSTEM_VARIABLE_ID) {
+      availableVariables.push(systemParameter);
     }
   }
   return availableVariables;

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -80,7 +80,7 @@ import { current, isDraft } from "immer";
  * structuredClone can be invoked on draft and throw error
  * extract current snapshot before cloning
  */
-const unwrap = <Value>(value: Value) =>
+export const unwrap = <Value>(value: Value) =>
   isDraft(value) ? current(value) : value;
 
 export const updateWebstudioData = (mutate: (data: WebstudioData) => void) => {
@@ -522,7 +522,8 @@ const traverseStyleValue = (
 
 export const extractWebstudioFragment = (
   data: Omit<WebstudioData, "pages">,
-  rootInstanceId: string
+  rootInstanceId: string,
+  options: { unsetVariables?: Set<DataSource["id"]> } = {}
 ): WebstudioFragment => {
   const {
     assets,
@@ -604,8 +605,12 @@ export const extractWebstudioFragment = (
   const fragmentDataSources: DataSources = new Map();
   const fragmentResourceIds = new Set<Resource["id"]>();
   const unsetNameById = new Map<DataSource["id"], DataSource["name"]>();
+  const unsetVariables = options.unsetVariables ?? new Set();
   for (const dataSource of dataSources.values()) {
-    if (fragmentInstanceIds.has(dataSource.scopeInstanceId ?? "")) {
+    if (
+      fragmentInstanceIds.has(dataSource.scopeInstanceId ?? "") &&
+      unsetVariables.has(dataSource.id) === false
+    ) {
       fragmentDataSources.set(dataSource.id, dataSource);
       if (dataSource.type === "resource") {
         fragmentResourceIds.add(dataSource.resourceId);

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -14,6 +14,7 @@ import {
   collectionComponent,
   portalComponent,
   ROOT_INSTANCE_ID,
+  SYSTEM_VARIABLE_ID,
 } from "@webstudio-is/sdk";
 import { normalizeProps, textContentAttribute } from "@webstudio-is/react-sdk";
 import { mapGroupBy } from "~/shared/shim";
@@ -135,6 +136,8 @@ const $unscopedVariableValues = computed(
   ],
   (dataSources, dataSourceVariables, resourceValues, page, system) => {
     const values = new Map<string, unknown>();
+    // support global system
+    values.set(SYSTEM_VARIABLE_ID, system);
     for (const [dataSourceId, dataSource] of dataSources) {
       if (dataSource.type === "variable") {
         values.set(
@@ -144,7 +147,7 @@ const $unscopedVariableValues = computed(
       }
       if (dataSource.type === "parameter") {
         let value = dataSourceVariables.get(dataSourceId);
-        // @todo support global system
+        // support page system
         if (dataSource.id === page?.systemDataSourceId) {
           value = system;
         }
@@ -420,6 +423,11 @@ export const $variableValuesByInstanceSelector = computed(
         variableValues
       );
       const variables = variablesByInstanceId.get(instanceId);
+      // set global system value
+      if (instanceId === ROOT_INSTANCE_ID) {
+        variableNames.set("system", SYSTEM_VARIABLE_ID);
+        variableValues.set(SYSTEM_VARIABLE_ID, system);
+      }
       if (variables) {
         for (const variable of variables) {
           // delete previous variable with the same name
@@ -433,6 +441,7 @@ export const $variableValuesByInstanceSelector = computed(
           if (variable.type === "parameter") {
             const value = dataSourceVariables.get(variable.id);
             variableValues.set(variable.id, value);
+            // set page system value
             if (variable.id === page.systemDataSourceId) {
               variableValues.set(variable.id, system);
             }

--- a/apps/builder/app/shared/page-utils.ts
+++ b/apps/builder/app/shared/page-utils.ts
@@ -15,8 +15,13 @@ import {
 import {
   extractWebstudioFragment,
   insertWebstudioFragmentCopy,
+  unwrap,
 } from "./instance-utils";
-import { findAvailableVariables } from "./data-variables";
+import {
+  findAvailableVariables,
+  restoreExpressionVariables,
+  unsetExpressionVariables,
+} from "./data-variables";
 
 const deduplicateName = (
   pages: Pages,
@@ -105,69 +110,78 @@ export const insertPageCopyMutable = ({
       startingInstanceId: ROOT_INSTANCE_ID,
     }),
   });
+  const unsetVariables = new Set<DataSource["id"]>();
+  const unsetNameById = new Map<DataSource["id"], DataSource["name"]>();
+  // replace legacy page system with global variable
+  if (page.systemDataSourceId) {
+    unsetVariables.add(page.systemDataSourceId);
+    unsetNameById.set(page.systemDataSourceId, "system");
+  }
+  const availableVariables = findAvailableVariables({
+    ...target.data,
+    startingInstanceId: ROOT_INSTANCE_ID,
+  });
+  const maskedIdByName = new Map<DataSource["name"], DataSource["id"]>();
+  for (const dataSource of availableVariables) {
+    maskedIdByName.set(dataSource.name, dataSource.id);
+  }
   // copy paste page body
   const { newInstanceIds, newDataSourceIds } = insertWebstudioFragmentCopy({
     data: target.data,
-    fragment: extractWebstudioFragment(source.data, page.rootInstanceId),
-    availableVariables: findAvailableVariables({
-      ...target.data,
-      startingInstanceId: ROOT_INSTANCE_ID,
+    fragment: extractWebstudioFragment(source.data, page.rootInstanceId, {
+      unsetVariables,
     }),
+    availableVariables,
   });
-  const newPageId = nanoid();
-  const newRootInstanceId =
+  // unwrap page draft
+  const newPage = structuredClone(unwrap(page));
+  newPage.id = nanoid();
+  delete newPage.systemDataSourceId;
+  newPage.rootInstanceId =
     newInstanceIds.get(page.rootInstanceId) ?? page.rootInstanceId;
-  const newSystemDataSourceId =
-    newDataSourceIds.get(page.systemDataSourceId ?? "") ??
-    page.systemDataSourceId;
-  const newPage: Page = {
-    ...page,
-    id: newPageId,
-    rootInstanceId: newRootInstanceId,
-    systemDataSourceId: newSystemDataSourceId,
-    name: deduplicateName(target.data.pages, target.folderId, page.name),
-    path: deduplicatePath(target.data.pages, target.folderId, page.path),
-    title: replaceDataSources(page.title, newDataSourceIds),
-    meta: {
-      ...page.meta,
-      description:
-        page.meta.description === undefined
-          ? undefined
-          : replaceDataSources(page.meta.description, newDataSourceIds),
-      excludePageFromSearch:
-        page.meta.excludePageFromSearch === undefined
-          ? undefined
-          : replaceDataSources(
-              page.meta.excludePageFromSearch,
-              newDataSourceIds
-            ),
-      socialImageUrl:
-        page.meta.socialImageUrl === undefined
-          ? undefined
-          : replaceDataSources(page.meta.socialImageUrl, newDataSourceIds),
-      language:
-        page.meta.language === undefined
-          ? undefined
-          : replaceDataSources(page.meta.language, newDataSourceIds),
-      status:
-        page.meta.status === undefined
-          ? undefined
-          : replaceDataSources(page.meta.status, newDataSourceIds),
-      redirect:
-        page.meta.redirect === undefined
-          ? undefined
-          : replaceDataSources(page.meta.redirect, newDataSourceIds),
-      custom: page.meta.custom?.map(({ property, content }) => ({
-        property,
-        content: replaceDataSources(content, newDataSourceIds),
-      })),
-    },
+  newPage.name = deduplicateName(target.data.pages, target.folderId, page.name);
+  newPage.path = deduplicatePath(target.data.pages, target.folderId, page.path);
+  const transformExpression = (expression: string) => {
+    // rebind expressions with from page system variable to global one
+    expression = unsetExpressionVariables({ expression, unsetNameById });
+    expression = restoreExpressionVariables({ expression, maskedIdByName });
+    expression = replaceDataSources(expression, newDataSourceIds);
+    return expression;
   };
+  newPage.title = transformExpression(newPage.title);
+  if (newPage.meta.description !== undefined) {
+    newPage.meta.description = transformExpression(newPage.meta.description);
+  }
+  if (newPage.meta.excludePageFromSearch !== undefined) {
+    newPage.meta.excludePageFromSearch = transformExpression(
+      newPage.meta.excludePageFromSearch
+    );
+  }
+  if (newPage.meta.socialImageUrl !== undefined) {
+    newPage.meta.socialImageUrl = transformExpression(
+      newPage.meta.socialImageUrl
+    );
+  }
+  if (newPage.meta.language !== undefined) {
+    newPage.meta.language = transformExpression(newPage.meta.language);
+  }
+  if (newPage.meta.status !== undefined) {
+    newPage.meta.status = transformExpression(newPage.meta.status);
+  }
+  if (newPage.meta.redirect !== undefined) {
+    newPage.meta.redirect = transformExpression(newPage.meta.redirect);
+  }
+  if (newPage.meta.custom) {
+    newPage.meta.custom = newPage.meta.custom.map(({ property, content }) => ({
+      property,
+      content: transformExpression(content),
+    }));
+  }
   target.data.pages.pages.push(newPage);
   for (const folder of target.data.pages.folders) {
     if (folder.id === target.folderId) {
-      folder.children.push(newPageId);
+      folder.children.push(newPage.id);
     }
   }
-  return newPageId;
+  return newPage.id;
 };

--- a/apps/builder/app/shared/webstudio-data-migrator.test.ts
+++ b/apps/builder/app/shared/webstudio-data-migrator.test.ts
@@ -7,7 +7,6 @@ import { migrateWebstudioDataMutable } from "./webstudio-data-migrator";
 const emptyData: WebstudioData = {
   pages: createDefaultPages({
     rootInstanceId: "rootInstanceId",
-    systemDataSourceId: "systemDataSourceId",
   }),
   assets: new Map(),
   dataSources: new Map(),

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -28,7 +28,7 @@
     "@codemirror/language": "^6.10.8",
     "@codemirror/lint": "^6.8.4",
     "@codemirror/state": "^6.5.2",
-    "@codemirror/view": "^6.36.2",
+    "@codemirror/view": "^6.36.3",
     "@floating-ui/dom": "^1.6.13",
     "@fontsource-variable/inter": "^5.0.20",
     "@fontsource-variable/manrope": "^5.0.20",

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -263,19 +263,7 @@ export const createBuild = async (
 ): Promise<void> => {
   const newInstances = createNewPageInstances();
   const [rootInstanceId] = newInstances[0];
-  const systemDataSource: DataSource = {
-    id: nanoid(),
-    scopeInstanceId: rootInstanceId,
-    name: "system",
-    type: "parameter",
-  };
-
-  const defaultPages = Pages.parse(
-    createDefaultPages({
-      rootInstanceId,
-      systemDataSourceId: systemDataSource.id,
-    })
-  );
+  const defaultPages = createDefaultPages({ rootInstanceId });
 
   const newBuild = await context.postgrest.client.from("Build").insert({
     id: crypto.randomUUID(),
@@ -283,9 +271,6 @@ export const createBuild = async (
     pages: serializePages(defaultPages),
     breakpoints: serializeData<Breakpoint>(new Map(createInitialBreakpoints())),
     instances: serializeData<Instance>(new Map(newInstances)),
-    dataSources: serializeData<DataSource>(
-      new Map([[systemDataSource.id, systemDataSource]])
-    ),
   });
   if (newBuild.error) {
     throw newBuild.error;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
         specifier: ^6.5.2
         version: 6.5.2
       '@codemirror/view':
-        specifier: ^6.36.2
-        version: 6.36.2
+        specifier: ^6.36.3
+        version: 6.36.3
       '@floating-ui/dom':
         specifier: ^1.6.13
         version: 1.6.13
@@ -2497,8 +2497,8 @@ packages:
   '@codemirror/state@6.5.2':
     resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
 
-  '@codemirror/view@6.36.2':
-    resolution: {integrity: sha512-DZ6ONbs8qdJK0fdN7AB82CgI6tYXf4HWk1wSVa0+9bhVznCuuvhQtX8bFBoy3dv8rZSQqUd8GvhVAcielcidrA==}
+  '@codemirror/view@6.36.3':
+    resolution: {integrity: sha512-N2bilM47QWC8Hnx0rMdDxO2x2ImJ1FvZWXubwKgjeoOrWwEiFrtpA7SFHcuZ+o2Ze2VzbkgbzWVj4+V18LVkeg==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -9900,14 +9900,14 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.10.8
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.2
+      '@codemirror/view': 6.36.3
       '@lezer/common': 1.2.3
 
   '@codemirror/commands@6.8.0':
     dependencies:
       '@codemirror/language': 6.10.8
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.2
+      '@codemirror/view': 6.36.3
       '@lezer/common': 1.2.3
 
   '@codemirror/lang-css@6.3.1':
@@ -9925,7 +9925,7 @@ snapshots:
       '@codemirror/lang-javascript': 6.2.3
       '@codemirror/language': 6.10.8
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.2
+      '@codemirror/view': 6.36.3
       '@lezer/common': 1.2.3
       '@lezer/css': 1.1.10
       '@lezer/html': 1.3.10
@@ -9936,7 +9936,7 @@ snapshots:
       '@codemirror/language': 6.10.8
       '@codemirror/lint': 6.8.4
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.2
+      '@codemirror/view': 6.36.3
       '@lezer/common': 1.2.3
       '@lezer/javascript': 1.4.19
 
@@ -9946,14 +9946,14 @@ snapshots:
       '@codemirror/lang-html': 6.4.9
       '@codemirror/language': 6.10.8
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.2
+      '@codemirror/view': 6.36.3
       '@lezer/common': 1.2.3
       '@lezer/markdown': 1.3.1
 
   '@codemirror/language@6.10.8':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.2
+      '@codemirror/view': 6.36.3
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
@@ -9962,14 +9962,14 @@ snapshots:
   '@codemirror/lint@6.8.4':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.2
+      '@codemirror/view': 6.36.3
       crelt: 1.0.6
 
   '@codemirror/state@6.5.2':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.36.2':
+  '@codemirror/view@6.36.3':
     dependencies:
       '@codemirror/state': 6.5.2
       style-mod: 4.1.2


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/4166

Now system is global variable and can be accessed in slots.

Legacy one can be deleted

<img width="264" alt="image" src="https://github.com/user-attachments/assets/1c1d60f5-6be2-4871-9970-3593e3e7c08a" />