### PR TITLE
fix: Show highlighted item in slash menu in content block

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/block-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/block-instance-outline.tsx
@@ -138,8 +138,11 @@ export const TemplatesMenu = ({
               value={value !== undefined ? JSON.stringify(value) : value}
               onValueChange={handleValueChangeComplete}
             >
-              {menuItems?.map(({ icon, title, id, value }) => (
+              {menuItems?.map((item) => (
                 <DropdownMenuRadioItem
+                  aria-selected={
+                    JSON.stringify(item.value) === JSON.stringify(value)
+                  }
                   onPointerEnter={() => {
                     handleValueChange(value);
                   }}
@@ -165,13 +168,13 @@ export const TemplatesMenu = ({
                         }
                       : undefined
                   }
-                  key={id}
-                  value={JSON.stringify(value)}
+                  key={item.id}
+                  value={JSON.stringify(item.value)}
                   {...{ [skipInertHandlersAttribute]: true }}
                 >
                   <Flex css={{ px: theme.spacing[3] }} gap={2} data-xxx>
-                    {icon}
-                    <Box>{title}</Box>
+                    {item.icon}
+                    <Box>{item.title}</Box>
                   </Flex>
                 </DropdownMenuRadioItem>
               ))}


### PR DESCRIPTION
## Description

When opening slash menu in content block and using arrow keys, current item is not highlighted

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
