### PR TITLE
refactor: upgrade uno

### DIFF
--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -34,15 +34,15 @@
   "private": true,
   "sideEffects": false,
   "dependencies": {
-    "@unocss/core": "^0.65.1",
-    "@unocss/preset-legacy-compat": "^0.65.1",
-    "@unocss/preset-uno": "^0.65.1",
+    "@unocss/core": "^66.0.0",
+    "@unocss/preset-legacy-compat": "^66.0.0",
+    "@unocss/preset-wind3": "^66.0.0",
     "@webstudio-is/css-engine": "workspace:*",
     "change-case": "^5.4.4",
     "colord": "^2.9.3",
     "css-tree": "^2.3.1",
     "openai": "^3.2.1",
-    "p-retry": "^6.2.0",
+    "p-retry": "^6.2.1",
     "warn-once": "^0.1.1"
   }
 }

--- a/packages/css-data/src/tailwind-parser/parse.ts
+++ b/packages/css-data/src/tailwind-parser/parse.ts
@@ -1,5 +1,5 @@
 import { UnoGenerator, createGenerator } from "@unocss/core";
-import { type Theme, presetUno } from "@unocss/preset-uno";
+import { presetWind3 } from "@unocss/preset-wind3";
 import { presetLegacyCompat } from "@unocss/preset-legacy-compat";
 import warnOnce from "warn-once";
 import { substituteVariables } from "./substitute";
@@ -7,12 +7,12 @@ import { parseCss, type ParsedStyleDecl } from "../parse-css";
 
 type Warn = (condition: boolean, message: string) => void;
 
-let unoLazy: UnoGenerator<Theme> | undefined = undefined;
+let unoLazy: UnoGenerator | undefined = undefined;
 
 const createUnoGenerator = async () => {
   unoLazy = await createGenerator({
     presets: [
-      presetUno(),
+      presetWind3({ preflight: "on-demand" }),
       // until we support oklch natively
       presetLegacyCompat({ legacyColorSpace: true }),
     ],
@@ -28,10 +28,7 @@ export const parseTailwindToCss = async (
   warn: Warn = warnOnce
 ): Promise<string> => {
   const generator = unoLazy ?? (await createUnoGenerator());
-  const generated = await generator.generate(classes, {
-    preflights: true,
-  });
-
+  const generated = await generator.generate(classes);
   const cssWithClasses = substituteVariables(generated.css, warn);
   return cssWithClasses;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1190,14 +1190,14 @@ importers:
   packages/css-data:
     dependencies:
       '@unocss/core':
-        specifier: ^0.65.1
-        version: 0.65.1
+        specifier: ^66.0.0
+        version: 66.0.0
       '@unocss/preset-legacy-compat':
-        specifier: ^0.65.1
-        version: 0.65.1
-      '@unocss/preset-uno':
-        specifier: ^0.65.1
-        version: 0.65.1
+        specifier: ^66.0.0
+        version: 66.0.0
+      '@unocss/preset-wind3':
+        specifier: ^66.0.0
+        version: 66.0.0
       '@webstudio-is/css-engine':
         specifier: workspace:*
         version: link:../css-engine
@@ -1214,8 +1214,8 @@ importers:
         specifier: ^3.2.1
         version: 3.2.1
       p-retry:
-        specifier: ^6.2.0
-        version: 6.2.0
+        specifier: ^6.2.1
+        version: 6.2.1
       warn-once:
         specifier: ^0.1.1
         version: 0.1.1
@@ -5258,26 +5258,23 @@ packages:
     resolution: {integrity: sha512-v/BpkeeYAsPkKCkR8BDwcno0llhzWVqPOamQrAEMdpZav2Y9OVjd9dwJyBLJWwf335B5DmlifECIkZRJCaGaHA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@unocss/core@0.65.1':
-    resolution: {integrity: sha512-Ke0WNZjfSCE6pniJb8PjiwhO6/McxVb1EQYrkkz8aJuR83xu+AEcTog9D4N9EUkRfHS5tZYXQtTj4Uh90T6CEg==}
+  '@unocss/core@66.0.0':
+    resolution: {integrity: sha512-PdVbSMHNDDkr++9nkqzsZRAkaU84gxMTEgYbqI7dt2p1DXp/5tomVtmMsr2/whXGYKRiUc0xZ3p4Pzraz8TcXA==}
 
-  '@unocss/extractor-arbitrary-variants@0.65.1':
-    resolution: {integrity: sha512-VpF7j29TlmVjNolkIjhQ/cwYkuPUoXLv+ko62YRMibE5632QepbNob69pNYGOZustrZt3LvgHD/GcriKwJO4BA==}
+  '@unocss/extractor-arbitrary-variants@66.0.0':
+    resolution: {integrity: sha512-vlkOIOuwBfaFBJcN6o7+obXjigjOlzVFN/jT6pG1WXbQDTRZ021jeF3i9INdb9D/0cQHSeDvNgi1TJ5oUxfiow==}
 
-  '@unocss/preset-legacy-compat@0.65.1':
-    resolution: {integrity: sha512-NKprPzVeZnwLs89APm4foJ01jz3KywwHIJo5n2RqmURdjVg71iW+H/YW3169i8s/0KlKUHO9qWKyOMNvqTZoqw==}
+  '@unocss/preset-legacy-compat@66.0.0':
+    resolution: {integrity: sha512-NpMyzNVkVDGt9nO1n7dZLBDvzAkUu2hCR3ePY//xnUn7Syl5SwPdCEuc7FzHHb/rdSVVsip1cvFEaThO2FnUXQ==}
 
-  '@unocss/preset-mini@0.65.1':
-    resolution: {integrity: sha512-dKIxi+ChWSZvXG8I7yVBjw4FLHdAvKrrCN9bjKpR4/4epKD6jRtEcR6S1wL6XSBWabh7V7D/VbVk+XZ6WsGuXA==}
+  '@unocss/preset-mini@66.0.0':
+    resolution: {integrity: sha512-d62eACnuKtR0dwCFOQXgvw5VLh5YSyK56xCzpHkh0j0GstgfDLfKTys0T/XVAAvdSvAy/8A8vhSNJ4PlIc9V2A==}
 
-  '@unocss/preset-uno@0.65.1':
-    resolution: {integrity: sha512-OSEkphrlR9/RM5un9t9AqVQXOGBLJgjcEweZSm2ng9AK7BsxBXuVP1FelmRqeXVYT5uFtBoD4dfgCgBjGFIW9Q==}
+  '@unocss/preset-wind3@66.0.0':
+    resolution: {integrity: sha512-WAGRmpi1sb2skvYn9DBQUvhfqrJ+VmQmn5ZGsT2ewvsk7HFCvVLAMzZeKrrTQepeNBRhg6HzFDDi8yg6yB5c9g==}
 
-  '@unocss/preset-wind@0.65.1':
-    resolution: {integrity: sha512-7rw3hAWOkWMSjoprWKcQidqJRFQm8qM0IdLjFLQa2ROSzPSnIlNisXGEwAphf4/VYdP7+URUnu5eySQsIRWRzg==}
-
-  '@unocss/rule-utils@0.65.1':
-    resolution: {integrity: sha512-XGXdXsRmIuMDQk/3Fd3g5JMhsyDGWsTfs6aN4vFQ1rfdSgY4UwbslqUNbIH9xxoTfmzUOJ2lhNrFw78RygCNSA==}
+  '@unocss/rule-utils@66.0.0':
+    resolution: {integrity: sha512-UJ51YHbwxYTGyj35ugsPlOT4gaa7tCbXdywZ3m5Nn0JgywwIqGmBFyiN9ZjHBHfJuDxmmPd6lxojoBscih/WMQ==}
     engines: {node: '>=14'}
 
   '@vanilla-extract/babel-plugin-debug-ids@1.0.6':
@@ -7844,8 +7841,8 @@ packages:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
-  p-retry@6.2.0:
-    resolution: {integrity: sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==}
+  p-retry@6.2.1:
+    resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
     engines: {node: '>=16.17'}
 
   p-try@2.2.0:
@@ -12597,39 +12594,32 @@ snapshots:
       '@typescript-eslint/types': 8.20.0
       eslint-visitor-keys: 4.2.0
 
-  '@unocss/core@0.65.1': {}
+  '@unocss/core@66.0.0': {}
 
-  '@unocss/extractor-arbitrary-variants@0.65.1':
+  '@unocss/extractor-arbitrary-variants@66.0.0':
     dependencies:
-      '@unocss/core': 0.65.1
+      '@unocss/core': 66.0.0
 
-  '@unocss/preset-legacy-compat@0.65.1':
+  '@unocss/preset-legacy-compat@66.0.0':
     dependencies:
-      '@unocss/core': 0.65.1
+      '@unocss/core': 66.0.0
 
-  '@unocss/preset-mini@0.65.1':
+  '@unocss/preset-mini@66.0.0':
     dependencies:
-      '@unocss/core': 0.65.1
-      '@unocss/extractor-arbitrary-variants': 0.65.1
-      '@unocss/rule-utils': 0.65.1
+      '@unocss/core': 66.0.0
+      '@unocss/extractor-arbitrary-variants': 66.0.0
+      '@unocss/rule-utils': 66.0.0
 
-  '@unocss/preset-uno@0.65.1':
+  '@unocss/preset-wind3@66.0.0':
     dependencies:
-      '@unocss/core': 0.65.1
-      '@unocss/preset-mini': 0.65.1
-      '@unocss/preset-wind': 0.65.1
-      '@unocss/rule-utils': 0.65.1
+      '@unocss/core': 66.0.0
+      '@unocss/preset-mini': 66.0.0
+      '@unocss/rule-utils': 66.0.0
 
-  '@unocss/preset-wind@0.65.1':
+  '@unocss/rule-utils@66.0.0':
     dependencies:
-      '@unocss/core': 0.65.1
-      '@unocss/preset-mini': 0.65.1
-      '@unocss/rule-utils': 0.65.1
-
-  '@unocss/rule-utils@0.65.1':
-    dependencies:
-      '@unocss/core': 0.65.1
-      magic-string: 0.30.15
+      '@unocss/core': 66.0.0
+      magic-string: 0.30.17
 
   '@vanilla-extract/babel-plugin-debug-ids@1.0.6':
     dependencies:
@@ -15927,7 +15917,7 @@ snapshots:
     dependencies:
       aggregate-error: 3.1.0
 
-  p-retry@6.2.0:
+  p-retry@6.2.1:
     dependencies:
       '@types/retry': 0.12.2
       is-network-error: 1.1.0


### PR DESCRIPTION
The new version deprecated "uno" preset in favor of wind3 and wind4 presets to support both tailwind versions. We can switch to wind4 later.