### PR TITLE
fix: Shorten page name correctly in the top bar

### DIFF
--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -46,10 +46,7 @@ const PagesButton = () => {
       }
     >
       <ToolbarButton
-        css={{
-          paddingInline: theme.panel.paddingInline,
-          maxWidth: theme.spacing[24],
-        }}
+        css={{ paddingInline: theme.panel.paddingInline }}
         aria-label="Toggle Pages"
         onClick={(event) => {
           $editingPageId.set(event.altKey ? page.id : undefined);
@@ -57,7 +54,9 @@ const PagesButton = () => {
         }}
         tabIndex={0}
       >
-        <Text truncate>{page.name}</Text>
+        <Text truncate css={{ maxWidth: theme.spacing[24] }}>
+          {page.name}
+        </Text>
       </ToolbarButton>
     </Tooltip>
   );


### PR DESCRIPTION
## Description

<img width="396" alt="image" src="https://github.com/user-attachments/assets/38a839cb-3261-4cbc-93bb-17410769abd6" />


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
