### PR TITLE
fix: pass system to resources in builder

### DIFF
--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -36,7 +36,7 @@ import { uploadingFileDataToAsset } from "~/builder/shared/assets/asset-utils";
 import { fetch } from "~/shared/fetch.client";
 import { $selectedPage, getInstanceKey } from "../awareness";
 import { computeExpression } from "../data-variables";
-import { $currentSystem, $currentSystemVariableId } from "../system";
+import { $currentSystem } from "../system";
 
 export const assetBaseUrl = "/cgi/asset/";
 
@@ -168,14 +168,10 @@ const $unscopedVariableValues = computed(
  * circular updates
  */
 const $loaderVariableValues = computed(
-  [
-    $dataSources,
-    $dataSourceVariables,
-    $currentSystemVariableId,
-    $currentSystem,
-  ],
-  (dataSources, dataSourceVariables, systemVariableId, system) => {
+  [$dataSources, $dataSourceVariables, $selectedPage, $currentSystem],
+  (dataSources, dataSourceVariables, selectedPage, system) => {
     const values = new Map<string, unknown>();
+    values.set(SYSTEM_VARIABLE_ID, system);
     for (const [dataSourceId, dataSource] of dataSources) {
       if (dataSource.type === "variable") {
         values.set(
@@ -185,7 +181,7 @@ const $loaderVariableValues = computed(
       }
       if (dataSource.type === "parameter") {
         let value = dataSourceVariables.get(dataSourceId);
-        if (dataSource.id === systemVariableId) {
+        if (dataSource.id === selectedPage?.systemDataSourceId) {
           value = system;
         }
         values.set(dataSourceId, value);

--- a/apps/builder/app/shared/system.ts
+++ b/apps/builder/app/shared/system.ts
@@ -1,10 +1,5 @@
 import { atom, computed } from "nanostores";
-import {
-  findPageByIdOrPath,
-  type Page,
-  type System,
-  SYSTEM_VARIABLE_ID,
-} from "@webstudio-is/sdk";
+import { findPageByIdOrPath, type Page, type System } from "@webstudio-is/sdk";
 import {
   compilePathnamePattern,
   matchPathnamePattern,

--- a/apps/builder/app/shared/system.ts
+++ b/apps/builder/app/shared/system.ts
@@ -14,12 +14,6 @@ import { $selectedPage } from "./awareness";
 import { $pages, $publishedOrigin } from "./nano-states";
 import { serverSyncStore } from "./sync";
 
-export const $currentSystemVariableId = computed(
-  $selectedPage,
-  // fallback to global system variable
-  (page) => page?.systemDataSourceId ?? SYSTEM_VARIABLE_ID
-);
-
 export const $systemDataByPage = atom(
   new Map<Page["id"], Pick<System, "search" | "params">>()
 );


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/4925

Loading resources with system variables
broken while switching to global system.