### PR TITLE
fix: Strange behaviour on scroll with tooltip content

### DIFF
--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -206,6 +206,7 @@ const subscribeSelectedInstance = (
       updateObservers();
     });
   };
+
   // update scroll state
   updateScroll();
 

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -204,11 +204,10 @@ const subscribeSelectedInstance = (
 
       // Having that elements can be changed (i.e. div => address tag change, observe again)
       updateObservers();
-
-      // update scroll state
-      updateScroll();
     });
   };
+  // update scroll state
+  updateScroll();
 
   // Lightweight update
   const updateOutline: MutationCallback = (mutationRecords) => {


### PR DESCRIPTION
## Description

https://discord.com/channels/955905230107738152/1345038669496586310/1345038669496586310

- [x] This fix introduces other bug https://p-0f63c6ab-adfe-4052-b065-d87223ef2b03-dot-fix-scroll-tooltip.development.webstudio.is/ start editing text in content block, up arrow, scroll on button is broken

<img width="290" alt="image" src="https://github.com/user-attachments/assets/ed2dff1e-ef01-4844-9123-e2212f9853a6" />


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
