### PR TITLE
fix: Fixes 2 bugs in advanced panel

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -476,7 +476,7 @@ export const Section = () => {
       </Box>
       <CopyPasteMenu
         onPaste={handleInsertStyles}
-        properties={currentProperties}
+        properties={[...recentProperties, ...currentProperties]}
       >
         <Flex gap="2" direction="column">
           <Flex

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -451,7 +451,7 @@ export const Section = () => {
     setSearchProperties(matched as CssProperty[]);
   };
 
-  const afterAddingStyles = () => {
+  const afterChangingStyles = () => {
     setIsAdding(false);
     requestAnimationFrame(() => {
       // We are either focusing the last value input from the recent list if available or the search input.
@@ -502,6 +502,7 @@ export const Section = () => {
                           (recentProperty) => recentProperty !== property
                         )
                       );
+                      afterChangingStyles();
                     }}
                   />
                 );
@@ -519,10 +520,10 @@ export const Section = () => {
                   onSubmit={(cssText: string) => {
                     const styles = handleInsertStyles(cssText);
                     if (styles.size > 0) {
-                      afterAddingStyles();
+                      afterChangingStyles();
                     }
                   }}
-                  onClose={afterAddingStyles}
+                  onClose={afterChangingStyles}
                   onFocus={() => {
                     if (isAdding === false) {
                       handleShowAddStyleInput();


### PR DESCRIPTION
## Description

Use case 1
1. add a property
2. copy all
3. paste into any text editor
4. see that recent one is not copied

Use case 2
1. add 2 properties
2. use backspace to reset the second property
3. focus should be on the first value after deleting the second one
4. use backspace to delete the first property
5. see focus jumped to search

## Steps for reproduction

1. click button
6. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
