### PR TITLE
refactor: generate only asset name for published sites

### DIFF
--- a/fixtures/react-router-docker/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/react-router-docker/app/__generated__/[another-page]._index.tsx
@@ -2,29 +2,19 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
 export const siteName = "";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "d0974db9300c1a3b0fb8b291dd9fabd45ad136478908394280af2f7087e3aecd",
-  name: "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg",
-  description: null,
-  projectId: "d845c167-ea07-4875-b08d-83e97c09dcce",
-  size: 64701,
-  type: "image",
-  format: "jpg",
-  createdAt: "2024-12-06T14:36:07.046+00:00",
-  meta: { width: 820, height: 985 },
-};
+export const favIconAsset: string | undefined =
+  "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   return (

--- a/fixtures/react-router-docker/app/__generated__/_index.tsx
+++ b/fixtures/react-router-docker/app/__generated__/_index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
@@ -16,22 +15,13 @@ import {
 
 export const siteName = "";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "d0974db9300c1a3b0fb8b291dd9fabd45ad136478908394280af2f7087e3aecd",
-  name: "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg",
-  description: null,
-  projectId: "d845c167-ea07-4875-b08d-83e97c09dcce",
-  size: 64701,
-  type: "image",
-  format: "jpg",
-  createdAt: "2024-12-06T14:36:07.046+00:00",
-  meta: { width: 820, height: 985 },
-};
+export const favIconAsset: string | undefined =
+  "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 export const CustomCode = () => {
   return <></>;

--- a/fixtures/react-router-docker/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-docker/app/routes/[another-page]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/react-router-docker/app/routes/_index.tsx
+++ b/fixtures/react-router-docker/app/routes/_index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/react-router-netlify/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/react-router-netlify/app/__generated__/[another-page]._index.tsx
@@ -2,29 +2,19 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
 export const siteName = "";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "d0974db9300c1a3b0fb8b291dd9fabd45ad136478908394280af2f7087e3aecd",
-  name: "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg",
-  description: null,
-  projectId: "d845c167-ea07-4875-b08d-83e97c09dcce",
-  size: 64701,
-  type: "image",
-  format: "jpg",
-  createdAt: "2024-12-06T14:36:07.046+00:00",
-  meta: { width: 820, height: 985 },
-};
+export const favIconAsset: string | undefined =
+  "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   return (

--- a/fixtures/react-router-netlify/app/__generated__/_index.tsx
+++ b/fixtures/react-router-netlify/app/__generated__/_index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
@@ -16,22 +15,13 @@ import {
 
 export const siteName = "";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "d0974db9300c1a3b0fb8b291dd9fabd45ad136478908394280af2f7087e3aecd",
-  name: "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg",
-  description: null,
-  projectId: "d845c167-ea07-4875-b08d-83e97c09dcce",
-  size: 64701,
-  type: "image",
-  format: "jpg",
-  createdAt: "2024-12-06T14:36:07.046+00:00",
-  meta: { width: 820, height: 985 },
-};
+export const favIconAsset: string | undefined =
+  "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 export const CustomCode = () => {
   return <></>;

--- a/fixtures/react-router-netlify/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-netlify/app/routes/[another-page]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/react-router-netlify/app/routes/_index.tsx
+++ b/fixtures/react-router-netlify/app/routes/_index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/react-router-vercel/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/react-router-vercel/app/__generated__/[another-page]._index.tsx
@@ -2,29 +2,19 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
 export const siteName = "";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "d0974db9300c1a3b0fb8b291dd9fabd45ad136478908394280af2f7087e3aecd",
-  name: "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg",
-  description: null,
-  projectId: "d845c167-ea07-4875-b08d-83e97c09dcce",
-  size: 64701,
-  type: "image",
-  format: "jpg",
-  createdAt: "2024-12-06T14:36:07.046+00:00",
-  meta: { width: 820, height: 985 },
-};
+export const favIconAsset: string | undefined =
+  "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   return (

--- a/fixtures/react-router-vercel/app/__generated__/_index.tsx
+++ b/fixtures/react-router-vercel/app/__generated__/_index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
@@ -16,22 +15,13 @@ import {
 
 export const siteName = "";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "d0974db9300c1a3b0fb8b291dd9fabd45ad136478908394280af2f7087e3aecd",
-  name: "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg",
-  description: null,
-  projectId: "d845c167-ea07-4875-b08d-83e97c09dcce",
-  size: 64701,
-  type: "image",
-  format: "jpg",
-  createdAt: "2024-12-06T14:36:07.046+00:00",
-  meta: { width: 820, height: 985 },
-};
+export const favIconAsset: string | undefined =
+  "147-1478573_cat-icon-png-black-cat-png-icon.png_ZJ6-qJjk1RlFzuYwyCXdp.jpeg";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 export const CustomCode = () => {
   return <></>;

--- a/fixtures/react-router-vercel/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-vercel/app/routes/[another-page]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/react-router-vercel/app/routes/_index.tsx
+++ b/fixtures/react-router-vercel/app/routes/_index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/ssg-netlify-by-project-id/app/__generated__/_index.tsx
+++ b/fixtures/ssg-netlify-by-project-id/app/__generated__/_index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
@@ -11,12 +10,12 @@ import {
 
 export const siteName = undefined;
 
-export const favIconAsset: ImageAsset | undefined = undefined;
+export const favIconAsset: string | undefined = undefined;
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 export const CustomCode = () => {
   return <></>;

--- a/fixtures/ssg-netlify-by-project-id/pages/index/+Head.tsx
+++ b/fixtures/ssg-netlify-by-project-id/pages/index/+Head.tsx
@@ -60,7 +60,7 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
         <link
           rel="icon"
           href={imageLoader({
-            src: `${assetBaseUrl}${favIconAsset.name}`,
+            src: `${assetBaseUrl}${favIconAsset}`,
             // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
             width: 144,
             height: 144,
@@ -72,18 +72,18 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       )}
       {pageFontAssets.map((asset) => (
         <link
-          key={asset.id}
+          key={asset}
           rel="preload"
-          href={`${assetBaseUrl}${asset.name}`}
+          href={`${assetBaseUrl}${asset}`}
           as="font"
           crossOrigin="anonymous"
         />
       ))}
       {pageBackgroundImageAssets.map((asset) => (
         <link
-          key={asset.id}
+          key={asset}
           rel="preload"
-          href={`${assetBaseUrl}${asset.name}`}
+          href={`${assetBaseUrl}${asset}`}
           as="image"
         />
       ))}

--- a/fixtures/ssg/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/ssg/app/__generated__/[another-page]._index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
@@ -11,12 +10,12 @@ import {
 
 export const siteName = "";
 
-export const favIconAsset: ImageAsset | undefined = undefined;
+export const favIconAsset: string | undefined = undefined;
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   return (

--- a/fixtures/ssg/app/__generated__/_index.tsx
+++ b/fixtures/ssg/app/__generated__/_index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
@@ -14,12 +13,12 @@ import {
 
 export const siteName = "";
 
-export const favIconAsset: ImageAsset | undefined = undefined;
+export const favIconAsset: string | undefined = undefined;
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 export const CustomCode = () => {
   return <></>;

--- a/fixtures/ssg/pages/another-page/+Head.tsx
+++ b/fixtures/ssg/pages/another-page/+Head.tsx
@@ -60,7 +60,7 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
         <link
           rel="icon"
           href={imageLoader({
-            src: `${assetBaseUrl}${favIconAsset.name}`,
+            src: `${assetBaseUrl}${favIconAsset}`,
             // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
             width: 144,
             height: 144,
@@ -72,18 +72,18 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       )}
       {pageFontAssets.map((asset) => (
         <link
-          key={asset.id}
+          key={asset}
           rel="preload"
-          href={`${assetBaseUrl}${asset.name}`}
+          href={`${assetBaseUrl}${asset}`}
           as="font"
           crossOrigin="anonymous"
         />
       ))}
       {pageBackgroundImageAssets.map((asset) => (
         <link
-          key={asset.id}
+          key={asset}
           rel="preload"
-          href={`${assetBaseUrl}${asset.name}`}
+          href={`${assetBaseUrl}${asset}`}
           as="image"
         />
       ))}

--- a/fixtures/ssg/pages/index/+Head.tsx
+++ b/fixtures/ssg/pages/index/+Head.tsx
@@ -60,7 +60,7 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
         <link
           rel="icon"
           href={imageLoader({
-            src: `${assetBaseUrl}${favIconAsset.name}`,
+            src: `${assetBaseUrl}${favIconAsset}`,
             // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
             width: 144,
             height: 144,
@@ -72,18 +72,18 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       )}
       {pageFontAssets.map((asset) => (
         <link
-          key={asset.id}
+          key={asset}
           rel="preload"
-          href={`${assetBaseUrl}${asset.name}`}
+          href={`${assetBaseUrl}${asset}`}
           as="font"
           crossOrigin="anonymous"
         />
       ))}
       {pageBackgroundImageAssets.map((asset) => (
         <link
-          key={asset.id}
+          key={asset}
           rel="preload"
-          href={`${assetBaseUrl}${asset.name}`}
+          href={`${assetBaseUrl}${asset}`}
           as="image"
         />
       ))}

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/[another-page]._index.tsx
@@ -2,19 +2,18 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
 export const siteName = "";
 
-export const favIconAsset: ImageAsset | undefined = undefined;
+export const favIconAsset: string | undefined = undefined;
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   return (

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
@@ -16,12 +15,12 @@ import {
 
 export const siteName = "";
 
-export const favIconAsset: ImageAsset | undefined = undefined;
+export const favIconAsset: string | undefined = undefined;
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 export const CustomCode = () => {
   return <></>;

--- a/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
@@ -151,7 +151,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -166,7 +166,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -175,7 +175,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -151,7 +151,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -166,7 +166,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -175,7 +175,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-features/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -2,29 +2,19 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Image as Image } from "@webstudio-is/sdk-components-react";
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   return (

--- a/fixtures/webstudio-features/app/__generated__/[class-names]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[class-names]._index.tsx
@@ -2,29 +2,19 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Box as Box } from "@webstudio-is/sdk-components-react";
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   let [classVar, set$classVar] = useVariableState<any>("varClass");

--- a/fixtures/webstudio-features/app/__generated__/[content-block]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[content-block]._index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import {
@@ -13,22 +12,13 @@ import {
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   return (

--- a/fixtures/webstudio-features/app/__generated__/[expressions]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[expressions]._index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import {
@@ -13,22 +12,13 @@ import {
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   let jsonResourceVariable = useResource("jsonResourceVariable_1");

--- a/fixtures/webstudio-features/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[form]._index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
@@ -18,22 +17,13 @@ import {
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   let [formState, set$formState] = useVariableState<any>("initial");

--- a/fixtures/webstudio-features/app/__generated__/[head-tag]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[head-tag]._index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
@@ -18,22 +17,13 @@ import {
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   return (

--- a/fixtures/webstudio-features/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[heading-with-id]._index.tsx
@@ -2,29 +2,19 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   return (

--- a/fixtures/webstudio-features/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[nested].[nested-page]._index.tsx
@@ -2,29 +2,19 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   return (

--- a/fixtures/webstudio-features/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[radix]._index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import {
@@ -20,22 +19,13 @@ import {
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   let [accordionValue, set$accordionValue] = useVariableState<any>("0");

--- a/fixtures/webstudio-features/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[resources]._index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import {
@@ -12,22 +11,13 @@ import {
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   let list = useResource("list_1");

--- a/fixtures/webstudio-features/app/__generated__/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[sitemap.xml]._index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   XmlNode as XmlNode,
@@ -11,22 +10,13 @@ import {
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Page = (_props: { system: any }) => {
   const system = _props.system;

--- a/fixtures/webstudio-features/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/_index.tsx
@@ -2,7 +2,6 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
 import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
@@ -18,22 +17,13 @@ import {
 
 export const siteName = "KittyGuardedZone";
 
-export const favIconAsset: ImageAsset | undefined = {
-  id: "88d5e2ff-b8f2-4899-aaf8-dde4ade6da10",
-  name: "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png",
-  description: null,
-  projectId: "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-  size: 268326,
-  type: "image",
-  format: "png",
-  createdAt: "2023-10-30T13:51:08.416+00:00",
-  meta: { width: 790, height: 786 },
-};
+export const favIconAsset: string | undefined =
+  "DALL_E_2023-10-30_12.39.46_-_Photo_logo_with_a_bold_cat_silhouette_centered_on_a_contrasting_background_designed_for_clarity_at_small_32x32_favicon_resolution_00h6cEA8u2pJRvVJv7hRe.png";
 
 // Font assets on current page (can be preloaded)
-export const pageFontAssets: FontAsset[] = [];
+export const pageFontAssets: string[] = [];
 
-export const pageBackgroundImageAssets: ImageAsset[] = [];
+export const pageBackgroundImageAssets: string[] = [];
 
 const Script = ({ children, ...props }: Record<string, string | boolean>) => {
   if (children == null) {

--- a/fixtures/webstudio-features/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[_route_with_symbols_]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-features/app/routes/[class-names]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[class-names]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-features/app/routes/[content-block]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[content-block]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-features/app/routes/[expressions]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[expressions]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-features/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[form]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-features/app/routes/[head-tag]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[head-tag]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-features/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[heading-with-id]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-features/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[nested].[nested-page]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-features/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[radix]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-features/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[resources]._index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/fixtures/webstudio-features/app/routes/_index.tsx
+++ b/fixtures/webstudio-features/app/routes/_index.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -29,8 +29,6 @@ import type {
   DataSource,
   Deployment,
   Asset,
-  FontAsset,
-  ImageAsset,
   Resource,
   WsComponentMeta,
 } from "@webstudio-is/sdk";
@@ -300,8 +298,8 @@ export const prebuild = async (options: {
     Object.entries(coreMetas)
   );
   const siteDataByPage: SiteDataByPage = {};
-  const fontAssetsByPage: Record<Page["id"], FontAsset[]> = {};
-  const backgroundImageAssetsByPage: Record<Page["id"], ImageAsset[]> = {};
+  const fontAssetsByPage: Record<Page["id"], string[]> = {};
+  const backgroundImageAssetsByPage: Record<Page["id"], string[]> = {};
 
   for (const page of Object.values(siteData.pages)) {
     const instanceMap = new Map(siteData.build.instances);
@@ -396,8 +394,9 @@ export const prebuild = async (options: {
     );
 
     const pageFontAssets = siteData.assets
-      .filter((asset): asset is FontAsset => asset.type === "font")
-      .filter((fontAsset) => pageFontFamilySet.has(fontAsset.meta.family));
+      .filter((asset) => asset.type === "font")
+      .filter((fontAsset) => pageFontFamilySet.has(fontAsset.meta.family))
+      .map((asset) => asset.name);
 
     fontAssetsByPage[page.id] = pageFontAssets;
 
@@ -422,8 +421,9 @@ export const prebuild = async (options: {
     );
 
     const backgroundImageAssets = siteData.assets
-      .filter((asset): asset is ImageAsset => asset.type === "image")
-      .filter((imageAsset) => backgroundImageAssetIdSet.has(imageAsset.id));
+      .filter((asset) => asset.type === "image")
+      .filter((imageAsset) => backgroundImageAssetIdSet.has(imageAsset.id))
+      .map((asset) => asset.name);
 
     backgroundImageAssetsByPage[page.id] = backgroundImageAssets;
   }
@@ -588,7 +588,7 @@ export const prebuild = async (options: {
     const contactEmail: undefined | string =
       // fallback to user email when contact email is empty string
       projectMeta?.contactEmail || siteData.user?.email || undefined;
-    const favIconAsset = assets.get(projectMeta?.faviconAssetId ?? "");
+    const favIconAsset = assets.get(projectMeta?.faviconAssetId ?? "")?.name;
 
     const pagePath = getPagePath(page.id, siteData.build.pages);
 
@@ -597,20 +597,19 @@ export const prebuild = async (options: {
       /* This is a auto generated file for building the project */ \n
 
       import { Fragment, useState } from "react";
-      import type { FontAsset, ImageAsset } from "@webstudio-is/sdk";
       import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
       ${componentImports}
 
       export const siteName = ${JSON.stringify(projectMeta?.siteName)};
 
-      export const favIconAsset: ImageAsset | undefined =
+      export const favIconAsset: string | undefined =
         ${JSON.stringify(favIconAsset)};
 
       // Font assets on current page (can be preloaded)
-      export const pageFontAssets: FontAsset[] =
+      export const pageFontAssets: string[] =
         ${JSON.stringify(pageFontAssets)}
 
-      export const pageBackgroundImageAssets: ImageAsset[] =
+      export const pageBackgroundImageAssets: string[] =
         ${JSON.stringify(pageBackgroundImageAssets)}
 
       ${

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -151,7 +151,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -166,7 +166,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -175,7 +175,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/packages/cli/templates/react-router/app/route-templates/html.tsx
+++ b/packages/cli/templates/react-router/app/route-templates/html.tsx
@@ -150,7 +150,7 @@ export const links: LinksFunction = () => {
     result.push({
       rel: "icon",
       href: imageLoader({
-        src: `${assetBaseUrl}${favIconAsset.name}`,
+        src: `${assetBaseUrl}${favIconAsset}`,
         // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
         width: 144,
         height: 144,
@@ -165,7 +165,7 @@ export const links: LinksFunction = () => {
   for (const asset of pageFontAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${asset.name}`,
+      href: `${assetBaseUrl}${asset}`,
       as: "font",
       crossOrigin: "anonymous",
     });
@@ -174,7 +174,7 @@ export const links: LinksFunction = () => {
   for (const backgroundImageAsset of pageBackgroundImageAssets) {
     result.push({
       rel: "preload",
-      href: `${assetBaseUrl}${backgroundImageAsset.name}`,
+      href: `${assetBaseUrl}${backgroundImageAsset}`,
       as: "image",
     });
   }

--- a/packages/cli/templates/ssg/app/route-templates/html/+Head.tsx
+++ b/packages/cli/templates/ssg/app/route-templates/html/+Head.tsx
@@ -60,7 +60,7 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
         <link
           rel="icon"
           href={imageLoader({
-            src: `${assetBaseUrl}${favIconAsset.name}`,
+            src: `${assetBaseUrl}${favIconAsset}`,
             // width,height must be multiple of 48 https://developers.google.com/search/docs/appearance/favicon-in-search
             width: 144,
             height: 144,
@@ -72,18 +72,18 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       )}
       {pageFontAssets.map((asset) => (
         <link
-          key={asset.id}
+          key={asset}
           rel="preload"
-          href={`${assetBaseUrl}${asset.name}`}
+          href={`${assetBaseUrl}${asset}`}
           as="font"
           crossOrigin="anonymous"
         />
       ))}
       {pageBackgroundImageAssets.map((asset) => (
         <link
-          key={asset.id}
+          key={asset}
           rel="preload"
-          href={`${assetBaseUrl}${asset.name}`}
+          href={`${assetBaseUrl}${asset}`}
           as="image"
         />
       ))}

--- a/packages/react-sdk/placeholder.d.ts
+++ b/packages/react-sdk/placeholder.d.ts
@@ -5,21 +5,16 @@ declare module "__CONSTANTS__" {
 }
 
 declare module "__CLIENT__" {
-  import type {
-    FontAsset,
-    ImageAsset,
-    ResourceRequest,
-    System,
-  } from "@webstudio-is/sdk";
+  import type { ResourceRequest, System } from "@webstudio-is/sdk";
 
   export const siteName: string;
 
-  export const favIconAsset: ImageAsset | undefined;
+  export const favIconAsset: string | undefined;
 
   // Font assets on current page (can be preloaded)
-  export const pageFontAssets: FontAsset[];
+  export const pageFontAssets: string[];
 
-  export const pageBackgroundImageAssets: ImageAsset[];
+  export const pageBackgroundImageAssets: string[];
 
   export const CustomCode: () => ReactNode;
 


### PR DESCRIPTION
We don't really need anything from asset object on published sites except the name to resolve the file.

Here got rid from Asset objects for favicon, fonts and backgrounds. This should reduce client bundle where a lot of assets are used.