### PR TITLE
experimental: support linear() easing

### DIFF
--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -327,6 +327,12 @@ test("parse transition-timing-function property", () => {
     type: "invalid",
     value: "ease, testing",
   });
+  expect(
+    parseCssValue("transitionTimingFunction", "linear(0 0%, 1 100%)")
+  ).toEqual({
+    type: "layers",
+    value: [{ type: "unparsed", value: "linear(0 0%,1 100%)" }],
+  });
 });
 
 test("parse transition-behavior property as layers", () => {


### PR DESCRIPTION
Now it is parsed as "unparsed" :)
