### PR TITLE
refactor: migrate repeated styles to hyphenated properties

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backdrop-filter/backdrop-filter.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backdrop-filter/backdrop-filter.tsx
@@ -1,6 +1,6 @@
 import {
   toValue,
-  type StyleProperty,
+  type CssProperty,
   type StyleValue,
 } from "@webstudio-is/css-engine";
 import { Tooltip, Flex, Text } from "@webstudio-is/design-system";
@@ -16,12 +16,11 @@ import {
 } from "../../shared/repeated-style";
 import { useComputedStyleDecl } from "../../shared/model";
 
-export const properties = ["backdropFilter"] satisfies [
-  StyleProperty,
-  ...StyleProperty[],
+export const properties = ["backdrop-filter"] satisfies [
+  CssProperty,
+  ...CssProperty[],
 ];
 
-const property: StyleProperty = properties[0];
 const label = "Backdrop Filters";
 const initialBackdropFilter = "blur(0px)";
 
@@ -34,7 +33,7 @@ const getItemProps = (_index: number, value: StyleValue) => {
 };
 
 export const Section = () => {
-  const styleDecl = useComputedStyleDecl("backdropFilter");
+  const styleDecl = useComputedStyleDecl("backdrop-filter");
 
   return (
     <RepeatedStyleSection
@@ -44,7 +43,7 @@ export const Section = () => {
       onAdd={() => {
         addRepeatedStyleItem(
           [styleDecl],
-          parseCssFragment(initialBackdropFilter, ["backdropFilter"])
+          parseCssFragment(initialBackdropFilter, ["backdrop-filter"])
         );
       }}
     >
@@ -55,14 +54,14 @@ export const Section = () => {
         renderItemContent={(index, primaryValue) => (
           <FilterSectionContent
             index={index}
-            property={property}
+            property="backdrop-filter"
             propertyValue={toValue(primaryValue)}
             layer={primaryValue}
             onEditLayer={(index, value, options) => {
               editRepeatedStyleItem(
                 [styleDecl],
                 index,
-                new Map([["backdropFilter", value]]),
+                new Map([["backdrop-filter", value]]),
                 options
               );
             }}

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
@@ -59,7 +59,7 @@ const Spacer = styled("div", {
 });
 
 const BackgroundRepeat = ({ index }: { index: number }) => {
-  const styleDecl = useComputedStyleDecl("backgroundRepeat");
+  const styleDecl = useComputedStyleDecl("background-repeat");
   const value = getRepeatedStyleItem(styleDecl, index);
   const items = [
     {
@@ -112,7 +112,7 @@ const BackgroundRepeat = ({ index }: { index: number }) => {
           label="Background Repeat"
           code={`background-repeat: ${item.value};`}
           description={item.description}
-          properties={["backgroundRepeat"]}
+          properties={["background-repeat"]}
         >
           <ToggleGroupButton
             value={item.value}
@@ -132,7 +132,7 @@ const BackgroundRepeat = ({ index }: { index: number }) => {
 };
 
 const BackgroundAttachment = ({ index }: { index: number }) => {
-  const styleDecl = useComputedStyleDecl("backgroundAttachment");
+  const styleDecl = useComputedStyleDecl("background-attachment");
   const value = getRepeatedStyleItem(styleDecl, index);
   return (
     <ToggleGroup
@@ -153,7 +153,7 @@ const BackgroundAttachment = ({ index }: { index: number }) => {
 };
 
 export const BackgroundContent = ({ index }: { index: number }) => {
-  const backgroundImage = useComputedStyleDecl("backgroundImage");
+  const backgroundImage = useComputedStyleDecl("background-image");
 
   const elementRef = useRef<HTMLDivElement>(null);
   const [imageGradientToggle, setImageGradientToggle] = useState<
@@ -204,11 +204,11 @@ export const BackgroundContent = ({ index }: { index: number }) => {
                 <PropertyInlineLabel
                   label="Image"
                   description={propertyDescriptions.backgroundImage}
-                  properties={["backgroundImage"]}
+                  properties={["background-image"]}
                 />
               </Flex>
               <FloatingPanelProvider container={elementRef}>
-                <ImageControl property="backgroundImage" index={index} />
+                <ImageControl property="background-image" index={index} />
               </FloatingPanelProvider>
             </>
           )}
@@ -216,16 +216,16 @@ export const BackgroundContent = ({ index }: { index: number }) => {
           <PropertyInlineLabel
             label="Clip"
             description={propertyDescriptions.backgroundClip}
-            properties={["backgroundClip"]}
+            properties={["background-clip"]}
           />
-          <SelectControl property="backgroundClip" index={index} />
+          <SelectControl property="background-clip" index={index} />
 
           <PropertyInlineLabel
             label="Origin"
             description={propertyDescriptions.backgroundOrigin}
-            properties={["backgroundOrigin"]}
+            properties={["background-origin"]}
           />
-          <SelectControl property="backgroundOrigin" index={index} />
+          <SelectControl property="background-origin" index={index} />
         </Grid>
 
         <Spacer />
@@ -249,7 +249,7 @@ export const BackgroundContent = ({ index }: { index: number }) => {
               <PropertyInlineLabel
                 label="Repeat"
                 description={propertyDescriptions.backgroundRepeat}
-                properties={["backgroundRepeat"]}
+                properties={["background-repeat"]}
               />
               <Flex css={{ justifySelf: "end" }}>
                 <BackgroundRepeat index={index} />
@@ -260,7 +260,7 @@ export const BackgroundContent = ({ index }: { index: number }) => {
           <PropertyInlineLabel
             label="Attachment"
             description={propertyDescriptions.backgroundAttachment}
-            properties={["backgroundAttachment"]}
+            properties={["background-attachment"]}
           />
           <Flex css={{ justifySelf: "end" }}>
             <BackgroundAttachment index={index} />
@@ -269,9 +269,9 @@ export const BackgroundContent = ({ index }: { index: number }) => {
           <PropertyInlineLabel
             label="Blend mode"
             description={propertyDescriptions.backgroundBlendMode}
-            properties={["backgroundBlendMode"]}
+            properties={["background-blend-mode"]}
           />
-          <SelectControl property="backgroundBlendMode" index={index} />
+          <SelectControl property="background-blend-mode" index={index} />
         </Grid>
       </BackgroundSection>
       <Separator css={{ gridColumn: "span 2" }} />

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -28,7 +28,7 @@ const isTransparent = (color: StyleValue) =>
   color.type === "keyword" && color.value === "transparent";
 
 export const BackgroundGradient = ({ index }: { index: number }) => {
-  const styleDecl = useComputedStyleDecl("backgroundImage");
+  const styleDecl = useComputedStyleDecl("background-image");
   let styleValue = styleDecl.cascadedValue;
   if (styleValue.type === "layers") {
     styleValue = styleValue.value[index];
@@ -71,11 +71,11 @@ export const BackgroundGradient = ({ index }: { index: number }) => {
     }
 
     const parsed = parseCssFragment(intermediateValue.value, [
-      "backgroundImage",
+      "background-image",
       "background",
     ]);
-    const backgroundImage = parsed.get("backgroundImage");
-    const backgroundColor = parsed.get("backgroundColor");
+    const backgroundImage = parsed.get("background-image");
+    const backgroundColor = parsed.get("background-color");
 
     // set invalid state
     if (backgroundColor?.type === "invalid" || backgroundImage === undefined) {
@@ -89,13 +89,13 @@ export const BackgroundGradient = ({ index }: { index: number }) => {
     }
     setIntermediateValue(undefined);
     if (backgroundColor && isTransparent(backgroundColor) === false) {
-      setProperty("backgroundColor")(backgroundColor);
+      setProperty("background-color")(backgroundColor);
     }
     // insert all new layers at current position
     editRepeatedStyleItem(
       [styleDecl],
       index,
-      new Map([["backgroundImage", backgroundImage]])
+      new Map([["background-image", backgroundImage]])
     );
   };
 

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-image.tsx
@@ -92,7 +92,7 @@ const getInitialValue = (
 export const BackgroundImage = ({ index }: { index: number }) => {
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
-  const styleDecl = useComputedStyleDecl("backgroundImage");
+  const styleDecl = useComputedStyleDecl("background-image");
   const styleValue = getRepeatedStyleItem(styleDecl, index);
   const [errors, setErrors] = useState<string[]>(() =>
     getInitialErrors(styleValue)
@@ -107,8 +107,8 @@ export const BackgroundImage = ({ index }: { index: number }) => {
       value: value,
     });
 
-    const parsed = parseCssFragment(value, ["backgroundImage", "background"]);
-    const newValue = parsed.get("backgroundImage");
+    const parsed = parseCssFragment(value, ["background-image", "background"]);
+    const newValue = parsed.get("background-image");
 
     if (newValue === undefined || newValue?.type === "invalid") {
       setIntermediateValue({

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-position.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-position.tsx
@@ -29,8 +29,8 @@ const calculateBackgroundPosition = (value: undefined | StyleValue) => {
 
 export const BackgroundPosition = ({ index }: { index: number }) => {
   const [backgroundPositionX, backgroundPositionY] = useComputedStyles([
-    "backgroundPositionX",
-    "backgroundPositionY",
+    "background-position-x",
+    "background-position-y",
   ]);
   const xValue = getRepeatedStyleItem(backgroundPositionX, index);
   const yValue = getRepeatedStyleItem(backgroundPositionY, index);
@@ -42,7 +42,7 @@ export const BackgroundPosition = ({ index }: { index: number }) => {
       <PropertyInlineLabel
         label="Position"
         description={propertyDescriptions.backgroundPosition}
-        properties={["backgroundPositionX", "backgroundPositionY"]}
+        properties={["background-position-x", "background-position-y"]}
       />
       <Flex gap="6">
         <PositionGrid
@@ -68,10 +68,10 @@ export const BackgroundPosition = ({ index }: { index: number }) => {
           <PropertyInlineLabel
             label="Left"
             description="Left position offset"
-            properties={["backgroundPositionX"]}
+            properties={["background-position-x"]}
           />
           <CssValueInputContainer
-            property="backgroundPositionX"
+            property="background-position-x"
             styleSource="default"
             getOptions={() => [
               { type: "keyword", value: "center" },
@@ -91,10 +91,10 @@ export const BackgroundPosition = ({ index }: { index: number }) => {
           <PropertyInlineLabel
             label="Top"
             description="Top position offset"
-            properties={["backgroundPositionY"]}
+            properties={["background-position-y"]}
           />
           <CssValueInputContainer
-            property="backgroundPositionY"
+            property="background-position-y"
             styleSource="default"
             getOptions={() => [
               { type: "keyword", value: "center" },

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
@@ -37,7 +37,7 @@ const toTuple = (
 };
 
 export const BackgroundSize = ({ index }: { index: number }) => {
-  const property = "backgroundSize";
+  const property = "background-size";
   const styleDecl = useComputedStyleDecl(property);
   const styleValue = getRepeatedStyleItem(styleDecl, index);
 
@@ -129,14 +129,14 @@ export const BackgroundSize = ({ index }: { index: number }) => {
         gapY={1}
       >
         <PropertyInlineLabel
-          properties={["backgroundSize"]}
+          properties={["background-size"]}
           label="Width"
           description="The width of the background image."
           disabled={customSizeDisabled}
         />
 
         <PropertyInlineLabel
-          properties={["backgroundSize"]}
+          properties={["background-size"]}
           label="Height"
           description="The height of the background image."
           disabled={customSizeDisabled}

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
@@ -5,7 +5,7 @@ import { styled, theme } from "@webstudio-is/design-system";
 import {
   StyleValue,
   toValue,
-  type StyleProperty,
+  type CssProperty,
 } from "@webstudio-is/css-engine";
 import { $assets } from "~/shared/nano-states";
 import brokenImage from "~/shared/images/broken-image-placeholder.svg";
@@ -14,16 +14,16 @@ import { useComputedStyles } from "../../shared/model";
 import { getComputedRepeatedItem } from "../../shared/repeated-style";
 
 export const repeatedProperties = [
-  "backgroundImage",
-  "backgroundAttachment",
-  "backgroundClip",
-  "backgroundOrigin",
-  "backgroundPositionX",
-  "backgroundPositionY",
-  "backgroundRepeat",
-  "backgroundSize",
-  "backgroundBlendMode",
-] satisfies [StyleProperty, ...StyleProperty[]];
+  "background-image",
+  "background-attachment",
+  "background-clip",
+  "background-origin",
+  "background-position-x",
+  "background-position-y",
+  "background-repeat",
+  "background-size",
+  "background-blend-mode",
+] satisfies [CssProperty, ...CssProperty[]];
 
 const thumbSize = theme.spacing[9];
 

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -1,5 +1,5 @@
 import { useStore } from "@nanostores/react";
-import type { StyleProperty } from "@webstudio-is/css-engine";
+import type { CssProperty } from "@webstudio-is/css-engine";
 import { propertyDescriptions } from "@webstudio-is/css-data";
 import { Flex, Grid, theme } from "@webstudio-is/design-system";
 import { $assets } from "~/shared/nano-states";
@@ -19,10 +19,10 @@ import {
   repeatedProperties,
 } from "./background-thumbnail";
 
-export const properties = [...repeatedProperties, "backgroundColor"] satisfies [
-  StyleProperty,
-  ...StyleProperty[],
-];
+export const properties = [
+  ...repeatedProperties,
+  "background-color",
+] satisfies [CssProperty, ...CssProperty[]];
 
 export const Section = () => {
   const styles = useComputedStyles(repeatedProperties);
@@ -58,9 +58,9 @@ export const Section = () => {
           <PropertyLabel
             label="Color"
             description={propertyDescriptions.backgroundColor}
-            properties={["backgroundColor"]}
+            properties={["background-color"]}
           />
-          <ColorControl property="backgroundColor" />
+          <ColorControl property="background-color" />
         </Grid>
       </Flex>
     </RepeatedStyleSection>

--- a/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
@@ -1,7 +1,7 @@
 import { colord, type RgbaColor } from "colord";
 import {
   toValue,
-  type StyleProperty,
+  type CssProperty,
   type StyleValue,
 } from "@webstudio-is/css-engine";
 import { RepeatedStyleSection } from "../../shared/style-section";
@@ -15,12 +15,11 @@ import {
 } from "../../shared/repeated-style";
 import { parseCssFragment } from "../../shared/css-fragment";
 
-export const properties = ["boxShadow"] satisfies [
-  StyleProperty,
-  ...StyleProperty[],
+export const properties = ["box-shadow"] satisfies [
+  CssProperty,
+  ...CssProperty[],
 ];
 
-const property: StyleProperty = properties[0];
 const label = "Box Shadows";
 const initialBoxShadow = "0px 2px 5px 0px rgba(0, 0, 0, 0.2)";
 
@@ -94,13 +93,13 @@ export const Section = () => {
             index={index}
             layer={value}
             computedLayer={getComputedRepeatedItem(styleDecl, index)}
-            property={property}
+            property="box-shadow"
             propertyValue={toValue(value)}
             onEditLayer={(index, value, options) => {
               editRepeatedStyleItem(
                 [styleDecl],
                 index,
-                new Map([["boxShadow", value]]),
+                new Map([["box-shadow", value]]),
                 options
               );
             }}

--- a/apps/builder/app/builder/features/style-panel/sections/text-shadows/text-shadows.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/text-shadows/text-shadows.tsx
@@ -1,7 +1,7 @@
 import { colord, type RgbaColor } from "colord";
 import {
   toValue,
-  type StyleProperty,
+  type CssProperty,
   type StyleValue,
 } from "@webstudio-is/css-engine";
 import { RepeatedStyleSection } from "../../shared/style-section";
@@ -15,12 +15,11 @@ import {
 import { parseCssFragment } from "../../shared/css-fragment";
 import { useComputedStyleDecl } from "../../shared/model";
 
-export const properties = ["textShadow"] satisfies [
-  StyleProperty,
-  ...StyleProperty[],
+export const properties = ["text-shadow"] satisfies [
+  CssProperty,
+  ...CssProperty[],
 ];
 
-const property: StyleProperty = properties[0];
 const label = "Text Shadows";
 const initialTextShadow = "0px 2px 5px rgba(0, 0, 0, 0.2)";
 
@@ -81,13 +80,13 @@ export const Section = () => {
             index={index}
             layer={value}
             computedLayer={getComputedRepeatedItem(styleDecl, index)}
-            property={property}
+            property="text-shadow"
             propertyValue={toValue(value)}
             onEditLayer={(index, value, options) => {
               editRepeatedStyleItem(
                 [styleDecl],
                 index,
-                new Map([["textShadow", value]]),
+                new Map([["text-shadow", value]]),
                 options
               );
             }}

--- a/apps/builder/app/builder/features/style-panel/shared/css-fragment.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-fragment.test.ts
@@ -7,14 +7,14 @@ setEnv("*");
 
 test("parse var()", () => {
   const result = new Map([
-    ["backgroundImage", parseCssValue("backgroundImage", "var(--bg)")],
+    ["background-image", parseCssValue("backgroundImage", "var(--bg)")],
   ]);
   expect(
-    parseCssFragment("var(--bg)", ["backgroundImage", "background"])
+    parseCssFragment("var(--bg)", ["background-image", "background"])
   ).toEqual(result);
   expect(
     parseCssFragment("background-image: var(--bg)", [
-      "backgroundImage",
+      "background-image",
       "background",
     ])
   ).toEqual(result);
@@ -22,34 +22,34 @@ test("parse var()", () => {
 
 test("fallback further to valid values", () => {
   const result = new Map([
-    ["backgroundImage", parseCssValue("backgroundImage", "none")],
-    ["backgroundPositionX", parseCssValue("backgroundPositionX", "0%")],
-    ["backgroundPositionY", parseCssValue("backgroundPositionY", "0%")],
-    ["backgroundSize", parseCssValue("backgroundSize", "auto auto")],
-    ["backgroundRepeat", parseCssValue("backgroundRepeat", "repeat")],
-    ["backgroundAttachment", parseCssValue("backgroundAttachment", "scroll")],
-    ["backgroundOrigin", parseCssValue("backgroundOrigin", "padding-box")],
-    ["backgroundClip", parseCssValue("backgroundClip", "border-box")],
+    ["background-image", parseCssValue("backgroundImage", "none")],
+    ["background-position-x", parseCssValue("backgroundPositionX", "0%")],
+    ["background-position-y", parseCssValue("backgroundPositionY", "0%")],
+    ["background-size", parseCssValue("backgroundSize", "auto auto")],
+    ["background-repeat", parseCssValue("backgroundRepeat", "repeat")],
+    ["background-attachment", parseCssValue("backgroundAttachment", "scroll")],
+    ["background-origin", parseCssValue("backgroundOrigin", "padding-box")],
+    ["background-clip", parseCssValue("backgroundClip", "border-box")],
     [
-      "backgroundColor",
+      "background-color",
       parseCssValue("backgroundColor", "rgba(255, 255, 255, 1)"),
     ],
   ]);
-  expect(parseCssFragment("#fff", ["backgroundImage", "background"])).toEqual(
+  expect(parseCssFragment("#fff", ["background-image", "background"])).toEqual(
     result
   );
 });
 
 test("parse shorthand property", () => {
   const result = new Map([
-    ["transitionProperty", parseCssValue("transitionProperty", "opacity")],
-    ["transitionDuration", parseCssValue("transitionDuration", "1s")],
+    ["transition-property", parseCssValue("transitionProperty", "opacity")],
+    ["transition-duration", parseCssValue("transitionDuration", "1s")],
     [
-      "transitionTimingFunction",
+      "transition-timing-function",
       parseCssValue("transitionTimingFunction", "ease"),
     ],
-    ["transitionDelay", parseCssValue("transitionDelay", "0s")],
-    ["transitionBehavior", parseCssValue("transitionBehavior", "normal")],
+    ["transition-delay", parseCssValue("transitionDelay", "0s")],
+    ["transition-behavior", parseCssValue("transitionBehavior", "normal")],
   ]);
   expect(parseCssFragment("opacity 1s", ["transition"])).toEqual(result);
   expect(parseCssFragment("transition: opacity 1s", ["transition"])).toEqual(
@@ -68,8 +68,8 @@ test("parse longhand properties", () => {
     )
   ).toEqual(
     new Map([
-      ["transitionProperty", parseCssValue("transitionProperty", "opacity")],
-      ["transitionDuration", parseCssValue("transitionDuration", "1s")],
+      ["transition-property", parseCssValue("transitionProperty", "opacity")],
+      ["transition-duration", parseCssValue("transitionDuration", "1s")],
     ])
   );
 });

--- a/apps/builder/app/builder/features/style-panel/shared/css-fragment.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-fragment.tsx
@@ -7,9 +7,9 @@ import {
   completionKeymap,
   type CompletionSource,
 } from "@codemirror/autocomplete";
-import { camelCaseProperty, parseCss } from "@webstudio-is/css-data";
+import { parseCss } from "@webstudio-is/css-data";
 import { css as style } from "@webstudio-is/design-system";
-import type { StyleProperty, StyleValue } from "@webstudio-is/css-engine";
+import type { CssProperty, StyleValue } from "@webstudio-is/css-engine";
 import {
   EditorContent,
   EditorDialog,
@@ -22,7 +22,7 @@ import { $availableVariables } from "./model";
 export const parseCssFragment = (
   css: string,
   fallbacks: string[]
-): Map<StyleProperty, StyleValue> => {
+): Map<CssProperty, StyleValue> => {
   let parsed = parseCss(`.styles{${css}}`);
   if (parsed.length === 0) {
     for (const fallbackProperty of fallbacks) {
@@ -34,10 +34,7 @@ export const parseCssFragment = (
     }
   }
   return new Map(
-    parsed.map((styleDecl) => [
-      camelCaseProperty(styleDecl.property),
-      styleDecl.value,
-    ])
+    parsed.map((styleDecl) => [styleDecl.property, styleDecl.value])
   );
 };
 

--- a/apps/builder/app/builder/features/style-panel/shared/filter-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/filter-content.tsx
@@ -75,7 +75,7 @@ const filterFunctions = {
 
 type FilterContentProps = {
   index: number;
-  property: "filter" | "backdropFilter";
+  property: "filter" | "backdrop-filter";
   layer: StyleValue;
   propertyValue: string;
   tooltip: JSX.Element;
@@ -221,7 +221,7 @@ export const FilterSectionContent = ({
       layer.args.type === "tuple" ? (
         <ShadowContent
           index={index}
-          property="dropShadow"
+          property="drop-shadow"
           layer={layer.args}
           propertyValue={toValue(layer.args)}
           onEditLayer={(_, dropShadowLayers, options) => {

--- a/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
@@ -2,6 +2,7 @@ import { useMemo, type ComponentProps, type JSX } from "react";
 import type { RgbaColor } from "colord";
 import {
   toValue,
+  type CssProperty,
   type LayersValue,
   type StyleProperty,
   type StyleValue,
@@ -24,7 +25,11 @@ import { repeatUntil } from "~/shared/array-utils";
 import type { ComputedStyleDecl } from "~/shared/style-object-model";
 import { createBatchUpdate, type StyleUpdateOptions } from "./use-style-data";
 import { ColorThumb } from "./color-thumb";
-import { parseCssValue, properties } from "@webstudio-is/css-data";
+import {
+  camelCaseProperty,
+  parseCssValue,
+  properties,
+} from "@webstudio-is/css-data";
 
 const isRepeatedValue = (
   styleValue: StyleValue
@@ -112,7 +117,7 @@ const normalizeStyleValue = (
 
 export const addRepeatedStyleItem = (
   styles: ComputedStyleDecl[],
-  newItems: Map<StyleProperty, StyleValue>
+  newItems: Map<CssProperty, StyleValue>
 ) => {
   if (styles[0].cascadedValue.type === "var") {
     const primaryValue = reparseComputedValue(styles[0]);
@@ -123,7 +128,7 @@ export const addRepeatedStyleItem = (
   }
   const batch = createBatchUpdate();
   const currentStyles = new Map(
-    styles.map((styleDecl) => [styleDecl.property, styleDecl])
+    styles.map((styleDecl) => [styleDecl.property as StyleProperty, styleDecl])
   );
   const primaryValue = styles[0].cascadedValue;
   let primaryCount = 0;
@@ -133,7 +138,8 @@ export const addRepeatedStyleItem = (
   if (primaryValue.type === "var") {
     primaryCount = 1;
   }
-  for (const [property, newValue] of newItems) {
+  for (const [hyphenatedProperty, newValue] of newItems) {
+    const property = camelCaseProperty(hyphenatedProperty);
     if (newValue.type !== "layers" && newValue.type !== "tuple") {
       continue;
     }
@@ -164,14 +170,15 @@ export const addRepeatedStyleItem = (
 export const editRepeatedStyleItem = (
   styles: ComputedStyleDecl[],
   index: number,
-  newItems: Map<StyleProperty, StyleValue>,
+  newItems: Map<CssProperty, StyleValue>,
   options?: StyleUpdateOptions
 ) => {
   const batch = createBatchUpdate();
   const currentStyles = new Map(
     styles.map((styleDecl) => [styleDecl.property, styleDecl])
   );
-  for (const [property, value] of newItems) {
+  for (const [hyphenatedProperty, value] of newItems) {
+    const property = camelCaseProperty(hyphenatedProperty);
     const styleDecl = currentStyles.get(property);
     if (styleDecl === undefined) {
       continue;

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import {
-  hyphenateProperty,
   toValue,
   type InvalidValue,
   type LayersValue,
@@ -70,7 +69,7 @@ import { ColorPicker } from "./color-picker";
 
 type ShadowContentProps = {
   index: number;
-  property: "boxShadow" | "textShadow" | "dropShadow";
+  property: "box-shadow" | "text-shadow" | "drop-shadow";
   layer: StyleValue;
   computedLayer?: StyleValue;
   propertyValue: string;
@@ -100,7 +99,7 @@ const boxShadowInsetValues = [
 ] as const;
 
 const shadowPropertySyntaxes = {
-  boxShadow: {
+  "box-shadow": {
     x: propertySyntaxes.boxShadowOffsetX,
     y: propertySyntaxes.boxShadowOffsetY,
     blur: propertySyntaxes.boxShadowBlurRadius,
@@ -108,13 +107,13 @@ const shadowPropertySyntaxes = {
     color: propertySyntaxes.boxShadowColor,
     position: propertySyntaxes.boxShadowPosition,
   },
-  textShadow: {
+  "text-shadow": {
     x: propertySyntaxes.textShadowOffsetX,
     y: propertySyntaxes.textShadowOffsetY,
     blur: propertySyntaxes.textShadowBlurRadius,
     color: propertySyntaxes.textShadowColor,
   },
-  dropShadow: {
+  "drop-shadow": {
     x: propertySyntaxes.dropShadowOffsetX,
     y: propertySyntaxes.dropShadowOffsetY,
     blur: propertySyntaxes.dropShadowBlurRadius,
@@ -174,10 +173,10 @@ export const ShadowContent = ({
     // https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow#formal_syntax
     // Both share a similar syntax but the property name is different.
     const parsed = parseCssFragment(intermediateValue.value, [
-      property === "dropShadow" ? "textShadow" : property,
+      property === "drop-shadow" ? "text-shadow" : property,
     ]);
     const parsedValue = parsed.get(
-      property === "dropShadow" ? "textShadow" : property
+      property === "drop-shadow" ? "text-shadow" : property
     );
     if (parsedValue?.type === "layers" || parsedValue?.type === "var") {
       onEditLayer(index, parsedValue, { isEphemeral: false });
@@ -208,7 +207,7 @@ export const ShadowContent = ({
         css={{
           padding: theme.panel.padding,
           gridTemplateColumns:
-            property === "boxShadow" ? "1fr 1fr" : "1fr 1fr 1fr",
+            property === "box-shadow" ? "1fr 1fr" : "1fr 1fr 1fr",
         }}
       >
         <Flex direction="column" gap="1">
@@ -283,12 +282,12 @@ export const ShadowContent = ({
           />
         </Flex>
 
-        {property === "boxShadow" ? (
+        {property === "box-shadow" ? (
           <Flex direction="column" gap="1">
             <PropertyInlineLabel
               label="Spread"
               title="Spread Radius"
-              description={shadowPropertySyntaxes.boxShadow.spread}
+              description={shadowPropertySyntaxes["box-shadow"].spread}
             />
             <CssValueInputContainer
               key="boxShadowSpread"
@@ -314,7 +313,7 @@ export const ShadowContent = ({
         gap="2"
         css={{
           padding: theme.panel.padding,
-          ...(property === "boxShadow" && { gridTemplateColumns: "3fr 1fr" }),
+          ...(property === "box-shadow" && { gridTemplateColumns: "3fr 1fr" }),
         }}
       >
         <Flex direction="column" gap="1">
@@ -346,11 +345,11 @@ export const ShadowContent = ({
           />
         </Flex>
 
-        {property === "boxShadow" ? (
+        {property === "box-shadow" ? (
           <Flex direction="column" gap="1">
             <PropertyInlineLabel
               label="Inset"
-              description={shadowPropertySyntaxes.boxShadow.position}
+              description={shadowPropertySyntaxes["box-shadow"].position}
             />
             <ToggleGroup
               type="single"
@@ -397,8 +396,8 @@ export const ShadowContent = ({
                   variant="wrapped"
                   content={
                     <Text>
-                      Paste a {hyphenateProperty(property)} CSS code without the
-                      property name, for example:
+                      Paste a {property} CSS code without the property name, for
+                      example:
                       <br /> <br />
                       <Text variant="monoBold">
                         0px 2px 5px 0px rgba(0, 0, 0, 0.2)


### PR DESCRIPTION
These all are now using hyphenated properties instead of camel case

- background
- text-shadow
- box-shadow
- backdrop-filter