### PR TITLE
fix: Optionally memorize min height in style panel advanced css editor

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -22,6 +22,7 @@ import { getDots } from "../../shared/style-section";
 import { CssEditor, type CssEditorApi } from "../../../../shared/css-editor";
 import { $advancedStylesLonghands } from "./stores";
 import { $selectedInstanceKey } from "~/shared/awareness";
+import { getSetting } from "~/builder/shared/client-settings";
 
 // Only here to keep the same section module interface
 export const properties = [];
@@ -141,6 +142,7 @@ export const Section = () => {
         onDeleteAllDeclarations={handleDeleteAllDeclarations}
         apiRef={apiRef}
         recentProperties={recentProperties}
+        memorizeMinHeight={getSetting("stylePanelMode") !== "advanced"}
       />
     </AdvancedStyleSection>
   );

--- a/apps/builder/app/builder/shared/css-editor/css-editor.tsx
+++ b/apps/builder/app/builder/shared/css-editor/css-editor.tsx
@@ -319,6 +319,7 @@ export const CssEditor = ({
   apiRef,
   showSearch = true,
   recentProperties = [],
+  memorizeMinHeight = true,
 }: {
   onDeleteProperty: DeleteProperty;
   onSetProperty: SetProperty;
@@ -327,6 +328,9 @@ export const CssEditor = ({
   styleMap: CssStyleMap;
   apiRef?: RefObject<CssEditorApi>;
   showSearch?: boolean;
+  // When used as part of some larger scroll area to avoid scroll jumps during search.
+  // For example advanced section in the style panel.
+  memorizeMinHeight?: boolean;
   recentProperties?: Array<CssProperty>;
 }) => {
   const [isAdding, setIsAdding] = useState(false);
@@ -353,10 +357,6 @@ export const CssEditor = ({
 
   const showRecentProperties =
     recentProperties.length > 0 && searchProperties === undefined;
-
-  const memorizeMinHeight = () => {
-    setMinHeight(containerRef.current?.getBoundingClientRect().height ?? 0);
-  };
 
   const handleInsertStyles = (cssText: string) => {
     const styleMap = parseStyleInput(cssText);
@@ -386,7 +386,9 @@ export const CssEditor = ({
       return handleAbortSearch();
     }
 
-    memorizeMinHeight();
+    if (memorizeMinHeight) {
+      setMinHeight(containerRef.current?.getBoundingClientRect().height ?? 0);
+    }
 
     const styles = [];
     for (const [property, value] of styleMap) {


### PR DESCRIPTION
[Discussion](https://discord.com/channels/955905230107738152/1347444065402224691)

## Description

When advanced css editor is used in the style panel, we are avoiding jumps by preserving the scroll height, but in advanced mode when there is no parent scroll - we don't need that, so we can avoid blank space scrollbar.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
