### PR TITLE
refactor: avoid rendering button inside button

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -216,6 +216,7 @@ export const ColorPopover = ({
         <ColorThumb
           color={styleValueToRgbaColor(value)}
           css={{ margin: theme.spacing[2] }}
+          interactive={true}
           tabIndex={-1}
         />
       </PopoverTrigger>

--- a/apps/builder/app/builder/features/style-panel/shared/color-thumb.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-thumb.tsx
@@ -58,13 +58,14 @@ const thumbStyle = css({
   },
 });
 
-type Props = Omit<ComponentProps<"button">, "color"> & {
+type Props = Omit<ComponentProps<"button" | "span">, "color"> & {
+  interactive?: boolean;
   color?: RgbaColor;
   css?: CSS;
 };
 
 export const ColorThumb = forwardRef<ElementRef<"button">, Props>(
-  ({ color = transparentColor, css, ...rest }, ref) => {
+  ({ interactive, color = transparentColor, css, ...rest }, ref) => {
     const background =
       color === undefined || color.a < 1
         ? // Chessboard pattern 5x5
@@ -72,8 +73,10 @@ export const ColorThumb = forwardRef<ElementRef<"button">, Props>(
         : colord(color).toRgbString();
     const borderColor = calcBorderColor(color);
 
+    const Component = interactive ? "button" : "span";
+
     return (
-      <button
+      <Component
         {...rest}
         ref={ref}
         style={{


### PR DESCRIPTION
Color thumb should be a button only inside of color picker when it is clickable. In case of repeated style it is just a visual indicator.

This fixes huge react warnings about button rendered inside of another button.