### PR TITLE
fix: Chrome dev mode scrolls into center aligned text editor

### DIFF
--- a/@types/navigator.d.ts
+++ b/@types/navigator.d.ts
@@ -1,0 +1,3 @@
+interface Navigator {
+  userAgentData?: { brands: Array<{ brand: string; version: string }> };
+}

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -177,6 +177,11 @@ const CaretColorPlugin = () => {
   return null;
 };
 
+const isChrome = () =>
+  navigator.userAgentData?.brands.some(
+    (brand) => brand.brand === "Google Chrome"
+  );
+
 const OnChangeOnBlurPlugin = ({
   onChange,
 }: {
@@ -187,6 +192,16 @@ const OnChangeOnBlurPlugin = ({
 
   useEffect(
     () => () => {
+      // Ensures editable content is saved if no blur event occurs before unmount.
+      // This can happen in Firefox and Safari.
+      // To reproduce: create a Content Block, edit a paragraph, then type `/` and select Heading or Paragraph from the menu.
+      // Without this, changes may be lost on unmount in FF and Safari.
+
+      if (isChrome()) {
+        // Fixes an issue in DEV MODE where, if text is center-aligned inside Flex/Grid,
+        // the code below causes Chrome to scroll the editable text block to the center of the view.
+        return;
+      }
       // The issue is related to React’s development mode.
       // When we set the initial selection in the Editor, we disable Lexical’s internal
       // scrolling using the update operation tag tag: "skip-scroll-into-view".


### PR DESCRIPTION
## Description

Fixes an issue in DEV MODE where, if text is center-aligned inside Flex/Grid,
the code below causes Chrome to scroll the editable text block to the center of the view.


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
