### PR TITLE
refactor: hyphenate style engine

### DIFF
--- a/apps/builder/app/builder/features/navigator/css-preview.tsx
+++ b/apps/builder/app/builder/features/navigator/css-preview.tsx
@@ -6,11 +6,7 @@ import {
   textVariants,
   theme,
 } from "@webstudio-is/design-system";
-import {
-  generateStyleMap,
-  hyphenateProperty,
-  mergeStyles,
-} from "@webstudio-is/css-engine";
+import { generateStyleMap, mergeStyles } from "@webstudio-is/css-engine";
 import type { StyleMap } from "@webstudio-is/css-engine";
 import { CollapsibleSection } from "~/builder/shared/collapsible-section";
 import { highlightCss } from "~/builder/shared/code-highlight";
@@ -37,7 +33,6 @@ const getCssText = (
 
   // Aggregate styles by category so we can group them when rendering.
   for (const styleDecl of definedComputedStyles) {
-    const property = hyphenateProperty(styleDecl.property);
     let group;
     if (
       styleDecl.source.name === "local" ||
@@ -53,7 +48,7 @@ const getCssText = (
     }
     if (group) {
       if (styleDecl.source.instanceId === instanceId) {
-        group.set(property, styleDecl.cascadedValue);
+        group.set(styleDecl.property, styleDecl.cascadedValue);
       }
     }
   }

--- a/apps/builder/app/builder/features/style-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/style-panel/property-label.tsx
@@ -55,14 +55,13 @@ if (typeof window !== "undefined") {
 const renderCss = (styles: ComputedStyleDecl[], isComputed: boolean) => {
   let css = "";
   for (const styleDecl of styles) {
-    const property = hyphenateProperty(styleDecl.property);
     let value;
     if (isComputed) {
       value = toValue(styleDecl.usedValue);
     } else {
       value = toValue(styleDecl.cascadedValue);
     }
-    css += `${property}: ${value};\n`;
+    css += `${styleDecl.property}: ${value};\n`;
   }
   return css;
 };

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/stores.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/stores.ts
@@ -65,7 +65,7 @@ export const $advancedStylesLonghands = computed(
     }
     for (const style of definedStyles) {
       const { property, value, listed } = style;
-      const hyphenatedProperty = hyphenateProperty(property);
+      const hyphenatedProperty = property;
       // When property is listed, it was added from advanced panel.
       // If we are in advanced mode, we show them all.
       if (

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-property.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react";
 import type { CssProperty } from "@webstudio-is/css-engine";
-import { hyphenateProperty, toValue } from "@webstudio-is/css-engine";
+import { toValue } from "@webstudio-is/css-engine";
 import { Box, Grid, ToggleButton } from "@webstudio-is/design-system";
 import { CssValueInputContainer } from "../../shared/css-value-input";
 import { styleConfigByName } from "../../shared/configs";
@@ -117,10 +117,7 @@ export const BorderProperty = ({
           {styles.map((styleDecl) => (
             <CssValueInputContainer
               key={styleDecl.property}
-              icon={
-                borderPropertyOptions[hyphenateProperty(styleDecl.property)]
-                  ?.icon
-              }
+              icon={borderPropertyOptions[styleDecl.property]?.icon}
               property={styleDecl.property}
               styleSource={styleDecl.source.name}
               getOptions={() =>

--- a/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from "react";
 import { theme } from "@webstudio-is/design-system";
-import { hyphenateProperty, type CssProperty } from "@webstudio-is/css-engine";
+import type { CssProperty } from "@webstudio-is/css-engine";
 import { SpaceLayout } from "./layout";
 import { ValueText } from "../shared/value-text";
 import { useScrub } from "../shared/scrub";
@@ -153,8 +153,7 @@ export const Section = () => {
 
   const scrubStatus = useScrub({
     value: styles.find(
-      (styleDecl) =>
-        hyphenateProperty(styleDecl.property) === hoverTarget?.property
+      (styleDecl) => styleDecl.property === hoverTarget?.property
     )?.usedValue,
     target: hoverTarget,
     getModifiersGroup: getSpaceModifiersGroup,
@@ -217,7 +216,7 @@ export const Section = () => {
         onClick={(event) => {
           const property = hoverTarget?.property;
           const styleValueSource = styles.find(
-            (styleDecl) => hyphenateProperty(styleDecl.property) === property
+            (styleDecl) => styleDecl.property === property
           )?.source.name;
 
           if (

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-property.tsx
@@ -17,7 +17,6 @@ import {
   ComboboxScrollArea,
 } from "@webstudio-is/design-system";
 import {
-  hyphenateProperty,
   toValue,
   type KeywordValue,
   type StyleValue,
@@ -70,9 +69,8 @@ const $animatableDefinedProperties = computed(
   (definedStyles) => {
     const animatableProperties = new Set<string>();
     for (const { property } of definedStyles) {
-      const hyphenatedProperty = hyphenateProperty(property);
-      if (isAnimatableProperty(hyphenatedProperty)) {
-        animatableProperties.add(hyphenatedProperty);
+      if (isAnimatableProperty(property)) {
+        animatableProperties.add(property);
       }
     }
     return animatableProperties;

--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transitions.tsx
@@ -7,7 +7,6 @@ import {
 } from "@webstudio-is/design-system";
 import { propertiesData } from "@webstudio-is/css-data";
 import {
-  hyphenateProperty,
   toValue,
   type CssProperty,
   type LayerValueItem,
@@ -48,7 +47,7 @@ const getTransitionLayers = (
 ) => {
   const transitionPropertyValue = styles[0].cascadedValue;
   const currentPropertyValue = styles.find(
-    (styleDecl) => hyphenateProperty(styleDecl.property) === property
+    (styleDecl) => styleDecl.property === property
   )?.cascadedValue;
   const transitionPropertiesCount =
     transitionPropertyValue.type === "layers"

--- a/apps/builder/app/builder/features/style-panel/shared/repeated-style.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/repeated-style.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { setEnv } from "@webstudio-is/feature-flags";
 import {
   toValue,
-  type StyleProperty,
+  type CssProperty,
   type StyleValue,
 } from "@webstudio-is/css-engine";
 import { parseCssValue } from "@webstudio-is/css-data";
@@ -50,7 +50,7 @@ beforeEach(() => {
   $styles.set(new Map());
 });
 
-const setRawProperty = (property: StyleProperty, value: string) => {
+const setRawProperty = (property: CssProperty, value: string) => {
   setProperty(property)(parseCssValue(property, value));
 };
 
@@ -101,13 +101,14 @@ test("get repeated style item by index", () => {
 
 describe("add repeated item", () => {
   test("add layer to var", () => {
-    const $transitionProperty =
-      createComputedStyleDeclStore("transitionProperty");
-    setRawProperty("transitionProperty", "var(--my-property)");
+    const $transitionProperty = createComputedStyleDeclStore(
+      "transition-property"
+    );
+    setRawProperty("transition-property", "var(--my-property)");
     expect($transitionProperty.get().cascadedValue.type).toEqual("var");
     addRepeatedStyleItem(
       [$transitionProperty.get()],
-      parseCssFragment("opacity", ["transitionProperty"])
+      parseCssFragment("opacity", ["transition-property"])
     );
     expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
       "var(--my-property), opacity"
@@ -115,15 +116,16 @@ describe("add repeated item", () => {
   });
 
   test("add layer to repeated style", () => {
-    const $transitionProperty =
-      createComputedStyleDeclStore("transitionProperty");
-    addRepeatedStyleItem(
-      [$transitionProperty.get()],
-      parseCssFragment("opacity", ["transitionProperty"])
+    const $transitionProperty = createComputedStyleDeclStore(
+      "transition-property"
     );
     addRepeatedStyleItem(
       [$transitionProperty.get()],
-      parseCssFragment("transform", ["transitionProperty"])
+      parseCssFragment("opacity", ["transition-property"])
+    );
+    addRepeatedStyleItem(
+      [$transitionProperty.get()],
+      parseCssFragment("transform", ["transition-property"])
     );
     expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
       "opacity, transform"
@@ -146,7 +148,7 @@ describe("add repeated item", () => {
   });
 
   test("ignore when new item is not layers or tuple", () => {
-    const $backgroundColor = createComputedStyleDeclStore("backgroundColor");
+    const $backgroundColor = createComputedStyleDeclStore("background-color");
     addRepeatedStyleItem(
       [$backgroundColor.get()],
       parseCssFragment("none", ["background"])
@@ -158,13 +160,15 @@ describe("add repeated item", () => {
   });
 
   test("align properties with primary property", () => {
-    const $transitionProperty =
-      createComputedStyleDeclStore("transitionProperty");
-    const $transitionDuration =
-      createComputedStyleDeclStore("transitionDuration");
-    const $transitionDelay = createComputedStyleDeclStore("transitionDelay");
-    setRawProperty("transitionProperty", "opacity, transform");
-    setRawProperty("transitionDuration", "1s");
+    const $transitionProperty = createComputedStyleDeclStore(
+      "transition-property"
+    );
+    const $transitionDuration = createComputedStyleDeclStore(
+      "transition-duration"
+    );
+    const $transitionDelay = createComputedStyleDeclStore("transition-delay");
+    setRawProperty("transition-property", "opacity, transform");
+    setRawProperty("transition-duration", "1s");
     addRepeatedStyleItem(
       [
         $transitionProperty.get(),
@@ -185,12 +189,12 @@ describe("add repeated item", () => {
 
 describe("edit item in repeated style", () => {
   test("edit single variable", () => {
-    const $backgroundImage = createComputedStyleDeclStore("backgroundImage");
-    setRawProperty("backgroundImage", "none");
+    const $backgroundImage = createComputedStyleDeclStore("background-image");
+    setRawProperty("background-image", "none");
     editRepeatedStyleItem(
       [$backgroundImage.get()],
       0,
-      parseCssFragment("var(--gradient1)", ["backgroundImage"])
+      parseCssFragment("var(--gradient1)", ["background-image"])
     );
     expect(toValue($backgroundImage.get().cascadedValue)).toEqual(
       "var(--gradient1)"
@@ -200,7 +204,7 @@ describe("edit item in repeated style", () => {
       [$backgroundImage.get()],
       // use greater index when access computed items
       2,
-      parseCssFragment("var(--gradient2)", ["backgroundImage"])
+      parseCssFragment("var(--gradient2)", ["background-image"])
     );
     expect(toValue($backgroundImage.get().cascadedValue)).toEqual(
       "var(--gradient2)"
@@ -209,12 +213,12 @@ describe("edit item in repeated style", () => {
   });
 
   test("edit variable in multiple layers", () => {
-    const $backgroundImage = createComputedStyleDeclStore("backgroundImage");
-    setRawProperty("backgroundImage", "none, none");
+    const $backgroundImage = createComputedStyleDeclStore("background-image");
+    setRawProperty("background-image", "none, none");
     editRepeatedStyleItem(
       [$backgroundImage.get()],
       1,
-      parseCssFragment("var(--gradient1)", ["backgroundImage"])
+      parseCssFragment("var(--gradient1)", ["background-image"])
     );
     expect(toValue($backgroundImage.get().cascadedValue)).toEqual(
       "none, var(--gradient1)"
@@ -223,7 +227,7 @@ describe("edit item in repeated style", () => {
     editRepeatedStyleItem(
       [$backgroundImage.get()],
       1,
-      parseCssFragment("var(--gradient2)", ["backgroundImage"])
+      parseCssFragment("var(--gradient2)", ["background-image"])
     );
     expect(toValue($backgroundImage.get().cascadedValue)).toEqual(
       "none, var(--gradient2)"
@@ -232,13 +236,14 @@ describe("edit item in repeated style", () => {
   });
 
   test("edit layer", () => {
-    const $transitionProperty =
-      createComputedStyleDeclStore("transitionProperty");
-    setRawProperty("transitionProperty", "opacity, transform");
+    const $transitionProperty = createComputedStyleDeclStore(
+      "transition-property"
+    );
+    setRawProperty("transition-property", "opacity, transform");
     editRepeatedStyleItem(
       [$transitionProperty.get()],
       1,
-      parseCssFragment("width", ["transitionProperty"])
+      parseCssFragment("width", ["transition-property"])
     );
     expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
       "opacity, width"
@@ -260,9 +265,10 @@ describe("edit item in repeated style", () => {
 });
 
 test("set layers item into repeated style", () => {
-  const $transitionProperty =
-    createComputedStyleDeclStore("transitionProperty");
-  setRawProperty("transitionProperty", "opacity, transform");
+  const $transitionProperty = createComputedStyleDeclStore(
+    "transition-property"
+  );
+  setRawProperty("transition-property", "opacity, transform");
   setRepeatedStyleItem($transitionProperty.get(), 0, {
     type: "unparsed",
     value: "width",
@@ -281,9 +287,10 @@ test("set layers item into repeated style", () => {
 });
 
 test("unpack item from layers value in repeated style", () => {
-  const $transitionProperty =
-    createComputedStyleDeclStore("transitionProperty");
-  setRawProperty("transitionProperty", "opacity, transform");
+  const $transitionProperty = createComputedStyleDeclStore(
+    "transition-property"
+  );
+  setRawProperty("transition-property", "opacity, transform");
   setRepeatedStyleItem($transitionProperty.get(), 1, {
     type: "layers",
     value: [{ type: "unparsed", value: "width" }],
@@ -295,30 +302,31 @@ test("unpack item from layers value in repeated style", () => {
 
 describe("delete repeated item", () => {
   test("delete var or other not releated value in repeated style", () => {
-    const $backgroundImage = createComputedStyleDeclStore("backgroundImage");
+    const $backgroundImage = createComputedStyleDeclStore("background-image");
     // var()
-    setRawProperty("backgroundImage", "var(--my-bg)");
+    setRawProperty("background-image", "var(--my-bg)");
     deleteRepeatedStyleItem([$backgroundImage.get()], 0);
     expect(toValue($backgroundImage.get().cascadedValue)).toEqual("none");
     // inherit
-    setRawProperty("backgroundImage", "inherit");
+    setRawProperty("background-image", "inherit");
     deleteRepeatedStyleItem([$backgroundImage.get()], 0);
     expect(toValue($backgroundImage.get().cascadedValue)).toEqual("none");
   });
 
   test("convert to var when it is the only left in repeated style", () => {
-    const $backgroundImage = createComputedStyleDeclStore("backgroundImage");
+    const $backgroundImage = createComputedStyleDeclStore("background-image");
     // var()
-    setRawProperty("backgroundImage", "var(--bg1), var(--bg2)");
+    setRawProperty("background-image", "var(--bg1), var(--bg2)");
     deleteRepeatedStyleItem([$backgroundImage.get()], 1);
     expect(toValue($backgroundImage.get().cascadedValue)).toEqual("var(--bg1)");
     expect($backgroundImage.get().cascadedValue.type).toEqual("var");
   });
 
   test("delete layer from repeated style", () => {
-    const $transitionProperty =
-      createComputedStyleDeclStore("transitionProperty");
-    setRawProperty("transitionProperty", "opacity, transform");
+    const $transitionProperty = createComputedStyleDeclStore(
+      "transition-property"
+    );
+    setRawProperty("transition-property", "opacity, transform");
     deleteRepeatedStyleItem([$transitionProperty.get()], 0);
     expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
       "transform"
@@ -326,9 +334,10 @@ describe("delete repeated item", () => {
   });
 
   test("delete value without layers from repeated style", () => {
-    const $transitionProperty =
-      createComputedStyleDeclStore("transitionProperty");
-    setRawProperty("transitionProperty", "opacity");
+    const $transitionProperty = createComputedStyleDeclStore(
+      "transition-property"
+    );
+    setRawProperty("transition-property", "opacity");
     expect($transitionProperty.get().source.name).toEqual("local");
     deleteRepeatedStyleItem([$transitionProperty.get()], 0);
     expect($transitionProperty.get().source.name).toEqual("default");
@@ -336,12 +345,14 @@ describe("delete repeated item", () => {
   });
 
   test("align layers with primary when toggling toggle", () => {
-    const $transitionProperty =
-      createComputedStyleDeclStore("transitionProperty");
-    const $transitionDuration =
-      createComputedStyleDeclStore("transitionDuration");
-    setRawProperty("transitionProperty", "opacity, transform, color");
-    setRawProperty("transitionDuration", "1s, 2s");
+    const $transitionProperty = createComputedStyleDeclStore(
+      "transition-property"
+    );
+    const $transitionDuration = createComputedStyleDeclStore(
+      "transition-duration"
+    );
+    setRawProperty("transition-property", "opacity, transform, color");
+    setRawProperty("transition-duration", "1s, 2s");
     deleteRepeatedStyleItem(
       [$transitionProperty.get(), $transitionDuration.get()],
       0
@@ -363,8 +374,8 @@ describe("delete repeated item", () => {
 
 describe("toggle repeated item", () => {
   test("toggle var in repeated style", () => {
-    const $backgroundImage = createComputedStyleDeclStore("backgroundImage");
-    setRawProperty("backgroundImage", "var(--my-bg)");
+    const $backgroundImage = createComputedStyleDeclStore("background-image");
+    setRawProperty("background-image", "var(--my-bg)");
     toggleRepeatedStyleItem([$backgroundImage.get()], 0);
     expect(toValue($backgroundImage.get().cascadedValue)).toEqual("");
     toggleRepeatedStyleItem([$backgroundImage.get()], 0);
@@ -374,16 +385,17 @@ describe("toggle repeated item", () => {
   });
 
   test("ignore toggling not repeated value in repeated style", () => {
-    const $backgroundImage = createComputedStyleDeclStore("backgroundImage");
-    setRawProperty("backgroundImage", "inherit");
+    const $backgroundImage = createComputedStyleDeclStore("background-image");
+    setRawProperty("background-image", "inherit");
     toggleRepeatedStyleItem([$backgroundImage.get()], 0);
     expect(toValue($backgroundImage.get().cascadedValue)).toEqual("inherit");
   });
 
   test("toggle layer in repeated style", () => {
-    const $transitionProperty =
-      createComputedStyleDeclStore("transitionProperty");
-    setRawProperty("transitionProperty", "opacity, transform");
+    const $transitionProperty = createComputedStyleDeclStore(
+      "transition-property"
+    );
+    setRawProperty("transition-property", "opacity, transform");
     toggleRepeatedStyleItem([$transitionProperty.get()], 0);
     expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
       "transform"
@@ -406,12 +418,14 @@ describe("toggle repeated item", () => {
   });
 
   test("align layers with primary when toggling toggle", () => {
-    const $transitionProperty =
-      createComputedStyleDeclStore("transitionProperty");
-    const $transitionDuration =
-      createComputedStyleDeclStore("transitionDuration");
-    setRawProperty("transitionProperty", "opacity, transform, color");
-    setRawProperty("transitionDuration", "1s, 2s");
+    const $transitionProperty = createComputedStyleDeclStore(
+      "transition-property"
+    );
+    const $transitionDuration = createComputedStyleDeclStore(
+      "transition-duration"
+    );
+    setRawProperty("transition-property", "opacity, transform, color");
+    setRawProperty("transition-duration", "1s, 2s");
     toggleRepeatedStyleItem(
       [$transitionProperty.get(), $transitionDuration.get()],
       0
@@ -426,9 +440,10 @@ describe("toggle repeated item", () => {
 
 describe("swap repeated items", () => {
   test("swap layers in repeated style", () => {
-    const $transitionProperty =
-      createComputedStyleDeclStore("transitionProperty");
-    setRawProperty("transitionProperty", "opacity, transform");
+    const $transitionProperty = createComputedStyleDeclStore(
+      "transition-property"
+    );
+    setRawProperty("transition-property", "opacity, transform");
     swapRepeatedStyleItems([$transitionProperty.get()], 0, 1);
     expect(toValue($transitionProperty.get().cascadedValue)).toEqual(
       "transform, opacity"

--- a/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/repeated-style.tsx
@@ -1,7 +1,6 @@
 import { useMemo, type ComponentProps, type JSX } from "react";
 import type { RgbaColor } from "colord";
 import {
-  hyphenateProperty,
   toValue,
   type CssProperty,
   type LayersValue,
@@ -9,11 +8,7 @@ import {
   type TupleValue,
   type UnparsedValue,
 } from "@webstudio-is/css-engine";
-import {
-  camelCaseProperty,
-  parseCssValue,
-  propertiesData,
-} from "@webstudio-is/css-data";
+import { parseCssValue, propertiesData } from "@webstudio-is/css-data";
 import { EyeClosedIcon, EyeOpenIcon, MinusIcon } from "@webstudio-is/icons";
 import {
   CssValueListArrowFocus,
@@ -106,9 +101,9 @@ const normalizeStyleValue = (
   const items = value.type === itemType ? value.value : [];
   // prefill initial value when no items to repeated
   if (items.length === 0 && primaryItemsCount > 0) {
-    const meta = propertiesData[hyphenateProperty(styleDecl.property)];
+    const meta = propertiesData[styleDecl.property];
     if (meta) {
-      items.push(meta.initial as unknown as UnparsedValue);
+      items.push(meta.initial as UnparsedValue);
     }
   }
   return {
@@ -140,8 +135,7 @@ export const addRepeatedStyleItem = (
   if (primaryValue.type === "var") {
     primaryCount = 1;
   }
-  for (const [hyphenatedProperty, newValue] of newItems) {
-    const property = camelCaseProperty(hyphenatedProperty);
+  for (const [property, newValue] of newItems) {
     if (newValue.type !== "layers" && newValue.type !== "tuple") {
       continue;
     }
@@ -158,7 +152,7 @@ export const addRepeatedStyleItem = (
     } else if (styleDecl.cascadedValue.type === valueType) {
       oldItems = repeatUntil(styleDecl.cascadedValue.value, primaryCount);
     } else if (primaryCount > 0) {
-      const meta = propertiesData[hyphenatedProperty];
+      const meta = propertiesData[property];
       if (meta) {
         oldItems = repeatUntil([meta.initial], primaryCount);
       }
@@ -181,8 +175,7 @@ export const editRepeatedStyleItem = (
   const currentStyles = new Map(
     styles.map((styleDecl) => [styleDecl.property, styleDecl])
   );
-  for (const [hyphenatedProperty, value] of newItems) {
-    const property = camelCaseProperty(hyphenatedProperty);
+  for (const [property, value] of newItems) {
     const styleDecl = currentStyles.get(property);
     if (styleDecl === undefined) {
       continue;

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -13,6 +13,7 @@
 
 import { nanoid } from "nanoid";
 import { useFocusWithin } from "@react-aria/interactions";
+import { useStore } from "@nanostores/react";
 import {
   Box,
   ComboboxListbox,
@@ -36,6 +37,7 @@ import {
   Text,
 } from "@webstudio-is/design-system";
 import { CheckMarkIcon, DotIcon } from "@webstudio-is/icons";
+import type { StyleSource } from "@webstudio-is/sdk";
 import {
   forwardRef,
   useState,
@@ -59,9 +61,7 @@ import { useSortable } from "./use-sortable";
 import { matchSorter } from "match-sorter";
 import { StyleSourceBadge } from "./style-source-badge";
 import { humanizeString } from "~/shared/string-utils";
-import { $definedStyles } from "../shared/model";
-import type { StyleDecl, StyleSource } from "@webstudio-is/sdk";
-import { useStore } from "@nanostores/react";
+import { $definedStyles, type DefinedStyleDecl } from "../shared/model";
 
 type IntermediateItem = {
   id: StyleSource["id"];
@@ -119,7 +119,7 @@ type TextFieldBaseWrapperProps<Item extends IntermediateItem> = Omit<
 // Returns true if style source has defined styles including on the states.
 const getHasStylesMap = <Item extends IntermediateItem>(
   styleSourceItems: Array<Item>,
-  definedStyles: Set<Partial<StyleDecl>>
+  definedStyles: Set<Partial<DefinedStyleDecl>>
 ) => {
   const map = new Map<Item["id"], boolean>();
   for (const item of styleSourceItems) {

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -18,6 +18,7 @@ import {
   type TransformValue,
   type VarValue,
   createRegularStyleSheet,
+  hyphenateProperty,
   toValue,
   toVarFallback,
 } from "@webstudio-is/css-engine";
@@ -658,7 +659,7 @@ const subscribeEphemeralStyle = () => {
 
           // Use the actual style value as a fallback (non-ephemeral); see the “Lazy” comment above.
           const computedStyleDecl = createComputedStyleDeclStore(
-            styleDecl.property
+            hyphenateProperty(styleDecl.property)
           ).get();
 
           const value =

--- a/apps/builder/app/shared/style-object-model.test.tsx
+++ b/apps/builder/app/shared/style-object-model.test.tsx
@@ -11,7 +11,7 @@ import {
 } from "@webstudio-is/sdk";
 import { $, renderData } from "@webstudio-is/template";
 import { camelCaseProperty, parseCss } from "@webstudio-is/css-data";
-import type { StyleProperty, StyleValue } from "@webstudio-is/css-engine";
+import type { CssProperty, StyleValue } from "@webstudio-is/css-engine";
 import {
   type StyleObjectModel,
   getComputedStyleDecl,
@@ -262,14 +262,14 @@ test("support currentcolor keyword", () => {
     getComputedStyleDecl({
       model,
       instanceSelector,
-      property: "borderTopColor",
+      property: "border-top-color",
     }).usedValue
   ).toEqual({ type: "keyword", value: "blue" });
   expect(
     getComputedStyleDecl({
       model,
       instanceSelector,
-      property: "backgroundColor",
+      property: "background-color",
     }).usedValue
   ).toEqual({ type: "keyword", value: "blue" });
 });
@@ -351,7 +351,7 @@ test("compute single custom property without layers", () => {
     getComputedStyleDecl({
       model,
       instanceSelector: ["body"],
-      property: "backgroundImage",
+      property: "background-image",
     }).computedValue
   ).toEqual({
     type: "unparsed",
@@ -374,7 +374,7 @@ test("support custom properties in layers", () => {
     getComputedStyleDecl({
       model,
       instanceSelector: ["body"],
-      property: "backgroundImage",
+      property: "background-image",
     }).computedValue
   ).toEqual({
     type: "layers",
@@ -600,7 +600,7 @@ test("allow multiple usages of the same custom property", () => {
     getComputedStyleDecl({
       model,
       instanceSelector: ["box", "body"],
-      property: "backgroundImage",
+      property: "background-image",
     }).usedValue
   ).toEqual({
     type: "layers",
@@ -769,7 +769,7 @@ test("support html styles", () => {
     getComputedStyleDecl({
       model,
       instanceSelector: ["headingId", "bodyId"],
-      property: "marginTop",
+      property: "margin-top",
     }).usedValue
   ).toEqual({ type: "unit", value: 0.67, unit: "em" });
   // tag without browser styles
@@ -971,7 +971,7 @@ test("fallback cascaded value to inherited computed value", () => {
     getComputedStyleDecl({
       model,
       instanceSelector: ["box", "body"],
-      property: "borderTopColor",
+      property: "border-top-color",
     }).cascadedValue
   ).toEqual({ type: "keyword", value: "currentColor" });
 });
@@ -990,14 +990,14 @@ test("work with unknown or invalid properties", () => {
     getComputedStyleDecl({
       model,
       instanceSelector,
-      property: "unknownProperty" as StyleProperty,
+      property: "unknownProperty" as CssProperty,
     }).usedValue
   ).toEqual({ type: "unparsed", value: "[object Object]" });
   expect(
     getComputedStyleDecl({
       model,
       instanceSelector,
-      property: "undefinedProperty" as StyleProperty,
+      property: "undefinedProperty" as CssProperty,
     }).usedValue
   ).toEqual({ type: "invalid", value: "" });
 });
@@ -1491,7 +1491,7 @@ describe("style value source", () => {
       getComputedStyleDecl({
         model,
         instanceSelector: ["body"],
-        property: "borderTopColor",
+        property: "border-top-color",
       }).source
     ).toEqual({
       name: "local",


### PR DESCRIPTION
Migrated style object model to hyphenated css properties. A lot of conversions no longer necessary.