### PR TITLE
feat: Improve search and new property autocompletion in advanced style panel

### DIFF
--- a/apps/builder/app/builder/shared/css-editor/add-style-input.tsx
+++ b/apps/builder/app/builder/shared/css-editor/add-style-input.tsx
@@ -37,7 +37,12 @@ import {
 import { composeEventHandlers } from "~/shared/event-utils";
 import { parseStyleInput } from "./parse-style-input";
 
-type SearchItem = { property: string; label: string; value?: string };
+type SearchItem = {
+  property: string;
+  label: string;
+  value?: string;
+  key: string;
+};
 
 const autoCompleteItems: Array<SearchItem> = [];
 
@@ -56,6 +61,8 @@ const getAutocompleteItems = () => {
   for (const property in propertiesData) {
     const hyphenatedProperty = hyphenateProperty(property);
     autoCompleteItems.push({
+      // Allow matching "gr te co" -> "grid-template-columns"
+      key: hyphenatedProperty.replace(/-/g, " "),
       property: hyphenatedProperty,
       label: hyphenatedProperty,
     });
@@ -63,6 +70,8 @@ const getAutocompleteItems = () => {
 
   for (const property of shorthandProperties) {
     autoCompleteItems.push({
+      // Allow matching "gr te co" -> "grid-template-columns"
+      key: property.replace(/-/g, " "),
       property,
       label: property,
     });
@@ -78,6 +87,8 @@ const getAutocompleteItems = () => {
       }
       const hyphenatedProperty = hyphenateProperty(property);
       autoCompleteItems.push({
+        // Allow matching "gr te co" -> "grid-template-columns"
+        key: `${hyphenatedProperty.replace(/-/g, " ")} ${value}`,
         property: hyphenatedProperty,
         value,
         label: `${hyphenatedProperty}: ${value}`,
@@ -92,13 +103,9 @@ const getAutocompleteItems = () => {
   return autoCompleteItems;
 };
 
-const matchOrSuggestToCreate = (
-  search: string,
-  items: Array<SearchItem>,
-  itemToString: (item: SearchItem) => string
-) => {
+const matchOrSuggestToCreate = (search: string, items: Array<SearchItem>) => {
   const matched = matchSorter(items, search, {
-    keys: [itemToString],
+    keys: ["key"],
   });
 
   // Limit the array to 100 elements
@@ -112,6 +119,7 @@ const matchOrSuggestToCreate = (
     // We will suggest to insert their shorthand first.
     if (styleMap.size > 1) {
       matched.push({
+        key: "",
         property: search,
         label: `Create "${search}"`,
       });
@@ -119,6 +127,7 @@ const matchOrSuggestToCreate = (
     // Now we will suggest to insert each longhand separately.
     for (const [property, value] of styleMap) {
       matched.push({
+        key: "",
         property,
         value: toValue(value),
         label: `Create "${generateStyleMap(new Map([[property, value]]))}"`,
@@ -150,6 +159,7 @@ export const AddStyleInput = forwardRef<
   const [item, setItem] = useState<SearchItem>({
     property: "",
     label: "",
+    key: "",
   });
   const highlightedItemRef = useRef<SearchItem>();
 
@@ -160,7 +170,13 @@ export const AddStyleInput = forwardRef<
     defaultHighlightedIndex: 0,
     getItemProps: () => ({ text: "sentence" }),
     match: matchOrSuggestToCreate,
-    onChange: (value) => setItem({ property: value ?? "", label: value ?? "" }),
+    onChange: (input) => {
+      return setItem({
+        property: input ?? "",
+        label: input ?? "",
+        key: input ?? "",
+      });
+    },
     onItemSelect: (item) => {
       clear();
       // When there is no value, property can be:
@@ -198,7 +214,7 @@ export const AddStyleInput = forwardRef<
   const inputProps = combobox.getInputProps();
 
   const clear = () => {
-    setItem({ property: "", label: "" });
+    setItem({ property: "", label: "", key: "" });
   };
 
   const handleEnter = (event: KeyboardEvent) => {

--- a/apps/builder/app/builder/shared/css-editor/css-editor.tsx
+++ b/apps/builder/app/builder/shared/css-editor/css-editor.tsx
@@ -392,11 +392,16 @@ export const CssEditor = ({
 
     const styles = [];
     for (const [property, value] of styleMap) {
-      styles.push({ property, value: toValue(value) });
+      styles.push({
+        // Allows searching for property or value and using something like this:
+        // "gr te co" -> "grid-template-columns"
+        key: `${property.replace(/-/g, " ")} ${toValue(value)}`,
+        property,
+      });
     }
 
     const matched = matchSorter(styles, search, {
-      keys: ["property", "value"],
+      keys: ["key"],
     }).map(({ property }) => property);
 
     setSearchProperties(matched);


### PR DESCRIPTION
## Description

1. Allow matching "gr te co" -> "grid-template-columns" when searching
2. Same thing when adding a new property/value

## Steps for reproduction

1. click button
3. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
