### PR TITLE
refactor: store webhook form action as resource

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
@@ -10,6 +10,7 @@ import { UrlControl } from "./url";
 import type { ControlProps } from "../shared";
 import { JsonControl } from "./json";
 import { TextContent } from "./text-content";
+import { ResourceControl } from "./resource-control";
 
 export const renderControl = ({
   meta,
@@ -43,6 +44,10 @@ export const renderControl = ({
 
   if (meta.control === "text") {
     return <TextControl key={key} meta={meta} prop={prop} {...rest} />;
+  }
+
+  if (meta.control === "resource") {
+    return <ResourceControl key={key} meta={meta} prop={prop} {...rest} />;
   }
 
   if (meta.control === "code") {

--- a/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
@@ -58,11 +58,31 @@ export const ResourceControl = ({
           resource.url = urlExpression;
         }
       } else {
+        let method: Resource["method"] = "get";
+        for (const prop of data.props.values()) {
+          if (
+            prop.instanceId === instanceId &&
+            prop.type === "string" &&
+            prop.name === "method"
+          ) {
+            const value = prop.value.toLowerCase();
+            if (
+              value === "get" ||
+              value === "post" ||
+              value === "put" ||
+              value === "delete"
+            ) {
+              method = value;
+            }
+            break;
+          }
+        }
+
         const newResource: Resource = {
           id: nanoid(),
           name: propName,
           url: urlExpression,
-          method: "get",
+          method,
           headers: [{ name: "Content-Type", value: "application/json" }],
         };
         const newProp: Prop = {

--- a/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
@@ -1,0 +1,141 @@
+import { useId } from "react";
+import { useStore } from "@nanostores/react";
+import { InputField } from "@webstudio-is/design-system";
+import { isLiteralExpression, Resource, type Prop } from "@webstudio-is/sdk";
+import {
+  BindingControl,
+  BindingPopover,
+  type BindingVariant,
+} from "~/builder/shared/binding-popover";
+import {
+  type ControlProps,
+  useLocalValue,
+  ResponsiveLayout,
+  Label,
+  humanizeAttribute,
+} from "../shared";
+import { $resources } from "~/shared/nano-states";
+import { $selectedInstanceResourceScope } from "../resource-panel";
+import { computeExpression } from "~/shared/data-variables";
+import { updateWebstudioData } from "~/shared/instance-utils";
+import { nanoid } from "nanoid";
+
+export const ResourceControl = ({
+  meta,
+  prop,
+  propName,
+  instanceId,
+  deletable,
+}: ControlProps<"resource">) => {
+  const resources = useStore($resources);
+  const { variableValues, scope, aliases } = useStore(
+    $selectedInstanceResourceScope
+  );
+
+  let computedValue: unknown;
+  let expression: string = JSON.stringify("");
+  if (prop?.type === "string") {
+    expression = JSON.stringify(prop.value);
+    computedValue = prop.value;
+  }
+  if (prop?.type === "expression") {
+    expression = prop.value;
+    computedValue = computeExpression(prop.value, variableValues);
+  }
+  if (prop?.type === "resource") {
+    const resource = resources.get(prop.value);
+    if (resource) {
+      expression = resource.url;
+      computedValue = computeExpression(resource.url, variableValues);
+    }
+  }
+
+  const updateResourceUrl = (urlExpression: string) => {
+    updateWebstudioData((data) => {
+      if (prop?.type === "resource") {
+        const resource = data.resources.get(prop.value);
+        if (resource) {
+          resource.url = urlExpression;
+        }
+      } else {
+        const newResource: Resource = {
+          id: nanoid(),
+          name: propName,
+          url: urlExpression,
+          method: "get",
+          headers: [{ name: "Content-Type", value: "application/json" }],
+        };
+        const newProp: Prop = {
+          id: prop?.id ?? nanoid(),
+          instanceId,
+          name: propName,
+          type: "resource",
+          value: newResource.id,
+        };
+        data.props.set(newProp.id, newProp);
+        data.resources.set(newResource.id, newResource);
+      }
+    });
+  };
+
+  const deletePropAndResource = () => {
+    updateWebstudioData((data) => {
+      if (prop?.type === "resource") {
+        data.resources.delete(prop.value);
+      }
+      if (prop) {
+        data.props.delete(prop.id);
+      }
+    });
+  };
+
+  const id = useId();
+  const label = humanizeAttribute(meta.label || propName);
+  let variant: BindingVariant = "bound";
+  let readOnly = true;
+  if (isLiteralExpression(expression)) {
+    variant = "default";
+    readOnly = false;
+  }
+  const localValue = useLocalValue(String(computedValue ?? ""), (value) =>
+    updateResourceUrl(JSON.stringify(value))
+  );
+
+  return (
+    <ResponsiveLayout
+      label={
+        <Label htmlFor={id} description={meta.description} readOnly={readOnly}>
+          {label}
+        </Label>
+      }
+      deletable={deletable}
+      onDelete={deletePropAndResource}
+    >
+      <BindingControl>
+        <InputField
+          id={id}
+          disabled={readOnly}
+          value={localValue.value}
+          onChange={(event) => localValue.set(event.target.value)}
+          onBlur={localValue.save}
+          onSubmit={localValue.save}
+        />
+        <BindingPopover
+          scope={scope}
+          aliases={aliases}
+          validate={(value) => {
+            if (value !== undefined && typeof value !== "string") {
+              return `${label} expects a string value`;
+            }
+          }}
+          variant={variant}
+          value={expression}
+          onChange={(newExpression) => updateResourceUrl(newExpression)}
+          onRemove={(evaluatedValue) =>
+            updateResourceUrl(JSON.stringify(String(evaluatedValue)))
+          }
+        />
+      </BindingControl>
+    </ResponsiveLayout>
+  );
+};

--- a/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
@@ -58,7 +58,7 @@ export const ResourceControl = ({
           resource.url = urlExpression;
         }
       } else {
-        let method: Resource["method"] = "get";
+        let method: Resource["method"] = "post";
         for (const prop of data.props.values()) {
           if (
             prop.instanceId === instanceId &&
@@ -83,7 +83,7 @@ export const ResourceControl = ({
           name: propName,
           url: urlExpression,
           method,
-          headers: [{ name: "Content-Type", value: "application/json" }],
+          headers: [{ name: "Content-Type", value: `"application/json"` }],
         };
         const newProp: Prop = {
           id: prop?.id ?? nanoid(),

--- a/apps/builder/app/builder/features/settings-panel/controls/text.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef } from "react";
+import { useId } from "react";
 import { useStore } from "@nanostores/react";
 import { TextArea } from "@webstudio-is/design-system";
 import {
@@ -22,7 +22,6 @@ export const TextControl = ({
   propName,
   deletable,
   computedValue,
-  autoFocus,
   onChange,
   onDelete,
 }: ControlProps<"text">) => {
@@ -35,7 +34,6 @@ export const TextControl = ({
   });
   const id = useId();
   const label = humanizeAttribute(meta.label || propName);
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const { scope, aliases } = useStore($selectedInstanceScope);
   const expression =
     prop?.type === "expression" ? prop.value : JSON.stringify(computedValue);
@@ -43,16 +41,9 @@ export const TextControl = ({
     prop?.type === "expression" ? prop.value : undefined
   );
 
-  useEffect(() => {
-    if (autoFocus) {
-      textAreaRef.current?.focus();
-    }
-  }, [autoFocus]);
-
   const input = (
     <BindingControl>
       <TextArea
-        ref={textAreaRef}
         id={id}
         disabled={overwritable === false}
         autoGrow

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -59,10 +59,9 @@ const matchOrSuggestToCreate = (
 const renderProperty = (
   { propsLogic: logic, propValues, component, instanceId }: PropsSectionProps,
   { prop, propName, meta }: PropAndMeta,
-  { deletable, autoFocus }: { deletable?: boolean; autoFocus?: boolean } = {}
+  { deletable }: { deletable?: boolean } = {}
 ) =>
   renderControl({
-    autoFocus,
     key: propName,
     instanceId,
     meta,

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -72,7 +72,6 @@ export type ControlProps<Control> = {
   deletable: boolean;
   onChange: (value: PropValue) => void;
   onDelete: () => void;
-  autoFocus?: boolean;
 };
 
 export const RemovePropButton = (props: { onClick: () => void }) => (

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -570,11 +570,18 @@ const computeResource = (
 };
 
 const $computedResources = computed(
-  [$resources, $loaderVariableValues],
-  (resources, values) => {
+  [$dataSources, $resources, $loaderVariableValues],
+  (dataSources, resources, values) => {
     const computedResources: ResourceRequest[] = [];
-    for (const resource of resources.values()) {
-      computedResources.push(computeResource(resource, values));
+    // load only resources bound to variables
+    // action resources should not be loaded automatically
+    for (const dataSource of dataSources.values()) {
+      if (dataSource.type === "resource") {
+        const resource = resources.get(dataSource.resourceId);
+        if (resource) {
+          computedResources.push(computeResource(resource, values));
+        }
+      }
     }
     return computedResources;
   }

--- a/fixtures/react-router-docker/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-docker/app/routes/[another-page]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/react-router-docker/app/routes/_index.tsx
+++ b/fixtures/react-router-docker/app/routes/_index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/react-router-netlify/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-netlify/app/routes/[another-page]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/react-router-netlify/app/routes/_index.tsx
+++ b/fixtures/react-router-netlify/app/routes/_index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/react-router-vercel/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-vercel/app/routes/[another-page]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/react-router-vercel/app/routes/_index.tsx
+++ b/fixtures/react-router-vercel/app/routes/_index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
@@ -232,10 +232,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -232,10 +232,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[form]._index.server.tsx
@@ -9,7 +9,7 @@ export const getResources = (_props: { system: System }) => {
     name: "action",
     url: "/custom",
     method: "get",
-    headers: [],
+    headers: [{ name: "Content-Type", value: undefined / undefined }],
   };
   const _data = new Map<string, ResourceRequest>([]);
   const _action = new Map<string, ResourceRequest>([["action", action]]);

--- a/fixtures/webstudio-features/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[form]._index.server.tsx
@@ -9,7 +9,7 @@ export const getResources = (_props: { system: System }) => {
     name: "action",
     url: "/custom",
     method: "get",
-    headers: [{ name: "Content-Type", value: undefined / undefined }],
+    headers: [{ name: "Content-Type", value: "application/json" }],
   };
   const _data = new Map<string, ResourceRequest>([]);
   const _action = new Map<string, ResourceRequest>([["action", action]]);

--- a/fixtures/webstudio-features/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[_route_with_symbols_]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/routes/[animations]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[animations]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/routes/[class-names]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[class-names]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/routes/[content-block]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[content-block]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/routes/[expressions]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[expressions]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[form]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/routes/[head-tag]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[head-tag]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[heading-with-id]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[nested].[nested-page]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[radix]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[resources]._index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/fixtures/webstudio-features/app/routes/_index.tsx
+++ b/fixtures/webstudio-features/app/routes/_index.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -232,10 +232,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/packages/cli/templates/react-router/app/route-templates/html.tsx
+++ b/packages/cli/templates/react-router/app/route-templates/html.tsx
@@ -231,10 +231,6 @@ export const action = async ({
     formData.delete(formBotFieldName);
 
     if (resource) {
-      resource.headers.push({
-        name: "Content-Type",
-        value: "application/json",
-      });
       resource.body = Object.fromEntries(formData);
     } else {
       if (contactEmail === undefined) {

--- a/packages/sdk-components-react/src/webhook-form.ws.ts
+++ b/packages/sdk-components-react/src/webhook-form.ws.ts
@@ -21,6 +21,15 @@ export const meta: WsComponentMeta = {
 };
 
 export const propsMeta: WsComponentPropsMeta = {
-  props,
+  props: {
+    ...props,
+    action: {
+      type: "resource",
+      control: "resource",
+      description:
+        "The URI of a program that processes the information submitted via the form.",
+      required: true,
+    },
+  },
   initialProps: ["id", "className", "state", "action"],
 };

--- a/packages/sdk/src/resources-generator.test.tsx
+++ b/packages/sdk/src/resources-generator.test.tsx
@@ -385,7 +385,7 @@ test("replace form action with resource", () => {
   expect(data.resources).toEqual(
     toMap([
       {
-        headers: [{ name: "Content-Type", value: "application/json" }],
+        headers: [{ name: "Content-Type", value: `"application/json"` }],
         id: "formId",
         method: "post",
         name: "action",

--- a/packages/sdk/src/resources-generator.test.tsx
+++ b/packages/sdk/src/resources-generator.test.tsx
@@ -385,7 +385,7 @@ test("replace form action with resource", () => {
   expect(data.resources).toEqual(
     toMap([
       {
-        headers: [],
+        headers: [{ name: "Content-Type", value: "application/json" }],
         id: "formId",
         method: "post",
         name: "action",

--- a/packages/sdk/src/resources-generator.ts
+++ b/packages/sdk/src/resources-generator.ts
@@ -184,7 +184,9 @@ export const replaceFormActionsWithResources = ({
         name: "action",
         method: getMethod(method),
         url: JSON.stringify(action),
-        headers: [{ name: "Content-Type", value: "application/json" }],
+        headers: [
+          { name: "Content-Type", value: JSON.stringify("application/json") },
+        ],
       });
     }
   }

--- a/packages/sdk/src/resources-generator.ts
+++ b/packages/sdk/src/resources-generator.ts
@@ -184,7 +184,7 @@ export const replaceFormActionsWithResources = ({
         name: "action",
         method: getMethod(method),
         url: JSON.stringify(action),
-        headers: [],
+        headers: [{ name: "Content-Type", value: "application/json" }],
       });
     }
   }

--- a/packages/sdk/src/schema/prop-meta.ts
+++ b/packages/sdk/src/schema/prop-meta.ts
@@ -42,6 +42,13 @@ const Text = z.object({
   rows: z.number().optional(),
 });
 
+const Resource = z.object({
+  ...common,
+  control: z.literal("resource"),
+  type: z.literal("resource"),
+  defaultValue: z.string().optional(),
+});
+
 const Code = z.object({
   ...common,
   control: z.literal("code"),
@@ -178,6 +185,7 @@ export const PropMeta = z.union([
   Number,
   Range,
   Text,
+  Resource,
   Code,
   CodeText,
   Color,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/4093

Here's refactoring to unlock resource UI in webhook form

Need to test in builder and on published site

1. Create webhook form in main and try to update it on this branch. So legacy text prop should automatically migrate to resource.

2. New webhook form should create resource when type anything in action prop