### PR TITLE
build: upgrade typescript

### DIFF
--- a/apps/builder/app/builder/shared/expression-editor.tsx
+++ b/apps/builder/app/builder/shared/expression-editor.tsx
@@ -255,8 +255,10 @@ const scopeCompletionSource: CompletionSource = (context) => {
  */
 
 class VariableWidget extends WidgetType {
-  constructor(readonly text: string) {
+  text: string;
+  constructor(text: string) {
     super();
+    this.text = text;
   }
   toDOM(): HTMLElement {
     const span = document.createElement("span");

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -125,7 +125,7 @@
   "devDependencies": {
     "@remix-run/dev": "^2.16.0",
     "@types/debug": "^4.1.12",
-    "@types/dom-navigation": "^1.0.4",
+    "@types/dom-navigation": "^1.0.5",
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
     "@webstudio-is/tsconfig": "workspace:*",
@@ -133,8 +133,8 @@
     "html-tags": "^4.0.0",
     "react-router-dom": "^6.30.0",
     "react-test-renderer": "18.3.0-canary-14898b6a9-20240318",
-    "type-fest": "^4.32.0",
-    "typescript": "5.7.3",
+    "type-fest": "^4.37.0",
+    "typescript": "5.8.2",
     "vite": "^5.4.11",
     "vitest": "^3.0.8"
   },

--- a/fixtures/react-router-docker/package.json
+++ b/fixtures/react-router-docker/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
-    "typescript": "5.7.3"
+    "typescript": "5.8.2"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/fixtures/react-router-netlify/package.json
+++ b/fixtures/react-router-netlify/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
-    "typescript": "5.7.3"
+    "typescript": "5.8.2"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/fixtures/react-router-vercel/package.json
+++ b/fixtures/react-router-vercel/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
-    "typescript": "5.7.3"
+    "typescript": "5.8.2"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/fixtures/ssg-netlify-by-project-id/package.json
+++ b/fixtures/ssg-netlify-by-project-id/package.json
@@ -26,7 +26,7 @@
     "@types/react-dom": "^18.2.25",
     "@vitejs/plugin-react": "^4.3.4",
     "prettier": "3.5.3",
-    "typescript": "5.7.3",
+    "typescript": "5.8.2",
     "vite": "^5.4.11",
     "webstudio": "workspace:*"
   },

--- a/fixtures/ssg/package.json
+++ b/fixtures/ssg/package.json
@@ -26,7 +26,7 @@
     "@types/react-dom": "^18.2.25",
     "@vitejs/plugin-react": "^4.3.4",
     "prettier": "3.5.3",
-    "typescript": "5.7.3",
+    "typescript": "5.8.2",
     "vite": "^5.4.11",
     "webstudio": "workspace:*"
   },

--- a/fixtures/webstudio-cloudflare-template/package.json
+++ b/fixtures/webstudio-cloudflare-template/package.json
@@ -51,9 +51,9 @@
     "@remix-run/dev": "2.16.0",
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
-    "typescript": "5.7.3",
+    "fast-glob": "^3.3.2",
+    "typescript": "5.8.2",
     "vite": "^5.4.11",
-    "wrangler": "^3.63.2",
-    "fast-glob": "^3.3.2"
+    "wrangler": "^3.63.2"
   }
 }

--- a/fixtures/webstudio-features/package.json
+++ b/fixtures/webstudio-features/package.json
@@ -34,7 +34,7 @@
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
     "fast-glob": "^3.3.2",
-    "typescript": "5.7.3",
+    "typescript": "5.8.2",
     "webstudio": "workspace:*"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@storybook/react": "^8.6.4",
     "@storybook/react-vite": "^8.6.4",
     "@types/css-tree": "^2.3.1",
-    "@types/node": "^22.10.7",
+    "@types/node": "^22.13.10",
     "@types/react": "^18.2.70",
     "esbuild": "^0.25.1",
     "eslint": "^9.22.0",
@@ -50,7 +50,7 @@
     "simple-git-hooks": "^2.11.1",
     "storybook": "^8.6.4",
     "tsx": "^4.19.3",
-    "typescript": "5.7.3",
+    "typescript": "5.8.2",
     "typescript-eslint": "^8.26.1",
     "vite": "^5.4.11"
   },

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@webstudio-is/tsconfig": "workspace:*",
-    "type-fest": "^4.32.0"
+    "type-fest": "^4.37.0"
   },
   "exports": {
     ".": {

--- a/packages/cli/templates/defaults/package.json
+++ b/packages/cli/templates/defaults/package.json
@@ -26,7 +26,7 @@
     "@remix-run/dev": "2.16.0",
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
-    "typescript": "5.7.3",
+    "typescript": "5.8.2",
     "vite": "^5.4.11"
   },
   "engines": {

--- a/packages/cli/templates/react-router/package.json
+++ b/packages/cli/templates/react-router/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
-    "typescript": "5.7.3"
+    "typescript": "5.8.2"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/cli/templates/ssg/package.json
+++ b/packages/cli/templates/ssg/package.json
@@ -22,7 +22,7 @@
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
     "@vitejs/plugin-react": "^4.3.4",
-    "typescript": "5.7.3",
+    "typescript": "5.8.2",
     "vite": "^5.4.11"
   },
   "engines": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@webstudio-is/project": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
-    "type-fest": "^4.32.0",
+    "type-fest": "^4.37.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -65,7 +65,7 @@
     "match-sorter": "^8.0.0",
     "react-hot-toast": "^2.5.1",
     "token-transformer": "^0.0.28",
-    "type-fest": "^4.32.0",
+    "type-fest": "^4.37.0",
     "use-debounce": "^10.0.4",
     "warn-once": "^0.1.1"
   },

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -15,7 +15,7 @@
     "@webstudio-is/sdk": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",
     "nanoid": "^5.0.9",
-    "type-fest": "^4.32.0",
+    "type-fest": "^4.37.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/generate-arg-types/package.json
+++ b/packages/generate-arg-types/package.json
@@ -13,7 +13,7 @@
     "@webstudio-is/sdk": "workspace:*",
     "fast-glob": "^3.3.2",
     "react-docgen-typescript": "^2.2.2",
-    "typescript": "5.7.3",
+    "typescript": "5.8.2",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/jsx-utils/package.json
+++ b/packages/jsx-utils/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@webstudio-is/tsconfig": "workspace:^",
     "fast-glob": "^3.3.2",
-    "type-fest": "^4.32.0",
+    "type-fest": "^4.37.0",
     "vitest": "^3.0.8"
   },
   "exports": {

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -15,7 +15,7 @@
     "@webstudio-is/trpc-interface": "workspace:*",
     "nanoid": "^5.0.9",
     "slugify": "^1.6.6",
-    "type-fest": "^4.32.0",
+    "type-fest": "^4.37.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -19,7 +19,7 @@
     "react": "18.3.0-canary-14898b6a9-20240318",
     "react-dom": "18.3.0-canary-14898b6a9-20240318",
     "strip-indent": "^4.0.0",
-    "type-fest": "^4.32.0",
+    "type-fest": "^4.37.0",
     "vitest": "^3.0.8",
     "zod": "^3.22.4"
   },

--- a/packages/sdk-components-animation/package.json
+++ b/packages/sdk-components-animation/package.json
@@ -78,7 +78,7 @@
     "playwright": "^1.50.1",
     "react": "18.3.0-canary-14898b6a9-20240318",
     "react-dom": "18.3.0-canary-14898b6a9-20240318",
-    "type-fest": "^4.32.0",
+    "type-fest": "^4.37.0",
     "vitest": "^3.0.8",
     "zod": "^3.22.4"
   }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -48,7 +48,7 @@
     "acorn-walk": "^8.3.4",
     "change-case": "^5.4.4",
     "reserved-identifiers": "^1.0.0",
-    "type-fest": "^4.32.0",
+    "type-fest": "^4.37.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -17,6 +17,7 @@
     "skipLibCheck": true,
     "strict": true,
     "strictBuiltinIteratorReturn": true,
+    "erasableSyntaxOnly": true,
     "allowJs": false,
     "jsx": "react-jsx",
     "resolveJsonModule": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,16 +57,16 @@ importers:
         version: 8.6.4(storybook@8.6.4(prettier@3.5.3))
       '@storybook/react':
         specifier: ^8.6.4
-        version: 8.6.4(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(storybook@8.6.4(prettier@3.5.3))(typescript@5.7.3)
+        version: 8.6.4(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)
       '@storybook/react-vite':
         specifier: ^8.6.4
-        version: 8.6.4(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(rollup@4.24.0)(storybook@8.6.4(prettier@3.5.3))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))
+        version: 8.6.4(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(rollup@4.24.0)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))
       '@types/css-tree':
         specifier: ^2.3.1
         version: 2.3.1(patch_hash=ac22lciodhaj6xmoeignv36gyq)
       '@types/node':
-        specifier: ^22.10.7
-        version: 22.10.7
+        specifier: ^22.13.10
+        version: 22.13.10
       '@types/react':
         specifier: ^18.2.70
         version: 18.2.79
@@ -104,14 +104,14 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
       typescript-eslint:
         specifier: ^8.26.1
-        version: 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)
+        version: 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       vite:
         specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        version: 5.4.11(@types/node@22.13.10)
 
   apps/builder:
     dependencies:
@@ -207,16 +207,16 @@ importers:
         version: 3.27.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       '@remix-run/node':
         specifier: ^2.16.0
-        version: 2.16.0(typescript@5.7.3)
+        version: 2.16.0(typescript@5.8.2)
       '@remix-run/react':
         specifier: ^2.16.0
-        version: 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3)
+        version: 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2)
       '@remix-run/serve':
         specifier: ^2.16.0
-        version: 2.16.0(typescript@5.7.3)
+        version: 2.16.0(typescript@5.8.2)
       '@remix-run/server-runtime':
         specifier: ^2.16.0
-        version: 2.16.0(typescript@5.7.3)
+        version: 2.16.0(typescript@5.8.2)
       '@trpc/client':
         specifier: ^10.45.2
         version: 10.45.2(@trpc/server@10.45.2)
@@ -228,7 +228,7 @@ importers:
         version: 2.5.3
       '@vercel/remix':
         specifier: 2.15.3
-        version: 2.15.3(@remix-run/dev@2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/serve@2.16.0(typescript@5.7.3))(@types/node@22.10.7)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(@remix-run/node@2.16.0(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
+        version: 2.15.3(@remix-run/dev@2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/serve@2.16.0(typescript@5.8.2))(@types/node@22.13.10)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(@remix-run/node@2.16.0(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       '@webstudio-is/ai':
         specifier: workspace:*
         version: link:../../packages/ai
@@ -381,19 +381,19 @@ importers:
         version: 1.7.2(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       remix-auth:
         specifier: ^3.7.0
-        version: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))
+        version: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))
       remix-auth-form:
         specifier: ^1.5.0
-        version: 1.5.0(@remix-run/server-runtime@2.16.0(typescript@5.7.3))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3)))
+        version: 1.5.0(@remix-run/server-runtime@2.16.0(typescript@5.8.2))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2)))
       remix-auth-github:
         specifier: ^1.7.0
-        version: 1.7.0(@remix-run/server-runtime@2.16.0(typescript@5.7.3))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3)))
+        version: 1.7.0(@remix-run/server-runtime@2.16.0(typescript@5.8.2))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2)))
       remix-auth-google:
         specifier: ^2.0.0
-        version: 2.0.0(@remix-run/server-runtime@2.16.0(typescript@5.7.3))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3)))
+        version: 2.0.0(@remix-run/server-runtime@2.16.0(typescript@5.8.2))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2)))
       remix-auth-oauth2:
         specifier: ^2.3.0
-        version: 2.3.0(@remix-run/cloudflare@2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.7.3))(@remix-run/node@2.16.0(typescript@5.7.3))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3)))
+        version: 2.3.0(@remix-run/cloudflare@2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.8.2))(@remix-run/node@2.16.0(typescript@5.8.2))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2)))
       shallow-equal:
         specifier: ^3.1.0
         version: 3.1.0
@@ -430,13 +430,13 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.16.0
-        version: 2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/serve@2.16.0(typescript@5.7.3))(@types/node@22.10.7)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
+        version: 2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/serve@2.16.0(typescript@5.8.2))(@types/node@22.13.10)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
       '@types/dom-navigation':
-        specifier: ^1.0.4
-        version: 1.0.4
+        specifier: ^1.0.5
+        version: 1.0.5
       '@types/react':
         specifier: ^18.2.70
         version: 18.2.79
@@ -459,32 +459,32 @@ importers:
         specifier: 18.3.0-canary-14898b6a9-20240318
         version: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       type-fest:
-        specifier: ^4.32.0
-        version: 4.32.0
+        specifier: ^4.37.0
+        version: 4.37.0
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
       vite:
         specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        version: 5.4.11(@types/node@22.13.10)
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
 
   fixtures/react-router-docker:
     dependencies:
       '@react-router/dev':
         specifier: ^7.3.0
-        version: 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
+        version: 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
       '@react-router/fs-routes':
         specifier: ^7.3.0
-        version: 7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.7.3)
+        version: 7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.8.2)
       '@react-router/node':
         specifier: ^7.3.0
-        version: 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
+        version: 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
       '@react-router/serve':
         specifier: ^7.3.0
-        version: 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
+        version: 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
       '@webstudio-is/image':
         specifier: workspace:*
         version: link:../../packages/image
@@ -526,7 +526,7 @@ importers:
         version: 7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       vite:
         specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        version: 5.4.11(@types/node@22.13.10)
       webstudio:
         specifier: workspace:*
         version: link:../../packages/cli
@@ -538,23 +538,23 @@ importers:
         specifier: ^18.2.25
         version: 18.2.25
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
 
   fixtures/react-router-netlify:
     dependencies:
       '@netlify/vite-plugin-react-router':
         specifier: ^1.0.0
-        version: 1.0.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))
+        version: 1.0.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))
       '@react-router/dev':
         specifier: ^7.3.0
-        version: 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
+        version: 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
       '@react-router/fs-routes':
         specifier: ^7.3.0
-        version: 7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.7.3)
+        version: 7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.8.2)
       '@react-router/node':
         specifier: ^7.3.0
-        version: 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
+        version: 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
       '@webstudio-is/image':
         specifier: workspace:*
         version: link:../../packages/image
@@ -590,7 +590,7 @@ importers:
         version: 7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       vite:
         specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        version: 5.4.11(@types/node@22.13.10)
       webstudio:
         specifier: workspace:*
         version: link:../../packages/cli
@@ -602,23 +602,23 @@ importers:
         specifier: ^18.2.25
         version: 18.2.25
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
 
   fixtures/react-router-vercel:
     dependencies:
       '@react-router/dev':
         specifier: ^7.3.0
-        version: 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
+        version: 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
       '@react-router/fs-routes':
         specifier: ^7.3.0
-        version: 7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.7.3)
+        version: 7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.8.2)
       '@react-router/node':
         specifier: ^7.3.0
-        version: 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
+        version: 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
       '@vercel/react-router':
         specifier: ^1.1.0
-        version: 1.1.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(@react-router/node@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(isbot@5.1.23)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
+        version: 1.1.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(@react-router/node@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(isbot@5.1.23)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       '@webstudio-is/image':
         specifier: workspace:*
         version: link:../../packages/image
@@ -654,7 +654,7 @@ importers:
         version: 7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       vite:
         specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        version: 5.4.11(@types/node@22.13.10)
       webstudio:
         specifier: workspace:*
         version: link:../../packages/cli
@@ -666,8 +666,8 @@ importers:
         specifier: ^18.2.25
         version: 18.2.25
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
 
   fixtures/ssg:
     dependencies:
@@ -700,7 +700,7 @@ importers:
         version: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       vike:
         specifier: ^0.4.224
-        version: 0.4.224(vite@5.4.11(@types/node@22.10.7))
+        version: 0.4.224(vite@5.4.11(@types/node@22.13.10))
     devDependencies:
       '@types/react':
         specifier: ^18.2.70
@@ -710,16 +710,16 @@ importers:
         version: 18.2.25
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@5.4.11(@types/node@22.10.7))
+        version: 4.3.4(vite@5.4.11(@types/node@22.13.10))
       prettier:
         specifier: 3.5.3
         version: 3.5.3
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
       vite:
         specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        version: 5.4.11(@types/node@22.13.10)
       webstudio:
         specifier: workspace:*
         version: link:../../packages/cli
@@ -755,7 +755,7 @@ importers:
         version: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       vike:
         specifier: ^0.4.224
-        version: 0.4.224(vite@5.4.11(@types/node@22.10.7))
+        version: 0.4.224(vite@5.4.11(@types/node@22.13.10))
     devDependencies:
       '@types/react':
         specifier: ^18.2.70
@@ -765,16 +765,16 @@ importers:
         version: 18.2.25
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@5.4.11(@types/node@22.10.7))
+        version: 4.3.4(vite@5.4.11(@types/node@22.13.10))
       prettier:
         specifier: 3.5.3
         version: 3.5.3
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
       vite:
         specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        version: 5.4.11(@types/node@22.13.10)
       webstudio:
         specifier: workspace:*
         version: link:../../packages/cli
@@ -783,19 +783,19 @@ importers:
     dependencies:
       '@remix-run/cloudflare':
         specifier: 2.16.0
-        version: 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.7.3)
+        version: 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.8.2)
       '@remix-run/cloudflare-pages':
         specifier: 2.16.0
-        version: 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.7.3)
+        version: 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.8.2)
       '@remix-run/node':
         specifier: 2.16.0
-        version: 2.16.0(typescript@5.7.3)
+        version: 2.16.0(typescript@5.8.2)
       '@remix-run/react':
         specifier: 2.16.0
-        version: 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3)
+        version: 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2)
       '@remix-run/server-runtime':
         specifier: 2.16.0
-        version: 2.16.0(typescript@5.7.3)
+        version: 2.16.0(typescript@5.8.2)
       '@webstudio-is/image':
         specifier: workspace:*
         version: link:../../packages/image
@@ -841,7 +841,7 @@ importers:
         version: 4.20240701.0
       '@remix-run/dev':
         specifier: 2.16.0
-        version: 2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/serve@2.16.0(typescript@5.7.3))(@types/node@22.10.7)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
+        version: 2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/serve@2.16.0(typescript@5.8.2))(@types/node@22.13.10)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
       '@types/react':
         specifier: ^18.2.70
         version: 18.2.79
@@ -852,11 +852,11 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
       vite:
         specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        version: 5.4.11(@types/node@22.13.10)
       wrangler:
         specifier: ^3.63.2
         version: 3.63.2(@cloudflare/workers-types@4.20240701.0)
@@ -868,13 +868,13 @@ importers:
         version: 2.14.4
       '@react-router/dev':
         specifier: ^7.3.0
-        version: 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
+        version: 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
       '@react-router/fs-routes':
         specifier: ^7.3.0
-        version: 7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.7.3)
+        version: 7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.8.2)
       '@react-router/node':
         specifier: ^7.3.0
-        version: 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
+        version: 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
       '@webstudio-is/image':
         specifier: workspace:*
         version: link:../../packages/image
@@ -910,7 +910,7 @@ importers:
         version: 7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       vite:
         specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        version: 5.4.11(@types/node@22.13.10)
       webstudio:
         specifier: workspace:*
         version: link:../../packages/cli
@@ -925,8 +925,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
 
   packages/ai:
     dependencies:
@@ -1012,7 +1012,7 @@ importers:
         version: link:../tsconfig
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1033,8 +1033,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       type-fest:
-        specifier: ^4.32.0
-        version: 4.32.0
+        specifier: ^4.37.0
+        version: 4.37.0
 
   packages/cli:
     dependencies:
@@ -1086,31 +1086,31 @@ importers:
     devDependencies:
       '@netlify/vite-plugin-react-router':
         specifier: ^1.0.0
-        version: 1.0.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))
+        version: 1.0.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))
       '@react-router/dev':
         specifier: ^7.3.0
-        version: 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
+        version: 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
       '@react-router/fs-routes':
         specifier: ^7.3.0
-        version: 7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.7.3)
+        version: 7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.8.2)
       '@remix-run/cloudflare':
         specifier: ^2.16.0
-        version: 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.7.3)
+        version: 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.8.2)
       '@remix-run/cloudflare-pages':
         specifier: ^2.16.0
-        version: 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.7.3)
+        version: 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.8.2)
       '@remix-run/dev':
         specifier: ^2.16.0
-        version: 2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/serve@2.16.0(typescript@5.7.3))(@types/node@22.10.7)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
+        version: 2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/serve@2.16.0(typescript@5.8.2))(@types/node@22.13.10)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
       '@remix-run/node':
         specifier: ^2.16.0
-        version: 2.16.0(typescript@5.7.3)
+        version: 2.16.0(typescript@5.8.2)
       '@remix-run/react':
         specifier: ^2.16.0
-        version: 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3)
+        version: 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2)
       '@remix-run/server-runtime':
         specifier: ^2.16.0
-        version: 2.16.0(typescript@5.7.3)
+        version: 2.16.0(typescript@5.8.2)
       '@types/react':
         specifier: ^18.2.70
         version: 18.2.79
@@ -1122,10 +1122,10 @@ importers:
         version: 17.0.33
       '@vercel/react-router':
         specifier: ^1.1.0
-        version: 1.1.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(@react-router/node@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(isbot@5.1.23)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
+        version: 1.1.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(@react-router/node@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(isbot@5.1.23)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@5.4.11(@types/node@22.10.7))
+        version: 4.3.4(vite@5.4.11(@types/node@22.13.10))
       '@webstudio-is/http-client':
         specifier: workspace:*
         version: link:../http-client
@@ -1179,13 +1179,13 @@ importers:
         version: 1.3.0
       vike:
         specifier: ^0.4.224
-        version: 0.4.224(vite@5.4.11(@types/node@22.10.7))
+        version: 0.4.224(vite@5.4.11(@types/node@22.13.10))
       vite:
         specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        version: 5.4.11(@types/node@22.13.10)
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
       wrangler:
         specifier: ^3.63.2
         version: 3.63.2(@cloudflare/workers-types@4.20240701.0)
@@ -1237,7 +1237,7 @@ importers:
         version: 2.8.0
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1271,7 +1271,7 @@ importers:
         version: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
 
   packages/dashboard:
     dependencies:
@@ -1282,8 +1282,8 @@ importers:
         specifier: workspace:*
         version: link:../trpc-interface
       type-fest:
-        specifier: ^4.32.0
-        version: 4.32.0
+        specifier: ^4.37.0
+        version: 4.37.0
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1415,8 +1415,8 @@ importers:
         specifier: ^0.0.28
         version: 0.0.28
       type-fest:
-        specifier: ^4.32.0
-        version: 4.32.0
+        specifier: ^4.37.0
+        version: 4.37.0
       use-debounce:
         specifier: ^10.0.4
         version: 10.0.4(react@18.3.0-canary-14898b6a9-20240318)
@@ -1444,7 +1444,7 @@ importers:
         version: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1470,8 +1470,8 @@ importers:
         specifier: ^5.0.9
         version: 5.0.9
       type-fest:
-        specifier: ^4.32.0
-        version: 4.32.0
+        specifier: ^4.37.0
+        version: 4.37.0
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1493,7 +1493,7 @@ importers:
         version: link:../tsconfig
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1511,10 +1511,10 @@ importers:
         version: 3.3.2
       react-docgen-typescript:
         specifier: ^2.2.2
-        version: 2.2.2(typescript@5.7.3)
+        version: 2.2.2(typescript@5.8.2)
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1540,7 +1540,7 @@ importers:
         version: link:../tsconfig
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
 
   packages/icons:
     devDependencies:
@@ -1592,7 +1592,7 @@ importers:
         version: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
 
   packages/jsx-utils:
     dependencies:
@@ -1622,11 +1622,11 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       type-fest:
-        specifier: ^4.32.0
-        version: 4.32.0
+        specifier: ^4.37.0
+        version: 4.37.0
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
 
   packages/postgrest:
     dependencies:
@@ -1684,8 +1684,8 @@ importers:
         specifier: ^1.6.6
         version: 1.6.6
       type-fest:
-        specifier: ^4.32.0
-        version: 4.32.0
+        specifier: ^4.37.0
+        version: 4.37.0
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1720,7 +1720,7 @@ importers:
         version: link:../tsconfig
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
 
   packages/react-sdk:
     dependencies:
@@ -1771,11 +1771,11 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       type-fest:
-        specifier: ^4.32.0
-        version: 4.32.0
+        specifier: ^4.37.0
+        version: 4.37.0
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1804,8 +1804,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       type-fest:
-        specifier: ^4.32.0
-        version: 4.32.0
+        specifier: ^4.37.0
+        version: 4.37.0
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1824,7 +1824,7 @@ importers:
         version: 4.0.0
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
 
   packages/sdk-cli:
     dependencies:
@@ -1880,7 +1880,7 @@ importers:
         version: 18.2.25
       '@vitest/browser':
         specifier: ^3.0.8
-        version: 3.0.8(@testing-library/dom@10.4.0)(@types/node@22.10.7)(playwright@1.50.1)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(vitest@3.0.8)
+        version: 3.0.8(@testing-library/dom@10.4.0)(@types/node@22.13.10)(playwright@1.50.1)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(vitest@3.0.8)
       '@webstudio-is/css-data':
         specifier: workspace:*
         version: link:../css-data
@@ -1915,11 +1915,11 @@ importers:
         specifier: 18.3.0-canary-14898b6a9-20240318
         version: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       type-fest:
-        specifier: ^4.32.0
-        version: 4.32.0
+        specifier: ^4.37.0
+        version: 4.37.0
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1986,7 +1986,7 @@ importers:
         version: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
 
   packages/sdk-components-react-radix:
     dependencies:
@@ -2090,7 +2090,7 @@ importers:
     devDependencies:
       '@remix-run/react':
         specifier: ^2.16.0
-        version: 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3)
+        version: 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2)
       '@types/react':
         specifier: ^18.2.70
         version: 18.2.79
@@ -2161,7 +2161,7 @@ importers:
         version: link:../tsconfig
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
 
   packages/trpc-interface:
     dependencies:
@@ -2189,7 +2189,7 @@ importers:
         version: link:../tsconfig
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
 
   packages/tsconfig: {}
 
@@ -5141,8 +5141,8 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
-  '@types/dom-navigation@1.0.4':
-    resolution: {integrity: sha512-s4pCS4jogEzXQsqoPZdLU+GA/5Wq+GoFsgiN2VGI8tw5I2Y/CftGJpC76iVhyoD7JTTEo+p0w+eh8SItMaxmgg==}
+  '@types/dom-navigation@1.0.5':
+    resolution: {integrity: sha512-aM1Mr488jX62+6b9zdEtPHFnI7ILgvbII4BaBJMaqhhbDBupJJJ8+nXFVyQT1ptujOUAg6Sojkjk3j6rU73Bwg==}
 
   '@types/estree-jsx@1.0.0':
     resolution: {integrity: sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==}
@@ -5177,8 +5177,8 @@ packages:
   '@types/node@18.17.1':
     resolution: {integrity: sha512-xlR1jahfizdplZYRU59JlUx9uzF1ARa8jbhM11ccpCJya8kvos5jwdm2ZAgxSCwOl0fq21svP18EVwPBXMQudw==}
 
-  '@types/node@22.10.7':
-    resolution: {integrity: sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==}
+  '@types/node@22.13.10':
+    resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -8794,8 +8794,8 @@ packages:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
 
-  type-fest@4.32.0:
-    resolution: {integrity: sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==}
+  type-fest@4.37.0:
+    resolution: {integrity: sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==}
     engines: {node: '>=16'}
 
   type-is@1.6.18:
@@ -8809,8 +8809,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10412,17 +10412,17 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@inquirer/confirm@5.1.5(@types/node@22.10.7)':
+  '@inquirer/confirm@5.1.5(@types/node@22.13.10)':
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.10.7)
-      '@inquirer/type': 3.0.4(@types/node@22.10.7)
+      '@inquirer/core': 10.1.6(@types/node@22.13.10)
+      '@inquirer/type': 3.0.4(@types/node@22.13.10)
     optionalDependencies:
-      '@types/node': 22.10.7
+      '@types/node': 22.13.10
 
-  '@inquirer/core@10.1.6(@types/node@22.10.7)':
+  '@inquirer/core@10.1.6(@types/node@22.13.10)':
     dependencies:
       '@inquirer/figures': 1.0.10
-      '@inquirer/type': 3.0.4(@types/node@22.10.7)
+      '@inquirer/type': 3.0.4(@types/node@22.13.10)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -10430,13 +10430,13 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.10.7
+      '@types/node': 22.13.10
 
   '@inquirer/figures@1.0.10': {}
 
-  '@inquirer/type@3.0.4(@types/node@22.10.7)':
+  '@inquirer/type@3.0.4(@types/node@22.13.10)':
     optionalDependencies:
-      '@types/node': 22.10.7
+      '@types/node': 22.13.10
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -10447,14 +10447,14 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))':
     dependencies:
       glob: 10.3.3
       magic-string: 0.27.0
-      react-docgen-typescript: 2.2.2(typescript@5.7.3)
-      vite: 5.4.11(@types/node@22.10.7)
+      react-docgen-typescript: 2.2.2(typescript@5.8.2)
+      vite: 5.4.11(@types/node@22.13.10)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
@@ -10741,12 +10741,12 @@ snapshots:
       nanostores: 0.11.3
       react: 18.3.0-canary-14898b6a9-20240318
 
-  '@netlify/vite-plugin-react-router@1.0.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))':
+  '@netlify/vite-plugin-react-router@1.0.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))':
     dependencies:
-      '@react-router/node': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
+      '@react-router/node': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
       isbot: 5.1.23
       react-router: 7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.13.10)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -11633,7 +11633,7 @@ snapshots:
       react: 18.3.0-canary-14898b6a9-20240318
       react-dom: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
 
-  '@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))':
+  '@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.2
@@ -11644,7 +11644,7 @@ snapshots:
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
       '@npmcli/package-json': 4.0.1
-      '@react-router/node': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
+      '@react-router/node': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
       arg: 5.0.2
       babel-dead-code-elimination: 1.0.8
       chokidar: 4.0.3
@@ -11661,12 +11661,12 @@ snapshots:
       react-router: 7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       semver: 7.6.3
       set-cookie-parser: 2.6.0
-      valibot: 0.41.0(typescript@5.7.3)
-      vite: 5.4.11(@types/node@22.10.7)
-      vite-node: 3.0.0-beta.2(@types/node@22.10.7)
+      valibot: 0.41.0(typescript@5.8.2)
+      vite: 5.4.11(@types/node@22.13.10)
+      vite-node: 3.0.0-beta.2(@types/node@22.13.10)
     optionalDependencies:
-      '@react-router/serve': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
-      typescript: 5.7.3
+      '@react-router/serve': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
+      typescript: 5.8.2
       wrangler: 3.63.2(@cloudflare/workers-types@4.20240701.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -11681,22 +11681,22 @@ snapshots:
       - supports-color
       - terser
 
-  '@react-router/express@7.3.0(express@4.21.1)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)':
+  '@react-router/express@7.3.0(express@4.21.1)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)':
     dependencies:
-      '@react-router/node': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
+      '@react-router/node': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
       express: 4.21.1
       react-router: 7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
-  '@react-router/fs-routes@7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.7.3)':
+  '@react-router/fs-routes@7.3.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(typescript@5.8.2)':
     dependencies:
-      '@react-router/dev': 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
+      '@react-router/dev': 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
       minimatch: 9.0.4
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
-  '@react-router/node@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)':
+  '@react-router/node@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)':
     dependencies:
       '@mjackson/node-fetch-server': 0.2.0
       react-router: 7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
@@ -11704,12 +11704,12 @@ snapshots:
       stream-slice: 0.1.2
       undici: 6.21.0
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
-  '@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)':
+  '@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)':
     dependencies:
-      '@react-router/express': 7.3.0(express@4.21.1)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
-      '@react-router/node': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
+      '@react-router/express': 7.3.0(express@4.21.1)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
+      '@react-router/node': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
       compression: 1.7.4
       express: 4.21.1
       get-port: 5.1.1
@@ -11729,22 +11729,22 @@ snapshots:
     dependencies:
       react: 18.3.0-canary-14898b6a9-20240318
 
-  '@remix-run/cloudflare-pages@2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.7.3)':
+  '@remix-run/cloudflare-pages@2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.8.2)':
     dependencies:
       '@cloudflare/workers-types': 4.20240701.0
-      '@remix-run/cloudflare': 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.7.3)
+      '@remix-run/cloudflare': 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.8.2)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
-  '@remix-run/cloudflare@2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.7.3)':
+  '@remix-run/cloudflare@2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.8.2)':
     dependencies:
       '@cloudflare/kv-asset-handler': 0.1.3
       '@cloudflare/workers-types': 4.20240701.0
-      '@remix-run/server-runtime': 2.16.0(typescript@5.7.3)
+      '@remix-run/server-runtime': 2.16.0(typescript@5.8.2)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
-  '@remix-run/dev@2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/serve@2.16.0(typescript@5.7.3))(@types/node@22.10.7)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))':
+  '@remix-run/dev@2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/serve@2.16.0(typescript@5.8.2))(@types/node@22.13.10)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.2
@@ -11756,12 +11756,12 @@ snapshots:
       '@babel/types': 7.26.0
       '@mdx-js/mdx': 2.3.0
       '@npmcli/package-json': 4.0.1
-      '@remix-run/node': 2.16.0(typescript@5.7.3)
-      '@remix-run/react': 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3)
+      '@remix-run/node': 2.16.0(typescript@5.8.2)
+      '@remix-run/react': 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2)
       '@remix-run/router': 1.23.0
-      '@remix-run/server-runtime': 2.16.0(typescript@5.7.3)
+      '@remix-run/server-runtime': 2.16.0(typescript@5.8.2)
       '@types/mdx': 2.0.5
-      '@vanilla-extract/integration': 6.5.0(@types/node@22.10.7)
+      '@vanilla-extract/integration': 6.5.0(@types/node@22.13.10)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -11800,13 +11800,13 @@ snapshots:
       set-cookie-parser: 2.6.0
       tar-fs: 2.1.1
       tsconfig-paths: 4.2.0
-      valibot: 0.41.0(typescript@5.7.3)
-      vite-node: 3.0.0-beta.2(@types/node@22.10.7)
+      valibot: 0.41.0(typescript@5.8.2)
+      vite-node: 3.0.0-beta.2(@types/node@22.13.10)
       ws: 7.5.10
     optionalDependencies:
-      '@remix-run/serve': 2.16.0(typescript@5.7.3)
-      typescript: 5.7.3
-      vite: 5.4.11(@types/node@22.10.7)
+      '@remix-run/serve': 2.16.0(typescript@5.8.2)
+      typescript: 5.8.2
+      vite: 5.4.11(@types/node@22.13.10)
       wrangler: 3.63.2(@cloudflare/workers-types@4.20240701.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -11824,16 +11824,16 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@remix-run/express@2.16.0(express@4.21.1)(typescript@5.7.3)':
+  '@remix-run/express@2.16.0(express@4.21.1)(typescript@5.8.2)':
     dependencies:
-      '@remix-run/node': 2.16.0(typescript@5.7.3)
+      '@remix-run/node': 2.16.0(typescript@5.8.2)
       express: 4.21.1
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
-  '@remix-run/node@2.16.0(typescript@5.7.3)':
+  '@remix-run/node@2.16.0(typescript@5.8.2)':
     dependencies:
-      '@remix-run/server-runtime': 2.16.0(typescript@5.7.3)
+      '@remix-run/server-runtime': 2.16.0(typescript@5.8.2)
       '@remix-run/web-fetch': 4.4.2
       '@web3-storage/multipart-parser': 1.0.0
       cookie-signature: 1.2.0
@@ -11841,26 +11841,26 @@ snapshots:
       stream-slice: 0.1.2
       undici: 6.21.0
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
-  '@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3)':
+  '@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2)':
     dependencies:
       '@remix-run/router': 1.23.0
-      '@remix-run/server-runtime': 2.16.0(typescript@5.7.3)
+      '@remix-run/server-runtime': 2.16.0(typescript@5.8.2)
       react: 18.3.0-canary-14898b6a9-20240318
       react-dom: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       react-router: 6.30.0(react@18.3.0-canary-14898b6a9-20240318)
       react-router-dom: 6.30.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       turbo-stream: 2.4.0
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   '@remix-run/router@1.23.0': {}
 
-  '@remix-run/serve@2.16.0(typescript@5.7.3)':
+  '@remix-run/serve@2.16.0(typescript@5.8.2)':
     dependencies:
-      '@remix-run/express': 2.16.0(express@4.21.1)(typescript@5.7.3)
-      '@remix-run/node': 2.16.0(typescript@5.7.3)
+      '@remix-run/express': 2.16.0(express@4.21.1)(typescript@5.8.2)
+      '@remix-run/node': 2.16.0(typescript@5.8.2)
       chokidar: 3.6.0
       compression: 1.7.4
       express: 4.21.1
@@ -11871,7 +11871,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@remix-run/server-runtime@2.16.0(typescript@5.7.3)':
+  '@remix-run/server-runtime@2.16.0(typescript@5.8.2)':
     dependencies:
       '@remix-run/router': 1.23.0
       '@types/cookie': 0.6.0
@@ -11881,7 +11881,7 @@ snapshots:
       source-map: 0.7.4
       turbo-stream: 2.4.0
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   '@remix-run/web-blob@3.1.0':
     dependencies:
@@ -12066,13 +12066,13 @@ snapshots:
       storybook: 8.6.4(prettier@3.5.3)
       ts-dedent: 2.2.0
 
-  '@storybook/builder-vite@8.6.4(storybook@8.6.4(prettier@3.5.3))(vite@5.4.11(@types/node@22.10.7))':
+  '@storybook/builder-vite@8.6.4(storybook@8.6.4(prettier@3.5.3))(vite@5.4.11(@types/node@22.13.10))':
     dependencies:
       '@storybook/csf-plugin': 8.6.4(storybook@8.6.4(prettier@3.5.3))
       browser-assert: 1.2.1
       storybook: 8.6.4(prettier@3.5.3)
       ts-dedent: 2.2.0
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.13.10)
 
   '@storybook/components@8.6.4(storybook@8.6.4(prettier@3.5.3))':
     dependencies:
@@ -12120,12 +12120,12 @@ snapshots:
       react-dom: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       storybook: 8.6.4(prettier@3.5.3)
 
-  '@storybook/react-vite@8.6.4(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(rollup@4.24.0)(storybook@8.6.4(prettier@3.5.3))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))':
+  '@storybook/react-vite@8.6.4(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(rollup@4.24.0)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))
       '@rollup/pluginutils': 5.1.4(rollup@4.24.0)
-      '@storybook/builder-vite': 8.6.4(storybook@8.6.4(prettier@3.5.3))(vite@5.4.11(@types/node@22.10.7))
-      '@storybook/react': 8.6.4(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(storybook@8.6.4(prettier@3.5.3))(typescript@5.7.3)
+      '@storybook/builder-vite': 8.6.4(storybook@8.6.4(prettier@3.5.3))(vite@5.4.11(@types/node@22.13.10))
+      '@storybook/react': 8.6.4(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)
       find-up: 5.0.0
       magic-string: 0.30.17
       react: 18.3.0-canary-14898b6a9-20240318
@@ -12134,13 +12134,13 @@ snapshots:
       resolve: 1.22.8
       storybook: 8.6.4(prettier@3.5.3)
       tsconfig-paths: 4.2.0
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.13.10)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react@8.6.4(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(storybook@8.6.4(prettier@3.5.3))(typescript@5.7.3)':
+  '@storybook/react@8.6.4(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)':
     dependencies:
       '@storybook/components': 8.6.4(storybook@8.6.4(prettier@3.5.3))
       '@storybook/global': 5.0.0
@@ -12152,7 +12152,7 @@ snapshots:
       react-dom: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       storybook: 8.6.4(prettier@3.5.3)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   '@storybook/theming@8.6.4(storybook@8.6.4(prettier@3.5.3))':
     dependencies:
@@ -12251,7 +12251,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.12':
     dependencies:
-      '@types/node': 22.10.7
+      '@types/node': 22.13.10
 
   '@types/cookie@0.6.0': {}
 
@@ -12263,7 +12263,7 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
-  '@types/dom-navigation@1.0.4': {}
+  '@types/dom-navigation@1.0.5': {}
 
   '@types/estree-jsx@1.0.0':
     dependencies:
@@ -12273,7 +12273,7 @@ snapshots:
 
   '@types/fontkit@2.0.7':
     dependencies:
-      '@types/node': 22.10.7
+      '@types/node': 22.13.10
 
   '@types/hast@2.3.4':
     dependencies:
@@ -12295,12 +12295,12 @@ snapshots:
 
   '@types/node-fetch@2.6.4':
     dependencies:
-      '@types/node': 22.10.7
+      '@types/node': 22.13.10
       form-data: 3.0.1
 
   '@types/node@18.17.1': {}
 
-  '@types/node@22.10.7':
+  '@types/node@22.13.10':
     dependencies:
       undici-types: 6.20.0
 
@@ -12337,32 +12337,32 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  '@typescript-eslint/eslint-plugin@8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       '@typescript-eslint/scope-manager': 8.26.1
-      '@typescript-eslint/type-utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.26.1
       eslint: 9.22.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.26.1
       '@typescript-eslint/types': 8.26.1
-      '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.26.1
       debug: 4.4.0
       eslint: 9.22.0(jiti@2.4.2)
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12371,20 +12371,20 @@ snapshots:
       '@typescript-eslint/types': 8.26.1
       '@typescript-eslint/visitor-keys': 8.26.1
 
-  '@typescript-eslint/type-utils@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       debug: 4.4.0
       eslint: 9.22.0(jiti@2.4.2)
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.26.1': {}
 
-  '@typescript-eslint/typescript-estree@8.26.1(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.26.1(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 8.26.1
       '@typescript-eslint/visitor-keys': 8.26.1
@@ -12393,19 +12393,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.4
       semver: 7.7.1
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.22.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.26.1
       '@typescript-eslint/types': 8.26.1
-      '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.8.2)
       eslint: 9.22.0(jiti@2.4.2)
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12470,7 +12470,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@vanilla-extract/integration@6.5.0(@types/node@22.10.7)':
+  '@vanilla-extract/integration@6.5.0(@types/node@22.13.10)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.26.0)
@@ -12483,8 +12483,8 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.7.4
       outdent: 0.8.0
-      vite: 5.4.11(@types/node@22.10.7)
-      vite-node: 1.6.0(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.13.10)
+      vite-node: 1.6.0(@types/node@22.13.10)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -12499,21 +12499,21 @@ snapshots:
 
   '@vanilla-extract/private@1.0.5': {}
 
-  '@vercel/react-router@1.1.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(@react-router/node@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(isbot@5.1.23)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)':
+  '@vercel/react-router@1.1.0(@react-router/dev@7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(@react-router/node@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(isbot@5.1.23)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)':
     dependencies:
-      '@react-router/dev': 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3))(@types/node@22.10.7)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
-      '@react-router/node': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.7.3)
+      '@react-router/dev': 7.3.0(@react-router/serve@7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2))(@types/node@22.13.10)(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
+      '@react-router/node': 7.3.0(react-router@7.3.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318))(typescript@5.8.2)
       '@vercel/static-config': 3.0.0
       isbot: 5.1.23
       react: 18.3.0-canary-14898b6a9-20240318
       react-dom: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
       ts-morph: 12.0.0
 
-  '@vercel/remix@2.15.3(@remix-run/dev@2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/serve@2.16.0(typescript@5.7.3))(@types/node@22.10.7)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(@remix-run/node@2.16.0(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)':
+  '@vercel/remix@2.15.3(@remix-run/dev@2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/serve@2.16.0(typescript@5.8.2))(@types/node@22.13.10)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0)))(@remix-run/node@2.16.0(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)':
     dependencies:
-      '@remix-run/dev': 2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/serve@2.16.0(typescript@5.7.3))(@types/node@22.10.7)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
-      '@remix-run/node': 2.16.0(typescript@5.7.3)
-      '@remix-run/server-runtime': 2.16.0(typescript@5.7.3)
+      '@remix-run/dev': 2.16.0(patch_hash=yortwzoeu3uj2blmdikhhw5byy)(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/serve@2.16.0(typescript@5.8.2))(@types/node@22.13.10)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(wrangler@3.63.2(@cloudflare/workers-types@4.20240701.0))
+      '@remix-run/node': 2.16.0(typescript@5.8.2)
+      '@remix-run/server-runtime': 2.16.0(typescript@5.8.2)
       '@vercel/static-config': 3.0.0
       isbot: 3.6.13
       react: 18.3.0-canary-14898b6a9-20240318
@@ -12526,27 +12526,27 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
-  '@vitejs/plugin-react@4.3.4(vite@5.4.11(@types/node@22.10.7))':
+  '@vitejs/plugin-react@4.3.4(vite@5.4.11(@types/node@22.13.10))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.13.10)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.0.8(@testing-library/dom@10.4.0)(@types/node@22.10.7)(playwright@1.50.1)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(vitest@3.0.8)':
+  '@vitest/browser@3.0.8(@testing-library/dom@10.4.0)(@types/node@22.13.10)(playwright@1.50.1)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(vitest@3.0.8)':
     dependencies:
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.0.8(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))(vite@5.4.11(@types/node@22.10.7))
+      '@vitest/mocker': 3.0.8(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))(vite@5.4.11(@types/node@22.13.10))
       '@vitest/utils': 3.0.8
       magic-string: 0.30.17
-      msw: 2.7.3(@types/node@22.10.7)(typescript@5.7.3)
+      msw: 2.7.3(@types/node@22.13.10)(typescript@5.8.2)
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))
       ws: 8.18.1
     optionalDependencies:
       playwright: 1.50.1
@@ -12565,14 +12565,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.8(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))(vite@5.4.11(@types/node@22.10.7))':
+  '@vitest/mocker@3.0.8(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))(vite@5.4.11(@types/node@22.13.10))':
     dependencies:
       '@vitest/spy': 3.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      msw: 2.7.3(@types/node@22.10.7)(typescript@5.7.3)
-      vite: 5.4.11(@types/node@22.10.7)
+      msw: 2.7.3(@types/node@22.13.10)(typescript@5.8.2)
+      vite: 5.4.11(@types/node@22.13.10)
 
   '@vitest/pretty-format@3.0.8':
     dependencies:
@@ -13726,7 +13726,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 22.10.7
+      '@types/node': 22.13.10
       require-like: 0.1.2
 
   event-target-shim@5.0.1: {}
@@ -15336,12 +15336,12 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3):
+  msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.5(@types/node@22.10.7)
+      '@inquirer/confirm': 5.1.5(@types/node@22.13.10)
       '@mswjs/interceptors': 0.37.6
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
@@ -15354,10 +15354,10 @@ snapshots:
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
       strict-event-emitter: 0.5.1
-      type-fest: 4.32.0
+      type-fest: 4.37.0
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
 
@@ -15595,7 +15595,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.26.2
       index-to-position: 0.1.2
-      type-fest: 4.32.0
+      type-fest: 4.37.0
 
   parse-ms@2.1.0: {}
 
@@ -15839,9 +15839,9 @@ snapshots:
       react: 18.3.0-canary-14898b6a9-20240318
       react-dom: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
 
-  react-docgen-typescript@2.2.2(typescript@5.7.3):
+  react-docgen-typescript@2.2.2(typescript@5.8.2):
     dependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   react-docgen@7.1.0:
     dependencies:
@@ -15966,14 +15966,14 @@ snapshots:
     dependencies:
       find-up-simple: 1.0.1
       read-pkg: 9.0.1
-      type-fest: 4.32.0
+      type-fest: 4.37.0
 
   read-pkg@9.0.1:
     dependencies:
       '@types/normalize-package-data': 2.4.4
       normalize-package-data: 6.0.2
       parse-json: 8.1.0
-      type-fest: 4.32.0
+      type-fest: 4.37.0
       unicorn-magic: 0.1.0
 
   readable-stream@2.3.8:
@@ -16054,53 +16054,53 @@ snapshots:
       mdast-util-to-hast: 12.3.0
       unified: 10.1.2
 
-  remix-auth-form@1.5.0(@remix-run/server-runtime@2.16.0(typescript@5.7.3))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))):
+  remix-auth-form@1.5.0(@remix-run/server-runtime@2.16.0(typescript@5.8.2))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))):
     dependencies:
-      '@remix-run/server-runtime': 2.16.0(typescript@5.7.3)
-      remix-auth: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))
+      '@remix-run/server-runtime': 2.16.0(typescript@5.8.2)
+      remix-auth: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))
 
-  remix-auth-github@1.7.0(@remix-run/server-runtime@2.16.0(typescript@5.7.3))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))):
+  remix-auth-github@1.7.0(@remix-run/server-runtime@2.16.0(typescript@5.8.2))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))):
     dependencies:
-      '@remix-run/server-runtime': 2.16.0(typescript@5.7.3)
-      remix-auth: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))
-      remix-auth-oauth2: 1.11.2(@remix-run/server-runtime@2.16.0(typescript@5.7.3))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3)))
+      '@remix-run/server-runtime': 2.16.0(typescript@5.8.2)
+      remix-auth: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))
+      remix-auth-oauth2: 1.11.2(@remix-run/server-runtime@2.16.0(typescript@5.8.2))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2)))
     transitivePeerDependencies:
       - supports-color
 
-  remix-auth-google@2.0.0(@remix-run/server-runtime@2.16.0(typescript@5.7.3))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))):
+  remix-auth-google@2.0.0(@remix-run/server-runtime@2.16.0(typescript@5.8.2))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))):
     dependencies:
-      '@remix-run/server-runtime': 2.16.0(typescript@5.7.3)
-      remix-auth: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))
-      remix-auth-oauth2: 1.11.2(@remix-run/server-runtime@2.16.0(typescript@5.7.3))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3)))
+      '@remix-run/server-runtime': 2.16.0(typescript@5.8.2)
+      remix-auth: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))
+      remix-auth-oauth2: 1.11.2(@remix-run/server-runtime@2.16.0(typescript@5.8.2))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2)))
     transitivePeerDependencies:
       - supports-color
 
-  remix-auth-oauth2@1.11.2(@remix-run/server-runtime@2.16.0(typescript@5.7.3))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))):
+  remix-auth-oauth2@1.11.2(@remix-run/server-runtime@2.16.0(typescript@5.8.2))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))):
     dependencies:
-      '@remix-run/server-runtime': 2.16.0(typescript@5.7.3)
+      '@remix-run/server-runtime': 2.16.0(typescript@5.8.2)
       debug: 4.3.7
-      remix-auth: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))
+      remix-auth: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
 
-  remix-auth-oauth2@2.3.0(@remix-run/cloudflare@2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.7.3))(@remix-run/node@2.16.0(typescript@5.7.3))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))):
+  remix-auth-oauth2@2.3.0(@remix-run/cloudflare@2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.8.2))(@remix-run/node@2.16.0(typescript@5.8.2))(remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))):
     dependencies:
       '@oslojs/crypto': 0.6.2
       '@oslojs/encoding': 0.4.1
       '@oslojs/oauth2': 0.5.0
       debug: 4.3.7
-      remix-auth: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3))
+      remix-auth: 3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2))
     optionalDependencies:
-      '@remix-run/cloudflare': 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.7.3)
-      '@remix-run/node': 2.16.0(typescript@5.7.3)
+      '@remix-run/cloudflare': 2.16.0(@cloudflare/workers-types@4.20240701.0)(typescript@5.8.2)
+      '@remix-run/node': 2.16.0(typescript@5.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3))(@remix-run/server-runtime@2.16.0(typescript@5.7.3)):
+  remix-auth@3.7.0(@remix-run/react@2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2))(@remix-run/server-runtime@2.16.0(typescript@5.8.2)):
     dependencies:
-      '@remix-run/react': 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.7.3)
-      '@remix-run/server-runtime': 2.16.0(typescript@5.7.3)
+      '@remix-run/react': 2.16.0(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)(typescript@5.8.2)
+      '@remix-run/server-runtime': 2.16.0(typescript@5.8.2)
       uuid: 8.3.2
 
   remove-accents@0.5.0: {}
@@ -16603,9 +16603,9 @@ snapshots:
 
   trough@2.1.0: {}
 
-  ts-api-utils@2.0.1(typescript@5.7.3):
+  ts-api-utils@2.0.1(typescript@5.8.2):
     dependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   ts-custom-error@3.3.1: {}
 
@@ -16649,24 +16649,24 @@ snapshots:
 
   type-fest@2.19.0: {}
 
-  type-fest@4.32.0: {}
+  type-fest@4.37.0: {}
 
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  typescript-eslint@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3):
+  typescript-eslint@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.26.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       eslint: 9.22.0(jiti@2.4.2)
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.7.3: {}
+  typescript@5.8.2: {}
 
   ufo@1.5.3: {}
 
@@ -16888,9 +16888,9 @@ snapshots:
       kleur: 4.1.5
       sade: 1.8.1
 
-  valibot@0.41.0(typescript@5.7.3):
+  valibot@0.41.0(typescript@5.8.2):
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -16919,7 +16919,7 @@ snapshots:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.3
 
-  vike@0.4.224(vite@5.4.11(@types/node@22.10.7)):
+  vike@0.4.224(vite@5.4.11(@types/node@22.13.10)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.15
@@ -16936,15 +16936,15 @@ snapshots:
       source-map-support: 0.5.21
       tinyglobby: 0.2.12
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.13.10)
 
-  vite-node@1.6.0(@types/node@22.10.7):
+  vite-node@1.6.0(@types/node@22.13.10):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.13.10)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16956,13 +16956,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.0.0-beta.2(@types/node@22.10.7):
+  vite-node@3.0.0-beta.2(@types/node@22.13.10):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.13.10)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16974,13 +16974,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.0.8(@types/node@22.10.7):
+  vite-node@3.0.8(@types/node@22.13.10):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.13.10)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16992,19 +16992,19 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.11(@types/node@22.10.7):
+  vite@5.4.11(@types/node@22.13.10):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.24.0
     optionalDependencies:
-      '@types/node': 22.10.7
+      '@types/node': 22.13.10
       fsevents: 2.3.3
 
-  vitest@3.0.8(@types/debug@4.1.12)(@types/node@22.10.7)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3)):
+  vitest@3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.8)(jsdom@20.0.3)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2)):
     dependencies:
       '@vitest/expect': 3.0.8
-      '@vitest/mocker': 3.0.8(msw@2.7.3(@types/node@22.10.7)(typescript@5.7.3))(vite@5.4.11(@types/node@22.10.7))
+      '@vitest/mocker': 3.0.8(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))(vite@5.4.11(@types/node@22.13.10))
       '@vitest/pretty-format': 3.0.8
       '@vitest/runner': 3.0.8
       '@vitest/snapshot': 3.0.8
@@ -17020,13 +17020,13 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 5.4.11(@types/node@22.10.7)
-      vite-node: 3.0.8(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.13.10)
+      vite-node: 3.0.8(@types/node@22.13.10)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 22.10.7
-      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@22.10.7)(playwright@1.50.1)(typescript@5.7.3)(vite@5.4.11(@types/node@22.10.7))(vitest@3.0.8)
+      '@types/node': 22.13.10
+      '@vitest/browser': 3.0.8(@testing-library/dom@10.4.0)(@types/node@22.13.10)(playwright@1.50.1)(typescript@5.8.2)(vite@5.4.11(@types/node@22.13.10))(vitest@3.0.8)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Upgraded to 5.8 and bumped all type definitions.
Enabled erasable syntax only flag and got rid from one case in expression editor.