### PR TITLE
fix: allow searching css with dash e.g. flex-direction 

### DIFF
--- a/apps/builder/app/builder/shared/css-editor/add-style-input.tsx
+++ b/apps/builder/app/builder/shared/css-editor/add-style-input.tsx
@@ -103,7 +103,7 @@ const getAutocompleteItems = () => {
 };
 
 const matchOrSuggestToCreate = (search: string, items: Array<SearchItem>) => {
-  const matched = matchSorter(items, search, {
+  const matched = matchSorter(items, search.replaceAll("-", " "), {
     keys: ["key"],
   });
 

--- a/apps/builder/app/builder/shared/css-editor/css-editor.tsx
+++ b/apps/builder/app/builder/shared/css-editor/css-editor.tsx
@@ -389,7 +389,7 @@ export const CssEditor = ({
   };
 
   const handleSearch = (event: ChangeEvent<HTMLInputElement>) => {
-    const search = event.target.value.trim();
+    const search = event.target.value.trim().replaceAll("-", " ");
     if (search === "") {
       return handleAbortSearch();
     }


### PR DESCRIPTION
In advanced panel in both search in put and add property autocomplete right now if you type dash it won't find anything with dash

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
