### PR TITLE
fix: Vimeo and youtube inline option fix

### DIFF
--- a/packages/sdk-components-react/src/vimeo-play-button.tsx
+++ b/packages/sdk-components-react/src/vimeo-play-button.tsx
@@ -7,7 +7,6 @@ import {
 } from "react";
 import { VimeoContext } from "./vimeo";
 import { Button, defaultTag } from "./button";
-import interactionResponse from "await-interaction-response";
 
 export { defaultTag };
 
@@ -17,8 +16,7 @@ export const VimeoPlayButton = forwardRef<ElementRef<typeof defaultTag>, Props>(
   (props, ref) => {
     const vimeoContext = useContext(VimeoContext);
 
-    const handleClick = useCallback(async () => {
-      await interactionResponse();
+    const handleClick = useCallback(() => {
       vimeoContext.onInitPlayer();
     }, [vimeoContext]);
 

--- a/packages/sdk-components-react/src/vimeo-play-button.tsx
+++ b/packages/sdk-components-react/src/vimeo-play-button.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { VimeoContext } from "./vimeo";
 import { Button, defaultTag } from "./button";
+import interactionResponse from "await-interaction-response";
 
 export { defaultTag };
 
@@ -16,7 +17,8 @@ export const VimeoPlayButton = forwardRef<ElementRef<typeof defaultTag>, Props>(
   (props, ref) => {
     const vimeoContext = useContext(VimeoContext);
 
-    const handleClick = useCallback(() => {
+    const handleClick = useCallback(async () => {
+      await interactionResponse();
       vimeoContext.onInitPlayer();
     }, [vimeoContext]);
 

--- a/packages/sdk-components-react/src/vimeo.tsx
+++ b/packages/sdk-components-react/src/vimeo.tsx
@@ -14,6 +14,7 @@ import {
   useContext,
   createContext,
   type ContextType,
+  useRef,
 } from "react";
 import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 
@@ -250,7 +251,7 @@ type PlayerStatus = "initial" | "loading" | "ready";
 
 type PlayerProps = Pick<
   VimeoOptions,
-  "loading" | "autoplay" | "showPreview"
+  "loading" | "autoplay" | "showPreview" | "playsinline"
 > & {
   videoUrl: string;
   title: string | undefined;
@@ -270,16 +271,24 @@ const Player = ({
   autoplay,
   renderer,
   showPreview,
+  playsinline,
   onStatusChange,
   onPreviewImageUrlChange,
 }: PlayerProps) => {
   const [opacity, setOpacity] = useState(0);
+  const ref = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
     if (autoplay && renderer !== "canvas" && status === "initial") {
       onStatusChange("loading");
     }
   }, [autoplay, status, renderer, onStatusChange]);
+
+  useEffect(() => {
+    if (playsinline === false) {
+      ref.current?.requestFullscreen();
+    }
+  }, [playsinline]);
 
   useEffect(() => {
     if (renderer !== "canvas") {
@@ -312,6 +321,7 @@ const Player = ({
 
   return (
     <iframe
+      ref={ref}
       title={title}
       src={videoUrl}
       loading={loading}
@@ -440,6 +450,7 @@ export const Vimeo = forwardRef<Ref, Props>(
               <Player
                 title={rest.title}
                 autoplay={autoplay}
+                playsinline={playsinline}
                 videoUrl={videoUrl}
                 previewImageUrl={previewImageUrl}
                 loading={loading}

--- a/packages/sdk-components-react/src/vimeo.tsx
+++ b/packages/sdk-components-react/src/vimeo.tsx
@@ -247,6 +247,15 @@ const EmptyState = () => {
   );
 };
 
+export const requestFullscreen = (element: HTMLIFrameElement) => {
+  const isTouchDevice = "ontouchstart" in window;
+  // Allows it to work on small screens on desktop too and makes it easy to test.
+  const isMobileResolution = window.matchMedia("(max-width: 1024px)").matches;
+  if (isMobileResolution || isTouchDevice) {
+    element.requestFullscreen();
+  }
+};
+
 type PlayerStatus = "initial" | "loading" | "ready";
 
 type PlayerProps = Pick<
@@ -283,13 +292,6 @@ const Player = ({
       onStatusChange("loading");
     }
   }, [autoplay, status, renderer, onStatusChange]);
-
-  //  useEffect(() => {
-  //    if (playsinline === false) {
-  //      ref.current?.requestFullscreen();
-  //      console.log(111);
-  //    }
-  //  }, [playsinline]);
 
   useEffect(() => {
     if (renderer !== "canvas") {
@@ -339,9 +341,8 @@ const Player = ({
       onLoad={() => {
         onStatusChange("ready");
         setOpacity(1);
-        if (playsinline === false) {
-          ref.current?.requestFullscreen();
-          console.log(111);
+        if (ref.current && playsinline === false) {
+          requestFullscreen(ref.current);
         }
       }}
     />
@@ -384,7 +385,7 @@ export const Vimeo = forwardRef<Ref, Props>(
       loop = false,
       muted = false,
       pip = false,
-      playsinline = true,
+      playsinline = false,
       showPortrait = true,
       quality = "auto",
       responsive = true,

--- a/packages/sdk-components-react/src/vimeo.tsx
+++ b/packages/sdk-components-react/src/vimeo.tsx
@@ -341,7 +341,7 @@ const Player = ({
       onLoad={() => {
         onStatusChange("ready");
         setOpacity(1);
-        if (ref.current && playsinline === false) {
+        if (ref.current && !playsinline && !autoplay) {
           requestFullscreen(ref.current);
         }
       }}

--- a/packages/sdk-components-react/src/vimeo.tsx
+++ b/packages/sdk-components-react/src/vimeo.tsx
@@ -284,11 +284,12 @@ const Player = ({
     }
   }, [autoplay, status, renderer, onStatusChange]);
 
-  useEffect(() => {
-    if (playsinline === false) {
-      ref.current?.requestFullscreen();
-    }
-  }, [playsinline]);
+  //  useEffect(() => {
+  //    if (playsinline === false) {
+  //      ref.current?.requestFullscreen();
+  //      console.log(111);
+  //    }
+  //  }, [playsinline]);
 
   useEffect(() => {
     if (renderer !== "canvas") {
@@ -338,6 +339,10 @@ const Player = ({
       onLoad={() => {
         onStatusChange("ready");
         setOpacity(1);
+        if (playsinline === false) {
+          ref.current?.requestFullscreen();
+          console.log(111);
+        }
       }}
     />
   );

--- a/packages/sdk-components-react/src/vimeo.ws.ts
+++ b/packages/sdk-components-react/src/vimeo.ws.ts
@@ -42,6 +42,7 @@ const initialProps: Array<keyof ComponentProps<typeof Vimeo>> = [
   "showTitle",
   "showControls",
   "controlsColor",
+  "playsinline",
 ];
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/youtube.tsx
+++ b/packages/sdk-components-react/src/youtube.tsx
@@ -6,9 +6,10 @@ import {
   type ComponentProps,
   useContext,
   type ContextType,
+  useRef,
 } from "react";
 import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
-import { VimeoContext } from "./vimeo";
+import { VimeoContext, requestFullscreen } from "./vimeo";
 
 /**
  * Options for configuring the YouTube player parameters.
@@ -362,7 +363,7 @@ const EmptyState = () => {
 
 type PlayerProps = Pick<
   YouTubePlayerOptions,
-  "loading" | "autoplay" | "showPreview"
+  "loading" | "autoplay" | "showPreview" | "inline"
 > & {
   videoUrl: string;
   title: string | undefined;
@@ -380,12 +381,14 @@ const Player = ({
   videoUrl,
   previewImageUrl,
   autoplay,
+  inline,
   renderer,
   showPreview,
   onStatusChange,
   onPreviewImageUrlChange,
 }: PlayerProps) => {
   const [opacity, setOpacity] = useState(0);
+  const ref = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
     if (autoplay && renderer !== "canvas" && status === "initial") {
@@ -417,6 +420,7 @@ const Player = ({
 
   return (
     <iframe
+      ref={ref}
       title={title}
       src={videoUrl}
       loading={loading}
@@ -433,6 +437,9 @@ const Player = ({
       onLoad={() => {
         onStatusChange("ready");
         setOpacity(1);
+        if (inline === false && ref.current) {
+          requestFullscreen(ref.current);
+        }
       }}
     />
   );
@@ -463,6 +470,7 @@ export const YouTube = forwardRef<Ref, Props>(
       showPreview,
       children,
       privacyEnhancedMode,
+      inline = false,
       ...rest
     },
     ref
@@ -478,6 +486,7 @@ export const YouTube = forwardRef<Ref, Props>(
     const videoUrl = getVideoUrl(
       {
         ...rest,
+        inline,
         url,
         autoplay: true,
       },
@@ -508,6 +517,7 @@ export const YouTube = forwardRef<Ref, Props>(
                 videoUrl={videoUrl}
                 previewImageUrl={previewImageUrl}
                 loading={loading}
+                inline={inline}
                 showPreview={showPreview}
                 renderer={renderer}
                 status={status}

--- a/packages/sdk-components-react/src/youtube.tsx
+++ b/packages/sdk-components-react/src/youtube.tsx
@@ -437,7 +437,7 @@ const Player = ({
       onLoad={() => {
         onStatusChange("ready");
         setOpacity(1);
-        if (inline === false && ref.current) {
+        if (!inline && !autoplay && ref.current) {
           requestFullscreen(ref.current);
         }
       }}


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/5016

## Description

Since we are lazily initializing the player and using autoplay, players won't request full screen, so we need to request the fullscreen ourselves.

1. inline is now false by default 
2. only for mobile/touch, custom logic checks if the device has touch or has resolution lower than 1024px



## Steps for reproduction

1. add vimeo component
2. put a video url, e.g. https://vimeo.com/1062544169
3. publish
4. play on a touch device or just a resolution smaller than 1024
5. see it goes full screen
6. repeaat the same with youtube
 

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
