### PR TITLE
fix: reparent within another slot instance

### DIFF
--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -403,7 +403,7 @@ export const reparentInstanceMutable = (
     }
   }
   // try to use slot fragment as target instead of slot itself
-  let parentInstance = data.instances.get(dropTarget.parentSelector[0]);
+  const parentInstance = data.instances.get(dropTarget.parentSelector[0]);
   if (
     parentInstance?.component === portalComponent &&
     parentInstance.children.length > 0 &&
@@ -422,7 +422,7 @@ export const reparentInstanceMutable = (
     if (parent === undefined) {
       return;
     }
-    let prevPosition = parent.children.findIndex(
+    const prevPosition = parent.children.findIndex(
       (child) => child.type === "id" && child.value === rootInstanceId
     );
     const child = parent.children[prevPosition];


### PR DESCRIPTION
Ivan found a bug. Reparent slot child into another instance of the same slot got this child removed.

Now refactored whole thing (almost). The main difference is same parent move will not do delete/paste but will just update child position. This fixes bug above and makes other logic slightly simpler.

Rewritten reparentInstance with reparentInstanceMutable to simplify testing and make it composable (if ever need). Added more tests.