### PR TITLE
refactor: show build id for debug purposes

### DIFF
--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -283,7 +283,16 @@ const Publish = ({
       if (publishResult.error === "NOT_IMPLEMENTED") {
         error = (
           <>
-            Build data for publishing has been successfully created. Use{" "}
+            <Tooltip
+              content={
+                <Text userSelect="text">
+                  {project.latestBuildVirtual?.buildId}
+                </Text>
+              }
+            >
+              <span>Build data</span>
+            </Tooltip>{" "}
+            for publishing has been successfully created. Use{" "}
             <Link href="https://docs.webstudio.is/university/self-hosting/cli">
               Webstudio&nbsp;CLI
             </Link>{" "}


### PR DESCRIPTION
When publish website locally or in test environment we cannot see failed build id. Here added one behind tooltip.

<img width="469" alt="Screenshot 2025-03-21 at 00 08 17" src="https://github.com/user-attachments/assets/4041f04d-bc92-4d5a-8250-68d7d2ba8f54" />
