### PR TITLE
fix: fix the tip for ellipsis

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
@@ -289,19 +289,19 @@ const TypographySectionAdvancedPopover = () => {
         >
           <Grid css={{ gridTemplateColumns: "5fr 5fr" }} gap={2}>
             <PropertyLabel
-              label="White Space"
+              label="White Space Collapse"
               description={propertyDescriptions.whiteSpaceCollapse}
               properties={["white-space-collapse"]}
             />
             <SelectControl property="white-space-collapse" />
             <PropertyLabel
-              label="Wrap Mode"
+              label="Text Wrap Mode"
               description={propertyDescriptions.textWrapMode}
               properties={["text-wrap-mode"]}
             />
             <SelectControl property="text-wrap-mode" />
             <PropertyLabel
-              label="Wrap Style"
+              label="Text Wrap Style"
               description={propertyDescriptions.textWrapStyle}
               properties={["text-wrap-style"]}
             />

--- a/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
@@ -372,7 +372,7 @@ const TypographySectionAdvancedPopover = () => {
                   {
                     child: <TextTruncateIcon />,
                     description:
-                      "The overflowing text is truncated with an ellipsis (...) to indicate that there is more content. To make the text-overflow: ellipsis property work, you need to set the following CSS properties: white-space: nowrap; overflow: hidden;",
+                      "The overflowing text is truncated with an ellipsis (...) to indicate that there is more content. To make the text-overflow: ellipsis property work, you need to set the following CSS properties: text-wrap-mode: nowrap; overflow: hidden;",
                     value: "ellipsis",
                   },
                 ]}


### PR DESCRIPTION
## Description

<img width="272" alt="image" src="https://github.com/user-attachments/assets/2cd2c2fb-b934-4fba-bf17-1553f5dbb316" />

This was misleading because we acually only need "text-wrap-mode" and "white space" in the UI is not actually white-space property

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
