### PR TITLE
experimental: Always show css value input instead of an add button

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/animation/animation-keyframes.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/animation/animation-keyframes.tsx
@@ -14,8 +14,6 @@ import {
   SectionTitle,
   SectionTitleButton,
   SectionTitleLabel,
-  Box,
-  Button,
 } from "@webstudio-is/design-system";
 import { MinusIcon, PlusIcon } from "@webstudio-is/icons";
 import type { AnimationKeyframe } from "@webstudio-is/sdk";
@@ -26,7 +24,7 @@ import {
 } from "~/builder/features/style-panel/shared/css-value-input";
 import { useIds } from "~/shared/form-utils";
 import { calcOffsets, findInsertionIndex, moveItem } from "./keyframe-helpers";
-import { CssEditor, type CssEditorApi } from "~/builder/shared/css-editor";
+import { CssEditor } from "~/builder/shared/css-editor";
 import type { ComputedStyleDecl } from "~/shared/style-object-model";
 
 const unitOptions = [
@@ -134,8 +132,6 @@ const Keyframe = ({
   ) => void;
 }) => {
   const ids = useIds(["offset"]);
-  const apiRef = useRef<CssEditorApi>();
-
   const declarations: Array<ComputedStyleDecl> = useMemo(
     () =>
       (Object.keys(value.styles) as Array<CssProperty>).map((property) => {
@@ -179,10 +175,10 @@ const Keyframe = ({
       <Grid>
         <CssEditor
           showSearch={false}
+          showAddStyleInput
           propertiesPosition="top"
           virtualize={false}
           declarations={declarations}
-          apiRef={apiRef}
           onAddDeclarations={(addedStyleMap) => {
             const styles = { ...value.styles };
             for (const [property, value] of addedStyleMap) {
@@ -209,17 +205,6 @@ const Keyframe = ({
           }}
         />
       </Grid>
-      <Box css={{ paddingInline: theme.panel.paddingInline }}>
-        <Button
-          onClick={() => {
-            apiRef.current?.showAddStyleInput();
-          }}
-          prefix={<PlusIcon />}
-          color="ghost"
-        >
-          Add
-        </Button>
-      </Box>
     </>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/advanced/advanced.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { useStore } from "@nanostores/react";
 import { PlusIcon } from "@webstudio-is/icons";
 import {
@@ -19,7 +19,7 @@ import {
 } from "../../shared/use-style-data";
 import { useComputedStyles } from "../../shared/model";
 import { getDots } from "../../shared/style-section";
-import { CssEditor, type CssEditorApi } from "../../../../shared/css-editor";
+import { CssEditor } from "../../../../shared/css-editor";
 import { $advancedStyleDeclarations } from "./stores";
 import { $selectedInstanceKey } from "~/shared/awareness";
 
@@ -64,7 +64,6 @@ const AdvancedStyleSection = (props: {
 
 export const Section = () => {
   const advancedStyleDeclarations = useStore($advancedStyleDeclarations);
-  const apiRef = useRef<CssEditorApi>();
   const properties = advancedStyleDeclarations.map(
     (styleDecl) => styleDecl.property
   );
@@ -74,6 +73,7 @@ export const Section = () => {
   const [recentPropertiesMap, setRecentPropertiesMap] = useState<
     Map<string, Array<CssProperty>>
   >(new Map());
+  const [showAddStyleInput, setShowAddStyleInput] = useState<boolean>(false);
 
   const recentProperties = selectedInstanceKey
     ? (recentPropertiesMap.get(selectedInstanceKey) ?? [])
@@ -131,7 +131,7 @@ export const Section = () => {
       label="Advanced"
       properties={properties}
       onAdd={() => {
-        apiRef.current?.showAddStyleInput();
+        setShowAddStyleInput(true);
       }}
     >
       <CssEditor
@@ -140,8 +140,9 @@ export const Section = () => {
         onSetProperty={setProperty}
         onAddDeclarations={handleAddDeclarations}
         onDeleteAllDeclarations={handleDeleteAllDeclarations}
-        apiRef={apiRef}
         recentProperties={recentProperties}
+        showAddStyleInput={showAddStyleInput}
+        onToggleAddStyleInput={setShowAddStyleInput}
       />
     </AdvancedStyleSection>
   );

--- a/apps/builder/app/builder/shared/css-editor/index.ts
+++ b/apps/builder/app/builder/shared/css-editor/index.ts
@@ -1,1 +1,1 @@
-export { CssEditor, type CssEditorApi } from "./css-editor";
+export { CssEditor } from "./css-editor";


### PR DESCRIPTION
## Description
![image](https://github.com/user-attachments/assets/1bc62b07-45b6-4f19-82f3-ad04c09ae775)

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
