### PR TITLE
feat: navigate to pro features on publish dialog

### DIFF
--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -219,7 +219,7 @@ const findInstanceSelector = (
   parentInstanceById: Map<Instance["id"], Instance["id"]>,
   startingInstanceId: Instance["id"]
 ) => {
-  let instanceSelector = [];
+  const instanceSelector = [];
   let currentInstanceId: undefined | Instance["id"] = startingInstanceId;
   while (currentInstanceId) {
     instanceSelector.push(currentInstanceId);

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -225,7 +225,7 @@ const $usedProFeatures = computed(
     }
     // specified emails for default webhook form
     if ((pages?.meta?.contactEmail ?? "").trim()) {
-      features.set("Custom contant email", undefined);
+      features.set("Custom contact email", undefined);
     }
     // pages with dynamic paths
     for (const page of [pages.homePage, ...pages.pages]) {

--- a/apps/builder/app/shared/awareness.test.tsx
+++ b/apps/builder/app/shared/awareness.test.tsx
@@ -1,0 +1,47 @@
+import { expect, test } from "vitest";
+import { findAwarenessByInstanceId } from "./awareness";
+import { createDefaultPages } from "@webstudio-is/project-build";
+import { $, renderData } from "@webstudio-is/template";
+
+test("find awareness by instance", () => {
+  const pages = createDefaultPages({
+    homePageId: "homePageId",
+    rootInstanceId: "bodyId",
+  });
+  const { instances } = renderData(
+    <$.Body ws:id="bodyId">
+      <$.Box ws:id="boxId">
+        <$.Text ws:id="textId"></$.Text>
+      </$.Box>
+    </$.Body>
+  );
+  expect(findAwarenessByInstanceId(pages, instances, "textId")).toEqual({
+    pageId: "homePageId",
+    instanceSelector: ["textId", "boxId", "bodyId"],
+  });
+});
+
+test("find awareness by instance inside of slot", () => {
+  const pages = createDefaultPages({
+    homePageId: "homePageId",
+    rootInstanceId: "bodyId",
+  });
+  const { instances } = renderData(
+    <$.Body ws:id="bodyId">
+      <$.Slot ws:id="slotOneId">
+        <$.Fragment ws:id="fragmentId">
+          <$.Box ws:id="boxId"></$.Box>
+        </$.Fragment>
+      </$.Slot>
+      <$.Slot ws:id="slotTwoId">
+        <$.Fragment ws:id="fragmentId">
+          <$.Box ws:id="boxId"></$.Box>
+        </$.Fragment>
+      </$.Slot>
+    </$.Body>
+  );
+  expect(findAwarenessByInstanceId(pages, instances, "boxId")).toEqual({
+    pageId: "homePageId",
+    instanceSelector: ["boxId", "fragmentId", "slotTwoId", "bodyId"],
+  });
+});

--- a/apps/builder/app/shared/awareness.ts
+++ b/apps/builder/app/shared/awareness.ts
@@ -6,9 +6,11 @@ import {
   ROOT_INSTANCE_ID,
   type Page,
   rootComponent,
+  Pages,
 } from "@webstudio-is/sdk";
 import { $pages } from "./nano-states/pages";
 import { $instances, $selectedInstanceSelector } from "./nano-states/instances";
+import type { InstanceSelector } from "./tree-utils";
 
 export type Awareness = {
   pageId: Page["id"];
@@ -182,4 +184,51 @@ export const selectInstance = (
       instanceSelector,
     });
   }
+};
+
+const findPageId = (pages: Pages, instanceSelector: InstanceSelector) => {
+  const rootInstanceId = instanceSelector.at(-1);
+  for (const page of [pages.homePage, ...pages.pages]) {
+    if (page.rootInstanceId === rootInstanceId) {
+      return page.id;
+    }
+  }
+  return pages.homePage.id;
+};
+
+const parentInstanceByIdCache = new WeakMap<
+  Instances,
+  Map<Instance["id"], Instance["id"]>
+>();
+
+/**
+ * traverse the tree up until body to build awareness
+ * when instance id is inside of slot last matching parent is used to further
+ */
+export const findAwarenessByInstanceId = (
+  pages: Pages,
+  instances: Instances,
+  startingInstanceId: Instance["id"]
+): Awareness => {
+  // recompute parent instances only when instances are changed
+  let parentInstanceById = parentInstanceByIdCache.get(instances);
+  if (parentInstanceById === undefined) {
+    parentInstanceById = new Map<Instance["id"], Instance["id"]>();
+    for (const instance of instances.values()) {
+      for (const child of instance.children) {
+        if (child.type === "id") {
+          parentInstanceById.set(child.value, instance.id);
+        }
+      }
+    }
+    parentInstanceByIdCache.set(instances, parentInstanceById);
+  }
+  const instanceSelector = [];
+  let currentInstanceId: undefined | Instance["id"] = startingInstanceId;
+  while (currentInstanceId) {
+    instanceSelector.push(currentInstanceId);
+    currentInstanceId = parentInstanceById.get(currentInstanceId);
+  }
+  const pageId = findPageId(pages, instanceSelector);
+  return { pageId, instanceSelector };
 };

--- a/apps/builder/app/shared/awareness.ts
+++ b/apps/builder/app/shared/awareness.ts
@@ -10,7 +10,7 @@ import {
 import { $pages } from "./nano-states/pages";
 import { $instances, $selectedInstanceSelector } from "./nano-states/instances";
 
-type Awareness = {
+export type Awareness = {
   pageId: Page["id"];
   instanceSelector?: Instance["id"][];
 };


### PR DESCRIPTION
Users don't know where to find pro features accidentally created while being on pro tier or added with marketplace.

Here wrapped items in used pro featured with links (buttons actually) which navigate to instances.


https://github.com/user-attachments/assets/7dd879fa-4e1b-4f66-9dd3-18308cd62f58

