### PR TITLE
fix: style panel indication issue when we use calc()

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/style-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/style-section.tsx
@@ -19,10 +19,7 @@ export const getDots = (styles: ComputedStyleDecl[]) => {
 
   for (const styleDecl of styles) {
     // Unparsed values are not editable directly in the section, so we don't show the dot
-    if (
-      styleDecl.usedValue.type === "unparsed" ||
-      styleDecl.usedValue.type === "guaranteedInvalid"
-    ) {
+    if (styleDecl.usedValue.type === "guaranteedInvalid") {
       return [];
     }
 


### PR DESCRIPTION
## Description
fixes issue #4872 
removed the checks for unparsed  style values that was returning an empty array

## Steps for reproduction

1. use calc as a value in any of the inputs.
2. then close the section accordian to see the blue dot.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
