### PR TITLE
fix: Allow creating variables when input starts with dashes in advanced style section

### DIFF
--- a/apps/builder/app/builder/shared/css-editor/add-style-input.tsx
+++ b/apps/builder/app/builder/shared/css-editor/add-style-input.tsx
@@ -100,7 +100,10 @@ const getAutocompleteItems = () => {
 };
 
 const matchOrSuggestToCreate = (search: string, items: Array<SearchItem>) => {
-  const matched = matchSorter(items, search.replaceAll("-", " "), {
+  const searchWithSpaces = search.startsWith("--")
+    ? search
+    : search.replaceAll("-", " ");
+  const matched = matchSorter(items, searchWithSpaces, {
     keys: ["key"],
   });
 


### PR DESCRIPTION
## Description

We broke this as we introduced  a more flexible search to combobox when you add properties

## Steps for reproduction

1. advanced panel
2. type --x
3. see you can create that variable right away without adding value

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
