### PR TITLE
fix: reset spacing values with alt-click

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
@@ -12,7 +12,7 @@ import { InputPopover } from "../shared/input-popover";
 import { StyleSection } from "../../shared/style-section";
 import { useKeyboardNavigation } from "../shared/keyboard";
 import { useComputedStyleDecl, useComputedStyles } from "../../shared/model";
-import { createBatchUpdate } from "../../shared/use-style-data";
+import { createBatchUpdate, deleteProperty } from "../../shared/use-style-data";
 import { useModifierKeys, type Modifiers } from "../../shared/modifier-keys";
 
 const movementMapSpace = {
@@ -125,6 +125,11 @@ const Cell = ({
           onHover({ property, element: event.currentTarget })
         }
         onMouseLeave={() => onHover(undefined)}
+        onClick={(event) => {
+          if (event.altKey) {
+            deleteProperty(property);
+          }
+        }}
       />
     </>
   );


### PR DESCRIPTION
## Description

When alt-clicking on the label in spacing, reset the value

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
