### PR TITLE
fix: use non-zero exit code for cancelled init flow

### DIFF
--- a/packages/cli/src/commands/init-flow.ts
+++ b/packages/cli/src/commands/init-flow.ts
@@ -24,7 +24,7 @@ type ProjectTemplates = (typeof PROJECT_TEMPLATES)[number]["value"];
 const exitIfCancelled = <Value>(value: Value | symbol): Value => {
   if (isCancel(value)) {
     cancel("Project initialization is cancelled");
-    process.exit(0);
+    process.exit(1);
   }
   return value;
 };


### PR DESCRIPTION
A non-zero exit code indicates that the process did not complete. Alternatively, we could use a 130 exit code, which commonly refers to Control+C termination.