### PR TITLE
feat: add "Accessible Label" setting

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/settings-panel/property-label.tsx
@@ -17,7 +17,11 @@ import { showAttribute } from "@webstudio-is/react-sdk";
 import { updateWebstudioData } from "~/shared/instance-utils";
 import { $selectedInstance } from "~/shared/awareness";
 import { $props, $registeredComponentPropsMetas } from "~/shared/nano-states";
-import { humanizeAttribute, showAttributeMeta } from "./shared";
+import {
+  ariaLabelAttributeMeta,
+  humanizeAttribute,
+  showAttributeMeta,
+} from "./shared";
 
 const usePropMeta = (name: string) => {
   const store = useMemo(() => {
@@ -26,6 +30,9 @@ const usePropMeta = (name: string) => {
       (instance, propsMetas) => {
         if (name === showAttribute) {
           return showAttributeMeta;
+        }
+        if (name === "aria-label") {
+          return ariaLabelAttributeMeta;
         }
         const metas = propsMetas.get(instance?.component ?? "");
         const propMeta = metas?.props[name];

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -3,7 +3,11 @@ import { useStore } from "@nanostores/react";
 import type { PropMeta, Instance, Prop } from "@webstudio-is/sdk";
 import { collectionComponent, descendantComponent } from "@webstudio-is/sdk";
 import { showAttribute, textContentAttribute } from "@webstudio-is/react-sdk";
-import { showAttributeMeta, type PropValue } from "../shared";
+import {
+  ariaLabelAttributeMeta,
+  showAttributeMeta,
+  type PropValue,
+} from "../shared";
 import {
   $isContentMode,
   $registeredComponentMetas,
@@ -181,6 +185,7 @@ export const usePropsLogic = ({
   const initialPropsNames = new Set(meta.initialProps ?? []);
 
   const systemProps: PropAndMeta[] = [];
+
   // descendant component is not actually rendered
   // but affects styling of nested elements
   // hiding descendant does not hide nested elements and confuse users
@@ -191,6 +196,12 @@ export const usePropsLogic = ({
       meta: showAttributeMeta,
     });
   }
+
+  systemProps.push({
+    propName: "aria-label",
+    prop: getAndDelete(unprocessedSaved, "aria-label"),
+    meta: ariaLabelAttributeMeta,
+  });
 
   const canHaveTextContent =
     instanceMeta?.type === "container" &&

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -50,6 +50,15 @@ export const showAttributeMeta: PropMeta = {
     "Removes the instance from the DOM. Breakpoints have no effect on this setting.",
 };
 
+export const ariaLabelAttributeMeta: PropMeta = {
+  label: "Accessible Label",
+  required: false,
+  control: "text",
+  type: "string",
+  description:
+    "Used by screen readers to describe the element. Do not set this if the element has a visible label.",
+};
+
 export type PropValue =
   | { type: "number"; value: number }
   | { type: "string"; value: string }


### PR DESCRIPTION
## Description

Allow the user to set the [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) attribute.

This is maybe a controversial feature, but it would be useful for post-processing that I'm doing on the generated output. 😅 

<img width="241" alt="Screenshot 2025-03-27 at 14 54 23" src="https://github.com/user-attachments/assets/ba391e63-8376-4f47-a022-09d0309941b2" />
<img width="247" alt="Screenshot 2025-03-27 at 14 56 51" src="https://github.com/user-attachments/assets/dcd22816-2525-4e9e-b11e-7d6b161ed348" />

## Before merging

- [x] tested locally ~~and on preview environment (preview dev login: 0000)~~
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] ~~if any new env variables are added, added them to `.env` file~~
