### PR TITLE
fix: backspace when StyleSourceInput is empty

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -535,7 +535,7 @@ export const StyleSourceInput = (
         label === "" &&
         props.editingItemId === undefined
       ) {
-        const item = value[value.length - 2];
+        const item = value[value.length - 1];
         if (item) {
           props.onDetachItem?.(item.id);
         }


### PR DESCRIPTION
## Description

At some point, the local token was moved to the start of the style source array, but the backspace logic was never updated. This led to the 2nd-to-last source being detached, which is unexpected.

## Steps for reproduction

1. Select a layer with 2+ style sources
2. Press the Command+Enter keys to focus the style sources input.
3. Press the Backspace key and notice the 2nd-to-last source gets detached, but it *should* be the last source getting detached

## Code Review

- [x] hi @kof, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
