### PR TITLE
fix: prevent dragging folder inside of itself

### DIFF
--- a/apps/builder/app/builder/features/pages/page-utils.test.ts
+++ b/apps/builder/app/builder/features/pages/page-utils.test.ts
@@ -331,6 +331,47 @@ describe("reparent pages and folders", () => {
     expect(folder1?.children).toEqual(["page2"]);
     expect(folder2?.children).toEqual(["page3", "page1"]);
   });
+
+  test("move folder into another folder", () => {
+    const { f, register, pages } = createPages();
+    register([f("folder1", []), f("folder2", [])]);
+    reparentPageOrFolderMutable(pages.folders, "folder1", "folder2", 1);
+    expect(pages.folders).toEqual([
+      expect.objectContaining({
+        id: "root",
+        children: ["homePageId", "folder2"],
+      }),
+      expect.objectContaining({ id: "folder1", children: [] }),
+      expect.objectContaining({ id: "folder2", children: ["folder1"] }),
+    ]);
+  });
+
+  test("prevent reparanting folder into itself", () => {
+    const { f, register, pages } = createPages();
+    register([f("folder1", [])]);
+    reparentPageOrFolderMutable(pages.folders, "folder1", "folder1", 1);
+    expect(pages.folders).toEqual([
+      expect.objectContaining({
+        id: "root",
+        children: ["homePageId", "folder1"],
+      }),
+      expect.objectContaining({ id: "folder1", children: [] }),
+    ]);
+  });
+
+  test("prevent reparanting folder own children", () => {
+    const { f, register, pages } = createPages();
+    register([f("folder1", [f("folder2", [])])]);
+    reparentPageOrFolderMutable(pages.folders, "folder1", "folder2", 1);
+    expect(pages.folders).toEqual([
+      expect.objectContaining({
+        id: "root",
+        children: ["homePageId", "folder1"],
+      }),
+      expect.objectContaining({ id: "folder2", children: [] }),
+      expect.objectContaining({ id: "folder1", children: ["folder2"] }),
+    ]);
+  });
 });
 
 describe("getAllChildrenAndSelf", () => {

--- a/apps/builder/app/builder/features/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/pages/page-utils.ts
@@ -167,6 +167,15 @@ export const reparentPageOrFolderMutable = (
   newFolderId: string,
   newPosition: number
 ) => {
+  const childrenAndSelf = getAllChildrenAndSelf(
+    pageOrFolderId,
+    folders,
+    "folder"
+  );
+  // make sure target folder is not self or descendants
+  if (childrenAndSelf.includes(newFolderId)) {
+    return;
+  }
   const prevParent = findParentFolderByChildId(pageOrFolderId, folders);
   const nextParent = folders.find((folder) => folder.id === newFolderId);
   if (prevParent === undefined || nextParent === undefined) {

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -17,7 +17,7 @@
     "test": "pnpm build:http-client && vitest run"
   },
   "dependencies": {
-    "@atlaskit/pragmatic-drag-and-drop": "^1.5.0",
+    "@atlaskit/pragmatic-drag-and-drop": "^1.5.2",
     "@bomb.sh/args": "^0.3.0",
     "@codemirror/autocomplete": "^6.18.6",
     "@codemirror/commands": "^6.8.0",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -25,7 +25,7 @@
     "react-dom": "18.3.0-canary-14898b6a9-20240318"
   },
   "dependencies": {
-    "@atlaskit/pragmatic-drag-and-drop": "^1.5.0",
+    "@atlaskit/pragmatic-drag-and-drop": "^1.5.2",
     "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^2.1.0",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
     "@floating-ui/dom": "^1.6.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ importers:
   apps/builder:
     dependencies:
       '@atlaskit/pragmatic-drag-and-drop':
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^1.5.2
+        version: 1.5.2
       '@bomb.sh/args':
         specifier: ^0.3.0
         version: 0.3.0
@@ -1301,8 +1301,8 @@ importers:
   packages/design-system:
     dependencies:
       '@atlaskit/pragmatic-drag-and-drop':
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^1.5.2
+        version: 1.5.2
       '@atlaskit/pragmatic-drag-and-drop-auto-scroll':
         specifier: ^2.1.0
         version: 2.1.0
@@ -2211,8 +2211,8 @@ packages:
   '@atlaskit/pragmatic-drag-and-drop-hitbox@1.0.3':
     resolution: {integrity: sha512-/Sbu/HqN2VGLYBhnsG7SbRNg98XKkbF6L7XDdBi+izRybfaK1FeMfodPpm/xnBHPJzwYMdkE0qtLyv6afhgMUA==}
 
-  '@atlaskit/pragmatic-drag-and-drop@1.5.0':
-    resolution: {integrity: sha512-VnHcgOBALm+mbL9CoJPI6wBNQeB0is+CkejdfAlaP8RfBoELe+0sQtE8j4Z4fPRqDzo11OEqUYKHkmx4Ttzozg==}
+  '@atlaskit/pragmatic-drag-and-drop@1.5.2':
+    resolution: {integrity: sha512-fDuTwlDD11r3ev5tLJ6JnzQUiG9v77c8zGcNdO7RRNtZZbOHam8CFhmyFGY4E/mLjvgYng0UkcyCrSBc4FXYZw==}
 
   '@aws-crypto/sha256-js@5.2.0':
     resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
@@ -9400,15 +9400,15 @@ snapshots:
 
   '@atlaskit/pragmatic-drag-and-drop-auto-scroll@2.1.0':
     dependencies:
-      '@atlaskit/pragmatic-drag-and-drop': 1.5.0
+      '@atlaskit/pragmatic-drag-and-drop': 1.5.2
       '@babel/runtime': 7.25.0
 
   '@atlaskit/pragmatic-drag-and-drop-hitbox@1.0.3':
     dependencies:
-      '@atlaskit/pragmatic-drag-and-drop': 1.5.0
+      '@atlaskit/pragmatic-drag-and-drop': 1.5.2
       '@babel/runtime': 7.25.0
 
-  '@atlaskit/pragmatic-drag-and-drop@1.5.0':
+  '@atlaskit/pragmatic-drag-and-drop@1.5.2':
     dependencies:
       '@babel/runtime': 7.25.0
       bind-event-listener: 3.0.0


### PR DESCRIPTION
User reported the case which probably bugged us a few times but we could not figure out why.

Here added guard to prevent reparanting page folder inside of itself or child folders.