### PR TITLE
refactor: manually namespace meta

### DIFF
--- a/apps/builder/app/shared/matcher.test.tsx
+++ b/apps/builder/app/shared/matcher.test.tsx
@@ -4,6 +4,7 @@ import {
   expression,
   renderTemplate,
   renderData,
+  createProxy,
 } from "@webstudio-is/template";
 import { coreMetas } from "@webstudio-is/sdk";
 import * as baseMetas from "@webstudio-is/sdk-components-react/metas";
@@ -788,21 +789,25 @@ describe("is tree matching", () => {
 });
 
 describe("is instance detachable", () => {
-  const metas = new Map(Object.entries({ ...baseMetas, ...radixMetas }));
+  const metas = new Map(Object.entries(baseMetas));
+  const radix = createProxy("@webstudio-is/sdk-components-react-radix:");
+  for (const [component, meta] of Object.entries(radixMetas)) {
+    metas.set(`@webstudio-is/sdk-components-react-radix:${component}`, meta);
+  }
 
   test("allow deleting one of matching instances", () => {
     expect(
       isInstanceDetachable({
         ...renderData(
           <$.Body ws:id="body">
-            <$.Tabs ws:id="tabs">
-              <$.TabsList ws:id="list">
-                <$.TabsTrigger ws:id="trigger1"></$.TabsTrigger>
-                <$.TabsTrigger ws:id="trigger2"></$.TabsTrigger>
-              </$.TabsList>
-              <$.TabsContent ws:id="content1"></$.TabsContent>
-              <$.TabsContent ws:id="content2"></$.TabsContent>
-            </$.Tabs>
+            <radix.Tabs ws:id="tabs">
+              <radix.TabsList ws:id="list">
+                <radix.TabsTrigger ws:id="trigger1"></radix.TabsTrigger>
+                <radix.TabsTrigger ws:id="trigger2"></radix.TabsTrigger>
+              </radix.TabsList>
+              <radix.TabsContent ws:id="content1"></radix.TabsContent>
+              <radix.TabsContent ws:id="content2"></radix.TabsContent>
+            </radix.Tabs>
           </$.Body>
         ),
         metas,
@@ -816,12 +821,12 @@ describe("is instance detachable", () => {
       isInstanceDetachable({
         ...renderData(
           <$.Body ws:id="body">
-            <$.Tabs ws:id="tabs">
-              <$.TabsList ws:id="list">
-                <$.TabsTrigger ws:id="trigger1"></$.TabsTrigger>
-              </$.TabsList>
-              <$.TabsContent ws:id="content1"></$.TabsContent>
-            </$.Tabs>
+            <radix.Tabs ws:id="tabs">
+              <radix.TabsList ws:id="list">
+                <radix.TabsTrigger ws:id="trigger1"></radix.TabsTrigger>
+              </radix.TabsList>
+              <radix.TabsContent ws:id="content1"></radix.TabsContent>
+            </radix.Tabs>
           </$.Body>
         ),
         metas,
@@ -835,7 +840,7 @@ describe("is instance detachable", () => {
       isInstanceDetachable({
         ...renderData(
           <$.Body ws:id="body">
-            <$.Tabs ws:id="tabs"></$.Tabs>
+            <radix.Tabs ws:id="tabs"></radix.Tabs>
             <$.Box ws:id="box"></$.Box>
           </$.Body>
         ),

--- a/apps/builder/app/shared/nano-states/components.ts
+++ b/apps/builder/app/shared/nano-states/components.ts
@@ -2,12 +2,11 @@ import { nanoid } from "nanoid";
 import { shallowEqual } from "shallow-equal";
 import type { ExoticComponent } from "react";
 import { atom, computed } from "nanostores";
-import {
-  type AnyComponent,
-  type Hook,
-  type HookContext,
-  namespaceMeta,
-  type InstanceData,
+import type {
+  AnyComponent,
+  Hook,
+  HookContext,
+  InstanceData,
 } from "@webstudio-is/react-sdk";
 import {
   getIndexesWithinAncestors,
@@ -210,12 +209,7 @@ export const registerComponentLibrary = ({
   const prevMetas = $registeredComponentMetas.get();
   const nextMetas = new Map(prevMetas);
   for (const [componentName, meta] of Object.entries(metas)) {
-    nextMetas.set(
-      `${prefix}${componentName}`,
-      namespace === undefined
-        ? meta
-        : namespaceMeta(meta, namespace, new Set(Object.keys(metas)))
-    );
+    nextMetas.set(`${prefix}${componentName}`, meta);
   }
   $registeredComponentMetas.set(nextMetas);
 

--- a/packages/cli/src/framework-react-router.ts
+++ b/packages/cli/src/framework-react-router.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { readFile, rm } from "node:fs/promises";
 import type { WsComponentMeta } from "@webstudio-is/sdk";
-import { generateRemixRoute, namespaceMeta } from "@webstudio-is/react-sdk";
+import { generateRemixRoute } from "@webstudio-is/react-sdk";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
 import * as animationComponentMetas from "@webstudio-is/sdk-components-animation/metas";
 import * as reactRouterComponentMetas from "@webstudio-is/sdk-components-react-router/metas";
@@ -34,21 +34,13 @@ export const createFramework = async (): Promise<Framework> => {
   const radixComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
   for (const [name, meta] of Object.entries(radixComponentMetas)) {
     const namespace = "@webstudio-is/sdk-components-react-radix";
-    radixComponentNamespacedMetas[`${namespace}:${name}`] = namespaceMeta(
-      meta,
-      namespace,
-      new Set(Object.keys(radixComponentMetas))
-    );
+    radixComponentNamespacedMetas[`${namespace}:${name}`] = meta;
   }
 
   const animationComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
   for (const [name, meta] of Object.entries(animationComponentMetas)) {
     const namespace = "@webstudio-is/sdk-components-animation";
-    animationComponentNamespacedMetas[`${namespace}:${name}`] = namespaceMeta(
-      meta as WsComponentMeta,
-      namespace,
-      new Set(Object.keys(animationComponentMetas))
-    );
+    animationComponentNamespacedMetas[`${namespace}:${name}`] = meta;
   }
 
   return {

--- a/packages/cli/src/framework-remix.ts
+++ b/packages/cli/src/framework-remix.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { readFile, rm } from "node:fs/promises";
 import type { WsComponentMeta } from "@webstudio-is/sdk";
-import { generateRemixRoute, namespaceMeta } from "@webstudio-is/react-sdk";
+import { generateRemixRoute } from "@webstudio-is/react-sdk";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
 import * as animationComponentMetas from "@webstudio-is/sdk-components-animation/metas";
 import * as remixComponentMetas from "@webstudio-is/sdk-components-react-remix/metas";
@@ -34,21 +34,13 @@ export const createFramework = async (): Promise<Framework> => {
   const radixComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
   for (const [name, meta] of Object.entries(radixComponentMetas)) {
     const namespace = "@webstudio-is/sdk-components-react-radix";
-    radixComponentNamespacedMetas[`${namespace}:${name}`] = namespaceMeta(
-      meta,
-      namespace,
-      new Set(Object.keys(radixComponentMetas))
-    );
+    radixComponentNamespacedMetas[`${namespace}:${name}`] = meta;
   }
 
   const animationComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
   for (const [name, meta] of Object.entries(animationComponentMetas)) {
     const namespace = "@webstudio-is/sdk-components-animation";
-    animationComponentNamespacedMetas[`${namespace}:${name}`] = namespaceMeta(
-      meta as WsComponentMeta,
-      namespace,
-      new Set(Object.keys(animationComponentMetas))
-    );
+    animationComponentNamespacedMetas[`${namespace}:${name}`] = meta;
   }
 
   return {

--- a/packages/cli/src/framework-vike-ssg.ts
+++ b/packages/cli/src/framework-vike-ssg.ts
@@ -1,7 +1,6 @@
 import { join } from "node:path";
 import { readFile, rm } from "node:fs/promises";
 import type { WsComponentMeta } from "@webstudio-is/sdk";
-import { namespaceMeta } from "@webstudio-is/react-sdk";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
 import * as animationComponentMetas from "@webstudio-is/sdk-components-animation/metas";
 import * as radixComponentMetas from "@webstudio-is/sdk-components-react-radix/metas";
@@ -36,21 +35,13 @@ export const createFramework = async (): Promise<Framework> => {
   const radixComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
   for (const [name, meta] of Object.entries(radixComponentMetas)) {
     const namespace = "@webstudio-is/sdk-components-react-radix";
-    radixComponentNamespacedMetas[`${namespace}:${name}`] = namespaceMeta(
-      meta,
-      namespace,
-      new Set(Object.keys(radixComponentMetas))
-    );
+    radixComponentNamespacedMetas[`${namespace}:${name}`] = meta;
   }
 
   const animationComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
   for (const [name, meta] of Object.entries(animationComponentMetas)) {
     const namespace = "@webstudio-is/sdk-components-animation";
-    animationComponentNamespacedMetas[`${namespace}:${name}`] = namespaceMeta(
-      meta as WsComponentMeta,
-      namespace,
-      new Set(Object.keys(animationComponentMetas))
-    );
+    animationComponentNamespacedMetas[`${namespace}:${name}`] = meta;
   }
 
   return {

--- a/packages/react-sdk/src/embed-template.test.tsx
+++ b/packages/react-sdk/src/embed-template.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { generateDataFromEmbedTemplate, namespaceMeta } from "./embed-template";
+import { generateDataFromEmbedTemplate } from "./embed-template";
 import { showAttribute } from "./props";
 
 const expectString = expect.any(String);
@@ -662,33 +662,5 @@ test("generate data for embedding from instance child bound to variables", () =>
     assets: [],
     breakpoints: [],
     resources: [],
-  });
-});
-
-test("add namespace to constants and indexWithinAncestor", () => {
-  expect(
-    namespaceMeta(
-      {
-        type: "container",
-        label: "",
-        icon: "",
-        constraints: {
-          relation: "ancestor",
-          component: { $nin: ["Button", "Box"] },
-        },
-        indexWithinAncestor: "Tooltip",
-      },
-      "my-namespace",
-      new Set(["Tooltip", "Button"])
-    )
-  ).toEqual({
-    type: "container",
-    label: "",
-    icon: "",
-    constraints: {
-      relation: "ancestor",
-      component: { $nin: ["my-namespace:Button", "my-namespace:Box"] },
-    },
-    indexWithinAncestor: "my-namespace:Tooltip",
   });
 });

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -8,10 +8,8 @@ import type {
   Breakpoint,
   DataSource,
   WebstudioFragment,
-  Matcher,
   EmbedTemplateVariable,
   WsEmbedTemplate,
-  EmbedTemplateInstance,
   WsComponentMeta,
 } from "@webstudio-is/sdk";
 import {
@@ -274,48 +272,4 @@ export const generateDataFromEmbedTemplate = (
     assets: [],
     resources: [],
   };
-};
-
-const namespaceMatcher = (namespace: string, matcher: Matcher) => {
-  const newMatcher = structuredClone(matcher);
-  if (newMatcher.component?.$eq) {
-    newMatcher.component.$eq = `${namespace}:${newMatcher.component.$eq}`;
-  }
-  if (newMatcher.component?.$neq) {
-    newMatcher.component.$neq = `${namespace}:${newMatcher.component.$neq}`;
-  }
-  if (newMatcher.component?.$in) {
-    newMatcher.component.$in = newMatcher.component.$in.map(
-      (component) => `${namespace}:${component}`
-    );
-  }
-  if (newMatcher.component?.$nin) {
-    newMatcher.component.$nin = newMatcher.component.$nin.map(
-      (component) => `${namespace}:${component}`
-    );
-  }
-  return newMatcher;
-};
-
-export const namespaceMeta = (
-  meta: WsComponentMeta,
-  namespace: string,
-  components: Set<EmbedTemplateInstance["component"]>
-) => {
-  const newMeta = { ...meta };
-  if (newMeta.constraints) {
-    if (Array.isArray(newMeta.constraints)) {
-      newMeta.constraints = newMeta.constraints.map((matcher) =>
-        namespaceMatcher(namespace, matcher)
-      );
-    } else {
-      newMeta.constraints = namespaceMatcher(namespace, newMeta.constraints);
-    }
-  }
-  if (newMeta.indexWithinAncestor) {
-    newMeta.indexWithinAncestor = components.has(newMeta.indexWithinAncestor)
-      ? `${namespace}:${newMeta.indexWithinAncestor}`
-      : newMeta.indexWithinAncestor;
-  }
-  return newMeta;
 };

--- a/packages/sdk-cli/src/generate-stories.ts
+++ b/packages/sdk-cli/src/generate-stories.ts
@@ -147,12 +147,13 @@ export const generateStories = async () => {
         );
         namespaceMetas = new Map(Object.entries(await import(metasUrl)));
       }
-      for (let [name, meta] of namespaceMetas) {
+      for (const [name, meta] of namespaceMetas) {
+        let prefixedName = name;
         if (namespace !== BASE_NAMESPACE && namespace !== WS_NAMESPACE) {
-          name = `${namespace}:${name}`;
+          prefixedName = `${namespace}:${name}`;
         }
-        if (components.has(name)) {
-          usedMetas.set(name, meta as WsComponentMeta);
+        if (components.has(prefixedName)) {
+          usedMetas.set(prefixedName, meta as WsComponentMeta);
         }
       }
     }

--- a/packages/sdk-cli/src/generate-stories.ts
+++ b/packages/sdk-cli/src/generate-stories.ts
@@ -13,10 +13,7 @@ import {
   coreMetas,
   generateCss,
 } from "@webstudio-is/sdk";
-import {
-  generateWebstudioComponent,
-  namespaceMeta,
-} from "@webstudio-is/react-sdk";
+import { generateWebstudioComponent } from "@webstudio-is/react-sdk";
 import { renderTemplate, type TemplateMeta } from "@webstudio-is/template";
 
 const WS_NAMESPACE = "ws";
@@ -153,11 +150,6 @@ export const generateStories = async () => {
       for (let [name, meta] of namespaceMetas) {
         if (namespace !== BASE_NAMESPACE && namespace !== WS_NAMESPACE) {
           name = `${namespace}:${name}`;
-          meta = namespaceMeta(
-            meta as WsComponentMeta,
-            namespace,
-            new Set(metas.keys())
-          );
         }
         if (components.has(name)) {
           usedMetas.set(name, meta as WsComponentMeta);

--- a/packages/sdk-components-animation/src/animate-text.ws.ts
+++ b/packages/sdk-components-animation/src/animate-text.ws.ts
@@ -1,5 +1,6 @@
 import { TextAnimationIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
+import { animation } from "./shared/meta";
 import { props } from "./__generated__/animate-text.props";
 
 export const meta: WsComponentMeta = {
@@ -11,7 +12,7 @@ export const meta: WsComponentMeta = {
   order: 6,
   label: "Text Animation",
   constraints: [
-    { relation: "parent", component: { $eq: "AnimateChildren" } },
+    { relation: "parent", component: { $eq: animation.AnimateChildren } },
     {
       relation: "child",
       text: false,

--- a/packages/sdk-components-animation/src/shared/meta.ts
+++ b/packages/sdk-components-animation/src/shared/meta.ts
@@ -1,0 +1,14 @@
+const createMetaProxy = (prefix: string): Record<string, string> => {
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return `${prefix}${prop as string}`;
+      },
+    }
+  );
+};
+
+export const animation = createMetaProxy(
+  "@webstudio-is/sdk-components-animation:"
+);

--- a/packages/sdk-components-animation/src/stagger-animation.ws.ts
+++ b/packages/sdk-components-animation/src/stagger-animation.ws.ts
@@ -1,5 +1,6 @@
 import { StaggerAnimationIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
+import { animation } from "./shared/meta";
 import { props } from "./__generated__/stagger-animation.props";
 
 export const meta: WsComponentMeta = {
@@ -11,7 +12,7 @@ export const meta: WsComponentMeta = {
   order: 6,
   label: "Stagger Animation",
   constraints: [
-    { relation: "parent", component: { $eq: "AnimateChildren" } },
+    { relation: "parent", component: { $eq: animation.AnimateChildren } },
     {
       relation: "child",
       text: false,

--- a/packages/sdk-components-react-radix/src/accordion.ws.ts
+++ b/packages/sdk-components-react-radix/src/accordion.ws.ts
@@ -12,6 +12,7 @@ import {
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
 import { div, h3, button } from "@webstudio-is/sdk/normalize.css";
+import { radix } from "./shared/meta";
 import { buttonReset } from "./shared/preset-styles";
 import {
   propsAccordion,
@@ -32,7 +33,7 @@ export const metaAccordion: WsComponentMeta = {
   constraints: [
     {
       relation: "descendant",
-      component: { $eq: "AccordionItem" },
+      component: { $eq: radix.AccordionItem },
     },
   ],
 };
@@ -44,18 +45,18 @@ export const metaAccordionItem: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "Accordion" },
+      component: { $eq: radix.Accordion },
     },
     {
       relation: "descendant",
-      component: { $eq: "AccordionHeader" },
+      component: { $eq: radix.AccordionHeader },
     },
     {
       relation: "descendant",
-      component: { $eq: "AccordionContent" },
+      component: { $eq: radix.AccordionContent },
     },
   ],
-  indexWithinAncestor: "Accordion",
+  indexWithinAncestor: radix.Accordion,
   presetStyle,
 };
 
@@ -66,11 +67,11 @@ export const metaAccordionHeader: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "AccordionItem" },
+      component: { $eq: radix.AccordionItem },
     },
     {
       relation: "descendant",
-      component: { $eq: "AccordionTrigger" },
+      component: { $eq: radix.AccordionTrigger },
     },
   ],
   presetStyle: {
@@ -94,7 +95,7 @@ export const metaAccordionTrigger: WsComponentMeta = {
   icon: TriggerIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "AccordionHeader" },
+    component: { $eq: radix.AccordionHeader },
   },
   states: [
     ...defaultStates,
@@ -115,7 +116,7 @@ export const metaAccordionContent: WsComponentMeta = {
   icon: ContentIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "AccordionItem" },
+    component: { $eq: radix.AccordionItem },
   },
   presetStyle,
 };

--- a/packages/sdk-components-react-radix/src/checkbox.ws.ts
+++ b/packages/sdk-components-react-radix/src/checkbox.ws.ts
@@ -5,6 +5,7 @@ import {
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
 import { button, span } from "@webstudio-is/sdk/normalize.css";
+import { radix } from "./shared/meta";
 import { buttonReset } from "./shared/preset-styles";
 import {
   propsCheckbox,
@@ -15,7 +16,7 @@ export const metaCheckbox: WsComponentMeta = {
   type: "container",
   constraints: {
     relation: "descendant",
-    component: { $eq: "CheckboxIndicator" },
+    component: { $eq: radix.CheckboxIndicator },
   },
   icon: CheckboxCheckedIcon,
   states: [
@@ -40,7 +41,7 @@ export const metaCheckboxIndicator: WsComponentMeta = {
   type: "container",
   constraints: {
     relation: "ancestor",
-    component: { $eq: "Checkbox" },
+    component: { $eq: radix.Checkbox },
   },
   icon: TriggerIcon,
   states: defaultStates,

--- a/packages/sdk-components-react-radix/src/collapsible.ws.ts
+++ b/packages/sdk-components-react-radix/src/collapsible.ws.ts
@@ -5,6 +5,7 @@ import {
 } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { div } from "@webstudio-is/sdk/normalize.css";
+import { radix } from "./shared/meta";
 import {
   propsCollapsible,
   propsCollapsibleContent,
@@ -16,11 +17,11 @@ export const metaCollapsible: WsComponentMeta = {
   constraints: [
     {
       relation: "descendant",
-      component: { $eq: "CollapsibleTrigger" },
+      component: { $eq: radix.CollapsibleTrigger },
     },
     {
       relation: "descendant",
-      component: { $eq: "CollapsibleContent" },
+      component: { $eq: radix.CollapsibleContent },
     },
   ],
   presetStyle: {
@@ -34,7 +35,7 @@ export const metaCollapsibleTrigger: WsComponentMeta = {
   icon: TriggerIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "Collapsible" },
+    component: { $eq: radix.Collapsible },
   },
 };
 
@@ -46,7 +47,7 @@ export const metaCollapsibleContent: WsComponentMeta = {
   icon: ContentIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "Collapsible" },
+    component: { $eq: radix.Collapsible },
   },
 };
 

--- a/packages/sdk-components-react-radix/src/dialog.ws.ts
+++ b/packages/sdk-components-react-radix/src/dialog.ws.ts
@@ -13,6 +13,7 @@ import {
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
 import { div, button, h2, p } from "@webstudio-is/sdk/normalize.css";
+import { radix } from "./shared/meta";
 import {
   propsDialog,
   propsDialogContent,
@@ -30,7 +31,7 @@ export const metaDialogTrigger: WsComponentMeta = {
   icon: TriggerIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "Dialog" },
+    component: { $eq: radix.Dialog },
   },
 };
 
@@ -43,11 +44,11 @@ export const metaDialogOverlay: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "Dialog" },
+      component: { $eq: radix.Dialog },
     },
     {
       relation: "descendant",
-      component: { $eq: "DialogContent" },
+      component: { $eq: radix.DialogContent },
     },
   ],
 };
@@ -61,23 +62,23 @@ export const metaDialogContent: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "DialogOverlay" },
+      component: { $eq: radix.DialogOverlay },
     },
     // often deleted by users
     // though radix starts throwing warnings in console
     /*
     {
       relation: "descendant",
-      component: { $eq: "DialogTitle" },
+      component: { $eq: radix.DialogTitle },
     },
     {
       relation: "descendant",
-      component: { $eq: "DialogDescription" },
+      component: { $eq: radix.DialogDescription },
     },
     */
     {
       relation: "descendant",
-      component: { $eq: "DialogClose" },
+      component: { $eq: radix.DialogClose },
     },
   ],
 };
@@ -90,7 +91,7 @@ export const metaDialogTitle: WsComponentMeta = {
   icon: HeadingIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "DialogContent" },
+    component: { $eq: radix.DialogContent },
   },
 };
 
@@ -102,7 +103,7 @@ export const metaDialogDescription: WsComponentMeta = {
   icon: TextIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "DialogContent" },
+    component: { $eq: radix.DialogContent },
   },
 };
 
@@ -116,7 +117,7 @@ export const metaDialogClose: WsComponentMeta = {
   label: "Close Button",
   constraints: {
     relation: "ancestor",
-    component: { $eq: "DialogContent" },
+    component: { $eq: radix.DialogContent },
   },
 };
 
@@ -126,11 +127,11 @@ export const metaDialog: WsComponentMeta = {
   constraints: [
     {
       relation: "descendant",
-      component: { $eq: "DialogTrigger" },
+      component: { $eq: radix.DialogTrigger },
     },
     {
       relation: "descendant",
-      component: { $eq: "DialogOverlay" },
+      component: { $eq: radix.DialogOverlay },
     },
   ],
 };

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -9,6 +9,7 @@ import {
 } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { div } from "@webstudio-is/sdk/normalize.css";
+import { radix } from "./shared/meta";
 import {
   propsNavigationMenu,
   propsNavigationMenuItem,
@@ -28,11 +29,11 @@ export const metaNavigationMenu: WsComponentMeta = {
   constraints: [
     {
       relation: "descendant",
-      component: { $eq: "NavigationMenuList" },
+      component: { $eq: radix.NavigationMenuList },
     },
     {
       relation: "descendant",
-      component: { $eq: "NavigationMenuViewport" },
+      component: { $eq: radix.NavigationMenuViewport },
     },
   ],
 };
@@ -43,11 +44,11 @@ export const metaNavigationMenuList: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "NavigationMenu" },
+      component: { $eq: radix.NavigationMenu },
     },
     {
       relation: "descendant",
-      component: { $eq: "NavigationMenuItem" },
+      component: { $eq: radix.NavigationMenuItem },
     },
   ],
   presetStyle: {
@@ -61,12 +62,12 @@ export const metaNavigationMenuItem: WsComponentMeta = {
   icon: ListItemIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "NavigationMenuList" },
+    component: { $eq: radix.NavigationMenuList },
   },
   presetStyle: {
     div,
   },
-  indexWithinAncestor: "NavigationMenu",
+  indexWithinAncestor: radix.NavigationMenu,
   label: "Menu Item",
 };
 
@@ -75,7 +76,7 @@ export const metaNavigationMenuTrigger: WsComponentMeta = {
   icon: TriggerIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "NavigationMenuItem" },
+    component: { $eq: radix.NavigationMenuItem },
   },
   label: "Menu Trigger",
 };
@@ -85,9 +86,9 @@ export const metaNavigationMenuContent: WsComponentMeta = {
   icon: ContentIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "NavigationMenuItem" },
+    component: { $eq: radix.NavigationMenuItem },
   },
-  indexWithinAncestor: "NavigationMenu",
+  indexWithinAncestor: radix.NavigationMenu,
   presetStyle: {
     div,
   },
@@ -100,11 +101,13 @@ export const metaNavigationMenuLink: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "NavigationMenu" },
+      component: { $eq: radix.NavigationMenu },
     },
     {
       relation: "ancestor",
-      component: { $in: ["NavigationMenuContent", "NavigationMenuItem"] },
+      component: {
+        $in: [radix.NavigationMenuContent, radix.NavigationMenuItem],
+      },
     },
   ],
   label: "Accessible Link Wrapper",
@@ -115,7 +118,7 @@ export const metaNavigationMenuViewport: WsComponentMeta = {
   icon: ViewportIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "NavigationMenu" },
+    component: { $eq: radix.NavigationMenu },
   },
   presetStyle: {
     div,

--- a/packages/sdk-components-react-radix/src/popover.ws.ts
+++ b/packages/sdk-components-react-radix/src/popover.ws.ts
@@ -1,6 +1,7 @@
 import { PopoverIcon, TriggerIcon, ContentIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { div } from "@webstudio-is/sdk/normalize.css";
+import { radix } from "./shared/meta";
 import {
   propsPopover,
   propsPopoverContent,
@@ -13,7 +14,7 @@ export const metaPopoverTrigger: WsComponentMeta = {
   icon: TriggerIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "Popover" },
+    component: { $eq: radix.Popover },
   },
 };
 
@@ -25,7 +26,7 @@ export const metaPopoverContent: WsComponentMeta = {
   icon: ContentIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "Popover" },
+    component: { $eq: radix.Popover },
   },
 };
 
@@ -35,11 +36,11 @@ export const metaPopover: WsComponentMeta = {
   constraints: [
     {
       relation: "descendant",
-      component: { $eq: "PopoverTrigger" },
+      component: { $eq: radix.PopoverTrigger },
     },
     {
       relation: "descendant",
-      component: { $eq: "PopoverContent" },
+      component: { $eq: radix.PopoverContent },
     },
   ],
 };

--- a/packages/sdk-components-react-radix/src/radio-group.ws.ts
+++ b/packages/sdk-components-react-radix/src/radio-group.ws.ts
@@ -5,6 +5,7 @@ import {
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
 import { button, div, span } from "@webstudio-is/sdk/normalize.css";
+import { radix } from "./shared/meta";
 import { buttonReset } from "./shared/preset-styles";
 import {
   propsRadioGroup,
@@ -16,7 +17,7 @@ export const metaRadioGroup: WsComponentMeta = {
   type: "container",
   constraints: {
     relation: "descendant",
-    component: { $eq: "RadioGroupItem" },
+    component: { $eq: radix.RadioGroupItem },
   },
   icon: RadioGroupIcon,
   states: [
@@ -42,11 +43,11 @@ export const metaRadioGroupItem: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "RadioGroup" },
+      component: { $eq: radix.RadioGroup },
     },
     {
       relation: "descendant",
-      component: { $eq: "RadioGroupIndicator" },
+      component: { $eq: radix.RadioGroupIndicator },
     },
   ],
   icon: ItemIcon,
@@ -61,7 +62,7 @@ export const metaRadioGroupIndicator: WsComponentMeta = {
   icon: TriggerIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "RadioGroupItem" },
+    component: { $eq: radix.RadioGroupItem },
   },
   states: defaultStates,
   presetStyle: {

--- a/packages/sdk-components-react-radix/src/select.ws.ts
+++ b/packages/sdk-components-react-radix/src/select.ws.ts
@@ -10,6 +10,7 @@ import {
 } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { button, div, span } from "@webstudio-is/sdk/normalize.css";
+import { radix } from "./shared/meta";
 import {
   propsSelect,
   propsSelectContent,
@@ -27,11 +28,11 @@ export const metaSelect: WsComponentMeta = {
   constraints: [
     {
       relation: "descendant",
-      component: { $eq: "SelectTrigger" },
+      component: { $eq: radix.SelectTrigger },
     },
     {
       relation: "descendant",
-      component: { $eq: "SelectContent" },
+      component: { $eq: radix.SelectContent },
     },
   ],
 };
@@ -45,11 +46,11 @@ export const metaSelectTrigger: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "Select" },
+      component: { $eq: radix.Select },
     },
     {
       relation: "descendant",
-      component: { $eq: "SelectValue" },
+      component: { $eq: radix.SelectValue },
     },
   ],
 };
@@ -63,7 +64,7 @@ export const metaSelectValue: WsComponentMeta = {
   },
   constraints: {
     relation: "ancestor",
-    component: { $eq: "SelectTrigger" },
+    component: { $eq: radix.SelectTrigger },
   },
 };
 
@@ -76,11 +77,11 @@ export const metaSelectContent: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "Select" },
+      component: { $eq: radix.Select },
     },
     {
       relation: "descendant",
-      component: { $eq: "SelectViewport" },
+      component: { $eq: radix.SelectViewport },
     },
   ],
 };
@@ -94,11 +95,11 @@ export const metaSelectViewport: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "SelectContent" },
+      component: { $eq: radix.SelectContent },
     },
     {
       relation: "descendant",
-      component: { $eq: "SelectItem" },
+      component: { $eq: radix.SelectItem },
     },
   ],
 };
@@ -109,15 +110,15 @@ export const metaSelectItem: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "SelectViewport" },
+      component: { $eq: radix.SelectViewport },
     },
     {
       relation: "descendant",
-      component: { $eq: "SelectItemIndicator" },
+      component: { $eq: radix.SelectItemIndicator },
     },
     {
       relation: "descendant",
-      component: { $eq: "SelectItemText" },
+      component: { $eq: radix.SelectItemText },
     },
   ],
   presetStyle: {
@@ -131,7 +132,7 @@ export const metaSelectItemIndicator: WsComponentMeta = {
   icon: CheckMarkIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "SelectItem" },
+    component: { $eq: radix.SelectItem },
   },
   presetStyle: {
     span,
@@ -144,7 +145,7 @@ export const metaSelectItemText: WsComponentMeta = {
   icon: TextIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "SelectItem" },
+    component: { $eq: radix.SelectItem },
   },
   presetStyle: {
     span,

--- a/packages/sdk-components-react-radix/src/shared/meta.ts
+++ b/packages/sdk-components-react-radix/src/shared/meta.ts
@@ -1,0 +1,14 @@
+const createMetaProxy = (prefix: string): Record<string, string> => {
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return `${prefix}${prop as string}`;
+      },
+    }
+  );
+};
+
+export const radix = createMetaProxy(
+  "@webstudio-is/sdk-components-react-radix:"
+);

--- a/packages/sdk-components-react-radix/src/switch.ws.ts
+++ b/packages/sdk-components-react-radix/src/switch.ws.ts
@@ -5,6 +5,7 @@ import {
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
 import { button, span } from "@webstudio-is/sdk/normalize.css";
+import { radix } from "./shared/meta";
 import { buttonReset } from "./shared/preset-styles";
 import { propsSwitch, propsSwitchThumb } from "./__generated__/switch.props";
 
@@ -12,7 +13,7 @@ export const metaSwitch: WsComponentMeta = {
   type: "container",
   constraints: {
     relation: "descendant",
-    component: { $eq: "SwitchThumb" },
+    component: { $eq: radix.SwitchThumb },
   },
   icon: SwitchIcon,
   states: [
@@ -37,7 +38,7 @@ export const metaSwitchThumb: WsComponentMeta = {
   type: "container",
   constraints: {
     relation: "ancestor",
-    component: { $eq: "Switch" },
+    component: { $eq: radix.Switch },
   },
   icon: TriggerIcon,
   states: [

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -11,6 +11,7 @@ import {
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
 import { button, div } from "@webstudio-is/sdk/normalize.css";
+import { radix } from "./shared/meta";
 import { buttonReset } from "./shared/preset-styles";
 import {
   propsTabs,
@@ -29,15 +30,15 @@ export const metaTabs: WsComponentMeta = {
   constraints: [
     {
       relation: "descendant",
-      component: { $eq: "TabsTrigger" },
+      component: { $eq: radix.TabsTrigger },
     },
     {
       relation: "descendant",
-      component: { $eq: "TabsList" },
+      component: { $eq: radix.TabsList },
     },
     {
       relation: "descendant",
-      component: { $eq: "TabsContent" },
+      component: { $eq: radix.TabsContent },
     },
   ],
   presetStyle,
@@ -48,7 +49,7 @@ export const metaTabsList: WsComponentMeta = {
   icon: HeaderIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "Tabs" },
+    component: { $eq: radix.Tabs },
   },
   presetStyle,
 };
@@ -59,14 +60,14 @@ export const metaTabsTrigger: WsComponentMeta = {
   constraints: [
     {
       relation: "ancestor",
-      component: { $eq: "TabsList" },
+      component: { $eq: radix.TabsList },
     },
     {
       relation: "ancestor",
-      component: { $neq: "TabsTrigger" },
+      component: { $neq: radix.TabsTrigger },
     },
   ],
-  indexWithinAncestor: "Tabs",
+  indexWithinAncestor: radix.Tabs,
   label: "Tab Trigger",
   states: [
     ...defaultStates,
@@ -87,9 +88,9 @@ export const metaTabsContent: WsComponentMeta = {
   icon: ContentIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "Tabs" },
+    component: { $eq: radix.Tabs },
   },
-  indexWithinAncestor: "Tabs",
+  indexWithinAncestor: radix.Tabs,
   presetStyle,
 };
 

--- a/packages/sdk-components-react-radix/src/tooltip.ws.ts
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.ts
@@ -1,6 +1,7 @@
 import { TooltipIcon, TriggerIcon, ContentIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { div } from "@webstudio-is/sdk/normalize.css";
+import { radix } from "./shared/meta";
 import {
   propsTooltip,
   propsTooltipContent,
@@ -13,7 +14,7 @@ export const metaTooltipTrigger: WsComponentMeta = {
   icon: TriggerIcon,
   constraints: {
     relation: "ancestor",
-    component: { $eq: "Tooltip" },
+    component: { $eq: radix.Tooltip },
   },
 };
 
@@ -25,7 +26,7 @@ export const metaTooltipContent: WsComponentMeta = {
   },
   constraints: {
     relation: "ancestor",
-    component: { $eq: "Tooltip" },
+    component: { $eq: radix.Tooltip },
   },
 };
 
@@ -34,11 +35,11 @@ export const metaTooltip: WsComponentMeta = {
   constraints: [
     {
       relation: "descendant",
-      component: { $eq: "TooltipTrigger" },
+      component: { $eq: radix.TooltipTrigger },
     },
     {
       relation: "descendant",
-      component: { $eq: "TooltipContent" },
+      component: { $eq: radix.TooltipContent },
     },
   ],
   icon: TooltipIcon,


### PR DESCRIPTION
Here got rid from auto namespacing meta.constraints and meta.indexWithinAncestor to unlock using components from other sdk packages.

Now package prefixes should be explicitly specified in meta though with the help of proxy.

Though exports are still need to prefix automatically when install package.