### PR TITLE
refactor: add tag property control

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
             const results = [
               await assertSize('./fixtures/ssg/dist/client', 352),
               await assertSize('./fixtures/react-router-netlify/build/client', 368),
-              await assertSize('./fixtures/webstudio-features/build/client', 1028),
+              await assertSize('./fixtures/webstudio-features/build/client', 1032),
             ]
             for (const result of results) {
               if (result.passed) {

--- a/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
@@ -11,6 +11,7 @@ import type { ControlProps } from "../shared";
 import { JsonControl } from "./json";
 import { TextContent } from "./text-content";
 import { ResourceControl } from "./resource-control";
+import { TagControl } from "./tag-control";
 
 export const renderControl = ({
   meta,
@@ -22,6 +23,10 @@ export const renderControl = ({
 
   if (meta.control === "textContent") {
     return <TextContent key={key} meta={meta} prop={prop} {...rest} />;
+  }
+
+  if (meta.control === "tag") {
+    return <TagControl key={key} meta={meta} prop={prop} {...rest} />;
   }
 
   // never render parameter props

--- a/apps/builder/app/builder/features/settings-panel/controls/tag-control.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/tag-control.tsx
@@ -1,0 +1,45 @@
+import { useStore } from "@nanostores/react";
+import { Select } from "@webstudio-is/design-system";
+import { $selectedInstance } from "~/shared/awareness";
+import { updateWebstudioData } from "~/shared/instance-utils";
+import { type ControlProps, VerticalLayout } from "../shared";
+import { FieldLabel } from "../property-label";
+
+export const TagControl = ({ meta, prop }: ControlProps<"tag">) => {
+  const instance = useStore($selectedInstance);
+  const propTag = prop?.type === "string" ? prop.value : undefined;
+  const instanceTag = instance?.tag;
+  const defaultTag = meta.options[0];
+  const value = propTag ?? instanceTag ?? defaultTag;
+  return (
+    <VerticalLayout
+      label={
+        <FieldLabel description="Use this property to change the HTML tag of this element to semantically structure and describe the content of a webpage. This can be important for accessibility tools and search engine optimization.">
+          Tag
+        </FieldLabel>
+      }
+    >
+      <Select
+        fullWidth
+        value={value}
+        options={meta.options}
+        onChange={(value) => {
+          if (instance === undefined) {
+            return;
+          }
+          const instanceId = instance.id;
+          updateWebstudioData((data) => {
+            // clean legacy <Box tag> and <Text tag>
+            if (prop) {
+              data.props.delete(prop.id);
+            }
+            const instance = data.instances.get(instanceId);
+            if (instance) {
+              instance.tag = value;
+            }
+          });
+        }}
+      />
+    </VerticalLayout>
+  );
+};

--- a/apps/builder/app/builder/features/settings-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/settings-panel/property-label.tsx
@@ -1,3 +1,4 @@
+import { micromark } from "micromark";
 import { useMemo, useState } from "react";
 import { computed } from "nanostores";
 import { useStore } from "@nanostores/react";
@@ -18,7 +19,6 @@ import { updateWebstudioData } from "~/shared/instance-utils";
 import { $selectedInstance } from "~/shared/awareness";
 import { $props, $registeredComponentPropsMetas } from "~/shared/nano-states";
 import { humanizeAttribute, showAttributeMeta } from "./shared";
-import { micromark } from "micromark";
 
 const usePropMeta = (name: string) => {
   const store = useMemo(() => {
@@ -230,6 +230,11 @@ export const FieldLabel = ({
               </Text>
               {description && (
                 <Text
+                  css={{
+                    "> *": {
+                      marginTop: 0,
+                    },
+                  }}
                   dangerouslySetInnerHTML={{ __html: micromark(description) }}
                 ></Text>
               )}

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -70,6 +70,7 @@ import {
   editablePlaceholderAttribute,
   editingPlaceholderVariable,
 } from "~/canvas/shared/styles";
+import { tagProperty } from "@webstudio-is/sdk/runtime";
 
 const ContentEditable = ({
   placeholder,
@@ -280,9 +281,17 @@ const useInstanceProps = (instanceSelector: InstanceSelector) => {
   const [instanceId] = instanceSelector;
   const $instancePropsObject = useMemo(() => {
     return computed(
-      [$propValuesByInstanceSelectorWithMemoryProps, $indexesWithinAncestors],
-      (propValuesByInstanceSelector, indexesWithinAncestors) => {
+      [
+        $propValuesByInstanceSelectorWithMemoryProps,
+        $instances,
+        $indexesWithinAncestors,
+      ],
+      (propValuesByInstanceSelector, instances, indexesWithinAncestors) => {
         const instancePropsObject: Record<Prop["name"], unknown> = {};
+        const tag = instances.get(instanceId)?.tag;
+        if (tag !== undefined) {
+          instancePropsObject[tagProperty] = tag;
+        }
         const index = indexesWithinAncestors.get(instanceId);
         if (index !== undefined) {
           instancePropsObject[indexAttribute] = index.toString();

--- a/apps/builder/app/shared/style-object-model.test.tsx
+++ b/apps/builder/app/shared/style-object-model.test.tsx
@@ -73,13 +73,11 @@ const createModel = ({
         values: prop.value.split(" "),
       });
     }
-    if (prop.name === "ws:tag" && prop.type === "string") {
-      instanceTags.set(prop.instanceId, prop.value as HtmlTags);
-    }
   }
   const instanceComponents = new Map<string, string>();
   for (const instance of instances.values()) {
     instanceComponents.set(instance.id, instance.component);
+    instanceTags.set(instance.id, (instance.tag ?? "div") as HtmlTags);
   }
   const presetStyles = new Map<string, StyleValue>();
   for (const [componentName, css] of Object.entries(presets ?? {})) {

--- a/packages/react-sdk/src/component-generator.test.tsx
+++ b/packages/react-sdk/src/component-generator.test.tsx
@@ -1272,3 +1272,32 @@ test("render empty component when no instances found", () => {
     )
   );
 });
+
+test("render tag property on components", () => {
+  expect(
+    generateWebstudioComponent({
+      classesMap: new Map(),
+      scope: createScope(),
+      name: "Page",
+      rootInstanceId: "bodyId",
+      parameters: [],
+      metas: new Map(),
+      ...renderData(
+        <$.Body ws:id="bodyId">
+          <$.Box ws:id="spanId" ws:tag="span"></$.Box>
+        </$.Body>
+      ),
+    })
+  ).toEqual(
+    validateJSX(
+      clear(`
+      const Page = () => {
+      return <Body>
+      <Box
+      data-ws-tag="span" />
+      </Body>
+      }
+    `)
+    )
+  );
+});

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -20,6 +20,7 @@ import {
   descendantComponent,
   getIndexesWithinAncestors,
 } from "@webstudio-is/sdk";
+import { tagProperty } from "@webstudio-is/sdk/runtime";
 import { indexAttribute, isAttributeNameSafe, showAttribute } from "./props";
 
 /**
@@ -170,6 +171,9 @@ export const generateJsxElement = ({
   const index = indexesWithinAncestors.get(instance.id);
   if (index !== undefined) {
     generatedProps += `\n${indexAttribute}="${index}"`;
+  }
+  if (instance.tag !== undefined) {
+    generatedProps += `\n${tagProperty}=${JSON.stringify(instance.tag)}`;
   }
 
   let conditionValue: undefined | string;

--- a/packages/sdk-components-react-radix/src/checkbox.template.tsx
+++ b/packages/sdk-components-react-radix/src/checkbox.template.tsx
@@ -69,7 +69,7 @@ export const meta: TemplateMeta = {
           <$.HtmlEmbed ws:label="Indicator Icon" code={CheckMarkIcon} />
         </radix.CheckboxIndicator>
       </radix.Checkbox>
-      <$.Text ws:label="Checkbox Label" tag="span">
+      <$.Text ws:label="Checkbox Label" ws:tag="span">
         {new PlaceholderValue("Checkbox")}
       </$.Text>
     </radix.Label>

--- a/packages/sdk-components-react-radix/src/sheet.template.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.template.tsx
@@ -89,7 +89,7 @@ export const meta: TemplateMeta = {
             flex-grow: 1;
           `}
         >
-          <$.Box ws:label="Navigation" tag="nav" role="navigation">
+          <$.Box ws:label="Navigation" ws:tag="nav">
             <$.Box
               ws:label="Sheet Header"
               ws:style={css`

--- a/packages/sdk-components-react/src/__generated__/box.props.ts
+++ b/packages/sdk-components-react/src/__generated__/box.props.ts
@@ -536,26 +536,7 @@ export const props: Record<string, PropMeta> = {
     description:
       "Overrides the browser's default tab order and follows the one specified instead.",
   },
-  tag: {
-    description:
-      "Use this property to change the HTML tag of this element to semantically structure and describe the content of a webpage. This can be important for accessibility tools and search engine optimization.",
-    required: false,
-    control: "select",
-    type: "string",
-    defaultValue: "div",
-    options: [
-      "div",
-      "address",
-      "article",
-      "aside",
-      "figure",
-      "footer",
-      "header",
-      "main",
-      "nav",
-      "section",
-    ],
-  },
+  tag: { required: false, control: "text", type: "string" },
   title: {
     required: false,
     control: "text",

--- a/packages/sdk-components-react/src/box.tsx
+++ b/packages/sdk-components-react/src/box.tsx
@@ -1,30 +1,20 @@
 import {
-  createElement,
   forwardRef,
+  createElement,
   type ElementRef,
   type ComponentProps,
 } from "react";
+import { getTagFromComponentProps } from "@webstudio-is/sdk/runtime";
 
-export const defaultTag = "div";
+const defaultTag = "div";
 
-// We don't want to enable all tags because Box is usually a container and we have specific components for many tags.
 type Props = ComponentProps<typeof defaultTag> & {
-  /** Use this property to change the HTML tag of this element to semantically structure and describe the content of a webpage. This can be important for accessibility tools and search engine optimization. */
-  tag?:
-    | "div"
-    | "header"
-    | "footer"
-    | "nav"
-    | "main"
-    | "section"
-    | "article"
-    | "aside"
-    | "address"
-    | "figure";
+  tag?: string;
 };
 
 export const Box = forwardRef<ElementRef<typeof defaultTag>, Props>(
-  ({ tag = defaultTag, ...props }, ref) => {
+  ({ tag: legacyTag, ...props }, ref) => {
+    const tag = getTagFromComponentProps(props) ?? legacyTag ?? defaultTag;
     return createElement(tag, { ...props, ref });
   }
 );

--- a/packages/sdk-components-react/src/box.ws.ts
+++ b/packages/sdk-components-react/src/box.ws.ts
@@ -1,8 +1,6 @@
-import type { ComponentProps } from "react";
 import { BoxIcon } from "@webstudio-is/icons/svg";
 import {
   defaultStates,
-  type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
@@ -19,22 +17,6 @@ import {
   section,
 } from "@webstudio-is/sdk/normalize.css";
 import { props } from "./__generated__/box.props";
-import type { Box } from "./box";
-
-type BoxTags = NonNullable<ComponentProps<typeof Box>["tag"]>;
-
-const presetStyle = {
-  div,
-  address,
-  article,
-  aside,
-  figure,
-  footer,
-  header,
-  main,
-  nav,
-  section,
-} satisfies PresetStyle<BoxTags>;
 
 export const meta: WsComponentMeta = {
   category: "general",
@@ -43,11 +25,42 @@ export const meta: WsComponentMeta = {
     "A container for content. By default this is a Div, but the tag can be changed in settings.",
   icon: BoxIcon,
   states: defaultStates,
-  presetStyle,
+  presetStyle: {
+    div,
+    address,
+    article,
+    aside,
+    figure,
+    footer,
+    header,
+    main,
+    nav,
+    section,
+  },
   order: 0,
 };
 
 export const propsMeta: WsComponentPropsMeta = {
-  props,
-  initialProps: ["id", "className", "tag"],
+  props: {
+    ...props,
+    tag: {
+      required: true,
+      control: "tag",
+      type: "string",
+      options: [
+        "div",
+        "header",
+        "footer",
+        "nav",
+        "main",
+        "section",
+        "article",
+        "aside",
+        "address",
+        "figure",
+        "span",
+      ],
+    },
+  },
+  initialProps: ["tag", "id", "className"],
 };

--- a/packages/sdk-components-react/src/checkbox.template.tsx
+++ b/packages/sdk-components-react/src/checkbox.template.tsx
@@ -8,7 +8,7 @@ export const meta: TemplateMeta = {
   template: (
     <$.Label ws:label="Checkbox Field">
       <$.Checkbox />
-      <$.Text ws:label="Checkbox Label" tag="span">
+      <$.Text ws:label="Checkbox Label" ws:tag="span">
         {new PlaceholderValue("Checkbox")}
       </$.Text>
     </$.Label>

--- a/packages/sdk-components-react/src/heading.tsx
+++ b/packages/sdk-components-react/src/heading.tsx
@@ -1,21 +1,21 @@
-import { forwardRef, type ElementRef, type ComponentProps } from "react";
+import {
+  forwardRef,
+  type ElementRef,
+  type ComponentProps,
+  createElement,
+} from "react";
+import { getTagFromComponentProps } from "@webstudio-is/sdk/runtime";
 
 const defaultTag = "h1";
 
 type Props = ComponentProps<typeof defaultTag> & {
-  /** Use HTML heading levels (h1-h6) to structure content hierarchically, with h1 as the main title and subsequent levels representing sub-sections. Maintain a logical order and avoid skipping levels to ensure consistent and meaningful organization. */
-  tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  tag?: string;
 };
 
 export const Heading = forwardRef<ElementRef<typeof defaultTag>, Props>(
-  ({ tag = defaultTag, children, ...props }, ref) => {
-    // Can't map it in the destricturing, default type won't be generated correctly
-    const Tag = tag;
-    return (
-      <Tag {...props} ref={ref}>
-        {children}
-      </Tag>
-    );
+  ({ tag: legacyTag, ...props }, ref) => {
+    const tag = getTagFromComponentProps(props) ?? legacyTag ?? defaultTag;
+    return createElement(tag, { ...props, ref });
   }
 );
 

--- a/packages/sdk-components-react/src/heading.ws.ts
+++ b/packages/sdk-components-react/src/heading.ws.ts
@@ -1,35 +1,36 @@
 import { HeadingIcon } from "@webstudio-is/icons/svg";
-import type { ComponentProps } from "react";
 import {
   defaultStates,
-  type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
 import { h1, h2, h3, h4, h5, h6 } from "@webstudio-is/sdk/normalize.css";
-import type { Heading } from "./heading";
 import { props } from "./__generated__/heading.props";
-
-type HeadingTags = NonNullable<ComponentProps<typeof Heading>["tag"]>;
-
-const presetStyle = {
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-} satisfies PresetStyle<HeadingTags>;
 
 export const meta: WsComponentMeta = {
   type: "container",
   placeholder: "Heading",
   icon: HeadingIcon,
   states: defaultStates,
-  presetStyle,
+  presetStyle: {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+  },
 };
 
 export const propsMeta: WsComponentPropsMeta = {
-  props,
-  initialProps: ["id", "className", "tag"],
+  props: {
+    ...props,
+    tag: {
+      required: true,
+      control: "tag",
+      type: "string",
+      options: ["h1", "h2", "h3", "h4", "h5", "h6"],
+    },
+  },
+  initialProps: ["tag", "id", "className"],
 };

--- a/packages/sdk-components-react/src/radio-button.template.tsx
+++ b/packages/sdk-components-react/src/radio-button.template.tsx
@@ -8,7 +8,7 @@ export const meta: TemplateMeta = {
   template: (
     <$.Label ws:label="Radio Field">
       <$.RadioButton />
-      <$.Text ws:label="Radio Label" tag="span">
+      <$.Text ws:label="Radio Label" ws:tag="span">
         {new PlaceholderValue("Radio")}
       </$.Text>
     </$.Label>

--- a/packages/sdk-components-react/src/text.tsx
+++ b/packages/sdk-components-react/src/text.tsx
@@ -1,22 +1,21 @@
-import { forwardRef, type ElementRef, type ComponentProps } from "react";
+import {
+  forwardRef,
+  createElement,
+  type ElementRef,
+  type ComponentProps,
+} from "react";
+import { getTagFromComponentProps } from "@webstudio-is/sdk/runtime";
 
-export const defaultTag = "div";
+const defaultTag = "div";
 
-// We don't want to enable all tags because Box is usually a container and we have specific components for many tags.
 type Props = ComponentProps<typeof defaultTag> & {
-  /** Use this property to change the HTML tag of this element to semantically structure and describe the content of a webpage. This can be important for accessibility tools and search engine optimization. */
-  tag?: "div" | "span" | "figcaption" | "cite";
+  tag?: string;
 };
 
 export const Text = forwardRef<ElementRef<typeof defaultTag>, Props>(
-  ({ tag = defaultTag, children, ...props }, ref) => {
-    // Can't map it in the destricturing, default type won't be generated correctly
-    const Tag = tag;
-    return (
-      <Tag {...props} ref={ref}>
-        {children}
-      </Tag>
-    );
+  ({ tag: legacyTag, ...props }, ref) => {
+    const tag = getTagFromComponentProps(props) ?? legacyTag ?? defaultTag;
+    return createElement(tag, { ...props, ref });
   }
 );
 

--- a/packages/sdk-components-react/src/text.ws.ts
+++ b/packages/sdk-components-react/src/text.ws.ts
@@ -1,32 +1,36 @@
 import { TextIcon } from "@webstudio-is/icons/svg";
 import {
   defaultStates,
-  type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
 import { div } from "@webstudio-is/sdk/normalize.css";
 import { props } from "./__generated__/text.props";
-import type { defaultTag } from "./text";
-
-const presetStyle = {
-  div: [
-    ...div,
-    {
-      property: "min-height",
-      value: { type: "unit", unit: "em", value: 1 },
-    },
-  ],
-} satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
   type: "container",
   icon: TextIcon,
   states: defaultStates,
-  presetStyle,
+  presetStyle: {
+    div: [
+      ...div,
+      {
+        property: "min-height",
+        value: { type: "unit", unit: "em", value: 1 },
+      },
+    ],
+  },
 };
 
 export const propsMeta: WsComponentPropsMeta = {
-  props,
-  initialProps: ["id", "className", "tag"],
+  props: {
+    ...props,
+    tag: {
+      required: true,
+      control: "tag",
+      type: "string",
+      options: ["div", "cite", "figcaption", "span"],
+    },
+  },
+  initialProps: ["tag", "id", "className"],
 };

--- a/packages/sdk/src/core-templates.tsx
+++ b/packages/sdk/src/core-templates.tsx
@@ -42,12 +42,12 @@ const blockMeta: TemplateMeta = {
     <ws.block>
       <BlockTemplate ws:label="Templates">
         <$.Paragraph></$.Paragraph>
-        <$.Heading ws:label="Heading 1" tag="h1"></$.Heading>
-        <$.Heading ws:label="Heading 2" tag="h2"></$.Heading>
-        <$.Heading ws:label="Heading 3" tag="h3"></$.Heading>
-        <$.Heading ws:label="Heading 4" tag="h4"></$.Heading>
-        <$.Heading ws:label="Heading 5" tag="h5"></$.Heading>
-        <$.Heading ws:label="Heading 6" tag="h6"></$.Heading>
+        <$.Heading ws:label="Heading 1" ws:tag="h1"></$.Heading>
+        <$.Heading ws:label="Heading 2" ws:tag="h2"></$.Heading>
+        <$.Heading ws:label="Heading 3" ws:tag="h3"></$.Heading>
+        <$.Heading ws:label="Heading 4" ws:tag="h4"></$.Heading>
+        <$.Heading ws:label="Heading 5" ws:tag="h5"></$.Heading>
+        <$.Heading ws:label="Heading 6" ws:tag="h6"></$.Heading>
         <$.List ws:label="List (Unordered)">
           <$.ListItem></$.ListItem>
         </$.List>

--- a/packages/sdk/src/runtime.ts
+++ b/packages/sdk/src/runtime.ts
@@ -1,3 +1,11 @@
 export * from "./resource-loader";
 export * from "./to-string";
 export * from "./form-fields";
+
+export const tagProperty = "data-ws-tag";
+
+export const getTagFromComponentProps = (
+  props: Record<string, unknown>
+): string | undefined => {
+  return props[tagProperty] as string | undefined;
+};

--- a/packages/sdk/src/schema/instances.ts
+++ b/packages/sdk/src/schema/instances.ts
@@ -28,6 +28,7 @@ export const Instance = z.object({
   type: z.literal("instance"),
   id: InstanceId,
   component: z.string(),
+  tag: z.string().optional(),
   label: z.string().optional(),
   children: z.array(InstanceChild),
 });

--- a/packages/sdk/src/schema/prop-meta.ts
+++ b/packages/sdk/src/schema/prop-meta.ts
@@ -16,6 +16,14 @@ const common = {
   required: z.boolean(),
 };
 
+const Tag = z.object({
+  ...common,
+  control: z.literal("tag"),
+  type: z.literal("string"),
+  defaultValue: z.undefined().optional(),
+  options: z.array(z.string()),
+});
+
 const Number = z.object({
   ...common,
   control: z.literal("number"),
@@ -182,6 +190,7 @@ const AnimationAction = z.object({
 });
 
 export const PropMeta = z.union([
+  Tag,
   Number,
   Range,
   Text,

--- a/packages/template/src/jsx.test.tsx
+++ b/packages/template/src/jsx.test.tsx
@@ -569,3 +569,27 @@ test("render ws:show attribute", () => {
     },
   ]);
 });
+
+test("render ws:tag property", () => {
+  const { instances, props } = renderTemplate(
+    <$.Body ws:id="body">
+      <$.Box ws:tag="span"></$.Box>
+    </$.Body>
+  );
+  expect(instances).toEqual([
+    {
+      type: "instance",
+      id: "body",
+      component: "Body",
+      children: [{ type: "id", value: "0" }],
+    },
+    {
+      type: "instance",
+      id: "0",
+      component: "Box",
+      tag: "span",
+      children: [],
+    },
+  ]);
+  expect(props).toEqual([]);
+});

--- a/packages/template/src/jsx.ts
+++ b/packages/template/src/jsx.ts
@@ -254,10 +254,15 @@ export const renderTemplate = (
   };
   const children = traverseJsx(root, (element, children) => {
     const instanceId = element.props?.["ws:id"] ?? getId(element);
+    let tag: string | undefined;
     for (const entry of Object.entries({ ...element.props })) {
       const [_name, value] = entry;
       let [name] = entry;
       if (name === "ws:id" || name === "ws:label" || name === "children") {
+        continue;
+      }
+      if (name === "ws:tag") {
+        tag = value as string;
         continue;
       }
       if (name === "ws:style") {
@@ -339,9 +344,6 @@ export const renderTemplate = (
       type: "instance",
       id: instanceId,
       component,
-      ...(element.props?.["ws:label"]
-        ? { label: element.props?.["ws:label"] }
-        : undefined),
       children: children.map((child): Instance["children"][number] => {
         if (typeof child === "string") {
           return { type: "text", value: child };
@@ -356,6 +358,12 @@ export const renderTemplate = (
         return { type: "id", value: child.props?.["ws:id"] ?? getId(child) };
       }),
     };
+    if (element.props?.["ws:label"]) {
+      instance.label = element.props?.["ws:label"];
+    }
+    if (tag) {
+      instance.tag = tag;
+    }
     instances.push(instance);
     return { type: "id", value: instance.id };
   });
@@ -407,6 +415,7 @@ type ComponentProps = Record<string, unknown> &
   Record<`${string}:expression`, string> & {
     "ws:id"?: string;
     "ws:label"?: string;
+    "ws:tag"?: string;
     "ws:style"?: TemplateStyleDecl[];
     "ws:show"?: boolean | Expression;
     children?: ReactNode | Expression | PlaceholderValue;


### PR DESCRIPTION
https://github.com/webstudio-is/webstudio/issues/3632

Here added dedicated tag property control which will automatically migrate Box, Text and Heading components to instance.tag internally and will be used for ws:element component.

Later will extend tag control with tag descriptions and auto inferring matching tags.

<img width="428" alt="Screenshot 2025-04-02 at 15 56 46" src="https://github.com/user-attachments/assets/fa8d24ba-b9e8-4221-b47a-a9e923475bb6" />
