### PR TITLE
fix: show proper shadow labels

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/box-shadows/box-shadows.tsx
@@ -1,4 +1,5 @@
-import { colord, type RgbaColor } from "colord";
+import { colord, extend, type RgbaColor } from "colord";
+import namesPlugin from "colord/plugins/names";
 import {
   toValue,
   type CssProperty,
@@ -15,6 +16,9 @@ import {
 } from "../../shared/repeated-style";
 import { parseCssFragment } from "../../shared/css-fragment";
 
+// To support color names
+extend([namesPlugin]);
+
 export const properties = ["box-shadow"] satisfies [
   CssProperty,
   ...CssProperty[],
@@ -24,46 +28,29 @@ const label = "Box Shadows";
 const initialBoxShadow = "0px 2px 5px 0px rgba(0, 0, 0, 0.2)";
 
 const getItemProps = (layer: StyleValue, computedLayer?: StyleValue) => {
-  let values: StyleValue[] = [];
-  if (layer.type === "tuple") {
-    values = layer.value;
-  }
-  if (layer.type === "var" && computedLayer?.type === "tuple") {
-    values = computedLayer.value;
-  }
+  const shadowValue =
+    computedLayer?.type === "shadow" ? computedLayer : undefined;
   const labels = [];
-  let color: RgbaColor | undefined;
-  let isInset = false;
-
+  if (shadowValue?.position === "inset") {
+    labels.push("Inner:");
+  } else {
+    labels.push("Outer:");
+  }
   if (layer.type === "var") {
     labels.push(`--${layer.value}`);
-  }
-  for (const item of values) {
-    if (item.type === "rgb") {
-      color = colord(toValue(item)).toRgb();
-      continue;
-    }
-    if (item.type === "keyword") {
-      if (item.value === "inset") {
-        isInset = true;
-        continue;
-      }
-      if (colord(item.value).isValid()) {
-        color = colord(item.value).toRgb();
-        continue;
-      }
-    }
-    if (layer.type !== "var") {
-      labels.push(toValue(item));
-    }
-  }
-
-  if (isInset) {
-    labels.unshift("Inner Shadow:");
+  } else if (shadowValue) {
+    labels.push(toValue(shadowValue.offsetX));
+    labels.push(toValue(shadowValue.offsetY));
+    labels.push(toValue(shadowValue.blur));
+    labels.push(toValue(shadowValue.spread));
   } else {
-    labels.unshift("Outer Shadow:");
+    labels.push(toValue(shadowValue));
   }
-
+  let color: undefined | RgbaColor;
+  const colordValue = colord(toValue(shadowValue?.color));
+  if (colordValue.isValid()) {
+    color = colordValue.toRgb();
+  }
   return { label: labels.join(" "), color };
 };
 

--- a/apps/builder/app/builder/features/style-panel/sections/text-shadows/text-shadows.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/text-shadows/text-shadows.tsx
@@ -1,4 +1,5 @@
-import { colord, type RgbaColor } from "colord";
+import { colord, extend, type RgbaColor } from "colord";
+import namesPlugin from "colord/plugins/names";
 import {
   toValue,
   type CssProperty,
@@ -15,6 +16,9 @@ import {
 import { parseCssFragment } from "../../shared/css-fragment";
 import { useComputedStyleDecl } from "../../shared/model";
 
+// To support color names
+extend([namesPlugin]);
+
 export const properties = ["text-shadow"] satisfies [
   CssProperty,
   ...CssProperty[],
@@ -24,33 +28,23 @@ const label = "Text Shadows";
 const initialTextShadow = "0px 2px 5px rgba(0, 0, 0, 0.2)";
 
 const getItemProps = (layer: StyleValue, computedLayer?: StyleValue) => {
-  let values: StyleValue[] = [];
-  if (layer.type === "tuple") {
-    values = layer.value;
-  }
-  if (layer.type === "var" && computedLayer?.type === "tuple") {
-    values = computedLayer.value;
-  }
-  const labels = ["Text Shadow:"];
-  let color: RgbaColor | undefined;
-
+  const shadowValue =
+    computedLayer?.type === "shadow" ? computedLayer : undefined;
+  const labels = [];
   if (layer.type === "var") {
     labels.push(`--${layer.value}`);
+  } else if (shadowValue) {
+    labels.push(toValue(shadowValue.offsetX));
+    labels.push(toValue(shadowValue.offsetY));
+    labels.push(toValue(shadowValue.blur));
+  } else {
+    labels.push(toValue(shadowValue));
   }
-  for (const item of values) {
-    if (item.type === "rgb") {
-      color = colord(toValue(item)).toRgb();
-      continue;
-    }
-    if (item.type === "keyword" && colord(item.value).isValid()) {
-      color = colord(item.value).toRgb();
-      continue;
-    }
-    if (layer.type !== "var") {
-      labels.push(toValue(item));
-    }
+  let color: undefined | RgbaColor;
+  const colordValue = colord(toValue(shadowValue?.color));
+  if (colordValue.isValid()) {
+    color = colordValue.toRgb();
   }
-
   return { label: labels.join(" "), color };
 };
 

--- a/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/shadow-content.tsx
@@ -225,7 +225,7 @@ export const ShadowContent = ({
             // outline-offset is a fake property for validating box-shadow's offsetX.
             property="outline-offset"
             styleSource="local"
-            disabled={disabledControls}
+            aria-disabled={disabledControls}
             getOptions={() => $availableUnitVariables.get()}
             value={shadowValue.offsetX}
             onUpdate={(value, options) => {
@@ -249,7 +249,7 @@ export const ShadowContent = ({
             // outline-offset is a fake property for validating box-shadow's offsetY.
             property="outline-offset"
             styleSource="local"
-            disabled={disabledControls}
+            aria-disabled={disabledControls}
             getOptions={() => $availableUnitVariables.get()}
             value={shadowValue.offsetY}
             onUpdate={(value, options) => {
@@ -273,7 +273,7 @@ export const ShadowContent = ({
             // border-top-width is a fake property for validating box-shadow's blur.
             property="border-top-width"
             styleSource="local"
-            disabled={disabledControls}
+            aria-disabled={disabledControls}
             getOptions={() => $availableUnitVariables.get()}
             value={shadowValue.blur ?? { type: "unit", value: 0, unit: "px" }}
             onUpdate={(value, options) => {
@@ -298,7 +298,7 @@ export const ShadowContent = ({
               // outline-offset is a fake property for validating box-shadow's spread.
               property="outline-offset"
               styleSource="local"
-              disabled={disabledControls}
+              aria-disabled={disabledControls}
               getOptions={() => $availableUnitVariables.get()}
               value={
                 shadowValue.spread ?? { type: "unit", value: 0, unit: "px" }
@@ -330,7 +330,7 @@ export const ShadowContent = ({
           />
           <ColorPicker
             property="color"
-            disabled={disabledControls}
+            aria-disabled={disabledControls}
             value={shadowValue.color ?? defaultColor}
             currentColor={computedShadow?.color ?? defaultColor}
             getOptions={() => [
@@ -363,7 +363,7 @@ export const ShadowContent = ({
             />
             <ToggleGroup
               type="single"
-              disabled={disabledControls}
+              aria-disabled={disabledControls}
               value={shadowValue.position}
               defaultValue="inset"
               onValueChange={(value) =>


### PR DESCRIPTION
Ref https://discord.com/channels/955905230107738152/1356952800621494363/1356952800621494363

Forgot about labels while migrating to shadow value

<img width="250" alt="Screenshot 2025-04-02 at 20 24 35" src="https://github.com/user-attachments/assets/9e2995e9-5f43-4408-b573-52d6b11e4b94" />
