### PR TITLE
fix: render delete icon only in design mode for folder settings and duplicate icon for page settings #5038

### DIFF
--- a/apps/builder/app/builder/features/pages/folder-settings.tsx
+++ b/apps/builder/app/builder/features/pages/folder-settings.tsx
@@ -1,53 +1,53 @@
-import { z } from "zod";
-import { type FocusEventHandler, useState, useCallback, type JSX } from "react";
 import { useStore } from "@nanostores/react";
-import { useDebouncedCallback } from "use-debounce";
-import slugify from "slugify";
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+  Flex,
+  Grid,
+  InputErrorsTooltip,
+  InputField,
+  Label,
+  PanelTitle,
+  ScrollArea,
+  Separator,
+  Text,
+  TitleSuffixSpacer,
+  Tooltip,
+  rawTheme,
+  theme,
+} from "@webstudio-is/design-system";
+import {
+  ChevronsLeftIcon,
+  InfoCircleIcon,
+  TrashIcon,
+} from "@webstudio-is/icons";
 import {
   Folder,
   Pages,
   ROOT_FOLDER_ID,
   findParentFolderByChildId,
 } from "@webstudio-is/sdk";
-import {
-  theme,
-  Button,
-  Label,
-  InputErrorsTooltip,
-  Tooltip,
-  InputField,
-  Grid,
-  ScrollArea,
-  rawTheme,
-  Flex,
-  Dialog,
-  DialogContent,
-  Text,
-  DialogClose,
-  DialogTitle,
-  PanelTitle,
-  Separator,
-  TitleSuffixSpacer,
-} from "@webstudio-is/design-system";
-import {
-  ChevronsLeftIcon,
-  TrashIcon,
-  InfoCircleIcon,
-} from "@webstudio-is/icons";
-import { useIds } from "~/shared/form-utils";
-import { $pages } from "~/shared/nano-states";
 import { nanoid } from "nanoid";
-import { serverSyncStore } from "~/shared/sync";
+import { useCallback, useState, type FocusEventHandler, type JSX } from "react";
+import slugify from "slugify";
+import { useDebouncedCallback } from "use-debounce";
+import { z } from "zod";
+import { useIds } from "~/shared/form-utils";
 import { useEffectEvent } from "~/shared/hook-utils/effect-event";
+import { useUnmount } from "~/shared/hook-utils/use-mount";
+import { updateWebstudioData } from "~/shared/instance-utils";
+import { $pages, $isDesignMode } from "~/shared/nano-states";
+import { serverSyncStore } from "~/shared/sync";
+import { Form } from "./form";
 import {
-  isSlugAvailable,
-  registerFolderChildMutable,
   deleteFolderWithChildrenMutable,
   deletePageMutable,
+  isSlugAvailable,
+  registerFolderChildMutable,
 } from "./page-utils";
-import { Form } from "./form";
-import { updateWebstudioData } from "~/shared/instance-utils";
-import { useUnmount } from "~/shared/hook-utils/use-mount";
 
 const Values = Folder.pick({ name: true, slug: true }).extend({
   parentFolderId: z.string(),
@@ -462,20 +462,24 @@ const FolderSettingsView = ({
     onDelete();
   };
 
+  const isDesignMode = useStore($isDesignMode);
+
   return (
     <>
       <PanelTitle
         suffix={
           <>
-            <Tooltip content="Delete folder" side="bottom">
-              <Button
-                color="ghost"
-                prefix={<TrashIcon />}
-                onClick={hanldeRequestDelete}
-                aria-label="Delete folder"
-                tabIndex={2}
-              />
-            </Tooltip>
+            {isDesignMode && (
+              <Tooltip content="Delete folder" side="bottom">
+                <Button
+                  color="ghost"
+                  prefix={<TrashIcon />}
+                  onClick={hanldeRequestDelete}
+                  aria-label="Delete folder"
+                  tabIndex={2}
+                />
+              </Tooltip>
+            )}
             <Tooltip content="Close folder settings" side="bottom">
               <Button
                 color="ghost"

--- a/apps/builder/app/builder/features/pages/page-settings.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings.tsx
@@ -1678,16 +1678,17 @@ const PageSettingsView = ({
                 />
               </Tooltip>
             )}
-
-            <Tooltip content="Duplicate page" side="bottom">
-              <Button
-                color="ghost"
-                prefix={<CopyIcon />}
-                onClick={onDuplicate}
-                aria-label="Duplicate page"
-                tabIndex={2}
-              />
-            </Tooltip>
+            {isDesignMode && (
+              <Tooltip content="Duplicate page" side="bottom">
+                <Button
+                  color="ghost"
+                  prefix={<CopyIcon />}
+                  onClick={onDuplicate}
+                  aria-label="Duplicate page"
+                  tabIndex={2}
+                />
+              </Tooltip>
+            )}
 
             <Tooltip content="Close page settings" side="bottom">
               <Button


### PR DESCRIPTION
fixes: #5038 

## Description
delete button shows on folder settings in content mode and duplicate button shows for page setting. this fix removes these buttons in content mode. 

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. switch to content mode on your project
2. got to page/folder settings
3. expect that duplicate icon/delete icon should not be visible
4. 
## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
