### PR TITLE
fix case sensitive path in redirects ( old path field ) #5079

### DIFF
--- a/apps/builder/app/builder/features/project-settings/section-redirects.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-redirects.tsx
@@ -1,31 +1,31 @@
-import { useState, type ChangeEvent, useRef } from "react";
-import { flushSync } from "react-dom";
 import { useStore } from "@nanostores/react";
 import {
-  Grid,
-  Flex,
-  InputField,
   Button,
-  Text,
-  theme,
+  Flex,
+  Grid,
+  InputErrorsTooltip,
+  InputField,
+  Link,
   List,
   ListItem,
-  SmallIconButton,
-  InputErrorsTooltip,
   Select,
-  Link,
-  truncate,
+  SmallIconButton,
+  Text,
+  theme,
   Tooltip,
+  truncate,
 } from "@webstudio-is/design-system";
 import { ArrowRightIcon, TrashIcon } from "@webstudio-is/icons";
 import {
-  PagePath,
+  OldPagePath,
   PageRedirect,
   ProjectNewRedirectPath,
 } from "@webstudio-is/sdk";
+import { useRef, useState, type ChangeEvent } from "react";
+import { flushSync } from "react-dom";
+import { matchPathnamePattern } from "~/builder/shared/url-pattern";
 import { $pages, $publishedOrigin } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
-import { matchPathnamePattern } from "~/builder/shared/url-pattern";
 import { getExistingRoutePaths, sectionSpacing } from "./utils";
 
 export const SectionRedirects = () => {
@@ -58,7 +58,7 @@ export const SectionRedirects = () => {
   };
 
   const validateOldPath = (oldPath: string): string[] => {
-    const oldPathValidationResult = PagePath.safeParse(oldPath);
+    const oldPathValidationResult = OldPagePath.safeParse(oldPath);
 
     if (oldPathValidationResult.success === true) {
       if (oldPath.startsWith("/") === true) {

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -114,6 +114,29 @@ export const PagePath = z
     "/build prefix is reserved for the system"
   );
 
+export const OldPagePath = z
+  .string()
+  .refine((path) => path !== "", "Can't be empty")
+  .refine((path) => path !== "/", "Can't be just a /")
+  .refine(
+    (path) => path === "" || path.startsWith("/"),
+    "Must start with a / or a full URL e.g. https://website.org"
+  )
+  .refine((path) => path.endsWith("/") === false, "Can't end with a /")
+  .refine((path) => path.includes("//") === false, "Can't contain repeating /")
+  .refine(
+    (path) => /^[-_a-zA-Z0-9*:?\\/.]*$/.test(path), // Allow uppercase letters (A-Z)
+    "Only a-z, A-Z, 0-9, -, _, /, :, ?, . and * are allowed"
+  )
+  .refine(
+    (path) => path !== "/s" && path.startsWith("/s/") === false,
+    "/s prefix is reserved for the system"
+  )
+  .refine(
+    (path) => path !== "/build" && path.startsWith("/build/") === false,
+    "/build prefix is reserved for the system"
+  );
+
 const Page = z.object({
   ...commonPageFields,
   path: PagePath,
@@ -145,7 +168,7 @@ export const ProjectNewRedirectPath = PagePath.or(
 );
 
 export const PageRedirect = z.object({
-  old: PagePath,
+  old: OldPagePath,
   new: ProjectNewRedirectPath,
   status: z.enum(["301", "302"]).optional(),
 });


### PR DESCRIPTION
fixes #5079 

## Description
this fix was to allow case sensitive path in redirects (specifically the "old-path" field), for users migrating from legacy system this could be important. 

![Screen Shot 2025-04-03 at 2 00 54 PM](https://github.com/user-attachments/assets/011d9026-4a54-436c-b26c-8b3300b52c5b)



1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click on project setting
2. go to redirects tab
3. input a path with uppercase letter(s) in the old-path field and the page you want to redirect to 
4. This should work without any error

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
