### PR TITLE
feat: show toast when builder is offline

### DIFF
--- a/apps/builder/app/builder/features/topbar/sync-status.tsx
+++ b/apps/builder/app/builder/features/topbar/sync-status.tsx
@@ -9,7 +9,7 @@ import {
 } from "@webstudio-is/design-system";
 import { OfflineIcon } from "@webstudio-is/icons";
 import { useEffect } from "react";
-import { queueStatus } from "~/builder/shared/sync";
+import { $queueStatus } from "~/builder/shared/sync";
 
 const $isOnline = atom(false);
 
@@ -24,7 +24,7 @@ const subscribeIsOnline = () => {
 };
 
 export const SyncStatus = () => {
-  const statusObject = useStore(queueStatus);
+  const statusObject = useStore($queueStatus);
   const isOnline = useStore($isOnline);
   useEffect(subscribeIsOnline, []);
 

--- a/apps/builder/app/builder/shared/sync/index.ts
+++ b/apps/builder/app/builder/shared/sync/index.ts
@@ -1,1 +1,1 @@
-export { useSyncServer, queueStatus } from "./sync-server";
+export { useSyncServer, $queueStatus } from "./sync-server";


### PR DESCRIPTION
We need to make lack of connection more visible and will show toast along with offline status.

<img width="1236" alt="Screenshot 2025-04-05 at 14 21 30" src="https://github.com/user-attachments/assets/cc8e7033-9702-4f62-8c9f-e9797fda1f65" />
