### PR TITLE
feat: create a marketplace-link automatically when user submits to marketplace, and keep this link hidden in share link modal.

### DIFF
--- a/apps/builder/app/shared/share-project/index.ts
+++ b/apps/builder/app/shared/share-project/index.ts
@@ -1,1 +1,2 @@
 export { ShareProjectContainer } from "./share-project-container";
+export { MARKETPLACE_SHARE_LINK } from "./share-project";

--- a/apps/builder/app/shared/share-project/share-project-container.tsx
+++ b/apps/builder/app/shared/share-project/share-project-container.tsx
@@ -2,7 +2,11 @@ import { useEffect, useRef, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
 import { builderUrl } from "~/shared/router-utils";
 import { trpcClient } from "../trpc/trpc-client";
-import { ShareProject, type LinkOptions } from "./share-project";
+import {
+  MARKETPLACE_SHARE_LINK,
+  ShareProject,
+  type LinkOptions,
+} from "./share-project";
 
 const useShareProjectContainer = (projectId: string) => {
   const {
@@ -21,7 +25,12 @@ const useShareProjectContainer = (projectId: string) => {
 
   useEffect(() => {
     load({ projectId }, (data) => {
-      setLinks(data ?? []);
+      // prevent user from editing the auto-generated market place share token
+      const filterLinks = data.filter(
+        (link) => link.name !== MARKETPLACE_SHARE_LINK
+      );
+
+      setLinks(filterLinks ?? []);
     });
   }, [load, projectId]);
 
@@ -66,7 +75,10 @@ const useShareProjectContainer = (projectId: string) => {
       },
       () => {
         load({ projectId }, (data) => {
-          setLinks(data ?? []);
+          const filterLinks = data.filter(
+            (link) => link.name !== MARKETPLACE_SHARE_LINK
+          );
+          setLinks(filterLinks ?? []);
         });
       }
     );

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -39,6 +39,8 @@ import { CopyToClipboard } from "~/builder/shared/copy-to-clipboard";
 import { useIds } from "../form-utils";
 import type { BuilderMode } from "../nano-states";
 
+export const MARKETPLACE_SHARE_LINK = "wstd-marketplace-link";
+
 const Item = (props: ComponentProps<typeof Flex>) => (
   <Flex
     direction="column"
@@ -109,7 +111,10 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
   };
 
   const saveCustomLinkName = () => {
-    if (customLinkName.length === 0) {
+    if (
+      customLinkName.length === 0 ||
+      customLinkName === MARKETPLACE_SHARE_LINK
+    ) {
       return;
     }
 
@@ -137,7 +142,12 @@ const Menu = ({ name, hasProPlan, value, onChange, onDelete }: MenuProps) => {
           <Label htmlFor={ids.name}>Name</Label>
           <InputField
             id={ids.name}
-            color={customLinkName.length === 0 ? "error" : undefined}
+            color={
+              customLinkName.length === 0 ||
+              customLinkName.trim() === MARKETPLACE_SHARE_LINK
+                ? "error"
+                : undefined
+            }
             value={customLinkName}
             onChange={(event) => setCustomLinkName(event.target.value)}
             onKeyDown={(event) => {


### PR DESCRIPTION
## Description
fixes: #4424 

The approach to fix this goes as follows.
1. create a share link with the name "wstd-marketplace-link" with view permission automatically when user submits for review.
2. also delete the link when they unlist from marketplace.
3. we are hiding this link in the share links modal, in order to prevent the user from getting confused about the link.
4. we also prevent the user from creating a share link with the name 'wstd-marketplace-link' ( need to show some toast message maybe, right now only shows error ui )

But I don't get how the reject or approve process works, in order to add some stuff to delete the share link when the project get's rejected.


## Steps for reproduction

1. click button
6. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
