### PR TITLE
build: Fix firefox vitest tests timeout

### DIFF
--- a/packages/sdk-components-animation/vitest.config.ts
+++ b/packages/sdk-components-animation/vitest.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
             headless: true,
             screenshotFailures: false,
             instances: [{ browser: "chromium" }, { browser: "firefox" }],
+            fileParallelism: false,
           },
         },
       },


### PR DESCRIPTION
## Description

Based on comments here

https://github.com/vitest-dev/vitest/issues/7377

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
