### PR TITLE
fix: autocomplete properties with invalid values

### DIFF
--- a/apps/builder/app/builder/shared/css-editor/parse-style-input.test.ts
+++ b/apps/builder/app/builder/shared/css-editor/parse-style-input.test.ts
@@ -87,4 +87,11 @@ describe("parseStyleInput", () => {
       new Map([["color", { type: "keyword", value: "red" }]])
     );
   });
+
+  test("output property with invalid value", () => {
+    const result = parseStyleInput("rotate: z 0;");
+    expect(result).toEqual(
+      new Map([["rotate", { type: "invalid", value: "z 0" }]])
+    );
+  });
 });

--- a/apps/builder/app/builder/shared/css-editor/parse-style-input.ts
+++ b/apps/builder/app/builder/shared/css-editor/parse-style-input.ts
@@ -43,17 +43,12 @@ const ensureValue = (css: string) => {
  */
 export const parseStyleInput = (css: string): CssStyleMap => {
   css = ensureValue(css);
-
   const styles = parseCss(`selector{${css}}`);
-
   const styleMap: CssStyleMap = new Map();
-
   for (const { property, value } of styles) {
     // somethingunknown: red; -> --somethingunknown: red;
     if (
-      // Note: currently in tests it returns unparsed, but in the client it returns invalid,
-      // because we use native APIs when available in parseCss.
-      value.type === "invalid" ||
+      (propertiesData[property] === undefined && !property.startsWith("--")) ||
       (value.type === "unparsed" && property.startsWith("--") === false)
     ) {
       styleMap.set(`--${property}`, value);

--- a/apps/builder/app/builder/shared/css-editor/parse-style-input.ts
+++ b/apps/builder/app/builder/shared/css-editor/parse-style-input.ts
@@ -46,16 +46,17 @@ export const parseStyleInput = (css: string): CssStyleMap => {
   const styles = parseCss(`selector{${css}}`);
   const styleMap: CssStyleMap = new Map();
   for (const { property, value } of styles) {
-    // somethingunknown: red; -> --somethingunknown: red;
-    if (
-      (propertiesData[property] === undefined && !property.startsWith("--")) ||
-      (value.type === "unparsed" && property.startsWith("--") === false)
-    ) {
-      styleMap.set(`--${property}`, value);
-    } else {
-      // @todo This should be returning { type: "guaranteedInvalid" }
+    if (property.startsWith("--")) {
       styleMap.set(property, value);
+      continue;
     }
+    // somethingunknown: red; -> --somethingunknown: red;
+    if (propertiesData[property] === undefined || value.type === "unparsed") {
+      styleMap.set(`--${property}`, value);
+      continue;
+    }
+    // @todo This should be returning { type: "guaranteedInvalid" }
+    styleMap.set(property, value);
   }
   return styleMap;
 };

--- a/apps/builder/app/builder/shared/css-editor/parse-style-input.ts
+++ b/apps/builder/app/builder/shared/css-editor/parse-style-input.ts
@@ -51,7 +51,7 @@ export const parseStyleInput = (css: string): CssStyleMap => {
       continue;
     }
     // somethingunknown: red; -> --somethingunknown: red;
-    if (propertiesData[property] === undefined || value.type === "unparsed") {
+    if (propertiesData[property] === undefined) {
       styleMap.set(`--${property}`, value);
       continue;
     }


### PR DESCRIPTION
The logic assumed invalid values should become custom properties. Here replaced that heuristic with property name check.

<img width="294" alt="Screenshot 2025-04-11 at 19 11 54" src="https://github.com/user-attachments/assets/d2f08fbf-93ab-47c6-a075-3f4d311cc718" />
