### PR TITLE
feat: avoid generating unused preset styles

### DIFF
--- a/apps/builder/app/shared/copy-paste.test.tsx
+++ b/apps/builder/app/shared/copy-paste.test.tsx
@@ -28,6 +28,7 @@ import {
 } from "./instance-utils";
 import { $project } from "./nano-states";
 import { findAvailableVariables } from "./data-variables";
+import { camelCaseProperty } from "@webstudio-is/css-data";
 
 $project.set({ id: "current_project" } as Project);
 
@@ -83,8 +84,14 @@ const insertStyles = ({
   styleSourceId: string;
   style: TemplateStyleDecl[];
 }) => {
-  for (const styleDecl of style) {
-    const newStyleDecl = { breakpointId, styleSourceId, ...styleDecl };
+  for (const { state, property, value } of style) {
+    const newStyleDecl = {
+      breakpointId,
+      styleSourceId,
+      state,
+      property: camelCaseProperty(property),
+      value,
+    };
     data.styles.set(getStyleDeclKey(newStyleDecl), newStyleDecl);
   }
 };

--- a/fixtures/react-router-docker/app/__generated__/index.css
+++ b/fixtures/react-router-docker/app/__generated__/index.css
@@ -26,46 +26,6 @@
     border-left-width: 1px;
     outline-width: 1px;
   }
-  h2.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h3.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h4.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h5.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h6.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
   div.w-text {
     box-sizing: border-box;
     border-top-width: 1px;

--- a/fixtures/react-router-netlify/app/__generated__/index.css
+++ b/fixtures/react-router-netlify/app/__generated__/index.css
@@ -26,46 +26,6 @@
     border-left-width: 1px;
     outline-width: 1px;
   }
-  h2.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h3.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h4.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h5.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h6.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
   div.w-text {
     box-sizing: border-box;
     border-top-width: 1px;

--- a/fixtures/react-router-vercel/app/__generated__/index.css
+++ b/fixtures/react-router-vercel/app/__generated__/index.css
@@ -26,46 +26,6 @@
     border-left-width: 1px;
     outline-width: 1px;
   }
-  h2.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h3.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h4.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h5.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h6.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
   div.w-text {
     box-sizing: border-box;
     border-top-width: 1px;

--- a/fixtures/ssg-netlify-by-project-id/app/__generated__/index.css
+++ b/fixtures/ssg-netlify-by-project-id/app/__generated__/index.css
@@ -26,44 +26,4 @@
     border-left-width: 1px;
     outline-width: 1px;
   }
-  h2.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h3.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h4.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h5.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h6.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
 }

--- a/fixtures/ssg/app/__generated__/index.css
+++ b/fixtures/ssg/app/__generated__/index.css
@@ -26,46 +26,6 @@
     border-left-width: 1px;
     outline-width: 1px;
   }
-  h2.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h3.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h4.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h5.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h6.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
   div.w-text {
     box-sizing: border-box;
     border-top-width: 1px;

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/index.css
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/index.css
@@ -26,46 +26,6 @@
     border-left-width: 1px;
     outline-width: 1px;
   }
-  h2.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h3.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h4.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h5.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h6.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
   div.w-text {
     box-sizing: border-box;
     border-top-width: 1px;

--- a/fixtures/webstudio-features/app/__generated__/index.css
+++ b/fixtures/webstudio-features/app/__generated__/index.css
@@ -26,14 +26,6 @@
     border-left-width: 1px;
     outline-width: 1px;
   }
-  h2.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
   h3.w-heading {
     box-sizing: border-box;
     border-top-width: 1px;
@@ -42,103 +34,7 @@
     border-left-width: 1px;
     outline-width: 1px;
   }
-  h4.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h5.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  h6.w-heading {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
   div.w-box {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  address.w-box {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  article.w-box {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  aside.w-box {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  figure.w-box {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  footer.w-box {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  header.w-box {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  main.w-box {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  nav.w-box {
-    box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
-  }
-  section.w-box {
     box-sizing: border-box;
     border-top-width: 1px;
     border-right-width: 1px;

--- a/packages/sdk/src/css.test.tsx
+++ b/packages/sdk/src/css.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { $, ws, css, renderData } from "@webstudio-is/template";
+import { $, ws, css, renderData, createProxy } from "@webstudio-is/template";
 import { generateCss, type CssConfig } from "./css";
 import type { Breakpoint } from "./schema/breakpoints";
 import { rootComponent } from "./core-metas";
@@ -150,9 +150,12 @@ Map {
 
 test("generate component presets with multiple tags", () => {
   const { cssText, atomicCssText, classes, atomicClasses } = generateAllCss({
+    ...renderData(
+      <$.ListItem tag="div">
+        <$.ListItem tag="a"></$.ListItem>
+      </$.ListItem>
+    ),
     assets: new Map(),
-    instances: new Map(),
-    props: new Map(),
     breakpoints: new Map(),
     styleSourceSelections: new Map([]),
     styles: new Map(),
@@ -163,18 +166,12 @@ test("generate component presets with multiple tags", () => {
           type: "container",
           icon: "",
           presetStyle: {
-            div: [
-              {
-                property: "display",
-                value: { type: "keyword", value: "block" },
-              },
-            ],
-            a: [
-              {
-                property: "user-select",
-                value: { type: "keyword", value: "none" },
-              },
-            ],
+            div: css`
+              display: block;
+            `,
+            a: css`
+              user-select: none;
+            `,
           },
         },
       ],
@@ -194,15 +191,27 @@ test("generate component presets with multiple tags", () => {
 "
 `);
   expect(cssText).toEqual(atomicCssText);
-  expect(classes).toMatchInlineSnapshot(`Map {}`);
+  expect(classes).toEqual(
+    new Map([
+      ["0", ["w-list-item"]],
+      ["1", ["w-list-item"]],
+    ])
+  );
   expect(classes).toEqual(atomicClasses);
 });
 
 test("deduplicate component presets for similarly named components", () => {
+  const radix = createProxy("@webstudio/radix:");
+  const aria = createProxy("@webstudio/aria:");
   const { cssText, atomicCssText, classes, atomicClasses } = generateAllCss({
+    ...renderData(
+      <$.ListItem>
+        <radix.ListItem>
+          <aria.ListItem></aria.ListItem>
+        </radix.ListItem>
+      </$.ListItem>
+    ),
     assets: new Map(),
-    instances: new Map(),
-    props: new Map(),
     breakpoints: new Map(),
     styleSourceSelections: new Map([]),
     styles: new Map(),
@@ -213,12 +222,9 @@ test("deduplicate component presets for similarly named components", () => {
           type: "container",
           icon: "",
           presetStyle: {
-            div: [
-              {
-                property: "display",
-                value: { type: "keyword", value: "block" },
-              },
-            ],
+            div: css`
+              display: block;
+            `,
           },
         },
       ],
@@ -228,12 +234,9 @@ test("deduplicate component presets for similarly named components", () => {
           type: "container",
           icon: "",
           presetStyle: {
-            div: [
-              {
-                property: "display",
-                value: { type: "keyword", value: "flex" },
-              },
-            ],
+            div: css`
+              display: flex;
+            `,
           },
         },
       ],
@@ -243,12 +246,9 @@ test("deduplicate component presets for similarly named components", () => {
           type: "container",
           icon: "",
           presetStyle: {
-            div: [
-              {
-                property: "display",
-                value: { type: "keyword", value: "grid" },
-              },
-            ],
+            div: css`
+              display: grid;
+            `,
           },
         },
       ],
@@ -270,7 +270,13 @@ test("deduplicate component presets for similarly named components", () => {
 "
 `);
   expect(cssText).toEqual(atomicCssText);
-  expect(classes).toMatchInlineSnapshot(`Map {}`);
+  expect(classes).toEqual(
+    new Map([
+      ["0", ["w-list-item"]],
+      ["1", ["w-list-item-1"]],
+      ["2", ["w-list-item-2"]],
+    ])
+  );
   expect(classes).toEqual(atomicClasses);
 });
 
@@ -298,12 +304,9 @@ test("expose preset classes to instances", () => {
           type: "container",
           icon: "",
           presetStyle: {
-            div: [
-              {
-                property: "display",
-                value: { type: "keyword", value: "block" },
-              },
-            ],
+            div: css`
+              display: block;
+            `,
           },
         },
       ],
@@ -313,12 +316,9 @@ test("expose preset classes to instances", () => {
           type: "container",
           icon: "",
           presetStyle: {
-            div: [
-              {
-                property: "display",
-                value: { type: "keyword", value: "flex" },
-              },
-            ],
+            div: css`
+              display: flex;
+            `,
           },
         },
       ],
@@ -395,12 +395,9 @@ test("generate classes with instance and meta label", () => {
           icon: "",
           label: "body meta label",
           presetStyle: {
-            div: [
-              {
-                property: "display",
-                value: { type: "keyword", value: "block" },
-              },
-            ],
+            div: css`
+              display: block;
+            `,
           },
         },
       ],
@@ -411,12 +408,9 @@ test("generate classes with instance and meta label", () => {
           icon: "",
           label: "box meta label",
           presetStyle: {
-            div: [
-              {
-                property: "display",
-                value: { type: "keyword", value: "flex" },
-              },
-            ],
+            div: css`
+              display: flex;
+            `,
           },
         },
       ],
@@ -494,12 +488,9 @@ test("generate :root preset and user styles", () => {
           icon: "",
           label: "Global Root",
           presetStyle: {
-            html: [
-              {
-                property: "display",
-                value: { type: "keyword", value: "grid" },
-              },
-            ],
+            html: css`
+              display: grid;
+            `,
           },
         },
       ],
@@ -534,4 +525,70 @@ test("generate :root preset and user styles", () => {
 }"
 `);
   expect(atomicClasses).toEqual(new Map());
+});
+
+test("generate presets only for used tags", () => {
+  const { cssText, classes } = generateCss({
+    ...renderData(
+      <$.Body ws:id="body">
+        {/* first tag in preset */}
+        <$.Box></$.Box>
+        {/* legacy tag property */}
+        <$.Box tag="span"></$.Box>
+        {/* modern ws:tag property */}
+        <$.Box ws:tag="article"></$.Box>
+      </$.Body>
+    ),
+    atomic: false,
+    breakpoints: toMap([{ id: "base", label: "" }]),
+    styleSourceSelections: new Map(),
+    styles: new Map(),
+    componentMetas: new Map([
+      [
+        "Box",
+        {
+          type: "container",
+          icon: "",
+          presetStyle: {
+            div: css`
+              display: block;
+            `,
+            span: css`
+              display: block;
+            `,
+            article: css`
+              display: block;
+            `,
+            section: css`
+              display: block;
+            `,
+            main: css`
+              display: block;
+            `,
+          },
+        },
+      ],
+    ]),
+    assetBaseUrl: "",
+  });
+  expect(cssText).toMatchInlineSnapshot(`
+"@layer presets {
+  div.w-box {
+    display: block
+  }
+  span.w-box {
+    display: block
+  }
+  article.w-box {
+    display: block
+  }
+}
+"`);
+  expect(classes).toEqual(
+    new Map([
+      ["0", ["w-box"]],
+      ["1", ["w-box"]],
+      ["2", ["w-box"]],
+    ])
+  );
 });

--- a/packages/template/src/css.ts
+++ b/packages/template/src/css.ts
@@ -1,9 +1,9 @@
-import { camelCaseProperty, parseCss } from "@webstudio-is/css-data";
-import type { StyleProperty, StyleValue } from "@webstudio-is/css-engine";
+import { parseCss } from "@webstudio-is/css-data";
+import type { CssProperty, StyleValue } from "@webstudio-is/css-engine";
 
 export type TemplateStyleDecl = {
   state?: string;
-  property: StyleProperty;
+  property: CssProperty;
   value: StyleValue;
 };
 
@@ -14,7 +14,7 @@ export const css = (
   const cssString = `.styles{ ${String.raw({ raw: strings }, ...values)} }`;
   const styles: TemplateStyleDecl[] = [];
   for (const { state, property, value } of parseCss(cssString)) {
-    styles.push({ state, property: camelCaseProperty(property), value });
+    styles.push({ state, property: property, value });
   }
   return styles;
 };

--- a/packages/template/src/jsx.ts
+++ b/packages/template/src/jsx.ts
@@ -14,6 +14,7 @@ import type {
 } from "@webstudio-is/sdk";
 import { showAttribute } from "@webstudio-is/react-sdk";
 import type { TemplateStyleDecl } from "./css";
+import { camelCaseProperty } from "@webstudio-is/css-data";
 
 export class Variable {
   name: string;
@@ -276,11 +277,13 @@ export const renderTemplate = (
           values: [styleSourceId],
         });
         const localStyles = value as TemplateStyleDecl[];
-        for (const styleDecl of localStyles) {
+        for (const { state, property, value } of localStyles) {
           styles.push({
             breakpointId: getBreakpointId(),
             styleSourceId,
-            ...styleDecl,
+            state,
+            property: camelCaseProperty(property),
+            value,
           });
         }
         continue;


### PR DESCRIPTION
Now we have first-class support for html tags and able to figure out which tags are rendered so unused preset styles can be removed from websites.

For example

```
<Box ws:tag="div">
  <Box ws:tag="span">
  </Box>
</Box>
```

will render only div.w-box and span.w-box though there are more presets for for other tags like main, section etc.

Before all tags were generated