### PR TITLE
fix: remove scrub icon from gap input

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -660,14 +660,7 @@ export const CssValueInput = ({
 
   const finalPrefix =
     prefix ||
-    (icon && (
-      <NestedIconLabel
-        color={styleSource}
-        css={value.type === "unit" ? { cursor: "ew-resize" } : undefined}
-      >
-        {icon}
-      </NestedIconLabel>
-    ));
+    (icon && <NestedIconLabel color={styleSource}>{icon}</NestedIconLabel>);
 
   const keywordButtonElement =
     value.type === "keyword" && items.length !== 0 ? (


### PR DESCRIPTION
We no longer support scrub on input icons like in gap.