### PR TITLE
refactor: describe descendants in component content model

### DIFF
--- a/apps/builder/app/shared/content-model.test.tsx
+++ b/apps/builder/app/shared/content-model.test.tsx
@@ -561,41 +561,6 @@ describe("component content model", () => {
     ).toBeFalsy();
   });
 
-  test("prevent self nesting with descendants restriction", () => {
-    expect(
-      isTreeSatisfyingContentModel({
-        ...renderData(
-          <ws.element ws:tag="body" ws:id="bodyId">
-            <$.Vimeo>
-              <$.VimeoSpinner>
-                <$.VimeoSpinner></$.VimeoSpinner>
-              </$.VimeoSpinner>
-            </$.Vimeo>
-          </ws.element>
-        ),
-        metas: defaultMetas,
-        instanceSelector: ["bodyId"],
-      })
-    ).toBeFalsy();
-    expect(
-      isTreeSatisfyingContentModel({
-        ...renderData(
-          <ws.element ws:tag="body" ws:id="bodyId">
-            <$.Vimeo>
-              <$.VimeoSpinner>
-                <$.Vimeo>
-                  <$.VimeoSpinner></$.VimeoSpinner>
-                </$.Vimeo>
-              </$.VimeoSpinner>
-            </$.Vimeo>
-          </ws.element>
-        ),
-        metas: defaultMetas,
-        instanceSelector: ["bodyId"],
-      })
-    ).toBeTruthy();
-  });
-
   test("pass constraints when check deep in the tree", () => {
     expect(
       isTreeSatisfyingContentModel({

--- a/apps/builder/app/shared/content-model.ts
+++ b/apps/builder/app/shared/content-model.ts
@@ -246,10 +246,6 @@ const getAllowedParentCategories = ({
   metas: Metas;
   instanceSelector: InstanceSelector;
 }) => {
-  // @todo
-  if (instanceSelector.length === 0) {
-    // return;
-  }
   const instanceId = instanceSelector[1];
   const instance = instances.get(instanceId);
   if (instance === undefined) {

--- a/packages/sdk-components-animation/src/animate-children.ws.ts
+++ b/packages/sdk-components-animation/src/animate-children.ws.ts
@@ -1,5 +1,6 @@
 import { AnimationGroupIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
+import { animation } from "./shared/meta";
 
 export const meta: WsComponentMeta = {
   category: "animations",
@@ -8,9 +9,14 @@ export const meta: WsComponentMeta = {
   icon: AnimationGroupIcon,
   order: 5,
   label: "Animation Group",
-  constraints: {
-    relation: "child",
-    text: false,
+  contentModel: {
+    category: "instance",
+    children: [
+      "instance",
+      animation.AnimateText,
+      animation.StaggerAnimation,
+      animation.VideoAnimation,
+    ],
   },
 };
 

--- a/packages/sdk-components-animation/src/animate-text.ws.ts
+++ b/packages/sdk-components-animation/src/animate-text.ws.ts
@@ -1,8 +1,7 @@
 import { TextAnimationIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
-import { animation } from "./shared/meta";
-import { props } from "./__generated__/animate-text.props";
 import { div } from "@webstudio-is/sdk/normalize.css";
+import { props } from "./__generated__/animate-text.props";
 
 export const meta: WsComponentMeta = {
   category: "animations",
@@ -12,13 +11,10 @@ export const meta: WsComponentMeta = {
   icon: TextAnimationIcon,
   order: 6,
   label: "Text Animation",
-  constraints: [
-    { relation: "parent", component: { $eq: animation.AnimateChildren } },
-    {
-      relation: "child",
-      text: false,
-    },
-  ],
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+  },
   presetStyle: {
     div,
   },

--- a/packages/sdk-components-animation/src/stagger-animation.ws.ts
+++ b/packages/sdk-components-animation/src/stagger-animation.ws.ts
@@ -1,8 +1,7 @@
 import { StaggerAnimationIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
-import { animation } from "./shared/meta";
-import { props } from "./__generated__/stagger-animation.props";
 import { div } from "@webstudio-is/sdk/normalize.css";
+import { props } from "./__generated__/stagger-animation.props";
 
 export const meta: WsComponentMeta = {
   category: "animations",
@@ -12,13 +11,10 @@ export const meta: WsComponentMeta = {
   icon: StaggerAnimationIcon,
   order: 6,
   label: "Stagger Animation",
-  constraints: [
-    { relation: "parent", component: { $eq: animation.AnimateChildren } },
-    {
-      relation: "child",
-      text: false,
-    },
-  ],
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+  },
   presetStyle: {
     div,
   },

--- a/packages/sdk-components-animation/src/video-animation.ws.ts
+++ b/packages/sdk-components-animation/src/video-animation.ws.ts
@@ -1,19 +1,15 @@
 import { Youtube1cIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
-import { animation } from "./shared/meta";
 import { props } from "./__generated__/video-animation.props";
 
 export const meta: WsComponentMeta = {
   type: "container",
   icon: Youtube1cIcon,
   label: "Video Animation",
-  constraints: [
-    { relation: "parent", component: { $eq: animation.AnimateChildren } },
-    {
-      relation: "child",
-      text: false,
-    },
-  ],
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+  },
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react/src/blockquote.ws.ts
+++ b/packages/sdk-components-react/src/blockquote.ws.ts
@@ -60,7 +60,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   placeholder: "Blockquote",
   icon: BlockquoteIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/body.ws.ts
+++ b/packages/sdk-components-react/src/body.ws.ts
@@ -24,7 +24,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   icon: BodyIcon,
   states: defaultStates,
   presetStyle,

--- a/packages/sdk-components-react/src/bold.ws.ts
+++ b/packages/sdk-components-react/src/bold.ws.ts
@@ -14,7 +14,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   label: "Bold Text",
   icon: BoldIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/box.ws.ts
+++ b/packages/sdk-components-react/src/box.ws.ts
@@ -20,7 +20,6 @@ import { props } from "./__generated__/box.props";
 
 export const meta: WsComponentMeta = {
   category: "general",
-  type: "container",
   description:
     "A container for content. By default this is a Div, but the tag can be changed in settings.",
   icon: BoxIcon,

--- a/packages/sdk-components-react/src/button.ws.ts
+++ b/packages/sdk-components-react/src/button.ws.ts
@@ -15,7 +15,6 @@ const presetStyle = {
 
 export const meta: WsComponentMeta = {
   icon: ButtonElementIcon,
-  type: "container",
   presetStyle,
   states: [
     ...defaultStates,

--- a/packages/sdk-components-react/src/form.ws.ts
+++ b/packages/sdk-components-react/src/form.ws.ts
@@ -18,7 +18,6 @@ const presetStyle = {
 
 export const meta: WsComponentMeta = {
   category: "forms",
-  type: "container",
   label: "Form",
   description: "Create filters, surveys, searches and more.",
   icon: FormIcon,

--- a/packages/sdk-components-react/src/fragment.ws.ts
+++ b/packages/sdk-components-react/src/fragment.ws.ts
@@ -1,7 +1,6 @@
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 
 export const meta: WsComponentMeta = {
-  type: "container",
   icon: "",
 };
 

--- a/packages/sdk-components-react/src/head-slot.ws.ts
+++ b/packages/sdk-components-react/src/head-slot.ws.ts
@@ -7,7 +7,6 @@ import { props } from "./__generated__/head.props";
 
 export const meta: WsComponentMeta = {
   icon: HeaderIcon,
-  type: "container",
   description: "Inserts children into the head of the document",
   contentModel: {
     category: "instance",

--- a/packages/sdk-components-react/src/head-title.ws.ts
+++ b/packages/sdk-components-react/src/head-title.ws.ts
@@ -1,13 +1,9 @@
 import { WindowTitleIcon } from "@webstudio-is/icons/svg";
-import {
-  type WsComponentMeta,
-  type WsComponentPropsMeta,
-} from "@webstudio-is/sdk";
+import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { props } from "./__generated__/head-title.props";
 
 export const meta: WsComponentMeta = {
   icon: WindowTitleIcon,
-  type: "container",
   contentModel: {
     category: "none",
     children: ["text"],

--- a/packages/sdk-components-react/src/heading.ws.ts
+++ b/packages/sdk-components-react/src/heading.ws.ts
@@ -8,7 +8,6 @@ import { h1, h2, h3, h4, h5, h6 } from "@webstudio-is/sdk/normalize.css";
 import { props } from "./__generated__/heading.props";
 
 export const meta: WsComponentMeta = {
-  type: "container",
   placeholder: "Heading",
   icon: HeadingIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/html-embed.ws.ts
+++ b/packages/sdk-components-react/src/html-embed.ws.ts
@@ -8,7 +8,6 @@ import { props } from "./__generated__/html-embed.props";
 
 export const meta: WsComponentMeta = {
   category: "general",
-  type: "container",
   label: "HTML Embed",
   description: "Used to add HTML code to the page, such as an SVG or script.",
   icon: EmbedIcon,

--- a/packages/sdk-components-react/src/italic.ws.ts
+++ b/packages/sdk-components-react/src/italic.ws.ts
@@ -20,7 +20,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   label: "Italic Text",
   icon: TextItalicIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/label.ws.ts
+++ b/packages/sdk-components-react/src/label.ws.ts
@@ -17,7 +17,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   label: "Input Label",
   icon: LabelIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/link.ws.ts
+++ b/packages/sdk-components-react/src/link.ws.ts
@@ -20,7 +20,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   placeholder: "Link",
   icon: LinkIcon,
   presetStyle,

--- a/packages/sdk-components-react/src/list-item.ws.ts
+++ b/packages/sdk-components-react/src/list-item.ws.ts
@@ -8,7 +8,6 @@ import { li } from "@webstudio-is/sdk/normalize.css";
 import { props } from "./__generated__/list-item.props";
 
 export const meta: WsComponentMeta = {
-  type: "container",
   placeholder: "List item",
   icon: ListItemIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/list.ws.ts
+++ b/packages/sdk-components-react/src/list.ws.ts
@@ -43,7 +43,6 @@ const presetStyle = {
 } satisfies PresetStyle<ListTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   icon: ListIcon,
   states: defaultStates,
   presetStyle,

--- a/packages/sdk-components-react/src/markdown-embed.ws.ts
+++ b/packages/sdk-components-react/src/markdown-embed.ws.ts
@@ -7,7 +7,6 @@ import {
 import { props } from "./__generated__/markdown-embed.props";
 
 export const meta: WsComponentMeta = {
-  type: "container",
   icon: MarkdownEmbedIcon,
   contentModel: {
     category: "instance",

--- a/packages/sdk-components-react/src/paragraph.ws.ts
+++ b/packages/sdk-components-react/src/paragraph.ws.ts
@@ -14,7 +14,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   placeholder: "Paragraph",
   icon: TextAlignLeftIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/rich-text-link.ws.ts
+++ b/packages/sdk-components-react/src/rich-text-link.ws.ts
@@ -1,9 +1,6 @@
 import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { meta as linkMeta, propsMeta as linkPropsMeta } from "./link.ws";
 
-export const meta: WsComponentMeta = {
-  ...linkMeta,
-  type: "container",
-};
+export const meta: WsComponentMeta = linkMeta;
 
 export const propsMeta: WsComponentPropsMeta = linkPropsMeta;

--- a/packages/sdk-components-react/src/select.ws.ts
+++ b/packages/sdk-components-react/src/select.ws.ts
@@ -20,7 +20,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   icon: SelectIcon,
   presetStyle,
   states: [

--- a/packages/sdk-components-react/src/slot.ws.ts
+++ b/packages/sdk-components-react/src/slot.ws.ts
@@ -3,7 +3,6 @@ import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 
 export const meta: WsComponentMeta = {
   category: "general",
-  type: "container",
   description:
     "Slot is a container for content that you want to reference across the project. Changes made to a Slot's children will be reflected in all other instances of that Slot.",
   icon: SlotComponentIcon,

--- a/packages/sdk-components-react/src/span.ws.ts
+++ b/packages/sdk-components-react/src/span.ws.ts
@@ -14,7 +14,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   label: "Text",
   icon: PaintBrushIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/subscript.ws.ts
+++ b/packages/sdk-components-react/src/subscript.ws.ts
@@ -14,7 +14,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   label: "Subscript Text",
   icon: SubscriptIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/superscript.ws.ts
+++ b/packages/sdk-components-react/src/superscript.ws.ts
@@ -14,7 +14,6 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  type: "container",
   label: "Superscript Text",
   icon: SuperscriptIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/text.ws.ts
+++ b/packages/sdk-components-react/src/text.ws.ts
@@ -8,7 +8,6 @@ import { div } from "@webstudio-is/sdk/normalize.css";
 import { props } from "./__generated__/text.props";
 
 export const meta: WsComponentMeta = {
-  type: "container",
   icon: TextIcon,
   states: defaultStates,
   presetStyle: {

--- a/packages/sdk-components-react/src/time.ws.ts
+++ b/packages/sdk-components-react/src/time.ws.ts
@@ -14,7 +14,6 @@ const presetStyle = {
 
 export const meta: WsComponentMeta = {
   category: "localization",
-  type: "container",
   description:
     "Converts machine-readable date and time to a human-readable format.",
   icon: CalendarIcon,

--- a/packages/sdk-components-react/src/vimeo-play-button.ws.ts
+++ b/packages/sdk-components-react/src/vimeo-play-button.ws.ts
@@ -9,7 +9,6 @@ import { props } from "./__generated__/vimeo-play-button.props";
 
 export const meta: WsComponentMeta = {
   category: "hidden",
-  type: "container",
   label: "Play Button",
   icon: ButtonElementIcon,
   states: defaultStates,

--- a/packages/sdk-components-react/src/vimeo-spinner.ws.ts
+++ b/packages/sdk-components-react/src/vimeo-spinner.ws.ts
@@ -8,7 +8,6 @@ import { BoxIcon } from "@webstudio-is/icons/svg";
 import { props } from "./__generated__/vimeo-spinner.props";
 
 export const meta: WsComponentMeta = {
-  type: "container",
   icon: BoxIcon,
   states: defaultStates,
   category: "hidden",

--- a/packages/sdk-components-react/src/vimeo.ws.ts
+++ b/packages/sdk-components-react/src/vimeo.ws.ts
@@ -10,17 +10,12 @@ import { props } from "./__generated__/vimeo.props";
 import type { Vimeo } from "./vimeo";
 
 export const meta: WsComponentMeta = {
-  type: "container",
   icon: VimeoIcon,
   states: defaultStates,
   contentModel: {
     category: "instance",
-    children: [
-      "instance",
-      "VimeoSpinner",
-      "VimeoPlayButton",
-      "VimeoPreviewImage",
-    ],
+    children: ["instance"],
+    descendants: ["VimeoSpinner", "VimeoPlayButton", "VimeoPreviewImage"],
   },
   presetStyle: {
     div,

--- a/packages/sdk-components-react/src/webhook-form.ws.ts
+++ b/packages/sdk-components-react/src/webhook-form.ws.ts
@@ -6,7 +6,6 @@ import { props } from "./__generated__/webhook-form.props";
 export const meta: WsComponentMeta = {
   label: "Webhook Form",
   icon: WebhookFormIcon,
-  type: "container",
   presetStyle: {
     form,
   },

--- a/packages/sdk-components-react/src/xml-node.ws.ts
+++ b/packages/sdk-components-react/src/xml-node.ws.ts
@@ -5,7 +5,6 @@ import { props } from "./__generated__/xml-node.props";
 export const meta: WsComponentMeta = {
   category: "xml",
   order: 6,
-  type: "container",
   icon: XmlIcon,
   description: "XML Node",
 };

--- a/packages/sdk-components-react/src/xml-time.ws.ts
+++ b/packages/sdk-components-react/src/xml-time.ws.ts
@@ -4,7 +4,6 @@ import { props } from "./__generated__/xml-time.props";
 
 export const meta: WsComponentMeta = {
   category: "xml",
-  type: "container",
   description: "Converts machine-readable date and time to ISO format.",
   icon: CalendarIcon,
   order: 7,

--- a/packages/sdk-components-react/src/youtube.ws.ts
+++ b/packages/sdk-components-react/src/youtube.ws.ts
@@ -10,17 +10,12 @@ import { props } from "./__generated__/youtube.props";
 import type { YouTube } from "./youtube";
 
 export const meta: WsComponentMeta = {
-  type: "container",
   icon: YoutubeIcon,
   states: defaultStates,
   contentModel: {
     category: "instance",
-    children: [
-      "instance",
-      "VimeoSpinner",
-      "VimeoPlayButton",
-      "VimeoPreviewImage",
-    ],
+    children: ["instance"],
+    descendants: ["VimeoSpinner", "VimeoPlayButton", "VimeoPreviewImage"],
   },
   presetStyle: {
     div,

--- a/packages/sdk/src/core-metas.ts
+++ b/packages/sdk/src/core-metas.ts
@@ -125,7 +125,6 @@ const blockMeta: WsComponentMeta = {
   contentModel: {
     category: "instance",
     children: [blockTemplateComponent, "instance"],
-    // @todo prevent deleting block template
   },
 };
 

--- a/packages/sdk/src/schema/component-meta.ts
+++ b/packages/sdk/src/schema/component-meta.ts
@@ -64,6 +64,15 @@ export const defaultStates: ComponentState[] = [
   { selector: ":focus-within", label: "Focus Within" },
 ];
 
+/**
+ * rich-text - can be edited as rich text
+ * instance - other instances accepted
+ * ComponentName - accept specific components with none category
+ */
+const ComponentContent = z.string() as z.ZodType<
+  "instance" | "rich-text" | (string & {})
+>;
+
 export const ContentModel = z.object({
   /*
    * instance - accepted by any parent with "instance" in children categories
@@ -71,14 +80,13 @@ export const ContentModel = z.object({
    */
   category: z.union([z.literal("instance"), z.literal("none")]),
   /**
-   * transparent - pass through possible children from parent
-   * rich-text - can be edited as rich text
-   * instance - other instances accepted
-   * ComponentName - accept specific components with none category
+   * enforce direct children of category or components
    */
-  children: z.array(z.string()) as z.ZodType<
-    Array<"transparent" | "instance" | "rich-text" | (string & {})>
-  >,
+  children: z.array(ComponentContent),
+  /**
+   * enforce descendants of category or components
+   */
+  descendants: z.array(ComponentContent).optional(),
 });
 
 export type ContentModel = z.infer<typeof ContentModel>;


### PR DESCRIPTION
Here replaced "transparent" keyword with more explicit "descendants" list in component content model.

This will enable use case with child constraint while allowing other instances to be children like here

```
  contentModel: {
    category: "instance",
    children: [
      "instance",
      "AnimateText",
      "StaggerAnimation",
      "VideoAnimation",
    ],
  },
```

and descendants are described like this

```
  contentModel: {
    category: "instance",
    children: ["instance"],
    descendants: ["VimeoSpinner", "VimeoPlayButton", "VimeoPreviewImage"],
  },
```