### PR TITLE
refactor: migrate radix to component content model

### DIFF
--- a/apps/builder/app/shared/matcher.test.tsx
+++ b/apps/builder/app/shared/matcher.test.tsx
@@ -813,25 +813,6 @@ describe("is instance detachable", () => {
     ).toBeTruthy();
   });
 
-  test("prevent deleting last matching instance", () => {
-    expect(
-      isInstanceDetachable({
-        ...renderData(
-          <$.Body ws:id="body">
-            <radix.Tabs ws:id="tabs">
-              <radix.TabsList ws:id="list">
-                <radix.TabsTrigger ws:id="trigger1"></radix.TabsTrigger>
-              </radix.TabsList>
-              <radix.TabsContent ws:id="content1"></radix.TabsContent>
-            </radix.Tabs>
-          </$.Body>
-        ),
-        metas,
-        instanceSelector: ["trigger1", "list", "tabs", "body"],
-      })
-    ).toBeFalsy();
-  });
-
   test("allow deleting when siblings not matching", () => {
     expect(
       isInstanceDetachable({

--- a/apps/builder/app/shared/matcher.test.tsx
+++ b/apps/builder/app/shared/matcher.test.tsx
@@ -677,7 +677,6 @@ describe("is tree matching", () => {
     [
       "ListItem",
       {
-        type: "container",
         icon: "",
         constraints: {
           relation: "parent",
@@ -688,7 +687,6 @@ describe("is tree matching", () => {
     [
       "Tabs",
       {
-        type: "container",
         icon: "",
         constraints: {
           relation: "descendant",

--- a/packages/react-sdk/src/component-generator.test.tsx
+++ b/packages/react-sdk/src/component-generator.test.tsx
@@ -1148,14 +1148,8 @@ test("generate prop with index within ancestor", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map<string, WsComponentMeta>([
-        [
-          "TabsTrigger",
-          { type: "container", icon: "", indexWithinAncestor: "Tabs" },
-        ],
-        [
-          "TabsContent",
-          { type: "container", icon: "", indexWithinAncestor: "Tabs" },
-        ],
+        ["TabsTrigger", { icon: "", indexWithinAncestor: "Tabs" }],
+        ["TabsContent", { icon: "", indexWithinAncestor: "Tabs" }],
       ]),
       ...renderData(
         <$.Body ws:id="body">
@@ -1212,10 +1206,7 @@ test("ignore ws:block-template when generate index attribute", () => {
       rootInstanceId: "bodyId",
       parameters: [],
       metas: new Map<string, WsComponentMeta>([
-        [
-          "TabsTrigger",
-          { type: "container", icon: "", indexWithinAncestor: "Tabs" },
-        ],
+        ["TabsTrigger", { icon: "", indexWithinAncestor: "Tabs" }],
       ]),
       ...renderData(
         <$.Body ws:id="bodyId">

--- a/packages/sdk-components-animation/src/animate-children.ws.ts
+++ b/packages/sdk-components-animation/src/animate-children.ws.ts
@@ -4,7 +4,6 @@ import { animation } from "./shared/meta";
 
 export const meta: WsComponentMeta = {
   category: "animations",
-  type: "container",
   description: "Animation Group component is designed to animate its children.",
   icon: AnimationGroupIcon,
   order: 5,

--- a/packages/sdk-components-animation/src/animate-text.ws.ts
+++ b/packages/sdk-components-animation/src/animate-text.ws.ts
@@ -5,7 +5,6 @@ import { props } from "./__generated__/animate-text.props";
 
 export const meta: WsComponentMeta = {
   category: "animations",
-  type: "container",
   description:
     "Text animation allows you to split text by char or by word to animate it.",
   icon: TextAnimationIcon,

--- a/packages/sdk-components-animation/src/stagger-animation.ws.ts
+++ b/packages/sdk-components-animation/src/stagger-animation.ws.ts
@@ -5,7 +5,6 @@ import { props } from "./__generated__/stagger-animation.props";
 
 export const meta: WsComponentMeta = {
   category: "animations",
-  type: "container",
   description:
     "Stagger animation allows you to animate children elements with a sliding window.",
   icon: StaggerAnimationIcon,

--- a/packages/sdk-components-animation/src/video-animation.ws.ts
+++ b/packages/sdk-components-animation/src/video-animation.ws.ts
@@ -3,7 +3,6 @@ import type { WsComponentMeta, WsComponentPropsMeta } from "@webstudio-is/sdk";
 import { props } from "./__generated__/video-animation.props";
 
 export const meta: WsComponentMeta = {
-  type: "container",
   icon: Youtube1cIcon,
   label: "Video Animation",
   contentModel: {

--- a/packages/sdk-components-react-radix/src/accordion.ws.ts
+++ b/packages/sdk-components-react-radix/src/accordion.ws.ts
@@ -7,7 +7,6 @@ import {
 } from "@webstudio-is/icons/svg";
 import {
   defaultStates,
-  type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
@@ -22,58 +21,40 @@ import {
   propsAccordionContent,
 } from "./__generated__/accordion.props";
 
-const presetStyle = {
-  div,
-} satisfies PresetStyle<"div">;
-
 export const metaAccordion: WsComponentMeta = {
-  type: "container",
   icon: AccordionIcon,
-  presetStyle,
-  constraints: [
-    {
-      relation: "descendant",
-      component: { $eq: radix.AccordionItem },
-    },
-  ],
+  contentModel: {
+    category: "instance",
+    children: ["instance"],
+    descendants: [radix.AccordionItem],
+  },
+  presetStyle: {
+    div,
+  },
 };
 
 export const metaAccordionItem: WsComponentMeta = {
-  type: "container",
   label: "Item",
   icon: ItemIcon,
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.Accordion },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.AccordionHeader },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.AccordionContent },
-    },
-  ],
   indexWithinAncestor: radix.Accordion,
-  presetStyle,
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [radix.AccordionHeader, radix.AccordionContent],
+  },
+  presetStyle: {
+    div,
+  },
 };
 
 export const metaAccordionHeader: WsComponentMeta = {
-  type: "container",
   label: "Item Header",
   icon: HeaderIcon,
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.AccordionItem },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.AccordionTrigger },
-    },
-  ],
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [radix.AccordionTrigger],
+  },
   presetStyle: {
     h3: [
       ...h3,
@@ -90,12 +71,11 @@ export const metaAccordionHeader: WsComponentMeta = {
 };
 
 export const metaAccordionTrigger: WsComponentMeta = {
-  type: "container",
   label: "Item Trigger",
   icon: TriggerIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.AccordionHeader },
+  contentModel: {
+    category: "none",
+    children: ["instance", "rich-text"],
   },
   states: [
     ...defaultStates,
@@ -111,14 +91,15 @@ export const metaAccordionTrigger: WsComponentMeta = {
 };
 
 export const metaAccordionContent: WsComponentMeta = {
-  type: "container",
   label: "Item Content",
   icon: ContentIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.AccordionItem },
+  contentModel: {
+    category: "none",
+    children: ["instance", "rich-text"],
   },
-  presetStyle,
+  presetStyle: {
+    div,
+  },
 };
 
 export const propsMetaAccordion: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/checkbox.ws.ts
+++ b/packages/sdk-components-react-radix/src/checkbox.ws.ts
@@ -13,12 +13,12 @@ import {
 } from "./__generated__/checkbox.props";
 
 export const metaCheckbox: WsComponentMeta = {
-  type: "container",
-  constraints: {
-    relation: "descendant",
-    component: { $eq: radix.CheckboxIndicator },
-  },
   icon: CheckboxCheckedIcon,
+  contentModel: {
+    category: "instance",
+    children: ["instance"],
+    descendants: [radix.CheckboxIndicator],
+  },
   states: [
     ...defaultStates,
     {
@@ -38,12 +38,11 @@ export const metaCheckbox: WsComponentMeta = {
 };
 
 export const metaCheckboxIndicator: WsComponentMeta = {
-  type: "container",
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.Checkbox },
-  },
   icon: TriggerIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance", "rich-text"],
+  },
   states: defaultStates,
   presetStyle: {
     span,

--- a/packages/sdk-components-react-radix/src/collapsible.ws.ts
+++ b/packages/sdk-components-react-radix/src/collapsible.ws.ts
@@ -13,41 +13,33 @@ import {
 } from "./__generated__/collapsible.props";
 
 export const metaCollapsible: WsComponentMeta = {
-  type: "container",
-  constraints: [
-    {
-      relation: "descendant",
-      component: { $eq: radix.CollapsibleTrigger },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.CollapsibleContent },
-    },
-  ],
+  icon: CollapsibleIcon,
+  contentModel: {
+    category: "instance",
+    children: ["instance"],
+    descendants: [radix.CollapsibleTrigger, radix.CollapsibleContent],
+  },
   presetStyle: {
     div,
   },
-  icon: CollapsibleIcon,
 };
 
 export const metaCollapsibleTrigger: WsComponentMeta = {
-  type: "container",
   icon: TriggerIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.Collapsible },
+  contentModel: {
+    category: "none",
+    children: ["instance", "rich-text"],
   },
 };
 
 export const metaCollapsibleContent: WsComponentMeta = {
-  type: "container",
+  icon: ContentIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance", "rich-text"],
+  },
   presetStyle: {
     div,
-  },
-  icon: ContentIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.Collapsible },
   },
 };
 

--- a/packages/sdk-components-react-radix/src/dialog.ws.ts
+++ b/packages/sdk-components-react-radix/src/dialog.ws.ts
@@ -27,113 +27,83 @@ import { buttonReset } from "./shared/preset-styles";
 
 // @todo add [data-state] to button and link
 export const metaDialogTrigger: WsComponentMeta = {
-  type: "container",
   icon: TriggerIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.Dialog },
+  contentModel: {
+    category: "none",
+    children: ["instance"],
   },
 };
 
 export const metaDialogOverlay: WsComponentMeta = {
-  type: "container",
+  icon: OverlayIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [radix.DialogContent],
+  },
   presetStyle: {
     div,
   },
-  icon: OverlayIcon,
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.Dialog },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.DialogContent },
-    },
-  ],
 };
 
 export const metaDialogContent: WsComponentMeta = {
-  type: "container",
+  icon: ContentIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [
+      radix.DialogTitle,
+      radix.DialogDescription,
+      radix.DialogClose,
+    ],
+  },
   presetStyle: {
     div,
   },
-  icon: ContentIcon,
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.DialogOverlay },
-    },
-    // often deleted by users
-    // though radix starts throwing warnings in console
-    /*
-    {
-      relation: "descendant",
-      component: { $eq: radix.DialogTitle },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.DialogDescription },
-    },
-    */
-    {
-      relation: "descendant",
-      component: { $eq: radix.DialogClose },
-    },
-  ],
 };
 
 export const metaDialogTitle: WsComponentMeta = {
-  type: "container",
+  icon: HeadingIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance", "rich-text"],
+  },
   presetStyle: {
     h2,
-  },
-  icon: HeadingIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.DialogContent },
   },
 };
 
 export const metaDialogDescription: WsComponentMeta = {
-  type: "container",
+  icon: TextIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance", "rich-text"],
+  },
   presetStyle: {
     p,
-  },
-  icon: TextIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.DialogContent },
   },
 };
 
 export const metaDialogClose: WsComponentMeta = {
-  type: "container",
-  presetStyle: {
-    button: [buttonReset, button].flat(),
-  },
-  states: defaultStates,
   icon: ButtonElementIcon,
   label: "Close Button",
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.DialogContent },
+  contentModel: {
+    category: "none",
+    children: ["instance", "rich-text"],
+  },
+  states: defaultStates,
+  presetStyle: {
+    button: [buttonReset, button].flat(),
   },
 };
 
 export const metaDialog: WsComponentMeta = {
-  type: "container",
   icon: DialogIcon,
-  constraints: [
-    {
-      relation: "descendant",
-      component: { $eq: radix.DialogTrigger },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.DialogOverlay },
-    },
-  ],
+  contentModel: {
+    category: "instance",
+    children: ["instance"],
+    descendants: [radix.DialogTrigger, radix.DialogOverlay],
+  },
 };
 
 export const propsMetaDialog: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/label.ws.ts
+++ b/packages/sdk-components-react-radix/src/label.ws.ts
@@ -1,22 +1,18 @@
 import { LabelIcon } from "@webstudio-is/icons/svg";
 import {
   defaultStates,
-  type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
 import { label } from "@webstudio-is/sdk/normalize.css";
 import { props } from "./__generated__/label.props";
 
-const presetStyle = {
-  label,
-} satisfies PresetStyle<"label">;
-
 export const meta: WsComponentMeta = {
-  type: "container",
   icon: LabelIcon,
-  presetStyle,
   states: defaultStates,
+  presetStyle: {
+    label,
+  },
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -21,109 +21,89 @@ import {
 } from "./__generated__/navigation-menu.props";
 
 export const metaNavigationMenu: WsComponentMeta = {
-  type: "container",
   icon: NavigationMenuIcon,
+  contentModel: {
+    category: "instance",
+    children: ["instance"],
+    descendants: [radix.NavigationMenuList, radix.NavigationMenuViewport],
+  },
   presetStyle: {
     div,
   },
-  constraints: [
-    {
-      relation: "descendant",
-      component: { $eq: radix.NavigationMenuList },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.NavigationMenuViewport },
-    },
-  ],
 };
 
 export const metaNavigationMenuList: WsComponentMeta = {
-  type: "container",
   icon: ListIcon,
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.NavigationMenu },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.NavigationMenuItem },
-    },
-  ],
+  label: "Menu List",
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [radix.NavigationMenuItem],
+  },
   presetStyle: {
     div,
   },
-  label: "Menu List",
 };
 
 export const metaNavigationMenuItem: WsComponentMeta = {
-  type: "container",
   icon: ListItemIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.NavigationMenuList },
+  label: "Menu Item",
+  indexWithinAncestor: radix.NavigationMenu,
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [
+      radix.NavigationMenuTrigger,
+      radix.NavigationMenuContent,
+      radix.NavigationMenuLink,
+    ],
   },
   presetStyle: {
     div,
   },
-  indexWithinAncestor: radix.NavigationMenu,
-  label: "Menu Item",
 };
 
 export const metaNavigationMenuTrigger: WsComponentMeta = {
-  type: "container",
   icon: TriggerIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.NavigationMenuItem },
-  },
   label: "Menu Trigger",
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+  },
 };
 
 export const metaNavigationMenuContent: WsComponentMeta = {
-  type: "container",
   icon: ContentIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.NavigationMenuItem },
+  label: "Menu Content",
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [radix.NavigationMenuLink],
   },
-  indexWithinAncestor: radix.NavigationMenu,
   presetStyle: {
     div,
   },
-  label: "Menu Content",
 };
 
 export const metaNavigationMenuLink: WsComponentMeta = {
-  type: "container",
   icon: BoxIcon,
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.NavigationMenu },
-    },
-    {
-      relation: "ancestor",
-      component: {
-        $in: [radix.NavigationMenuContent, radix.NavigationMenuItem],
-      },
-    },
-  ],
   label: "Accessible Link Wrapper",
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+  },
 };
 
 export const metaNavigationMenuViewport: WsComponentMeta = {
-  type: "container",
   icon: ViewportIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.NavigationMenu },
+  label: "Menu Viewport",
+  contentModel: {
+    category: "none",
+    children: ["instance"],
   },
   presetStyle: {
     div,
   },
-  label: "Menu Viewport",
 };
 
 export const propsMetaNavigationMenu: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/popover.ws.ts
+++ b/packages/sdk-components-react-radix/src/popover.ws.ts
@@ -10,39 +10,31 @@ import {
 
 // @todo add [data-state] to button and link
 export const metaPopoverTrigger: WsComponentMeta = {
-  type: "container",
   icon: TriggerIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.Popover },
+  contentModel: {
+    category: "none",
+    children: ["instance"],
   },
 };
 
 export const metaPopoverContent: WsComponentMeta = {
-  type: "container",
+  icon: ContentIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+  },
   presetStyle: {
     div,
-  },
-  icon: ContentIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.Popover },
   },
 };
 
 export const metaPopover: WsComponentMeta = {
-  type: "container",
   icon: PopoverIcon,
-  constraints: [
-    {
-      relation: "descendant",
-      component: { $eq: radix.PopoverTrigger },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.PopoverContent },
-    },
-  ],
+  contentModel: {
+    category: "instance",
+    children: ["instance"],
+    descendants: [radix.PopoverTrigger, radix.PopoverContent],
+  },
 };
 
 export const propsMetaPopover: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/radio-group.ws.ts
+++ b/packages/sdk-components-react-radix/src/radio-group.ws.ts
@@ -14,12 +14,12 @@ import {
 } from "./__generated__/radio-group.props";
 
 export const metaRadioGroup: WsComponentMeta = {
-  type: "container",
-  constraints: {
-    relation: "descendant",
-    component: { $eq: radix.RadioGroupItem },
-  },
   icon: RadioGroupIcon,
+  contentModel: {
+    category: "instance",
+    children: ["instance"],
+    descendants: [radix.RadioGroupItem],
+  },
   states: [
     ...defaultStates,
     {
@@ -39,18 +39,12 @@ export const metaRadioGroup: WsComponentMeta = {
 };
 
 export const metaRadioGroupItem: WsComponentMeta = {
-  type: "container",
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.RadioGroup },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.RadioGroupIndicator },
-    },
-  ],
   icon: ItemIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [radix.RadioGroupIndicator],
+  },
   states: defaultStates,
   presetStyle: {
     button: [button, buttonReset].flat(),
@@ -58,11 +52,10 @@ export const metaRadioGroupItem: WsComponentMeta = {
 };
 
 export const metaRadioGroupIndicator: WsComponentMeta = {
-  type: "container",
   icon: TriggerIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.RadioGroupItem },
+  contentModel: {
+    category: "none",
+    children: ["instance"],
   },
   states: defaultStates,
   presetStyle: {

--- a/packages/sdk-components-react-radix/src/select.ws.ts
+++ b/packages/sdk-components-react-radix/src/select.ws.ts
@@ -23,116 +23,80 @@ import {
 } from "./__generated__/select.props";
 
 export const metaSelect: WsComponentMeta = {
-  type: "container",
   icon: SelectIcon,
-  constraints: [
-    {
-      relation: "descendant",
-      component: { $eq: radix.SelectTrigger },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.SelectContent },
-    },
-  ],
+  contentModel: {
+    category: "instance",
+    children: ["instance"],
+    descendants: [radix.SelectTrigger, radix.SelectContent],
+  },
 };
 
 export const metaSelectTrigger: WsComponentMeta = {
-  type: "container",
   icon: TriggerIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [radix.SelectValue],
+  },
   presetStyle: {
     button,
   },
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.Select },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.SelectValue },
-    },
-  ],
 };
 
 export const metaSelectValue: WsComponentMeta = {
-  type: "container",
   label: "Value",
   icon: FormTextFieldIcon,
+  contentModel: {
+    category: "none",
+    children: [],
+  },
   presetStyle: {
     span,
-  },
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.SelectTrigger },
   },
 };
 
 export const metaSelectContent: WsComponentMeta = {
-  type: "container",
   icon: ContentIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [radix.SelectViewport],
+  },
   presetStyle: {
     div,
   },
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.Select },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.SelectViewport },
-    },
-  ],
 };
 
 export const metaSelectViewport: WsComponentMeta = {
-  type: "container",
   icon: ViewportIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [radix.SelectItem],
+  },
   presetStyle: {
     div,
   },
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.SelectContent },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.SelectItem },
-    },
-  ],
 };
 
 export const metaSelectItem: WsComponentMeta = {
-  type: "container",
   icon: ItemIcon,
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.SelectViewport },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.SelectItemIndicator },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.SelectItemText },
-    },
-  ],
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [radix.SelectItemIndicator, radix.SelectItemText],
+  },
   presetStyle: {
     div,
   },
 };
 
 export const metaSelectItemIndicator: WsComponentMeta = {
-  type: "container",
   label: "Indicator",
   icon: CheckMarkIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.SelectItem },
+  contentModel: {
+    category: "none",
+    children: ["instance"],
   },
   presetStyle: {
     span,
@@ -140,12 +104,11 @@ export const metaSelectItemIndicator: WsComponentMeta = {
 };
 
 export const metaSelectItemText: WsComponentMeta = {
-  type: "container",
   label: "Item Text",
   icon: TextIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.SelectItem },
+  contentModel: {
+    category: "none",
+    children: ["instance", "rich-text"],
   },
   presetStyle: {
     span,

--- a/packages/sdk-components-react-radix/src/switch.ws.ts
+++ b/packages/sdk-components-react-radix/src/switch.ws.ts
@@ -10,12 +10,12 @@ import { buttonReset } from "./shared/preset-styles";
 import { propsSwitch, propsSwitchThumb } from "./__generated__/switch.props";
 
 export const metaSwitch: WsComponentMeta = {
-  type: "container",
-  constraints: {
-    relation: "descendant",
-    component: { $eq: radix.SwitchThumb },
-  },
   icon: SwitchIcon,
+  contentModel: {
+    category: "instance",
+    children: ["instance"],
+    descendants: [radix.SwitchThumb],
+  },
   states: [
     ...defaultStates,
     {
@@ -35,12 +35,11 @@ export const metaSwitch: WsComponentMeta = {
 };
 
 export const metaSwitchThumb: WsComponentMeta = {
-  type: "container",
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.Switch },
-  },
   icon: TriggerIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+  },
   states: [
     ...defaultStates,
     {

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -6,7 +6,6 @@ import {
 } from "@webstudio-is/icons/svg";
 import {
   defaultStates,
-  type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
@@ -20,55 +19,38 @@ import {
   propsTabsContent,
 } from "./__generated__/tabs.props";
 
-const presetStyle = {
-  div,
-} satisfies PresetStyle<"div">;
-
 export const metaTabs: WsComponentMeta = {
-  type: "container",
   icon: TabsIcon,
-  constraints: [
-    {
-      relation: "descendant",
-      component: { $eq: radix.TabsTrigger },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.TabsList },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.TabsContent },
-    },
-  ],
-  presetStyle,
+  contentModel: {
+    category: "instance",
+    children: ["instance"],
+    descendants: [radix.TabsList, radix.TabsContent],
+  },
+  presetStyle: {
+    div,
+  },
 };
 
 export const metaTabsList: WsComponentMeta = {
-  type: "container",
   icon: HeaderIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.Tabs },
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+    descendants: [radix.TabsTrigger],
   },
-  presetStyle,
+  presetStyle: {
+    div,
+  },
 };
 
 export const metaTabsTrigger: WsComponentMeta = {
-  type: "container",
   icon: TriggerIcon,
-  constraints: [
-    {
-      relation: "ancestor",
-      component: { $eq: radix.TabsList },
-    },
-    {
-      relation: "ancestor",
-      component: { $neq: radix.TabsTrigger },
-    },
-  ],
-  indexWithinAncestor: radix.Tabs,
   label: "Tab Trigger",
+  indexWithinAncestor: radix.Tabs,
+  contentModel: {
+    category: "none",
+    children: ["instance", "rich-text"],
+  },
   states: [
     ...defaultStates,
     {
@@ -83,15 +65,16 @@ export const metaTabsTrigger: WsComponentMeta = {
 };
 
 export const metaTabsContent: WsComponentMeta = {
-  type: "container",
   label: "Tab Content",
   icon: ContentIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.Tabs },
-  },
   indexWithinAncestor: radix.Tabs,
-  presetStyle,
+  contentModel: {
+    category: "none",
+    children: ["instance", "rich-text"],
+  },
+  presetStyle: {
+    div,
+  },
 };
 
 export const propsMetaTabs: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/tooltip.ws.ts
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.ts
@@ -10,39 +10,31 @@ import {
 
 // @todo add [data-state] to button and link
 export const metaTooltipTrigger: WsComponentMeta = {
-  type: "container",
   icon: TriggerIcon,
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.Tooltip },
+  contentModel: {
+    category: "none",
+    children: ["instance"],
   },
 };
 
 export const metaTooltipContent: WsComponentMeta = {
-  type: "container",
   icon: ContentIcon,
+  contentModel: {
+    category: "none",
+    children: ["instance"],
+  },
   presetStyle: {
     div,
-  },
-  constraints: {
-    relation: "ancestor",
-    component: { $eq: radix.Tooltip },
   },
 };
 
 export const metaTooltip: WsComponentMeta = {
-  type: "container",
-  constraints: [
-    {
-      relation: "descendant",
-      component: { $eq: radix.TooltipTrigger },
-    },
-    {
-      relation: "descendant",
-      component: { $eq: radix.TooltipContent },
-    },
-  ],
   icon: TooltipIcon,
+  contentModel: {
+    category: "instance",
+    children: ["instance"],
+    descendants: [radix.TooltipTrigger, radix.TooltipContent],
+  },
 };
 
 export const propsMetaTooltip: WsComponentPropsMeta = {

--- a/packages/sdk/src/schema/component-meta.ts
+++ b/packages/sdk/src/schema/component-meta.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 import type { HtmlTags } from "html-tags";
+import type { Simplify } from "type-fest";
+import { StyleValue, type CssProperty } from "@webstudio-is/css-engine";
 import { PropMeta } from "./prop-meta";
 import { Matchers } from "./instances";
-import { StyleValue, type CssProperty } from "@webstudio-is/css-engine";
-import type { Simplify } from "type-fest";
 
 export const PresetStyleDecl = z.object({
   // State selector, e.g. :hover
@@ -93,8 +93,6 @@ export type ContentModel = z.infer<typeof ContentModel>;
 
 export const WsComponentMeta = z.object({
   category: z.enum(componentCategories).optional(),
-  // container - can accept other components with dnd or be edited as text              ..
-  type: z.enum(["container"]).optional(),
   /**
    * a property used as textual placeholder when no content specified while in builder
    * also signals to not insert components inside unless dropped explicitly


### PR DESCRIPTION
Replaced legacy constraints with component content model in radix components. Checked all locally.

Removed meta.type for good.