### PR TITLE
fix: show initial properties in advanced panel

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/model.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/model.tsx
@@ -268,6 +268,15 @@ export const $computedStyleDeclarations = computed(
       styleSourceSelections,
       styles,
     });
+    // In advanced mode we assume user knows the properties they need, so we don't need to show these.
+    // @todo will be fully deleted https://github.com/webstudio-is/webstudio/issues/4871
+    definedStyles.push(
+      { property: "cursor" },
+      { property: "mix-blend-mode" },
+      { property: "opacity" },
+      { property: "pointer-events" },
+      { property: "user-select" }
+    );
     const computedStyles = new Map<string, ComputedStyleDecl>();
     for (const { property, listed } of definedStyles) {
       // deduplicate by property name


### PR DESCRIPTION
Opacity and others when defined are duplicated
and not shown at all when not defined.

<img width="247" alt="Screenshot 2025-04-23 at 00 18 06" src="https://github.com/user-attachments/assets/70a329eb-c714-4ba8-a839-ca330c30a0f3" />
