### PR TITLE
feat: support paste from other browsers

### DIFF
--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -3,7 +3,7 @@ import {
   $authTokenPermissions,
   $textEditingInstanceSelector,
 } from "../nano-states";
-import * as instance from "./plugin-instance";
+import { instanceText, instanceJson } from "./plugin-instance";
 import * as markdown from "./plugin-markdown";
 import * as webflow from "./plugin-webflow/plugin-webflow";
 import { builderApi } from "../builder-api";
@@ -64,7 +64,7 @@ const validateClipboardEvent = (event: ClipboardEvent) => {
 
 const defaultMimeType = "application/json";
 
-type Plugin = {
+export type Plugin = {
   mimeType?: string;
   onCopy?: () => undefined | string;
   onCut?: () => undefined | string;
@@ -134,7 +134,7 @@ const initPlugins = ({
 
 export const initCopyPaste = ({ signal }: { signal: AbortSignal }) => {
   initPlugins({
-    plugins: [instance, markdown, webflow],
+    plugins: [instanceJson, instanceText, markdown, webflow],
     signal,
   });
 };

--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -62,10 +62,8 @@ const validateClipboardEvent = (event: ClipboardEvent) => {
   return true;
 };
 
-const defaultMimeType = "application/json";
-
 export type Plugin = {
-  mimeType?: string;
+  mimeType: string;
   onCopy?: () => undefined | string;
   onCut?: () => undefined | string;
   onPaste?: (data: string) => boolean | Promise<boolean>;
@@ -83,7 +81,7 @@ const initPlugins = ({
       return;
     }
 
-    for (const { mimeType = defaultMimeType, onCopy } of plugins) {
+    for (const { mimeType, onCopy } of plugins) {
       const data = onCopy?.();
 
       if (data) {
@@ -99,7 +97,7 @@ const initPlugins = ({
     if (validateClipboardEvent(event) === false) {
       return;
     }
-    for (const { mimeType = defaultMimeType, onCut } of plugins) {
+    for (const { mimeType, onCut } of plugins) {
       const data = onCut?.();
       if (data) {
         // must prevent default, otherwise setData() will not work
@@ -115,7 +113,7 @@ const initPlugins = ({
       return;
     }
 
-    for (const { mimeType = defaultMimeType, onPaste } of plugins) {
+    for (const { mimeType, onPaste } of plugins) {
       // this shouldn't matter, but just in case
       event.preventDefault();
       const data = event.clipboardData?.getData(mimeType).trim();

--- a/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
@@ -25,7 +25,7 @@ import {
   $props,
   $registeredComponentMetas,
 } from "../nano-states";
-import { onCopy, onPaste } from "./plugin-instance";
+import { instanceText } from "./plugin-instance";
 import { createDefaultPages } from "@webstudio-is/project-build";
 import { $awareness, selectInstance } from "../awareness";
 
@@ -96,9 +96,9 @@ describe("paste target", () => {
   test("is inside selected instance", () => {
     $instances.set(instances);
     selectInstance(["box1", "body0"]);
-    const clipboardData = onCopy() ?? "";
+    const clipboardData = instanceText.onCopy?.() ?? "";
     selectInstance(["box2", "body0"]);
-    onPaste(clipboardData);
+    instanceText.onPaste?.(clipboardData);
 
     const instancesDifference = getMapDifference(instances, $instances.get());
     const [newBox1] = instancesDifference.keys();
@@ -113,7 +113,7 @@ describe("paste target", () => {
   test("is after selected instance when same as copied", () => {
     $instances.set(instances);
     selectInstance(["box1", "body0"]);
-    onPaste(onCopy() ?? "");
+    instanceText.onPaste?.(instanceText.onCopy?.() ?? "");
 
     const instancesDifference = getMapDifference(instances, $instances.get());
     const [newBox1] = instancesDifference.keys();
@@ -190,9 +190,9 @@ describe("data sources", () => {
     $dataSources.set(dataSources);
     $props.set(props);
     selectInstance(["box1", "body0"]);
-    const clipboardData = onCopy() ?? "";
+    const clipboardData = instanceText.onCopy?.() ?? "";
     selectInstance(["body0"]);
-    onPaste(clipboardData);
+    instanceText.onPaste?.(clipboardData);
 
     const instancesDifference = getMapDifference(instances, $instances.get());
     const [newBox1, newBox2] = instancesDifference.keys();
@@ -259,9 +259,9 @@ describe("data sources", () => {
     $props.set(props);
     $dataSources.set(dataSources);
     selectInstance(["box2", "box1", "body0"]);
-    const clipboardData = onCopy() ?? "";
+    const clipboardData = instanceText.onCopy?.() ?? "";
     selectInstance(["box1", "body0"]);
-    onPaste(clipboardData);
+    instanceText.onPaste?.(clipboardData);
 
     const instancesDifference = getMapDifference(instances, $instances.get());
     const [newBox2] = instancesDifference.keys();
@@ -340,9 +340,9 @@ describe("data sources", () => {
     $props.set(props);
     $dataSources.set(dataSources);
     selectInstance(["list", "body"]);
-    const clipboardData = onCopy() ?? "";
+    const clipboardData = instanceText.onCopy?.() ?? "";
     selectInstance(["body"]);
-    onPaste(clipboardData);
+    instanceText.onPaste?.(clipboardData);
 
     const instancesDifference = getMapDifference(instances, $instances.get());
     const [collectionId] = instancesDifference.keys();
@@ -397,8 +397,8 @@ test("when paste into copied instance insert after it", () => {
     ])
   );
   selectInstance(["box", "body"]);
-  const clipboardData = onCopy() ?? "";
-  onPaste(clipboardData);
+  const clipboardData = instanceText.onCopy?.() ?? "";
+  instanceText.onPaste?.(clipboardData);
 
   expect($instances.get()).toEqual(
     toMap([
@@ -423,9 +423,9 @@ test("prevent pasting portal into own descendants", () => {
   ]);
   $instances.set(instances);
   selectInstance(["portal", "body"]);
-  const clipboardData = onCopy() ?? "";
+  const clipboardData = instanceText.onCopy?.() ?? "";
   selectInstance(["box", "fragment", "portal", "body"]);
-  onPaste(clipboardData);
+  instanceText.onPaste?.(clipboardData);
   expect($instances.get()).toEqual(instances);
 });
 
@@ -445,9 +445,9 @@ test("prevent pasting portal into copy of it", () => {
   ]);
   $instances.set(instances);
   selectInstance(["portal1", "body"]);
-  const clipboardData = onCopy() ?? "";
+  const clipboardData = instanceText.onCopy?.() ?? "";
   selectInstance(["portal2", "body"]);
-  onPaste(clipboardData);
+  instanceText.onPaste?.(clipboardData);
   expect($instances.get()).toEqual(instances);
 });
 
@@ -466,9 +466,9 @@ test("insert portal into its sibling", () => {
     ])
   );
   selectInstance(["portal", "body"]);
-  const clipboardData = onCopy() ?? "";
+  const clipboardData = instanceText.onCopy?.() ?? "";
   selectInstance(["sibling", "body"]);
-  onPaste(clipboardData);
+  instanceText.onPaste?.(clipboardData);
 
   expect($instances.get()).toEqual(
     toMap([
@@ -500,12 +500,12 @@ test("insert into portal fragment when portal is a target", () => {
     ])
   );
   selectInstance(["box", "body"]);
-  const clipboardData = onCopy() ?? "";
+  const clipboardData = instanceText.onCopy?.() ?? "";
   selectInstance(["portal", "body"]);
 
   // fragment not exists
   const prevInstances = $instances.get();
-  onPaste(clipboardData);
+  instanceText.onPaste?.(clipboardData);
   const [boxId, fragmentId] = getMapDifference(
     prevInstances,
     $instances.get()
@@ -526,7 +526,7 @@ test("insert into portal fragment when portal is a target", () => {
   );
 
   // fragment already exists
-  onPaste(clipboardData);
+  instanceText.onPaste?.(clipboardData);
   expect($instances.get()).toEqual(
     toMap([
       createInstance("body", "Body", [

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -23,6 +23,7 @@ import {
 } from "../instance-utils";
 import { $selectedInstancePath } from "../awareness";
 import { findAvailableVariables } from "../data-variables";
+import type { Plugin } from "./init-copy-paste";
 
 const version = "@webstudio/instance/v0.1";
 
@@ -69,9 +70,7 @@ const parse = (clipboardData: string): InstanceData | undefined => {
   }
 };
 
-export const mimeType = "application/json";
-
-export const getPortalFragmentSelector = (
+const getPortalFragmentSelector = (
   instances: Instances,
   instanceSelector: InstanceSelector
 ) => {
@@ -152,7 +151,7 @@ const findPasteTarget = (data: InstanceData): undefined | Insertable => {
   return insertable;
 };
 
-export const onPaste = (clipboardData: string) => {
+const onPaste = (clipboardData: string) => {
   const fragment = parse(clipboardData);
 
   if (fragment === undefined) {
@@ -186,7 +185,7 @@ export const onPaste = (clipboardData: string) => {
   return true;
 };
 
-export const onCopy = () => {
+const onCopy = () => {
   const selectedInstanceSelector = $selectedInstanceSelector.get();
   if (selectedInstanceSelector === undefined) {
     return;
@@ -198,7 +197,7 @@ export const onCopy = () => {
   return stringify(data);
 };
 
-export const onCut = () => {
+const onCut = () => {
   const instancePath = $selectedInstancePath.get();
   if (instancePath === undefined) {
     return;
@@ -218,4 +217,16 @@ export const onCut = () => {
     return;
   }
   return stringify(data);
+};
+
+export const instanceText: Plugin = {
+  mimeType: "text/plain",
+  onCopy,
+  onCut,
+  onPaste,
+};
+
+export const instanceJson: Plugin = {
+  mimeType: "application/json",
+  onPaste,
 };


### PR DESCRIPTION
Users started to build own marketplaces. And we found paste something copied from other browser like firefox -> chromium based app doesn't work. This is because OSs guarantee only text/plain to be stored in system clipboard.

Here I changed copy paste logic to copy as text/plain and paste as both application/json and text/plain if possible.