### PR TITLE
fix: set xml node background to white

### DIFF
--- a/packages/sdk-components-react/src/head-slot.tsx
+++ b/packages/sdk-components-react/src/head-slot.tsx
@@ -26,7 +26,6 @@ export const HeadSlot = forwardRef<
     <div
       ref={ref}
       style={{
-        backgroundColor: "rgba(255,255,255,1)",
         padding: "8px",
         position: "fixed",
         top: 0,

--- a/packages/sdk-components-react/src/xml-node.tsx
+++ b/packages/sdk-components-react/src/xml-node.tsx
@@ -71,7 +71,7 @@ export const XmlNode = forwardRef<ElementRef<"div">, Props>(
     };
 
     return (
-      <div {...props}>
+      <div {...props} style={{ backgroundColor: "rgba(255,255,255,1)" }}>
         <span>
           <span style={{ color: "#800000" }}>&lt;{elementName}</span>
           {attributeEntries.length > 0 && renderAttributes(attributeEntries)}


### PR DESCRIPTION
## Description

fixes #5015 
Added `backgroundColor` to `white` for `XMLNode` so the content is visible even when the `GlobalRoot` is set to something else.

## Steps for reproduction

- Create a demo project.
- Create a XML with sitemap.xml
- Now, switch back to the home page and set the `backgroudnColor` of the global root to some random colour.
- Then, switch back to the sitemap page. Now, the contents are not visible as the background is inherited from the GlobalRoot. This fix will help in setting to white whenever a xml node is used.

## Code Review
- [ ] hi @kof, I need you to do
  - test it on preview

## Before requesting a review
- [x] made a self-review

## Before merging
- [x] tested locally and on preview environment (preview dev login: 0000)