### PR TITLE
fix: og-image bug fix for local assets

### DIFF
--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -286,6 +286,7 @@ const Outlet = () => {
         host={host}
         siteName={siteName}
         imageLoader={imageLoader}
+        assetBaseUrl={assetBaseUrl}
       />
       <PageSettingsTitle>{pageMeta.title}</PageSettingsTitle>
       <PageSettingsCanonicalLink href={url} />

--- a/packages/cli/templates/react-router/app/route-templates/html.tsx
+++ b/packages/cli/templates/react-router/app/route-templates/html.tsx
@@ -285,6 +285,7 @@ const Outlet = () => {
         host={host}
         siteName={siteName}
         imageLoader={imageLoader}
+        assetBaseUrl={assetBaseUrl}
       />
       <PageSettingsTitle>{pageMeta.title}</PageSettingsTitle>
     </ReactSdkContext.Provider>

--- a/packages/cli/templates/ssg/app/route-templates/html/+Head.tsx
+++ b/packages/cli/templates/ssg/app/route-templates/html/+Head.tsx
@@ -20,7 +20,7 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
   let socialImageUrl = pageMeta.socialImageUrl;
   if (pageMeta.socialImageAssetName) {
     socialImageUrl = `${origin}${imageLoader({
-      src: pageMeta.socialImageAssetName,
+      src: `${assetBaseUrl}/${pageMeta.socialImageAssetName}`,
       // Do not transform social image (not enough information do we need to do this)
       format: "raw",
     })}`;

--- a/packages/react-sdk/src/page-settings-meta.tsx
+++ b/packages/react-sdk/src/page-settings-meta.tsx
@@ -66,12 +66,14 @@ export const PageSettingsMeta = ({
   siteName,
   pageMeta,
   imageLoader,
+  assetBaseUrl,
 }: {
   url?: string;
   host: string;
   siteName: string;
   pageMeta: PageMeta;
   imageLoader: ImageLoader;
+  assetBaseUrl: string;
 }) => {
   const metas: // | { title: string }
   { property?: string; name?: string; content: string }[] = [];
@@ -121,7 +123,9 @@ export const PageSettingsMeta = ({
     metas.push({
       property: "og:image",
       content: `https://${host}${imageLoader({
-        src: pageMeta.socialImageAssetName,
+        src: assetBaseUrl
+          ? `${assetBaseUrl}${pageMeta.socialImageAssetName}`
+          : pageMeta.socialImageAssetName,
         // Do not transform social image (not enough information do we need to do this)
         format: "raw",
       })}`,


### PR DESCRIPTION
## Description

Currently when a project is exported using `cli` and the built using any inbuilt templates. The `og:image` fails with local assets. As the cli is not prefixing the `assetBaseUrl` to the image name. Which is failing to load.

## Bug 
Deployed Url - https://og-image-bug.netlify.app/
Open GH - https://orcascan.com/tools/open-graph-validator?url=https%3A%2F%2Fog-image-bug.netlify.app%2F
![Screenshot 2025-05-05 at 6 18 20 PM](https://github.com/user-attachments/assets/4e2f2739-0d9f-4254-98ec-cbb7310a2023)

### Fixed version
Deployed url - https://og-image-fix.netlify.app/
Open GH - https://orcascan.com/tools/open-graph-validator?url=https%3A%2F%2Fog-image-fix.netlify.app%2F
![Screenshot 2025-05-05 at 6 19 06 PM](https://github.com/user-attachments/assets/932db416-91df-44e4-9576-3256a8d0d76a)

I am passing the `assetBaseUrl` to `ProjectSettingsMeta` inside the `react-sdk`. And using it as prefix if defined.


## Steps for reproduction

- Create a project and add a page to it.
- Upload and use an image for the `SocialImage` section under Page Settings.
- Deploy the site, and share it anywhere for the `og:image` to kick in when shared.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)