### PR TITLE
fix: default twitter og preview to use `summary_large_image` for bigger previews

### DIFF
--- a/fixtures/ssg-netlify-by-project-id/pages/index/+Head.tsx
+++ b/fixtures/ssg-netlify-by-project-id/pages/index/+Head.tsx
@@ -25,7 +25,7 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       format: "raw",
     })}`;
   }
-  const isTwitterCardSizeExists = pageMeta.custom.some(
+  const isTwitterCardSizeDefined = pageMeta.custom.some(
     (meta) => meta.property === "twitter:card"
   );
   return (
@@ -58,9 +58,11 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       {pageMeta.custom.map(({ property, content }) => (
         <meta key={property} property={property} content={content} />
       ))}
-      {isTwitterCardSizeExists === false && (
-        <meta property="twitter:card" content="summary_large_image" />
-      )}
+      {(pageMeta.socialImageAssetName !== undefined ||
+        pageMeta.socialImageUrl !== undefined) &&
+        isTwitterCardSizeDefined === false && (
+          <meta property="twitter:card" content="summary_large_image" />
+        )}
 
       {favIconAsset && (
         <link

--- a/fixtures/ssg-netlify-by-project-id/pages/index/+Head.tsx
+++ b/fixtures/ssg-netlify-by-project-id/pages/index/+Head.tsx
@@ -25,6 +25,9 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       format: "raw",
     })}`;
   }
+  const isTwitterCardSizeExists = pageMeta.custom.some(
+    (meta) => meta.property === "twitter:card"
+  );
   return (
     <>
       {data.url && <meta property="og:url" content={data.url} />}
@@ -55,6 +58,9 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       {pageMeta.custom.map(({ property, content }) => (
         <meta key={property} property={property} content={content} />
       ))}
+      {isTwitterCardSizeExists === false && (
+        <meta property="twitter:card" content="summary_large_image" />
+      )}
 
       {favIconAsset && (
         <link

--- a/fixtures/ssg/pages/another-page/+Head.tsx
+++ b/fixtures/ssg/pages/another-page/+Head.tsx
@@ -25,7 +25,7 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       format: "raw",
     })}`;
   }
-  const isTwitterCardSizeExists = pageMeta.custom.some(
+  const isTwitterCardSizeDefined = pageMeta.custom.some(
     (meta) => meta.property === "twitter:card"
   );
   return (
@@ -58,9 +58,11 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       {pageMeta.custom.map(({ property, content }) => (
         <meta key={property} property={property} content={content} />
       ))}
-      {isTwitterCardSizeExists === false && (
-        <meta property="twitter:card" content="summary_large_image" />
-      )}
+      {(pageMeta.socialImageAssetName !== undefined ||
+        pageMeta.socialImageUrl !== undefined) &&
+        isTwitterCardSizeDefined === false && (
+          <meta property="twitter:card" content="summary_large_image" />
+        )}
 
       {favIconAsset && (
         <link

--- a/fixtures/ssg/pages/another-page/+Head.tsx
+++ b/fixtures/ssg/pages/another-page/+Head.tsx
@@ -25,6 +25,9 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       format: "raw",
     })}`;
   }
+  const isTwitterCardSizeExists = pageMeta.custom.some(
+    (meta) => meta.property === "twitter:card"
+  );
   return (
     <>
       {data.url && <meta property="og:url" content={data.url} />}
@@ -55,6 +58,9 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       {pageMeta.custom.map(({ property, content }) => (
         <meta key={property} property={property} content={content} />
       ))}
+      {isTwitterCardSizeExists === false && (
+        <meta property="twitter:card" content="summary_large_image" />
+      )}
 
       {favIconAsset && (
         <link

--- a/fixtures/ssg/pages/index/+Head.tsx
+++ b/fixtures/ssg/pages/index/+Head.tsx
@@ -25,7 +25,7 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       format: "raw",
     })}`;
   }
-  const isTwitterCardSizeExists = pageMeta.custom.some(
+  const isTwitterCardSizeDefined = pageMeta.custom.some(
     (meta) => meta.property === "twitter:card"
   );
   return (
@@ -58,9 +58,11 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       {pageMeta.custom.map(({ property, content }) => (
         <meta key={property} property={property} content={content} />
       ))}
-      {isTwitterCardSizeExists === false && (
-        <meta property="twitter:card" content="summary_large_image" />
-      )}
+      {(pageMeta.socialImageAssetName !== undefined ||
+        pageMeta.socialImageUrl !== undefined) &&
+        isTwitterCardSizeDefined === false && (
+          <meta property="twitter:card" content="summary_large_image" />
+        )}
 
       {favIconAsset && (
         <link

--- a/fixtures/ssg/pages/index/+Head.tsx
+++ b/fixtures/ssg/pages/index/+Head.tsx
@@ -25,6 +25,9 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       format: "raw",
     })}`;
   }
+  const isTwitterCardSizeExists = pageMeta.custom.some(
+    (meta) => meta.property === "twitter:card"
+  );
   return (
     <>
       {data.url && <meta property="og:url" content={data.url} />}
@@ -55,6 +58,9 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       {pageMeta.custom.map(({ property, content }) => (
         <meta key={property} property={property} content={content} />
       ))}
+      {isTwitterCardSizeExists === false && (
+        <meta property="twitter:card" content="summary_large_image" />
+      )}
 
       {favIconAsset && (
         <link

--- a/packages/cli/templates/ssg/app/route-templates/html/+Head.tsx
+++ b/packages/cli/templates/ssg/app/route-templates/html/+Head.tsx
@@ -25,7 +25,7 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       format: "raw",
     })}`;
   }
-  const isTwitterCardSizeExists = pageMeta.custom.some(
+  const isTwitterCardSizeDefined = pageMeta.custom.some(
     (meta) => meta.property === "twitter:card"
   );
   return (
@@ -58,9 +58,11 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       {pageMeta.custom.map(({ property, content }) => (
         <meta key={property} property={property} content={content} />
       ))}
-      {isTwitterCardSizeExists === false && (
-        <meta property="twitter:card" content="summary_large_image" />
-      )}
+      {(pageMeta.socialImageAssetName !== undefined ||
+        pageMeta.socialImageUrl !== undefined) &&
+        isTwitterCardSizeDefined === false && (
+          <meta property="twitter:card" content="summary_large_image" />
+        )}
 
       {favIconAsset && (
         <link

--- a/packages/cli/templates/ssg/app/route-templates/html/+Head.tsx
+++ b/packages/cli/templates/ssg/app/route-templates/html/+Head.tsx
@@ -25,6 +25,9 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       format: "raw",
     })}`;
   }
+  const isTwitterCardSizeExists = pageMeta.custom.some(
+    (meta) => meta.property === "twitter:card"
+  );
   return (
     <>
       {data.url && <meta property="og:url" content={data.url} />}
@@ -55,6 +58,9 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
       {pageMeta.custom.map(({ property, content }) => (
         <meta key={property} property={property} content={content} />
       ))}
+      {isTwitterCardSizeExists === false && (
+        <meta property="twitter:card" content="summary_large_image" />
+      )}
 
       {favIconAsset && (
         <link

--- a/packages/react-sdk/src/page-settings-meta.tsx
+++ b/packages/react-sdk/src/page-settings-meta.tsx
@@ -137,5 +137,12 @@ export const PageSettingsMeta = ({
 
   metas.push(...pageMeta.custom);
 
+  const isTwitterCardSizeExists = pageMeta.custom.some(
+    (meta) => meta.property === "twitter:card"
+  );
+  if (isTwitterCardSizeExists === false) {
+    metas.push({ property: "twitter:card", content: "summary_large_image" });
+  }
+
   return metas.map((meta, index) => <Meta key={index} {...meta} />);
 };

--- a/packages/react-sdk/src/page-settings-meta.tsx
+++ b/packages/react-sdk/src/page-settings-meta.tsx
@@ -137,10 +137,14 @@ export const PageSettingsMeta = ({
 
   metas.push(...pageMeta.custom);
 
-  const isTwitterCardSizeExists = pageMeta.custom.some(
+  const isTwitterCardSizeDefined = pageMeta.custom.some(
     (meta) => meta.property === "twitter:card"
   );
-  if (isTwitterCardSizeExists === false) {
+  if (
+    (pageMeta.socialImageAssetName !== undefined ||
+      pageMeta.socialImageUrl !== undefined) &&
+    isTwitterCardSizeDefined === false
+  ) {
     metas.push({ property: "twitter:card", content: "summary_large_image" });
   }
 


### PR DESCRIPTION
## Description

fixes #3104 

For forcing twitter to use large-card size. We need to set `summary_large_image` meta tag in the header.

## Steps for reproduction

- Create a new project with a page.
- Set an image for the social image in the page settings.
- Deploy the site, and check the open graph preview using some of the tools online

https://tweethunter.io/tweetpik/twitter-card-validator?url=https%3A%2F%2Fcelebrated-pony-026734.netlify.app%2F
<img width="811" alt="Screenshot 2025-05-06 at 8 41 02 PM" src="https://github.com/user-attachments/assets/c1b0ad29-c0c1-49be-8106-a3f7ec6a1387" />


https://robolly.com/twitter-card-preview?url=https://celebrated-pony-026734.netlify.app

<img width="1176" alt="Screenshot 2025-05-06 at 8 40 57 PM" src="https://github.com/user-attachments/assets/dcf59282-9f91-44fc-b775-87d4a2749e57" />


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document