### PR TITLE
fix: show elipsis for longer social image names

### DIFF
--- a/apps/builder/app/builder/features/pages/image-info.tsx
+++ b/apps/builder/app/builder/features/pages/image-info.tsx
@@ -44,7 +44,11 @@ export const ImageInfo = ({ asset, onDelete }: ImageInfoProps) => {
         >
           <Grid flow={"column"} gap={1} align={"center"}>
             <ImageIcon />
-            <Text truncate variant={"labelsTitleCase"}>
+            <Text
+              truncate
+              variant={"labelsTitleCase"}
+              css={{ overflow: "hidden" }}
+            >
               {asset.name}
             </Text>
           </Grid>

--- a/apps/builder/app/builder/features/pages/image-info.tsx
+++ b/apps/builder/app/builder/features/pages/image-info.tsx
@@ -44,11 +44,7 @@ export const ImageInfo = ({ asset, onDelete }: ImageInfoProps) => {
         >
           <Grid flow={"column"} gap={1} align={"center"}>
             <ImageIcon />
-            <Text
-              truncate
-              variant={"labelsTitleCase"}
-              css={{ overflow: "hidden" }}
-            >
+            <Text truncate variant={"labelsTitleCase"}>
               {asset.name}
             </Text>
           </Grid>

--- a/packages/design-system/src/utilities.ts
+++ b/packages/design-system/src/utilities.ts
@@ -145,5 +145,5 @@ export const useResize = ({
 export const truncate = (): CSS => ({
   whiteSpace: "nowrap",
   textOverflow: "ellipsis",
-  overflow: "clip",
+  overflow: "hidden",
 });


### PR DESCRIPTION
## Description

Just a small fix for `elipsis` for longer file names for social images. Noticed while working with the social image bug.

<img width="440" alt="Screenshot 2025-05-07 at 7 30 53 PM" src="https://github.com/user-attachments/assets/8e9b6afe-ad21-414f-95c8-fea30ed553b1" />
<img width="472" alt="Screenshot 2025-05-07 at 7 30 34 PM" src="https://github.com/user-attachments/assets/28eb99dc-a16e-4da4-8177-3f72f96ce56d" />


## Steps for reproduction

- Upload any image with longer file names under page settings.

## Code Review

- [ ] hi @kof, I need you to do
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)