### PR TITLE
fix: allow deleting from input in preview mode

### DIFF
--- a/apps/builder/app/canvas/shared/commands.ts
+++ b/apps/builder/app/canvas/shared/commands.ts
@@ -29,6 +29,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
     {
       name: "deleteInstanceCanvas",
       defaultHotkeys: ["backspace", "delete"],
+      preventDefault: false,
       disableHotkeyOutsideApp: true,
       // We are not disabling "Backspace" or "Delete" on the canvas. This is the main reason we have separate functions: deleteInstanceCanvas and deleteInstanceBuilder.
       disableOnInputLikeControls: false,


### PR DESCRIPTION
Fixes https://discord.com/channels/955905230107738152/1369211497590554675

Delete on canvas is separateed from the one in builder so we can safely remove preventDefault to allow entering or deleting from inputs in preview mode.