### PR TITLE
fix: set correct date time property in Time component

### DIFF
--- a/packages/sdk-components-react/src/__generated__/time.props.ts
+++ b/packages/sdk-components-react/src/__generated__/time.props.ts
@@ -215,13 +215,6 @@ export const props: Record<string, PropMeta> = {
     defaultValue: "medium",
     options: ["full", "long", "medium", "short", "none"],
   },
-  dateTime: {
-    required: false,
-    control: "text",
-    type: "string",
-    defaultValue: "dateTime attribute is not set",
-    description: "Machine-readable value",
-  },
   language: {
     required: false,
     control: "select",

--- a/packages/sdk-components-react/src/__generated__/time.props.ts
+++ b/packages/sdk-components-react/src/__generated__/time.props.ts
@@ -215,7 +215,7 @@ export const props: Record<string, PropMeta> = {
     defaultValue: "medium",
     options: ["full", "long", "medium", "short", "none"],
   },
-  datetime: {
+  dateTime: {
     required: false,
     control: "text",
     type: "string",

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -346,7 +346,7 @@ const parseDate = (datetimeString: string) => {
 };
 
 type TimeProps = {
-  datetime?: string;
+  dateTime?: string;
   language?: Language;
   country?: Country;
   dateStyle?: DateStyle;
@@ -360,7 +360,7 @@ export const Time = forwardRef<ElementRef<"time">, TimeProps>(
       country = DEFAULT_COUNTRY,
       dateStyle = DEFAULT_DATE_STYLE,
       timeStyle = DEFAULT_TIME_STYLE,
-      datetime = INITIAL_DATE_STRING,
+      dateTime = INITIAL_DATE_STRING,
       ...props
     },
     ref
@@ -375,7 +375,7 @@ export const Time = forwardRef<ElementRef<"time">, TimeProps>(
     };
 
     const datetimeString =
-      datetime === null ? INVALID_DATE_STRING : datetime.toString();
+      dateTime === null ? INVALID_DATE_STRING : dateTime.toString();
 
     const date = parseDate(datetimeString);
     let formattedDate = datetimeString;

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type ElementRef } from "react";
+import { forwardRef, type ComponentProps, type ElementRef } from "react";
 
 const languages = [
   "af",
@@ -345,8 +345,7 @@ const parseDate = (datetimeString: string) => {
   }
 };
 
-type TimeProps = {
-  dateTime?: string;
+type TimeProps = Pick<ComponentProps<"time">, "dateTime"> & {
   language?: Language;
   country?: Country;
   dateStyle?: DateStyle;
@@ -360,6 +359,7 @@ export const Time = forwardRef<ElementRef<"time">, TimeProps>(
       country = DEFAULT_COUNTRY,
       dateStyle = DEFAULT_DATE_STYLE,
       timeStyle = DEFAULT_TIME_STYLE,
+      // native html attribute in react style
       dateTime = INITIAL_DATE_STRING,
       ...props
     },

--- a/packages/sdk-components-react/src/time.ws.ts
+++ b/packages/sdk-components-react/src/time.ws.ts
@@ -23,5 +23,5 @@ export const meta: WsComponentMeta = {
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["dateTime", "language", "country", "dateStyle", "timeStyle"],
+  initialProps: ["datetime", "language", "country", "dateStyle", "timeStyle"],
 };

--- a/packages/sdk-components-react/src/time.ws.ts
+++ b/packages/sdk-components-react/src/time.ws.ts
@@ -23,5 +23,5 @@ export const meta: WsComponentMeta = {
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["datetime", "language", "country", "dateStyle", "timeStyle"],
+  initialProps: ["dateTime", "language", "country", "dateStyle", "timeStyle"],
 };


### PR DESCRIPTION
All html attributes all converted to react style though in case of Time property was converted.
The easiest solution is to rename the actual property to accept converted time.
