### PR TITLE
experimental: add matching tag when insert element component

### DIFF
--- a/apps/builder/app/builder/features/components/components.tsx
+++ b/apps/builder/app/builder/features/components/components.tsx
@@ -39,6 +39,7 @@ import {
 import {
   getComponentTemplateData,
   getInstanceLabel,
+  insertWebstudioElementAt,
   insertWebstudioFragmentAt,
 } from "~/shared/instance-utils";
 import type { Publish } from "~/shared/pubsub";
@@ -215,9 +216,13 @@ export const ComponentsPanel = ({
   const [selectedComponent, setSelectedComponent] = useState<string>();
 
   const handleInsert = (component: string) => {
-    const fragment = getComponentTemplateData(component);
-    if (fragment) {
-      insertWebstudioFragmentAt(fragment);
+    if (component === elementComponent) {
+      insertWebstudioElementAt();
+    } else {
+      const fragment = getComponentTemplateData(component);
+      if (fragment) {
+        insertWebstudioFragmentAt(fragment);
+      }
     }
     onClose();
   };

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -311,13 +311,13 @@ export const insertWebstudioElementAt = (insertable?: Insertable) => {
   let matchingTag: undefined | string;
   for (const tag of tags) {
     element.tag = tag;
-    const isMatching = isTreeSatisfyingContentModel({
+    const isSatisfying = isTreeSatisfyingContentModel({
       instances: newInstances,
       props,
       metas,
       instanceSelector: [element.id, ...insertable.parentSelector],
     });
-    if (isMatching) {
+    if (isSatisfying) {
       matchingTag = tag;
       break;
     }

--- a/packages/html-data/bin/elements.ts
+++ b/packages/html-data/bin/elements.ts
@@ -76,6 +76,17 @@ for (const [tag, element] of Object.entries(elementsByTag)) {
   }
   tags.push(tag);
 }
+const getTagScore = (tag: string) => {
+  if (tag === "div") {
+    return 20;
+  }
+  if (tag === "span") {
+    return 10;
+  }
+  return 0;
+};
+// put div and span first
+tags.sort((left, right) => getTagScore(right) - getTagScore(left));
 const tagsContent = `export const tags: string[] = ${JSON.stringify(tags, null, 2)};
 `;
 const tagsFile = "../sdk/src/__generated__/tags.ts";

--- a/packages/sdk/src/__generated__/tags.ts
+++ b/packages/sdk/src/__generated__/tags.ts
@@ -1,4 +1,6 @@
 export const tags: string[] = [
+  "div",
+  "span",
   "a",
   "abbr",
   "address",
@@ -26,7 +28,6 @@ export const tags: string[] = [
   "details",
   "dfn",
   "dialog",
-  "div",
   "dl",
   "dt",
   "em",
@@ -83,7 +84,6 @@ export const tags: string[] = [
   "slot",
   "small",
   "source",
-  "span",
   "strong",
   "sub",
   "summary",

--- a/packages/sdk/src/core-templates.tsx
+++ b/packages/sdk/src/core-templates.tsx
@@ -18,7 +18,7 @@ const elementMeta: TemplateMeta = {
   order: 0,
   description:
     "An HTML element is a core building block for web pages, structuring and displaying content like text, images, and links.",
-  template: <ws.element ws:tag="div"></ws.element>,
+  template: <ws.element></ws.element>,
 };
 
 const collectionItem = new Parameter("collectionItem");


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3632

Now element does not provide default tag and instead builder will try to find tag matching its parent.

This way we can insert element, give it "ul" tag
and then insert another element into it which will match only "li"

https://github.com/user-attachments/assets/3ea87624-9524-4f2e-91b2-d658d16d7a1b


