### PR TITLE
experimental: override some tags with components

### DIFF
--- a/fixtures/webstudio-features/.webstudio/data.json
+++ b/fixtures/webstudio-features/.webstudio/data.json
@@ -1,10 +1,10 @@
 {
   "build": {
-    "id": "f0dfc2e7-240a-4542-ad28-a4cb68b2d9db",
+    "id": "043bda3f-0d77-4656-aa9c-652c1a1f272e",
     "projectId": "cddc1d44-af37-4cb6-a430-d300cf6f932d",
-    "version": 583,
-    "createdAt": "2025-04-14T09:45:34.257+00:00",
-    "updatedAt": "2025-04-14T09:45:34.257+00:00",
+    "version": 593,
+    "createdAt": "2025-05-15T22:04:05.511+00:00",
+    "updatedAt": "2025-05-15T22:04:05.511+00:00",
     "pages": {
       "meta": {
         "siteName": "KittyGuardedZone",
@@ -2165,6 +2165,18 @@
             "value": "center"
           }
         }
+      ],
+      [
+        "U6kV-2LTnN9kR4jWfLb1c:UoTkWyaFuTYJihS3MFYK5:display:",
+        {
+          "breakpointId": "UoTkWyaFuTYJihS3MFYK5",
+          "styleSourceId": "U6kV-2LTnN9kR4jWfLb1c",
+          "property": "display",
+          "value": {
+            "type": "keyword",
+            "value": "block"
+          }
+        }
       ]
     ],
     "styleSources": [
@@ -2481,6 +2493,13 @@
         {
           "type": "local",
           "id": "hEVSzkOEBn_3dNyo65PAM"
+        }
+      ],
+      [
+        "U6kV-2LTnN9kR4jWfLb1c",
+        {
+          "type": "local",
+          "id": "U6kV-2LTnN9kR4jWfLb1c"
         }
       ]
     ],
@@ -2799,6 +2818,13 @@
           "instanceId": "g__o13UKOkD0KImnp-sWp",
           "values": ["hEVSzkOEBn_3dNyo65PAM"]
         }
+      ],
+      [
+        "Ol5bklKKxyJaS7Q3jcCfD",
+        {
+          "instanceId": "Ol5bklKKxyJaS7Q3jcCfD",
+          "values": ["U6kV-2LTnN9kR4jWfLb1c"]
+        }
       ]
     ],
     "props": [
@@ -2810,16 +2836,6 @@
           "name": "src",
           "type": "asset",
           "value": "cd939c56-bcdd-4e64-bd9c-567a9bccd3da"
-        }
-      ],
-      [
-        "SYK4hpLQ9tHnESKDtPvI9",
-        {
-          "id": "SYK4hpLQ9tHnESKDtPvI9",
-          "instanceId": "l9AI_pShC-BH4ibxK6kNT",
-          "name": "href",
-          "type": "string",
-          "value": "https://github.com/"
         }
       ],
       [
@@ -4111,6 +4127,16 @@
           "type": "boolean",
           "value": true
         }
+      ],
+      [
+        "qG9NyGQuq0KVR0zvf76Er",
+        {
+          "id": "qG9NyGQuq0KVR0zvf76Er",
+          "instanceId": "Ol5bklKKxyJaS7Q3jcCfD",
+          "name": "href",
+          "type": "string",
+          "value": "https://github.com/"
+        }
       ]
     ],
     "dataSources": [
@@ -4432,7 +4458,7 @@
             },
             {
               "type": "id",
-              "value": "l9AI_pShC-BH4ibxK6kNT"
+              "value": "Ol5bklKKxyJaS7Q3jcCfD"
             },
             {
               "type": "id",
@@ -4506,20 +4532,6 @@
           "id": "pX1ovPI7NdC0HRjkw6Kpw",
           "component": "Image",
           "children": []
-        }
-      ],
-      [
-        "l9AI_pShC-BH4ibxK6kNT",
-        {
-          "type": "instance",
-          "id": "l9AI_pShC-BH4ibxK6kNT",
-          "component": "Link",
-          "children": [
-            {
-              "type": "text",
-              "value": "Click here to adore more kittens"
-            }
-          ]
         }
       ],
       [
@@ -6725,6 +6737,21 @@
             {
               "type": "text",
               "value": "UGLY"
+            }
+          ]
+        }
+      ],
+      [
+        "Ol5bklKKxyJaS7Q3jcCfD",
+        {
+          "type": "instance",
+          "id": "Ol5bklKKxyJaS7Q3jcCfD",
+          "component": "ws:element",
+          "tag": "a",
+          "children": [
+            {
+              "type": "text",
+              "value": "Click here to adore more kittens"
             }
           ]
         }

--- a/fixtures/webstudio-features/app/__generated__/$resources.sitemap.xml.ts
+++ b/fixtures/webstudio-features/app/__generated__/$resources.sitemap.xml.ts
@@ -1,26 +1,26 @@
 export const sitemap = [
   {
     path: "/",
-    lastModified: "2025-04-14",
+    lastModified: "2025-05-15",
   },
   {
     path: "/_route_with_symbols_",
-    lastModified: "2025-04-14",
+    lastModified: "2025-05-15",
   },
   {
     path: "/form",
-    lastModified: "2025-04-14",
+    lastModified: "2025-05-15",
   },
   {
     path: "/heading-with-id",
-    lastModified: "2025-04-14",
+    lastModified: "2025-05-15",
   },
   {
     path: "/resources",
-    lastModified: "2025-04-14",
+    lastModified: "2025-05-15",
   },
   {
     path: "/nested/nested-page",
-    lastModified: "2025-04-14",
+    lastModified: "2025-05-15",
   },
 ];

--- a/fixtures/webstudio-features/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -8,7 +8,7 @@ import { Image as Image } from "@webstudio-is/sdk-components-react";
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[animations]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[animations]._index.tsx
@@ -15,7 +15,7 @@ import {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[class-names]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[class-names]._index.tsx
@@ -8,7 +8,7 @@ import { Box as Box } from "@webstudio-is/sdk-components-react";
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[content-block]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[content-block]._index.tsx
@@ -12,7 +12,7 @@ import {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[duration]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[duration]._index.tsx
@@ -9,7 +9,7 @@ import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[expressions]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[expressions]._index.tsx
@@ -12,7 +12,7 @@ import {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[form]._index.tsx
@@ -17,7 +17,7 @@ import {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[head-tag]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[head-tag]._index.tsx
@@ -17,7 +17,7 @@ import {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[heading-with-id]._index.tsx
@@ -8,7 +8,7 @@ import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[nested].[nested-page]._index.tsx
@@ -8,7 +8,7 @@ import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[radix]._index.tsx
@@ -19,7 +19,7 @@ import {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[resources]._index.tsx
@@ -11,7 +11,7 @@ import {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[sitemap.xml]._index.tsx
@@ -10,7 +10,7 @@ import {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/[text-duration]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[text-duration]._index.tsx
@@ -12,7 +12,7 @@ import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 

--- a/fixtures/webstudio-features/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/_index.tsx
@@ -6,6 +6,7 @@ import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,
+  Link as Link_1,
 } from "@webstudio-is/sdk-components-react-router";
 import {
   Heading as Heading,
@@ -17,7 +18,7 @@ import {
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";
 
-export const lastPublished = "2025-04-14T09:45:34.257Z";
+export const lastPublished = "2025-05-15T22:04:05.511Z";
 
 export const siteName = "KittyGuardedZone";
 
@@ -72,9 +73,9 @@ const Page = (_props: { system: any }) => {
               "a little kitten painted in black and white gouache with a thick brush"
             }
           </Paragraph>
-          <Link href={"https://github.com/"} className={`w-link`}>
+          <Link_1 href={"https://github.com/"} className={`w-element ch2exr5`}>
             {"Click here to adore more kittens"}
-          </Link>
+          </Link_1>
           <Text tag={"span"} className={`w-text`}>
             {" or "}
           </Text>

--- a/fixtures/webstudio-features/app/__generated__/index.css
+++ b/fixtures/webstudio-features/app/__generated__/index.css
@@ -8,6 +8,14 @@
     white-space: pre-wrap;
     white-space-collapse: preserve;
   }
+  a.w-element {
+    box-sizing: border-box;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    outline-width: 1px;
+  }
   body.w-body {
     box-sizing: border-box;
     border-top-width: 1px;

--- a/fixtures/webstudio-features/package.json
+++ b/fixtures/webstudio-features/package.json
@@ -6,7 +6,7 @@
     "dev": "react-router dev",
     "cli": "NODE_OPTIONS='--conditions=webstudio --import=tsx' webstudio",
     "fixtures:link": "pnpm cli link --link https://p-cddc1d44-af37-4cb6-a430-d300cf6f932d-dot-${BUILDER_HOST:-main.development.webstudio.is}'?authToken=1cdc6026-dd5b-4624-b89b-9bd45e9bcc3d'",
-    "fixtures:sync": "pnpm cli sync --buildId f0dfc2e7-240a-4542-ad28-a4cb68b2d9db && pnpm prettier --write ./.webstudio/",
+    "fixtures:sync": "pnpm cli sync --buildId 043bda3f-0d77-4656-aa9c-652c1a1f272e && pnpm prettier --write ./.webstudio/",
     "fixtures:build": "pnpm cli build --template react-router --template ./.template && pnpm prettier --write ./app/ ./package.json ./tsconfig.json"
   },
   "private": true,

--- a/packages/cli/src/framework-react-router.ts
+++ b/packages/cli/src/framework-react-router.ts
@@ -4,7 +4,6 @@ import type { WsComponentMeta } from "@webstudio-is/sdk";
 import { generateRemixRoute } from "@webstudio-is/react-sdk";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
 import * as animationComponentMetas from "@webstudio-is/sdk-components-animation/metas";
-import * as reactRouterComponentMetas from "@webstudio-is/sdk-components-react-router/metas";
 import * as radixComponentMetas from "@webstudio-is/sdk-components-react-radix/metas";
 import type { Framework } from "./framework";
 
@@ -31,37 +30,36 @@ export const createFramework = async (): Promise<Framework> => {
   // cleanup route templates after reading to not bloat generated code
   await rm(routeTemplatesDir, { recursive: true, force: true });
 
-  const radixComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
-  for (const [name, meta] of Object.entries(radixComponentMetas)) {
-    const namespace = "@webstudio-is/sdk-components-react-radix";
-    radixComponentNamespacedMetas[`${namespace}:${name}`] = meta;
+  const base = "@webstudio-is/sdk-components-react";
+  const reactRouter = "@webstudio-is/sdk-components-react-router";
+  const reactRadix = "@webstudio-is/sdk-components-react-radix";
+  const animation = "@webstudio-is/sdk-components-animation";
+  const components: Record<string, string> = {};
+  const metas: Record<string, WsComponentMeta> = {};
+  for (const [name, meta] of Object.entries(baseComponentMetas)) {
+    components[name] = `${base}:${name}`;
+    metas[name] = meta;
   }
-
-  const animationComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
+  for (const name of ["Body", "Link", "RichTextLink", "Form", "RemixForm"]) {
+    components[name] = `${reactRouter}:${name}`;
+  }
+  for (const [name, meta] of Object.entries(radixComponentMetas)) {
+    components[`${reactRadix}:${name}`] = `${reactRadix}:${name}`;
+    metas[`${reactRadix}:${name}`] = meta;
+  }
   for (const [name, meta] of Object.entries(animationComponentMetas)) {
-    const namespace = "@webstudio-is/sdk-components-animation";
-    animationComponentNamespacedMetas[`${namespace}:${name}`] = meta;
+    components[`${animation}:${name}`] = `${animation}:${name}`;
+    metas[`${animation}:${name}`] = meta;
   }
 
   return {
-    components: [
-      {
-        source: "@webstudio-is/sdk-components-react",
-        metas: baseComponentMetas,
-      },
-      {
-        source: "@webstudio-is/sdk-components-animation",
-        metas: animationComponentNamespacedMetas,
-      },
-      {
-        source: "@webstudio-is/sdk-components-react-radix",
-        metas: radixComponentNamespacedMetas,
-      },
-      {
-        source: "@webstudio-is/sdk-components-react-router",
-        metas: reactRouterComponentMetas,
-      },
-    ],
+    metas,
+    components,
+    tags: {
+      body: `${reactRouter}:Body`,
+      a: `${reactRouter}:Link`,
+      form: `${reactRouter}:RemixForm`,
+    },
     html: ({ pagePath }: { pagePath: string }) => [
       {
         file: join("app", "routes", `${generateRemixRoute(pagePath)}.tsx`),

--- a/packages/cli/src/framework-remix.ts
+++ b/packages/cli/src/framework-remix.ts
@@ -4,7 +4,6 @@ import type { WsComponentMeta } from "@webstudio-is/sdk";
 import { generateRemixRoute } from "@webstudio-is/react-sdk";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
 import * as animationComponentMetas from "@webstudio-is/sdk-components-animation/metas";
-import * as remixComponentMetas from "@webstudio-is/sdk-components-react-remix/metas";
 import * as radixComponentMetas from "@webstudio-is/sdk-components-react-radix/metas";
 import type { Framework } from "./framework";
 
@@ -31,37 +30,36 @@ export const createFramework = async (): Promise<Framework> => {
   // cleanup route templates after reading to not bloat generated code
   await rm(routeTemplatesDir, { recursive: true, force: true });
 
-  const radixComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
-  for (const [name, meta] of Object.entries(radixComponentMetas)) {
-    const namespace = "@webstudio-is/sdk-components-react-radix";
-    radixComponentNamespacedMetas[`${namespace}:${name}`] = meta;
+  const base = "@webstudio-is/sdk-components-react";
+  const remix = "@webstudio-is/sdk-components-react-remix";
+  const reactRadix = "@webstudio-is/sdk-components-react-radix";
+  const animation = "@webstudio-is/sdk-components-animation";
+  const components: Record<string, string> = {};
+  const metas: Record<string, WsComponentMeta> = {};
+  for (const [name, meta] of Object.entries(baseComponentMetas)) {
+    components[name] = `${base}:${name}`;
+    metas[name] = meta;
   }
-
-  const animationComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
+  for (const name of ["Body", "Link", "RichTextLink", "Form", "RemixForm"]) {
+    components[name] = `${remix}:${name}`;
+  }
+  for (const [name, meta] of Object.entries(radixComponentMetas)) {
+    components[`${reactRadix}:${name}`] = `${reactRadix}:${name}`;
+    metas[`${reactRadix}:${name}`] = meta;
+  }
   for (const [name, meta] of Object.entries(animationComponentMetas)) {
-    const namespace = "@webstudio-is/sdk-components-animation";
-    animationComponentNamespacedMetas[`${namespace}:${name}`] = meta;
+    components[`${animation}:${name}`] = `${animation}:${name}`;
+    metas[`${animation}:${name}`] = meta;
   }
 
   return {
-    components: [
-      {
-        source: "@webstudio-is/sdk-components-react",
-        metas: baseComponentMetas,
-      },
-      {
-        source: "@webstudio-is/sdk-components-animation",
-        metas: animationComponentNamespacedMetas,
-      },
-      {
-        source: "@webstudio-is/sdk-components-react-radix",
-        metas: radixComponentNamespacedMetas,
-      },
-      {
-        source: "@webstudio-is/sdk-components-react-remix",
-        metas: remixComponentMetas,
-      },
-    ],
+    metas,
+    components,
+    tags: {
+      body: `${remix}:Body`,
+      a: `${remix}:Link`,
+      form: `${remix}:RemixForm`,
+    },
     html: ({ pagePath }: { pagePath: string }) => [
       {
         file: join("app", "routes", `${generateRemixRoute(pagePath)}.tsx`),

--- a/packages/cli/src/framework-vike-ssg.ts
+++ b/packages/cli/src/framework-vike-ssg.ts
@@ -32,33 +32,28 @@ export const createFramework = async (): Promise<Framework> => {
   // cleanup route templates after reading to not bloat generated code
   await rm(routeTemplatesDir, { recursive: true, force: true });
 
-  const radixComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
-  for (const [name, meta] of Object.entries(radixComponentMetas)) {
-    const namespace = "@webstudio-is/sdk-components-react-radix";
-    radixComponentNamespacedMetas[`${namespace}:${name}`] = meta;
+  const base = "@webstudio-is/sdk-components-react";
+  const reactRadix = "@webstudio-is/sdk-components-react-radix";
+  const animation = "@webstudio-is/sdk-components-animation";
+  const components: Record<string, string> = {};
+  const metas: Record<string, WsComponentMeta> = {};
+  for (const [name, meta] of Object.entries(baseComponentMetas)) {
+    components[name] = `${base}:${name}`;
+    metas[name] = meta;
   }
-
-  const animationComponentNamespacedMetas: Record<string, WsComponentMeta> = {};
+  for (const [name, meta] of Object.entries(radixComponentMetas)) {
+    components[`${reactRadix}:${name}`] = `${reactRadix}:${name}`;
+    metas[`${reactRadix}:${name}`] = meta;
+  }
   for (const [name, meta] of Object.entries(animationComponentMetas)) {
-    const namespace = "@webstudio-is/sdk-components-animation";
-    animationComponentNamespacedMetas[`${namespace}:${name}`] = meta;
+    components[`${animation}:${name}`] = `${animation}:${name}`;
+    metas[`${animation}:${name}`] = meta;
   }
 
   return {
-    components: [
-      {
-        source: "@webstudio-is/sdk-components-react",
-        metas: baseComponentMetas,
-      },
-      {
-        source: "@webstudio-is/sdk-components-animation",
-        metas: animationComponentNamespacedMetas,
-      },
-      {
-        source: "@webstudio-is/sdk-components-react-radix",
-        metas: radixComponentNamespacedMetas,
-      },
-    ],
+    metas,
+    components,
+    tags: {},
     html: ({ pagePath }: { pagePath: string }) => {
       // ignore dynamic pages in static export
       if (isPathnamePattern(pagePath)) {

--- a/packages/cli/src/framework.ts
+++ b/packages/cli/src/framework.ts
@@ -1,17 +1,17 @@
 import type { WsComponentMeta } from "@webstudio-is/sdk";
 
-type FrameworkComponentEntry = {
-  source: string;
-  metas: Record<string, WsComponentMeta>;
-};
-
 type FrameworkTemplateEntry = {
   file: string;
   template: string;
 };
 
 export type Framework = {
-  components: FrameworkComponentEntry[];
+  // instance.component: WsComponentMeta
+  metas: Record<string, WsComponentMeta>;
+  // instance.component: "importSource:importSpecifier"
+  components: Record<string, string>;
+  // instance.tag: "importSource:importSpecifier"
+  tags: Record<string, string>;
   html: (params: { pagePath: string }) => FrameworkTemplateEntry[];
   xml: (params: { pagePath: string }) => FrameworkTemplateEntry[];
   redirect: (params: { pagePath: string }) => FrameworkTemplateEntry[];

--- a/packages/html-data/bin/aria.ts
+++ b/packages/html-data/bin/aria.ts
@@ -159,5 +159,6 @@ await writeFile(
     classesMap: new Map(),
     parameters: [],
     metas: new Map(),
+    tagsOverrides: {},
   }) + "export { Page }"
 );

--- a/packages/html-data/bin/aria.ts
+++ b/packages/html-data/bin/aria.ts
@@ -159,6 +159,5 @@ await writeFile(
     classesMap: new Map(),
     parameters: [],
     metas: new Map(),
-    tagsOverrides: {},
   }) + "export { Page }"
 );

--- a/packages/html-data/bin/attributes.ts
+++ b/packages/html-data/bin/attributes.ts
@@ -270,7 +270,6 @@ await writeFile(
     classesMap: new Map(),
     parameters: [],
     metas: new Map(),
-    tagsOverrides: {},
   }) + "export { Page }"
 );
 

--- a/packages/html-data/bin/attributes.ts
+++ b/packages/html-data/bin/attributes.ts
@@ -270,6 +270,7 @@ await writeFile(
     classesMap: new Map(),
     parameters: [],
     metas: new Map(),
+    tagsOverrides: {},
   }) + "export { Page }"
 );
 

--- a/packages/react-sdk/src/component-generator.test.tsx
+++ b/packages/react-sdk/src/component-generator.test.tsx
@@ -85,6 +85,7 @@ test("generate jsx element with children and without them", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "body" }],
       ...renderData(<$.Body ws:id="body">Children</$.Body>),
     })
@@ -103,6 +104,7 @@ test("generate jsx element with children and without them", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "image" }],
       ...renderData(<$.Image ws:id="image"></$.Image>),
     })
@@ -123,6 +125,7 @@ test("generate jsx element with namespaces components", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "body" }],
       ...renderData(<library.Body ws:id="body"></library.Body>),
     })
@@ -139,6 +142,7 @@ test("generate jsx element with namespaces components", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "image" }],
       ...renderData(<library.Image ws:id="image"></library.Image>),
     })
@@ -158,6 +162,7 @@ test("generate jsx element with literal props", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "body" }],
       ...renderData(<$.Body ws:id="body" string="string" number={0}></$.Body>),
     })
@@ -176,6 +181,7 @@ test("generate jsx element with literal props", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "image" }],
       ...renderData(
         <$.Image
@@ -203,6 +209,7 @@ test("ignore asset and page props", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "box" }],
       ...renderData(
         <$.Box
@@ -229,6 +236,7 @@ test("generate jsx element with data sources and action", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "box" }],
       ...renderData(
         <$.Box
@@ -261,6 +269,7 @@ test("generate jsx element with condition based on show prop", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "box" }],
       ...renderData(<$.Box ws:id="box" data-ws-show={true}></$.Box>),
     })
@@ -277,6 +286,7 @@ test("generate jsx element with condition based on show prop", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "box" }],
       ...renderData(<$.Box ws:id="box" data-ws-show={false}></$.Box>),
     })
@@ -288,6 +298,7 @@ test("generate jsx element with condition based on show prop", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "box" }],
       ...renderData(
         <$.Box ws:id="box" data-ws-show={expression`${condition}`}></$.Box>
@@ -309,6 +320,7 @@ test("generate jsx children with text", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [
         { type: "text", value: "Some\ntext" },
         { type: "text", value: 'Escaped "text"' },
@@ -336,6 +348,7 @@ test("exclude text placeholders", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [
         { type: "text", value: "Text" },
         { type: "text", value: "Placeholder text", placeholder: true },
@@ -361,6 +374,7 @@ test("generate jsx children with expression", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [
         { type: "expression", value: "'Hello ' + $ws$dataSource$var" },
       ],
@@ -392,6 +406,7 @@ test("generate jsx children with nested instances", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "form" }],
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
@@ -421,6 +436,7 @@ test("deduplicate base and namespaced components with same short name", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [
         { type: "id", value: "button1" },
         { type: "id", value: "button2" },
@@ -449,6 +465,7 @@ test("generate collection component as map", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
+      tagsOverrides: {},
       children: [{ type: "id", value: "list" }],
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),

--- a/packages/react-sdk/src/component-generator.test.tsx
+++ b/packages/react-sdk/src/component-generator.test.tsx
@@ -85,7 +85,6 @@ test("generate jsx element with children and without them", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "body" }],
       ...renderData(<$.Body ws:id="body">Children</$.Body>),
     })
@@ -104,7 +103,6 @@ test("generate jsx element with children and without them", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "image" }],
       ...renderData(<$.Image ws:id="image"></$.Image>),
     })
@@ -125,7 +123,6 @@ test("generate jsx element with namespaces components", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "body" }],
       ...renderData(<library.Body ws:id="body"></library.Body>),
     })
@@ -142,7 +139,6 @@ test("generate jsx element with namespaces components", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "image" }],
       ...renderData(<library.Image ws:id="image"></library.Image>),
     })
@@ -162,7 +158,6 @@ test("generate jsx element with literal props", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "body" }],
       ...renderData(<$.Body ws:id="body" string="string" number={0}></$.Body>),
     })
@@ -181,7 +176,6 @@ test("generate jsx element with literal props", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "image" }],
       ...renderData(
         <$.Image
@@ -209,7 +203,6 @@ test("ignore asset and page props", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "box" }],
       ...renderData(
         <$.Box
@@ -236,7 +229,6 @@ test("generate jsx element with data sources and action", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "box" }],
       ...renderData(
         <$.Box
@@ -269,7 +261,6 @@ test("generate jsx element with condition based on show prop", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "box" }],
       ...renderData(<$.Box ws:id="box" data-ws-show={true}></$.Box>),
     })
@@ -286,7 +277,6 @@ test("generate jsx element with condition based on show prop", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "box" }],
       ...renderData(<$.Box ws:id="box" data-ws-show={false}></$.Box>),
     })
@@ -298,7 +288,6 @@ test("generate jsx element with condition based on show prop", () => {
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "box" }],
       ...renderData(
         <$.Box ws:id="box" data-ws-show={expression`${condition}`}></$.Box>
@@ -320,7 +309,6 @@ test("generate jsx children with text", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [
         { type: "text", value: "Some\ntext" },
         { type: "text", value: 'Escaped "text"' },
@@ -348,7 +336,6 @@ test("exclude text placeholders", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [
         { type: "text", value: "Text" },
         { type: "text", value: "Placeholder text", placeholder: true },
@@ -374,7 +361,6 @@ test("generate jsx children with expression", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [
         { type: "expression", value: "'Hello ' + $ws$dataSource$var" },
       ],
@@ -406,7 +392,6 @@ test("generate jsx children with nested instances", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "form" }],
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
@@ -436,7 +421,6 @@ test("deduplicate base and namespaced components with same short name", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [
         { type: "id", value: "button1" },
         { type: "id", value: "button2" },
@@ -465,7 +449,6 @@ test("generate collection component as map", () => {
     generateJsxChildren({
       scope: createScope(),
       metas: new Map(),
-      tagsOverrides: {},
       children: [{ type: "id", value: "list" }],
       usedDataSources: new Map(),
       indexesWithinAncestors: new Map(),
@@ -501,7 +484,6 @@ test("generate component with variables and actions", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <$.Input
@@ -541,7 +523,6 @@ test("merge classes if no className", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(<$.Body ws:id="body"></$.Body>),
     })
   ).toEqual(
@@ -565,7 +546,6 @@ test("add classes and merge classes", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(<$.Body ws:id="body" className='cls2 "cls3"'></$.Body>),
     })
   ).toEqual(
@@ -589,7 +569,6 @@ test("add classes", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(<$.Body ws:id="body" className='cls2 "cls3"'></$.Body>),
     })
   ).toEqual(
@@ -614,7 +593,6 @@ test("add bind classes and merge classes", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body
           ws:id="body"
@@ -646,7 +624,6 @@ test("avoid generating collection parameter variable as state", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <ws.collection
@@ -708,7 +685,6 @@ test("generate both page system and global system variables when present", () =>
         },
       ],
       metas: new Map(),
-      tagsOverrides: {},
       ...data,
     })
   ).toEqual(
@@ -741,7 +717,6 @@ test("generate resources loading", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body
           ws:id="body"
@@ -803,7 +778,6 @@ test("avoid generating unused variables", () => {
         },
       ],
       metas: new Map(),
-      tagsOverrides: {},
       ...data,
     })
   ).toMatchInlineSnapshot(`
@@ -825,7 +799,6 @@ test("avoid generating descendant component", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <ws.descendant></ws.descendant>
@@ -852,7 +825,6 @@ test("generate conditional collection", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <ws.collection
@@ -892,7 +864,6 @@ test("generate conditional body", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body" data-ws-show={expression`${condition}`}></$.Body>
       ),
@@ -927,7 +898,6 @@ test("generate resource prop", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <$.Form ws:id="form1" action={myResource}></$.Form>
@@ -957,7 +927,6 @@ test("skip unsafe properties", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body
           ws:id="body"
@@ -990,7 +959,6 @@ test("variable names can be js identifiers", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <$.Input
@@ -1031,7 +999,6 @@ test("renders nothing if only templates are present in block", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <ws.block ws:id="block">
@@ -1065,7 +1032,6 @@ test("renders only block children", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <ws.block ws:id="block">
@@ -1101,7 +1067,6 @@ test("generate unset variables as undefined", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <$.Box>{expression`a + b`}</$.Box>
@@ -1141,7 +1106,6 @@ test("generate global variables", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...data,
     })
   ).toEqual(
@@ -1178,7 +1142,6 @@ test("ignore unused global variables", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...data,
     })
   ).toEqual(
@@ -1206,7 +1169,6 @@ test("generate prop with index within ancestor", () => {
         ["TabsTrigger", { indexWithinAncestor: "Tabs" }],
         ["TabsContent", { indexWithinAncestor: "Tabs" }],
       ]),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <$.Tabs>
@@ -1264,7 +1226,6 @@ test("ignore ws:block-template when generate index attribute", () => {
       metas: new Map<string, WsComponentMeta>([
         ["TabsTrigger", { indexWithinAncestor: "Tabs" }],
       ]),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="bodyId">
           <$.Tabs>
@@ -1308,7 +1269,6 @@ test("render empty component when no instances found", () => {
       rootInstanceId: "",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(<$.Body ws:id="bodyId"></$.Body>),
     })
   ).toEqual(
@@ -1331,7 +1291,6 @@ test("render tag property on components", () => {
       rootInstanceId: "bodyId",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="bodyId">
           <$.Box ws:id="spanId" ws:tag="span"></$.Box>
@@ -1361,7 +1320,6 @@ test("render ws:element component with div tag by default", () => {
       rootInstanceId: "bodyId",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="bodyId">
           <ws.element id="element1">
@@ -1396,7 +1354,6 @@ test("render ws:element component with ws:tag", () => {
       rootInstanceId: "bodyId",
       parameters: [],
       metas: new Map(),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="bodyId">
           <ws.element ws:tag="p" id="paragraph">
@@ -1466,7 +1423,6 @@ test("convert attributes to react compatible when render components with tags", 
       rootInstanceId: "bodyId",
       parameters: [],
       metas: new Map([["Box", { presetStyle: { div: [] } }]]),
-      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="bodyId">
           <$.Box class="my-class" for="my-id" autocomplete="off"></$.Box>

--- a/packages/react-sdk/src/component-generator.test.tsx
+++ b/packages/react-sdk/src/component-generator.test.tsx
@@ -484,6 +484,7 @@ test("generate component with variables and actions", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <$.Input
@@ -523,6 +524,7 @@ test("merge classes if no className", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(<$.Body ws:id="body"></$.Body>),
     })
   ).toEqual(
@@ -546,6 +548,7 @@ test("add classes and merge classes", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(<$.Body ws:id="body" className='cls2 "cls3"'></$.Body>),
     })
   ).toEqual(
@@ -569,6 +572,7 @@ test("add classes", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(<$.Body ws:id="body" className='cls2 "cls3"'></$.Body>),
     })
   ).toEqual(
@@ -593,6 +597,7 @@ test("add bind classes and merge classes", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body
           ws:id="body"
@@ -624,6 +629,7 @@ test("avoid generating collection parameter variable as state", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <ws.collection
@@ -685,6 +691,7 @@ test("generate both page system and global system variables when present", () =>
         },
       ],
       metas: new Map(),
+      tagsOverrides: {},
       ...data,
     })
   ).toEqual(
@@ -717,6 +724,7 @@ test("generate resources loading", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body
           ws:id="body"
@@ -778,6 +786,7 @@ test("avoid generating unused variables", () => {
         },
       ],
       metas: new Map(),
+      tagsOverrides: {},
       ...data,
     })
   ).toMatchInlineSnapshot(`
@@ -799,6 +808,7 @@ test("avoid generating descendant component", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <ws.descendant></ws.descendant>
@@ -825,6 +835,7 @@ test("generate conditional collection", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <ws.collection
@@ -864,6 +875,7 @@ test("generate conditional body", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body" data-ws-show={expression`${condition}`}></$.Body>
       ),
@@ -898,6 +910,7 @@ test("generate resource prop", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <$.Form ws:id="form1" action={myResource}></$.Form>
@@ -927,6 +940,7 @@ test("skip unsafe properties", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body
           ws:id="body"
@@ -959,6 +973,7 @@ test("variable names can be js identifiers", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <$.Input
@@ -999,6 +1014,7 @@ test("renders nothing if only templates are present in block", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <ws.block ws:id="block">
@@ -1032,6 +1048,7 @@ test("renders only block children", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <ws.block ws:id="block">
@@ -1067,6 +1084,7 @@ test("generate unset variables as undefined", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <$.Box>{expression`a + b`}</$.Box>
@@ -1106,6 +1124,7 @@ test("generate global variables", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...data,
     })
   ).toEqual(
@@ -1142,6 +1161,7 @@ test("ignore unused global variables", () => {
       rootInstanceId: "body",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...data,
     })
   ).toEqual(
@@ -1169,6 +1189,7 @@ test("generate prop with index within ancestor", () => {
         ["TabsTrigger", { indexWithinAncestor: "Tabs" }],
         ["TabsContent", { indexWithinAncestor: "Tabs" }],
       ]),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="body">
           <$.Tabs>
@@ -1226,6 +1247,7 @@ test("ignore ws:block-template when generate index attribute", () => {
       metas: new Map<string, WsComponentMeta>([
         ["TabsTrigger", { indexWithinAncestor: "Tabs" }],
       ]),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="bodyId">
           <$.Tabs>
@@ -1269,6 +1291,7 @@ test("render empty component when no instances found", () => {
       rootInstanceId: "",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(<$.Body ws:id="bodyId"></$.Body>),
     })
   ).toEqual(
@@ -1291,6 +1314,7 @@ test("render tag property on components", () => {
       rootInstanceId: "bodyId",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="bodyId">
           <$.Box ws:id="spanId" ws:tag="span"></$.Box>
@@ -1320,6 +1344,7 @@ test("render ws:element component with div tag by default", () => {
       rootInstanceId: "bodyId",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="bodyId">
           <ws.element id="element1">
@@ -1354,6 +1379,7 @@ test("render ws:element component with ws:tag", () => {
       rootInstanceId: "bodyId",
       parameters: [],
       metas: new Map(),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="bodyId">
           <ws.element ws:tag="p" id="paragraph">
@@ -1423,6 +1449,7 @@ test("convert attributes to react compatible when render components with tags", 
       rootInstanceId: "bodyId",
       parameters: [],
       metas: new Map([["Box", { presetStyle: { div: [] } }]]),
+      tagsOverrides: {},
       ...renderData(
         <$.Body ws:id="bodyId">
           <$.Box class="my-class" for="my-id" autocomplete="off"></$.Box>
@@ -1512,6 +1539,40 @@ test("ignore props similar to standard attributes on react components without ta
        class={"my-class"}
        for={"my-id"}
        autocomplete={"off"} />
+       </Body>
+       }
+     `)
+    )
+  );
+});
+
+test("overrides some element tags with provided components", () => {
+  expect(
+    generateWebstudioComponent({
+      classesMap: new Map(),
+      scope: createScope(),
+      name: "Page",
+      rootInstanceId: "bodyId",
+      parameters: [],
+      metas: new Map([["HeadSlot", { icon: "" }]]),
+      tagsOverrides: {
+        body: "namespace:Body",
+        a: "namespace:Link",
+      },
+      ...renderData(
+        <ws.element ws:tag="body" ws:id="bodyId">
+          <ws.element ws:tag="a"></ws.element>
+          <ws.element ws:tag="div"></ws.element>
+        </ws.element>
+      ),
+    })
+  ).toEqual(
+    validateJSX(
+      clear(`
+       const Page = () => {
+       return <Body>
+       <Link />
+       <div />
        </Body>
        }
      `)

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -145,6 +145,7 @@ export const generateJsxElement = ({
   context = "jsx",
   scope,
   metas,
+  tagsOverrides,
   instance,
   props,
   dataSources,
@@ -156,6 +157,10 @@ export const generateJsxElement = ({
   context?: "expression" | "jsx";
   scope: Scope;
   metas: Map<Instance["component"], WsComponentMeta>;
+  /**
+   * Record<tag, componentDescriptor>
+   */
+  tagsOverrides: Record<string, string>;
   instance: Instance;
   props: Props;
   dataSources: DataSources;
@@ -280,18 +285,20 @@ export const generateJsxElement = ({
     generatedElement += `)}\n`;
   } else if (instance.component === blockComponent) {
     generatedElement += children;
-  } else if (instance.component === elementComponent) {
-    const tagName = instance.tag ?? "div";
-    if (instance.children.length === 0) {
-      generatedElement += `<${tagName}${generatedProps} />\n`;
-    } else {
-      generatedElement += `<${tagName}${generatedProps}>\n`;
-      generatedElement += children;
-      generatedElement += `</${tagName}>\n`;
-    }
   } else {
-    const [_namespace, shortName] = parseComponentName(instance.component);
-    const componentVariable = scope.getName(instance.component, shortName);
+    let componentVariable;
+    if (instance.component === elementComponent) {
+      componentVariable = instance.tag ?? "div";
+      // replace html tag with component if available
+      const componentDescriptor = tagsOverrides[componentVariable];
+      if (componentDescriptor !== undefined) {
+        const [_importSource, importSpecifier] = componentDescriptor.split(":");
+        componentVariable = scope.getName(componentDescriptor, importSpecifier);
+      }
+    } else {
+      const [_namespace, shortName] = parseComponentName(instance.component);
+      componentVariable = scope.getName(instance.component, shortName);
+    }
     if (instance.children.length === 0) {
       generatedElement += `<${componentVariable}${generatedProps} />\n`;
     } else {
@@ -335,6 +342,7 @@ export const generateJsxElement = ({
 export const generateJsxChildren = ({
   scope,
   metas,
+  tagsOverrides,
   children,
   instances,
   props,
@@ -346,6 +354,8 @@ export const generateJsxChildren = ({
 }: {
   scope: Scope;
   metas: Map<Instance["component"], WsComponentMeta>;
+  // Record<tag, componentDescriptor>
+  tagsOverrides: Record<string, string>;
   children: Instance["children"];
   instances: Instances;
   props: Props;
@@ -389,6 +399,7 @@ export const generateJsxChildren = ({
         context: "jsx",
         scope,
         metas,
+        tagsOverrides,
         instance,
         props,
         dataSources,
@@ -399,6 +410,7 @@ export const generateJsxChildren = ({
           classesMap,
           scope,
           metas,
+          tagsOverrides,
           children: instance.children,
           instances,
           props,
@@ -424,6 +436,7 @@ export const generateWebstudioComponent = ({
   props,
   dataSources,
   metas,
+  tagsOverrides,
   classesMap,
 }: {
   scope: Scope;
@@ -435,6 +448,10 @@ export const generateWebstudioComponent = ({
   dataSources: DataSources;
   classesMap: Map<string, Array<string>>;
   metas: Map<Instance["component"], WsComponentMeta>;
+  /**
+   * Record<tag, componentDescriptor>
+   */
+  tagsOverrides: Record<string, string>;
 }) => {
   const instance = instances.get(rootInstanceId);
   const indexesWithinAncestors = getIndexesWithinAncestors(metas, instances, [
@@ -449,6 +466,7 @@ export const generateWebstudioComponent = ({
       context: "expression",
       scope,
       metas,
+      tagsOverrides,
       instance,
       props,
       dataSources,
@@ -458,6 +476,7 @@ export const generateWebstudioComponent = ({
       children: generateJsxChildren({
         scope,
         metas,
+        tagsOverrides,
         children: instance.children,
         instances,
         props,

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -160,7 +160,7 @@ export const generateJsxElement = ({
   /**
    * Record<tag, componentDescriptor>
    */
-  tagsOverrides: Record<string, string>;
+  tagsOverrides?: Record<string, string>;
   instance: Instance;
   props: Props;
   dataSources: DataSources;
@@ -290,7 +290,7 @@ export const generateJsxElement = ({
     if (instance.component === elementComponent) {
       componentVariable = instance.tag ?? "div";
       // replace html tag with component if available
-      const componentDescriptor = tagsOverrides[componentVariable];
+      const componentDescriptor = tagsOverrides?.[componentVariable];
       if (componentDescriptor !== undefined) {
         const [_importSource, importSpecifier] = componentDescriptor.split(":");
         componentVariable = scope.getName(componentDescriptor, importSpecifier);
@@ -355,7 +355,7 @@ export const generateJsxChildren = ({
   scope: Scope;
   metas: Map<Instance["component"], WsComponentMeta>;
   // Record<tag, componentDescriptor>
-  tagsOverrides: Record<string, string>;
+  tagsOverrides?: Record<string, string>;
   children: Instance["children"];
   instances: Instances;
   props: Props;
@@ -451,7 +451,7 @@ export const generateWebstudioComponent = ({
   /**
    * Record<tag, componentDescriptor>
    */
-  tagsOverrides: Record<string, string>;
+  tagsOverrides?: Record<string, string>;
 }) => {
   const instance = instances.get(rootInstanceId);
   const indexesWithinAncestors = getIndexesWithinAncestors(metas, instances, [

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -17,20 +17,10 @@
       "webstudio": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
       "import": "./lib/components.js"
-    },
-    "./metas": {
-      "webstudio": "./src/metas.ts",
-      "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js"
-    },
-    "./props": {
-      "webstudio": "./src/props.ts",
-      "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js"
     }
   },
   "scripts": {
-    "build": "vite build --config ../../vite.sdk-components.config.ts",
+    "build": "rm -rf lib && esbuild src/components.ts --outdir=lib --bundle --format=esm --packages=external",
     "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc"
   },

--- a/packages/sdk-components-react-remix/src/metas.ts
+++ b/packages/sdk-components-react-remix/src/metas.ts
@@ -1,9 +1,0 @@
-// this lets CLI detect which components are overriden
-// without importing components runtime
-export {
-  Body,
-  Link,
-  RichTextLink,
-  Form,
-  RemixForm,
-} from "@webstudio-is/sdk-components-react/metas";

--- a/packages/sdk-components-react-remix/src/remix-form.tsx
+++ b/packages/sdk-components-react-remix/src/remix-form.tsx
@@ -9,10 +9,13 @@ export const RemixForm = forwardRef<
     Pick<FormProps, "encType"> & {
       // Remix's default behavior includes method values in both uppercase and lowercase,
       // resulting in our UI displaying a list that encompasses both variants.
-      method?: Lowercase<NonNullable<FormProps["method"]>>;
+      method?: Lowercase<NonNullable<FormProps["method"]>> | "dialog";
       action?: string;
     }
->(({ action, ...props }, ref) => {
+>(({ action, method, ...props }, ref) => {
+  if (method === "dialog") {
+    return <form {...props} ref={ref} />;
+  }
   // remix casts action to relative url
   if (
     action === undefined ||
@@ -22,6 +25,7 @@ export const RemixForm = forwardRef<
     return (
       <Form
         action={action}
+        method={method}
         {...props}
         ref={ref}
         // Preserve scroll position for navigation on the same path, as it's used for filtering and sorting

--- a/packages/sdk-components-react-router/package.json
+++ b/packages/sdk-components-react-router/package.json
@@ -17,20 +17,10 @@
       "webstudio": "./src/components.ts",
       "types": "./lib/types/components.d.ts",
       "import": "./lib/components.js"
-    },
-    "./metas": {
-      "webstudio": "./src/metas.ts",
-      "types": "./lib/types/metas.d.ts",
-      "import": "./lib/metas.js"
-    },
-    "./props": {
-      "webstudio": "./src/props.ts",
-      "types": "./lib/types/props.d.ts",
-      "import": "./lib/props.js"
     }
   },
   "scripts": {
-    "build": "vite build --config ../../vite.sdk-components.config.ts",
+    "build": "rm -rf lib && esbuild src/components.ts --outdir=lib --bundle --format=esm --packages=external",
     "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc"
   },

--- a/packages/sdk-components-react-router/src/remix-form.tsx
+++ b/packages/sdk-components-react-router/src/remix-form.tsx
@@ -9,10 +9,13 @@ export const RemixForm = forwardRef<
     Pick<FormProps, "encType"> & {
       // Remix's default behavior includes method values in both uppercase and lowercase,
       // resulting in our UI displaying a list that encompasses both variants.
-      method?: Lowercase<NonNullable<FormProps["method"]>>;
+      method?: Lowercase<NonNullable<FormProps["method"]>> | "dialog";
       action?: string;
     }
->(({ action, ...props }, ref) => {
+>(({ action, method, ...props }, ref) => {
+  if (method === "dialog") {
+    return <form {...props} ref={ref} />;
+  }
   // remix casts action to relative url
   if (
     action === undefined ||
@@ -22,6 +25,7 @@ export const RemixForm = forwardRef<
     return (
       <Form
         action={action}
+        method={method}
         {...props}
         ref={ref}
         // Preserve scroll position for navigation on the same path, as it's used for filtering and sorting


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3632

Remix client routing should still work even if we go full html. Here added tag overrides to component generator so sdk could pass component replacements for some tags like

- body -> Body
- a -> Link
- form -> RemixForm

See example here https://github.com/webstudio-is/webstudio/pull/5210/files#diff-f2df0aea6543a33e57d770ff1791da886ab3dfd6dec37da4a41a611b9b13a19aR6
