### PR TITLE
fix: handle autoplay property in youtube and vimeo

### DIFF
--- a/packages/sdk-components-react/src/vimeo.tsx
+++ b/packages/sdk-components-react/src/vimeo.tsx
@@ -352,6 +352,8 @@ type Props = Omit<ComponentProps<typeof defaultTag>, keyof VimeoOptions> &
      * Example: "Video about web development tips".
      */
     title?: string | undefined;
+    // temporary prop until props render is fixed
+    autoPlay?: boolean;
   };
 type Ref = ElementRef<typeof defaultTag>;
 
@@ -360,7 +362,8 @@ export const Vimeo = forwardRef<Ref, Props>(
     {
       url,
       loading = "lazy",
-      autoplay = false,
+      autoPlay,
+      autoplay = autoPlay ?? false,
       autopause = true,
       showByline = false,
       showControls = true,

--- a/packages/sdk-components-react/src/youtube.tsx
+++ b/packages/sdk-components-react/src/youtube.tsx
@@ -470,6 +470,8 @@ type Props = Omit<
      * Example: "Video about web development tips".
      */
     title?: string | undefined;
+    // temporary prop until props render is fixed
+    autoPlay?: boolean;
   };
 type Ref = ElementRef<typeof defaultTag>;
 
@@ -478,7 +480,8 @@ export const YouTube = forwardRef<Ref, Props>(
     {
       url,
       loading = "lazy",
-      autoplay,
+      autoPlay,
+      autoplay = autoPlay ?? false,
       showPreview,
       showAnnotations,
       showCaptions,


### PR DESCRIPTION
We have issue with distincting html attributes and component properties. I have an idea for proper fix. For now fast fix with just aliasing autoplay and autoPlay.