### PR TITLE
fix: normalize html attributes only when not defined by component

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.stories.tsx
@@ -199,10 +199,10 @@ const checkProp = (options = defaultOptions, label?: string): PropMeta => ({
 
 registerComponentLibrary({
   components: {},
-  metas: {},
   templates: {},
-  propsMetas: {
+  metas: {
     Box: {
+      icon: "",
       props: {
         initialText: textProp("", "multi\nline"),
         initialShortText: shortTextProp(),

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useState, useLayoutEffect, useRef } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import { useStore } from "@nanostores/react";
-import { type Instances, coreMetas, corePropsMetas } from "@webstudio-is/sdk";
+import { type Instances, coreMetas } from "@webstudio-is/sdk";
 import { coreTemplates } from "@webstudio-is/sdk/core-templates";
 import type { Components } from "@webstudio-is/react-sdk";
 import { wsImageLoader } from "@webstudio-is/image";
@@ -240,13 +240,11 @@ export const Canvas = () => {
     registerComponentLibrary({
       components: {},
       metas: coreMetas,
-      propsMetas: corePropsMetas,
       templates: coreTemplates,
     });
     registerComponentLibrary({
       components: baseComponents,
       metas: baseComponentMetas,
-      propsMetas: {},
       hooks: baseComponentHooks,
       templates: baseComponentTemplates,
     });
@@ -257,14 +255,12 @@ export const Canvas = () => {
         Body,
       },
       metas: {},
-      propsMetas: {},
       templates: {},
     });
     registerComponentLibrary({
       namespace: "@webstudio-is/sdk-components-react-radix",
       components: radixComponents,
       metas: radixComponentMetas,
-      propsMetas: {},
       hooks: radixComponentHooks,
       templates: radixTemplates,
     });
@@ -272,7 +268,6 @@ export const Canvas = () => {
       namespace: "@webstudio-is/sdk-components-animation",
       components: animationComponents,
       metas: animationComponentMetas,
-      propsMetas: {},
       hooks: animationComponentHooks,
       templates: animationTemplates,
     });

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -301,9 +301,8 @@ const useInstanceProps = (instanceSelector: InstanceSelector) => {
         if (tag !== undefined) {
           instancePropsObject[tagProperty] = tag;
         }
-        const hasTags =
-          Object.keys(metas.get(instance?.component ?? "")?.presetStyle ?? {})
-            .length > 0;
+        const meta = metas.get(instance?.component ?? "");
+        const hasTags = Object.keys(meta?.presetStyle ?? {}).length > 0;
         const index = indexesWithinAncestors.get(instanceId);
         if (index !== undefined) {
           instancePropsObject[indexProperty] = index.toString();
@@ -311,12 +310,13 @@ const useInstanceProps = (instanceSelector: InstanceSelector) => {
         const instanceProps = propValuesByInstanceSelector.get(instanceKey);
         if (instanceProps) {
           for (const [name, value] of instanceProps) {
-            if (hasTags) {
-              const reactName = standardAttributesToReactProps[name] ?? name;
-              instancePropsObject[reactName] = value;
-            } else {
-              instancePropsObject[name] = value;
+            let propName = name;
+            // convert html attribute only when component has tags
+            // and does not specify own property with this name
+            if (hasTags && !meta?.props?.[propName]) {
+              propName = standardAttributesToReactProps[propName] ?? propName;
             }
+            instancePropsObject[propName] = value;
           }
         }
         return instancePropsObject;

--- a/apps/builder/app/shared/nano-states/components.ts
+++ b/apps/builder/app/shared/nano-states/components.ts
@@ -12,7 +12,6 @@ import {
   getIndexesWithinAncestors,
   type Instance,
   type WsComponentMeta,
-  type WsComponentPropsMeta,
 } from "@webstudio-is/sdk";
 import type { InstanceSelector } from "../tree-utils";
 import { $memoryProps, $props } from "./misc";
@@ -176,15 +175,10 @@ export const $registeredTemplates = atom(
   new Map<string, GeneratedTemplateMeta>()
 );
 
-export const $registeredComponentPropsMetas = atom(
-  new Map<string, WsComponentPropsMeta>()
-);
-
 export const registerComponentLibrary = ({
   namespace,
   components,
   metas,
-  propsMetas,
   hooks,
   templates,
 }: {
@@ -193,7 +187,6 @@ export const registerComponentLibrary = ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   components: Record<Instance["component"], ExoticComponent<any>>;
   metas: Record<Instance["component"], WsComponentMeta>;
-  propsMetas: Record<Instance["component"], WsComponentPropsMeta>;
   hooks?: Hook[];
   templates: Record<Instance["component"], TemplateMeta>;
 }) => {
@@ -206,22 +199,10 @@ export const registerComponentLibrary = ({
   }
   $registeredComponents.set(nextComponents);
 
-  const prevPropsMetas = $registeredComponentPropsMetas.get();
-  const nextPropsMetas = new Map(prevPropsMetas);
-  for (const [componentName, propsMeta] of Object.entries(propsMetas)) {
-    nextPropsMetas.set(`${prefix}${componentName}`, propsMeta);
-  }
-
   const prevMetas = $registeredComponentMetas.get();
   const nextMetas = new Map(prevMetas);
   for (const [componentName, meta] of Object.entries(metas)) {
     nextMetas.set(`${prefix}${componentName}`, meta);
-    if (meta.initialProps || meta.props) {
-      nextPropsMetas.set(`${prefix}${componentName}`, {
-        initialProps: meta.initialProps,
-        props: meta.props ?? {},
-      });
-    }
   }
   $registeredComponentMetas.set(nextMetas);
 
@@ -241,6 +222,4 @@ export const registerComponentLibrary = ({
     const nextHooks = [...prevHooks, ...hooks];
     $registeredComponentHooks.set(nextHooks);
   }
-
-  $registeredComponentPropsMetas.set(nextPropsMetas);
 };

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -43,7 +43,6 @@ import {
   $blockChildOutline,
   $textToolbar,
   $registeredComponentMetas,
-  $registeredComponentPropsMetas,
   $registeredTemplates,
   $modifierKeys,
 } from "~/shared/nano-states";
@@ -146,10 +145,6 @@ export const createObjectPool = () => {
     new NanostoresSyncObject(
       "registeredComponentMetas",
       $registeredComponentMetas
-    ),
-    new NanostoresSyncObject(
-      "registeredComponentPropsMetas",
-      $registeredComponentPropsMetas
     ),
     new NanostoresSyncObject("registeredTemplates", $registeredTemplates),
     new NanostoresSyncObject("canvasScrollbarWidth", $canvasScrollbarSize),

--- a/packages/react-sdk/src/component-generator.test.tsx
+++ b/packages/react-sdk/src/component-generator.test.tsx
@@ -3,6 +3,7 @@ import { expect, test } from "vitest";
 import stripIndent from "strip-indent";
 import {
   createScope,
+  elementComponent,
   ROOT_INSTANCE_ID,
   SYSTEM_VARIABLE_ID,
   WsComponentMeta,
@@ -1386,7 +1387,9 @@ test("convert attributes to react compatible when render ws:element", () => {
       name: "Page",
       rootInstanceId: "bodyId",
       parameters: [],
-      metas: new Map(),
+      metas: new Map([
+        [elementComponent, { icon: "", presetStyle: { div: [] } }],
+      ]),
       ...renderData(
         <$.Body ws:id="bodyId">
           <ws.element
@@ -1437,6 +1440,46 @@ test("convert attributes to react compatible when render components with tags", 
        htmlFor={"my-id"}
        autoComplete={"off"}
        className={\`\${"my-class"}\`} />
+       </Body>
+       }
+     `)
+    )
+  );
+});
+
+test("ignore props similar to standard attributes when react components defines them", () => {
+  expect(
+    generateWebstudioComponent({
+      classesMap: new Map(),
+      scope: createScope(),
+      name: "Page",
+      rootInstanceId: "bodyId",
+      parameters: [],
+      metas: new Map([
+        [
+          "Vimeo",
+          {
+            icon: "",
+            presetStyle: { div: [] },
+            props: {
+              autoplay: { type: "boolean", control: "boolean", required: true },
+            },
+          },
+        ],
+      ]),
+      ...renderData(
+        <$.Body ws:id="bodyId">
+          <$.Vimeo autoplay={true}></$.Vimeo>
+        </$.Body>
+      ),
+    })
+  ).toEqual(
+    validateJSX(
+      clear(`
+       const Page = () => {
+       return <Body>
+       <Vimeo
+       autoplay={true} />
        </Body>
        }
      `)

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -170,8 +170,8 @@ export const generateJsxElement = ({
     return "";
   }
 
-  const hasTags =
-    Object.keys(metas.get(instance.component)?.presetStyle ?? {}).length > 0;
+  const meta = metas.get(instance.component);
+  const hasTags = Object.keys(meta?.presetStyle ?? {}).length > 0;
 
   let generatedProps = "";
 
@@ -204,7 +204,9 @@ export const generateJsxElement = ({
       continue;
     }
     let name = prop.name;
-    if (instance.component === elementComponent || hasTags) {
+    // convert html attribute only when component has tags
+    // and does not specify own property with this name
+    if (hasTags && !meta?.props?.[prop.name]) {
       name = standardAttributesToReactProps[prop.name] ?? prop.name;
     }
 

--- a/packages/sdk/src/core-metas.ts
+++ b/packages/sdk/src/core-metas.ts
@@ -8,10 +8,7 @@ import {
 } from "@webstudio-is/icons/svg";
 import { html } from "./__generated__/normalize.css";
 import * as normalize from "./__generated__/normalize.css";
-import type {
-  WsComponentMeta,
-  WsComponentPropsMeta,
-} from "./schema/component-meta";
+import type { WsComponentMeta } from "./schema/component-meta";
 import type { Instance } from "./schema/instances";
 import { tagProperty } from "./runtime";
 import { tags } from "./__generated__/tags";
@@ -26,10 +23,6 @@ const rootMeta: WsComponentMeta = {
   },
 };
 
-const rootPropsMeta: WsComponentPropsMeta = {
-  props: {},
-};
-
 export const elementComponent = "ws:element";
 
 const elementMeta: WsComponentMeta = {
@@ -37,9 +30,6 @@ const elementMeta: WsComponentMeta = {
   icon: BoxIcon,
   // convert [object Module] to [object Object] to enable structured cloning
   presetStyle: { ...normalize },
-};
-
-const elementPropsMeta: WsComponentPropsMeta = {
   initialProps: [tagProperty, "id", "class"],
   props: {
     [tagProperty]: {
@@ -62,9 +52,7 @@ const collectionMeta: WsComponentMeta = {
     category: "instance",
     children: ["instance"],
   },
-};
-
-const collectionPropsMeta: WsComponentPropsMeta = {
+  initialProps: ["data"],
   props: {
     data: {
       required: true,
@@ -72,7 +60,6 @@ const collectionPropsMeta: WsComponentPropsMeta = {
       type: "json",
     },
   },
-  initialProps: ["data"],
 };
 
 export const descendantComponent = "ws:descendant";
@@ -86,9 +73,7 @@ const descendantMeta: WsComponentMeta = {
   },
   // @todo infer possible presets
   presetStyle: {},
-};
-
-const descendantPropsMeta: WsComponentPropsMeta = {
+  initialProps: ["selector"],
   props: {
     selector: {
       required: true,
@@ -114,7 +99,6 @@ const descendantPropsMeta: WsComponentPropsMeta = {
       ],
     },
   },
-  initialProps: ["selector"],
 };
 
 export const blockComponent = "ws:block";
@@ -129,10 +113,6 @@ export const blockTemplateMeta: WsComponentMeta = {
   },
 };
 
-const blockTemplatePropsMeta: WsComponentPropsMeta = {
-  props: {},
-};
-
 const blockMeta: WsComponentMeta = {
   label: "Content Block",
   icon: ContentBlockIcon,
@@ -142,10 +122,6 @@ const blockMeta: WsComponentMeta = {
   },
 };
 
-const blockPropsMeta: WsComponentPropsMeta = {
-  props: {},
-};
-
 export const coreMetas = {
   [rootComponent]: rootMeta,
   [elementComponent]: elementMeta,
@@ -153,15 +129,6 @@ export const coreMetas = {
   [descendantComponent]: descendantMeta,
   [blockComponent]: blockMeta,
   [blockTemplateComponent]: blockTemplateMeta,
-};
-
-export const corePropsMetas = {
-  [rootComponent]: rootPropsMeta,
-  [elementComponent]: elementPropsMeta,
-  [collectionComponent]: collectionPropsMeta,
-  [descendantComponent]: descendantPropsMeta,
-  [blockComponent]: blockPropsMeta,
-  [blockTemplateComponent]: blockTemplatePropsMeta,
 };
 
 // components with custom implementation

--- a/packages/sdk/src/schema/component-meta.ts
+++ b/packages/sdk/src/schema/component-meta.ts
@@ -21,16 +21,6 @@ export type PresetStyle<Tag extends HtmlTags = HtmlTags> = Partial<
   Record<Tag, PresetStyleDecl[]>
 >;
 
-// props are separated from the rest of the meta
-// so they can be exported separately and potentially tree-shaken
-const WsComponentPropsMeta = z.object({
-  props: z.record(PropMeta),
-  // Props that will be always visible in properties panel.
-  initialProps: z.array(z.string()).optional(),
-});
-
-export type WsComponentPropsMeta = z.infer<typeof WsComponentPropsMeta>;
-
 export const componentCategories = [
   "general",
   "typography",


### PR DESCRIPTION
Proper fix for https://github.com/webstudio-is/webstudio/pull/5211

Now props meta are available in component generator and can be used to figure if prop is defined by component or comes from html attributes. Added same logic in canvas and component generator.

Also got rid from no longer necessary registeredComponentPropsMetas store since all props are described by component meta.