### PR TITLE
feat: add element component

### DIFF
--- a/apps/builder/app/builder/features/command-panel/command-panel.tsx
+++ b/apps/builder/app/builder/features/command-panel/command-panel.tsx
@@ -24,6 +24,7 @@ import {
   componentCategories,
   collectionComponent,
   parseComponentName,
+  elementComponent,
 } from "@webstudio-is/sdk";
 import type { Breakpoint, Page } from "@webstudio-is/sdk";
 import type { TemplateMeta } from "@webstudio-is/template";
@@ -38,6 +39,7 @@ import {
 } from "~/shared/nano-states";
 import {
   getComponentTemplateData,
+  insertWebstudioElementAt,
   insertWebstudioFragmentAt,
 } from "~/shared/instance-utils";
 import { humanizeString } from "~/shared/string-utils";
@@ -203,9 +205,13 @@ const ComponentOptionsGroup = ({ options }: { options: ComponentOption[] }) => {
             value={component}
             onSelect={() => {
               closeCommandPanel();
-              const fragment = getComponentTemplateData(component);
-              if (fragment) {
-                insertWebstudioFragmentAt(fragment);
+              if (component === elementComponent) {
+                insertWebstudioElementAt();
+              } else {
+                const fragment = getComponentTemplateData(component);
+                if (fragment) {
+                  insertWebstudioFragmentAt(fragment);
+                }
               }
             }}
           >

--- a/apps/builder/app/builder/features/command-panel/command-panel.tsx
+++ b/apps/builder/app/builder/features/command-panel/command-panel.tsx
@@ -24,7 +24,6 @@ import {
   componentCategories,
   collectionComponent,
   parseComponentName,
-  elementComponent,
 } from "@webstudio-is/sdk";
 import type { Breakpoint, Page } from "@webstudio-is/sdk";
 import type { TemplateMeta } from "@webstudio-is/template";
@@ -163,9 +162,6 @@ const $componentOptions = computed(
         namespace === "@webstudio-is/sdk-components-animation" &&
         shortName === "VideoAnimation"
       ) {
-        continue;
-      }
-      if (isFeatureEnabled("element") === false && name === elementComponent) {
         continue;
       }
 

--- a/apps/builder/app/builder/features/components/components.tsx
+++ b/apps/builder/app/builder/features/components/components.tsx
@@ -101,9 +101,6 @@ const $metas = computed(
       ) {
         continue;
       }
-      if (isFeatureEnabled("element") === false && name === elementComponent) {
-        continue;
-      }
 
       availableComponents.add(name);
       metas.push({

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -104,7 +104,7 @@ const renderProperty = (
     },
   });
 
-const forbiddenProperties = new Set(["style", "class", "className"]);
+const forbiddenProperties = new Set(["style"]);
 
 const $availableProps = computed(
   [

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -6,6 +6,7 @@ import {
 } from "@webstudio-is/sdk";
 import type { Instance } from "@webstudio-is/sdk";
 import { toast } from "@webstudio-is/design-system";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { createCommandsEmitter, type Command } from "~/shared/commands-emitter";
 import {
   $editingItemSelector,
@@ -528,15 +529,19 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       handler: () => unwrap(),
     },
 
-    {
-      name: "pasteHtmlWithTailwindClasses",
-      handler: async () => {
-        const html = await navigator.clipboard.readText();
-        let fragment = generateFragmentFromHtml(html);
-        fragment = await generateFragmentFromTailwind(fragment);
-        return insertWebstudioFragmentAt(fragment);
-      },
-    },
+    ...(isFeatureEnabled("tailwind")
+      ? [
+          {
+            name: "pasteHtmlWithTailwindClasses",
+            handler: async () => {
+              const html = await navigator.clipboard.readText();
+              let fragment = generateFragmentFromHtml(html);
+              fragment = await generateFragmentFromTailwind(fragment);
+              return insertWebstudioFragmentAt(fragment);
+            },
+          },
+        ]
+      : []),
 
     // history
 

--- a/apps/builder/app/shared/copy-paste/plugin-html.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-html.ts
@@ -1,4 +1,3 @@
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { generateFragmentFromHtml } from "../html";
 import { insertWebstudioFragmentAt } from "../instance-utils";
 import type { Plugin } from "./init-copy-paste";
@@ -6,9 +5,6 @@ import type { Plugin } from "./init-copy-paste";
 export const html: Plugin = {
   mimeType: "text/plain",
   onPaste: (html: string) => {
-    if (!isFeatureEnabled("element")) {
-      return false;
-    }
     const fragment = generateFragmentFromHtml(html);
     return insertWebstudioFragmentAt(fragment);
   },

--- a/packages/css-engine/src/core/atomic.test.ts
+++ b/packages/css-engine/src/core/atomic.test.ts
@@ -279,3 +279,23 @@ test("generate merged properties as single rule", () => {
 }"
 `);
 });
+
+test("convert :local-link to [aria-current=page] selector", () => {
+  const sheet = createRegularStyleSheet();
+  const rule = sheet.addNestingRule(".instance");
+  sheet.addMediaRule("x");
+  rule.setDeclaration({
+    breakpoint: "x",
+    selector: ":local-link",
+    property: "color",
+    value: { type: "keyword", value: "green" },
+  });
+  expect(generateAtomic(sheet, { getKey: () => "" }).cssText)
+    .toMatchInlineSnapshot(`
+    "@media all {
+      .c3mubaz[aria-current=page] {
+        color: green
+      }
+    }"
+  `);
+});

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -258,7 +258,11 @@ export class NestingRule {
       if (declaration.breakpoint !== breakpoint) {
         continue;
       }
-      const { selector: nestedSelector } = declaration;
+      let nestedSelector = declaration.selector;
+      // polyfill :local-link with framework specific logic
+      if (nestedSelector === ":local-link") {
+        nestedSelector = "[aria-current=page]";
+      }
       const selector = this.#selector + this.#descendantSuffix + nestedSelector;
       let style = styleBySelector.get(selector);
       if (style === undefined) {

--- a/packages/css-engine/src/core/style-sheet-regular.test.ts
+++ b/packages/css-engine/src/core/style-sheet-regular.test.ts
@@ -765,3 +765,19 @@ test("generate merged properties as single rule", () => {
 }"
 `);
 });
+
+test("convert :local-link to [aria-current=page] selector", () => {
+  const sheet = createRegularStyleSheet();
+  const rule = sheet.addNestingRule(".instance");
+  rule.setDeclaration({
+    breakpoint: "base",
+    selector: ":local-link",
+    property: "color",
+    value: { type: "keyword", value: "green" },
+  });
+  expect(rule.toString({ breakpoint: "base" })).toMatchInlineSnapshot(`
+    ".instance[aria-current=page] {
+      color: green
+    }"
+  `);
+});

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -5,4 +5,4 @@ export const aiRadixComponents = false;
 export const animation = false;
 export const videoAnimation = false;
 export const resourceProp = false;
-export const element = false;
+export const tailwind = false;

--- a/packages/html-data/src/pseudo-classes.ts
+++ b/packages/html-data/src/pseudo-classes.ts
@@ -4,7 +4,7 @@ const location = [
   // ':link',
   ":visited",
   // ':any-link',
-  // ':local-link',
+  ":local-link",
   // ':target',
   // ':target-within',
 ];

--- a/packages/sdk-components-react/src/box.ws.ts
+++ b/packages/sdk-components-react/src/box.ws.ts
@@ -14,9 +14,6 @@ import {
 import { props } from "./__generated__/box.props";
 
 export const meta: WsComponentMeta = {
-  category: "general",
-  description:
-    "A container for content. By default this is a Div, but the tag can be changed in settings.",
   presetStyle: {
     div,
     address,
@@ -29,7 +26,6 @@ export const meta: WsComponentMeta = {
     nav,
     section,
   },
-  order: 0,
   initialProps: ["tag", "id", "class"],
   props: {
     ...props,

--- a/packages/sdk-components-react/src/head-slot.template.tsx
+++ b/packages/sdk-components-react/src/head-slot.template.tsx
@@ -4,7 +4,7 @@ export const meta: TemplateMeta = {
   category: "general",
   description:
     "The Head Slot component lets you customize page-specific head elements (like canonical URLs), which merge with your site's global head settings, with Head Slot definitions taking priority over Page Settings. For site-wide head changes, use Project Settings instead.",
-  order: 6,
+  order: 5,
   template: (
     <$.HeadSlot>
       <$.HeadTitle ws:label="Title">Title</$.HeadTitle>

--- a/packages/sdk-components-react/src/html-embed.ws.ts
+++ b/packages/sdk-components-react/src/html-embed.ws.ts
@@ -7,7 +7,7 @@ export const meta: WsComponentMeta = {
   label: "HTML Embed",
   description: "Used to add HTML code to the page, such as an SVG or script.",
   icon: EmbedIcon,
-  order: 2,
+  order: 3,
   contentModel: {
     category: "instance",
     children: [descendantComponent],

--- a/packages/sdk-components-react/src/link.template.tsx
+++ b/packages/sdk-components-react/src/link.template.tsx
@@ -1,9 +1,0 @@
-import { type TemplateMeta, $ } from "@webstudio-is/template";
-
-export const meta: TemplateMeta = {
-  category: "general",
-  description:
-    "Use a link to send your users to another page, section, or resource. Configure links in the Settings panel.",
-  order: 1,
-  template: <$.Link></$.Link>,
-};

--- a/packages/sdk-components-react/src/slot.ws.ts
+++ b/packages/sdk-components-react/src/slot.ws.ts
@@ -6,5 +6,5 @@ export const meta: WsComponentMeta = {
   description:
     "Slot is a container for content that you want to reference across the project. Changes made to a Slot's children will be reflected in all other instances of that Slot.",
   icon: SlotComponentIcon,
-  order: 5,
+  order: 4,
 };

--- a/packages/sdk-components-react/src/templates.ts
+++ b/packages/sdk-components-react/src/templates.ts
@@ -1,6 +1,5 @@
 export { meta as ContentEmbed } from "./content-embed.template";
 export { meta as MarkdownEmbed } from "./markdown-embed.template";
-export { meta as Link } from "./link.template";
 export { meta as Form } from "./webhook-form.template";
 export { meta as Vimeo } from "./vimeo.template";
 export { meta as YouTube } from "./youtube.template";

--- a/packages/sdk-components-react/src/vimeo.template.tsx
+++ b/packages/sdk-components-react/src/vimeo.template.tsx
@@ -1,5 +1,5 @@
 import { PlayIcon, SpinnerIcon } from "@webstudio-is/icons/svg";
-import { type TemplateMeta, $, css } from "@webstudio-is/template";
+import { type TemplateMeta, $, css, ws } from "@webstudio-is/template";
 
 export const meta: TemplateMeta = {
   category: "media",
@@ -64,7 +64,8 @@ export const meta: TemplateMeta = {
         `}
         aria-label="Play button"
       >
-        <$.Box
+        <ws.element
+          ws:tag="div"
           ws:label="Play Icon"
           ws:style={css`
             width: 60px;
@@ -73,7 +74,7 @@ export const meta: TemplateMeta = {
           aria-hidden={true}
         >
           <$.HtmlEmbed ws:label="Play SVG" code={PlayIcon} />
-        </$.Box>
+        </ws.element>
       </$.VimeoPlayButton>
     </$.Vimeo>
   ),

--- a/packages/sdk-components-react/src/webhook-form.template.tsx
+++ b/packages/sdk-components-react/src/webhook-form.template.tsx
@@ -1,6 +1,8 @@
 import {
   $,
+  ws,
   ActionValue,
+  css,
   expression,
   PlaceholderValue,
   Variable,
@@ -20,28 +22,59 @@ export const meta: TemplateMeta = {
         new ActionValue(["state"], expression`${formState} = state`)
       }
     >
-      <$.Box
+      <ws.element
+        ws:tag="div"
         ws:label="Form Content"
         ws:show={expression`${formState} === 'initial' || ${formState} === 'error'`}
       >
-        <$.Label>{new PlaceholderValue("Name")}</$.Label>
-        <$.Input name="name" />
-        <$.Label>{new PlaceholderValue("Email")}</$.Label>
-        <$.Input name="email" />
-        <$.Button>{new PlaceholderValue("Submit")}</$.Button>
-      </$.Box>
-      <$.Box
+        <ws.element
+          ws:tag="label"
+          ws:style={css`
+            display: block;
+          `}
+        >
+          {new PlaceholderValue("Name")}
+        </ws.element>
+        <ws.element
+          ws:tag="input"
+          ws:style={css`
+            display: block;
+          `}
+          name="name"
+        />
+        <ws.element
+          ws:tag="label"
+          ws:style={css`
+            display: block;
+          `}
+        >
+          {new PlaceholderValue("Email")}
+        </ws.element>
+        <ws.element
+          ws:tag="input"
+          ws:style={css`
+            display: block;
+          `}
+          name="email"
+        />
+        <ws.element ws:tag="button">
+          {new PlaceholderValue("Submit")}
+        </ws.element>
+      </ws.element>
+      <ws.element
+        ws:tag="div"
         ws:label="Success Message"
         ws:show={expression`${formState} === 'success'`}
       >
         {new PlaceholderValue("Thank you for getting in touch!")}
-      </$.Box>
-      <$.Box
+      </ws.element>
+      <ws.element
+        ws:tag="div"
         ws:label="Error Message"
         ws:show={expression`${formState} === 'error'`}
       >
         {new PlaceholderValue("Sorry, something went wrong.")}
-      </$.Box>
+      </ws.element>
     </$.Form>
   ),
 };

--- a/packages/sdk-components-react/src/youtube.template.tsx
+++ b/packages/sdk-components-react/src/youtube.template.tsx
@@ -1,5 +1,5 @@
 import { PlayIcon, SpinnerIcon } from "@webstudio-is/icons/svg";
-import { type TemplateMeta, $, css } from "@webstudio-is/template";
+import { type TemplateMeta, $, css, ws } from "@webstudio-is/template";
 
 export const meta: TemplateMeta = {
   label: "YouTube",
@@ -68,7 +68,8 @@ export const meta: TemplateMeta = {
         `}
         aria-label="Play button"
       >
-        <$.Box
+        <ws.element
+          ws:tag="div"
           ws:label="Play Icon"
           ws:style={css`
             width: 60px;
@@ -77,7 +78,7 @@ export const meta: TemplateMeta = {
           aria-hidden={true}
         >
           <$.HtmlEmbed ws:label="Play SVG" code={PlayIcon} />
-        </$.Box>
+        </ws.element>
       </$.VimeoPlayButton>
     </$.YouTube>
   ),

--- a/packages/sdk/src/core-templates.tsx
+++ b/packages/sdk/src/core-templates.tsx
@@ -7,20 +7,35 @@ import {
   ws,
   type TemplateMeta,
 } from "@webstudio-is/template";
+import { CheckboxCheckedIcon, RadioCheckedIcon } from "@webstudio-is/icons/svg";
 import {
   blockComponent,
   collectionComponent,
   descendantComponent,
   elementComponent,
 } from "./core-metas";
-import { CheckboxCheckedIcon, RadioCheckedIcon } from "@webstudio-is/icons/svg";
 
 const elementMeta: TemplateMeta = {
   category: "general",
-  order: 0,
+  order: 1,
   description:
     "An HTML element is a core building block for web pages, structuring and displaying content like text, images, and links.",
   template: <ws.element></ws.element>,
+};
+
+const linkMeta: TemplateMeta = {
+  category: "general",
+  description:
+    "Use a link to send your users to another page, section, or resource. Configure links in the Settings panel.",
+  order: 2,
+  template: (
+    <ws.element
+      ws:tag="a"
+      ws:style={css`
+        display: inline-block;
+      `}
+    ></ws.element>
+  ),
 };
 
 const collectionItem = new Parameter("collectionItem");
@@ -33,9 +48,9 @@ const collectionMeta: TemplateMeta = {
       data={["Collection Item 1", "Collection Item 2", "Collection Item 3"]}
       item={collectionItem}
     >
-      <$.Box>
-        <$.Text>{expression`${collectionItem}`}</$.Text>
-      </$.Box>
+      <ws.element ws:tag="div">
+        <ws.element ws:tag="div">{expression`${collectionItem}`}</ws.element>
+      </ws.element>
     </ws.collection>
   ),
 };
@@ -52,20 +67,20 @@ const blockMeta: TemplateMeta = {
   template: (
     <ws.block>
       <BlockTemplate ws:label="Templates">
-        <$.Paragraph></$.Paragraph>
-        <$.Heading ws:label="Heading 1" ws:tag="h1"></$.Heading>
-        <$.Heading ws:label="Heading 2" ws:tag="h2"></$.Heading>
-        <$.Heading ws:label="Heading 3" ws:tag="h3"></$.Heading>
-        <$.Heading ws:label="Heading 4" ws:tag="h4"></$.Heading>
-        <$.Heading ws:label="Heading 5" ws:tag="h5"></$.Heading>
-        <$.Heading ws:label="Heading 6" ws:tag="h6"></$.Heading>
-        <$.List ws:label="List (Unordered)">
-          <$.ListItem></$.ListItem>
-        </$.List>
-        <$.List ws:label="List (Ordered)" ordered={true}>
-          <$.ListItem></$.ListItem>
-        </$.List>
-        <$.Link></$.Link>
+        <ws.element ws:tag="p"></ws.element>
+        <ws.element ws:label="Heading 1" ws:tag="h1"></ws.element>
+        <ws.element ws:label="Heading 2" ws:tag="h2"></ws.element>
+        <ws.element ws:label="Heading 3" ws:tag="h3"></ws.element>
+        <ws.element ws:label="Heading 4" ws:tag="h4"></ws.element>
+        <ws.element ws:label="Heading 5" ws:tag="h5"></ws.element>
+        <ws.element ws:label="Heading 6" ws:tag="h6"></ws.element>
+        <ws.element ws:tag="ul">
+          <ws.element ws:tag="li"></ws.element>
+        </ws.element>
+        <ws.element ws:tag="ol">
+          <ws.element ws:tag="li"></ws.element>
+        </ws.element>
+        <ws.element ws:tag="a"></ws.element>
         <$.Image
           ws:style={css`
             margin-right: auto;
@@ -74,35 +89,35 @@ const blockMeta: TemplateMeta = {
             height: auto;
           `}
         />
-        <$.Separator />
-        <$.Blockquote></$.Blockquote>
+        <ws.element ws:tag="hr" />
+        <ws.element ws:tag="blockquote"></ws.element>
         <$.HtmlEmbed />
-        <$.CodeText />
+        <ws.element ws:tag="code" />
       </BlockTemplate>
-      <$.Paragraph>
+      <ws.element ws:tag="p">
         The Content Block component designates regions on the page where
         pre-styled instances can be inserted in{" "}
-        <$.RichTextLink href="https://wstd.us/content-block">
+        <ws.element ws:tag="a" href="https://wstd.us/content-block">
           Content mode
-        </$.RichTextLink>
+        </ws.element>
         .
-      </$.Paragraph>
-      <$.List>
-        <$.ListItem>
+      </ws.element>
+      <ws.element ws:tag="ul">
+        <ws.element ws:tag="li">
           In Content mode, you can edit any direct child instances that were
           pre-added to the Content Block, as well as add new instances
           predefined in Templates.
-        </$.ListItem>
-        <$.ListItem>
+        </ws.element>
+        <ws.element ws:tag="li">
           To predefine instances for insertion in Content mode, switch to Design
           mode and add them to the Templates container.
-        </$.ListItem>
-        <$.ListItem>
+        </ws.element>
+        <ws.element ws:tag="li">
           To insert predefined instances in Content mode, click the + button
           while hovering over the Content Block on the canvas and choose an
           instance from the list.
-        </$.ListItem>
-      </$.List>
+        </ws.element>
+      </ws.element>
     </ws.block>
   ),
 };
@@ -337,6 +352,7 @@ const forms: Record<string, TemplateMeta> = {
 
 export const coreTemplates = {
   [elementComponent]: elementMeta,
+  link: linkMeta,
   [collectionComponent]: collectionMeta,
   [descendantComponent]: descendantMeta,
   [blockComponent]: blockMeta,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3632

Here unflagged element component in components panel and html paste.

Additionally

- migrate link template to html element
- added :local-link state to links which is replaced with [aria-current=page] when css is generated, sadly not yet supported in any browser
- migrated many templates from legacy components to html elements
- put tailwind paste behind flag