### PR TITLE
fix: prevent checkbox and radio changing in design mode

### DIFF
--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -76,13 +76,12 @@ const switchPageAndUpdateSystem = (href: string, formData?: FormData) => {
 
 export const subscribeInterceptedEvents = () => {
   const handleClick = (event: MouseEvent) => {
-    // Prevent forwarding the click event on an input element when the associated label has a "for" attribute
-    if (
-      event.target instanceof Element &&
-      event.target.closest("label[for]") &&
-      !$isPreviewMode.get()
-    ) {
-      event.preventDefault();
+    if (event.target instanceof Element && !$isPreviewMode.get()) {
+      // Prevent forwarding the click event on an input element when the associated label has a "for" attribute
+      // and prevent checkbox or radio inputs changing when clicked
+      if (event.target.closest("label[for]") || event.target.closest("input")) {
+        event.preventDefault();
+      }
     }
 
     if (


### PR DESCRIPTION
User can click on checkboxes and radio inputs on canvas and make them checked. We don't want this in design mode.