### PR TITLE
perf: improve instance selection performance

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -7,6 +7,7 @@ import {
   type Instance,
   type Props,
   descendantComponent,
+  rootComponent,
 } from "@webstudio-is/sdk";
 import {
   theme,
@@ -344,7 +345,7 @@ export const PropsSectionContainer = ({
   });
 
   const propsMetas = useStore($selectedInstancePropsMetas);
-  if (propsMetas.size === 0) {
+  if (propsMetas.size === 0 || instance.component === rootComponent) {
     return;
   }
 

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -27,10 +27,7 @@ import {
 } from "~/shared/dom-utils";
 import { subscribeScrollState } from "~/canvas/shared/scroll-state";
 import { $selectedInstanceOutline } from "~/shared/nano-states";
-import {
-  hasCollapsedMutationRecord,
-  setDataCollapsed,
-} from "~/canvas/collapsed";
+import { setDataCollapsed } from "~/canvas/collapsed";
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { $awareness } from "~/shared/awareness";
 
@@ -236,7 +233,7 @@ const subscribeSelectedInstance = (
 
   // Lightweight update
   const updateOutline: MutationCallback = (mutationRecords) => {
-    if (hasCollapsedMutationRecord(mutationRecords)) {
+    if (hasDoNotTrackMutationRecord(mutationRecords)) {
       return;
     }
 
@@ -247,10 +244,6 @@ const subscribeSelectedInstance = (
 
   const mutationHandler: MutationCallback = (mutationRecords) => {
     if (hasDoNotTrackMutationRecord(mutationRecords)) {
-      return;
-    }
-
-    if (hasCollapsedMutationRecord(mutationRecords)) {
       return;
     }
 

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -219,6 +219,10 @@ export const getAllElementsBoundingBox = (
 
 const doNotTrackMutationAttribute = "data-ws-do-not-track-mutation";
 
+export const doNotTrackMutation = (element: Element) => {
+  element.setAttribute(doNotTrackMutationAttribute, "true");
+};
+
 export const hasDoNotTrackMutationAttribute = (element: Element) => {
   return element.hasAttribute(doNotTrackMutationAttribute);
 };
@@ -363,7 +367,10 @@ export const scrollIntoView = (anchor: HTMLElement, rect: DOMRect) => {
 
   requestAnimationFrame(() => {
     const savedPosition = (scrollParent as HTMLElement).style.position;
-    (scrollParent as HTMLElement).style.position = "relative";
+    // avoid updating <html> to prevent full page repaint and freeze on big projects
+    if (scrollParent.tagName !== "HTML") {
+      (scrollParent as HTMLElement).style.position = "relative";
+    }
 
     const matrix = getViewportToLocalMatrix(scrollParent);
 
@@ -387,6 +394,9 @@ export const scrollIntoView = (anchor: HTMLElement, rect: DOMRect) => {
 
     scrollParent.removeChild(scrollDiv);
 
-    (scrollParent as HTMLElement).style.position = savedPosition;
+    // avoid updating <html> to prevent full page repaint and freeze on big projects
+    if (scrollParent.tagName !== "HTML") {
+      (scrollParent as HTMLElement).style.position = savedPosition;
+    }
   });
 };


### PR DESCRIPTION
We have html element mutations in a few places and each can add ~250ms of repaint time on large projects. Here I got rid of it in two places

1. Collapsed logic enforced document height to preserve scroll position. Instead I created an absolutely positioned div which enforced scroll where collapsed elements are reset.
2. Scroll into view logic defined position absolute on scroll container. Though it's not necessary on html element so just ignored it.