### PR TITLE
fix: prevent typing only inside of textarea and input on canvas

### DIFF
--- a/apps/builder/app/canvas/interceptor.ts
+++ b/apps/builder/app/canvas/interceptor.ts
@@ -159,8 +159,13 @@ export const subscribeInterceptedEvents = () => {
     if ($isPreviewMode.get()) {
       return;
     }
-    // prevent typing in inputs only in canvas mode
-    event.preventDefault();
+    if (
+      event.target instanceof HTMLInputElement ||
+      event.target instanceof HTMLTextAreaElement
+    ) {
+      // prevent typing in inputs only in canvas mode
+      event.preventDefault();
+    }
   };
 
   // Note: Event handlers behave unexpectedly when used inside a dialog component.


### PR DESCRIPTION
Accidentally broke when fixed links download attribute