### PR TITLE
fix: autocomplete tags on body when page has invalid content

### DIFF
--- a/apps/builder/app/builder/features/command-panel/command-panel.tsx
+++ b/apps/builder/app/builder/features/command-panel/command-panel.tsx
@@ -265,7 +265,9 @@ const $tagOptions = computed(
     newInstances.set(childInstance.id, childInstance);
     newInstances.set(instance.id, {
       ...instance,
-      children: [...instance.children, { type: "id", value: childInstance.id }],
+      // avoid preserving original children to not invalidate tag
+      // when some descendants do not satisfy content model
+      children: [{ type: "id", value: childInstance.id }],
     });
     for (const tag of tags) {
       childInstance.tag = tag;


### PR DESCRIPTION
Removed children from content model check in command panel tags.