### PR TITLE
fix: return back box-sizing: border-box on <hr>

### DIFF
--- a/packages/sdk/src/__generated__/normalize.css.ts
+++ b/packages/sdk/src/__generated__/normalize.css.ts
@@ -141,6 +141,7 @@ export const body: StyleDecl[] = [
 export const hr: StyleDecl[] = [
   { property: "height", value: { type: "unit", unit: "number", value: 0 } },
   { property: "color", value: { type: "keyword", value: "inherit" } },
+  { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
 ];
 
 export const b: StyleDecl[] = [

--- a/packages/sdk/src/normalize.css
+++ b/packages/sdk/src/normalize.css
@@ -99,12 +99,15 @@ body {
 /**
  * 1. Add the correct height in Firefox.
  * 2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+ * 3. width: 100% inside flexbox will overflow <hr> out of it
  */
 hr {
   /* 1 */
   height: 0;
   /* 2 */
   color: inherit;
+  /* 3 */
+  box-sizing: border-box;
 }
 
 /**


### PR DESCRIPTION
Accidentally removed it while refactoring preset styles.