### PR TITLE
fix: ignore content model checks for XmlNode component

### DIFF
--- a/apps/builder/app/shared/content-model.test.tsx
+++ b/apps/builder/app/shared/content-model.test.tsx
@@ -505,6 +505,22 @@ test("support video > source", () => {
   ).toBeTruthy();
 });
 
+test("support xml node with tags", () => {
+  expect(
+    isTreeSatisfyingContentModel({
+      ...renderData(
+        <ws.element ws:tag="body" ws:id="bodyId">
+          <$.XmlNode tag="url">
+            <$.XmlNode tag="loc"></$.XmlNode>
+          </$.XmlNode>
+        </ws.element>
+      ),
+      metas: defaultMetas,
+      instanceSelector: ["bodyId"],
+    })
+  ).toBeTruthy();
+});
+
 describe("component content model", () => {
   test("restrict children with specific component", () => {
     expect(

--- a/apps/builder/app/shared/content-model.ts
+++ b/apps/builder/app/shared/content-model.ts
@@ -37,11 +37,11 @@ const getTag = ({
   metas: Metas;
   props: Props;
 }) => {
-  const meta = metas.get(instance.component);
   // ignore tag property on xml nodes
-  if (meta?.category === "xml") {
+  if (instance.component === "XmlNode") {
     return;
   }
+  const meta = metas.get(instance.component);
   const metaTag = Object.keys(meta?.presetStyle ?? {}).at(0);
   return instance.tag ?? getTagByInstanceId(props).get(instance.id) ?? metaTag;
 };

--- a/apps/builder/app/shared/content-model.ts
+++ b/apps/builder/app/shared/content-model.ts
@@ -38,6 +38,10 @@ const getTag = ({
   props: Props;
 }) => {
   const meta = metas.get(instance.component);
+  // ignore tag property on xml nodes
+  if (meta?.category === "xml") {
+    return;
+  }
   const metaTag = Object.keys(meta?.presetStyle ?? {}).at(0);
   return instance.tag ?? getTagByInstanceId(props).get(instance.id) ?? metaTag;
 };


### PR DESCRIPTION
We rely on "tag" in legacy components though it is primary way to setup tag on xml nodes. Here added exception for all xml components.