### PR TITLE
fix: Create .gitattributes to fix error due to line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,43 @@
+# Enforce LF endings across all text files
+* text=auto eol=lf
+
+# --- TypeScript & JavaScript ---
+*.ts     text eol=lf
+*.tsx    text eol=lf
+*.js     text eol=lf
+*.jsx    text eol=lf
+
+# --- CSS ---
+*.css    text eol=lf
+
+# --- Shell Scripts ---
+*.sh     text eol=lf
+
+# --- SQL (PL/pgSQL scripts) ---
+*.sql    text eol=lf
+
+# --- Docker ---
+Dockerfile* text eol=lf
+*.dockerignore text eol=lf
+
+# --- Config & Markup ---
+*.json   text eol=lf
+*.yml    text eol=lf
+*.yaml   text eol=lf
+*.env    text eol=lf
+*.md     text eol=lf
+*.toml   text eol=lf
+*.html   text eol=lf
+*.xml    text eol=lf
+
+# --- Binary files (no line ending normalization) ---
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.ico    binary
+*.woff   binary
+*.woff2  binary
+*.ttf    binary
+*.eot    binary
+*.pdf    binary


### PR DESCRIPTION
Added Git Attributes file to ensure that line endings are the same regardless of the OS (This was causing problems for Windows + Docker)

## Steps for reproduction (Windows)

1. Clone webstudion builder and open with vs code, docker, etc.
2. every single file will have a git status of "m" (modified) due to changed line endings

## Code Review

 hi @kof, I need you to take a look and make sure this is an ideal fix

It seems to work great on my end.
