### PR TITLE
fix: File Permission Error in Windows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,9 +19,16 @@
   // "forwardPorts": [3000, 5432],
   "forwardPorts": [5173],
 
+  // Allow the container to use the default command from the base image
+  "overrideCommand": false,
+  // Mount the project folder from your local machine into the container for live code access
+  "mounts": [
+    "source=${localWorkspaceFolder},target=/workspaces/webstudio,type=bind,consistency=cached"
+  ],
+  
   // Use 'postCreateCommand' to run commands after the container is created.
 
-  "postCreateCommand": ".devcontainer/postinstall.sh",
+  "postCreateCommand": "chmod +x .devcontainer/postinstall.sh && .devcontainer/postinstall.sh",
   // "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Please ignore the commits...they're kind of messy from the other pr I made. As you can see only one file is changed in this pr.
##Description

When opening the local builder in a dev container via VSCode and Docker, several errors arise. This is due to file permissions.

Here's a list of what's going on (according to chatGPT):
1.Fixes file permission issues on Windows using postCreateCommand
2.Mounts project folder with consistency=cached for better performance

##Steps for reproduction

  Open in dev container
  Error

##Before requesting a review

It works on my Windows PC
