### PR TITLE
fix: avoid error when domain does not exist in iana

### DIFF
--- a/apps/builder/app/builder/features/topbar/add-domain.tsx
+++ b/apps/builder/app/builder/features/topbar/add-domain.tsx
@@ -54,7 +54,7 @@ export const AddDomain = ({
       });
       // enforce www subdomain when no support for cname flattening
       // and root cname can conflict with MX or NS
-      if (!registrar.cnameFlattening) {
+      if (registrar.known && !registrar.cnameFlattening) {
         domain = `www.${domain}`;
       }
     }

--- a/packages/domain/src/rdap.ts
+++ b/packages/domain/src/rdap.ts
@@ -91,15 +91,14 @@ export const isDomainUsingCloudflareNameservers = async (domain: string) => {
     console.error(
       "RDAP Server for the given top level domain could not be found."
     );
+    return undefined;
   }
 
-  if (rdapServer) {
-    const data = await fetchRdap(rdapServer, domain);
-    if (data) {
-      // detect by nameservers rather than registrar url
-      // sometimes stored as *.NS.CLOUDFLARE.COM
-      return data.toLowerCase().includes(".ns.cloudflare.com");
-    }
+  const data = await fetchRdap(rdapServer, domain);
+  if (data) {
+    // detect by nameservers rather than registrar url
+    // sometimes stored as *.NS.CLOUDFLARE.COM
+    return data.toLowerCase().includes(".ns.cloudflare.com");
   }
   return false;
 };

--- a/packages/domain/src/rdap.ts
+++ b/packages/domain/src/rdap.ts
@@ -88,7 +88,7 @@ export const isDomainUsingCloudflareNameservers = async (domain: string) => {
 
   const rdapServer = await findRdapServer(topLevelDomain);
   if (!rdapServer) {
-    throw new Error(
+    console.error(
       "RDAP Server for the given top level domain could not be found."
     );
   }

--- a/packages/domain/src/trpc/domain.ts
+++ b/packages/domain/src/trpc/domain.ts
@@ -28,8 +28,12 @@ export const domainRouter = router({
   findDomainRegistrar: procedure
     .input(z.object({ domain: z.string() }))
     .query(async ({ input }) => {
+      const isCloudflare = await isDomainUsingCloudflareNameservers(
+        input.domain
+      );
       return {
-        cnameFlattening: await isDomainUsingCloudflareNameservers(input.domain),
+        known: isCloudflare !== undefined,
+        cnameFlattening: isCloudflare === true,
       };
     }),
 


### PR DESCRIPTION
We use iana registry to find if cloudflare nameserver is used for domain and we can avoid using www.