### PR TITLE
feat: automatically paste tailwind when html has inception mark

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-html.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-html.ts
@@ -1,7 +1,10 @@
 import { generateFragmentFromHtml } from "../html";
 import { insertWebstudioFragmentAt } from "../instance-utils";
+import { generateFragmentFromTailwind } from "../tailwind/tailwind";
 import { denormalizeSrcProps } from "./asset-upload";
 import type { Plugin } from "./init-copy-paste";
+
+const inceptionMark = `<!-- Generated with Inception by Webstudio -->`;
 
 export const html: Plugin = {
   name: "html",
@@ -9,6 +12,9 @@ export const html: Plugin = {
   onPaste: async (html: string) => {
     let fragment = generateFragmentFromHtml(html);
     fragment = await denormalizeSrcProps(fragment);
+    if (html.includes(inceptionMark)) {
+      fragment = await generateFragmentFromTailwind(fragment);
+    }
     const result = insertWebstudioFragmentAt(fragment);
     return result;
   },

--- a/apps/builder/app/shared/copy-paste/plugin-html.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-html.ts
@@ -4,7 +4,7 @@ import { generateFragmentFromTailwind } from "../tailwind/tailwind";
 import { denormalizeSrcProps } from "./asset-upload";
 import type { Plugin } from "./init-copy-paste";
 
-const inceptionMark = `<!-- Generated with Inception by Webstudio -->`;
+const inceptionMark = `<!-- @webstudio/incation/1 -->`;
 
 export const html: Plugin = {
   name: "html",


### PR DESCRIPTION
We want to reduce friction in pasting from inception and will automatically process tailwind classes and generate styles when paste into builder without using command panel.