### PR TITLE
fix: avoid body when insert section from marketplace

### DIFF
--- a/apps/builder/app/builder/features/marketplace/templates.tsx
+++ b/apps/builder/app/builder/features/marketplace/templates.tsx
@@ -13,6 +13,7 @@ import {
 import { ChevronLeftIcon, ExternalLinkIcon } from "@webstudio-is/icons";
 import {
   elementComponent,
+  Instance,
   ROOT_FOLDER_ID,
   type Asset,
   type Page,
@@ -33,6 +34,10 @@ import { Card } from "./card";
 import type { MarketplaceOverviewItem } from "~/shared/marketplace/types";
 import { selectPage } from "~/shared/awareness";
 
+const isBody = (instance: Instance) =>
+  instance.component === "Body" ||
+  (instance.component === elementComponent && instance.tag === "body");
+
 /**
  * Insert page as a template.
  * - Currently only supports inserting everything from the body
@@ -46,17 +51,12 @@ const insertSection = ({
   instanceId: string;
 }) => {
   const fragment = extractWebstudioFragment(data, instanceId);
-  const body = fragment.instances.find(
-    (instance) => instance.component === "Body"
-  );
+  const body = fragment.instances.find(isBody);
   // remove body and use its children as root insrances
   if (body) {
-    fragment.instances = fragment.instances.filter((instance) => {
-      const isBody =
-        instance.component === "Body" ||
-        (instance.component === elementComponent && instance.tag === "body");
-      return !isBody;
-    });
+    fragment.instances = fragment.instances.filter(
+      (instance) => !isBody(instance)
+    );
     fragment.children = body.children;
   }
   const insertable = findClosestInsertable(fragment);


### PR DESCRIPTION
We remove body from pages when insert section
but I forgot to add a check for body element which replaced Body component for new pages.