### PR TITLE
fix: allow <p> inside of <hgroup>

### DIFF
--- a/packages/html-data/bin/elements.ts
+++ b/packages/html-data/bin/elements.ts
@@ -76,6 +76,12 @@ const elementsByTag: Record<string, Element> = {};
       if (tag === "summary") {
         categories.push("interactive");
       }
+      // hgroup also accepts paragraphs
+      // https://html.spec.whatwg.org/multipage/sections.html#the-hgroup-element
+      // https://github.com/whatwg/html/pull/11524
+      if (tag === "hgroup") {
+        children.push("p");
+      }
       elementsByTag[tag] = {
         description,
         categories,

--- a/packages/html-data/src/__generated__/elements.ts
+++ b/packages/html-data/src/__generated__/elements.ts
@@ -273,6 +273,7 @@ export const elementsByTag: Record<string, Element> = {
       "h5",
       "h6",
       "script-supporting elements",
+      "p",
     ],
   },
   hr: {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-community/discussions/241

Never supported heading outline algorithm was never supported and the latest update to html spec allowed paragraphs as part of this removal for lower level subtitles or descriptions.

Though indices tables were not updated. I [sent PR](https://github.com/whatwg/html/pull/11524)