### PR TITLE
fix: avoid using global color for head slot and xml

### DIFF
--- a/packages/sdk-components-react/src/xml-node.tsx
+++ b/packages/sdk-components-react/src/xml-node.tsx
@@ -88,6 +88,7 @@ export const XmlNode = forwardRef<ElementRef<"div">, Props>(
               style={{
                 display: isTextChild ? "inline" : "block",
                 marginLeft: isTextChild ? 0 : "1rem",
+                color: "#000000",
               }}
             >
               {children}


### PR DESCRIPTION
Fixes https://discord.com/channels/955905230107738152/1398319996832059574/1398319996832059574

Here explicitly specified black color for text in xml and head slot. This prevents white color on root to override text.