### PR TITLE
fix: relax redirects validation

### DIFF
--- a/apps/builder/app/builder/features/project-settings/section-redirects.tsx
+++ b/apps/builder/app/builder/features/project-settings/section-redirects.tsx
@@ -22,7 +22,6 @@ import {
 } from "@webstudio-is/sdk";
 import { useRef, useState, type ChangeEvent } from "react";
 import { flushSync } from "react-dom";
-import { matchPathnamePattern } from "~/builder/shared/url-pattern";
 import { $pages, $publishedOrigin } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync";
 import { getExistingRoutePaths, sectionSpacing } from "./utils";
@@ -82,32 +81,9 @@ export const SectionRedirects = () => {
 
   const validateNewPath = (newPath: string): string[] => {
     const newPathValidationResult = ProjectNewRedirectPath.safeParse(newPath);
-
-    if (newPathValidationResult.success === true) {
-      /*
-        This is the new path, that users want to redirect to.
-        If the new path doesn't exist, it's not a valid redirect.
-      */
-
-      if (newPath === "/") {
-        return [];
-      }
-
-      if (newPath.startsWith("/") === true) {
-        let matched = false;
-        for (const pattern of existingPaths) {
-          if (matchPathnamePattern(pattern, newPath)) {
-            matched = true;
-          }
-        }
-        if (matched === false) {
-          return ["This path doesn't exist in the project"];
-        }
-      }
-
+    if (newPathValidationResult.success) {
       return [];
     }
-
     return newPathValidationResult.error.format()._errors;
   };
 

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -152,21 +152,16 @@ const ProjectMeta = z.object({
 });
 export type ProjectMeta = z.infer<typeof ProjectMeta>;
 
-export const ProjectNewRedirectPath = PagePath.or(
-  z.string().refine((data) => {
-    // Users should be able to redirect from any old-path to the home page in the new project.
-    if (data === "/") {
-      return true;
-    }
-
-    try {
-      new URL(data);
-      return true;
-    } catch {
-      return false;
-    }
-  }, "Must be a valid URL")
-);
+export const ProjectNewRedirectPath = z.string().refine((data) => {
+  // Users should be able to redirect from any old-path to the home page in the new project.
+  try {
+    // can be relative and absolute paths
+    new URL(data, "http://url.com");
+    return true;
+  } catch {
+    return false;
+  }
+}, "Must be a valid URL");
 
 export const PageRedirect = z.object({
   old: OldPagePath,


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/5337

1. checking specific characters will always be error prone
2. checking matching paths is no longer relevant with `/*` which matches them all
3. added check to validate url or path with `new URL()`