### PR TITLE
fix: accept any string in <iframe> name attribute

### DIFF
--- a/packages/html-data/bin/attributes.ts
+++ b/packages/html-data/bin/attributes.ts
@@ -163,7 +163,7 @@ for (const row of rows) {
     .split(/\s*;\s*/)
     .filter((item) => item.startsWith('"') && item.endsWith('"'))
     .map((item) => item.slice(1, -1));
-  if (value.includes("valid navigable target name or keyword")) {
+  if (attribute === "target" || attribute === "formtarget") {
     possibleOptions = ["_blank", "_self", "_parent", "_top"];
   }
   if (value.includes("input type keyword")) {

--- a/packages/html-data/src/__generated__/attributes-jsx-test.tsx
+++ b/packages/html-data/src/__generated__/attributes-jsx-test.tsx
@@ -2075,7 +2075,7 @@ const Page = () => {
         allowFullScreen={true}
         height={0}
         loading={"lazy"}
-        name={"_blank"}
+        name={""}
         referrerPolicy={""}
         sandbox={""}
         src={""}
@@ -2538,14 +2538,7 @@ const Page = () => {
         xmlLang={""}
         xmlSpace={""}
       />
-      <object
-        data={""}
-        form={""}
-        height={0}
-        name={"_blank"}
-        type={""}
-        width={0}
-      />
+      <object data={""} form={""} height={0} name={""} type={""} width={0} />
       <ol reversed={true} start={0} type={"1"} />
       <optgroup disabled={true} label={""} />
       <option disabled={true} label={""} value={""} />

--- a/packages/html-data/src/__generated__/attributes.ts
+++ b/packages/html-data/src/__generated__/attributes.ts
@@ -973,11 +973,10 @@ const attribute_y2_gxmray: Attribute = {
   type: "string",
 };
 
-const attribute_name_1dbhjn1: Attribute = {
+const attribute_name_14zrnwf: Attribute = {
   name: "name",
   description: "Name of content navigable",
-  type: "select",
-  options: ["_blank", "_self", "_parent", "_top"],
+  type: "string",
 };
 
 const attribute_type_1swzf44: Attribute = {
@@ -3726,7 +3725,7 @@ export const attributesByTag: Record<string, undefined | Attribute[]> = {
     },
     attribute_height_10887hn,
     attribute_loading_yzzdw4,
-    attribute_name_1dbhjn1,
+    attribute_name_14zrnwf,
     attribute_referrerpolicy_tpprqt,
     {
       name: "sandbox",
@@ -4365,7 +4364,7 @@ export const attributesByTag: Record<string, undefined | Attribute[]> = {
     },
     attribute_form_1v3e5z4,
     attribute_height_10887hn,
-    attribute_name_1dbhjn1,
+    attribute_name_14zrnwf,
     attribute_type_1swzf44,
     attribute_width_d9q964,
   ],


### PR DESCRIPTION
Fixes https://discord.com/channels/955905230107738152/1400906922235920445/1400906922235920445

The spec does not clearly indicate possible values and in case of iframe and object name attribute accepts any string.