### PR TITLE
fix: remove vercel route configs

### DIFF
--- a/apps/builder/app/routes/_canvas.canvas.tsx
+++ b/apps/builder/app/routes/_canvas.canvas.tsx
@@ -38,8 +38,3 @@ const CanvasRoute = () => {
 };
 
 export default CanvasRoute;
-
-// Reduces Vercel function size from 29MB to 9MB for unknown reasons; effective when used in limited files.
-export const config = {
-  maxDuration: 30,
-};

--- a/apps/builder/app/routes/_ui.(builder).tsx
+++ b/apps/builder/app/routes/_ui.(builder).tsx
@@ -293,8 +293,3 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 };
 
 export default BuilderRoute;
-
-// Reduces Vercel function size from 29MB to 9MB for unknown reasons; effective when used in limited files.
-export const config = {
-  maxDuration: 30,
-};

--- a/apps/builder/app/routes/_ui.login._index.tsx
+++ b/apps/builder/app/routes/_ui.login._index.tsx
@@ -111,8 +111,3 @@ const LoginRoute = () => {
 };
 
 export default LoginRoute;
-
-// Reduces Vercel function size from 29MB to 9MB for unknown reasons; effective when used in limited files.
-export const config = {
-  maxDuration: 30,
-};

--- a/apps/builder/app/routes/rest.patch.ts
+++ b/apps/builder/app/routes/rest.patch.ts
@@ -453,8 +453,3 @@ export const action = async ({
     };
   }
 };
-
-// Reduces Vercel function size from 29MB to 9MB for unknown reasons; effective when used in limited files.
-export const config = {
-  maxDuration: 30, // seconds
-};


### PR DESCRIPTION
These official documented route configs started to wipe whole builder. We should migrate away from vercel ASAP.
