### PR TITLE
fix: keep property in advanced panel when use color thumb

### DIFF
--- a/apps/builder/app/builder/shared/css-editor/css-editor.tsx
+++ b/apps/builder/app/builder/shared/css-editor/css-editor.tsx
@@ -153,7 +153,7 @@ const AdvancedPropertyValue = ({
               }
             }}
             onChangeComplete={(styleValue) => {
-              onSetProperty(styleDecl.property)(styleValue);
+              onSetProperty(styleDecl.property)(styleValue, { listed: true });
             }}
           />
         )


### PR DESCRIPTION
Edited value lost "listed" flag when threw it out of advanced panel.