### PR TITLE
fix: avoid optimizing .ico in docker template

### DIFF
--- a/fixtures/react-router-docker/app/constants.mjs
+++ b/fixtures/react-router-docker/app/constants.mjs
@@ -25,7 +25,7 @@ export const imageLoader = (props) => {
     return props.src;
   }
   // IPX (sharp) does not support ico
-  if (props.src.endsWith('.ico')) {
+  if (props.src.endsWith(".ico")) {
     return props.src;
   }
   // handle absolute urls

--- a/fixtures/react-router-docker/app/constants.mjs
+++ b/fixtures/react-router-docker/app/constants.mjs
@@ -24,6 +24,10 @@ export const imageLoader = (props) => {
   if (props.format === "raw") {
     return props.src;
   }
+  // IPX (sharp) does not support ico
+  if (props.src.endsWith('.ico')) {
+    return props.src;
+  }
   // handle absolute urls
   const path = UrlCanParse(props.src) ? `/${props.src}` : props.src;
   // https://github.com/unjs/ipx?tab=readme-ov-file#modifiers

--- a/packages/cli/templates/react-router-docker/app/constants.mjs
+++ b/packages/cli/templates/react-router-docker/app/constants.mjs
@@ -24,6 +24,10 @@ export const imageLoader = (props) => {
   if (props.format === "raw") {
     return props.src;
   }
+  // IPX (sharp) does not support ico
+  if (props.src.endsWith('.ico')) {
+    return props.src;
+  }
   // handle absolute urls
   const path = UrlCanParse(props.src) ? `/${props.src}` : props.src;
   // https://github.com/unjs/ipx?tab=readme-ov-file#modifiers


### PR DESCRIPTION
IPX we use for image generation does not support .ico format and fails to process it. Here I just skip image optimization for .ico and pass url directly.