### PR TITLE
feat: cache resources

### DIFF
--- a/fixtures/react-router-cloudflare/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-cloudflare/app/routes/[another-page]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-cloudflare/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-cloudflare/app/routes/[another-page]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-cloudflare/app/routes/_index.tsx
+++ b/fixtures/react-router-cloudflare/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-cloudflare/app/routes/_index.tsx
+++ b/fixtures/react-router-cloudflare/app/routes/_index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-docker/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-docker/app/routes/[another-page]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-docker/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-docker/app/routes/[another-page]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-docker/app/routes/_index.tsx
+++ b/fixtures/react-router-docker/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-docker/app/routes/_index.tsx
+++ b/fixtures/react-router-docker/app/routes/_index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-netlify/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-netlify/app/routes/[another-page]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-netlify/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-netlify/app/routes/[another-page]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-netlify/app/routes/_index.tsx
+++ b/fixtures/react-router-netlify/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-netlify/app/routes/_index.tsx
+++ b/fixtures/react-router-netlify/app/routes/_index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-vercel/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-vercel/app/routes/[another-page]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-vercel/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-vercel/app/routes/[another-page]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-vercel/app/routes/_index.tsx
+++ b/fixtures/react-router-vercel/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/react-router-vercel/app/routes/_index.tsx
+++ b/fixtures/react-router-vercel/app/routes/_index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
@@ -13,6 +13,7 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
+  cachedFetch,
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk/runtime";
@@ -43,7 +44,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +54,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
@@ -44,7 +44,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -54,7 +54,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -13,6 +13,7 @@ import {
   isLocalResource,
   loadResource,
   loadResources,
+  cachedFetch,
   formIdFieldName,
   formBotFieldName,
 } from "@webstudio-is/sdk/runtime";
@@ -43,7 +44,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +54,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -44,7 +44,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -54,7 +54,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[_route_with_symbols_]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[_route_with_symbols_]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[animations]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[animations]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[animations]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[animations]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[class-names]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[class-names]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[class-names]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[class-names]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[content-block]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[content-block]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[content-block]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[content-block]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[duration]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[duration]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[duration]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[duration]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[expressions]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[expressions]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[expressions]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[expressions]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[form]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[form]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[head-tag]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[head-tag]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[head-tag]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[head-tag]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[heading-with-id]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[heading-with-id]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[nested].[nested-page]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[nested].[nested-page]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[radix]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[radix]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[resources]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[resources]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[text-duration]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[text-duration]._index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/[text-duration]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[text-duration]._index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/_index.tsx
+++ b/fixtures/webstudio-features/app/routes/_index.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/fixtures/webstudio-features/app/routes/_index.tsx
+++ b/fixtures/webstudio-features/app/routes/_index.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "../__generated__/$resources.sitemap.xml";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -53,8 +53,8 @@ const cachedFetch: typeof fetch = async (input, init) => {
         // https://developers.cloudflare.com/workers/reference/how-the-cache-works/#cache-api
         const requestCacheControl = request.headers.get("Cache-Control");
         response = response.clone();
-        if (!response.headers.has("Cache-Control") && requestCacheControl) {
-          response.headers.append("Cache-Control", requestCacheControl);
+        if (requestCacheControl) {
+          response.headers.set("Cache-Control", requestCacheControl);
         }
         cache.put(request, response);
       }

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -52,7 +52,11 @@ const cachedFetch: typeof fetch = async (input, init) => {
         cache.put(request, response);
       }
     }
-    return new Response(request.headers.get("Cache-Control") ?? "");
+    return new Response(
+      Array.from(request.headers.entries())
+        .map(([key, value]) => `${key}=${value}`)
+        .join("\n")
+    );
   }
   return fetch(input, init);
 };

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -52,15 +52,11 @@ const cachedFetch: typeof fetch = async (input, init) => {
         // put Cache-Control from request into response
         // https://developers.cloudflare.com/workers/reference/how-the-cache-works/#cache-api
         const requestCacheControl = request.headers.get("Cache-Control");
-        const responseWithCacheControl = response.clone();
-        if (
-          !responseWithCacheControl.headers.has("Cache-Control") &&
-          requestCacheControl
-        ) {
+        response = response.clone();
+        if (!response.headers.has("Cache-Control") && requestCacheControl) {
           response.headers.append("Cache-Control", requestCacheControl);
         }
-
-        cache.put(request, responseWithCacheControl);
+        cache.put(request, response);
       }
     }
     return response;

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -44,7 +44,7 @@ import { sitemap } from "__SITEMAP__";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -54,7 +54,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -52,7 +52,7 @@ const cachedFetch: typeof fetch = async (input, init) => {
         cache.put(request, response);
       }
     }
-    return response;
+    return new Response(request.headers.get("Cache-Control") ?? "");
   }
   return fetch(input, init);
 };

--- a/packages/cli/templates/react-router/app/route-templates/html.tsx
+++ b/packages/cli/templates/react-router/app/route-templates/html.tsx
@@ -43,7 +43,7 @@ import { sitemap } from "__SITEMAP__";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return cachedFetch(input, init, projectId);
+    return cachedFetch(projectId, input, init);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -53,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return cachedFetch(input, init, projectId);
+  return cachedFetch(projectId, input, init);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/packages/cli/templates/react-router/app/route-templates/html.tsx
+++ b/packages/cli/templates/react-router/app/route-templates/html.tsx
@@ -15,6 +15,7 @@ import {
   loadResources,
   formIdFieldName,
   formBotFieldName,
+  cachedFetch,
 } from "@webstudio-is/sdk/runtime";
 import {
   ReactSdkContext,
@@ -42,7 +43,7 @@ import { sitemap } from "__SITEMAP__";
 
 const customFetch: typeof fetch = (input, init) => {
   if (typeof input !== "string") {
-    return fetch(input, init);
+    return cachedFetch(input, init, projectId);
   }
 
   if (isLocalResource(input, "sitemap.xml")) {
@@ -52,7 +53,7 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
-  return fetch(input, init);
+  return cachedFetch(input, init, projectId);
 };
 
 export const loader = async (arg: LoaderFunctionArgs) => {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -41,6 +41,7 @@
     "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {
+    "@emotion/hash": "^0.9.2",
     "@webstudio-is/css-engine": "workspace:*",
     "@webstudio-is/fonts": "workspace:*",
     "@webstudio-is/icons": "workspace:*",

--- a/packages/sdk/src/resource-loader.ts
+++ b/packages/sdk/src/resource-loader.ts
@@ -108,9 +108,9 @@ const getCacheKey = async (request: Request) => {
 };
 
 export const cachedFetch = async (
+  namespace: string,
   input: RequestInfo | URL,
-  init: RequestInit,
-  namespace: string
+  init?: RequestInit
 ) => {
   if (globalThis.caches) {
     const request = new Request(input, init);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1805,6 +1805,9 @@ importers:
 
   packages/sdk:
     dependencies:
+      '@emotion/hash':
+        specifier: ^0.9.2
+        version: 0.9.2
       '@webstudio-is/css-engine':
         specifier: workspace:*
         version: link:../css-engine


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/4077

How it works

- Cache-Control opts in caching (Cache-Control: max-age=3600)
- cached response is matched by url, method and body
- cache is invalidated with Cache-Control change
- responses stored with the cache are not replicated across regions
- responses are not shared between projects

Link for testing
https://test-cache-hcevl.wstd.work/?message=hello