### PR TITLE
feat: add search params list to resource UI

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/curl.test.ts
+++ b/apps/builder/app/builder/features/settings-panel/curl.test.ts
@@ -4,6 +4,7 @@ import { generateCurl, parseCurl, type CurlRequest } from "./curl";
 test("support url", () => {
   const result = {
     url: "https://my-url/hello-world",
+    searchParams: [],
     method: "get",
     headers: [],
   };
@@ -19,6 +20,7 @@ test("support multiline command with backslashes", () => {
   `)
   ).toEqual({
     url: "https://my-url/hello-world",
+    searchParams: [],
     method: "get",
     headers: [],
   });
@@ -27,6 +29,7 @@ test("support multiline command with backslashes", () => {
 test("forgive missing closed quotes", () => {
   expect(parseCurl(`curl "https://my-url/hello-world`)).toEqual({
     url: "https://my-url/hello-world",
+    searchParams: [],
     method: "get",
     headers: [],
   });
@@ -43,6 +46,7 @@ test("skip when invalid", () => {
 test("support method with --request and -X flags", () => {
   const result = {
     url: "https://my-url/hello-world",
+    searchParams: [],
     method: "post",
     headers: [],
   };
@@ -62,19 +66,41 @@ test("support --get and -G flags", () => {
   expect(
     parseCurl(`curl --get https://my-url --data limit=3 --data first=0`)
   ).toEqual({
-    url: "https://my-url?limit=3&first=0",
+    url: "https://my-url/",
+    searchParams: [
+      { name: "limit", value: "3" },
+      { name: "first", value: "0" },
+    ],
     method: "get",
     headers: [],
   });
   expect(parseCurl(`curl -G https://my-url -d limit=3 -d first=0`)).toEqual({
-    url: "https://my-url?limit=3&first=0",
+    url: "https://my-url/",
+    searchParams: [
+      { name: "limit", value: "3" },
+      { name: "first", value: "0" },
+    ],
     method: "get",
     headers: [],
   });
   expect(
     parseCurl(`curl -G https://my-url?filter=1 -d limit=3 -d first=0`)
   ).toEqual({
-    url: "https://my-url?filter=1&limit=3&first=0",
+    url: "https://my-url/",
+    searchParams: [
+      { name: "filter", value: "1" },
+      { name: "limit", value: "3" },
+      { name: "first", value: "0" },
+    ],
+    method: "get",
+    headers: [],
+  });
+  expect(parseCurl(`curl -G https://my-url?filter -d limit`)).toEqual({
+    url: "https://my-url/",
+    searchParams: [
+      { name: "filter", value: "" },
+      { name: "limit", value: "" },
+    ],
     method: "get",
     headers: [],
   });
@@ -85,12 +111,14 @@ test("support headers with --header and -H flags", () => {
     parseCurl(`curl https://my-url/hello-world --header "name: value"`)
   ).toEqual({
     url: "https://my-url/hello-world",
+    searchParams: [],
     method: "get",
     headers: [{ name: "name", value: "value" }],
   });
   expect(parseCurl(`curl https://my-url/hello-world -H "name: value"`)).toEqual(
     {
       url: "https://my-url/hello-world",
+      searchParams: [],
       method: "get",
       headers: [{ name: "name", value: "value" }],
     }
@@ -101,6 +129,7 @@ test("support headers with --header and -H flags", () => {
     )
   ).toEqual({
     url: "https://my-url/hello-world",
+    searchParams: [],
     method: "get",
     headers: [
       { name: "name", value: "value1" },
@@ -119,7 +148,8 @@ test("default to post method and urlencoded header when data is specified", () =
         --data-raw param=4
     `)
   ).toEqual({
-    url: "https://my-url",
+    url: "https://my-url/",
+    searchParams: [],
     method: "post",
     headers: [
       { name: "content-type", value: "application/x-www-form-urlencoded" },
@@ -132,7 +162,8 @@ test("encode data for get request", () => {
   expect(
     parseCurl(`curl -G https://my-url --data-urlencode param=привет`)
   ).toEqual({
-    url: "https://my-url?param=%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82",
+    url: "https://my-url/",
+    searchParams: [{ name: "param", value: "привет" }],
     method: "get",
     headers: [],
   });
@@ -142,7 +173,8 @@ test("encode data for post request", () => {
   expect(
     parseCurl(`curl https://my-url --data-urlencode param=привет`)
   ).toEqual({
-    url: "https://my-url",
+    url: "https://my-url/",
+    searchParams: [],
     method: "post",
     headers: [
       { name: "content-type", value: "application/x-www-form-urlencoded" },
@@ -160,6 +192,7 @@ test("support text body", () => {
     `)
   ).toEqual({
     url: "https://my-url/hello-world",
+    searchParams: [],
     method: "post",
     headers: [{ name: "content-type", value: "plain/text" }],
     body: `{"param":"value"}`,
@@ -170,6 +203,7 @@ test("support text body", () => {
     )
   ).toEqual({
     url: "https://my-url/hello-world",
+    searchParams: [],
     method: "post",
     headers: [{ name: "content-type", value: "plain/text" }],
     body: `{"param":"value"}`,
@@ -186,6 +220,7 @@ test("support text body with explicit method", () => {
     `)
   ).toEqual({
     url: "https://my-url/hello-world",
+    searchParams: [],
     method: "put",
     headers: [{ name: "content-type", value: "plain/text" }],
     body: `{"param":"value"}`,
@@ -199,6 +234,7 @@ test("support json body", () => {
     )
   ).toEqual({
     url: "https://my-url/hello-world",
+    searchParams: [],
     method: "post",
     headers: [{ name: "content-type", value: "application/json" }],
     body: { param: "value" },
@@ -213,12 +249,13 @@ test("generate curl with json body", () => {
   expect(
     generateCurl({
       url: "https://my-url.com",
+      searchParams: [],
       method: "post",
       headers: [{ name: "content-type", value: "application/json" }],
       body: { param: "value" },
     })
   ).toMatchInlineSnapshot(`
-"curl "https://my-url.com" \\
+"curl "https://my-url.com/" \\
   --request post \\
   --header "content-type: application/json" \\
   --data "{\\"param\\":\\"value\\"}""
@@ -229,12 +266,13 @@ test("generate curl with text body", () => {
   expect(
     generateCurl({
       url: "https://my-url.com",
+      searchParams: [],
       method: "post",
       headers: [],
       body: "my data",
     })
   ).toMatchInlineSnapshot(`
-"curl "https://my-url.com" \\
+"curl "https://my-url.com/" \\
   --request post \\
   --data "my data""
 `);
@@ -244,18 +282,38 @@ test("generate curl without body", () => {
   expect(
     generateCurl({
       url: "https://my-url.com",
+      searchParams: [],
       method: "post",
       headers: [],
     })
   ).toMatchInlineSnapshot(`
-"curl "https://my-url.com" \\
+"curl "https://my-url.com/" \\
   --request post"
+`);
+});
+
+test("generate curl with search params", () => {
+  expect(
+    generateCurl({
+      url: "https://my-url.com",
+      searchParams: [
+        { name: "search", value: "term1" },
+        { name: "search", value: "term2" },
+        { name: "filter", value: "привет" },
+      ],
+      method: "get",
+      headers: [],
+    })
+  ).toMatchInlineSnapshot(`
+"curl "https://my-url.com/?search=term1&search=term2&filter=%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82" \\
+  --request get"
 `);
 });
 
 test("multiline graphql is idempotent", () => {
   const request: CurlRequest = {
     url: "https://eu-central-1-shared-euc1-02.cdn.hygraph.com/content/clorhpxi8qx7r01t6hfp1b5f6/master",
+    searchParams: [],
     method: "post",
     headers: [{ name: "Content-Type", value: "application/json" }],
     body: {
@@ -276,7 +334,8 @@ test("multiline graphql is idempotent", () => {
 
 test("support basic http authentication", () => {
   expect(parseCurl(`curl https://my-url.com -u "user:password"`)).toEqual({
-    url: "https://my-url.com",
+    url: "https://my-url.com/",
+    searchParams: [],
     method: "get",
     headers: [
       {

--- a/apps/builder/app/builder/features/settings-panel/curl.ts
+++ b/apps/builder/app/builder/features/settings-panel/curl.ts
@@ -26,7 +26,7 @@ const getMethod = (value: string): ResourceRequest["method"] => {
 
 export type CurlRequest = Pick<
   ResourceRequest,
-  "url" | "method" | "headers" | "body"
+  "url" | "searchParams" | "method" | "headers" | "body"
 >;
 
 const encodeSearchParams = (data: string[]) => {
@@ -84,12 +84,18 @@ export const parseCurl = (curl: string): undefined | CurlRequest => {
     return;
   }
   // curl url
-  let url = args._[1].toString();
+  const url = new URL(args._[1].toString());
   const defaultMethod = args.data ? "post" : "get";
   const method: CurlRequest["method"] = args.get
     ? "get"
     : getMethod(args.request ?? defaultMethod);
   let contentType: undefined | string;
+  const searchParams: NonNullable<ResourceRequest["searchParams"]> = [];
+  for (const [name, value] of url.searchParams) {
+    searchParams.push({ name, value });
+  }
+  // remove all search params from url
+  url.search = "";
   const headers: ResourceRequest["headers"] = (
     (args.header as string[]) ?? []
   ).map((header) => {
@@ -105,9 +111,10 @@ export const parseCurl = (curl: string): undefined | CurlRequest => {
   }
   let body: undefined | unknown;
   if (args.get && args.data) {
-    const separator = url.includes("?") ? "&" : "?";
-    const search = encodeSearchParams(args.data);
-    url = `${url}${separator}${search}`;
+    for (const pair of args.data) {
+      const [name, value = ""] = pair.split("=");
+      searchParams.push({ name, value });
+    }
   } else if (args.data) {
     body = args.data[0];
     if (contentType === "application/json") {
@@ -126,7 +133,8 @@ export const parseCurl = (curl: string): undefined | CurlRequest => {
     }
   }
   return {
-    url: url as string,
+    url: url.toString(),
+    searchParams,
     method,
     headers,
     body,
@@ -134,10 +142,11 @@ export const parseCurl = (curl: string): undefined | CurlRequest => {
 };
 
 export const generateCurl = (request: CurlRequest) => {
-  const args = [
-    `curl ${JSON.stringify(request.url)}`,
-    `--request ${request.method}`,
-  ];
+  const url = new URL(request.url);
+  for (const { name, value } of request.searchParams) {
+    url.searchParams.append(name, value);
+  }
+  const args = [`curl ${JSON.stringify(url)}`, `--request ${request.method}`];
   for (const header of request.headers) {
     args.push(`--header "${header.name}: ${header.value}"`);
   }

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -251,6 +251,9 @@ const SearchParamPair = ({
       css={{ gridTemplateColumns: `120px 1fr min-content` }}
     >
       <InputField
+        // autofocus only new fields
+        autoFocus={name === ""}
+        placeholder="Name"
         name="search-param-name"
         value={name}
         onChange={(event) => onChange(event.target.value, value)}
@@ -263,6 +266,7 @@ const SearchParamPair = ({
       />
       <BindingControl>
         <InputField
+          placeholder="Value"
           name="search-param-value-literal"
           // expressions with variables cannot be edited
           disabled={isLiteralExpression(value) === false}
@@ -368,6 +372,9 @@ const HeaderPair = ({
       css={{ gridTemplateColumns: `120px 1fr min-content` }}
     >
       <InputField
+        // autofocus only new fields
+        autoFocus={name === ""}
+        placeholder="Name"
         name="header-name"
         value={name}
         onChange={(event) => onChange(event.target.value, value)}
@@ -375,6 +382,7 @@ const HeaderPair = ({
       <input hidden={true} readOnly={true} name="header-value" value={value} />
       <BindingControl>
         <InputField
+          placeholder="Value"
           name="header-value-validator"
           // expressions with variables cannot be edited
           disabled={isLiteralExpression(value) === false}

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -29,7 +29,6 @@ import {
 import { sitemapResourceUrl } from "@webstudio-is/sdk/runtime";
 import {
   Box,
-  Button,
   Flex,
   Grid,
   InputErrorsTooltip,

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -36,6 +36,7 @@ import {
   Label,
   Select,
   SmallIconButton,
+  Text,
   TextArea,
   Tooltip,
   theme,
@@ -345,6 +346,11 @@ export const SearchParams = ({
             }}
           />
         ))}
+        {searchParams.length === 0 && (
+          <Text color="subtle" align="center">
+            No search params
+          </Text>
+        )}
       </Grid>
     </Grid>
   );
@@ -458,6 +464,11 @@ export const Headers = ({
             }}
           />
         ))}
+        {headers.length === 0 && (
+          <Text color="subtle" align="center">
+            No headers
+          </Text>
+        )}
       </Grid>
     </Grid>
   );

--- a/apps/builder/app/shared/nano-states/props.ts
+++ b/apps/builder/app/shared/nano-states/props.ts
@@ -539,8 +539,12 @@ const computeResourceRequest = (
   const request: ResourceRequest = {
     id: resource.id,
     name: resource.name,
-    url: computeExpression(resource.url, values),
     method: resource.method,
+    url: computeExpression(resource.url, values),
+    searchParams: (resource.searchParams ?? []).map(({ name, value }) => ({
+      name,
+      value: computeExpression(value, values),
+    })),
     headers: resource.headers.map(({ name, value }) => ({
       name,
       value: computeExpression(value, values),

--- a/fixtures/webstudio-features/app/__generated__/[expressions]._index.server.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[expressions]._index.server.tsx
@@ -8,6 +8,7 @@ export const getResources = (_props: { system: System }) => {
     id: "fjMzCru8O2U31xY2P1Ovr",
     name: "jsonResourceVariable",
     url: "https://httpbin.org/get?hello=world",
+    searchParams: [],
     method: "get",
     headers: [],
   };

--- a/fixtures/webstudio-features/app/__generated__/[form]._index.server.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[form]._index.server.tsx
@@ -8,6 +8,7 @@ export const getResources = (_props: { system: System }) => {
     id: "isNSM3wXcnHFikwNPlEOL",
     name: "action",
     url: "/custom",
+    searchParams: [],
     method: "get",
     headers: [{ name: "Content-Type", value: "application/json" }],
   };

--- a/fixtures/webstudio-features/app/__generated__/[resources]._index.server.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[resources]._index.server.tsx
@@ -8,6 +8,7 @@ export const getResources = (_props: { system: System }) => {
     id: "1vX6SQdaCjJN6MvJlG_cQ",
     name: "list",
     url: "https://gist.githubusercontent.com/TrySound/56507c301ec85669db5f1541406a9259/raw/a49548730ab592c86b9e7781f5b29beec4765494/collection.json",
+    searchParams: [],
     method: "get",
     headers: [],
   };

--- a/packages/sdk/src/resource-loader.test.ts
+++ b/packages/sdk/src/resource-loader.test.ts
@@ -23,6 +23,7 @@ describe("loadResource", () => {
       id: "1",
       name: "resource",
       url: "https://example.com/resource",
+      searchParams: [],
       method: "get",
       headers: [],
       body: undefined,
@@ -55,6 +56,7 @@ describe("loadResource", () => {
       id: "1",
       name: "resource",
       url: "https://example.com/resource",
+      searchParams: [],
       method: "get",
       headers: [],
       body: undefined,
@@ -73,5 +75,35 @@ describe("loadResource", () => {
       status: 200,
       statusText: "",
     });
+  });
+
+  test("should fetch resource with search params", async () => {
+    const mockResponse = new Response(JSON.stringify({ key: "value" }), {
+      status: 200,
+    });
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const resourceRequest: ResourceRequest = {
+      id: "1",
+      name: "resource",
+      url: "https://example.com/resource",
+      searchParams: [
+        { name: "search", value: "term1" },
+        { name: "search", value: "term2" },
+        { name: "filter", value: "привет" },
+      ],
+      method: "get",
+      headers: [],
+    };
+
+    await loadResource(mockFetch, resourceRequest);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/resource?search=term1&search=term2&filter=%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82",
+      {
+        method: "get",
+        headers: new Headers(),
+      }
+    );
   });
 });

--- a/packages/sdk/src/resource-loader.ts
+++ b/packages/sdk/src/resource-loader.ts
@@ -47,7 +47,7 @@ export const loadResource = async (
     }
   }
   try {
-    const response = await customFetch(url, requestInit);
+    const response = await customFetch(url.href, requestInit);
 
     let data = await response.text();
 

--- a/packages/sdk/src/resources-generator.test.tsx
+++ b/packages/sdk/src/resources-generator.test.tsx
@@ -11,6 +11,7 @@ import {
   generateResources,
   replaceFormActionsWithResources,
 } from "./resources-generator";
+import type { DataSource } from "./schema/data-sources";
 
 const toMap = <T extends { id: string }>(list: T[]) =>
   new Map(list.map((item) => [item.id, item] as const));
@@ -48,6 +49,8 @@ test("generate resources loader", () => {
         id: "resourceId",
         name: "resourceName",
         url: "https://my-json.com",
+        searchParams: [
+        ],
         method: "post",
         headers: [
           { name: "Content-Type", value: "application/json" },
@@ -113,6 +116,8 @@ test("generate variable and use in resources loader", () => {
         id: "resourceId",
         name: "resourceName",
         url: "https://my-json.com/",
+        searchParams: [
+        ],
         method: "post",
         headers: [
           { name: "Authorization", value: "Token " + AccessToken },
@@ -158,6 +163,7 @@ test("generate page system variable and use in resources loader", () => {
           id: "resourceId",
           name: "resourceName",
           url: `"https://my-json.com/" + $ws$dataSource$variableSystemId.params.slug`,
+          searchParams: [],
           method: "post",
           headers: [{ name: "Content-Type", value: `"application/json"` }],
           body: `{ body: true }`,
@@ -173,6 +179,8 @@ test("generate page system variable and use in resources loader", () => {
         id: "resourceId",
         name: "resourceName",
         url: "https://my-json.com/" + system?.params?.slug,
+        searchParams: [
+        ],
         method: "post",
         headers: [
           { name: "Content-Type", value: "application/json" },
@@ -215,6 +223,8 @@ test("generate global system variable and use in resources loader", () => {
         id: "resource:0",
         name: "My Resource",
         url: "https://my-json.com/" + system?.params?.slug,
+        searchParams: [
+        ],
         method: "post",
         headers: [
           { name: "Content-Type", value: "application/json" },
@@ -245,6 +255,70 @@ test("generate empty resources loader", () => {
     "import type { System, ResourceRequest } from "@webstudio-is/sdk";
     export const getResources = (_props: { system: System }) => {
       const _data = new Map<string, ResourceRequest>([
+      ])
+      const _action = new Map<string, ResourceRequest>([
+      ])
+      return { data: _data, action: _action }
+    }
+    "
+  `);
+});
+
+test("generate resource loader with search params", () => {
+  expect(
+    generateResources({
+      scope: createScope(),
+      page: { rootInstanceId: "body" } as Page,
+      dataSources: toMap<DataSource>([
+        {
+          id: "variableTermId",
+          scopeInstanceId: "body",
+          type: "variable",
+          name: "term",
+          value: { type: "string", value: "my-term" },
+        },
+        {
+          id: "variableResourceId",
+          scopeInstanceId: "body",
+          type: "resource",
+          name: "variableName",
+          resourceId: "resourceId",
+        },
+      ]),
+      resources: toMap([
+        {
+          id: "resourceId",
+          name: "resourceName",
+          method: "get",
+          url: `"https://my-json.com"`,
+          searchParams: [
+            {
+              name: "search",
+              value: `$ws$dataSource$variableTermId`,
+            },
+          ],
+          headers: [],
+        },
+      ]),
+      props: new Map(),
+    })
+  ).toMatchInlineSnapshot(`
+    "import type { System, ResourceRequest } from "@webstudio-is/sdk";
+    export const getResources = (_props: { system: System }) => {
+      let term = "my-term"
+      const resourceName: ResourceRequest = {
+        id: "resourceId",
+        name: "resourceName",
+        url: "https://my-json.com",
+        searchParams: [
+          { name: "search", value: term },
+        ],
+        method: "get",
+        headers: [
+        ],
+      }
+      const _data = new Map<string, ResourceRequest>([
+        ["resourceName", resourceName],
       ])
       const _action = new Map<string, ResourceRequest>([
       ])
@@ -351,6 +425,8 @@ test("generate action resource", () => {
         id: "resourceId",
         name: "resourceName",
         url: "https://my-url.com",
+        searchParams: [
+        ],
         method: "post",
         headers: [
         ],

--- a/packages/sdk/src/resources-generator.ts
+++ b/packages/sdk/src/resources-generator.ts
@@ -36,6 +36,17 @@ export const generateResources = ({
       scope,
     });
     generatedRequest += `    url: ${url},\n`;
+    generatedRequest += `    searchParams: [\n`;
+    for (const searchParam of resource.searchParams ?? []) {
+      const value = generateExpression({
+        expression: searchParam.value,
+        dataSources,
+        usedDataSources,
+        scope,
+      });
+      generatedRequest += `      { name: "${searchParam.name}", value: ${value} },\n`;
+    }
+    generatedRequest += `    ],\n`;
     generatedRequest += `    method: "${resource.method}",\n`;
     generatedRequest += `    headers: [\n`;
     for (const header of resource.headers) {

--- a/packages/sdk/src/schema/resources.ts
+++ b/packages/sdk/src/schema/resources.ts
@@ -9,6 +9,12 @@ const Method = z.union([
   z.literal("delete"),
 ]);
 
+const SearchParam = z.object({
+  name: z.string(),
+  // expression
+  value: z.string(),
+});
+
 const Header = z.object({
   name: z.string(),
   // expression
@@ -22,6 +28,7 @@ export const Resource = z.object({
   method: Method,
   // expression
   url: z.string(),
+  searchParams: z.array(SearchParam).optional(),
   headers: z.array(Header),
   // expression
   body: z.optional(z.string()),
@@ -35,6 +42,7 @@ export const ResourceRequest = z.object({
   name: z.string(),
   method: Method,
   url: z.string(),
+  searchParams: z.array(SearchParam),
   headers: z.array(Header),
   body: z.optional(z.unknown()),
 });


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/issues/3691

Editing search params separately from url can improve experience working with external CMS or databases like baserow.

Also made headers list more compact and aligned with search params.
Validation is simplified, empty pairs will be just ignored without blocking user with validation errors.

https://github.com/user-attachments/assets/3102d2c8-a902-4e86-8011-d71346fb5491

