### PR TITLE
fix: reduce patch size to let users duplicate huge pages

### DIFF
--- a/apps/builder/app/builder/shared/sync/sync-server.ts
+++ b/apps/builder/app/builder/shared/sync/sync-server.ts
@@ -168,10 +168,18 @@ const syncServer = async function () {
         if (details.authToken) {
           headers.append("x-auth-token", details.authToken);
         }
+        // revise patches are not used on the server and reduce possible patch size
+        const optimizedTransactions = transactions.map((transaction) => ({
+          ...transaction,
+          payload: transaction.payload.map((change) => ({
+            namespace: change.namespace,
+            patches: change.patches,
+          })),
+        }));
         const response = await fetch(restPatchPath(), {
           method: "post",
           body: JSON.stringify({
-            transactions,
+            transactions: optimizedTransactions,
             buildId: details.buildId,
             projectId,
             // provide latest stored version to server

--- a/apps/builder/app/routes/rest.patch.ts
+++ b/apps/builder/app/routes/rest.patch.ts
@@ -1,6 +1,5 @@
-import { applyPatches, enableMapSet, enablePatches } from "immer";
+import { applyPatches, enableMapSet, enablePatches, type Patch } from "immer";
 import type { ActionFunctionArgs } from "@remix-run/server-runtime";
-import type { Change } from "immerhin";
 import {
   Breakpoints,
   Breakpoint,
@@ -50,6 +49,11 @@ import { publicStaticEnv } from "~/env/env.static";
 import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import { checkCsrf } from "~/services/csrf-session.server";
 import type { Transaction } from "~/shared/sync-client";
+
+type Change = {
+  namespace: string;
+  patches: Array<Patch>;
+};
 
 type PatchData = {
   transactions: Transaction<Change[]>[];


### PR DESCRIPTION
User is trying to duplicate huge page and gets "413 Content Too Large". Here I'm trying to reduce patch request size by removing revise patches which are not used on server.