### PR TITLE
fix: show resource validation error as response

### DIFF
--- a/apps/builder/app/shared/resources.ts
+++ b/apps/builder/app/shared/resources.ts
@@ -22,6 +22,7 @@ export const getResourceKey = (resource: ResourceRequest) => {
     );
   } catch {
     // guard from invalid resources
+    return "";
   }
 };
 

--- a/apps/builder/app/shared/resources.ts
+++ b/apps/builder/app/shared/resources.ts
@@ -7,18 +7,23 @@ import { fetch } from "./fetch.client";
 
 const MAX_PENDING_RESOURCES = 5;
 
-export const getResourceKey = (resource: ResourceRequest) =>
-  hash(
-    JSON.stringify([
-      // explicitly list all fields to keep hash stable
-      resource.name,
-      resource.method,
-      resource.url,
-      resource.searchParams,
-      resource.headers,
-      resource.body,
-    ])
-  );
+export const getResourceKey = (resource: ResourceRequest) => {
+  try {
+    return hash(
+      JSON.stringify([
+        // explicitly list all fields to keep hash stable
+        resource.name,
+        resource.method,
+        resource.url,
+        resource.searchParams,
+        resource.headers,
+        resource.body,
+      ])
+    );
+  } catch {
+    // guard from invalid resources
+  }
+};
 
 const queue = new Map<string, ResourceRequest>();
 const pending = new Map<string, ResourceRequest>();


### PR DESCRIPTION
Sometimes users are able to save broken resource
for example without header value. We need to prevent failing all requests and instead fail only broken one.