### PR TITLE
feat: enabling safe functions in expression engine

### DIFF
--- a/packages/sdk/src/expression.test.ts
+++ b/packages/sdk/src/expression.test.ts
@@ -418,19 +418,19 @@ describe("transpile expression", () => {
         expression: "title.toLowerCase()",
         executable: true,
       })
-    ).toEqual("title?.toLowerCase()");
+    ).toEqual("title?.toLowerCase?.()");
     expect(
       transpileExpression({
         expression: "user.name.replace(' ', '-')",
         executable: true,
       })
-    ).toEqual("user?.name?.replace(' ', '-')");
+    ).toEqual("user?.name?.replace?.(' ', '-')");
     expect(
       transpileExpression({
         expression: "data.title.split('-')",
         executable: true,
       })
-    ).toEqual("data?.title?.split('-')");
+    ).toEqual("data?.title?.split?.('-')");
   });
 
   test("transpile chained string methods with optional chaining", () => {
@@ -439,13 +439,52 @@ describe("transpile expression", () => {
         expression: "title.toLowerCase().replace(/\\s+/g, '-')",
         executable: true,
       })
-    ).toEqual("title?.toLowerCase()?.replace(/\\s+/g, '-')");
+    ).toEqual("title?.toLowerCase?.()?.replace?.(/\\s+/g, '-')");
     expect(
       transpileExpression({
         expression: "user.name.toLowerCase().replace(' ', '-').split('-')",
         executable: true,
       })
-    ).toEqual("user?.name?.toLowerCase()?.replace(' ', '-')?.split('-')");
+    ).toEqual("user?.name?.toLowerCase?.()?.replace?.(' ', '-')?.split?.('-')");
+  });
+
+  test("transpile array methods with optional chaining", () => {
+    expect(
+      transpileExpression({
+        expression: "items.map(item => item.id)",
+        executable: true,
+      })
+    ).toEqual("items?.map?.(item => item?.id)");
+    expect(
+      transpileExpression({
+        expression: "data.list.filter(x => x > 0)",
+        executable: true,
+      })
+    ).toEqual("data?.list?.filter?.(x => x > 0)");
+  });
+
+  test("transpile nested method calls with optional chaining", () => {
+    expect(
+      transpileExpression({
+        expression: "obj.method().prop.anotherMethod()",
+        executable: true,
+      })
+    ).toEqual("obj?.method?.()?.prop?.anotherMethod?.()");
+  });
+
+  test("preserve existing optional chaining", () => {
+    expect(
+      transpileExpression({
+        expression: "obj?.method?.()",
+        executable: true,
+      })
+    ).toEqual("obj?.method?.()");
+    expect(
+      transpileExpression({
+        expression: "obj?.prop?.method?.()",
+        executable: true,
+      })
+    ).toEqual("obj?.prop?.method?.()");
   });
 });
 

--- a/packages/sdk/src/expression.ts
+++ b/packages/sdk/src/expression.ts
@@ -293,6 +293,19 @@ export const transpileExpression = ({
         replacements.push([dotIndex, dotIndex, "?."]);
       }
     },
+    CallExpression(node) {
+      if (executable === false || node.optional) {
+        return;
+      }
+      // Add optional chaining to method calls: obj.method() -> obj?.method?.()
+      if (node.callee.type === "MemberExpression") {
+        // Find the opening parenthesis after the method name
+        const openParenIndex = expression.indexOf("(", node.callee.end);
+        if (openParenIndex !== -1) {
+          replacements.push([openParenIndex, openParenIndex, "?."]);
+        }
+      }
+    },
   });
   // order from the latest to the first insertion to not break other positions
   replacements.sort(([leftStart], [rightStart]) => rightStart - leftStart);


### PR DESCRIPTION
## Description

allowing toLowerCase(), replace(), and split() to be used in the expression editor. 

Real life use-case explained in the discord message. 
https://discord.com/channels/955905230107738152/1418928616648998992/1419623805541814393

## Steps for reproduction

1. use any of the mentioned functions in the expression editor
2. they're currently not allowed even though they'd be safe to use 
3. those functions (and presumably others as well) can be used in hosted webstudio by deploying my changes on a locally hosted webstudio editor, using the functions, and copying the pages containing the functions to the hosted version. 
-> validation check bypass 

## Code Review

- [x] hi @kof, I need you to do
  - conceptual review (does webstudio WANT to allow these functions?)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
