### PR TITLE
fix: Set css states on the right element

### DIFF
--- a/packages/sdk-components-react-radix/src/radio-group.ws.ts
+++ b/packages/sdk-components-react-radix/src/radio-group.ws.ts
@@ -16,10 +16,6 @@ export const metaRadioGroup: WsComponentMeta = {
     children: ["instance"],
     descendants: [radix.RadioGroupItem],
   },
-  states: [
-    { label: "Checked", selector: "[data-state=checked]" },
-    { label: "Unchecked", selector: "[data-state=unchecked]" },
-  ],
   presetStyle: {
     div,
   },
@@ -34,6 +30,10 @@ export const metaRadioGroupItem: WsComponentMeta = {
     children: ["instance"],
     descendants: [radix.RadioGroupIndicator],
   },
+  states: [
+    { label: "Checked", selector: "[data-state=checked]" },
+    { label: "Unchecked", selector: "[data-state=unchecked]" },
+  ],
   presetStyle: {
     button: [button, buttonReset].flat(),
   },
@@ -47,6 +47,10 @@ export const metaRadioGroupIndicator: WsComponentMeta = {
     category: "none",
     children: ["instance"],
   },
+  states: [
+    { label: "Checked", selector: "[data-state=checked]" },
+    { label: "Unchecked", selector: "[data-state=unchecked]" },
+  ],
   presetStyle: {
     span,
   },


### PR DESCRIPTION
## Description

Radio group route doesn't have checked/unchecked states via data-state attribute, only the button and indicator do.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
