### PR TITLE
fix: add current-date resource handler to CLI templates

### DIFF
--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -54,6 +54,24 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
+  if (isLocalResource(input, "current-date")) {
+    const now = new Date();
+    // Normalize to midnight UTC to prevent hydration mismatches
+    const startOfDay = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+    );
+    const data = {
+      iso: startOfDay.toISOString(),
+      year: startOfDay.getUTCFullYear(),
+      month: startOfDay.getUTCMonth() + 1, // 1-12 instead of 0-11
+      day: startOfDay.getUTCDate(),
+      timestamp: startOfDay.getTime(),
+    };
+    const response = new Response(JSON.stringify(data));
+    response.headers.set("content-type", "application/json; charset=utf-8");
+    return Promise.resolve(response);
+  }
+
   return cachedFetch(projectId, input, init);
 };
 

--- a/packages/cli/templates/defaults/app/route-templates/xml.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/xml.tsx
@@ -22,6 +22,24 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
+  if (isLocalResource(input, "current-date")) {
+    const now = new Date();
+    // Normalize to midnight UTC to prevent hydration mismatches
+    const startOfDay = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+    );
+    const data = {
+      iso: startOfDay.toISOString(),
+      year: startOfDay.getUTCFullYear(),
+      month: startOfDay.getUTCMonth() + 1, // 1-12 instead of 0-11
+      day: startOfDay.getUTCDate(),
+      timestamp: startOfDay.getTime(),
+    };
+    const response = new Response(JSON.stringify(data));
+    response.headers.set("content-type", "application/json; charset=utf-8");
+    return Promise.resolve(response);
+  }
+
   return fetch(input, init);
 };
 

--- a/packages/cli/templates/react-router/app/route-templates/html.tsx
+++ b/packages/cli/templates/react-router/app/route-templates/html.tsx
@@ -53,6 +53,24 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
+  if (isLocalResource(input, "current-date")) {
+    const now = new Date();
+    // Normalize to midnight UTC to prevent hydration mismatches
+    const startOfDay = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+    );
+    const data = {
+      iso: startOfDay.toISOString(),
+      year: startOfDay.getUTCFullYear(),
+      month: startOfDay.getUTCMonth() + 1, // 1-12 instead of 0-11
+      day: startOfDay.getUTCDate(),
+      timestamp: startOfDay.getTime(),
+    };
+    const response = new Response(JSON.stringify(data));
+    response.headers.set("content-type", "application/json; charset=utf-8");
+    return Promise.resolve(response);
+  }
+
   return cachedFetch(projectId, input, init);
 };
 

--- a/packages/cli/templates/react-router/app/route-templates/xml.tsx
+++ b/packages/cli/templates/react-router/app/route-templates/xml.tsx
@@ -22,6 +22,24 @@ const customFetch: typeof fetch = (input, init) => {
     return Promise.resolve(response);
   }
 
+  if (isLocalResource(input, "current-date")) {
+    const now = new Date();
+    // Normalize to midnight UTC to prevent hydration mismatches
+    const startOfDay = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+    );
+    const data = {
+      iso: startOfDay.toISOString(),
+      year: startOfDay.getUTCFullYear(),
+      month: startOfDay.getUTCMonth() + 1, // 1-12 instead of 0-11
+      day: startOfDay.getUTCDate(),
+      timestamp: startOfDay.getTime(),
+    };
+    const response = new Response(JSON.stringify(data));
+    response.headers.set("content-type", "application/json; charset=utf-8");
+    return Promise.resolve(response);
+  }
+
   return fetch(input, init);
 };
 

--- a/packages/cli/templates/ssg/app/route-templates/html/+data.ts
+++ b/packages/cli/templates/ssg/app/route-templates/html/+data.ts
@@ -1,7 +1,33 @@
 import type { PageContextServer } from "vike/types";
 import { redirect } from "vike/abort";
-import { loadResources } from "@webstudio-is/sdk/runtime";
+import { isLocalResource, loadResources } from "@webstudio-is/sdk/runtime";
 import { getPageMeta, getResources } from "__SERVER__";
+
+const customFetch: typeof fetch = (input, init) => {
+  if (typeof input !== "string") {
+    return fetch(input, init);
+  }
+
+  if (isLocalResource(input, "current-date")) {
+    const now = new Date();
+    // Normalize to midnight UTC to prevent hydration mismatches
+    const startOfDay = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+    );
+    const data = {
+      iso: startOfDay.toISOString(),
+      year: startOfDay.getUTCFullYear(),
+      month: startOfDay.getUTCMonth() + 1, // 1-12 instead of 0-11
+      day: startOfDay.getUTCDate(),
+      timestamp: startOfDay.getTime(),
+    };
+    const response = new Response(JSON.stringify(data));
+    response.headers.set("content-type", "application/json; charset=utf-8");
+    return Promise.resolve(response);
+  }
+
+  return fetch(input, init);
+};
 
 export const data = async (pageContext: PageContextServer) => {
   const url = new URL(pageContext.urlOriginal, "http://url");
@@ -18,7 +44,10 @@ export const data = async (pageContext: PageContextServer) => {
     pathname: url.pathname,
   };
 
-  const resources = await loadResources(fetch, getResources({ system }).data);
+  const resources = await loadResources(
+    customFetch,
+    getResources({ system }).data
+  );
   const pageMeta = getPageMeta({ system, resources });
 
   if (pageMeta.redirect) {


### PR DESCRIPTION
## Problem
The current-date system resource works in the Webstudio builder but fails in published sites with "dateTime attribute is not set" errors.

## Root Cause
The CLI templates' `customFetch` functions handle the `sitemap.xml` local resource but don't handle the `current-date` resource, causing fetch requests to fail when sites are published.

## Solution
Added `current-date` handler to all CLI template `customFetch` functions, following the same pattern as the existing `sitemap.xml` handler.

## Changes
- Add current-date handler to Remix HTML/XML templates
- Add current-date handler to React Router HTML/XML templates  
- Add customFetch with current-date handler to SSG template
- Normalize dates to midnight UTC to prevent hydration mismatches

## Testing
The fix ensures that when the Time component uses `system.currentDate`, it will work correctly in published sites, not just in the builder.
