### PR TITLE
fix: remove unnecessary border-width from preset styles

### DIFF
--- a/fixtures/react-router-cloudflare/app/__generated__/index.css
+++ b/fixtures/react-router-cloudflare/app/__generated__/index.css
@@ -10,47 +10,23 @@
   }
   body.w-body {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin: 0;
   }
   h1.w-heading {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   div.w-text {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     min-height: 1em;
   }
   a.w-link {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     display: inline-block;
   }
   img.w-image {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     max-width: 100%;
     display: block;
     height: auto;

--- a/fixtures/react-router-docker/app/__generated__/index.css
+++ b/fixtures/react-router-docker/app/__generated__/index.css
@@ -10,47 +10,23 @@
   }
   body.w-body {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin: 0;
   }
   h1.w-heading {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   div.w-text {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     min-height: 1em;
   }
   a.w-link {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     display: inline-block;
   }
   img.w-image {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     max-width: 100%;
     display: block;
     height: auto;

--- a/fixtures/react-router-netlify/app/__generated__/index.css
+++ b/fixtures/react-router-netlify/app/__generated__/index.css
@@ -10,47 +10,23 @@
   }
   body.w-body {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin: 0;
   }
   h1.w-heading {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   div.w-text {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     min-height: 1em;
   }
   a.w-link {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     display: inline-block;
   }
   img.w-image {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     max-width: 100%;
     display: block;
     height: auto;

--- a/fixtures/react-router-vercel/app/__generated__/index.css
+++ b/fixtures/react-router-vercel/app/__generated__/index.css
@@ -10,47 +10,23 @@
   }
   body.w-body {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin: 0;
   }
   h1.w-heading {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   div.w-text {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     min-height: 1em;
   }
   a.w-link {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     display: inline-block;
   }
   img.w-image {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     max-width: 100%;
     display: block;
     height: auto;

--- a/fixtures/ssg-netlify-by-project-id/app/__generated__/index.css
+++ b/fixtures/ssg-netlify-by-project-id/app/__generated__/index.css
@@ -10,20 +10,11 @@
   }
   body.w-body {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin: 0;
   }
   h1.w-heading {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
 }

--- a/fixtures/ssg/app/__generated__/index.css
+++ b/fixtures/ssg/app/__generated__/index.css
@@ -10,47 +10,23 @@
   }
   body.w-body {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin: 0;
   }
   h1.w-heading {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   div.w-text {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     min-height: 1em;
   }
   a.w-link {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     display: inline-block;
   }
   img.w-image {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     max-width: 100%;
     display: block;
     height: auto;

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/index.css
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/index.css
@@ -10,47 +10,23 @@
   }
   body.w-body {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin: 0;
   }
   h1.w-heading {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   div.w-text {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     min-height: 1em;
   }
   a.w-link {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     display: inline-block;
   }
   img.w-image {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     max-width: 100%;
     display: block;
     height: auto;

--- a/fixtures/webstudio-features/app/__generated__/index.css
+++ b/fixtures/webstudio-features/app/__generated__/index.css
@@ -10,106 +10,47 @@
   }
   a.w-element {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   body.w-body {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin: 0;
   }
   h1.w-heading {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   h3.w-heading {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   div.w-box {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   p.w-paragraph {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   img.w-image {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     max-width: 100%;
     display: block;
     height: auto;
   }
   a.w-link {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     display: inline-block;
   }
   div.w-text {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     min-height: 1em;
   }
   div.w-accordion {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   div.w-item {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   h3.w-item-header {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     margin-top: 0px;
     margin-bottom: 0px;
   }
@@ -132,27 +73,12 @@
   }
   div.w-item-content {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   form.w-webhook-form {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
   label.w-input-label {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
     display: block;
   }
   input.w-text-input {
@@ -160,10 +86,6 @@
     font-size: 100%;
     line-height: 1.15;
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -176,10 +98,6 @@
     font-size: 100%;
     line-height: 1.15;
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
     border-top-style: solid;
     border-right-style: solid;
     border-bottom-style: solid;
@@ -189,11 +107,6 @@
   }
   div.w-text-animation {
     box-sizing: border-box;
-    border-top-width: 1px;
-    border-right-width: 1px;
-    border-bottom-width: 1px;
-    border-left-width: 1px;
-    outline-width: 1px;
   }
 }
 @media all {

--- a/packages/sdk/src/__generated__/normalize.css.ts
+++ b/packages/sdk/src/__generated__/normalize.css.ts
@@ -8,23 +8,6 @@ type StyleDecl = {
 
 export const div: StyleDecl[] = [
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  { property: "outline-width", value: { type: "unit", unit: "px", value: 1 } },
 ];
 
 export const address = div;
@@ -113,22 +96,6 @@ export const body: StyleDecl[] = [
   },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
   {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
     property: "-webkit-font-smoothing",
     value: { type: "keyword", value: "antialiased" },
   },
@@ -150,22 +117,6 @@ export const b: StyleDecl[] = [
     value: { type: "unit", unit: "number", value: 700 },
   },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
 ];
 
 export const strong = b;
@@ -187,22 +138,6 @@ export const code: StyleDecl[] = [
   },
   { property: "font-size", value: { type: "unit", unit: "em", value: 1 } },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
 ];
 
 export const kbd = code;
@@ -214,22 +149,6 @@ export const pre = code;
 export const small: StyleDecl[] = [
   { property: "font-size", value: { type: "unit", unit: "%", value: 80 } },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
 ];
 
 export const sub: StyleDecl[] = [
@@ -241,22 +160,6 @@ export const sub: StyleDecl[] = [
   { property: "position", value: { type: "keyword", value: "relative" } },
   { property: "vertical-align", value: { type: "keyword", value: "baseline" } },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
   { property: "bottom", value: { type: "unit", unit: "em", value: -0.25 } },
 ];
 
@@ -269,22 +172,6 @@ export const sup: StyleDecl[] = [
   { property: "position", value: { type: "keyword", value: "relative" } },
   { property: "vertical-align", value: { type: "keyword", value: "baseline" } },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
   { property: "top", value: { type: "unit", unit: "em", value: -0.5 } },
 ];
 
@@ -292,22 +179,6 @@ export const table: StyleDecl[] = [
   {
     property: "text-indent",
     value: { type: "unit", unit: "number", value: 0 },
-  },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
   },
   {
     property: "border-top-color",
@@ -349,22 +220,6 @@ export const input: StyleDecl[] = [
     value: { type: "unit", unit: "number", value: 0 },
   },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
   { property: "border-top-style", value: { type: "keyword", value: "solid" } },
   {
     property: "border-right-style",
@@ -400,22 +255,6 @@ export const optgroup: StyleDecl[] = [
     value: { type: "unit", unit: "number", value: 0 },
   },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
 ];
 
 export const radio: StyleDecl[] = [
@@ -439,22 +278,6 @@ export const radio: StyleDecl[] = [
     value: { type: "unit", unit: "number", value: 0 },
   },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
   { property: "border-top-style", value: { type: "keyword", value: "none" } },
   { property: "border-right-style", value: { type: "keyword", value: "none" } },
   {
@@ -487,22 +310,6 @@ export const button: StyleDecl[] = [
     value: { type: "unit", unit: "number", value: 0 },
   },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
   { property: "border-top-style", value: { type: "keyword", value: "solid" } },
   {
     property: "border-right-style",
@@ -536,62 +343,14 @@ export const legend: StyleDecl[] = [
     value: { type: "unit", unit: "number", value: 0 },
   },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
 ];
 
 export const progress: StyleDecl[] = [
   { property: "vertical-align", value: { type: "keyword", value: "baseline" } },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
 ];
 
 export const summary: StyleDecl[] = [
   { property: "display", value: { type: "keyword", value: "list-item" } },
   { property: "box-sizing", value: { type: "keyword", value: "border-box" } },
-  {
-    property: "border-top-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-right-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-bottom-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
-  {
-    property: "border-left-width",
-    value: { type: "unit", unit: "px", value: 1 },
-  },
 ];

--- a/packages/sdk/src/normalize.css
+++ b/packages/sdk/src/normalize.css
@@ -55,9 +55,6 @@ span {
    * Use a better box model (opinionated).
    */
   box-sizing: border-box;
-  /* webstudio custom opinionated presets */
-  border-width: 1px;
-  outline-width: 1px;
 }
 
 /**
@@ -91,7 +88,6 @@ body {
   margin: 0;
   /* webstudio custom opinionated presets */
   box-sizing: border-box;
-  border-width: 1px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -128,7 +124,6 @@ strong {
   font-weight: 700;
   /* webstudio custom opinionated presets */
   box-sizing: border-box;
-  border-width: 1px;
 }
 
 /**
@@ -146,7 +141,6 @@ pre {
   font-size: 1em;
   /* webstudio custom opinionated presets */
   box-sizing: border-box;
-  border-width: 1px;
 }
 
 /**
@@ -156,7 +150,6 @@ small {
   font-size: 80%;
   /* webstudio custom opinionated presets */
   box-sizing: border-box;
-  border-width: 1px;
 }
 
 /**
@@ -170,7 +163,6 @@ sup {
   vertical-align: baseline;
   /* webstudio custom opinionated presets */
   box-sizing: border-box;
-  border-width: 1px;
 }
 
 sub {
@@ -193,7 +185,6 @@ Tabular data
 table {
   /* 1 */
   text-indent: 0;
-  border-width: 1px;
   /* 2 */
   border-color: inherit;
   box-sizing: border-box;
@@ -220,7 +211,6 @@ select {
   margin: 0;
   /* webstudio custom opinionated presets */
   box-sizing: border-box;
-  border-width: 1px;
 }
 
 /* Input and Textarea uses border style inset by default, wich we don't support in style panel. */
@@ -300,7 +290,6 @@ legend {
   padding: 0;
   /* webstudio custom opinionated presets */
   box-sizing: border-box;
-  border-width: 1px;
 }
 
 /**
@@ -310,7 +299,6 @@ progress {
   vertical-align: baseline;
   /* webstudio custom opinionated presets */
   box-sizing: border-box;
-  border-width: 1px;
 }
 
 /**
@@ -370,5 +358,4 @@ summary {
   display: list-item;
   /* webstudio custom opinionated presets */
   box-sizing: border-box;
-  border-width: 1px;
 }


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio/issues/5451

We used this to not confuse users with "medium" value but it heavily bloats resulting css and does affect much UX.

<img width="241" height="527" alt="image" src="https://github.com/user-attachments/assets/0be935a4-d563-4ae8-90e6-6c8bc7eedd11" />
