### PR TITLE
Enable HSL/OKLCH/Lab formats across color parsing and UI

### DIFF
--- a/@types/culori/index.d.ts
+++ b/@types/culori/index.d.ts
@@ -1,0 +1,5 @@
+declare module "culori" {
+  export function converter(mode: string): (color: unknown) => unknown;
+  export function parse(input: string): unknown;
+  export function formatCss(color: unknown): string | undefined;
+}

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -36,6 +36,7 @@
     "change-case": "^5.4.4",
     "colord": "^2.9.3",
     "css-tree": "^3.1.0",
+    "culori": "^4.0.2",
     "openai": "^3.2.1",
     "p-retry": "^6.2.1",
     "warn-once": "^0.1.1"

--- a/packages/css-data/src/color.ts
+++ b/packages/css-data/src/color.ts
@@ -1,0 +1,127 @@
+import { converter, formatCss, parse } from "culori";
+import type { RgbValue } from "@webstudio-is/css-engine";
+
+const toRgb = converter("rgb");
+
+export type ParsedColor = RgbValue & {
+  colorSpace?: string;
+  original?: string;
+};
+
+const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+
+const toByte = (value: number) => Math.round(clamp01(value) * 255);
+
+/**
+ * Parse arbitrary CSS color strings (CSS Color 4/5) into an RGB representation.
+ * Keeps the source color space and a normalized string so we can round-trip.
+ */
+export const parseCssColor = (input: string): ParsedColor | undefined => {
+  const normalizedInput = input.trim();
+  if (normalizedInput.length === 0) {
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parse(normalizedInput);
+  } catch {
+    return;
+  }
+
+  if (parsed === undefined || parsed === null) {
+    return;
+  }
+
+  const rgbResult = toRgb(parsed);
+  if (
+    rgbResult === undefined ||
+    rgbResult === null ||
+    typeof rgbResult !== "object"
+  ) {
+    return;
+  }
+
+  const {
+    r,
+    g,
+    b,
+    alpha: alphaValue,
+  } = rgbResult as {
+    r?: number;
+    g?: number;
+    b?: number;
+    alpha?: number;
+  };
+
+  if (typeof r !== "number" || typeof g !== "number" || typeof b !== "number") {
+    return;
+  }
+
+  const alpha = Number(clamp01(alphaValue ?? 1).toFixed(2));
+  const formatted = typeof parsed === "object" ? formatCss(parsed) : undefined;
+
+  const color: ParsedColor = {
+    type: "rgb",
+    r: toByte(r),
+    g: toByte(g),
+    b: toByte(b),
+    alpha,
+  };
+
+  const mode =
+    typeof parsed === "object" && parsed !== null && "mode" in parsed
+      ? (parsed as { mode?: string }).mode
+      : undefined;
+
+  if (mode && mode !== "rgb") {
+    color.colorSpace = mode;
+  }
+
+  if (mode && mode !== "rgb") {
+    color.original = formatted ?? normalizedInput;
+  }
+
+  return color;
+};
+
+/**
+ * Serialize an RGB color, optionally preserving the source color space when provided.
+ */
+export const formatRgbColor = (
+  color: ParsedColor,
+  preferredColorSpace?: string
+): string => {
+  const targetSpace = preferredColorSpace ?? color.colorSpace;
+  if (color.original && preferredColorSpace === color.colorSpace) {
+    return color.original;
+  }
+
+  const rgbColor = {
+    mode: "rgb",
+    r: clamp01(color.r / 255),
+    g: clamp01(color.g / 255),
+    b: clamp01(color.b / 255),
+    alpha: clamp01(color.alpha),
+  };
+
+  if (targetSpace) {
+    try {
+      const toPreferred = converter(targetSpace);
+      const converted = toPreferred(rgbColor);
+      const formattedPreferred = formatCss(converted);
+      if (formattedPreferred) {
+        return formattedPreferred;
+      }
+    } catch {
+      // If the color space is not supported, fall back to RGBA below.
+    }
+  }
+
+  const formatted = formatCss(rgbColor);
+  if (formatted) {
+    return formatted;
+  }
+
+  return `rgba(${color.r}, ${color.g}, ${color.b}, ${color.alpha})`;
+};

--- a/packages/css-data/src/culori.d.ts
+++ b/packages/css-data/src/culori.d.ts
@@ -1,0 +1,6 @@
+declare module "culori" {
+  // Minimal surface we use; culori ships JS only.
+  export function converter(mode: string): (color: unknown) => unknown;
+  export function parse(input: string): unknown;
+  export function formatCss(color: unknown): string | undefined;
+}

--- a/packages/css-data/src/index.ts
+++ b/packages/css-data/src/index.ts
@@ -17,3 +17,4 @@ export * from "./shorthands";
 export { shorthandProperties } from "./__generated__/shorthand-properties";
 
 export { properties as propertiesData } from "./__generated__/properties";
+export * from "./color";

--- a/packages/css-data/src/parse-css-value.test.ts
+++ b/packages/css-data/src/parse-css-value.test.ts
@@ -132,6 +132,15 @@ describe("Parse CSS value", () => {
         value: "red",
       });
     });
+
+    test("Supports OKLCH values", () => {
+      expect(parseCssValue("color", "oklch(0.7 0.12 45 / 0.8)")).toMatchObject({
+        type: "rgb",
+        alpha: 0.8,
+        colorSpace: "oklch",
+        original: "oklch(0.7 0.12 45 / 0.8)",
+      });
+    });
   });
 });
 

--- a/packages/css-data/src/property-parsers/gradient-utils.ts
+++ b/packages/css-data/src/property-parsers/gradient-utils.ts
@@ -6,11 +6,8 @@ import {
   type VarValue,
   toValue,
 } from "@webstudio-is/css-engine";
-import { colord, extend } from "colord";
-import namesPlugin from "colord/plugins/names";
 import type { GradientColorValue, GradientStop } from "./types";
-
-extend([namesPlugin]);
+import { parseCssColor } from "../color";
 
 export const angleUnitIdentifiers = ["deg", "grad", "rad", "turn"] as const;
 const angleUnitSet = new Set<string>(angleUnitIdentifiers);
@@ -119,16 +116,9 @@ export const getColor = (
     return parsed;
   }
   if (parsed.type === "keyword") {
-    const color = colord(parsed.value);
-    if (color.isValid()) {
-      const { r, g, b, a } = color.toRgb();
-      return {
-        type: "rgb",
-        r,
-        g,
-        b,
-        alpha: a,
-      } satisfies GradientColorValue;
+    const color = parseCssColor(parsed.value);
+    if (color) {
+      return color as GradientColorValue;
     }
   }
 };

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -22,6 +22,18 @@ describe("Convert WS CSS Values to native CSS strings", () => {
     expect(value).toBe("");
   });
 
+  test("rgb preserves original string when provided", () => {
+    const value = toValue({
+      type: "rgb",
+      r: 10,
+      g: 20,
+      b: 30,
+      alpha: 0.5,
+      original: "oklch(0.5 0.05 90 / 0.5)",
+    });
+    expect(value).toBe("oklch(0.5 0.05 90 / 0.5)");
+  });
+
   test("var", () => {
     const value = toValue({ type: "var", value: "namespace" });
     expect(value).toBe("var(--namespace)");

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -84,6 +84,9 @@ export const toValue = (
   }
 
   if (value.type === "rgb") {
+    if (value.original) {
+      return value.original;
+    }
     return `rgba(${value.r}, ${value.g}, ${value.b}, ${value.alpha})`;
   }
 

--- a/packages/css-engine/src/schema.ts
+++ b/packages/css-engine/src/schema.ts
@@ -60,6 +60,10 @@ const RgbValue = z.object({
   g: z.number(),
   b: z.number(),
   alpha: z.number(),
+  // Optional color space metadata used to preserve user intent when parsing CSS Color 4/5 formats.
+  colorSpace: z.string().optional(),
+  // Original CSS color string, used to round-trip non-rgb formats without losing fidelity.
+  original: z.string().optional(),
   hidden: z.boolean().optional(),
 });
 export type RgbValue = z.infer<typeof RgbValue>;

--- a/packages/design-system/src/components/gradient-picker.tsx
+++ b/packages/design-system/src/components/gradient-picker.tsx
@@ -18,6 +18,7 @@ import {
   type GradientStop,
   type ParsedGradient,
 } from "@webstudio-is/css-data";
+import { parseCssColor } from "@webstudio-is/css-data";
 import { colord, extend } from "colord";
 import mixPlugin from "colord/plugins/mix";
 import { ChevronFilledUpIcon } from "@webstudio-is/icons";
@@ -66,16 +67,9 @@ const toRgbColor = (
     return color;
   }
 
-  const parsed = colord(toValue(color));
-  if (parsed.isValid()) {
-    const { r, g, b, a } = parsed.toRgb();
-    return {
-      type: "rgb",
-      r,
-      g,
-      b,
-      alpha: a,
-    };
+  const parsed = parseCssColor(toValue(color));
+  if (parsed) {
+    return parsed;
   }
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1234,6 +1234,9 @@ importers:
       css-tree:
         specifier: ^3.1.0
         version: 3.1.0
+      culori:
+        specifier: ^4.0.2
+        version: 4.0.2
       openai:
         specifier: ^3.2.1
         version: 3.2.1
@@ -6118,6 +6121,10 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  culori@4.0.2:
+    resolution: {integrity: sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
@@ -13551,6 +13558,8 @@ snapshots:
     optional: true
 
   csstype@3.1.3: {}
+
+  culori@4.0.2: {}
 
   data-uri-to-buffer@2.0.2: {}
 


### PR DESCRIPTION
## Description
- Implements CSS Color 4/5 support across parsing, schema, and UI (Color Picker + Gradient Picker), including hsl/oklch/lab/etc. parsing/round-tripping.
- Adds format switcher and validation polish to the Color Picker.
- Issue: https://github.com/webstudio-is/webstudio/issues/3574

## Steps for reproduction
1. Open the style panel color picker.
2. Enter colors in various formats: `hsl(200 50% 40% / 0.6)`, `oklch(0.7 0.12 45)`, `lab(54% -12 32)`, `#00220011`.
3. Toggle formats via the switcher and verify the color stays consistent and is rendered correctly.
4. Enter an invalid string (e.g., `not-a-color`) and observe validation feedback.

## Code Review
- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review
- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what") — not added (code is straightforward)

## Before merging
- [x] tested locally (dev build) — works as expected
- [ ] tested on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [x] added/updated tests (css-data parse tests, css-engine to-value test)
- [n/a] if any new env variables are added, added them to `.env` file (none)
