### PR TITLE
feat: add JSON-LD Schema Markup with AI generation

### DIFF
--- a/apps/builder/app/builder/features/pages/schema-markup.tsx
+++ b/apps/builder/app/builder/features/pages/schema-markup.tsx
@@ -1,0 +1,407 @@
+import { useState } from "react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Flex,
+  Grid,
+  Label,
+  SmallIconButton,
+  Text,
+  theme,
+  Tooltip,
+} from "@webstudio-is/design-system";
+import {
+  TrashIcon,
+  PlusIcon,
+  InfoCircleIcon,
+  AiIcon,
+  AiLoadingIcon,
+  ChevronDownIcon,
+  AlertIcon,
+} from "@webstudio-is/icons";
+import { CodeEditor } from "~/builder/shared/code-editor";
+import { trpcClient } from "~/shared/trpc/trpc-client";
+
+type Script = {
+  type: "application/ld+json";
+  content: string;
+};
+
+type PageContext = {
+  pageName: string;
+  pageTitle: string;
+  pageDescription?: string;
+  siteName?: string;
+  siteUrl?: string;
+  pagePath?: string;
+  contactEmail?: string;
+  language?: string;
+  socialImageUrl?: string;
+};
+
+type SchemaMarkupProps = {
+  schemaMarkup: Script[];
+  onChange: (value: Script[]) => void;
+  pageContext: PageContext;
+};
+
+const defaultJsonLd = `{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "",
+  "url": ""
+}`;
+
+const schemaTypes = [
+  { value: "Organization", label: "Organization" },
+  { value: "LocalBusiness", label: "Local Business" },
+  { value: "Article", label: "Article" },
+  { value: "BlogPosting", label: "Blog Posting" },
+  { value: "Product", label: "Product" },
+  { value: "Event", label: "Event" },
+  { value: "FAQPage", label: "FAQ Page" },
+  { value: "HowTo", label: "How To" },
+  { value: "Person", label: "Person" },
+  { value: "WebSite", label: "Web Site" },
+  { value: "WebPage", label: "Web Page" },
+  { value: "BreadcrumbList", label: "Breadcrumb List" },
+  { value: "Review", label: "Review" },
+  { value: "Recipe", label: "Recipe" },
+  { value: "Course", label: "Course" },
+  { value: "JobPosting", label: "Job Posting" },
+  { value: "SoftwareApplication", label: "Software Application" },
+  { value: "VideoObject", label: "Video Object" },
+] as const;
+
+type SchemaType = (typeof schemaTypes)[number]["value"];
+
+const validateJsonLd = (content: string): string | undefined => {
+  if (content.trim() === "") {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(content);
+    if (typeof parsed !== "object" || parsed === null) {
+      return "JSON-LD must be an object";
+    }
+    if (!parsed["@context"]) {
+      return "JSON-LD should include @context";
+    }
+    if (!parsed["@type"]) {
+      return "JSON-LD should include @type";
+    }
+    return undefined;
+  } catch {
+    return "Invalid JSON syntax";
+  }
+};
+
+const getSchemaType = (content: string): string | undefined => {
+  try {
+    const parsed = JSON.parse(content);
+    return parsed["@type"];
+  } catch {
+    return undefined;
+  }
+};
+
+// Schema types that should only appear once per page
+// These represent singular entities that don't make sense to duplicate
+const singletonSchemaTypes = new Set([
+  "Organization",
+  "LocalBusiness",
+  "WebSite",
+  "WebPage",
+  "Person",
+  "FAQPage",
+  "BreadcrumbList",
+  "HowTo",
+  "Course",
+  "SoftwareApplication",
+]);
+
+const findDuplicateSchemaTypes = (scripts: Script[]): Map<string, number> => {
+  const typeCounts = new Map<string, number>();
+
+  for (const script of scripts) {
+    const schemaType = getSchemaType(script.content);
+    if (schemaType) {
+      typeCounts.set(schemaType, (typeCounts.get(schemaType) ?? 0) + 1);
+    }
+  }
+
+  // Return only singleton types that appear more than once
+  const duplicates = new Map<string, number>();
+  for (const [type, count] of typeCounts) {
+    if (count > 1 && singletonSchemaTypes.has(type)) {
+      duplicates.set(type, count);
+    }
+  }
+  return duplicates;
+};
+
+const ScriptItem = (props: {
+  content: string;
+  onDelete: () => void;
+  onChange: (content: string) => void;
+}) => {
+  const [localContent, setLocalContent] = useState(props.content);
+  const validationError = validateJsonLd(localContent);
+
+  return (
+    <Grid
+      gap={2}
+      css={{
+        padding: theme.spacing[4],
+        borderRadius: theme.borderRadius[4],
+        border: `1px solid ${validationError ? theme.colors.borderDestructiveMain : theme.colors.borderMain}`,
+        background: theme.colors.backgroundPanel,
+      }}
+    >
+      <Grid
+        flow="column"
+        gap={2}
+        align="center"
+        justify="between"
+        css={{ gridTemplateColumns: "1fr auto" }}
+      >
+        <Label>JSON-LD Schema</Label>
+        <SmallIconButton
+          variant="destructive"
+          icon={<TrashIcon />}
+          onClick={props.onDelete}
+          aria-label="Delete script"
+        />
+      </Grid>
+
+      <CodeEditor
+        lang="json"
+        title="JSON-LD Schema"
+        value={localContent}
+        onChange={(value) => {
+          setLocalContent(value);
+        }}
+        onChangeComplete={(value) => {
+          setLocalContent(value);
+          props.onChange(value);
+        }}
+      />
+
+      {validationError && (
+        <Text color="destructive" variant="small">
+          {validationError}
+        </Text>
+      )}
+    </Grid>
+  );
+};
+
+const useGenerateSchema = () => {
+  const { send, state, error } = trpcClient.ai.generateSchema.useMutation();
+  const isLoading = state === "submitting";
+
+  const generate = (
+    schemaType: SchemaType,
+    pageContext: PageContext,
+    onSuccess: (content: string) => void
+  ) => {
+    send(
+      {
+        schemaType,
+        pageContext: {
+          pageName: pageContext.pageName,
+          pageTitle: pageContext.pageTitle,
+          pageDescription: pageContext.pageDescription,
+          siteName: pageContext.siteName,
+          siteUrl: pageContext.siteUrl,
+          pagePath: pageContext.pagePath,
+          contactEmail: pageContext.contactEmail,
+          language: pageContext.language,
+          socialImageUrl: pageContext.socialImageUrl,
+        },
+      },
+      (generatedSchema: string) => {
+        onSuccess(generatedSchema);
+      }
+    );
+  };
+
+  return { generate, isLoading, error };
+};
+
+const GenerateWithAiButton = ({
+  isLoading,
+  onSelectType,
+}: {
+  isLoading: boolean;
+  onSelectType: (schemaType: SchemaType) => void;
+}) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          color="gradient"
+          disabled={isLoading}
+          css={{
+            justifySelf: "center",
+          }}
+          prefix={isLoading ? <AiLoadingIcon /> : <AiIcon />}
+          suffix={<ChevronDownIcon />}
+        >
+          {isLoading ? "Generating..." : "Generate with AI"}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        sideOffset={4}
+        css={{
+          maxHeight: 300,
+          overflowY: "auto",
+        }}
+      >
+        {schemaTypes.map(({ value, label }) => (
+          <DropdownMenuItem
+            key={value}
+            onSelect={() => onSelectType(value)}
+            disabled={isLoading}
+          >
+            {label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export const SchemaMarkup = (props: SchemaMarkupProps) => {
+  const { generate, isLoading, error } = useGenerateSchema();
+
+  const handleAiGenerate = (schemaType: SchemaType) => {
+    generate(schemaType, props.pageContext, (content) => {
+      const newSchemaMarkup = [
+        ...props.schemaMarkup,
+        { type: "application/ld+json" as const, content },
+      ];
+      props.onChange(newSchemaMarkup);
+    });
+  };
+
+  const duplicateTypes = findDuplicateSchemaTypes(props.schemaMarkup);
+
+  return (
+    <Grid gap={2} css={{ my: theme.spacing[5], mx: theme.spacing[8] }}>
+      <Grid flow="column" gap={1} justify="start" align="center">
+        <Label text="title">Schema Markup</Label>
+        <Tooltip
+          variant="wrapped"
+          content={
+            <Text>
+              Add JSON-LD structured data to help search engines understand your
+              page content. This can improve SEO and enable rich results in
+              search.{" "}
+              <Text
+                as="a"
+                href="https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data"
+                target="_blank"
+                rel="noopener noreferrer"
+                css={{ color: "inherit", textDecoration: "underline" }}
+              >
+                Learn more
+              </Text>
+            </Text>
+          }
+        >
+          <InfoCircleIcon tabIndex={0} />
+        </Tooltip>
+      </Grid>
+      <Text color="subtle">
+        Add structured data using JSON-LD format to improve how search engines
+        and AI tools understand your page content. Use AI to generate schemas or
+        add them manually.
+      </Text>
+
+      {duplicateTypes.size > 0 && (
+        <Flex
+          gap={2}
+          align="start"
+          css={{
+            padding: theme.spacing[5],
+            borderRadius: theme.borderRadius[4],
+            background: theme.colors.backgroundAlertNotification,
+            border: `1px solid ${theme.colors.backgroundAlertMain}`,
+          }}
+        >
+          <AlertIcon
+            color={theme.colors.backgroundAlertMain}
+            style={{ flexShrink: 0, marginTop: 2 }}
+          />
+          <Text variant="small">
+            <Text variant="small" as="span" css={{ fontWeight: 600 }}>
+              Duplicate schema types detected:
+            </Text>{" "}
+            {Array.from(duplicateTypes.entries())
+              .map(([type, count]) => `${type} (${count}×)`)
+              .join(", ")}
+            . Having multiple schemas of the same type on one page may confuse
+            search engines.
+          </Text>
+        </Flex>
+      )}
+
+      {error && (
+        <Text color="destructive" variant="small">
+          {error}
+        </Text>
+      )}
+
+      <Grid gap={3}>
+        {props.schemaMarkup.map((script, index) => (
+          <ScriptItem
+            key={index}
+            content={script.content}
+            onChange={(content) => {
+              const newSchemaMarkup = [...props.schemaMarkup];
+              newSchemaMarkup[index] = {
+                type: "application/ld+json",
+                content,
+              };
+              props.onChange(newSchemaMarkup);
+            }}
+            onDelete={() => {
+              const newSchemaMarkup = [...props.schemaMarkup];
+              newSchemaMarkup.splice(index, 1);
+              props.onChange(newSchemaMarkup);
+            }}
+          />
+        ))}
+
+        <Grid flow="column" gap={2} justify="center" align="center">
+          <GenerateWithAiButton
+            isLoading={isLoading}
+            onSelectType={handleAiGenerate}
+          />
+          <Button
+            type="button"
+            color="neutral"
+            prefix={<PlusIcon />}
+            onClick={() => {
+              const newSchemaMarkup = [
+                ...props.schemaMarkup,
+                {
+                  type: "application/ld+json" as const,
+                  content: defaultJsonLd,
+                },
+              ];
+              props.onChange(newSchemaMarkup);
+            }}
+          >
+            Add manually
+          </Button>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};

--- a/apps/builder/app/builder/shared/code-editor.tsx
+++ b/apps/builder/app/builder/shared/code-editor.tsx
@@ -26,6 +26,7 @@ import {
 } from "@codemirror/autocomplete";
 import { html } from "@codemirror/lang-html";
 import { markdown } from "@codemirror/lang-markdown";
+import { json } from "@codemirror/lang-json";
 import { css } from "@webstudio-is/design-system";
 import {
   EditorContent,
@@ -115,10 +116,24 @@ const getCssPropertiesExtensions = () => [
   autocompletion({ icons: false }),
 ];
 
+const getJsonExtensions = () => [
+  highlightActiveLine(),
+  highlightSpecialChars(),
+  indentOnInput(),
+  json(),
+  bracketMatching(),
+  closeBrackets(),
+  // render autocomplete in body
+  // to prevent popover scroll overflow
+  tooltips({ parent: document.body }),
+  autocompletion({ icons: false }),
+  keymap.of([...closeBracketsKeymap, ...completionKeymap]),
+];
+
 export const CodeEditor = forwardRef<
   HTMLDivElement,
   Omit<ComponentProps<typeof EditorContent>, "extensions"> & {
-    lang?: "html" | "markdown" | "css-properties";
+    lang?: "html" | "markdown" | "css-properties" | "json";
     title?: ReactNode;
     size?: "default" | "small";
   }
@@ -134,6 +149,10 @@ export const CodeEditor = forwardRef<
 
     if (lang === "css-properties") {
       return getCssPropertiesExtensions();
+    }
+
+    if (lang === "json") {
+      return getJsonExtensions();
     }
 
     if (lang === undefined) {

--- a/apps/builder/app/env/env.server.ts
+++ b/apps/builder/app/env/env.server.ts
@@ -64,6 +64,10 @@ const env = {
   POSTGREST_URL: process.env.POSTGREST_URL ?? "http://localhost:3000",
   POSTGREST_API_KEY: process.env.POSTGREST_API_KEY ?? "",
 
+  // AI Features (OpenAI)
+  OPENAI_KEY: process.env.OPENAI_KEY,
+  OPENAI_ORG: process.env.OPENAI_ORG,
+
   SECURE_COOKIE: true,
 
   // Used for project oauth login flow @todo remove ??

--- a/apps/builder/app/services/ai-router.server.ts
+++ b/apps/builder/app/services/ai-router.server.ts
@@ -1,0 +1,181 @@
+import { z } from "zod";
+import { procedure, router } from "@webstudio-is/trpc-interface/index.server";
+import env from "~/env/env.server";
+
+const schemaTypes = [
+  "Organization",
+  "LocalBusiness",
+  "Article",
+  "BlogPosting",
+  "Product",
+  "Event",
+  "FAQPage",
+  "HowTo",
+  "Person",
+  "WebSite",
+  "WebPage",
+  "BreadcrumbList",
+  "Review",
+  "Recipe",
+  "Course",
+  "JobPosting",
+  "SoftwareApplication",
+  "VideoObject",
+] as const;
+
+const generateSchemaPrompt = (
+  schemaType: (typeof schemaTypes)[number],
+  pageContext: {
+    pageName: string;
+    pageTitle: string;
+    pageDescription?: string;
+    siteName?: string;
+    siteUrl?: string;
+    pagePath?: string;
+    contactEmail?: string;
+    language?: string;
+    socialImageUrl?: string;
+  }
+) => {
+  const contextLines = [
+    `- Page name: ${pageContext.pageName}`,
+    `- Page title: ${pageContext.pageTitle}`,
+    pageContext.pageDescription
+      ? `- Page description: ${pageContext.pageDescription}`
+      : null,
+    pageContext.siteName
+      ? `- Site/Company name: ${pageContext.siteName}`
+      : null,
+    pageContext.siteUrl ? `- Full page URL: ${pageContext.siteUrl}` : null,
+    pageContext.pagePath ? `- Page path: ${pageContext.pagePath}` : null,
+    pageContext.contactEmail
+      ? `- Contact email: ${pageContext.contactEmail}`
+      : null,
+    pageContext.language ? `- Language: ${pageContext.language}` : null,
+    pageContext.socialImageUrl
+      ? `- Social/Preview image URL: ${pageContext.socialImageUrl}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return `Generate a valid JSON-LD structured data schema for a "${schemaType}" type.
+
+Context about the page and website:
+${contextLines}
+
+Requirements:
+1. Output ONLY valid JSON - no markdown code blocks, no explanations
+2. Include "@context": "https://schema.org" and "@type": "${schemaType}"
+3. Use the provided context data (site name, URL, email, image, etc.) in the schema where appropriate
+4. For values that aren't provided in the context and need user customization, use descriptive placeholder text like "[Add your address here]" or "[Add phone number]"
+5. Include all common/recommended properties for this schema type according to Google's guidelines
+6. If generating LocalBusiness, Organization, or similar: use the contactEmail for email field if provided
+7. If generating Article, BlogPosting: use appropriate datePublished and author fields
+8. Always include the full URL (siteUrl) where URL fields are needed
+9. Use the socialImageUrl for "image" fields when available
+
+Output the JSON object directly:`;
+};
+
+export const aiRouter = router({
+  generateSchema: procedure
+    .input(
+      z.object({
+        schemaType: z.enum(schemaTypes),
+        pageContext: z.object({
+          pageName: z.string(),
+          pageTitle: z.string(),
+          pageDescription: z.string().optional(),
+          siteName: z.string().optional(),
+          siteUrl: z.string().optional(),
+          pagePath: z.string().optional(),
+          contactEmail: z.string().optional(),
+          language: z.string().optional(),
+          socialImageUrl: z.string().optional(),
+        }),
+      })
+    )
+    .mutation(async ({ input }) => {
+      if (!env.OPENAI_KEY) {
+        throw new Error(
+          "AI features require OPENAI_KEY to be configured. Please set the OPENAI_KEY environment variable."
+        );
+      }
+
+      const prompt = generateSchemaPrompt(input.schemaType, input.pageContext);
+
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${env.OPENAI_KEY}`,
+      };
+
+      if (env.OPENAI_ORG) {
+        headers["OpenAI-Organization"] = env.OPENAI_ORG;
+      }
+
+      const response = await fetch(
+        "https://api.openai.com/v1/chat/completions",
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            model: "gpt-5.1",
+            messages: [
+              {
+                role: "system",
+                content:
+                  "You are a JSON-LD structured data expert. You generate valid schema.org JSON-LD markup for SEO. Always output raw JSON without markdown formatting.",
+              },
+              { role: "user", content: prompt },
+            ],
+            temperature: 0.7,
+            max_completion_tokens: 1000,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`OpenAI API error: ${response.status} - ${errorText}`);
+      }
+
+      const data = (await response.json()) as {
+        choices: Array<{ message: { content: string } }>;
+      };
+
+      const content = data.choices[0]?.message?.content;
+
+      if (!content) {
+        throw new Error("No response from AI");
+      }
+
+      // Clean up the response - remove markdown code blocks if present
+      let jsonContent = content.trim();
+      if (jsonContent.startsWith("```json")) {
+        jsonContent = jsonContent.slice(7);
+      } else if (jsonContent.startsWith("```")) {
+        jsonContent = jsonContent.slice(3);
+      }
+      if (jsonContent.endsWith("```")) {
+        jsonContent = jsonContent.slice(0, -3);
+      }
+      jsonContent = jsonContent.trim();
+
+      // Validate JSON
+      try {
+        const parsed = JSON.parse(jsonContent);
+        // Pretty-print the JSON
+        return JSON.stringify(parsed, null, 2);
+      } catch {
+        throw new Error("AI generated invalid JSON. Please try again.");
+      }
+    }),
+
+  getSchemaTypes: procedure.query(() => {
+    return schemaTypes.map((type) => ({
+      value: type,
+      label: type.replace(/([A-Z])/g, " $1").trim(),
+    }));
+  }),
+});

--- a/apps/builder/app/services/trcp-router.server.ts
+++ b/apps/builder/app/services/trcp-router.server.ts
@@ -6,6 +6,7 @@ import { dashboardProjectRouter } from "@webstudio-is/dashboard/index.server";
 import { marketplaceRouter } from "~/shared/marketplace/router.server";
 import { userRouter } from "./user-router.server";
 import { logoutRouter } from "./logout-router.server";
+import { aiRouter } from "./ai-router.server";
 
 export const appRouter = router({
   user: userRouter,
@@ -15,6 +16,7 @@ export const appRouter = router({
   authorizationToken: authorizationTokenRouter,
   dashboardProject: dashboardProjectRouter,
   logout: logoutRouter,
+  ai: aiRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -25,6 +25,7 @@
     "@codemirror/lang-css": "^6.3.1",
     "@codemirror/lang-html": "^6.4.9",
     "@codemirror/lang-javascript": "^6.2.3",
+    "@codemirror/lang-json": "^6.0.1",
     "@codemirror/lang-markdown": "^6.3.2",
     "@codemirror/language": "^6.11.0",
     "@codemirror/lint": "^6.8.5",

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -22,6 +22,7 @@ import {
   PageSettingsMeta,
   PageSettingsTitle,
   PageSettingsCanonicalLink,
+  PageSettingsSchemaMarkup,
 } from "@webstudio-is/react-sdk/runtime";
 import {
   projectId,
@@ -310,6 +311,7 @@ const Outlet = () => {
       />
       <PageSettingsTitle>{pageMeta.title}</PageSettingsTitle>
       <PageSettingsCanonicalLink href={url} />
+      <PageSettingsSchemaMarkup pageMeta={pageMeta} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/cli/templates/react-router/app/route-templates/html.tsx
+++ b/packages/cli/templates/react-router/app/route-templates/html.tsx
@@ -21,6 +21,7 @@ import {
   ReactSdkContext,
   PageSettingsMeta,
   PageSettingsTitle,
+  PageSettingsSchemaMarkup,
 } from "@webstudio-is/react-sdk/runtime";
 import {
   projectId,
@@ -308,6 +309,7 @@ const Outlet = () => {
         assetBaseUrl={constants.assetBaseUrl}
       />
       <PageSettingsTitle>{pageMeta.title}</PageSettingsTitle>
+      <PageSettingsSchemaMarkup pageMeta={pageMeta} />
     </ReactSdkContext.Provider>
   );
 };

--- a/packages/cli/templates/ssg/app/route-templates/html/+Head.tsx
+++ b/packages/cli/templates/ssg/app/route-templates/html/+Head.tsx
@@ -63,6 +63,15 @@ export const Head = ({ data }: { data: PageContext["data"] }) => {
         isTwitterCardSizeDefined === false && (
           <meta property="twitter:card" content="summary_large_image" />
         )}
+      {pageMeta.schemaMarkup?.map((script, index) => (
+        <script
+          key={index}
+          type={script.type}
+          dangerouslySetInnerHTML={{
+            __html: script.content,
+          }}
+        />
+      ))}
 
       {favIconAsset && (
         <link

--- a/packages/react-sdk/src/page-settings-schema-markup.tsx
+++ b/packages/react-sdk/src/page-settings-schema-markup.tsx
@@ -1,0 +1,78 @@
+import type { PageMeta } from "@webstudio-is/sdk";
+import { useEffect, useState } from "react";
+import { isElementRenderedWithReact } from "./page-settings-meta";
+
+const isServer = typeof window === "undefined";
+
+/**
+ * Script tags for JSON-LD are handled similarly to meta tags.
+ * We deduplicate on the server using the HTMLRewriter interface.
+ * To prevent React on the client from re-adding removed scripts, we skip rendering them client-side.
+ */
+const Script = ({
+  type,
+  content,
+}: {
+  type: "application/ld+json";
+  content: string;
+}) => {
+  const [shouldRender, setShouldRender] = useState(false);
+
+  useEffect(() => {
+    // Check if this script was already rendered by the server
+    // We identify scripts by their content hash
+    const selector = `script[type="application/ld+json"]`;
+    const allScripts = document.querySelectorAll(selector);
+
+    for (const script of allScripts) {
+      if (
+        !isElementRenderedWithReact(script) &&
+        script.textContent === content
+      ) {
+        // Server-rendered duplicate found, don't render
+        return;
+      }
+    }
+
+    // No server-rendered duplicate, we should render
+    setShouldRender(true);
+  }, [content]);
+
+  if (isServer) {
+    return (
+      <script
+        type={type}
+        dangerouslySetInnerHTML={{
+          __html: content,
+        }}
+      />
+    );
+  }
+
+  if (shouldRender === false) {
+    return null;
+  }
+
+  return (
+    <script
+      type={type}
+      dangerouslySetInnerHTML={{
+        __html: content,
+      }}
+    />
+  );
+};
+
+export const PageSettingsSchemaMarkup = ({
+  pageMeta,
+}: {
+  pageMeta: PageMeta;
+}) => {
+  return (
+    <>
+      {pageMeta.schemaMarkup?.map((script, index) => (
+        <Script key={index} type={script.type} content={script.content} />
+      ))}
+    </>
+  );
+};

--- a/packages/react-sdk/src/runtime.ts
+++ b/packages/react-sdk/src/runtime.ts
@@ -4,6 +4,7 @@ export * from "./variable-state";
 export { PageSettingsMeta } from "./page-settings-meta";
 export { PageSettingsTitle } from "./page-settings-title";
 export { PageSettingsCanonicalLink } from "./page-settings-canonical-link";
+export { PageSettingsSchemaMarkup } from "./page-settings-schema-markup";
 
 /**
  * React has issues rendering certain elements, such as errors when a <link> element has children.

--- a/packages/sdk/src/page-meta-generator.test.ts
+++ b/packages/sdk/src/page-meta-generator.test.ts
@@ -22,28 +22,30 @@ test("generate minimal static page meta factory", () => {
       assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Page title",
-    description: undefined,
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetName: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [
-    ],
-  };
-};
-"
-`);
+    "export const getPageMeta = ({
+      system,
+      resources,
+    }: {
+      system: System;
+      resources: Record<string, any>;
+    }): PageMeta => {
+      return {
+        title: "Page title",
+        description: undefined,
+        excludePageFromSearch: undefined,
+        language: undefined,
+        socialImageAssetName: undefined,
+        socialImageUrl: undefined,
+        status: undefined,
+        redirect: undefined,
+        custom: [
+        ],
+        schemaMarkup: [
+        ],
+      };
+    };
+    "
+  `);
 });
 
 test("generate complete static page meta factory", () => {
@@ -88,36 +90,38 @@ test("generate complete static page meta factory", () => {
       ]),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Page title",
-    description: "Page description",
-    excludePageFromSearch: true,
-    language: "en-US",
-    socialImageAssetName: "social-image-name",
-    socialImageUrl: undefined,
-    status: 302,
-    redirect: "/new-path",
-    custom: [
-      {
-        property: "custom-property-1",
-        content: "custom content 1",
-      },
-      {
-        property: "custom-property-2",
-        content: "custom content 2",
-      },
-    ],
-  };
-};
-"
-`);
+    "export const getPageMeta = ({
+      system,
+      resources,
+    }: {
+      system: System;
+      resources: Record<string, any>;
+    }): PageMeta => {
+      return {
+        title: "Page title",
+        description: "Page description",
+        excludePageFromSearch: true,
+        language: "en-US",
+        socialImageAssetName: "social-image-name",
+        socialImageUrl: undefined,
+        status: 302,
+        redirect: "/new-path",
+        custom: [
+          {
+            property: "custom-property-1",
+            content: "custom content 1",
+          },
+          {
+            property: "custom-property-2",
+            content: "custom content 2",
+          },
+        ],
+        schemaMarkup: [
+        ],
+      };
+    };
+    "
+  `);
 });
 
 test("generate asset url instead of id", () => {
@@ -138,28 +142,30 @@ test("generate asset url instead of id", () => {
       assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Page title",
-    description: undefined,
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetName: undefined,
-    socialImageUrl: "https://my-image",
-    status: undefined,
-    redirect: undefined,
-    custom: [
-    ],
-  };
-};
-"
-`);
+    "export const getPageMeta = ({
+      system,
+      resources,
+    }: {
+      system: System;
+      resources: Record<string, any>;
+    }): PageMeta => {
+      return {
+        title: "Page title",
+        description: undefined,
+        excludePageFromSearch: undefined,
+        language: undefined,
+        socialImageAssetName: undefined,
+        socialImageUrl: "https://my-image",
+        status: undefined,
+        redirect: undefined,
+        custom: [
+        ],
+        schemaMarkup: [
+        ],
+      };
+    };
+    "
+  `);
 });
 
 test("generate custom meta ignoring empty property name", () => {
@@ -183,32 +189,34 @@ test("generate custom meta ignoring empty property name", () => {
       assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  return {
-    title: "Page title",
-    description: undefined,
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetName: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [
-      {
-        property: "custom-property",
-        content: "custom content 1",
-      },
-    ],
-  };
-};
-"
-`);
+    "export const getPageMeta = ({
+      system,
+      resources,
+    }: {
+      system: System;
+      resources: Record<string, any>;
+    }): PageMeta => {
+      return {
+        title: "Page title",
+        description: undefined,
+        excludePageFromSearch: undefined,
+        language: undefined,
+        socialImageAssetName: undefined,
+        socialImageUrl: undefined,
+        status: undefined,
+        redirect: undefined,
+        custom: [
+          {
+            property: "custom-property",
+            content: "custom content 1",
+          },
+        ],
+        schemaMarkup: [
+        ],
+      };
+    };
+    "
+  `);
 });
 
 test("generate page meta factory with variables", () => {
@@ -235,29 +243,31 @@ test("generate page meta factory with variables", () => {
       assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  let VariableName = ""
-  return {
-    title: VariableName,
-    description: undefined,
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetName: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [
-    ],
-  };
-};
-"
-`);
+    "export const getPageMeta = ({
+      system,
+      resources,
+    }: {
+      system: System;
+      resources: Record<string, any>;
+    }): PageMeta => {
+      let VariableName = ""
+      return {
+        title: VariableName,
+        description: undefined,
+        excludePageFromSearch: undefined,
+        language: undefined,
+        socialImageAssetName: undefined,
+        socialImageUrl: undefined,
+        status: undefined,
+        redirect: undefined,
+        custom: [
+        ],
+        schemaMarkup: [
+        ],
+      };
+    };
+    "
+  `);
 });
 
 test("generate page meta factory with page system variable", () => {
@@ -284,29 +294,31 @@ test("generate page meta factory with page system variable", () => {
       assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  let system_1 = system
-  return {
-    title: system_1?.params?.slug,
-    description: undefined,
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetName: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [
-    ],
-  };
-};
-"
-`);
+    "export const getPageMeta = ({
+      system,
+      resources,
+    }: {
+      system: System;
+      resources: Record<string, any>;
+    }): PageMeta => {
+      let system_1 = system
+      return {
+        title: system_1?.params?.slug,
+        description: undefined,
+        excludePageFromSearch: undefined,
+        language: undefined,
+        socialImageAssetName: undefined,
+        socialImageUrl: undefined,
+        status: undefined,
+        redirect: undefined,
+        custom: [
+        ],
+        schemaMarkup: [
+        ],
+      };
+    };
+    "
+  `);
 });
 
 test("generate page meta factory with global system variable", () => {
@@ -325,29 +337,31 @@ test("generate page meta factory with global system variable", () => {
       assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  let system_1 = system
-  return {
-    title: system_1?.params?.slug,
-    description: undefined,
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetName: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [
-    ],
-  };
-};
-"
-`);
+    "export const getPageMeta = ({
+      system,
+      resources,
+    }: {
+      system: System;
+      resources: Record<string, any>;
+    }): PageMeta => {
+      let system_1 = system
+      return {
+        title: system_1?.params?.slug,
+        description: undefined,
+        excludePageFromSearch: undefined,
+        language: undefined,
+        socialImageAssetName: undefined,
+        socialImageUrl: undefined,
+        status: undefined,
+        redirect: undefined,
+        custom: [
+        ],
+        schemaMarkup: [
+        ],
+      };
+    };
+    "
+  `);
 });
 
 test("generate page meta factory with resources", () => {
@@ -374,29 +388,94 @@ test("generate page meta factory with resources", () => {
       assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  let CmsPage = resources.CmsPage
-  return {
-    title: CmsPage?.data?.title,
-    description: undefined,
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetName: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [
-    ],
-  };
-};
-"
-`);
+    "export const getPageMeta = ({
+      system,
+      resources,
+    }: {
+      system: System;
+      resources: Record<string, any>;
+    }): PageMeta => {
+      let CmsPage = resources.CmsPage
+      return {
+        title: CmsPage?.data?.title,
+        description: undefined,
+        excludePageFromSearch: undefined,
+        language: undefined,
+        socialImageAssetName: undefined,
+        socialImageUrl: undefined,
+        status: undefined,
+        redirect: undefined,
+        custom: [
+        ],
+        schemaMarkup: [
+        ],
+      };
+    };
+    "
+  `);
+});
+
+test("generate page meta factory with schemaMarkup", () => {
+  expect(
+    generatePageMeta({
+      globalScope: createScope(),
+      page: {
+        id: "",
+        name: "",
+        path: "",
+        rootInstanceId: "",
+        title: `"Page title"`,
+        meta: {
+          schemaMarkup: [
+            {
+              type: "application/ld+json",
+              content:
+                '{"@context":"https://schema.org","@type":"Organization","name":"Test Org"}',
+            },
+            {
+              type: "application/ld+json",
+              content:
+                '{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[]}',
+            },
+          ],
+        },
+      },
+      dataSources: new Map(),
+      assets: new Map(),
+    })
+  ).toMatchInlineSnapshot(`
+    "export const getPageMeta = ({
+      system,
+      resources,
+    }: {
+      system: System;
+      resources: Record<string, any>;
+    }): PageMeta => {
+      return {
+        title: "Page title",
+        description: undefined,
+        excludePageFromSearch: undefined,
+        language: undefined,
+        socialImageAssetName: undefined,
+        socialImageUrl: undefined,
+        status: undefined,
+        redirect: undefined,
+        custom: [
+        ],
+        schemaMarkup: [
+          {
+            type: "application/ld+json",
+            content: "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Organization\\",\\"name\\":\\"Test Org\\"}",
+          },
+          {
+            type: "application/ld+json",
+            content: "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"FAQPage\\",\\"mainEntity\\":[]}",
+          },
+        ],
+      };
+    };
+    "
+  `);
 });
 
 test("generate page meta factory without unused variables", () => {
@@ -444,27 +523,29 @@ test("generate page meta factory without unused variables", () => {
       assets: new Map(),
     })
   ).toMatchInlineSnapshot(`
-"export const getPageMeta = ({
-  system,
-  resources,
-}: {
-  system: System;
-  resources: Record<string, any>;
-}): PageMeta => {
-  let UsedName = ""
-  return {
-    title: UsedName,
-    description: undefined,
-    excludePageFromSearch: undefined,
-    language: undefined,
-    socialImageAssetName: undefined,
-    socialImageUrl: undefined,
-    status: undefined,
-    redirect: undefined,
-    custom: [
-    ],
-  };
-};
-"
-`);
+    "export const getPageMeta = ({
+      system,
+      resources,
+    }: {
+      system: System;
+      resources: Record<string, any>;
+    }): PageMeta => {
+      let UsedName = ""
+      return {
+        title: UsedName,
+        description: undefined,
+        excludePageFromSearch: undefined,
+        language: undefined,
+        socialImageAssetName: undefined,
+        socialImageUrl: undefined,
+        status: undefined,
+        redirect: undefined,
+        custom: [
+        ],
+        schemaMarkup: [
+        ],
+      };
+    };
+    "
+  `);
 });

--- a/packages/sdk/src/page-meta-generator.ts
+++ b/packages/sdk/src/page-meta-generator.ts
@@ -14,6 +14,7 @@ export type PageMeta = {
   status?: number;
   redirect?: string;
   custom: Array<{ property: string; content: string }>;
+  schemaMarkup: Array<{ type: "application/ld+json"; content: string }>;
 };
 
 export const generatePageMeta = ({
@@ -96,6 +97,20 @@ export const generatePageMeta = ({
     customExpression += `      },\n`;
   }
   customExpression += `    ]`;
+
+  // Generate schemaMarkup expression
+  let schemaMarkupExpression = "";
+  schemaMarkupExpression += `[\n`;
+  for (const schema of page.meta.schemaMarkup ?? []) {
+    const typeExpression = JSON.stringify(schema.type);
+    const contentExpression = JSON.stringify(schema.content);
+    schemaMarkupExpression += `      {\n`;
+    schemaMarkupExpression += `        type: ${typeExpression},\n`;
+    schemaMarkupExpression += `        content: ${contentExpression},\n`;
+    schemaMarkupExpression += `      },\n`;
+  }
+  schemaMarkupExpression += `    ]`;
+
   let generated = "";
   generated += `export const getPageMeta = ({\n`;
   generated += `  system,\n`;
@@ -142,6 +157,7 @@ export const generatePageMeta = ({
   generated += `    status: ${statusExpression},\n`;
   generated += `    redirect: ${redirectExpression},\n`;
   generated += `    custom: ${customExpression},\n`;
+  generated += `    schemaMarkup: ${schemaMarkupExpression},\n`;
   generated += `  };\n`;
   generated += `};\n`;
   return generated;

--- a/packages/sdk/src/page-meta-generator.ts
+++ b/packages/sdk/src/page-meta-generator.ts
@@ -14,7 +14,7 @@ export type PageMeta = {
   status?: number;
   redirect?: string;
   custom: Array<{ property: string; content: string }>;
-  schemaMarkup: Array<{ type: "application/ld+json"; content: string }>;
+  schemaMarkup?: Array<{ type: "application/ld+json"; content: string }>;
 };
 
 export const generatePageMeta = ({

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -70,6 +70,14 @@ const commonPageFields = {
         })
       )
       .optional(),
+    schemaMarkup: z
+      .array(
+        z.object({
+          type: z.enum(["application/ld+json"]),
+          content: z.string(),
+        })
+      )
+      .optional(),
   }),
   marketplace: z.optional(
     z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       '@codemirror/lang-javascript':
         specifier: ^6.2.3
         version: 6.2.3
+      '@codemirror/lang-json':
+        specifier: ^6.0.1
+        version: 6.0.2
       '@codemirror/lang-markdown':
         specifier: ^6.3.2
         version: 6.3.2
@@ -2603,6 +2606,9 @@ packages:
   '@codemirror/lang-javascript@6.2.3':
     resolution: {integrity: sha512-8PR3vIWg7pSu7ur8A07pGiYHgy3hHj+mRYRCSG8q+mPIrl0F02rgpGv+DsQTHRTc30rydOsf5PZ7yjKFg2Ackw==}
 
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
   '@codemirror/lang-markdown@6.3.2':
     resolution: {integrity: sha512-c/5MYinGbFxYl4itE9q/rgN/sMTjOr8XL5OWnC+EaRMLfCbVUmmubTJfdgpfcSS2SCaT7b+Q+xi3l6CgoE+BsA==}
 
@@ -3853,6 +3859,9 @@ packages:
 
   '@lezer/javascript@1.4.19':
     resolution: {integrity: sha512-j44kbR1QL26l6dMunZ1uhKBFteVGLVCBGNUD2sUaMnic+rbTviVuoK0CD1l9FTW31EueWvFFswCKMH7Z+M3JRA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
 
   '@lezer/lr@1.4.2':
     resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
@@ -10022,6 +10031,11 @@ snapshots:
       '@lezer/common': 1.2.3
       '@lezer/javascript': 1.4.19
 
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.11.0
+      '@lezer/json': 1.0.3
+
   '@codemirror/lang-markdown@6.3.2':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
@@ -10929,6 +10943,12 @@ snapshots:
       '@lezer/lr': 1.4.2
 
   '@lezer/javascript@1.4.19':
+    dependencies:
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
+
+  '@lezer/json@1.0.3':
     dependencies:
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1


### PR DESCRIPTION
## Description

Closes #5443

Adds per-page JSON-LD structured data (Schema Markup) configuration in Page Settings with AI-powered generation.

### Features:
- New "Schema Markup" section in Page Settings
- AI-powered schema generation using OpenAI GPT-5.1 with 18 schema.org types (Organization, Product, FAQ, Article, etc.)
- JSON editor with syntax highlighting and validation
- Duplicate singleton schema type warnings (e.g., warns if multiple Organization schemas on same page)
- Renders JSON-LD scripts in published pages via `<script type="application/ld+json">`

### Technical:
- New `schemaMarkup` field in page meta schema
- `SchemaMarkup` component for builder UI
- `PageSettingsSchemaMarkup` component for runtime rendering
- AI router with TRPC integration (requires `OPENAI_KEY` env variable)

## Steps for reproduction

1. Open Page Settings for any page
2. Scroll to "Schema Markup" section
3. Click "Generate with AI" and select a schema type (e.g., Organization)
4. Verify JSON-LD is generated with page context (title, URL, etc.)
5. Alternatively click "Add manually" to add empty template
6. Publish the page
7. Inspect the published page source - JSON-LD should appear in `<head>`

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [x] added tests
- [x] if any new env variables are added, added them to `.env` file
  - `OPENAI_KEY` - Required for AI schema generation
  - `OPENAI_ORG` - Optional OpenAI organization ID
