### PR TITLE
fix: Forgotten hint in keyboards shortcuts dialog about cmd+click in navigator nodes to expand all

### DIFF
--- a/apps/builder/app/builder/features/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.tsx
+++ b/apps/builder/app/builder/features/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.tsx
@@ -59,6 +59,13 @@ const additionalShortcuts = [
     defaultHotkeys: ["←"],
   },
   {
+    name: "expandAllNavigatorNodes",
+    label: "Expand all nodes",
+    description: "Click on arrow to expand or collapse all nodes",
+    category: "Navigator",
+    defaultHotkeys: ["meta+click", "ctrl+click"],
+  },
+  {
     name: "switchBreakpoint",
     label: "Switch breakpoints",
     description: "Switch to breakpoint by number (1-9)",
@@ -114,6 +121,7 @@ export const KeyboardShortcutsDialog = () => {
       "duplicateInstance",
       "expandNavigatorItem",
       "collapseNavigatorItem",
+      "expandAllNavigatorNodes",
     ],
     Panels: [
       "toggleComponentsPanel",


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
