### PR TITLE
fix: Fix scrub - disable it when its on non-numeric values

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/position/inset-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/position/inset-control.tsx
@@ -70,12 +70,13 @@ type HoverTarget = {
 export const InsetControl = () => {
   const styles = useComputedStyles(["top", "right", "bottom", "left"]);
   const [hoverTarget, setHoverTarget] = useState<HoverTarget>();
+  const styleValue = styles.find(
+    (styleDecl) => styleDecl.property === hoverTarget?.property
+  );
 
   const scrubStatus = useScrub({
-    value: styles.find(
-      (styleDecl) => styleDecl.property === hoverTarget?.property
-    )?.usedValue,
-    target: hoverTarget,
+    value: styleValue?.usedValue,
+    target: styleValue?.cascadedValue.type === "unit" ? hoverTarget : undefined,
     getModifiersGroup: getInsetModifiersGroup,
     onChange: (values, options) => {
       const batch = createBatchUpdate();

--- a/apps/builder/app/builder/features/style-panel/sections/shared/scrub.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/shared/scrub.tsx
@@ -81,14 +81,6 @@ export const useScrub = <P extends CssProperty>(props: {
       return;
     }
 
-    // Don't activate scrub for non-numeric intermediate values
-    const numericValue = Number.parseFloat(
-      finalTarget.element.textContent ?? ""
-    );
-    if (Number.isNaN(numericValue)) {
-      return;
-    }
-
     const property = finalTarget.property;
 
     const handleChange = (event: { value: number }, isEphemeral: boolean) => {

--- a/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
@@ -140,12 +140,12 @@ export { spaceProperties as properties };
 export const Section = () => {
   const styles = useComputedStyles(spaceProperties);
   const [hoverTarget, setHoverTarget] = useState<HoverTarget>();
-
+  const styleValue = styles.find(
+    (styleDecl) => styleDecl.property === hoverTarget?.property
+  );
   const scrubStatus = useScrub({
-    value: styles.find(
-      (styleDecl) => styleDecl.property === hoverTarget?.property
-    )?.usedValue,
-    target: hoverTarget,
+    value: styleValue?.usedValue,
+    target: styleValue?.cascadedValue.type === "unit" ? hoverTarget : undefined,
     getModifiersGroup: getSpaceModifiersGroup,
     onChange: (values, options) => {
       const batch = createBatchUpdate();


### PR DESCRIPTION
Missed case is scrubbing in spacing ui but hitting outisde the tiny button would not work at all now with the previous solution.

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
