### PR TITLE
fix: Fix content mode plus button z index

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -390,20 +390,6 @@ export const Builder = ({
             }}
           />
           <ProjectSettings />
-          <Main>
-            <Workspace>
-              {dataLoadingState === "loaded" && project && (
-                <CanvasIframe
-                  ref={iframeRefCallback}
-                  src={canvasUrl}
-                  title={project.title}
-                />
-              )}
-            </Workspace>
-          </Main>
-          <Main css={{ pointerEvents: "none" }}>
-            <CanvasToolsContainer />
-          </Main>
 
           <SidePanel
             gridArea="inspector"
@@ -432,6 +418,22 @@ export const Builder = ({
           >
             <SidebarLeft publish={publish} />
           </SidePanel>
+          {/* Main must be after side panels because in content mode the Plus button must be above the left sidebar, otherwise it won't be visible when content is full width */}
+          <Main>
+            <Workspace>
+              {dataLoadingState === "loaded" && project && (
+                <CanvasIframe
+                  ref={iframeRefCallback}
+                  src={canvasUrl}
+                  title={project.title}
+                />
+              )}
+            </Workspace>
+          </Main>
+          <Main css={{ pointerEvents: "none" }}>
+            <CanvasToolsContainer />
+          </Main>
+
           {project ? (
             <Topbar
               project={project}


### PR DESCRIPTION
## Description

In content mode when content is full width, the plus button was not visible because it was behind the left sidebar

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
