### PR TITLE
fix: icon and description for expand/collapse all items in keyboard shorcuts dialog

### DIFF
--- a/apps/builder/app/builder/features/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.tsx
+++ b/apps/builder/app/builder/features/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.tsx
@@ -42,7 +42,7 @@ const additionalShortcuts = [
     label: "Expand all items",
     description: "Click on arrow to expand or collapse all child items",
     category: "Navigator",
-    defaultHotkeys: ["alt+click", "alt+click"],
+    defaultHotkeys: ["alt+click"],
   },
   {
     name: "switchBreakpoint",


### PR DESCRIPTION
## Description

1. This pull request fixes the description of keyboard shortcut for expand / collapse of navigator items. The working shortcut for expand/collapse navigator items are alt + click on both osx and windows. But is listed in the Keyboard shortcuts dialog as **&#8984; + click** on osx and **CTRL + click** on windows.
2. This PR also changes the description of the shortcut to be more inline with other shortcuts for navigator items.

## Steps for reproduction

1. Open any project
2. Open the Keyboard shortcuts menu
- On OSX, the expand / collapse navigator items is listed as &#8984; + click
- On WIN, the shortcut is listed as CTRL + click

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
