### PR TITLE
fix: Bring back upload button in several cases

### DIFF
--- a/apps/builder/app/builder/shared/assets/asset-upload.tsx
+++ b/apps/builder/app/builder/shared/assets/asset-upload.tsx
@@ -121,13 +121,13 @@ const EnabledAssetUpload = ({ accept, type }: AssetUploadProps) => {
   );
 };
 
-export const AssetUpload = ({ type }: AssetUploadProps) => {
+export const AssetUpload = ({ type, accept }: AssetUploadProps) => {
   const authPermit = useStore($authPermit);
 
   if (authPermit !== "view") {
     // Split into a separate component to avoid using `useUpload` hook unnecessarily
     // (It's hard to mock this hook in storybook)
-    return <EnabledAssetUpload type={type} />;
+    return <EnabledAssetUpload type={type} accept={accept} />;
   }
 
   return (

--- a/apps/builder/app/shared/project-settings/image-control.tsx
+++ b/apps/builder/app/shared/project-settings/image-control.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 import { FloatingPanel } from "@webstudio-is/design-system";
 import { AssetManager } from "~/builder/shared/asset-manager";
+import { AssetUpload } from "~/builder/shared/assets";
 
 // @todo should be moved to shared as its being reused in another feature
 export const ImageControl = (props: {
@@ -10,6 +11,7 @@ export const ImageControl = (props: {
   return (
     <FloatingPanel
       title="Images"
+      titleSuffix={<AssetUpload type="image" accept="image/*" />}
       placement="bottom-within"
       content={
         <AssetManager


### PR DESCRIPTION
## Description

Regression, button for upload was removed in case of favicon, page settings, marketplace settings

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
