### PR TITLE
fix: Track font asset usages in font family to show correct asset info

### DIFF
--- a/apps/builder/app/builder/shared/asset-manager/asset-info.test.ts
+++ b/apps/builder/app/builder/shared/asset-manager/asset-info.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect } from "vitest";
-import type { Pages, Props, Styles } from "@webstudio-is/sdk";
-import type { ImageValue, StyleValue } from "@webstudio-is/css-engine";
+import type { Pages, Props, Styles, Asset } from "@webstudio-is/sdk";
+import type {
+  ImageValue,
+  FontFamilyValue,
+  StyleValue,
+} from "@webstudio-is/css-engine";
 import { __testing__ } from "./asset-info";
 
 const { traverseStyleValue, calculateUsagesByAssetId } = __testing__;
@@ -12,7 +16,7 @@ describe("asset-info", () => {
         type: "image",
         value: { type: "asset", value: "asset-1" },
       };
-      const results: ImageValue[] = [];
+      const results: (ImageValue | FontFamilyValue)[] = [];
       traverseStyleValue(imageValue, (value) => results.push(value));
       expect(results).toEqual([imageValue]);
     });
@@ -30,7 +34,7 @@ describe("asset-info", () => {
         type: "tuple",
         value: [imageValue1, imageValue2],
       };
-      const results: ImageValue[] = [];
+      const results: (ImageValue | FontFamilyValue)[] = [];
       traverseStyleValue(tupleValue, (value) => results.push(value));
       expect(results).toEqual([imageValue1, imageValue2]);
     });
@@ -48,7 +52,7 @@ describe("asset-info", () => {
         type: "layers",
         value: [imageValue1, imageValue2],
       };
-      const results: ImageValue[] = [];
+      const results: (ImageValue | FontFamilyValue)[] = [];
       traverseStyleValue(layersValue, (value) => results.push(value));
       expect(results).toEqual([imageValue1, imageValue2]);
     });
@@ -58,7 +62,7 @@ describe("asset-info", () => {
         type: "keyword",
         value: "auto",
       };
-      const results: ImageValue[] = [];
+      const results: (ImageValue | FontFamilyValue)[] = [];
       traverseStyleValue(keywordValue, (value) => results.push(value));
       expect(results).toEqual([]);
     });
@@ -76,9 +80,19 @@ describe("asset-info", () => {
         type: "layers",
         value: [nestedTuple],
       };
-      const results: ImageValue[] = [];
+      const results: (ImageValue | FontFamilyValue)[] = [];
       traverseStyleValue(layersValue, (value) => results.push(value));
       expect(results).toEqual([imageValue]);
+    });
+
+    test("calls callback for fontFamily values", () => {
+      const fontFamilyValue: FontFamilyValue = {
+        type: "fontFamily",
+        value: ["CustomFont", "Arial", "sans-serif"],
+      };
+      const results: (ImageValue | FontFamilyValue)[] = [];
+      traverseStyleValue(fontFamilyValue, (value) => results.push(value));
+      expect(results).toEqual([fontFamilyValue]);
     });
   });
 
@@ -99,8 +113,9 @@ describe("asset-info", () => {
       };
       const props: Props = new Map();
       const styles: Styles = new Map();
+      const assets = new Map<Asset["id"], Asset>();
 
-      const usages = calculateUsagesByAssetId({ pages, props, styles });
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
 
       expect(usages.get("favicon-asset")).toEqual([{ type: "favicon" }]);
     });
@@ -121,8 +136,9 @@ describe("asset-info", () => {
       };
       const props: Props = new Map();
       const styles: Styles = new Map();
+      const assets = new Map<Asset["id"], Asset>();
 
-      const usages = calculateUsagesByAssetId({ pages, props, styles });
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
 
       expect(usages.get("social-asset")).toEqual([
         { type: "socialImage", pageId: "home" },
@@ -155,8 +171,9 @@ describe("asset-info", () => {
       };
       const props: Props = new Map();
       const styles: Styles = new Map();
+      const assets = new Map<Asset["id"], Asset>();
 
-      const usages = calculateUsagesByAssetId({ pages, props, styles });
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
 
       expect(usages.get("thumbnail-asset")).toEqual([
         { type: "marketplaceThumbnail", pageId: "page-1" },
@@ -190,8 +207,9 @@ describe("asset-info", () => {
         ],
       ]);
       const styles: Styles = new Map();
+      const assets = new Map<Asset["id"], Asset>();
 
-      const usages = calculateUsagesByAssetId({ pages, props, styles });
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
 
       expect(usages.get("asset-1")).toEqual([
         { type: "prop", propId: "prop-1" },
@@ -235,8 +253,9 @@ describe("asset-info", () => {
         ],
       ]);
       const styles: Styles = new Map();
+      const assets = new Map<Asset["id"], Asset>();
 
-      const usages = calculateUsagesByAssetId({ pages, props, styles });
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
 
       expect(usages.get("asset-1")).toBeUndefined();
     });
@@ -270,8 +289,9 @@ describe("asset-info", () => {
           },
         ],
       ]);
+      const assets = new Map<Asset["id"], Asset>();
 
-      const usages = calculateUsagesByAssetId({ pages, props, styles });
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
 
       expect(usages.get("asset-1")).toEqual([
         { type: "style", styleDeclKey: "style-1:breakpoint-1:property" },
@@ -294,8 +314,9 @@ describe("asset-info", () => {
       };
       const props: Props = new Map();
       const styles: Styles = new Map();
+      const assets = new Map<Asset["id"], Asset>();
 
-      const usages = calculateUsagesByAssetId({ pages, props, styles });
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
 
       expect(usages.size).toBe(0);
     });
@@ -340,8 +361,9 @@ describe("asset-info", () => {
           },
         ],
       ]);
+      const assets = new Map<Asset["id"], Asset>();
 
-      const usages = calculateUsagesByAssetId({ pages, props, styles });
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
 
       expect(usages.get("asset-1")).toHaveLength(4);
       expect(usages.get("asset-1")).toEqual([
@@ -356,8 +378,9 @@ describe("asset-info", () => {
       const pages = undefined;
       const props: Props = new Map();
       const styles: Styles = new Map();
+      const assets = new Map<Asset["id"], Asset>();
 
-      const usages = calculateUsagesByAssetId({ pages, props, styles });
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
 
       expect(usages.size).toBe(0);
     });
@@ -400,14 +423,236 @@ describe("asset-info", () => {
           },
         ],
       ]);
+      const assets = new Map<Asset["id"], Asset>();
 
-      const usages = calculateUsagesByAssetId({ pages, props, styles });
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
 
       expect(usages.get("asset-1")).toEqual([
         { type: "style", styleDeclKey: "style-1:breakpoint-1:property" },
       ]);
       expect(usages.get("asset-2")).toEqual([
         { type: "style", styleDeclKey: "style-1:breakpoint-1:property" },
+      ]);
+    });
+
+    test("tracks font asset usage in fontFamily styles", () => {
+      const pages: Pages = {
+        meta: {},
+        homePage: {
+          id: "home",
+          name: "Home",
+          path: "",
+          title: "Home",
+          meta: {},
+          rootInstanceId: "root",
+        },
+        pages: [],
+        folders: [],
+      };
+      const props: Props = new Map();
+      const styles: Styles = new Map([
+        [
+          "style-1:breakpoint-1:fontFamily",
+          {
+            breakpointId: "breakpoint-1",
+            styleSourceId: "style-1",
+            property: "fontFamily",
+            value: {
+              type: "fontFamily",
+              value: ["CustomFont", "Arial", "sans-serif"],
+            },
+          },
+        ],
+      ]);
+      const assets = new Map<Asset["id"], Asset>([
+        [
+          "font-asset-1",
+          {
+            id: "font-asset-1",
+            type: "font",
+            name: "CustomFont",
+            format: "woff2",
+            size: 5000,
+            meta: { family: "CustomFont", style: "normal", weight: 400 },
+            createdAt: "2024-01-01",
+            projectId: "project-id",
+          },
+        ],
+      ]);
+
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
+
+      expect(usages.get("font-asset-1")).toEqual([
+        { type: "style", styleDeclKey: "style-1:breakpoint-1:fontFamily" },
+      ]);
+    });
+
+    test("tracks multiple font assets in same fontFamily style", () => {
+      const pages: Pages = {
+        meta: {},
+        homePage: {
+          id: "home",
+          name: "Home",
+          path: "",
+          title: "Home",
+          meta: {},
+          rootInstanceId: "root",
+        },
+        pages: [],
+        folders: [],
+      };
+      const props: Props = new Map();
+      const styles: Styles = new Map([
+        [
+          "style-1:breakpoint-1:fontFamily",
+          {
+            breakpointId: "breakpoint-1",
+            styleSourceId: "style-1",
+            property: "fontFamily",
+            value: {
+              type: "fontFamily",
+              value: ["CustomFont", "AnotherFont"],
+            },
+          },
+        ],
+      ]);
+      const assets = new Map<Asset["id"], Asset>([
+        [
+          "font-asset-1",
+          {
+            id: "font-asset-1",
+            type: "font",
+            name: "CustomFont",
+            format: "woff2",
+            size: 5000,
+            meta: { family: "CustomFont", style: "normal", weight: 400 },
+            createdAt: "2024-01-01",
+            projectId: "project-id",
+          },
+        ],
+        [
+          "font-asset-2",
+          {
+            id: "font-asset-2",
+            type: "font",
+            name: "AnotherFont",
+            format: "woff2",
+            size: 6000,
+            meta: { family: "AnotherFont", style: "normal", weight: 400 },
+            createdAt: "2024-01-01",
+            projectId: "project-id",
+          },
+        ],
+      ]);
+
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
+
+      expect(usages.get("font-asset-1")).toEqual([
+        { type: "style", styleDeclKey: "style-1:breakpoint-1:fontFamily" },
+      ]);
+      expect(usages.get("font-asset-2")).toEqual([
+        { type: "style", styleDeclKey: "style-1:breakpoint-1:fontFamily" },
+      ]);
+    });
+
+    test("ignores font families without matching assets", () => {
+      const pages: Pages = {
+        meta: {},
+        homePage: {
+          id: "home",
+          name: "Home",
+          path: "",
+          title: "Home",
+          meta: {},
+          rootInstanceId: "root",
+        },
+        pages: [],
+        folders: [],
+      };
+      const props: Props = new Map();
+      const styles: Styles = new Map([
+        [
+          "style-1:breakpoint-1:fontFamily",
+          {
+            breakpointId: "breakpoint-1",
+            styleSourceId: "style-1",
+            property: "fontFamily",
+            value: {
+              type: "fontFamily",
+              value: ["Arial", "sans-serif"],
+            },
+          },
+        ],
+      ]);
+      const assets = new Map<Asset["id"], Asset>();
+
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
+
+      expect(usages.size).toBe(0);
+    });
+
+    test("tracks same font used in multiple styles", () => {
+      const pages: Pages = {
+        meta: {},
+        homePage: {
+          id: "home",
+          name: "Home",
+          path: "",
+          title: "Home",
+          meta: {},
+          rootInstanceId: "root",
+        },
+        pages: [],
+        folders: [],
+      };
+      const props: Props = new Map();
+      const styles: Styles = new Map([
+        [
+          "style-1:breakpoint-1:fontFamily",
+          {
+            breakpointId: "breakpoint-1",
+            styleSourceId: "style-1",
+            property: "fontFamily",
+            value: {
+              type: "fontFamily",
+              value: ["CustomFont"],
+            },
+          },
+        ],
+        [
+          "style-2:breakpoint-1:fontFamily",
+          {
+            breakpointId: "breakpoint-1",
+            styleSourceId: "style-2",
+            property: "fontFamily",
+            value: {
+              type: "fontFamily",
+              value: ["CustomFont"],
+            },
+          },
+        ],
+      ]);
+      const assets = new Map<Asset["id"], Asset>([
+        [
+          "font-asset-1",
+          {
+            id: "font-asset-1",
+            type: "font",
+            name: "CustomFont",
+            format: "woff2",
+            size: 5000,
+            meta: { family: "CustomFont", style: "normal", weight: 400 },
+            createdAt: "2024-01-01",
+            projectId: "project-id",
+          },
+        ],
+      ]);
+
+      const usages = calculateUsagesByAssetId({ pages, props, styles, assets });
+
+      expect(usages.get("font-asset-1")).toEqual([
+        { type: "style", styleDeclKey: "style-1:breakpoint-1:fontFamily" },
+        { type: "style", styleDeclKey: "style-2:breakpoint-1:fontFamily" },
       ]);
     });
   });


### PR DESCRIPTION
## Description

Currently in asset info usages of a font asset is incorrect

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
