### PR TITLE
feat: When asset is deleted or uploaded - refresh asset resource

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,21 +39,93 @@
 
 ## Testing
 
-- Test utilities, not components
 - Every bug fix must have a test to prevent regression
+- Write tests for pure functions - avoid mocking whenever possible
+- Extract testable pure logic from side-effect code (I/O, network, DOM, React hooks)
+- **CRITICAL: Never define functions in test files that belong in implementation code**
+- If a test requires a pure function, that function must be exported from the implementation and imported in the test
 
-### Exporting Utilities for Testing
+### When to Test
 
-When testing internal utilities, export via `__testing__`:
+**DO test:**
+
+- Complex business logic with edge cases
+- Pure functions with non-trivial computation (algorithms, parsing, calculations)
+- Functions with multiple branches or conditions
+- Bug fixes (regression prevention)
+
+**DON'T test:**
+
+- Trivial wrappers around library/language features (e.g., `map.delete()`)
+- Simple data transformations with no logic
+- Coordination code that only orchestrates side effects
+- Direct framework integrations (DOM/React/hooks)
+
+### Writing Testable Code
+
+**WRONG** - Never define implementation logic in tests:
 
 ```typescript
-export const __testing__ = { internalUtility };
+// ❌ BAD: Function defined in test file
+const computeKey = (props: { assetId?: string }) => {
+  return props.assetId ?? "default";
+};
+
+test("computes key", () => {
+  expect(computeKey({ assetId: "123" })).toBe("123");
+});
 ```
 
-Import in tests:
+**CORRECT** - Extract to implementation, export, and test:
 
 ```typescript
-const { internalUtility } = __testing__;
+// implementation.ts
+export const computeKey = (props: {
+  assetId?: string;
+  src?: string;
+  defaultValue?: unknown;
+}) => {
+  return (
+    props.assetId?.toString() ??
+    (props.defaultValue != null ? String(props.defaultValue) : undefined) ??
+    (props.src != null ? String(props.src) : undefined)
+  );
+};
+
+// implementation.test.ts
+import { computeKey } from "./implementation";
+
+test("computes key", () => {
+  expect(computeKey({ assetId: "123" })).toBe("123");
+});
+```
+
+This ensures:
+
+- Implementation code is reusable and in the right place
+- Tests verify actual production code, not duplicates
+- No logic duplication between implementation and tests
+
+### Exporting for Tests
+
+**If the function is ALREADY used in production code:**
+
+- Use regular export: `export const utilityFn = ...`
+- The function has real production value beyond testing
+
+**If the function is ONLY needed for tests (internal utility not used elsewhere):**
+
+- Use `__testing__` export to signal it's for testing only:
+
+```typescript
+// implementation.ts
+const internalHelper = (x: number) => x * 2;
+
+export const __testing__ = { internalHelper };
+
+// implementation.test.ts
+import { __testing__ } from "./implementation";
+const { internalHelper } = __testing__;
 ```
 
 Don't create separate utility files just for testing.

--- a/apps/builder/app/builder/shared/assets/delete-assets.ts
+++ b/apps/builder/app/builder/shared/assets/delete-assets.ts
@@ -1,11 +1,18 @@
 import type { Asset } from "@webstudio-is/sdk";
 import { $assets } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync/sync-stores";
+import { onNextTransactionComplete } from "~/shared/sync/project-queue";
+import { invalidateAssets } from "~/shared/resources";
 
 export const deleteAssets = (assetIds: Asset["id"][]) => {
   serverSyncStore.createTransaction([$assets], (assets) => {
     for (const assetId of assetIds) {
       assets.delete(assetId);
     }
+  });
+
+  // Wait for server to confirm transaction, then invalidate cache
+  onNextTransactionComplete(() => {
+    invalidateAssets();
   });
 };

--- a/apps/builder/app/builder/shared/assets/upload-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/upload-assets.tsx
@@ -16,6 +16,8 @@ import {
   type UploadingFileData,
 } from "~/shared/nano-states";
 import { serverSyncStore } from "~/shared/sync/sync-stores";
+import { onNextTransactionComplete } from "~/shared/sync/project-queue";
+import { invalidateAssets } from "~/shared/resources";
 import {
   formatAssetName,
   getFileName,
@@ -38,6 +40,10 @@ const safeDeleteAssets = (assetIds: Asset["id"][], projectId: string) => {
       assets.delete(assetId);
     }
   });
+
+  onNextTransactionComplete(() => {
+    invalidateAssets();
+  });
 };
 
 const safeSetAsset = (asset: Asset, projectId: string) => {
@@ -51,6 +57,10 @@ const safeSetAsset = (asset: Asset, projectId: string) => {
 
   serverSyncStore.createTransaction([$assets], (assets) => {
     assets.set(asset.id, asset);
+  });
+
+  onNextTransactionComplete(() => {
+    invalidateAssets();
   });
 };
 

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.test.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, test, expect } from "vitest";
+import { __testing__ } from "./webstudio-component";
+
+const { computeComponentKey } = __testing__;
+
+describe("computeComponentKey - key generation logic", () => {
+  test("prioritizes assetId over other props", () => {
+    expect(
+      computeComponentKey({
+        $webstudio$canvasOnly$assetId: "asset-123",
+        src: "/image.jpg",
+        defaultValue: "default",
+      })
+    ).toBe("asset-123");
+  });
+
+  test("falls back to defaultValue when no assetId", () => {
+    expect(
+      computeComponentKey({
+        src: "/image.jpg",
+        defaultValue: "default-value",
+      })
+    ).toBe("default-value");
+  });
+
+  test("uses src when no assetId or defaultValue", () => {
+    expect(
+      computeComponentKey({
+        src: "/path/to/video.mp4",
+      })
+    ).toBe("/path/to/video.mp4");
+  });
+
+  test("returns undefined when no relevant props", () => {
+    expect(computeComponentKey({})).toBeUndefined();
+  });
+
+  test("handles null and undefined values", () => {
+    expect(
+      computeComponentKey({
+        src: null,
+        defaultValue: undefined,
+      })
+    ).toBeUndefined();
+  });
+
+  test("coerces defaultValue to string", () => {
+    expect(computeComponentKey({ defaultValue: 42 })).toBe("42");
+    expect(computeComponentKey({ defaultValue: true })).toBe("true");
+    expect(computeComponentKey({ defaultValue: 0 })).toBe("0");
+  });
+
+  test("coerces src to string", () => {
+    expect(computeComponentKey({ src: "string-src" })).toBe("string-src");
+    expect(computeComponentKey({ src: 123 })).toBe("123");
+    expect(computeComponentKey({ src: undefined })).toBeUndefined();
+  });
+
+  test("different assetIds produce different keys", () => {
+    const key1 = computeComponentKey({
+      $webstudio$canvasOnly$assetId: "asset-123",
+      src: "/image.jpg",
+    });
+    const key2 = computeComponentKey({
+      $webstudio$canvasOnly$assetId: "asset-456",
+      src: "/image.jpg",
+    });
+
+    expect(key1).not.toBe(key2);
+  });
+
+  test("different src values produce different keys", () => {
+    const key1 = computeComponentKey({ src: "/assets/video1.mp4" });
+    const key2 = computeComponentKey({ src: "/assets/video2.mp4" });
+
+    expect(key1).not.toBe(key2);
+  });
+});

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -41,6 +41,21 @@ import {
 } from "@webstudio-is/react-sdk";
 import { rawTheme } from "@webstudio-is/design-system";
 import { Input, Select, Textarea } from "@webstudio-is/sdk-components-react";
+
+const computeComponentKey = (props: Record<string, unknown>) => {
+  const assetId = props.$webstudio$canvasOnly$assetId;
+  const src = props.src;
+  const defaultValue = props.defaultValue;
+
+  return (
+    (typeof assetId === "string" ? assetId : undefined) ??
+    (defaultValue != null ? String(defaultValue) : undefined) ??
+    (src != null ? String(src) : undefined)
+  );
+};
+
+export const __testing__ = { computeComponentKey };
+
 import {
   $propValuesByInstanceSelectorWithMemoryProps,
   getIndexedInstanceId,
@@ -557,8 +572,9 @@ export const WebstudioComponentCanvas = forwardRef<
 
   // React ignores defaultValue changes after first render.
   // Key prop forces re-creation to reflect updates on canvas.
-  const key =
-    props.defaultValue != null ? props.defaultValue.toString() : undefined;
+  // Also use assetId to recreate component when asset changes (e.g., deleted, replaced)
+  // For expressions that resolve to asset URLs (via assets resource), use the src value itself
+  const key = computeComponentKey(props);
 
   const instanceElement = (
     <>

--- a/apps/builder/app/shared/resource-utils.ts
+++ b/apps/builder/app/shared/resource-utils.ts
@@ -1,0 +1,21 @@
+import hash from "@emotion/hash";
+import type { ResourceRequest } from "@webstudio-is/sdk";
+
+export const getResourceKey = (resource: ResourceRequest) => {
+  try {
+    return hash(
+      JSON.stringify([
+        // explicitly list all fields to keep hash stable
+        resource.name,
+        resource.method,
+        resource.url,
+        resource.searchParams,
+        resource.headers,
+        resource.body,
+      ])
+    );
+  } catch {
+    // guard from invalid resources
+    return "";
+  }
+};

--- a/apps/builder/app/shared/resources.test.ts
+++ b/apps/builder/app/shared/resources.test.ts
@@ -1,0 +1,212 @@
+import { describe, test, expect } from "vitest";
+import { getResourceKey } from "./resource-utils";
+import type { ResourceRequest } from "@webstudio-is/sdk";
+
+describe("getResourceKey - pure function tests", () => {
+  test("generates consistent hash for same resource", () => {
+    const resource: ResourceRequest = {
+      name: "test",
+      method: "get",
+      url: "/api/test",
+      searchParams: [],
+      headers: [],
+    };
+
+    const key1 = getResourceKey(resource);
+    const key2 = getResourceKey(resource);
+
+    expect(key1).toBe(key2);
+    expect(key1).toBeTruthy();
+    expect(typeof key1).toBe("string");
+  });
+
+  test("generates different hashes for different resources", () => {
+    const resource1: ResourceRequest = {
+      name: "test1",
+      method: "get",
+      url: "/api/test1",
+      searchParams: [],
+      headers: [],
+    };
+
+    const resource2: ResourceRequest = {
+      name: "test2",
+      method: "get",
+      url: "/api/test2",
+      searchParams: [],
+      headers: [],
+    };
+
+    const key1 = getResourceKey(resource1);
+    const key2 = getResourceKey(resource2);
+
+    expect(key1).not.toBe(key2);
+  });
+
+  test("different URLs produce different keys", () => {
+    const base: ResourceRequest = {
+      name: "api",
+      method: "get",
+      url: "/api/v1/users",
+      searchParams: [],
+      headers: [],
+    };
+
+    const modified: ResourceRequest = {
+      ...base,
+      url: "/api/v2/users",
+    };
+
+    expect(getResourceKey(base)).not.toBe(getResourceKey(modified));
+  });
+
+  test("different methods produce different keys", () => {
+    const base: ResourceRequest = {
+      name: "api",
+      method: "get",
+      url: "/api/users",
+      searchParams: [],
+      headers: [],
+    };
+
+    const modified: ResourceRequest = {
+      ...base,
+      method: "post",
+    };
+
+    expect(getResourceKey(base)).not.toBe(getResourceKey(modified));
+  });
+
+  test("search params affect the key", () => {
+    const withoutParams: ResourceRequest = {
+      name: "api",
+      method: "get",
+      url: "/api/users",
+      searchParams: [],
+      headers: [],
+    };
+
+    const withParams: ResourceRequest = {
+      ...withoutParams,
+      searchParams: [{ name: "page", value: "1" }],
+    };
+
+    expect(getResourceKey(withoutParams)).not.toBe(getResourceKey(withParams));
+  });
+
+  test("headers affect the key", () => {
+    const withoutHeaders: ResourceRequest = {
+      name: "api",
+      method: "get",
+      url: "/api/users",
+      searchParams: [],
+      headers: [],
+    };
+
+    const withHeaders: ResourceRequest = {
+      ...withoutHeaders,
+      headers: [{ name: "Authorization", value: "Bearer token" }],
+    };
+
+    expect(getResourceKey(withoutHeaders)).not.toBe(
+      getResourceKey(withHeaders)
+    );
+  });
+
+  test("body affects the key", () => {
+    const withoutBody: ResourceRequest = {
+      name: "api",
+      method: "post",
+      url: "/api/users",
+      searchParams: [],
+      headers: [],
+    };
+
+    const withBody: ResourceRequest = {
+      ...withoutBody,
+      body: JSON.stringify({ name: "John" }),
+    };
+
+    expect(getResourceKey(withoutBody)).not.toBe(getResourceKey(withBody));
+  });
+
+  test("handles resources with complex nested data", () => {
+    const resource: ResourceRequest = {
+      name: "complex",
+      method: "post",
+      url: "/api/test",
+      searchParams: [
+        { name: "filter", value: "active" },
+        { name: "sort", value: "desc" },
+      ],
+      headers: [
+        { name: "Content-Type", value: "application/json" },
+        { name: "Authorization", value: "Bearer xyz" },
+      ],
+      body: JSON.stringify({ data: { nested: { value: true } } }),
+    };
+
+    const key = getResourceKey(resource);
+    expect(key).toBeTruthy();
+    expect(typeof key).toBe("string");
+  });
+
+  test("order of search params matters", () => {
+    const resource1: ResourceRequest = {
+      name: "api",
+      method: "get",
+      url: "/api/test",
+      searchParams: [
+        { name: "a", value: "1" },
+        { name: "b", value: "2" },
+      ],
+      headers: [],
+    };
+
+    const resource2: ResourceRequest = {
+      name: "api",
+      method: "get",
+      url: "/api/test",
+      searchParams: [
+        { name: "b", value: "2" },
+        { name: "a", value: "1" },
+      ],
+      headers: [],
+    };
+
+    // Order matters because we serialize the array as-is
+    expect(getResourceKey(resource1)).not.toBe(getResourceKey(resource2));
+  });
+
+  test("returns empty string for invalid resource with circular reference", () => {
+    const invalidResource = {
+      name: "test",
+      method: "get" as const,
+      url: "/api/test",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      get searchParams(): any {
+        return [this];
+      },
+      headers: [],
+    };
+
+    const key = getResourceKey(invalidResource);
+    expect(key).toBe("");
+  });
+
+  test("assets system resource produces consistent key", () => {
+    const assetsResource: ResourceRequest = {
+      name: "assets",
+      method: "get",
+      url: "/$resources/assets",
+      searchParams: [],
+      headers: [],
+    };
+
+    const key1 = getResourceKey(assetsResource);
+    const key2 = getResourceKey(assetsResource);
+
+    expect(key1).toBe(key2);
+    expect(key1).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Description

When user is using asset resource and binding it on canvas, for example video file bound to video tag to the src attribute and then deletes the asset, it is expected that canvas reflects the deleted asset as well as the variable.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
