### PR TITLE
fix: Filter custom selectors to current instance only

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -191,3 +191,6 @@ When writing social posts for new releases:
 
 - After completing changes, review your own code against all instructions in this document.
 - If a component or module needs refactoring (e.g., too many props, too complex, violates guidelines), ask the user before proceeding.
+- Always perform these two checks:
+  1. What needs to be purified? (extract pure functions from side-effect code)
+  2. Which of the pure functions need tests? (see "When to Test" section)

--- a/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
@@ -1,5 +1,5 @@
 import { enableMapSet } from "immer";
-import { expect, test } from "vitest";
+import { expect, test, describe } from "vitest";
 import { registerContainers } from "~/shared/sync/sync-stores";
 import {
   $instances,
@@ -7,11 +7,114 @@ import {
   $styleSourceSelections,
   $styleSources,
 } from "~/shared/nano-states";
-import { addStyleSourceToInstance } from "./style-source-section";
+import { addStyleSourceToInstance, __testing__ } from "./style-source-section";
 import { $awareness } from "~/shared/awareness";
+
+const { getComponentStates } = __testing__;
 
 enableMapSet();
 registerContainers();
+
+describe("getComponentStates", () => {
+  test("returns predefined states for tag", () => {
+    const result = getComponentStates({
+      predefinedStates: [":visited", ":active"],
+      componentStates: [],
+      instanceStyleSourceIds: new Set(),
+      styles: [],
+      selectedStyleState: undefined,
+    });
+
+    // Should include universal states (:hover, :focus, etc.) and tag-specific states
+    expect(result.some((s) => s.selector === ":hover")).toBe(true);
+    expect(result.some((s) => s.selector === ":visited")).toBe(true);
+    expect(result.some((s) => s.selector === ":active")).toBe(true);
+    expect(result.every((s) => s.source === "native")).toBe(true);
+  });
+
+  test("includes selectors from instance styles only", () => {
+    const result = getComponentStates({
+      predefinedStates: [],
+      componentStates: [],
+      instanceStyleSourceIds: new Set(["style1"]),
+      styles: [
+        { styleSourceId: "style1", state: "::before" },
+        { styleSourceId: "other", state: "::after" },
+      ],
+      selectedStyleState: undefined,
+    });
+
+    // Should include ::before from instance's style source
+    expect(result.some((s) => s.selector === "::before")).toBe(true);
+    // Should NOT include ::after from other style source
+    expect(result.some((s) => s.selector === "::after")).toBe(false);
+  });
+
+  test("marks custom selectors correctly", () => {
+    const result = getComponentStates({
+      predefinedStates: [],
+      componentStates: [],
+      instanceStyleSourceIds: new Set(["style1"]),
+      styles: [{ styleSourceId: "style1", state: "::before" }],
+      selectedStyleState: undefined,
+    });
+
+    const beforeSelector = result.find((s) => s.selector === "::before");
+    expect(beforeSelector?.source).toBe("custom");
+    expect(beforeSelector?.type).toBe("pseudoElement");
+  });
+
+  test("includes currently selected state even without styles", () => {
+    const result = getComponentStates({
+      predefinedStates: [],
+      componentStates: [],
+      instanceStyleSourceIds: new Set(),
+      styles: [],
+      selectedStyleState: "::marker",
+    });
+
+    expect(result.some((s) => s.selector === "::marker")).toBe(true);
+  });
+
+  test("includes component states", () => {
+    const result = getComponentStates({
+      predefinedStates: [],
+      componentStates: [
+        { label: "Open", selector: "[data-state=open]" },
+        { label: "Closed", selector: "[data-state=closed]" },
+      ],
+      instanceStyleSourceIds: new Set(),
+      styles: [],
+      selectedStyleState: undefined,
+    });
+
+    const openState = result.find((s) => s.selector === "[data-state=open]");
+    expect(openState?.source).toBe("component");
+    expect(openState?.label).toBe("Open");
+  });
+
+  test("removes selector when styles are cleared", () => {
+    // First, with styles
+    const withStyles = getComponentStates({
+      predefinedStates: [],
+      componentStates: [],
+      instanceStyleSourceIds: new Set(["style1"]),
+      styles: [{ styleSourceId: "style1", state: "::before" }],
+      selectedStyleState: undefined,
+    });
+    expect(withStyles.some((s) => s.selector === "::before")).toBe(true);
+
+    // After clearing styles (empty styles array)
+    const withoutStyles = getComponentStates({
+      predefinedStates: [],
+      componentStates: [],
+      instanceStyleSourceIds: new Set(["style1"]),
+      styles: [],
+      selectedStyleState: undefined,
+    });
+    expect(withoutStyles.some((s) => s.selector === "::before")).toBe(false);
+  });
+});
 
 test("add style source to instance", () => {
   $instances.set(


### PR DESCRIPTION
Custom selectors like ::before were persisting in the style source menu after clearing styles because the code iterated over ALL project styles instead of filtering to the current instance's style sources.

- Extract getComponentStates as pure function
- Filter styles by instanceStyleSourceIds from styleSourceSelections
- Add regression tests for the bug fix
