### PR TITLE
fix: preserve -webkit-text-stroke prefix in CSS parsing

### DIFF
--- a/packages/css-data/src/parse-css.test.ts
+++ b/packages/css-data/src/parse-css.test.ts
@@ -539,6 +539,23 @@ describe("Parse CSS", () => {
     ]);
   });
 
+  test("keep prefix for -webkit-text-stroke", () => {
+    // shorthand is kept as-is (not expanded) but prefix is preserved
+    expect(parseCss(`a { -webkit-text-stroke: 1px black; }`)).toEqual([
+      {
+        selector: "a",
+        property: "-webkit-text-stroke",
+        value: {
+          type: "tuple",
+          value: [
+            { type: "unit", unit: "px", value: 1 },
+            { type: "keyword", value: "black" },
+          ],
+        },
+      },
+    ]);
+  });
+
   test("parse child combinator", () => {
     expect(parseCss(`a > b { color: #ff0000 }`)).toEqual([
       {

--- a/packages/css-data/src/parse-css.ts
+++ b/packages/css-data/src/parse-css.ts
@@ -24,6 +24,9 @@ const prefixedProperties = [
   "-moz-osx-font-smoothing",
   "-webkit-tap-highlight-color",
   "-webkit-overflow-scrolling",
+  "-webkit-text-stroke",
+  "-webkit-text-stroke-color",
+  "-webkit-text-stroke-width",
 ];
 const prefixes = ["webkit", "moz", "ms", "o"];
 const prefixRegex = new RegExp(`^-(${prefixes.join("|")})-`);


### PR DESCRIPTION
When entering -webkit-text-stroke in the advanced style section, it was incorrectly converted to --text-stroke (CSS variable). This happened because normalizeProperty() strips vendor prefixes from properties not in the prefixedProperties allowlist, and then parse-style-input.ts sees the unknown property 'text-stroke' and converts it to a CSS variable.

Changes:
- Add -webkit-text-stroke, -webkit-text-stroke-color, and -webkit-text-stroke-width to prefixedProperties list
- Add test for -webkit-text-stroke preservation

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
