### PR TITLE
fix: revert combobox defaultHighlightedIndex to -1

### DIFF
--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -268,7 +268,7 @@ export const useCombobox = <Item,>({
   onItemHighlight,
   stateReducer = (_state, { changes }) => changes,
   match = defaultMatch,
-  defaultHighlightedIndex = 0,
+  defaultHighlightedIndex = -1,
   ...rest
 }: UseComboboxProps<Item>) => {
   const [isOpen, setIsOpen] = useState(false);


### PR DESCRIPTION
When user enters a value that matches an autocomplete item but wants to keep their custom entry (not select the autocomplete suggestion), they need to press ESC to dismiss the autocomplete. With defaultHighlightedIndex=0, the first item was always highlighted and could interfere with this workflow.

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
