### PR TITLE
fix: Keep spacing popover open when using arrow keys

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -760,7 +760,12 @@ export const CssValueInput = ({
         unit: value.unit,
       };
 
-      onChangeComplete({ value: newValue, ...meta, type: "delta" });
+      onChangeComplete({
+        value: newValue,
+        ...meta,
+        type: "delta",
+        close: false,
+      });
       event.preventDefault();
     }
   };


### PR DESCRIPTION
When pressing arrow up/down to adjust values in the spacing UI popover, the popover would close immediately after applying the value. Now it stays open by passing close: false for delta (arrow key) changes.

