### PR TITLE
fix: Show Brave browser error message on forms

### DIFF
--- a/packages/sdk-components-react-router/src/webhook-form.tsx
+++ b/packages/sdk-components-react-router/src/webhook-form.tsx
@@ -9,7 +9,7 @@ import { useFetcher, type Fetcher, type FormProps } from "react-router";
 import {
   formIdFieldName,
   formBotFieldName,
-  getBraveErrorHtml,
+  isBraveBrowser,
 } from "@webstudio-is/sdk/runtime";
 
 export const defaultTag = "form";
@@ -104,6 +104,7 @@ export const WebhookForm = forwardRef<
     /**
      * Add hidden field generated using js with simple jsdom detector.
      * This is used to protect form submission against very simple bots.
+     * Skipped for Brave browser due to: https://github.com/brave/brave-browser/issues/46541
      */
     const handleSubmitAndAddHiddenJsField = (
       event: React.FormEvent<HTMLFormElement>
@@ -111,8 +112,13 @@ export const WebhookForm = forwardRef<
       const hiddenInput = document.createElement("input");
       hiddenInput.type = "hidden";
       hiddenInput.name = formBotFieldName;
-      // Non-numeric values are utilized for logging purposes.
-      hiddenInput.value = isJSDom() ? "jsdom" : Date.now().toString(16);
+      // Skip bot detection for Brave - Shields blocks matchMedia fingerprinting detection
+      if (isBraveBrowser()) {
+        hiddenInput.value = "brave";
+      } else {
+        // Non-numeric values are utilized for logging purposes.
+        hiddenInput.value = isJSDom() ? "jsdom" : Date.now().toString(16);
+      }
       event.currentTarget.appendChild(hiddenInput);
     };
 
@@ -130,7 +136,6 @@ export const WebhookForm = forwardRef<
           value={action?.toString()}
         />
         {children}
-        <div dangerouslySetInnerHTML={{ __html: getBraveErrorHtml() }} />
       </fetcher.Form>
     );
   }

--- a/packages/sdk/src/form-fields.ts
+++ b/packages/sdk/src/form-fields.ts
@@ -13,22 +13,10 @@ export const formBotFieldName = `ws--form-bot`;
  * causing form submissions to silently fail.
  * @see https://github.com/brave/brave-browser/issues/46541
  */
-const isBraveBrowser = (): boolean => {
+export const isBraveBrowser = (): boolean => {
   if (typeof navigator === "undefined") {
     return false;
   }
   // @ts-expect-error - brave is a non-standard property
   return navigator.brave?.isBrave?.() === true || navigator.brave !== undefined;
-};
-
-/**
- * Returns HTML string with Brave browser error message, or empty string if not Brave.
- * Render with dangerouslySetInnerHTML.
- * @see https://github.com/brave/brave-browser/issues/46541
- */
-export const getBraveErrorHtml = (): string => {
-  if (isBraveBrowser() === false) {
-    return "";
-  }
-  return `<div data-ws-brave-error style="color: red">This form doesn't work due to a <a href="https://github.com/brave/brave-browser/issues/46541" target="_blank" rel="noopener noreferrer">bug</a> in Brave browser. Disable Shields for this site or use a different browser.</div>`;
 };


### PR DESCRIPTION
Brave Shields blocks our bot protection mechanism (matchMedia fingerprinting detection), causing form submissions to silently fail.

- Added getBraveErrorHtml() in SDK that returns error message HTML
- Form component renders the error when Brave is detected

See: https://github.com/brave/brave-browser/issues/46541

