### PR TITLE
chore: add workflow_dispatch trigger to CLI R2 workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,11 +5,6 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspaces/webstudio",
-  "initializeCommand": "mkdir -p ~/.github ~/webstudio",
-  "mounts": [
-    "source=${localEnv:HOME}/webstudio/webstudio-saas,target=/workspaces/webstudio-saas,type=bind",
-    "source=${localEnv:HOME}/.github,target=/workspaces/webstudio/.github,type=bind"
-  ],
   "features": {
     "ghcr.io/robbert229/devcontainer-features/postgresql-client:1": {
       "version": "15"

--- a/.github/workflows/cli-r2.yaml
+++ b/.github/workflows/cli-r2.yaml
@@ -1,6 +1,12 @@
 name: CLI R2
 
 on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to build"
+        required: false
+        default: "main"
   push:
     branches:
       - "*.staging"
@@ -29,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }} # HEAD commit instead of merge commit
+          ref: ${{ inputs.ref || github.sha }} # Use input ref for workflow_dispatch, or HEAD commit
 
       # We need submodules here as this is used for the cloudflare build
       - uses: ./.github/actions/submodules-checkout
@@ -69,13 +75,23 @@ jobs:
 
       - name: Copy artifact
         run: |
-          # For staging
-          aws s3 cp cloudflare-template.tar.zst "s3://${ARTEFACT_BUCKET_NAME}/public/cloudflare-template/${{ github.ref_name }}.tar.zst"
+          # Get the actual SHA of the checked out commit
+          ACTUAL_SHA=$(git rev-parse HEAD)
 
-          # For production can be cached forever
+          # For staging/branch builds
+          if [ -n "${{ github.ref_name }}" ] && [ "${{ github.ref_name }}" != "" ]; then
+            aws s3 cp cloudflare-template.tar.zst "s3://${ARTEFACT_BUCKET_NAME}/public/cloudflare-template/${{ github.ref_name }}.tar.zst"
+          fi
+
+          # For production - use the actual SHA (can be cached forever)
           aws s3 cp \
           --metadata-directive REPLACE --cache-control "public,max-age=31536102,immutable" \
-          cloudflare-template.tar.zst "s3://${ARTEFACT_BUCKET_NAME}/public/cloudflare-template/${{ github.sha }}.tar.zst"
+          cloudflare-template.tar.zst "s3://${ARTEFACT_BUCKET_NAME}/public/cloudflare-template/${ACTUAL_SHA}.tar.zst"
+
+          # Also upload as "main" for workflow_dispatch on main branch
+          if [ "${{ inputs.ref }}" = "main" ] || [ "${{ github.ref_name }}" = "main" ]; then
+            aws s3 cp cloudflare-template.tar.zst "s3://${ARTEFACT_BUCKET_NAME}/public/cloudflare-template/main.tar.zst"
+          fi
 
         working-directory: ${{ github.workspace }}/..
         env:
@@ -103,7 +119,10 @@ jobs:
           node-version: 20
 
       - name: Copy atrifact via http
-        run: curl -o cloudflare-template.tar.zst ${{ secrets.ARTEFACT_BUCKET_URL }}/public/cloudflare-template/${{ github.ref_name }}.tar.zst
+        run: |
+          # For workflow_dispatch, use the input ref; for push, use branch name
+          ARTIFACT_REF="${{ inputs.ref || github.ref_name }}"
+          curl -o cloudflare-template.tar.zst "${{ secrets.ARTEFACT_BUCKET_URL }}/public/cloudflare-template/${ARTIFACT_REF}.tar.zst"
 
       - name: Extract archive
         run: tar --use-compress-program="zstd -d" -xf cloudflare-template.tar.zst -C .
@@ -131,6 +150,8 @@ jobs:
 
   delete-github-deployments:
     needs: checks
+    # Only delete deployments for branch pushes, not workflow_dispatch
+    if: github.event_name == 'push'
     uses: ./.github/workflows/delete-github-deployments.yml
     with:
       ref: ${{ github.ref_name }}


### PR DESCRIPTION
Allow manual triggering of the CLI R2 workflow to rebuild the cloudflare-template artifact. This is needed for the republish script to rebuild main.tar.zst when republishing accidentally unpublished sites.

Changes:
- Add workflow_dispatch trigger with optional ref input (defaults to 'main')
- Upload artifact as main.tar.zst when building main branch
- Fix checks job to use correct artifact path for workflow_dispatch
- Skip delete-github-deployments for workflow_dispatch (no branch to clean up)
- Remove local mounts from devcontainer.json

