### PR TITLE
chore: Mount user Copilot instructions into devcontainer

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       # preserve history
       - ./.local:/home/node/.local
       - docker-data:/var/lib/docker
+      - ${HOME}/.github/instructions:/home/node/.github/instructions
 
     entrypoint: ["/usr/local/share/docker-init.sh"]
     # Overrides default command so things don't shut down after the process ends.

--- a/.devcontainer/postinstall.sh
+++ b/.devcontainer/postinstall.sh
@@ -42,5 +42,11 @@ alias gitclean="(git remote | xargs git remote prune) && git branch -vv | egrep 
 alias gitrebase="git rebase --interactive main"
 EOF
 
+# Symlink workspace GitHub instructions to mounted user instructions (for Copilot)
+if [ -d "/home/node/.github/instructions" ]; then
+  mkdir -p /workspaces/webstudio/.github
+  ln -sfn /home/node/.github/instructions /workspaces/webstudio/.github/instructions
+fi
+
 
 echo "postinstall.sh finished"

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ packages/prisma-client/src/__generated__
 
 .temp
 *.timestamp-*.mjs
+
+# copilot instructions
+.github/instructions


### PR DESCRIPTION
- Mount ~/.github/instructions from host to devcontainer
- Symlink mounted instructions to workspace .github/instructions
- Add .github/instructions to gitignore
