### PR TITLE
fix: scrub on CSS value input not working

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -259,12 +259,17 @@ const useScrub = ({
       },
       shouldHandleEvent,
     });
+    // value.type and value.unit are intentionally in the dependency array
+    // to re-setup scrub when the value type changes (e.g., from keyword to unit)
   }, [
     shouldHandleEvent,
     property,
     updateIntermediateValue,
     onAbortStable,
     defaultUnit,
+    value.type,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    "unit" in value ? value.unit : undefined,
   ]);
 
   return [scrubRef, inputRef];


### PR DESCRIPTION
The scrub (drag to change value) feature was not working on CSS value inputs when the initial value was a keyword like 'auto'.

This was a regression from b18315e570 which changed the early-return checks to use valueRef.current.type but forgot to add value.type to the useEffect dependency array, so the scrub control was never re-attached when the value type changed.
