### PR TITLE
fix: add authorization checks 

### DIFF
--- a/packages/project/src/trpc/project-router.ts
+++ b/packages/project/src/trpc/project-router.ts
@@ -124,7 +124,17 @@ export const projectRouter = router({
           ctx.authorization.type !== "user" &&
           ctx.authorization.type !== "token"
         ) {
-          throw new Error("Not authorized");
+          throw new AuthorizationError("Not authorized");
+        }
+        const permit = await authorizeProject.getProjectPermit(
+          {
+            projectId: input.projectId,
+            permits: ["view", "build", "admin"],
+          },
+          ctx
+        );
+        if (permit === undefined) {
+          throw new AuthorizationError("Not authorized to access this project");
         }
         const publishedBuilds = await ctx.postgrest.client
           .from("published_builds")


### PR DESCRIPTION
closes https://github.com/webstudio-is/webstudio/issues/5621

to publishedBuilds and findManyByIds en…dpoints

- Add getProjectPermit check to publishedBuilds endpoint to verify user has access
- Add userId filtering to findManyByIds to only return user's own projects or approved marketplace templates
- Maintain belt-and-suspenders approach with both authType check and permit verification

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
