### PR TITLE
fix: remove unusable filter from allowedArrayMethods in expressions

### DIFF
--- a/apps/builder/app/builder/shared/expression-editor.test.ts
+++ b/apps/builder/app/builder/shared/expression-editor.test.ts
@@ -64,7 +64,6 @@ describe("generateCompletionOptions", () => {
       expect(labels).toContain("1");
       expect(labels).toContain("2");
       expect(labels).toContain("length");
-      expect(labels).toContain("filter()");
       expect(labels).toContain("slice()");
 
       // Check specific values
@@ -73,22 +72,6 @@ describe("generateCompletionOptions", () => {
         label: "length",
         detail: "3",
         type: "property",
-      });
-    });
-
-    test("includes array methods when searching", () => {
-      const target = [1, 2, 3];
-      const options = generateCompletionOptions({
-        target,
-        pathName: "fil",
-        pathLength: 1,
-      });
-
-      const methodOptions = options.filter((o) => o.type === "method");
-      expect(methodOptions).toContainEqual({
-        label: "filter()",
-        detail: "array method",
-        type: "method",
       });
     });
 
@@ -233,7 +216,6 @@ describe("generateCompletionOptions", () => {
       // Empty array has length and all array methods
       const labels = options.map((o) => o.label);
       expect(labels).toContain("length");
-      expect(labels).toContain("filter()");
       expect(labels).toContain("slice()");
 
       const lengthOption = options.find((o) => o.label === "length");

--- a/packages/sdk/src/expression.test.ts
+++ b/packages/sdk/src/expression.test.ts
@@ -456,12 +456,6 @@ describe("transpile expression", () => {
         executable: true,
       })
     ).toEqual("items?.map?.(item => item?.id)");
-    expect(
-      transpileExpression({
-        expression: "data.list.filter(x => x > 0)",
-        executable: true,
-      })
-    ).toEqual("data?.list?.filter?.(x => x > 0)");
   });
 
   test("transpile nested method calls with optional chaining", () => {

--- a/packages/sdk/src/expression.ts
+++ b/packages/sdk/src/expression.ts
@@ -43,13 +43,7 @@ export const allowedStringMethods = new Set([
   "toLocaleUpperCase",
 ]);
 
-export const allowedArrayMethods = new Set([
-  "at",
-  "includes",
-  "join",
-  "slice",
-  "filter",
-]);
+export const allowedArrayMethods = new Set(["at", "includes", "join", "slice"]);
 
 export const lintExpression = ({
   expression,


### PR DESCRIPTION
filter requires a callback (arrow function) which is blocked by the linter's blanket "Functions are not supported" rule, making it effectively dead code. Remove it and update all related tests.

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
