### PR TITLE
fix: Show lifetime deal purchases in profile menu

### DIFF
--- a/apps/builder/app/dashboard/profile-menu.tsx
+++ b/apps/builder/app/dashboard/profile-menu.tsx
@@ -61,10 +61,8 @@ export const ProfileMenu = ({
 }) => {
   const navigate = useNavigate();
   const nameOrEmail = user.username ?? user.email ?? defaultUserName;
-  const hasPaidPlan = userPlanFeatures.purchases.length > 0;
-  const subscriptions = userPlanFeatures.purchases.filter((purchase) =>
-    Boolean(purchase.subscriptionId)
-  );
+  const purchases = userPlanFeatures.purchases;
+  const hasPaidPlan = purchases.length > 0;
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -79,22 +77,28 @@ export const ProfileMenu = ({
           {user.username ?? defaultUserName}
           <Text>{user.email}</Text>
         </DropdownMenuLabel>
-        {subscriptions.length > 0 && (
+        {purchases.length > 0 && (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuLabel>Purchases</DropdownMenuLabel>
           </>
         )}
-        {subscriptions.map((purchase) => (
-          <DropdownMenuItem
-            key={purchase.subscriptionId}
-            onSelect={() =>
-              navigate(userPlanSubscriptionPath(purchase.subscriptionId))
-            }
-          >
-            {purchase.planName}
-          </DropdownMenuItem>
-        ))}
+        {purchases.map((purchase, index) =>
+          purchase.subscriptionId ? (
+            <DropdownMenuItem
+              key={purchase.subscriptionId}
+              onSelect={() =>
+                navigate(userPlanSubscriptionPath(purchase.subscriptionId))
+              }
+            >
+              {purchase.planName}
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuLabel key={index}>
+              {purchase.planName}
+            </DropdownMenuLabel>
+          )
+        )}
         {hasPaidPlan === false && (
           <DropdownMenuItem
             onSelect={() => {


### PR DESCRIPTION
Previously only purchases with a subscriptionId (recurring subscriptions) were displayed. Lifetime deals were counted as paid (no "Free" badge) but not shown in the dropdown. Now LTDs appear as non-clickable labels while subscriptions remain clickable and navigate to the billing portal.

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
