### PR TITLE
feat: add publish hints for unpublished custom domains

### DIFF
--- a/apps/builder/app/builder/features/topbar/domains.tsx
+++ b/apps/builder/app/builder/features/topbar/domains.tsx
@@ -8,12 +8,19 @@ import {
   InputField,
   styled,
   Flex,
+  Link,
+  SmallIconButton,
   NestedInputButton,
   Separator,
   toast,
 } from "@webstudio-is/design-system";
 import type { Project } from "@webstudio-is/project";
-import { AlertIcon, CheckCircleIcon, CopyIcon } from "@webstudio-is/icons";
+import {
+  AlertIcon,
+  CheckCircleIcon,
+  CopyIcon,
+  HelpIcon,
+} from "@webstudio-is/icons";
 import { CollapsibleDomainSection } from "./collapsible-domain-section";
 import {
   Fragment,
@@ -323,8 +330,8 @@ const DomainItem = ({
         <DomainCheckbox
           buildId={projectDomain.latestBuildVirtual?.buildId}
           defaultChecked={
-            projectDomain.latestBuildVirtual?.buildId != null &&
-            projectDomain.latestBuildVirtual?.buildId ===
+            projectDomain.latestBuildVirtual == null ||
+            projectDomain.latestBuildVirtual.buildId ===
               project.latestBuildVirtual?.buildId
           }
           domain={projectDomain.domain}
@@ -431,14 +438,31 @@ const DomainItem = ({
           )}
         </Grid>
 
-        <Text color="subtle">
-          <strong>To verify your domain:</strong>
-          <br />
-          Visit the admin console of your domain registrar (the website you
-          purchased your domain from) and create one <strong>CNAME</strong>{" "}
-          record and one <strong>TXT</strong> record with the values shown
-          below:
-        </Text>
+        <Flex align="center" gap="1">
+          <Text color="subtle">
+            <strong>Connect your domain</strong>
+          </Text>
+          <Tooltip
+            variant="wrapped"
+            content={
+              <Text>
+                Visit the admin console of your domain registrar (the website
+                you purchased your domain from) and create one CNAME record and
+                one TXT record with the values shown below.{" "}
+                <Link
+                  color="inherit"
+                  href="https://docs.webstudio.is/university/foundations/publishing-and-custom-domains"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Learn more.
+                </Link>
+              </Text>
+            }
+          >
+            <SmallIconButton icon={<HelpIcon />} />
+          </Tooltip>
+        </Flex>
 
         <Grid
           gap={2}

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -925,6 +925,13 @@ const Content = (props: {
   const { userPublishCount, maxPublishesAllowedPerUser } =
     useUserPublishCount();
 
+  const hasUnpublishedDomains = project.domainsVirtual.some(
+    (domain) =>
+      domain.verified &&
+      domain.status === "ACTIVE" &&
+      domain.latestBuildVirtual == null
+  );
+
   return (
     <form>
       <ScrollArea>
@@ -958,6 +965,18 @@ const Content = (props: {
           onExportClick={props.onExportClick}
         />
         <UpgradeBanner />
+        {hasUnpublishedDomains && (
+          <PanelBanner>
+            <Flex align="center" gap="1">
+              <InfoCircleIcon color={rawTheme.colors.foregroundMain} />
+              <Text variant="regularBold">Don't forget to publish</Text>
+            </Flex>
+            <Text>
+              You have a custom domain that hasn't been published yet. Hit
+              publish to make it live.
+            </Text>
+          </PanelBanner>
+        )}
         <Publish
           project={project}
           refresh={refreshProject}


### PR DESCRIPTION
- Show "Don't forget to publish" banner when a domain is connected but not yet published
- Default-check newly added domains so they're included on publish
- Move domain instructions into a tooltip with help icon and docs link

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
