### PR TITLE
fix: Discontinue a soft downgrade for free users

### DIFF
--- a/apps/builder/app/builder/features/publish/domain-checkbox.tsx
+++ b/apps/builder/app/builder/features/publish/domain-checkbox.tsx
@@ -19,6 +19,7 @@ interface DomainCheckboxProps {
   domain: string;
   buildId: string | undefined;
   disabled?: boolean;
+  isCustomDomain?: boolean;
 }
 
 export const DomainCheckbox = (props: DomainCheckboxProps) => {
@@ -56,8 +57,12 @@ export const DomainCheckbox = (props: DomainCheckboxProps) => {
     </Flex>
   );
 
-  const defaultChecked = allowStagingPublish ? props.defaultChecked : true;
-  const disabled = allowStagingPublish ? props.disabled : true;
+  // On free plan: custom domains are disabled+unchecked (can't publish to them).
+  // Staging domain behaves normally — user can still check/uncheck it.
+  const defaultChecked =
+    !allowStagingPublish && props.isCustomDomain ? false : props.defaultChecked;
+  const disabled =
+    !allowStagingPublish && props.isCustomDomain ? true : props.disabled;
 
   const hideDomainCheckbox =
     project.domainsVirtual.filter(

--- a/apps/builder/app/builder/features/publish/domains.tsx
+++ b/apps/builder/app/builder/features/publish/domains.tsx
@@ -336,6 +336,7 @@ const DomainItem = ({
           }
           domain={projectDomain.domain}
           disabled={domainStatus !== "VERIFIED_ACTIVE"}
+          isCustomDomain
         />
       }
       initiallyOpen={initiallyOpen}

--- a/apps/builder/app/builder/features/publish/publish.tsx
+++ b/apps/builder/app/builder/features/publish/publish.tsx
@@ -416,14 +416,9 @@ const Publish = ({
   const [hasSelectedDomains, setHasSelectedDomains] = useState(false);
   const userPlanFeatures = useStore($userPlanFeatures);
   const hasPaidPlan = userPlanFeatures.purchases.length > 0;
-  const { allowStagingPublish } = userPlanFeatures;
   const countdown = usePublishCountdown(isPublishing);
 
   useEffect(() => {
-    if (allowStagingPublish === false) {
-      setHasSelectedDomains(true);
-      return;
-    }
     const form = buttonRef.current?.closest("form");
 
     if (form == null) {
@@ -452,22 +447,17 @@ const Publish = ({
     return () => {
       observer.disconnect();
     };
-  }, [allowStagingPublish]);
+  }, []);
 
   const handlePublish = async (formData: FormData) => {
     setPublishError(undefined);
     setIsPublishing(true);
 
-    const domains = allowStagingPublish
-      ? formData
-          .getAll(domainToPublishName)
-          .map((domainEntry) => domainEntry.toString())
-      : [
-          project.domain,
-          ...project.domainsVirtual
-            .filter((domain) => domain.verified && domain.status === "ACTIVE")
-            .map((domain) => domain.domain),
-        ];
+    // Custom domain checkboxes are disabled on free plan so they are never
+    // submitted — only the staging (wstd.io) domain can appear in formData.
+    const domains = formData
+      .getAll(domainToPublishName)
+      .map((domainEntry) => domainEntry.toString());
 
     if (domains.length === 0) {
       toast.error("Please select at least one domain to publish");
@@ -807,7 +797,6 @@ const UpgradeBanner = () => {
   const { canAddDomain } = useCanAddDomain();
   const { userPublishCount, maxPublishesAllowedPerUser } =
     useUserPublishCount();
-
   if (userPublishCount >= maxPublishesAllowedPerUser) {
     return (
       <PanelBanner>


### PR DESCRIPTION
- Custom domain checkboxes are disabled+unchecked on free plan
- Staging domain checkbox remains enabled (user can check/uncheck)
- handlePublish reads formData directly; disabled checkboxes are never submitted so custom domains are naturally excluded
- Removed force-set of hasSelectedDomains on free plan so publish button correctly reflects actual checkbox state
