### PR TITLE
fix: keep the resource variable modal open when adding headers

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -298,6 +298,7 @@ const SearchParamPair = ({
         />
       </BindingControl>
       <SmallIconButton
+        type="button"
         aria-label="Delete search param"
         variant="destructive"
         icon={<TrashIcon />}
@@ -323,6 +324,7 @@ export const SearchParams = ({
       <Flex justify="between" align="center">
         <Label>Search params</Label>
         <SmallIconButton
+          type="button"
           aria-label="Add another search param"
           icon={<PlusIcon />}
           onClick={() => {
@@ -422,6 +424,7 @@ const HeaderPair = ({
         />
       </BindingControl>
       <SmallIconButton
+        type="button"
         aria-label="Delete header"
         variant="destructive"
         icon={<TrashIcon />}
@@ -447,6 +450,7 @@ export const Headers = ({
       <Flex justify="between" align="center">
         <Label>Headers</Label>
         <SmallIconButton
+          type="button"
           aria-label="Add another search param"
           icon={<PlusIcon />}
           onClick={() => {

--- a/apps/builder/docs/test-cases.md
+++ b/apps/builder/docs/test-cases.md
@@ -177,3 +177,13 @@
    - The name should change in the pages list as well (with a small delay)
    - Change the page path
    - Reload browser tab and open the page settings again and make sure your changes are persisted
+
+1. Data variables
+
+   - Select an element in the project
+   - Open Settings and create a new data variable
+   - Set the name and choose the `resource` type
+   - Enter a valid resource URL
+   - Add a header and verify the modal stays open and a new header row appears
+   - Add a search param and verify the modal stays open and a new search param row appears
+   - Save the variable, reopen it, and verify the header and search param persist


### PR DESCRIPTION
## Description

Prevent accidental form submit in the resource variable modal when adding or removing headers and search params. The icon buttons in the resource editor were acting as submit buttons, which caused the new-variable modal to close unexpectedly instead of updating the resource fields. Updated the builder test-cases document with a manual regression flow.

## Steps for reproduction

1. Select an element in a project
2. Open Settings for the element
3. Under data variables, create a new variable
4. Set the name
5. Select `resource` as the type
6. Enter a resource URL
7. Add a header
8. Expect the modal to stay open and a new header row to be added
9. Add a search param
10. Expect the modal to stay open and a new search param row to be added

https://github.com/user-attachments/assets/3dff2e22-284b-4548-8565-937255a732bb


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
