### PR TITLE
feat: use background color to highlight the selected navigator tree

### DIFF
--- a/apps/builder/app/builder/features/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator-tree.tsx
@@ -51,7 +51,7 @@ import {
   type ItemDropTarget,
   $propValuesByInstanceSelectorWithMemoryProps,
 } from "~/shared/nano-states";
-import type { InstanceSelector } from "~/shared/tree-utils";
+import { isDescendantOrSelf, type InstanceSelector } from "~/shared/tree-utils";
 import { serverSyncStore } from "~/shared/sync/sync-stores";
 import { reparentInstance, toggleInstanceShow } from "~/shared/instance-utils";
 import { emitCommand } from "~/builder/shared/commands";
@@ -661,6 +661,10 @@ export const NavigatorTree = () => {
             getInstanceKey(item.selector)
           );
           const show = Boolean(propValues?.get(showAttribute) ?? true);
+          const isSelectedDescendantItem =
+            selectedInstanceSelector !== undefined &&
+            item.selector.join() !== selectedInstanceSelector.join() &&
+            isDescendantOrSelf(item.selector, selectedInstanceSelector);
 
           // Hook memory prop
           const isAnimationSelected =
@@ -733,6 +737,7 @@ export const NavigatorTree = () => {
                 <TreeNode
                   level={level}
                   isSelected={selectedKey === key}
+                  isSelectedDescendant={isSelectedDescendantItem}
                   isHighlighted={hoveredKey === key || dropTargetKey === key}
                   isExpanded={item.isExpanded}
                   isActionVisible={isAnimating}

--- a/apps/builder/app/builder/features/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator-tree.tsx
@@ -619,7 +619,7 @@ export const NavigatorTree = () => {
         flexGrow: 1,
       }}
     >
-      <TreeRoot>
+      <TreeRoot showDepthBarsOnHover={false}>
         {rootMeta && isContentMode === false && (
           <TreeNode
             level={0}

--- a/apps/builder/app/builder/features/navigator/navigator-tree.tsx
+++ b/apps/builder/app/builder/features/navigator/navigator-tree.tsx
@@ -619,7 +619,7 @@ export const NavigatorTree = () => {
         flexGrow: 1,
       }}
     >
-      <TreeRoot showDepthBarsOnHover={false}>
+      <TreeRoot>
         {rootMeta && isContentMode === false && (
           <TreeNode
             level={0}

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -122,4 +122,10 @@ test("is descendant or self", () => {
   expect(isDescendantOrSelf(["1", "2", "3"], ["1", "2", "3"])).toBe(true);
   expect(isDescendantOrSelf(["0", "1", "2", "3"], ["1", "2", "3"])).toBe(true);
   expect(isDescendantOrSelf(["1", "2", "3"], ["0", "1", "2", "3"])).toBe(false);
+  expect(
+    isDescendantOrSelf(
+      ["item-child", "collection:entry-1", "collection", "body", "page-root"],
+      ["collection", "body", "page-root"]
+    )
+  ).toBe(true);
 });

--- a/packages/design-system/src/__generated__/figma-design-tokens.json
+++ b/packages/design-system/src/__generated__/figma-design-tokens.json
@@ -565,7 +565,7 @@
           "description": "color for current item in the navigator item, menu item, pages panel item components"
         },
         "current-child": {
-          "value": "{background.panel}",
+          "value": "#eef6ff",
           "type": "color",
           "description": "color for child of current item in the navigator item, pages panel item components"
         },

--- a/packages/design-system/src/__generated__/figma-design-tokens.ts
+++ b/packages/design-system/src/__generated__/figma-design-tokens.ts
@@ -404,7 +404,7 @@ export const color = {
   backgroundButtonDisabled: "#e9ebed",
   backgroundButtonDisabledDark: "#646464",
   backgroundItemCurrent: "#e1f0ff",
-  backgroundItemCurrentChild: "#fff",
+  backgroundItemCurrentChild: "#eef6ff",
   backgroundItemCurrentHidden: "#7e868c",
   backgroundItemMenuItemHover: "#efefef",
   backgroundTooltipMain: "#11181c",

--- a/packages/design-system/src/components/tree.stories.tsx
+++ b/packages/design-system/src/components/tree.stories.tsx
@@ -299,6 +299,16 @@ export const Tree = () => {
               </TreeNodeLabel>
             </TreeNode>
             <TreeNode
+              level={2}
+              isSelected={false}
+              isSelectedDescendant
+              isExpanded={undefined}
+              buttonProps={{}}
+              action={<SmallIconButton tabIndex={-1} icon={<EllipsesIcon />} />}
+            >
+              <TreeNodeLabel>Selected descendant node</TreeNodeLabel>
+            </TreeNode>
+            <TreeNode
               level={1}
               tabbable
               isSelected={false}

--- a/packages/design-system/src/components/tree.tsx
+++ b/packages/design-system/src/components/tree.tsx
@@ -31,8 +31,6 @@ const treeNodeLevel = "--tree-node-level";
 const treeNodeOutline = "--tree-node-outline";
 const treeNodeBackgroundColor = "--tree-node-background-color";
 const treeActionOpacity = "--tree-action-opacity";
-const treeDepthBarsVisibility = "--tree-depth-bars-visibility";
-const treeDepthBarsColor = "--tree-depth-bars-color";
 
 type TreeSelectionState = "none" | "selected" | "selected-descendant";
 
@@ -60,27 +58,10 @@ const ITEM_PADDING_RIGHT = 10;
 const BARS_GAP = 16;
 const EXPAND_WIDTH = 24;
 
-const TreeContainer = ({
-  children,
-  showDepthBarsOnHover,
-}: {
-  children: ReactNode;
-  showDepthBarsOnHover: boolean;
-}) => {
+const TreeContainer = ({ children }: { children: ReactNode }) => {
   const focusManager = useFocusManager();
   return (
     <Box
-      css={
-        showDepthBarsOnHover
-          ? {
-              // Display vertical depth bars on hover
-              // can be disabled to reduce visual clutter
-              "&:hover": {
-                [treeDepthBarsVisibility]: "visible",
-              },
-            }
-          : undefined
-      }
       onKeyDown={(event) => {
         if (event.defaultPrevented) {
           return;
@@ -116,18 +97,10 @@ const TreeContainer = ({
   );
 };
 
-export const TreeRoot = ({
-  children,
-  showDepthBarsOnHover = true,
-}: {
-  children: ReactNode;
-  showDepthBarsOnHover?: boolean;
-}) => {
+export const TreeRoot = ({ children }: { children: ReactNode }) => {
   return (
     <FocusScope>
-      <TreeContainer showDepthBarsOnHover={showDepthBarsOnHover}>
-        {children}
-      </TreeContainer>
+      <TreeContainer>{children}</TreeContainer>
     </FocusScope>
   );
 };
@@ -148,22 +121,6 @@ const NodeContainer = styled("div", {
     [treeNodeBackgroundColor]: theme.colors.backgroundItemCurrent,
     backgroundColor: `var(${treeNodeBackgroundColor})`,
   },
-});
-
-const DepthBars = styled("div", {
-  visibility: `var(${treeDepthBarsVisibility}, hidden)`,
-  position: "absolute",
-  top: 0,
-  left: 0,
-  width: `calc((var(${treeNodeLevel}) - 1) * ${BARS_GAP}px)`,
-  height: "100%",
-  backgroundImage: `repeating-linear-gradient(
-    to right,
-    transparent,
-    transparent ${BARS_GAP - 1}px,
-    var(${treeDepthBarsColor}, ${theme.colors.borderItemChildLine}) ${BARS_GAP - 1}px,
-    var(${treeDepthBarsColor}, ${theme.colors.borderItemChildLine}) ${BARS_GAP}px
-  )`,
 });
 
 const NodeButton = styled("button", {
@@ -519,7 +476,6 @@ export const TreeNode = ({
       }}
       onKeyDown={handleKeydown}
     >
-      <DepthBars />
       <NodeButton
         {...buttonProps}
         ref={buttonRef}

--- a/packages/design-system/src/components/tree.tsx
+++ b/packages/design-system/src/components/tree.tsx
@@ -60,15 +60,25 @@ const ITEM_PADDING_RIGHT = 10;
 const BARS_GAP = 16;
 const EXPAND_WIDTH = 24;
 
-const TreeContainer = ({ children }: { children: ReactNode }) => {
+const TreeContainer = ({
+  children,
+  showDepthBarsOnHover,
+}: {
+  children: ReactNode;
+  showDepthBarsOnHover: boolean;
+}) => {
   const focusManager = useFocusManager();
   return (
     <Box
-      css={{
-        "&:hover": {
-          [treeDepthBarsVisibility]: "visible",
-        },
-      }}
+      css={
+        showDepthBarsOnHover
+          ? {
+              "&:hover": {
+                [treeDepthBarsVisibility]: "visible",
+              },
+            }
+          : undefined
+      }
       onKeyDown={(event) => {
         if (event.defaultPrevented) {
           return;
@@ -104,10 +114,18 @@ const TreeContainer = ({ children }: { children: ReactNode }) => {
   );
 };
 
-export const TreeRoot = ({ children }: { children: ReactNode }) => {
+export const TreeRoot = ({
+  children,
+  showDepthBarsOnHover = true,
+}: {
+  children: ReactNode;
+  showDepthBarsOnHover?: boolean;
+}) => {
   return (
     <FocusScope>
-      <TreeContainer>{children}</TreeContainer>
+      <TreeContainer showDepthBarsOnHover={showDepthBarsOnHover}>
+        {children}
+      </TreeContainer>
     </FocusScope>
   );
 };

--- a/packages/design-system/src/components/tree.tsx
+++ b/packages/design-system/src/components/tree.tsx
@@ -73,6 +73,8 @@ const TreeContainer = ({
       css={
         showDepthBarsOnHover
           ? {
+              // Display vertical depth bars on hover
+              // can be disabled to reduce visual clutter
               "&:hover": {
                 [treeDepthBarsVisibility]: "visible",
               },

--- a/packages/design-system/src/components/tree.tsx
+++ b/packages/design-system/src/components/tree.tsx
@@ -34,6 +34,26 @@ const treeActionOpacity = "--tree-action-opacity";
 const treeDepthBarsVisibility = "--tree-depth-bars-visibility";
 const treeDepthBarsColor = "--tree-depth-bars-color";
 
+type TreeSelectionState = "none" | "selected" | "selected-descendant";
+
+const getTreeSelectionState = ({
+  isSelected,
+  isSelectedDescendant,
+}: {
+  isSelected: boolean;
+  isSelectedDescendant: boolean;
+}): TreeSelectionState => {
+  if (isSelected) {
+    return "selected";
+  }
+
+  if (isSelectedDescendant) {
+    return "selected-descendant";
+  }
+
+  return "none";
+};
+
 const ITEM_PADDING_LEFT = 8;
 // extra padding on the right to make sure scrollbar doesn't obscure anything
 const ITEM_PADDING_RIGHT = 10;
@@ -100,10 +120,13 @@ const NodeContainer = styled("div", {
     backgroundColor: `var(${treeNodeBackgroundColor})`,
     [treeActionOpacity]: 1,
   },
-  "&:has([aria-selected=true])": {
+  '&[data-selection-state="selected-descendant"]': {
+    [treeNodeBackgroundColor]: theme.colors.backgroundItemCurrentChild,
+    backgroundColor: `var(${treeNodeBackgroundColor})`,
+  },
+  '&[data-selection-state="selected"]': {
     [treeNodeBackgroundColor]: theme.colors.backgroundItemCurrent,
     backgroundColor: `var(${treeNodeBackgroundColor})`,
-    [treeDepthBarsColor]: theme.colors.borderItemChildLineCurrent,
   },
 });
 
@@ -404,6 +427,7 @@ export const TreeNode = ({
   level,
   tabbable,
   isSelected,
+  isSelectedDescendant = false,
   isHighlighted,
   isExpanded,
   isActionVisible,
@@ -416,6 +440,7 @@ export const TreeNode = ({
   level: number;
   tabbable?: boolean;
   isSelected: boolean;
+  isSelectedDescendant?: boolean;
   isHighlighted?: boolean;
   isExpanded?: undefined | boolean;
   isActionVisible?: boolean;
@@ -426,6 +451,10 @@ export const TreeNode = ({
   children: ReactNode;
 }) => {
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const selectionState = getTreeSelectionState({
+    isSelected,
+    isSelectedDescendant,
+  });
   // scroll the selected button into view when selected from canvas.
   useEffect(() => {
     if (isSelected) {
@@ -463,6 +492,7 @@ export const TreeNode = ({
   return (
     <NodeContainer
       {...nodeProps}
+      data-selection-state={selectionState}
       css={{
         [treeNodeLevel]: level,
         ...(isActionVisible && { [treeActionOpacity]: 1 }),


### PR DESCRIPTION
# Description

This updates the navigator to use Figma-style subtree highlighting instead of relying on vertical depth lines, which makes deeply nested selections easier to follow. The selected node keeps the primary selected background, its descendant subtree gets a lighter background, and the navigator hides depth bars to reduce visual noise.

Related to ([#5206](https://github.com/webstudio-is/webstudio/issues/5206))

## Steps for reproduction

1. Open the Builder and create or expand a deeply nested navigator tree.
2. Select a node that has multiple nested descendants.
3. Expect the selected node to have the active background, its descendant subtree to have a lighter background, and the navigator to no longer rely on vertical guide lines for orientation.

https://github.com/user-attachments/assets/c7be9884-43e2-46f1-bb58-68bcf0bad48c

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [x] added tests
- [ ] if any new env variables are added, added them to `.env` file
