### PR TITLE
fix: don't round decimal unitless values for properties that accept them

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
@@ -53,7 +53,12 @@ export const parseIntermediateOrInvalidValue = (
   if ("unit" in styleValue && styleValue.unit === "number") {
     const numericValue = Number(value);
     if (!Number.isNaN(numericValue) && !Number.isInteger(numericValue)) {
-      value = String(Math.round(numericValue));
+      // Only round if the decimal value is not valid for this property
+      // (e.g. z-index requires integers, but line-height accepts decimals)
+      const decimalTest = parseCssValue(property, value);
+      if (decimalTest.type === "invalid") {
+        value = String(Math.round(numericValue));
+      }
     }
   }
 

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
@@ -389,6 +389,48 @@ describe("Value ending with `-` should be considered unitless", () => {
     });
   });
 
+  test("Decimal number intermediate for line-height is not rounded", () => {
+    const result = parseIntermediateOrInvalidValue("line-height", {
+      type: "intermediate",
+      value: "1.5",
+      unit: "number",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 1.5,
+      unit: "number",
+    });
+  });
+
+  test("Decimal number intermediate for z-index is rounded to integer", () => {
+    const result = parseIntermediateOrInvalidValue("z-index", {
+      type: "intermediate",
+      value: "1.5",
+      unit: "number",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 2,
+      unit: "number",
+    });
+  });
+
+  test("Decimal number intermediate for column-count is rounded to integer", () => {
+    const result = parseIntermediateOrInvalidValue("column-count", {
+      type: "intermediate",
+      value: "2.7",
+      unit: "number",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 3,
+      unit: "number",
+    });
+  });
+
   test("Unitless expression transformed to unitless", () => {
     const result = parseIntermediateOrInvalidValue("line-height", {
       type: "intermediate",


### PR DESCRIPTION
Decimals like `line-height: 1.5` were being rounded to integers because the rounding logic in parseIntermediateOrInvalidValue applied to all `unit: "number"` values unconditionally. Now it only rounds when parseCssValue confirms the decimal is actually invalid for the property (e.g. z-index, column-count require integers; line-height does not).

