### PR TITLE
fix: exclude test and story files from tsconfig.dts.json builds

### DIFF
--- a/packages/css-engine/tsconfig.dts.json
+++ b/packages/css-engine/tsconfig.dts.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src", "../../@types/**/*.d.ts"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx"
+  ],
   "compilerOptions": {
     "declarationDir": "lib/types"
   }

--- a/packages/fonts/tsconfig.dts.json
+++ b/packages/fonts/tsconfig.dts.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx"
+  ],
   "compilerOptions": {
     "declarationDir": "lib/types"
   }

--- a/packages/http-client/tsconfig.dts.json
+++ b/packages/http-client/tsconfig.dts.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx"
+  ],
   "compilerOptions": {
     "declarationDir": "lib/types"
   }

--- a/packages/icons/tsconfig.dts.json
+++ b/packages/icons/tsconfig.dts.json
@@ -1,7 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["**/*.stories.tsx"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx"
+  ],
   "compilerOptions": {
     "declarationDir": "lib/types"
   }

--- a/packages/image/tsconfig.dts.json
+++ b/packages/image/tsconfig.dts.json
@@ -1,7 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["**/*.stories.tsx"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx"
+  ],
   "compilerOptions": {
     "declarationDir": "lib/types"
   }

--- a/packages/sdk-components-react-remix/tsconfig.dts.json
+++ b/packages/sdk-components-react-remix/tsconfig.dts.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx"
+  ],
   "compilerOptions": {
     "declarationDir": "lib/types"
   }

--- a/packages/sdk-components-react-router/tsconfig.dts.json
+++ b/packages/sdk-components-react-router/tsconfig.dts.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx"
+  ],
   "compilerOptions": {
     "declarationDir": "lib/types"
   }


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
