### PR TITLE
fix: restore short --variable label in CSS value input

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -45,10 +45,7 @@ import { useSyncPageUrl } from "~/shared/pages";
 import { useMount, useUnmount } from "~/shared/hook-utils/use-mount";
 import { subscribeCommands } from "~/builder/shared/commands";
 import { ProjectSettings } from "~/shared/project-settings";
-import type {
-  PlanFeatures,
-  Purchase,
-} from "@webstudio-is/trpc-interface/plan-features";
+import type { PlanFeatures, Purchase } from "@webstudio-is/plans";
 import {
   $activeSidebarPanel,
   $dataLoadingState,

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -349,8 +349,7 @@ const itemToString = (item: CssValueInputValue | null) => {
     return "";
   }
   if (item.type === "var") {
-    // Use toValue to include fallback when present
-    return toValue(item as StyleValue);
+    return `--${item.value}`;
   }
   if (item.type === "keyword") {
     // E.g. we want currentcolor to be lower case
@@ -920,7 +919,10 @@ export const CssValueInput = ({
               if (event.target instanceof HTMLInputElement) {
                 // We are setting the value on focus because we might have removed the var() from the value,
                 // but once focused, we need to show the full value
-                event.target.value = itemToString(value);
+                event.target.value =
+                  value.type === "var"
+                    ? toValue(value as StyleValue)
+                    : itemToString(value);
               }
             }}
             autoFocus={autoFocus}

--- a/apps/builder/app/dashboard/dashboard.stories.tsx
+++ b/apps/builder/app/dashboard/dashboard.stories.tsx
@@ -11,10 +11,7 @@ import {
 import { Dashboard, DashboardSetup } from "./dashboard";
 import { Card as CardComponent, CardContent, CardFooter } from "./shared/card";
 import { ThumbnailWithAbbr, ThumbnailLinkWithAbbr } from "./shared/thumbnail";
-import {
-  defaultPlanFeatures,
-  type PlanFeatures,
-} from "@webstudio-is/trpc-interface/plan-features";
+import { defaultPlanFeatures, type PlanFeatures } from "@webstudio-is/plans";
 import type { DashboardProject } from "@webstudio-is/dashboard";
 import { updateCsrfToken } from "~/shared/csrf.client";
 

--- a/apps/builder/app/dashboard/shared/types.ts
+++ b/apps/builder/app/dashboard/shared/types.ts
@@ -1,10 +1,7 @@
 import type { DashboardProject } from "@webstudio-is/dashboard";
 import type { WorkspaceWithRelation, Role } from "@webstudio-is/project";
 import type { User } from "~/shared/db/user.server";
-import type {
-  PlanFeatures,
-  Purchase,
-} from "@webstudio-is/trpc-interface/plan-features";
+import type { PlanFeatures, Purchase } from "@webstudio-is/plans";
 import type { Notifications } from "~/shared/polly/types";
 
 export type DashboardData = {

--- a/apps/builder/app/dashboard/workspace/manage-members-dialog.test.ts
+++ b/apps/builder/app/dashboard/workspace/manage-members-dialog.test.ts
@@ -14,7 +14,7 @@ const makeData = ({
   members = [] as {
     userId: string;
     email: string;
-    relation: string;
+    relation: "administrators" | "builders" | "editors" | "viewers";
     createdAt: string;
     username: string;
   }[],
@@ -22,7 +22,7 @@ const makeData = ({
     notificationId: string;
     recipientId: string;
     email: string;
-    relation: string;
+    relation: "administrators" | "builders" | "editors" | "viewers";
     createdAt: string;
   }[],
 } = {}) => ({ owner, members, pendingInvites, maxSeats });
@@ -41,14 +41,14 @@ describe("computeAvailableSeats", () => {
       {
         userId: "u1",
         email: "a@example.com",
-        relation: "editors",
+        relation: "editors" as const,
         createdAt: "",
         username: "",
       },
       {
         userId: "u2",
         email: "b@example.com",
-        relation: "viewers",
+        relation: "viewers" as const,
         createdAt: "",
         username: "",
       },
@@ -64,7 +64,7 @@ describe("computeAvailableSeats", () => {
         notificationId: "n1",
         recipientId: "r1",
         email: "c@example.com",
-        relation: "editors",
+        relation: "editors" as const,
         createdAt: "",
       },
     ];
@@ -92,7 +92,7 @@ describe("computeAvailableSeats", () => {
         notificationId: "n1",
         recipientId: "r1",
         email: "dup@example.com",
-        relation: "editors",
+        relation: "editors" as const,
         createdAt: "",
       },
     ];
@@ -117,7 +117,7 @@ describe("computeAvailableSeats", () => {
       {
         userId: "u1",
         email: "member@example.com",
-        relation: "editors",
+        relation: "editors" as const,
         createdAt: "",
         username: "",
       },
@@ -139,7 +139,7 @@ describe("computeAvailableSeats", () => {
       {
         userId: "u1",
         email: "a@example.com",
-        relation: "editors",
+        relation: "editors" as const,
         createdAt: "",
         username: "",
       },
@@ -154,14 +154,14 @@ describe("computeAvailableSeats", () => {
       {
         userId: "u1",
         email: "a@example.com",
-        relation: "editors",
+        relation: "editors" as const,
         createdAt: "",
         username: "",
       },
       {
         userId: "u2",
         email: "b@example.com",
-        relation: "viewers",
+        relation: "viewers" as const,
         createdAt: "",
         username: "",
       },

--- a/apps/builder/app/dashboard/workspace/manage-members-dialog.test.ts
+++ b/apps/builder/app/dashboard/workspace/manage-members-dialog.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, expect } from "vitest";
+import { __testing__ } from "./manage-members-dialog";
+
+const { computeAvailableSeats } = __testing__;
+
+const owner = {
+  userId: "owner-1",
+  email: "owner@example.com",
+  username: "owner",
+};
+
+const makeData = ({
+  maxSeats = 5,
+  members = [] as {
+    userId: string;
+    email: string;
+    relation: string;
+    createdAt: string;
+    username: string;
+  }[],
+  pendingInvites = [] as {
+    notificationId: string;
+    recipientId: string;
+    email: string;
+    relation: string;
+    createdAt: string;
+  }[],
+} = {}) => ({ owner, members, pendingInvites, maxSeats });
+
+describe("computeAvailableSeats", () => {
+  test("returns undefined when membersData is undefined", () => {
+    expect(computeAvailableSeats(undefined, [])).toBeUndefined();
+  });
+
+  test("returns maxSeats when workspace is empty", () => {
+    expect(computeAvailableSeats(makeData({ maxSeats: 5 }), [])).toBe(5);
+  });
+
+  test("subtracts accepted members", () => {
+    const members = [
+      {
+        userId: "u1",
+        email: "a@example.com",
+        relation: "editors",
+        createdAt: "",
+        username: "",
+      },
+      {
+        userId: "u2",
+        email: "b@example.com",
+        relation: "viewers",
+        createdAt: "",
+        username: "",
+      },
+    ];
+    expect(computeAvailableSeats(makeData({ maxSeats: 5, members }), [])).toBe(
+      3
+    );
+  });
+
+  test("subtracts confirmed pending invites", () => {
+    const pendingInvites = [
+      {
+        notificationId: "n1",
+        recipientId: "r1",
+        email: "c@example.com",
+        relation: "editors",
+        createdAt: "",
+      },
+    ];
+    expect(
+      computeAvailableSeats(makeData({ maxSeats: 5, pendingInvites }), [])
+    ).toBe(4);
+  });
+
+  test("subtracts optimistic pending entries not yet confirmed", () => {
+    const optimistic = [
+      {
+        notificationId: "opt-1",
+        email: "new@example.com",
+        relation: "viewers" as const,
+      },
+    ];
+    expect(computeAvailableSeats(makeData({ maxSeats: 5 }), optimistic)).toBe(
+      4
+    );
+  });
+
+  test("does not double-count optimistic entry already confirmed as pending invite", () => {
+    const pendingInvites = [
+      {
+        notificationId: "n1",
+        recipientId: "r1",
+        email: "dup@example.com",
+        relation: "editors",
+        createdAt: "",
+      },
+    ];
+    const optimistic = [
+      {
+        notificationId: "opt-1",
+        email: "dup@example.com",
+        relation: "editors" as const,
+      },
+    ];
+    // confirmed invite already counts; optimistic for same email is ignored
+    expect(
+      computeAvailableSeats(
+        makeData({ maxSeats: 5, pendingInvites }),
+        optimistic
+      )
+    ).toBe(4);
+  });
+
+  test("does not double-count optimistic entry already in accepted members", () => {
+    const members = [
+      {
+        userId: "u1",
+        email: "member@example.com",
+        relation: "editors",
+        createdAt: "",
+        username: "",
+      },
+    ];
+    const optimistic = [
+      {
+        notificationId: "opt-1",
+        email: "member@example.com",
+        relation: "editors" as const,
+      },
+    ];
+    expect(
+      computeAvailableSeats(makeData({ maxSeats: 5, members }), optimistic)
+    ).toBe(4);
+  });
+
+  test("returns 0 when all seats are used", () => {
+    const members = [
+      {
+        userId: "u1",
+        email: "a@example.com",
+        relation: "editors",
+        createdAt: "",
+        username: "",
+      },
+    ];
+    expect(computeAvailableSeats(makeData({ maxSeats: 1, members }), [])).toBe(
+      0
+    );
+  });
+
+  test("returns negative when seats are exceeded", () => {
+    const members = [
+      {
+        userId: "u1",
+        email: "a@example.com",
+        relation: "editors",
+        createdAt: "",
+        username: "",
+      },
+      {
+        userId: "u2",
+        email: "b@example.com",
+        relation: "viewers",
+        createdAt: "",
+        username: "",
+      },
+    ];
+    const optimistic = [
+      {
+        notificationId: "opt-1",
+        email: "new@example.com",
+        relation: "viewers" as const,
+      },
+    ];
+    // 1 maxSeat − 2 members − 1 optimistic = -2
+    expect(
+      computeAvailableSeats(makeData({ maxSeats: 1, members }), optimistic)
+    ).toBe(-2);
+  });
+});

--- a/apps/builder/app/dashboard/workspace/manage-members-dialog.test.ts
+++ b/apps/builder/app/dashboard/workspace/manage-members-dialog.test.ts
@@ -178,4 +178,48 @@ describe("computeAvailableSeats", () => {
       computeAvailableSeats(makeData({ maxSeats: 1, members }), optimistic)
     ).toBe(-2);
   });
+
+  test("confirmedMaxSeats overrides stale server maxSeats when higher", () => {
+    // Scenario: user confirmed paying for 2 extra seats but webhook hasn't fired.
+    // Server still returns maxSeats=3, but confirmedMaxSeats=5.
+    const members = [
+      {
+        userId: "u1",
+        email: "a@example.com",
+        relation: "editors" as const,
+        createdAt: "",
+        username: "",
+      },
+    ];
+    const pendingInvites = [
+      {
+        notificationId: "n1",
+        recipientId: "r1",
+        email: "b@example.com",
+        relation: "editors" as const,
+        createdAt: "",
+      },
+      {
+        notificationId: "n2",
+        recipientId: "r2",
+        email: "c@example.com",
+        relation: "editors" as const,
+        createdAt: "",
+      },
+    ];
+    // maxSeats=3 (stale), but 1 member + 2 pending = 3 occupied → would be 0 available.
+    // confirmedMaxSeats=5 → effectiveMax=5, available = 5-1-2 = 2.
+    expect(
+      computeAvailableSeats(
+        makeData({ maxSeats: 3, members, pendingInvites }),
+        [],
+        5
+      )
+    ).toBe(2);
+  });
+
+  test("confirmedMaxSeats is ignored when server maxSeats is already higher", () => {
+    // Webhook fired: server returns maxSeats=5, confirmedMaxSeats=4 (stale override).
+    expect(computeAvailableSeats(makeData({ maxSeats: 5 }), [], 4)).toBe(5);
+  });
 });

--- a/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
+++ b/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
@@ -231,17 +231,48 @@ type OptimisticPendingInvite = {
   relation: Role;
 };
 
+const computeAvailableSeats = (
+  membersData:
+    | Extract<
+        Exclude<
+          ReturnType<typeof trpcClient.workspace.listMembers.useQuery>["data"],
+          undefined
+        >,
+        { success: true }
+      >["data"]
+    | undefined,
+  optimisticPending: OptimisticPendingInvite[]
+): number | undefined => {
+  if (membersData === undefined) {
+    return;
+  }
+  const knownEmails = new Set([
+    membersData.owner.email,
+    ...membersData.members.map((m) => m.email ?? ""),
+    ...membersData.pendingInvites.map((i) => i.email),
+  ]);
+  const extraCount = optimisticPending.filter(
+    (o) => !knownEmails.has(o.email)
+  ).length;
+  return (
+    membersData.maxSeats -
+    membersData.members.length -
+    membersData.pendingInvites.length -
+    extraCount
+  );
+};
+
 const MemberList = ({
   workspaceId,
   canRemove,
-  result,
+  membersData,
   onRefresh,
   optimisticPending,
   onRemoveOptimistic,
 }: {
   workspaceId: string;
   canRemove: boolean;
-  result:
+  membersData:
     | Extract<
         Exclude<
           ReturnType<typeof trpcClient.workspace.listMembers.useQuery>["data"],
@@ -254,7 +285,7 @@ const MemberList = ({
   optimisticPending: OptimisticPendingInvite[];
   onRemoveOptimistic: (notificationId: string) => void;
 }) => {
-  if (result === undefined) {
+  if (membersData === undefined) {
     return (
       <Text color="subtle" align="center">
         Loading members…
@@ -262,7 +293,7 @@ const MemberList = ({
     );
   }
 
-  const { owner, members, pendingInvites } = result;
+  const { owner, members, pendingInvites } = membersData;
 
   // Emails already covered by confirmed pending invites or accepted members
   const knownEmails = new Set([
@@ -346,7 +377,7 @@ export const ManageMembersDialog = ({
   >([]);
 
   const { load, data } = trpcClient.workspace.listMembers.useQuery();
-  const result = data && "data" in data ? data.data : undefined;
+  const membersData = data?.success ? data.data : undefined;
   const handleRefresh = useCallback(() => {
     load({ workspaceId: workspace.id });
   }, [load, workspace.id]);
@@ -357,26 +388,7 @@ export const ManageMembersDialog = ({
     }
   }, [isOpen, isOwner, load, workspace.id]);
 
-  const availableSeats = (() => {
-    if (result === undefined) {
-      return;
-    }
-    const knownEmails = new Set([
-      result.owner.email,
-      ...result.members.map((m) => m.email ?? ""),
-      ...result.pendingInvites.map((i) => i.email),
-    ]);
-    const extraCount = optimisticPending.filter(
-      (o) => !knownEmails.has(o.email)
-    ).length;
-    return Math.max(
-      0,
-      result.maxSeats -
-        result.members.length -
-        result.pendingInvites.length -
-        extraCount
-    );
-  })();
+  const availableSeats = computeAvailableSeats(membersData, optimisticPending);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -473,7 +485,7 @@ export const ManageMembersDialog = ({
               <MemberList
                 workspaceId={workspace.id}
                 canRemove={isOwner}
-                result={result}
+                membersData={membersData}
                 onRefresh={handleRefresh}
                 optimisticPending={optimisticPending}
                 onRemoveOptimistic={(id) =>
@@ -488,8 +500,10 @@ export const ManageMembersDialog = ({
         <DialogActions>
           <Flex justify="between" align="center" grow>
             {availableSeats !== undefined && (
-              <Text color={availableSeats === 0 ? "destructive" : "subtle"}>
-                {availableSeats} more seats included
+              <Text color={availableSeats <= 0 ? "destructive" : "subtle"}>
+                {availableSeats >= 0
+                  ? `${availableSeats} more seats included`
+                  : `${-availableSeats} extra seat${-availableSeats === 1 ? "" : "s"} will be charged`}
               </Text>
             )}
             <DialogClose>
@@ -502,3 +516,5 @@ export const ManageMembersDialog = ({
     </Dialog>
   );
 };
+
+export const __testing__ = { computeAvailableSeats };

--- a/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
+++ b/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
@@ -254,11 +254,18 @@ const computeAvailableSeats = (
         { success: true }
       >["data"]
     | undefined,
-  optimisticPending: OptimisticPendingInvite[]
+  optimisticPending: OptimisticPendingInvite[],
+  // Optimistic upper bound for maxSeats set when extra seats are confirmed,
+  // to avoid flickering while the Stripe webhook has not yet updated TransactionLog.
+  confirmedMaxSeats?: number
 ): number | undefined => {
   if (membersData === undefined) {
     return;
   }
+  const effectiveMaxSeats =
+    confirmedMaxSeats !== undefined
+      ? Math.max(membersData.maxSeats, confirmedMaxSeats)
+      : membersData.maxSeats;
   const knownEmails = new Set([
     membersData.owner.email,
     ...membersData.members.map((m) => m.email ?? ""),
@@ -268,7 +275,7 @@ const computeAvailableSeats = (
     (o) => !knownEmails.has(o.email)
   ).length;
   return (
-    membersData.maxSeats -
+    effectiveMaxSeats -
     membersData.members.length -
     membersData.pendingInvites.length -
     extraCount
@@ -428,6 +435,10 @@ export const ManageMembersDialog = ({
     relation: Role;
     extraSeats: number;
   }>();
+  // Optimistic maxSeats ceiling: set when the user confirms extra-seat charges so
+  // the footer and confirmation gate stay correct while the Stripe webhook is in
+  // flight (TransactionLog not yet updated).
+  const [confirmedMaxSeats, setConfirmedMaxSeats] = useState<number>();
   const formRef = useRef<HTMLFormElement>(null);
 
   const { load, data } = trpcClient.workspace.listMembers.useQuery();
@@ -442,7 +453,22 @@ export const ManageMembersDialog = ({
     }
   }, [isOpen, isOwner, load, workspace.id]);
 
-  const availableSeats = computeAvailableSeats(membersData, optimisticPending);
+  // Clear the optimistic override once the server reflects the paid seats.
+  useEffect(() => {
+    if (
+      membersData !== undefined &&
+      confirmedMaxSeats !== undefined &&
+      membersData.maxSeats >= confirmedMaxSeats
+    ) {
+      setConfirmedMaxSeats(undefined);
+    }
+  }, [membersData, confirmedMaxSeats]);
+
+  const availableSeats = computeAvailableSeats(
+    membersData,
+    optimisticPending,
+    confirmedMaxSeats
+  );
 
   const performInvite = async (emails: string[], relation: Role) => {
     setErrors(undefined);
@@ -507,6 +533,14 @@ export const ManageMembersDialog = ({
           onConfirm={async () => {
             const confirm = pendingConfirm;
             setPendingConfirm(undefined);
+            // Optimistically raise confirmedMaxSeats so the footer and the
+            // confirmation gate reflect the payment before the webhook fires.
+            setConfirmedMaxSeats((prev) =>
+              Math.max(
+                prev ?? 0,
+                (membersData?.maxSeats ?? 0) + confirm.extraSeats
+              )
+            );
             await performInvite(confirm.emails, confirm.relation);
           }}
         />
@@ -517,6 +551,7 @@ export const ManageMembersDialog = ({
           onOpenChange(open);
           if (open === false) {
             setErrors(undefined);
+            setConfirmedMaxSeats(undefined);
           }
         }}
       >

--- a/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
+++ b/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRevalidator } from "@remix-run/react";
 import {
   Button,
@@ -44,7 +44,20 @@ const inviteMembers = async (
         failed.push(`${email}: ${result.error}`);
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Unknown error";
+      const raw = error instanceof Error ? error.message : "Unknown error";
+      // tRPC surfaces Zod input validation failures as a JSON array of issues.
+      // Extract the human-readable message(s) instead of dumping raw JSON.
+      let message = raw;
+      try {
+        const issues = JSON.parse(raw);
+        if (Array.isArray(issues) && issues.length > 0) {
+          message = issues
+            .map((i: { message?: string }) => i.message ?? "Invalid value")
+            .join(", ");
+        }
+      } catch {
+        // not JSON — use raw message as-is
+      }
       failed.push(`${email}: ${message}`);
     }
   }
@@ -356,6 +369,41 @@ const MemberList = ({
   );
 };
 
+const ExtraSeatsConfirmDialog = ({
+  memberCount,
+  extraSeats,
+  onConfirm,
+  onCancel,
+}: {
+  memberCount: number;
+  extraSeats: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) => (
+  <Dialog open onOpenChange={(open) => !open && onCancel()}>
+    <DialogContent>
+      <DialogTitle>Extra seats will be charged</DialogTitle>
+      <Flex direction="column" gap="2" css={{ padding: theme.spacing[5] }}>
+        <Text>
+          {`Inviting ${memberCount} member${
+            memberCount === 1 ? "" : "s"
+          } will add ${extraSeats} extra seat${
+            extraSeats === 1 ? "" : "s"
+          } to your billing.`}
+        </Text>
+      </Flex>
+      <DialogActions>
+        <Button color="neutral" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button autoFocus onClick={onConfirm}>
+          Confirm
+        </Button>
+      </DialogActions>
+    </DialogContent>
+  </Dialog>
+);
+
 export const ManageMembersDialog = ({
   workspace,
   userId,
@@ -375,6 +423,12 @@ export const ManageMembersDialog = ({
   const [optimisticPending, setOptimisticPending] = useState<
     OptimisticPendingInvite[]
   >([]);
+  const [pendingConfirm, setPendingConfirm] = useState<{
+    emails: string[];
+    relation: Role;
+    extraSeats: number;
+  }>();
+  const formRef = useRef<HTMLFormElement>(null);
 
   const { load, data } = trpcClient.workspace.listMembers.useQuery();
   const membersData = data?.success ? data.data : undefined;
@@ -390,6 +444,33 @@ export const ManageMembersDialog = ({
 
   const availableSeats = computeAvailableSeats(membersData, optimisticPending);
 
+  const performInvite = async (emails: string[], relation: Role) => {
+    setErrors(undefined);
+    setInviting(true);
+    const optimistic: OptimisticPendingInvite[] = emails.map((email) => ({
+      notificationId: crypto.randomUUID(),
+      email,
+      relation,
+    }));
+    setOptimisticPending((prev) => [...prev, ...optimistic]);
+
+    const failed = await inviteMembers(emails, workspace.id, relation);
+    setInviting(false);
+
+    if (failed.length > 0) {
+      setErrors(failed);
+      const failedEmails = new Set(failed.map((f) => f.split(":")[0].trim()));
+      setOptimisticPending((prev) =>
+        prev.filter((o) => !failedEmails.has(o.email))
+      );
+    } else {
+      formRef.current?.reset();
+    }
+
+    handleRefresh();
+    revalidator.revalidate();
+  };
+
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
@@ -404,116 +485,125 @@ export const ManageMembersDialog = ({
       return;
     }
 
-    setErrors(undefined);
-    setInviting(true);
-    // Add optimistic entries immediately so the UI shows them while the list refreshes
-    const optimistic: OptimisticPendingInvite[] = emails.map((email) => ({
-      notificationId: crypto.randomUUID(),
-      email,
-      relation: inviteRelation,
-    }));
-    setOptimisticPending((prev) => [...prev, ...optimistic]);
-
-    const failed = await inviteMembers(emails, workspace.id, inviteRelation);
-    setInviting(false);
-
-    if (failed.length > 0) {
-      setErrors(failed);
-      // Remove optimistic entries for emails that failed
-      const failedEmails = new Set(failed.map((f) => f.split(":")[0].trim()));
-      setOptimisticPending((prev) =>
-        prev.filter((o) => !failedEmails.has(o.email))
-      );
-    } else {
-      (event.target as HTMLFormElement).reset();
+    if (availableSeats !== undefined && emails.length > availableSeats) {
+      setPendingConfirm({
+        emails,
+        relation: inviteRelation,
+        extraSeats: emails.length - Math.max(0, availableSeats),
+      });
+      return;
     }
 
-    handleRefresh();
-    revalidator.revalidate();
+    await performInvite(emails, inviteRelation);
   };
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        onOpenChange(open);
-        if (open === false) {
-          setErrors(undefined);
-        }
-      }}
-    >
-      <DialogContent css={{ width: theme.spacing[34] }}>
-        <Flex as="form" direction="column" gap="3" onSubmit={handleSubmit}>
-          {isOwner && (
-            <Flex
-              gap="1"
-              direction="column"
+    <>
+      {pendingConfirm !== undefined && (
+        <ExtraSeatsConfirmDialog
+          memberCount={pendingConfirm.emails.length}
+          extraSeats={pendingConfirm.extraSeats}
+          onCancel={() => setPendingConfirm(undefined)}
+          onConfirm={async () => {
+            const confirm = pendingConfirm;
+            setPendingConfirm(undefined);
+            await performInvite(confirm.emails, confirm.relation);
+          }}
+        />
+      )}
+      <Dialog
+        open={isOpen}
+        onOpenChange={(open) => {
+          onOpenChange(open);
+          if (open === false) {
+            setErrors(undefined);
+          }
+        }}
+      >
+        <DialogContent css={{ width: theme.spacing[34] }}>
+          <Flex
+            as="form"
+            ref={formRef}
+            direction="column"
+            gap="3"
+            onSubmit={handleSubmit}
+          >
+            {isOwner && (
+              <Flex
+                gap="1"
+                direction="column"
+                css={{
+                  px: theme.spacing[7],
+                  paddingTop: theme.spacing[5],
+                }}
+              >
+                <Label>Invite members</Label>
+                <Flex gap="2">
+                  <Box css={{ flexGrow: 1 }}>
+                    <InputErrorsTooltip errors={errors}>
+                      <InputField
+                        name="emails"
+                        placeholder="alice@example.com, bob@example.com"
+                        color={errors ? "error" : undefined}
+                      />
+                    </InputErrorsTooltip>
+                  </Box>
+                  <RoleSelect
+                    value={inviteRelation}
+                    onChange={setInviteRelation}
+                  />
+                  <Button
+                    type="submit"
+                    state={inviting ? "pending" : undefined}
+                  >
+                    Invite
+                  </Button>
+                </Flex>
+              </Flex>
+            )}
+            <ScrollAreaNative
               css={{
-                px: theme.spacing[7],
-                paddingTop: theme.spacing[5],
+                maxHeight: 300,
+                paddingTop: isOwner ? undefined : theme.spacing[5],
               }}
             >
-              <Label>Invite members</Label>
-              <Flex gap="2">
-                <Box css={{ flexGrow: 1 }}>
-                  <InputErrorsTooltip errors={errors}>
-                    <InputField
-                      name="emails"
-                      placeholder="alice@example.com, bob@example.com"
-                      color={errors ? "error" : undefined}
-                    />
-                  </InputErrorsTooltip>
-                </Box>
-                <RoleSelect
-                  value={inviteRelation}
-                  onChange={setInviteRelation}
+              <Flex direction="column" gap="2" css={{ px: theme.spacing[7] }}>
+                <Text variant="labels">Members</Text>
+                <MemberList
+                  workspaceId={workspace.id}
+                  canRemove={isOwner}
+                  membersData={membersData}
+                  onRefresh={handleRefresh}
+                  optimisticPending={optimisticPending}
+                  onRemoveOptimistic={(id) =>
+                    setOptimisticPending((prev) =>
+                      prev.filter((o) => o.notificationId !== id)
+                    )
+                  }
                 />
-                <Button type="submit" state={inviting ? "pending" : undefined}>
-                  Invite
-                </Button>
               </Flex>
-            </Flex>
-          )}
-          <ScrollAreaNative
-            css={{
-              maxHeight: 300,
-              paddingTop: isOwner ? undefined : theme.spacing[5],
-            }}
-          >
-            <Flex direction="column" gap="2" css={{ px: theme.spacing[7] }}>
-              <Text variant="labels">Members</Text>
-              <MemberList
-                workspaceId={workspace.id}
-                canRemove={isOwner}
-                membersData={membersData}
-                onRefresh={handleRefresh}
-                optimisticPending={optimisticPending}
-                onRemoveOptimistic={(id) =>
-                  setOptimisticPending((prev) =>
-                    prev.filter((o) => o.notificationId !== id)
-                  )
-                }
-              />
-            </Flex>
-          </ScrollAreaNative>
-        </Flex>
-        <DialogActions>
-          <Flex justify="between" align="center" grow>
-            {availableSeats !== undefined && (
-              <Text color={availableSeats <= 0 ? "destructive" : "subtle"}>
-                {availableSeats >= 0
-                  ? `${availableSeats} more seats included`
-                  : `${-availableSeats} extra seat${-availableSeats === 1 ? "" : "s"} will be charged`}
-              </Text>
-            )}
-            <DialogClose>
-              <Button color="ghost">Cancel</Button>
-            </DialogClose>
+            </ScrollAreaNative>
           </Flex>
-        </DialogActions>
-        <DialogTitle>Members</DialogTitle>
-      </DialogContent>
-    </Dialog>
+          <DialogActions>
+            <Flex justify="between" align="center" grow>
+              {availableSeats !== undefined ? (
+                <Text color={availableSeats <= 0 ? "destructive" : "subtle"}>
+                  {availableSeats >= 0
+                    ? `${availableSeats} more seats included`
+                    : `${-availableSeats} extra seat${-availableSeats === 1 ? "" : "s"} will be charged`}
+                </Text>
+              ) : (
+                <div />
+              )}
+              <DialogClose>
+                <Button color="ghost">Cancel</Button>
+              </DialogClose>
+            </Flex>
+          </DialogActions>
+          <DialogTitle>Members</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };
 

--- a/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
+++ b/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
@@ -108,7 +108,7 @@ const MemberRow = (props: MemberRowProps) => {
     if (role === "pending") {
       return (
         <Text color="subtle" variant="regular">
-          Pending
+          Pending…
         </Text>
       );
     }
@@ -225,18 +225,28 @@ const MemberRow = (props: MemberRowProps) => {
   );
 };
 
+type OptimisticPendingInvite = {
+  notificationId: string;
+  email: string;
+  relation: Role;
+};
+
 const MemberList = ({
   workspaceId,
   canRemove,
   refreshKey,
   onRefresh,
   onSeatsLoaded,
+  optimisticPending,
+  onRemoveOptimistic,
 }: {
   workspaceId: string;
   canRemove: boolean;
   refreshKey: number;
   onRefresh: () => void;
   onSeatsLoaded?: (seatsUsed: number, maxSeats: number) => void;
+  optimisticPending: OptimisticPendingInvite[];
+  onRemoveOptimistic: (notificationId: string) => void;
 }) => {
   const { load, data } = trpcClient.workspace.listMembers.useQuery();
 
@@ -264,6 +274,16 @@ const MemberList = ({
   }
 
   const { owner, members, pendingInvites } = result;
+
+  // Emails already covered by confirmed pending invites or accepted members
+  const knownEmails = new Set([
+    owner.email,
+    ...members.map((m) => m.email ?? ""),
+    ...pendingInvites.map((i) => i.email),
+  ]);
+  const extraOptimistic = optimisticPending.filter(
+    (o) => !knownEmails.has(o.email)
+  );
 
   let index = 0;
 
@@ -300,6 +320,17 @@ const MemberList = ({
             }}
           />
         ))}
+        {extraOptimistic.map((invite) => (
+          <MemberRow
+            key={invite.notificationId}
+            email={invite.email}
+            role="pending"
+            relation={invite.relation}
+            canRemove={canRemove}
+            index={index++}
+            onRemove={() => onRemoveOptimistic(invite.notificationId)}
+          />
+        ))}
       </Box>
     </List>
   );
@@ -323,6 +354,9 @@ export const ManageMembersDialog = ({
   const [inviting, setInviting] = useState(false);
   const [inviteRelation, setInviteRelation] = useState<Role>("viewers");
   const [availableSeats, setAvailableSeats] = useState<number>();
+  const [optimisticPending, setOptimisticPending] = useState<
+    OptimisticPendingInvite[]
+  >([]);
   const handleSeatsLoaded = useCallback(
     (used: number, max: number) => setAvailableSeats(Math.max(0, max - used)),
     []
@@ -350,11 +384,24 @@ export const ManageMembersDialog = ({
 
     setErrors(undefined);
     setInviting(true);
+    // Add optimistic entries immediately so the UI shows them while the list refreshes
+    const optimistic: OptimisticPendingInvite[] = emails.map((email) => ({
+      notificationId: crypto.randomUUID(),
+      email,
+      relation: inviteRelation,
+    }));
+    setOptimisticPending((prev) => [...prev, ...optimistic]);
+
     const failed = await inviteMembers(emails, workspace.id, inviteRelation);
     setInviting(false);
 
     if (failed.length > 0) {
       setErrors(failed);
+      // Remove optimistic entries for emails that failed
+      const failedEmails = new Set(failed.map((f) => f.split(":")[0].trim()));
+      setOptimisticPending((prev) =>
+        prev.filter((o) => !failedEmails.has(o.email))
+      );
     } else {
       (event.target as HTMLFormElement).reset();
     }
@@ -418,6 +465,12 @@ export const ManageMembersDialog = ({
                 canRemove={isOwner}
                 refreshKey={membersKey}
                 onRefresh={() => setMembersKey((key) => key + 1)}
+                optimisticPending={optimisticPending}
+                onRemoveOptimistic={(id) =>
+                  setOptimisticPending((prev) =>
+                    prev.filter((o) => o.notificationId !== id)
+                  )
+                }
                 onSeatsLoaded={handleSeatsLoaded}
               />
             </Flex>

--- a/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
+++ b/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
@@ -234,37 +234,26 @@ type OptimisticPendingInvite = {
 const MemberList = ({
   workspaceId,
   canRemove,
-  refreshKey,
+  result,
   onRefresh,
-  onSeatsLoaded,
   optimisticPending,
   onRemoveOptimistic,
 }: {
   workspaceId: string;
   canRemove: boolean;
-  refreshKey: number;
+  result:
+    | Extract<
+        Exclude<
+          ReturnType<typeof trpcClient.workspace.listMembers.useQuery>["data"],
+          undefined
+        >,
+        { success: true }
+      >["data"]
+    | undefined;
   onRefresh: () => void;
-  onSeatsLoaded?: (seatsUsed: number, maxSeats: number) => void;
   optimisticPending: OptimisticPendingInvite[];
   onRemoveOptimistic: (notificationId: string) => void;
 }) => {
-  const { load, data } = trpcClient.workspace.listMembers.useQuery();
-
-  useEffect(() => {
-    load({ workspaceId });
-  }, [load, workspaceId, refreshKey]);
-
-  const result = data && "data" in data ? data.data : undefined;
-
-  useEffect(() => {
-    if (result !== undefined && onSeatsLoaded !== undefined) {
-      onSeatsLoaded(
-        result.members.length + result.pendingInvites.length,
-        result.maxSeats
-      );
-    }
-  }, [result, onSeatsLoaded]);
-
   if (result === undefined) {
     return (
       <Text color="subtle" align="center">
@@ -350,23 +339,44 @@ export const ManageMembersDialog = ({
   const isOwner = workspace.userId === userId;
   const revalidator = useRevalidator();
   const [errors, setErrors] = useState<string[]>();
-  const [membersKey, setMembersKey] = useState(0);
   const [inviting, setInviting] = useState(false);
   const [inviteRelation, setInviteRelation] = useState<Role>("viewers");
-  const [availableSeats, setAvailableSeats] = useState<number>();
   const [optimisticPending, setOptimisticPending] = useState<
     OptimisticPendingInvite[]
   >([]);
-  const handleSeatsLoaded = useCallback(
-    (used: number, max: number) => setAvailableSeats(Math.max(0, max - used)),
-    []
-  );
+
+  const { load, data } = trpcClient.workspace.listMembers.useQuery();
+  const result = data && "data" in data ? data.data : undefined;
+  const handleRefresh = useCallback(() => {
+    load({ workspaceId: workspace.id });
+  }, [load, workspace.id]);
 
   useEffect(() => {
     if (isOpen && isOwner) {
-      setMembersKey((key) => key + 1);
+      load({ workspaceId: workspace.id });
     }
-  }, [isOpen, isOwner]);
+  }, [isOpen, isOwner, load, workspace.id]);
+
+  const availableSeats = (() => {
+    if (result === undefined) {
+      return;
+    }
+    const knownEmails = new Set([
+      result.owner.email,
+      ...result.members.map((m) => m.email ?? ""),
+      ...result.pendingInvites.map((i) => i.email),
+    ]);
+    const extraCount = optimisticPending.filter(
+      (o) => !knownEmails.has(o.email)
+    ).length;
+    return Math.max(
+      0,
+      result.maxSeats -
+        result.members.length -
+        result.pendingInvites.length -
+        extraCount
+    );
+  })();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -406,7 +416,7 @@ export const ManageMembersDialog = ({
       (event.target as HTMLFormElement).reset();
     }
 
-    setMembersKey((key) => key + 1);
+    handleRefresh();
     revalidator.revalidate();
   };
 
@@ -463,15 +473,14 @@ export const ManageMembersDialog = ({
               <MemberList
                 workspaceId={workspace.id}
                 canRemove={isOwner}
-                refreshKey={membersKey}
-                onRefresh={() => setMembersKey((key) => key + 1)}
+                result={result}
+                onRefresh={handleRefresh}
                 optimisticPending={optimisticPending}
                 onRemoveOptimistic={(id) =>
                   setOptimisticPending((prev) =>
                     prev.filter((o) => o.notificationId !== id)
                   )
                 }
-                onSeatsLoaded={handleSeatsLoaded}
               />
             </Flex>
           </ScrollAreaNative>

--- a/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
+++ b/apps/builder/app/dashboard/workspace/manage-members-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRevalidator } from "@remix-run/react";
 import {
   Button,
@@ -26,6 +26,30 @@ import { TrashIcon } from "@webstudio-is/icons";
 import { type Workspace, type Role } from "@webstudio-is/project";
 import { nativeClient, trpcClient } from "~/shared/trpc/trpc-client";
 import { RoleSelect } from "./role-select";
+
+const inviteMembers = async (
+  emails: string[],
+  workspaceId: string,
+  relation: Role
+): Promise<string[]> => {
+  const failed: string[] = [];
+  for (const email of emails) {
+    try {
+      const result = await nativeClient.workspace.addMember.mutate({
+        workspaceId,
+        email,
+        relation,
+      });
+      if (!result.success) {
+        failed.push(`${email}: ${result.error}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      failed.push(`${email}: ${message}`);
+    }
+  }
+  return failed;
+};
 
 const memberItemStyle = css({
   paddingInline: theme.spacing[5],
@@ -206,11 +230,13 @@ const MemberList = ({
   canRemove,
   refreshKey,
   onRefresh,
+  onSeatsLoaded,
 }: {
   workspaceId: string;
   canRemove: boolean;
   refreshKey: number;
   onRefresh: () => void;
+  onSeatsLoaded?: (seatsUsed: number, maxSeats: number) => void;
 }) => {
   const { load, data } = trpcClient.workspace.listMembers.useQuery();
 
@@ -219,6 +245,15 @@ const MemberList = ({
   }, [load, workspaceId, refreshKey]);
 
   const result = data && "data" in data ? data.data : undefined;
+
+  useEffect(() => {
+    if (result !== undefined && onSeatsLoaded !== undefined) {
+      onSeatsLoaded(
+        result.members.length + result.pendingInvites.length,
+        result.maxSeats
+      );
+    }
+  }, [result, onSeatsLoaded]);
 
   if (result === undefined) {
     return (
@@ -287,6 +322,11 @@ export const ManageMembersDialog = ({
   const [membersKey, setMembersKey] = useState(0);
   const [inviting, setInviting] = useState(false);
   const [inviteRelation, setInviteRelation] = useState<Role>("viewers");
+  const [availableSeats, setAvailableSeats] = useState<number>();
+  const handleSeatsLoaded = useCallback(
+    (used: number, max: number) => setAvailableSeats(Math.max(0, max - used)),
+    []
+  );
 
   useEffect(() => {
     if (isOpen && isOwner) {
@@ -310,25 +350,7 @@ export const ManageMembersDialog = ({
 
     setErrors(undefined);
     setInviting(true);
-
-    const failed: string[] = [];
-    for (const email of emails) {
-      try {
-        const result = await nativeClient.workspace.addMember.mutate({
-          workspaceId: workspace.id,
-          email,
-          relation: inviteRelation,
-        });
-        if (!result.success) {
-          failed.push(`${email}: ${result.error}`);
-        }
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Unknown error";
-        failed.push(`${email}: ${message}`);
-      }
-    }
-
+    const failed = await inviteMembers(emails, workspace.id, inviteRelation);
     setInviting(false);
 
     if (failed.length > 0) {
@@ -396,14 +418,22 @@ export const ManageMembersDialog = ({
                 canRemove={isOwner}
                 refreshKey={membersKey}
                 onRefresh={() => setMembersKey((key) => key + 1)}
+                onSeatsLoaded={handleSeatsLoaded}
               />
             </Flex>
           </ScrollAreaNative>
         </Flex>
         <DialogActions>
-          <DialogClose>
-            <Button color="ghost">Cancel</Button>
-          </DialogClose>
+          <Flex justify="between" align="center" grow>
+            {availableSeats !== undefined && (
+              <Text color={availableSeats === 0 ? "destructive" : "subtle"}>
+                {availableSeats} more seats included
+              </Text>
+            )}
+            <DialogClose>
+              <Button color="ghost">Cancel</Button>
+            </DialogClose>
+          </Flex>
         </DialogActions>
         <DialogTitle>Members</DialogTitle>
       </DialogContent>

--- a/apps/builder/app/dashboard/workspace/workspace-dropdown.stories.tsx
+++ b/apps/builder/app/dashboard/workspace/workspace-dropdown.stories.tsx
@@ -1,7 +1,7 @@
 import type { StoryFn } from "@storybook/react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import type { WorkspaceWithRelation } from "@webstudio-is/project";
-import { defaultPlanFeatures } from "@webstudio-is/trpc-interface/plan-features";
+import { defaultPlanFeatures } from "@webstudio-is/plans";
 import { $planFeatures } from "~/shared/nano-states";
 import { $workspaces } from "./workspace-stores";
 import { WorkspaceSelector } from "./workspace-dropdown";

--- a/apps/builder/app/routes/_ui.(builder).tsx
+++ b/apps/builder/app/routes/_ui.(builder).tsx
@@ -20,8 +20,8 @@ import {
   authorizeProject,
 } from "@webstudio-is/trpc-interface/index.server";
 import { createContext } from "~/shared/context.server";
-import { getPlanInfo } from "@webstudio-is/trpc-interface/plan-client";
-import { defaultPlanFeatures } from "@webstudio-is/trpc-interface/plan-features";
+import { getPlanInfo } from "@webstudio-is/plans/index.server";
+import { defaultPlanFeatures } from "@webstudio-is/plans";
 import { dashboardPath, isBuilder, isDashboard } from "~/shared/router-utils";
 
 import env from "~/env/env.server";

--- a/apps/builder/app/routes/_ui.login._index.tsx
+++ b/apps/builder/app/routes/_ui.login._index.tsx
@@ -8,7 +8,7 @@ import { useLoaderData, type MetaFunction } from "@remix-run/react";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import env from "~/env/env.server";
 import type { LoginProps } from "~/auth/index.client";
-import { parsePlansEnv } from "@webstudio-is/trpc-interface/plan-features";
+import { parsePlansEnv } from "@webstudio-is/plans";
 import { useLoginErrorMessage } from "~/shared/session";
 import {
   comparePathnames,

--- a/apps/builder/app/services/workspace-router.server.ts
+++ b/apps/builder/app/services/workspace-router.server.ts
@@ -230,9 +230,44 @@ export const workspaceRouter = router({
         }
 
         // Pre-charge the seat before adding the member (Figma model).
+        // We validate user existence first so that a missing account never
+        // triggers a billing change.
         // When the payment worker is configured, a billing failure aborts the
         // invite so the member is never added. When the worker URL is not set
         // (self-hosted / dev), syncOwnerSeats returns early and this is a no-op.
+
+        // Validate the invitee exists and is not already a member before
+        // touching billing. This mirrors the checks in workspaceApi.addMember
+        // so that we never charge for a doomed invite.
+        const inviteeResult = await ctx.postgrest.client
+          .from("User")
+          .select("id")
+          .eq("email", input.email)
+          .maybeSingle();
+        if (inviteeResult.error) {
+          throw inviteeResult.error;
+        }
+        if (inviteeResult.data === null) {
+          throw new Error(
+            `No Webstudio account found for "${input.email}". The user needs to sign up first.`
+          );
+        }
+        const existingMemberResult = await ctx.postgrest.client
+          .from("WorkspaceMember")
+          .select("userId")
+          .eq("workspaceId", input.workspaceId)
+          .eq("userId", inviteeResult.data.id)
+          .is("removedAt", null)
+          .maybeSingle();
+        if (existingMemberResult.error) {
+          throw existingMemberResult.error;
+        }
+        if (existingMemberResult.data !== null) {
+          throw new Error(
+            `${input.email} is already a member of this workspace.`
+          );
+        }
+
         try {
           await syncOwnerSeats(input.workspaceId, ctx, +1);
         } catch (error) {

--- a/apps/builder/app/services/workspace-router.server.ts
+++ b/apps/builder/app/services/workspace-router.server.ts
@@ -298,7 +298,18 @@ export const workspaceRouter = router({
     .query(async ({ input, ctx }) => {
       try {
         const members = await workspaceApi.listMembers(input, ctx);
-        return { success: true as const, data: members };
+        return {
+          success: true as const,
+          data: {
+            ...members,
+            // paidSeats = actual Stripe subscription quantity for the current
+            // billing period (may stay > used count if a member was removed
+            // mid-period and the payment worker defers the reduction).
+            // Falls back to minSeats (seats included in the plan) when the
+            // subscription event hasn't arrived yet.
+            maxSeats: members.paidSeats ?? ctx.planFeatures.minSeats,
+          },
+        };
       } catch (error) {
         return createErrorResponse(error);
       }

--- a/apps/builder/app/services/workspace-router.server.ts
+++ b/apps/builder/app/services/workspace-router.server.ts
@@ -6,8 +6,8 @@ import {
 } from "@webstudio-is/trpc-interface/index.server";
 import { workspace as workspaceApi } from "@webstudio-is/project/index.server";
 import { roles } from "@webstudio-is/trpc-interface/authorize";
-import { getPlanInfo } from "@webstudio-is/trpc-interface/plan-client";
-import { defaultPlanFeatures } from "@webstudio-is/trpc-interface/plan-features";
+import { getPlanInfo, getPaidSeats } from "@webstudio-is/plans/index.server";
+import { defaultPlanFeatures } from "@webstudio-is/plans";
 import env from "~/env/env.server";
 
 const Name = z.string().min(2).max(100);
@@ -298,16 +298,14 @@ export const workspaceRouter = router({
     .query(async ({ input, ctx }) => {
       try {
         const members = await workspaceApi.listMembers(input, ctx);
+        const paidSeats = await getPaidSeats(members.owner.userId, ctx);
         return {
           success: true as const,
           data: {
             ...members,
-            // paidSeats = actual Stripe subscription quantity for the current
-            // billing period (may stay > used count if a member was removed
-            // mid-period and the payment worker defers the reduction).
-            // Falls back to minSeats (seats included in the plan) when the
-            // subscription event hasn't arrived yet.
-            maxSeats: members.paidSeats ?? ctx.planFeatures.minSeats,
+            // Falls back to minSeats (seats included in the plan) when no
+            // subscription event exists yet (free plan, AppSumo, etc.).
+            maxSeats: paidSeats ?? ctx.planFeatures.minSeats,
           },
         };
       } catch (error) {

--- a/apps/builder/app/shared/context.server.ts
+++ b/apps/builder/app/shared/context.server.ts
@@ -4,11 +4,11 @@ import { authenticator } from "~/services/auth.server";
 import { trpcSharedClient } from "~/services/trpc.server";
 import { entryApi } from "./entri/entri-api.server";
 
-import { defaultPlanFeatures } from "@webstudio-is/trpc-interface/plan-features";
+import { defaultPlanFeatures } from "@webstudio-is/plans";
 import {
   getPlanInfo,
   getAuthorizationOwnerId,
-} from "@webstudio-is/trpc-interface/plan-client";
+} from "@webstudio-is/plans/index.server";
 import { staticEnv } from "~/env/env.static.server";
 import { createClient } from "@webstudio-is/postgrest/index.server";
 import { builderAuthenticator } from "~/services/builder-auth.server";

--- a/apps/builder/app/shared/nano-states/misc.ts
+++ b/apps/builder/app/shared/nano-states/misc.ts
@@ -10,7 +10,7 @@ import {
   defaultPlanFeatures,
   type PlanFeatures,
   type Purchase,
-} from "@webstudio-is/trpc-interface/plan-features";
+} from "@webstudio-is/plans";
 import type { Role } from "@webstudio-is/project";
 import type { User } from "~/shared/db/user.server";
 import { toast, type Placement } from "@webstudio-is/design-system";

--- a/apps/builder/app/shared/permissions.ts
+++ b/apps/builder/app/shared/permissions.ts
@@ -1,6 +1,6 @@
 import type { Role } from "@webstudio-is/project";
 import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
-import type { PlanFeatures } from "@webstudio-is/trpc-interface/plan-features";
+import type { PlanFeatures } from "@webstudio-is/plans";
 
 /**
  * Human-readable descriptions of what each workspace role can do.

--- a/apps/builder/app/shared/polly/topic-resolvers.server.test.ts
+++ b/apps/builder/app/shared/polly/topic-resolvers.server.test.ts
@@ -6,13 +6,11 @@ import {
   json,
 } from "@webstudio-is/postgrest/testing";
 import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
-import { __testing__ } from "@webstudio-is/trpc-interface/plan-client";
 import { resolveTopics } from "./topic-resolvers.server";
 
 const server = createTestServer();
 
 afterEach(() => {
-  __testing__.resetProductCache();
   delete process.env.PLANS;
 });
 

--- a/apps/builder/app/shared/polly/topic-resolvers.server.ts
+++ b/apps/builder/app/shared/polly/topic-resolvers.server.ts
@@ -1,7 +1,7 @@
 import { notification } from "@webstudio-is/project/index.server";
 import { db as dashboardDb } from "@webstudio-is/dashboard/index.server";
-import { getPlanInfo } from "@webstudio-is/trpc-interface/plan-client";
-import { defaultPlanFeatures } from "@webstudio-is/trpc-interface/plan-features";
+import { getPlanInfo } from "@webstudio-is/plans/index.server";
+import { defaultPlanFeatures } from "@webstudio-is/plans";
 import { publicStaticEnv } from "~/env/env.static";
 import type { TopicResolvers, TopicName, SubscriptionResponse } from "./types";
 

--- a/packages/plans/src/index.server.ts
+++ b/packages/plans/src/index.server.ts
@@ -1,6 +1,7 @@
 export * from "./index";
 export {
   getPlanInfo,
+  getPaidSeats,
   getAuthorizationOwnerId,
   parsePlansEnv,
   parseProductMeta,

--- a/packages/plans/src/plan-client.server.test.ts
+++ b/packages/plans/src/plan-client.server.test.ts
@@ -8,7 +8,7 @@ import {
 import { type PlanFeatures, defaultPlanFeatures } from "./plan-features";
 import { getPlanInfo, __testing__ } from "./plan-client.server";
 
-const { parseProductMeta, mergeProductMetas, resetProductCache } = __testing__;
+const { parseProductMeta, mergeProductMetas } = __testing__;
 
 // ---------------------------------------------------------------------------
 // Unit tests for private helpers
@@ -17,7 +17,6 @@ const { parseProductMeta, mergeProductMetas, resetProductCache } = __testing__;
 const server = createTestServer();
 
 beforeEach(() => {
-  resetProductCache();
   vi.unstubAllEnvs();
 });
 
@@ -136,23 +135,6 @@ describe("getPlanInfo (msw)", () => {
     vi.stubEnv("PLANS", JSON.stringify([]));
     const result = await getPlanInfo(["user-1"], testContext);
     expect(result.get("user-1")?.purchases[0].planName).toBe("Pro");
-  });
-
-  test("Product table is queried only once across two calls (cache hit)", async () => {
-    vi.stubEnv("PLANS", JSON.stringify([]));
-    let productFetchCount = 0;
-    server.use(
-      db.get("UserProduct", () => json([proUserProduct])),
-      db.get("Product", () => {
-        productFetchCount += 1;
-        return json([proProduct]);
-      })
-    );
-
-    await getPlanInfo(["user-1"], testContext);
-    await getPlanInfo(["user-1"], testContext);
-
-    expect(productFetchCount).toBe(1);
   });
 });
 

--- a/packages/plans/src/plan-client.server.ts
+++ b/packages/plans/src/plan-client.server.ts
@@ -75,21 +75,32 @@ type Product = { id: string; name: string; meta: unknown };
 // The promise itself is cached to deduplicate concurrent cold-start requests.
 let productCachePromise: Promise<Map<string, Product>> | undefined;
 
-const getProductCache = (
+const fetchProducts = (
   postgrest: PostgrestContext
-): Promise<Map<string, Product>> => {
-  if (productCachePromise !== undefined) {
-    return productCachePromise;
-  }
-  const promise: Promise<Map<string, Product>> = Promise.resolve(
+): Promise<Map<string, Product>> =>
+  Promise.resolve(
     postgrest.client.from("Product").select("id, name, meta")
   ).then((result) => {
     if (result.error) {
-      productCachePromise = undefined;
       console.error(result.error);
       throw new Error("Failed to fetch products");
     }
     return new Map(result.data.map((p) => [p.id, p as Product]));
+  });
+
+const getProductCache = (
+  postgrest: PostgrestContext
+): Promise<Map<string, Product>> => {
+  // Skip caching in test environment so each test gets a fresh fetch.
+  if (process.env.VITEST !== undefined) {
+    return fetchProducts(postgrest);
+  }
+  if (productCachePromise !== undefined) {
+    return productCachePromise;
+  }
+  const promise = fetchProducts(postgrest);
+  promise.catch(() => {
+    productCachePromise = undefined;
   });
   productCachePromise = promise;
   return promise;
@@ -194,15 +205,48 @@ export const getPlanInfo = async (
   );
 };
 
-/** Resets the module-level product cache. Only for use in tests. */
-const resetProductCache = () => {
-  productCachePromise = undefined;
+/**
+ * Returns the Stripe subscription item quantity for the given user, derived
+ * from the latest customer.subscription.updated/created event in TransactionLog.
+ * Returns null when no subscription event exists yet (free plan, AppSumo, etc.).
+ */
+export const getPaidSeats = async (
+  userId: string,
+  context: { postgrest: PostgrestContext }
+): Promise<number | null> => {
+  const result = await context.postgrest.client
+    .from("TransactionLog")
+    .select("eventData")
+    .eq("userId", userId)
+    .in("eventType", [
+      "customer.subscription.updated",
+      "customer.subscription.created",
+    ])
+    .order("eventCreated", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const eventData = result.data?.eventData as
+    | {
+        data?: {
+          object?: {
+            items?: { data?: Array<{ quantity?: unknown }> };
+          };
+        };
+      }
+    | null
+    | undefined;
+  const rawQuantity = eventData?.data?.object?.items?.data?.[0]?.quantity;
+  return typeof rawQuantity === "number" ? rawQuantity : null;
 };
 
 export const __testing__ = {
   parseProductMeta,
   mergeProductMetas,
-  resetProductCache,
 };
 
 export const getAuthorizationOwnerId = (

--- a/packages/postgrest/src/__generated__/db-types.ts
+++ b/packages/postgrest/src/__generated__/db-types.ts
@@ -990,7 +990,6 @@ export type Database = {
           customerEmail: string | null;
           customerId: string | null;
           productId: string | null;
-          seatQuantity: number | null;
           subscriptionId: string | null;
           userId: string | null;
         };

--- a/packages/prisma-client/prisma/migrations/20260413000000_user_product_drop_seat_quantity/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20260413000000_user_product_drop_seat_quantity/migration.sql
@@ -1,6 +1,8 @@
 -- Remove seatQuantity from UserProduct view.
 -- Seat quantity is now derived directly from TransactionLog in the application layer.
-CREATE OR REPLACE VIEW "UserProduct" AS (
+-- NOTE: PostgreSQL's CREATE OR REPLACE VIEW cannot remove columns; DROP + CREATE is required.
+DROP VIEW IF EXISTS "UserProduct";
+CREATE VIEW "UserProduct" AS (
   SELECT
     "userId",
     "subscriptionId",

--- a/packages/prisma-client/prisma/migrations/20260413000000_user_product_drop_seat_quantity/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20260413000000_user_product_drop_seat_quantity/migration.sql
@@ -1,0 +1,48 @@
+-- Remove seatQuantity from UserProduct view.
+-- Seat quantity is now derived directly from TransactionLog in the application layer.
+CREATE OR REPLACE VIEW "UserProduct" AS (
+  SELECT
+    "userId",
+    "subscriptionId",
+    "productId",
+    "customerId",
+    "customerEmail"
+  FROM
+    "TransactionLog" AS tl
+  WHERE
+    "status" = 'complete'
+    AND "eventType" = 'checkout.session.completed'
+    AND NOT EXISTS (
+      SELECT
+        1
+      FROM
+        "TransactionLog" AS tlexsists
+      WHERE
+        tlexsists."subscriptionId" = tl."subscriptionId"
+        AND tlexsists."eventType" = 'customer.subscription.deleted'
+        AND tlexsists."status" = 'canceled'
+        AND tlexsists."eventCreated" > tl."eventCreated")
+      AND NOT EXISTS (
+        SELECT
+          1
+        FROM
+          "TransactionLog" AS tlexsists
+        WHERE
+          tlexsists."paymentIntent" = tl."paymentIntent"
+          AND tlexsists."eventType" = 'charge.refunded'
+          AND tlexsists."status" = 'succeeded'
+          AND tlexsists."eventCreated" > tl."eventCreated")
+      ORDER BY
+        "userId",
+        "eventCreated" DESC)
+    UNION ALL (
+      SELECT
+        "userId",
+        "subscriptionId",
+        "productId",
+        "customerId",
+        "customerEmail"
+      FROM
+        "TransactionLog"
+      WHERE
+        "eventType" = 'appsumo.activate');

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -14,6 +14,7 @@
     "@webstudio-is/asset-uploader": "workspace:*",
     "@webstudio-is/authorization-token": "workspace:*",
     "@webstudio-is/feature-flags": "workspace:*",
+    "@webstudio-is/plans": "workspace:*",
     "@webstudio-is/postgrest": "workspace:*",
     "@webstudio-is/project-build": "workspace:*",
     "@webstudio-is/trpc-interface": "workspace:*",

--- a/packages/project/src/db/notification.test.ts
+++ b/packages/project/src/db/notification.test.ts
@@ -7,7 +7,7 @@ import {
   testContext,
 } from "@webstudio-is/postgrest/testing";
 import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
-import { defaultPlanFeatures } from "@webstudio-is/trpc-interface/plan-features";
+import { defaultPlanFeatures } from "@webstudio-is/plans";
 import { accept, __testing__ } from "./notification";
 
 const { describeNotification } = __testing__;

--- a/packages/project/src/db/project.test.ts
+++ b/packages/project/src/db/project.test.ts
@@ -7,7 +7,7 @@ import {
   testContext,
 } from "@webstudio-is/postgrest/testing";
 import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
-import { defaultPlanFeatures } from "@webstudio-is/trpc-interface/plan-features";
+import { defaultPlanFeatures } from "@webstudio-is/plans";
 import { create } from "./project";
 
 const server = createTestServer();

--- a/packages/project/src/db/workspace.test.ts
+++ b/packages/project/src/db/workspace.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@webstudio-is/postgrest/testing";
 import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
 import { AuthorizationError } from "@webstudio-is/trpc-interface/index.server";
-import { defaultPlanFeatures } from "@webstudio-is/trpc-interface/plan-features";
+import { defaultPlanFeatures } from "@webstudio-is/plans";
 import {
   create,
   rename,

--- a/packages/project/src/db/workspace.test.ts
+++ b/packages/project/src/db/workspace.test.ts
@@ -255,17 +255,18 @@ describe("countAllMembers (msw)", () => {
 describe("addMember (msw)", () => {
   const ownerWorkspace = { id: "ws-1", userId: "user-1" };
 
-  test("silently succeeds when invited email does not exist", async () => {
+  test("throws when invited email does not exist", async () => {
     server.use(
       db.get("Workspace", () => json(ownerWorkspace)),
       db.get("User", () => json(null))
     );
 
-    const result = await addMember(
-      { workspaceId: "ws-1", email: "unknown@test.com", relation: "editors" },
-      createContext()
-    );
-    expect(typeof result.notificationId).toBe("string");
+    await expect(
+      addMember(
+        { workspaceId: "ws-1", email: "unknown@test.com", relation: "editors" },
+        createContext()
+      )
+    ).rejects.toThrow('No Webstudio account found for "unknown@test.com"');
   });
 
   test("throws when inviting yourself", async () => {
@@ -284,7 +285,7 @@ describe("addMember (msw)", () => {
     ).rejects.toThrow("already the owner");
   });
 
-  test("silently succeeds when invitee is already a member", async () => {
+  test("throws when invitee is already a member", async () => {
     server.use(
       db.get("Workspace", () => json(ownerWorkspace)),
       db.get("User", () =>
@@ -293,11 +294,12 @@ describe("addMember (msw)", () => {
       db.get("WorkspaceMember", () => json({ userId: "user-2" }))
     );
 
-    const result = await addMember(
-      { workspaceId: "ws-1", email: "other@test.com", relation: "editors" },
-      createContext()
-    );
-    expect(typeof result.notificationId).toBe("string");
+    await expect(
+      addMember(
+        { workspaceId: "ws-1", email: "other@test.com", relation: "editors" },
+        createContext()
+      )
+    ).rejects.toThrow("other@test.com is already a member");
   });
 });
 

--- a/packages/project/src/db/workspace.ts
+++ b/packages/project/src/db/workspace.ts
@@ -368,10 +368,10 @@ export const addMember = async (
     throw user.error;
   }
 
-  // User not found — silently succeed without creating a placeholder.
-  // Returns the same shape to prevent email enumeration.
   if (user.data === null) {
-    return { notificationId: crypto.randomUUID() };
+    throw new Error(
+      `No Webstudio account found for "${email}". The user needs to sign up first.`
+    );
   }
 
   if (user.data.id === userId) {
@@ -394,8 +394,7 @@ export const addMember = async (
   }
 
   if (existing.data !== null) {
-    // Already a member — silently succeed
-    return { notificationId: crypto.randomUUID() };
+    throw new Error(`${email} is already a member of this workspace.`);
   }
 
   // Create a pending notification instead of inserting directly

--- a/packages/project/src/db/workspace.ts
+++ b/packages/project/src/db/workspace.ts
@@ -590,25 +590,9 @@ export const listMembers = async (
 
   const usersById = new Map(users.data.map((u) => [u.id, u]));
 
-  // Fetch the Stripe seat quantity actually paid for this billing period.
-  // Only present when the owner has an active subscription.
-  const userProduct = await context.postgrest.client
-    .from("UserProduct")
-    .select("seatQuantity")
-    .eq("userId", workspace.data.userId)
-    .not("subscriptionId", "is", null)
-    .maybeSingle();
-
-  if (userProduct.error) {
-    throw userProduct.error;
-  }
-
-  const paidSeats: number | null = userProduct.data?.seatQuantity ?? null;
-
   const ownerUser = usersById.get(workspace.data.userId);
 
   return {
-    paidSeats,
     owner: {
       userId: workspace.data.userId,
       email: ownerUser?.email ?? "",

--- a/packages/project/src/db/workspace.ts
+++ b/packages/project/src/db/workspace.ts
@@ -590,9 +590,25 @@ export const listMembers = async (
 
   const usersById = new Map(users.data.map((u) => [u.id, u]));
 
+  // Fetch the Stripe seat quantity actually paid for this billing period.
+  // Only present when the owner has an active subscription.
+  const userProduct = await context.postgrest.client
+    .from("UserProduct")
+    .select("seatQuantity")
+    .eq("userId", workspace.data.userId)
+    .not("subscriptionId", "is", null)
+    .maybeSingle();
+
+  if (userProduct.error) {
+    throw userProduct.error;
+  }
+
+  const paidSeats: number | null = userProduct.data?.seatQuantity ?? null;
+
   const ownerUser = usersById.get(workspace.data.userId);
 
   return {
+    paidSeats,
     owner: {
       userId: workspace.data.userId,
       email: ownerUser?.email ?? "",

--- a/packages/project/src/trpc/workspace-router.ts
+++ b/packages/project/src/trpc/workspace-router.ts
@@ -82,8 +82,6 @@ export const workspaceRouter = router({
         }
 
         const { notificationId } = await workspaceApi.addMember(input, ctx);
-        // notificationId is always returned — it's a real ID for existing users
-        // and a fake UUID for non-existing users to prevent email enumeration.
         return { success: true as const, notificationId };
       } catch (error) {
         return createErrorResponse(error);

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -28,14 +28,6 @@
       "webstudio": "./src/index.server.ts",
       "import": "./src/index.server.ts"
     },
-    "./plan-features": {
-      "webstudio": "./src/shared/plan-features.ts",
-      "import": "./src/shared/plan-features.ts"
-    },
-    "./plan-client": {
-      "webstudio": "./src/shared/plan-client.server.ts",
-      "import": "./src/shared/plan-client.server.ts"
-    },
     "./authorize": {
       "webstudio": "./src/authorize/role.ts",
       "import": "./src/authorize/role.ts"

--- a/packages/trpc-interface/src/authorize/project.server.test.ts
+++ b/packages/trpc-interface/src/authorize/project.server.test.ts
@@ -6,7 +6,7 @@ import {
   testContext,
 } from "@webstudio-is/postgrest/testing";
 import type { AppContext } from "../context/context.server";
-import { defaultPlanFeatures } from "../shared/plan-features";
+import { defaultPlanFeatures } from "@webstudio-is/plans";
 import {
   checkProjectPermit,
   hasProjectPermit,

--- a/packages/trpc-interface/src/shared/plan-client.server.ts
+++ b/packages/trpc-interface/src/shared/plan-client.server.ts
@@ -1,7 +1,0 @@
-// Re-exported from @webstudio-is/plans — all plan client logic lives there.
-export {
-  getPlanInfo,
-  getAuthorizationOwnerId,
-  parsePlansEnv,
-  __testing__,
-} from "@webstudio-is/plans/index.server";

--- a/packages/trpc-interface/src/shared/plan-features.ts
+++ b/packages/trpc-interface/src/shared/plan-features.ts
@@ -1,7 +1,0 @@
-// Re-exported from @webstudio-is/plans — all plan feature logic lives there.
-export {
-  PlanFeaturesSchema,
-  defaultPlanFeatures,
-  parsePlansEnv,
-} from "@webstudio-is/plans";
-export type { PlanFeatures, Purchase } from "@webstudio-is/plans";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1767,6 +1767,9 @@ importers:
       '@webstudio-is/feature-flags':
         specifier: workspace:*
         version: link:../feature-flags
+      '@webstudio-is/plans':
+        specifier: workspace:*
+        version: link:../plans
       '@webstudio-is/postgrest':
         specifier: workspace:*
         version: link:../postgrest


### PR DESCRIPTION
## Problem

Commit cc20991b accidentally changed `itemToString` for `var` type values to use `toValue(item)`, which produces `var(--variable, fallback)` instead of the intended short `--variable` label.

This meant the CSS value input (when unfocused, and in the autocomplete dropdown) showed the full `var(--variable, fallback)` string, which is too long for small inputs and not how it previously displayed.

## Fix

- Restored `itemToString` to return `--${item.value}` for var types (short label)
- Updated the `onFocus` handler to explicitly call `toValue(value)` for var types, so the full `var(--variable, fallback)` is shown when the user focuses the input to edit it