### PR TITLE
feat: expose missing states to Radix components

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
@@ -80,17 +80,45 @@ describe("getComponentStates", () => {
     const result = getComponentStates({
       predefinedStates: [],
       componentStates: [
-        { label: "Open", selector: "[data-state=open]" },
-        { label: "Closed", selector: "[data-state=closed]" },
+        { label: "Open", selector: '[data-state="open"]' },
+        { label: "Closed", selector: '[data-state="closed"]' },
       ],
       instanceStyleSourceIds: new Set(),
       styles: [],
       selectedStyleState: undefined,
     });
 
-    const openState = result.find((s) => s.selector === "[data-state=open]");
+    const openState = result.find((s) => s.selector === '[data-state="open"]');
     expect(openState?.source).toBe("component");
     expect(openState?.label).toBe("Open");
+  });
+
+  test("does not duplicate component states when styles exist for the same selector", () => {
+    const result = getComponentStates({
+      predefinedStates: [],
+      componentStates: [
+        { label: "Open", selector: '[data-state="open"]' },
+        { label: "Closed", selector: '[data-state="closed"]' },
+      ],
+      instanceStyleSourceIds: new Set(["style1"]),
+      styles: [
+        { styleSourceId: "style1", state: '[data-state="open"]' },
+        { styleSourceId: "style1", state: '[data-state="closed"]' },
+      ],
+      selectedStyleState: undefined,
+    });
+
+    const openStates = result.filter(
+      (s) => s.selector === '[data-state="open"]'
+    );
+    expect(openStates).toHaveLength(1);
+    expect(openStates[0].source).toBe("component");
+
+    const closedStates = result.filter(
+      (s) => s.selector === '[data-state="closed"]'
+    );
+    expect(closedStates).toHaveLength(1);
+    expect(closedStates[0].source).toBe("component");
   });
 
   test("removes selector when styles are cleared", () => {

--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -316,6 +316,9 @@ const getComponentStates = ({
     usedSelectors.add(selectedStyleState);
   }
 
+  const componentStateSelectors = new Set(
+    componentStates.map((s) => s.selector)
+  );
   const allStateSelectors = new Set([...allStates, ...usedSelectors]);
 
   const toConfig = (selector: string): SelectorConfig => ({
@@ -326,7 +329,9 @@ const getComponentStates = ({
   });
 
   const states = Array.from(allStateSelectors)
-    .filter((state) => !isPseudoElement(state))
+    .filter(
+      (state) => !isPseudoElement(state) && !componentStateSelectors.has(state)
+    )
     .map(toConfig);
 
   const pseudoElements = Array.from(allStateSelectors)

--- a/packages/sdk-components-react-radix/src/accordion.template.tsx
+++ b/packages/sdk-components-react-radix/src/accordion.template.tsx
@@ -76,6 +76,12 @@ const createAccordionItem = (triggerText: string, contentText: string) => {
           line-height: ${fontSizeLineHeight.sm};
           transition: ${transition.all};
           padding-bottom: ${spacing[4]};
+          &[data-state="closed"] {
+            height: 0;
+          }
+          &[data-state="open"] {
+            height: var(--radix-accordion-content-height);
+          }
         `}
       >
         {new PlaceholderValue(contentText)}

--- a/packages/sdk-components-react-radix/src/accordion.ws.ts
+++ b/packages/sdk-components-react-radix/src/accordion.ws.ts
@@ -38,6 +38,10 @@ export const metaAccordionItem: WsComponentMeta = {
     children: ["instance"],
     descendants: [radix.AccordionHeader, radix.AccordionContent],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: { div },
   initialProps: ["value"],
   props: propsAccordionItem,
@@ -51,6 +55,10 @@ export const metaAccordionHeader: WsComponentMeta = {
     children: ["instance"],
     descendants: [radix.AccordionTrigger],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: {
     h3: [
       ...h3,
@@ -74,7 +82,10 @@ export const metaAccordionTrigger: WsComponentMeta = {
     category: "none",
     children: ["instance", "rich-text"],
   },
-  states: [{ label: "Open", selector: "[data-state=open]" }],
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: {
     button: [button, buttonReset].flat(),
   },
@@ -88,6 +99,10 @@ export const metaAccordionContent: WsComponentMeta = {
     category: "none",
     children: ["instance", "rich-text"],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: {
     div,
   },

--- a/packages/sdk-components-react-radix/src/checkbox.ws.ts
+++ b/packages/sdk-components-react-radix/src/checkbox.ws.ts
@@ -16,8 +16,9 @@ export const metaCheckbox: WsComponentMeta = {
     descendants: [radix.CheckboxIndicator],
   },
   states: [
-    { label: "Checked", selector: "[data-state=checked]" },
-    { label: "Unchecked", selector: "[data-state=unchecked]" },
+    { label: "Checked", selector: '[data-state="checked"]' },
+    { label: "Unchecked", selector: '[data-state="unchecked"]' },
+    { label: "Indeterminate", selector: '[data-state="indeterminate"]' },
   ],
   presetStyle: {
     button: [button, buttonReset].flat(),
@@ -32,6 +33,11 @@ export const metaCheckboxIndicator: WsComponentMeta = {
     category: "none",
     children: ["instance", "rich-text"],
   },
+  states: [
+    { label: "Checked", selector: '[data-state="checked"]' },
+    { label: "Unchecked", selector: '[data-state="unchecked"]' },
+    { label: "Indeterminate", selector: '[data-state="indeterminate"]' },
+  ],
   presetStyle: {
     span,
   },

--- a/packages/sdk-components-react-radix/src/collapsible.ws.ts
+++ b/packages/sdk-components-react-radix/src/collapsible.ws.ts
@@ -19,6 +19,10 @@ export const metaCollapsible: WsComponentMeta = {
     children: ["instance"],
     descendants: [radix.CollapsibleTrigger, radix.CollapsibleContent],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: {
     div,
   },
@@ -32,6 +36,10 @@ export const metaCollapsibleTrigger: WsComponentMeta = {
     category: "none",
     children: ["instance", "rich-text"],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   props: propsCollapsibleTrigger,
 };
 
@@ -41,6 +49,10 @@ export const metaCollapsibleContent: WsComponentMeta = {
     category: "none",
     children: ["instance", "rich-text"],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: {
     div,
   },

--- a/packages/sdk-components-react-radix/src/dialog.ws.ts
+++ b/packages/sdk-components-react-radix/src/dialog.ws.ts
@@ -21,13 +21,16 @@ import {
 } from "./__generated__/dialog.props";
 import { buttonReset } from "./shared/preset-styles";
 
-// @todo add [data-state] to button and link
 export const metaDialogTrigger: WsComponentMeta = {
   icon: TriggerIcon,
   contentModel: {
     category: "none",
     children: ["instance"],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   props: propsDialogTrigger,
 };
 
@@ -38,6 +41,10 @@ export const metaDialogOverlay: WsComponentMeta = {
     children: ["instance"],
     descendants: [radix.DialogContent],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: { div },
   props: propsDialogOverlay,
 };
@@ -53,6 +60,10 @@ export const metaDialogContent: WsComponentMeta = {
       radix.DialogClose,
     ],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: { div },
   props: propsDialogContent,
 };

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -73,6 +73,10 @@ export const metaNavigationMenuTrigger: WsComponentMeta = {
     category: "none",
     children: ["instance"],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   props: propsNavigationMenuTrigger,
 };
 
@@ -84,6 +88,10 @@ export const metaNavigationMenuContent: WsComponentMeta = {
     children: ["instance"],
     descendants: [radix.NavigationMenuLink],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: {
     div,
   },
@@ -107,6 +115,10 @@ export const metaNavigationMenuViewport: WsComponentMeta = {
     category: "none",
     children: ["instance"],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: {
     div,
   },

--- a/packages/sdk-components-react-radix/src/popover.ws.ts
+++ b/packages/sdk-components-react-radix/src/popover.ws.ts
@@ -15,13 +15,16 @@ import {
 } from "./__generated__/popover.props";
 import { buttonReset } from "./shared/preset-styles";
 
-// @todo add [data-state] to button and link
 export const metaPopoverTrigger: WsComponentMeta = {
   icon: TriggerIcon,
   contentModel: {
     category: "none",
     children: ["instance"],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   props: propsPopoverTrigger,
 };
 
@@ -32,6 +35,10 @@ export const metaPopoverContent: WsComponentMeta = {
     children: ["instance"],
     descendants: [radix.PopoverClose],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: {
     div,
   },

--- a/packages/sdk-components-react-radix/src/radio-group.ws.ts
+++ b/packages/sdk-components-react-radix/src/radio-group.ws.ts
@@ -31,8 +31,8 @@ export const metaRadioGroupItem: WsComponentMeta = {
     descendants: [radix.RadioGroupIndicator],
   },
   states: [
-    { label: "Checked", selector: "[data-state=checked]" },
-    { label: "Unchecked", selector: "[data-state=unchecked]" },
+    { label: "Checked", selector: '[data-state="checked"]' },
+    { label: "Unchecked", selector: '[data-state="unchecked"]' },
   ],
   presetStyle: {
     button: [button, buttonReset].flat(),
@@ -48,8 +48,8 @@ export const metaRadioGroupIndicator: WsComponentMeta = {
     children: ["instance"],
   },
   states: [
-    { label: "Checked", selector: "[data-state=checked]" },
-    { label: "Unchecked", selector: "[data-state=unchecked]" },
+    { label: "Checked", selector: '[data-state="checked"]' },
+    { label: "Unchecked", selector: '[data-state="unchecked"]' },
   ],
   presetStyle: {
     span,

--- a/packages/sdk-components-react-radix/src/select.ws.ts
+++ b/packages/sdk-components-react-radix/src/select.ws.ts
@@ -40,6 +40,10 @@ export const metaSelectTrigger: WsComponentMeta = {
     children: ["instance"],
     descendants: [radix.SelectValue],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: { button },
   props: propsSelectTrigger,
 };
@@ -63,6 +67,10 @@ export const metaSelectContent: WsComponentMeta = {
     children: ["instance"],
     descendants: [radix.SelectViewport],
   },
+  states: [
+    { label: "Open", selector: '[data-state="open"]' },
+    { label: "Closed", selector: '[data-state="closed"]' },
+  ],
   presetStyle: { div },
   props: propsSelectContent,
 };
@@ -85,6 +93,10 @@ export const metaSelectItem: WsComponentMeta = {
     children: ["instance"],
     descendants: [radix.SelectItemIndicator, radix.SelectItemText],
   },
+  states: [
+    { label: "Checked", selector: '[data-state="checked"]' },
+    { label: "Unchecked", selector: '[data-state="unchecked"]' },
+  ],
   presetStyle: { div },
   initialProps: ["value"],
   props: propsSelectItem,

--- a/packages/sdk-components-react-radix/src/switch.ws.ts
+++ b/packages/sdk-components-react-radix/src/switch.ws.ts
@@ -13,8 +13,8 @@ export const metaSwitch: WsComponentMeta = {
     descendants: [radix.SwitchThumb],
   },
   states: [
-    { label: "Checked", selector: "[data-state=checked]" },
-    { label: "Unchecked", selector: "[data-state=unchecked]" },
+    { label: "Checked", selector: '[data-state="checked"]' },
+    { label: "Unchecked", selector: '[data-state="unchecked"]' },
   ],
   presetStyle: {
     button: [button, buttonReset].flat(),
@@ -30,8 +30,8 @@ export const metaSwitchThumb: WsComponentMeta = {
     children: ["instance"],
   },
   states: [
-    { label: "Checked", selector: "[data-state=checked]" },
-    { label: "Unchecked", selector: "[data-state=unchecked]" },
+    { label: "Checked", selector: '[data-state="checked"]' },
+    { label: "Unchecked", selector: '[data-state="unchecked"]' },
   ],
   presetStyle: {
     span,

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -45,7 +45,10 @@ export const metaTabsTrigger: WsComponentMeta = {
     category: "none",
     children: ["instance", "rich-text"],
   },
-  states: [{ label: "Active", selector: "[data-state=active]" }],
+  states: [
+    { label: "Active", selector: '[data-state="active"]' },
+    { label: "Inactive", selector: '[data-state="inactive"]' },
+  ],
   presetStyle: {
     button: [button, buttonReset].flat(),
   },
@@ -60,6 +63,10 @@ export const metaTabsContent: WsComponentMeta = {
     category: "none",
     children: ["instance", "rich-text"],
   },
+  states: [
+    { label: "Active", selector: '[data-state="active"]' },
+    { label: "Inactive", selector: '[data-state="inactive"]' },
+  ],
   presetStyle: { div },
   props: propsTabsContent,
 };

--- a/packages/sdk-components-react-radix/src/tooltip.ws.ts
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.ts
@@ -8,13 +8,17 @@ import {
   propsTooltipTrigger,
 } from "./__generated__/tooltip.props";
 
-// @todo add [data-state] to button and link
 export const metaTooltipTrigger: WsComponentMeta = {
   icon: TriggerIcon,
   contentModel: {
     category: "none",
     children: ["instance"],
   },
+  states: [
+    { label: "Closed", selector: '[data-state="closed"]' },
+    { label: "Delayed open", selector: '[data-state="delayed-open"]' },
+    { label: "Instant open", selector: '[data-state="instant-open"]' },
+  ],
   props: propsTooltipTrigger,
 };
 
@@ -24,6 +28,11 @@ export const metaTooltipContent: WsComponentMeta = {
     category: "none",
     children: ["instance"],
   },
+  states: [
+    { label: "Closed", selector: '[data-state="closed"]' },
+    { label: "Delayed open", selector: '[data-state="delayed-open"]' },
+    { label: "Instant open", selector: '[data-state="instant-open"]' },
+  ],
   presetStyle: { div },
   initialProps: ["side", "sideOffset", "align", "alignOffset"],
   props: propsTooltipContent,


### PR DESCRIPTION
- Add open/closed states to AccordionItem and AccordionHeader (had none)
- Add closed state to AccordionTrigger (only had open)
- Fix AccordionContent height animation styles in template
- Fix deduplication bug in style panel: component states no longer appear twice when the instance already has styles for those selectors
- Add indeterminate state to Checkbox root and CheckboxIndicator
- Add open/closed states to all Collapsible parts
- Add open/closed states to DialogTrigger, DialogOverlay, DialogContent
- Add open/closed states to NavigationMenuTrigger, MenuContent, Viewport
- Add open/closed states to PopoverTrigger and PopoverContent
- Add open/closed states to SelectTrigger and SelectContent
- Add checked/unchecked states to SelectItem
- Add inactive state to TabsTrigger and add states to TabsContent
- Add closed/delayed-open/instant-open states to TooltipTrigger and Content
- Fix selector format: use '[data-state="value"]' (quoted) everywhere to match css-tree normalization output
- Update tests to use quoted selector form matching real parser output

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
