### PR TITLE
chore: add PlanConfig type with name and prices to parsePlansEnv

### DIFF
--- a/packages/plans/src/index.ts
+++ b/packages/plans/src/index.ts
@@ -3,4 +3,4 @@ export {
   defaultPlanFeatures,
   parsePlansEnv,
 } from "./plan-features";
-export type { PlanFeatures, Purchase } from "./plan-features";
+export type { PlanFeatures, Purchase, PlanConfig } from "./plan-features";

--- a/packages/plans/src/plan-client.server.ts
+++ b/packages/plans/src/plan-client.server.ts
@@ -188,7 +188,7 @@ export const getPlanInfo = async (
         }
         return [
           {
-            ...(plansByName.get(product.name) ?? defaultPlanFeatures),
+            ...(plansByName.get(product.name)?.features ?? defaultPlanFeatures),
             ...parseProductMeta(product.meta),
           },
         ];

--- a/packages/plans/src/plan-features.test.ts
+++ b/packages/plans/src/plan-features.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest";
 import {
   type PlanFeatures,
+  type PlanConfig,
   defaultPlanFeatures,
   parsePlansEnv,
 } from "./plan-features";
@@ -20,6 +21,13 @@ const fullFeatures: PlanFeatures = {
   maxWorkspaces: 1,
   maxProjectsAllowedPerUser: 100,
 };
+
+/** Helper to build expected PlanConfig objects in tests */
+const planConfig = (
+  name: string,
+  features: PlanFeatures,
+  prices: Record<string, string> = {}
+): PlanConfig => ({ name, features, prices });
 
 describe("parsePlansEnv", () => {
   const validEntry = JSON.stringify({ name: "Pro", features: fullFeatures });
@@ -48,13 +56,14 @@ describe("parsePlansEnv", () => {
       ])
     );
     expect(result.size).toBe(2);
-    expect(result.get("LTD T2")).toEqual(result.get("Pro"));
+    expect(result.get("LTD T2")).toEqual(planConfig("LTD T2", fullFeatures));
+    expect(result.get("Pro")).toEqual(planConfig("Pro", fullFeatures));
   });
 
   test("entry with no features key and no extends resolves to defaultPlanFeatures", () => {
     const result = parsePlansEnv(JSON.stringify([{ name: "Free" }]));
     expect(result.size).toBe(1);
-    expect(result.get("Free")).toEqual(defaultPlanFeatures);
+    expect(result.get("Free")).toEqual(planConfig("Free", defaultPlanFeatures));
   });
 
   test("extends: child inherits parent features and overrides specific fields", () => {
@@ -65,9 +74,11 @@ describe("parsePlansEnv", () => {
       ])
     );
     expect(result.size).toBe(2);
-    expect(result.get("Team")!.canDownloadAssets).toBe(true);
-    expect(result.get("Team")!.maxWorkspaces).toBe(50);
-    expect(result.get("Pro")!.maxWorkspaces).toBe(fullFeatures.maxWorkspaces);
+    expect(result.get("Team")!.features.canDownloadAssets).toBe(true);
+    expect(result.get("Team")!.features.maxWorkspaces).toBe(50);
+    expect(result.get("Pro")!.features.maxWorkspaces).toBe(
+      fullFeatures.maxWorkspaces
+    );
   });
 
   test("extends: throws when extending an unknown plan", () => {
@@ -87,13 +98,46 @@ describe("parsePlansEnv", () => {
   test("parses a single valid entry", () => {
     const result = parsePlansEnv(`[${validEntry}]`);
     expect(result.size).toBe(1);
-    expect(result.get("Pro")).toEqual(fullFeatures);
+    expect(result.get("Pro")).toEqual(planConfig("Pro", fullFeatures));
+  });
+
+  test("parses prices from entry", () => {
+    const result = parsePlansEnv(
+      JSON.stringify([
+        {
+          name: "Pro",
+          features: fullFeatures,
+          prices: { monthly: "price_abc", yearly: "price_def" },
+        },
+      ])
+    );
+    expect(result.size).toBe(1);
+    expect(result.get("Pro")!.prices).toEqual({
+      monthly: "price_abc",
+      yearly: "price_def",
+    });
+  });
+
+  test("prices default to empty object when not provided", () => {
+    const result = parsePlansEnv(`[${validEntry}]`);
+    expect(result.get("Pro")!.prices).toEqual({});
+  });
+
+  test("skips entry with invalid prices (non-string value)", () => {
+    const result = parsePlansEnv(
+      JSON.stringify([
+        { name: "Bad", features: fullFeatures, prices: { monthly: 123 } },
+        { name: "Pro", features: fullFeatures },
+      ])
+    );
+    expect(result.size).toBe(1);
+    expect(result.get("Pro")).toBeDefined();
   });
 
   test("parses multiple valid entries", () => {
     const result = parsePlansEnv(twoEntries);
     expect(result.size).toBe(2);
-    expect(result.get("Workspaces")!.maxWorkspaces).toBe(10);
+    expect(result.get("Workspaces")!.features.maxWorkspaces).toBe(10);
   });
 
   test("skips entries with invalid features (wrong type), keeps valid ones", () => {
@@ -104,7 +148,7 @@ describe("parsePlansEnv", () => {
       ])
     );
     expect(result.size).toBe(1);
-    expect(result.get("Pro")).toEqual(fullFeatures);
+    expect(result.get("Pro")).toEqual(planConfig("Pro", fullFeatures));
   });
 
   test("partial features without extends fills in from defaultPlanFeatures", () => {
@@ -112,10 +156,9 @@ describe("parsePlansEnv", () => {
       JSON.stringify([{ name: "Pro", features: { canDownloadAssets: true } }])
     );
     expect(result.size).toBe(1);
-    expect(result.get("Pro")).toEqual({
-      ...defaultPlanFeatures,
-      canDownloadAssets: true,
-    });
+    expect(result.get("Pro")).toEqual(
+      planConfig("Pro", { ...defaultPlanFeatures, canDownloadAssets: true })
+    );
   });
 
   test("strips unknown keys from features", () => {
@@ -126,7 +169,7 @@ describe("parsePlansEnv", () => {
     );
     expect(result.size).toBe(1);
     expect(
-      (result.get("Pro") as Record<string, unknown>)["admin"]
+      (result.get("Pro")!.features as Record<string, unknown>)["admin"]
     ).toBeUndefined();
   });
 });

--- a/packages/plans/src/plan-features.ts
+++ b/packages/plans/src/plan-features.ts
@@ -55,15 +55,24 @@ export type Purchase = {
   subscriptionId?: string;
 };
 
+const PricesSchema = z.record(z.string(), z.string());
+
+/** A parsed plan entry with resolved features and price IDs keyed by billing cycle */
+export type PlanConfig = {
+  name: string;
+  features: PlanFeatures;
+  prices: Record<string, string>;
+};
+
 /**
- * Parse the PLANS env variable (JSON array of {name, extends?, features}).
+ * Parse the PLANS env variable (JSON array of {name, extends?, features, prices?}).
  * - features is partial when extends is used; the parent plan fills in the rest.
  * - The final merged features are validated against the full PlanFeaturesSchema.
  * - Invalid entries are skipped with a console.error.
  * - An extends reference to an unknown plan name throws an error.
- * Returns a Map of plan name → resolved PlanFeatures.
+ * Returns a Map of plan name → { name, features, prices }.
  */
-export const parsePlansEnv = (raw: string): Map<string, PlanFeatures> => {
+export const parsePlansEnv = (raw: string): Map<string, PlanConfig> => {
   try {
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) {
@@ -74,6 +83,7 @@ export const parsePlansEnv = (raw: string): Map<string, PlanFeatures> => {
       name: string;
       extends?: string;
       features: Partial<PlanFeatures>;
+      prices: Record<string, string>;
     };
 
     // First pass: validate entry structure and collect partial features.
@@ -90,13 +100,23 @@ export const parsePlansEnv = (raw: string): Map<string, PlanFeatures> => {
         console.error("Invalid PLANS entry (extends must be a string):", item);
         return [];
       }
-      const result = PlanFeaturesSchema.partial().safeParse(
+      const featuresResult = PlanFeaturesSchema.partial().safeParse(
         "features" in item ? item.features : {}
       );
-      if (!result.success) {
+      if (!featuresResult.success) {
         console.error(
           `Invalid PLANS entry "${item.name}" features:`,
-          result.error.flatten()
+          featuresResult.error.flatten()
+        );
+        return [];
+      }
+      const pricesResult = PricesSchema.safeParse(
+        "prices" in item ? item.prices : {}
+      );
+      if (!pricesResult.success) {
+        console.error(
+          `Invalid PLANS entry "${item.name}" prices:`,
+          pricesResult.error.flatten()
         );
         return [];
       }
@@ -104,7 +124,8 @@ export const parsePlansEnv = (raw: string): Map<string, PlanFeatures> => {
         {
           name: item.name,
           extends: "extends" in item ? (item.extends as string) : undefined,
-          features: result.data,
+          features: featuresResult.data,
+          prices: pricesResult.data,
         } satisfies PlanEntry,
       ];
     });
@@ -116,7 +137,7 @@ export const parsePlansEnv = (raw: string): Map<string, PlanFeatures> => {
 
     // Second pass: resolve extends and validate the full feature set.
     // Every entry implicitly extends defaultPlanFeatures; "extends" picks a named plan on top of that.
-    const resolved = new Map<string, PlanFeatures>();
+    const resolved = new Map<string, PlanConfig>();
     for (const entry of entries) {
       if (entry.extends !== undefined && !byName.has(entry.extends)) {
         throw new Error(
@@ -138,7 +159,11 @@ export const parsePlansEnv = (raw: string): Map<string, PlanFeatures> => {
         );
         continue;
       }
-      resolved.set(entry.name, result.data);
+      resolved.set(entry.name, {
+        name: entry.name,
+        features: result.data,
+        prices: entry.prices,
+      });
     }
     return resolved;
   } catch (error) {


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
