### PR TITLE
feat: validate page path doesn't exceed 255 characters

### DIFF
--- a/packages/sdk/src/schema/pages.test.ts
+++ b/packages/sdk/src/schema/pages.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { OldPagePath, ProjectNewRedirectPath } from "./pages";
+import { OldPagePath, PagePath, ProjectNewRedirectPath } from "./pages";
 
 describe("OldPagePath", () => {
   describe("basic validation", () => {
@@ -188,6 +188,26 @@ describe("OldPagePath", () => {
     test("accepts emoji characters", () => {
       expect(OldPagePath.safeParse("/🎉").success).toBe(true);
       expect(OldPagePath.safeParse("/hello-🌍").success).toBe(true);
+    });
+  });
+});
+
+describe("PagePath", () => {
+  describe("path length validation", () => {
+    test("accepts a path of exactly 255 characters", () => {
+      const path = "/" + "a".repeat(254);
+      expect(PagePath.safeParse(path).success).toBe(true);
+    });
+
+    test("rejects a path exceeding 255 characters", () => {
+      const path = "/" + "a".repeat(255);
+      const result = PagePath.safeParse(path);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          "Path can't exceed 255 characters"
+        );
+      }
     });
   });
 });

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -109,7 +109,8 @@ const DefaultPagePage = z
     // And we cannot customize it due to bug in Remix: https://github.com/remix-run/remix/issues/2933
     (path) => path !== "/build" && path.startsWith("/build/") === false,
     "/build prefix is reserved for the system"
-  );
+  )
+  .refine((path) => path.length <= 255, "Path can't exceed 255 characters");
 
 export const OldPagePath = z
   .string()


### PR DESCRIPTION
## What

Adds a 255-character limit validation to the page path in the builder's page settings.

## Why

Previously, paths exceeding 255 characters would only cause a build failure. This change surfaces the error directly in the page settings UI, giving users immediate feedback when typing a path that's too long.

## How

- Added a `.refine()` to the `DefaultPagePage` Zod schema in `packages/sdk/src/schema/pages.ts`
- Uses `path.length <= 255` (safe because the upstream ASCII regex guarantees 1 byte = 1 character)
- Error displays via the existing `InputErrorsTooltip` on the Path field, same as other validations (e.g., umlaut rejection)

## Tests

Added boundary tests in `packages/sdk/src/schema/pages.test.ts`:
- Path of exactly 255 characters → accepted ✅
- Path of 256 characters → rejected with "Path can't exceed 255 characters" ✅

All 41 tests pass.