### PR TITLE
fix: resolve transitive var() references in shorthand expansion

### DIFF
--- a/packages/css-data/src/parse-css.test.ts
+++ b/packages/css-data/src/parse-css.test.ts
@@ -2120,6 +2120,95 @@ describe("var() substitution — border", () => {
   });
 });
 
+describe("var() substitution — transitive (nested) var() resolution", () => {
+  test("var() whose value contains var() — calc(var(--base) * N)", () => {
+    const result = decls(`
+      --base-size: 1rem;
+      --border-width: calc(var(--base-size) * 0.0625);
+      border: var(--border-width) solid red;
+    `);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        prop(
+          "border-top-width",
+          expect.objectContaining({
+            type: "unparsed",
+            value: "calc(1rem*0.0625)",
+          })
+        ),
+        prop("border-top-style", kw("solid")),
+        prop("border-top-color", kw("red")),
+      ])
+    );
+  });
+
+  test("var() whose value contains var() — color-mix(var(--clr))", () => {
+    const result = decls(`
+      --base-clr: green;
+      --border-color: color-mix(in srgb, var(--base-clr) 65%, black);
+      border: 2px solid var(--border-color);
+    `);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        prop("border-top-width", u(2, "px")),
+        prop("border-top-style", kw("solid")),
+        prop(
+          "border-top-color",
+          expect.objectContaining({
+            type: "unparsed",
+            value: "color-mix(in srgb,green 65%,black)",
+          })
+        ),
+      ])
+    );
+  });
+
+  test("full .use_calc scenario — calc and color-mix with transitive vars", () => {
+    const result = decls(`
+      --base-size: 1rem;
+      --base-clr: green;
+      --border-width: calc(var(--base-size) * 0.0625);
+      --border-color: color-mix(in srgb, var(--base-clr) 65%, black);
+      border: var(--border-width) solid var(--border-color);
+    `);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        prop(
+          "border-top-width",
+          expect.objectContaining({
+            type: "unparsed",
+            value: "calc(1rem*0.0625)",
+          })
+        ),
+        prop("border-top-style", kw("solid")),
+        prop(
+          "border-top-color",
+          expect.objectContaining({
+            type: "unparsed",
+            value: "color-mix(in srgb,green 65%,black)",
+          })
+        ),
+      ])
+    );
+  });
+
+  test("three levels of transitive vars", () => {
+    const result = decls(`
+      --a: 5px;
+      --b: var(--a);
+      --c: var(--b);
+      border: var(--c) solid red;
+    `);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        prop("border-top-width", u(5, "px")),
+        prop("border-top-style", kw("solid")),
+        prop("border-top-color", kw("red")),
+      ])
+    );
+  });
+});
+
 describe("var() substitution — outline", () => {
   test("var() for outline color", () => {
     const result = decls(`--clr: red; outline: 2px solid var(--clr);`);

--- a/packages/css-data/src/parse-css.ts
+++ b/packages/css-data/src/parse-css.ts
@@ -179,6 +179,17 @@ const resolveVars = (
   for (const s of [...subs].reverse()) {
     resolved = resolved.slice(0, s.start) + s.text + resolved.slice(s.end);
   }
+  // Substituted text may itself contain var() references (transitive vars).
+  // Re-resolve until no more substitutions are possible.
+  if (resolved !== value && resolved.includes("var(")) {
+    const deeper = resolveVars(resolved, customProperties, cssVars, depth + 1);
+    if (deeper) {
+      return {
+        resolved: deeper.resolved,
+        dropped: [...new Set([...dropped, ...deeper.dropped])],
+      };
+    }
+  }
   return { resolved, dropped };
 };
 


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
