### PR TITLE
feat: escape to exit preview mode

### DIFF
--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -8,6 +8,7 @@ import { createCommandsEmitter, type Command } from "~/shared/commands-emitter";
 import {
   $editingItemSelector,
   $isDesignMode,
+  $isPreviewMode,
   toggleBuilderMode,
   $project,
 } from "~/shared/nano-states";
@@ -75,6 +76,15 @@ const makeBreakpointCommand = <CommandName extends string>(
   },
 });
 
+const exitPreviewModeFromNonCanvasSource = (source: string) => {
+  if (source === "canvas") {
+    return;
+  }
+
+  setActiveSidebarPanel("auto");
+  toggleBuilderMode("preview");
+};
+
 export const { emitCommand, subscribeCommands } = createCommandsEmitter({
   source: "builder",
   externalCommands: [
@@ -99,7 +109,12 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       defaultHotkeys: ["escape"],
       // radix check event.defaultPrevented before invoking callbacks
       preventDefault: false,
-      handler: () => {
+      handler: (source) => {
+        if ($isPreviewMode.get()) {
+          exitPreviewModeFromNonCanvasSource(source);
+          return;
+        }
+
         const { publish } = $publisher.get();
         publish?.({ type: "cancelCurrentDrag" });
       },

--- a/apps/builder/app/shared/commands-emitter.test.ts
+++ b/apps/builder/app/shared/commands-emitter.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { $commandMetas, createCommandsEmitter } from "./commands-emitter";
+
+type CommandPayload = {
+  source: string;
+  name: string;
+};
+
+const pubsubMock = vi.hoisted(() => {
+  let publisher: { publish?: (action: unknown) => void } = {};
+  const subscribers = new Map<
+    string,
+    Array<(payload: CommandPayload) => void>
+  >();
+
+  return {
+    getPublisher: () => publisher,
+    setPublisher: (next: { publish?: (action: unknown) => void }) => {
+      publisher = next;
+    },
+    subscribe: (type: string, callback: (payload: CommandPayload) => void) => {
+      const callbacks = subscribers.get(type) ?? [];
+      callbacks.push(callback);
+      subscribers.set(type, callbacks);
+      return () => {
+        subscribers.set(
+          type,
+          (subscribers.get(type) ?? []).filter((item) => item !== callback)
+        );
+      };
+    },
+    emit: (type: string, payload: CommandPayload) => {
+      for (const callback of subscribers.get(type) ?? []) {
+        callback(payload);
+      }
+    },
+    reset: () => {
+      publisher = {};
+      subscribers.clear();
+    },
+  };
+});
+
+vi.mock("~/shared/pubsub", () => ({
+  $publisher: {
+    get: pubsubMock.getPublisher,
+    set: pubsubMock.setPublisher,
+  },
+  subscribe: pubsubMock.subscribe,
+}));
+
+vi.mock("~/shared/sync/sync-stores", () => ({
+  clientSyncStore: {
+    register: vi.fn(),
+    createTransaction: vi.fn(
+      (
+        stores: Array<{ get: () => unknown }>,
+        callback: (value: unknown) => void
+      ) => {
+        callback(stores[0].get());
+      }
+    ),
+  },
+}));
+
+const createTestCommand = (handler: (source: string) => void = vi.fn()) =>
+  createCommandsEmitter({
+    source: "builder",
+    commands: [
+      {
+        name: "testCommand",
+        handler,
+      },
+    ],
+  });
+
+describe("createCommandsEmitter", () => {
+  afterEach(() => {
+    pubsubMock.reset();
+    $commandMetas.set(new Map());
+  });
+
+  test("passes own source to handlers when emitting directly", () => {
+    const calls: string[] = [];
+    const { emitCommand } = createTestCommand((source) => {
+      calls.push(source);
+    });
+
+    emitCommand("testCommand");
+
+    expect(calls).toEqual(["builder"]);
+  });
+
+  test("publishes commands with own source", () => {
+    const publish = vi.fn();
+    pubsubMock.setPublisher({ publish });
+    const { emitCommand } = createTestCommand();
+
+    emitCommand("testCommand");
+
+    expect(publish).toHaveBeenCalledWith({
+      type: "command",
+      payload: {
+        source: "builder",
+        name: "testCommand",
+      },
+    });
+  });
+
+  test("passes published source to subscribed command handlers", () => {
+    const calls: string[] = [];
+    const { subscribeCommands } = createTestCommand((source) => {
+      calls.push(source);
+    });
+
+    const unsubscribe = subscribeCommands();
+    pubsubMock.emit("command", {
+      source: "canvas",
+      name: "testCommand",
+    });
+    unsubscribe();
+
+    expect(calls).toEqual(["canvas"]);
+  });
+});

--- a/apps/builder/app/shared/commands-emitter.ts
+++ b/apps/builder/app/shared/commands-emitter.ts
@@ -30,7 +30,7 @@ export type CommandMeta<CommandName extends string> = {
   keepCommandPanelOpen?: boolean;
 };
 
-type CommandHandler = () => void;
+type CommandHandler = (source: string) => void;
 
 /**
  * Command can be registered by builder, canvas or plugin
@@ -124,7 +124,7 @@ export const createCommandsEmitter = <CommandName extends string>({
         },
       });
     } else {
-      commandHandlers.get(name)?.();
+      commandHandlers.get(name)?.(source);
     }
   };
 
@@ -143,8 +143,8 @@ export const createCommandsEmitter = <CommandName extends string>({
       });
     }
 
-    const unsubscribePubsub = subscribe("command", ({ name }) => {
-      commandHandlers.get(name)?.();
+    const unsubscribePubsub = subscribe("command", ({ name, source }) => {
+      commandHandlers.get(name)?.(source);
     });
     const handleKeyDown = (event: KeyboardEvent) => {
       let emitted = false;

--- a/apps/builder/docs/test-cases.md
+++ b/apps/builder/docs/test-cases.md
@@ -193,3 +193,12 @@
    - The name should change in the pages list as well (with a small delay)
    - Change the page path
    - Reload browser tab and open the page settings again and make sure your changes are persisted
+
+1. Preview mode
+
+   - Enter preview mode from the top bar
+   - Press `escape` while focus is outside the canvas
+   - Check that preview mode exits and the builder UI is shown
+   - Enter preview mode again
+   - Press `escape` while interacting with the canvas
+   - Check that preview mode stays active and the canvas handles the key press


### PR DESCRIPTION
## Description

1. Related to #5501. This lets user escape exit preview mode when triggered from the builder UI, while preserving canvas-originated escape behavior so preview mode remains active when the canvas should handle the key event.

## Steps for reproduction

1. Open the builder and switch to preview mode.
2. Press Escape from the builder UI.
3. Expect preview mode to exit and the sidebar panel to return to auto.
4. Switch to preview mode again.
5. Press Escape while the focused inside the canvas.
6. Expect preview mode to stay active and canvas/native page behavior to be preserved.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [x] added tests
- [ ] if any new env variables are added, added them to `.env` file