### PR TITLE
feat: use declarative component-based configuration for content mode

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/text-content.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text-content.tsx
@@ -28,7 +28,7 @@ import {
   updateExpressionValue,
   useBindingState,
 } from "../shared";
-import { FieldLabel, useIsResettingBindingForbidden } from "../property-label";
+import { FieldLabel, useIsBindingResetForbidden } from "../property-label";
 
 const useInstance = (instanceId: Instance["id"]) => {
   const $store = useMemo(() => {
@@ -78,9 +78,9 @@ export const TextContent = ({
   const { overwritable, variant } = useBindingState(
     child.type === "expression" ? child.value : undefined
   );
-  const isResettingBindingForbidden = useIsResettingBindingForbidden(
-    child.type === "expression"
-  );
+  const isBindingResetForbidden = useIsBindingResetForbidden();
+  const isResetDisabled =
+    child.type === "expression" && isBindingResetForbidden;
 
   return (
     <VerticalLayout
@@ -105,11 +105,8 @@ export const TextContent = ({
             </>
           }
           resettable={hasChildren}
-          resetDisabled={isResettingBindingForbidden}
+          resetDisabled={isResetDisabled}
           onReset={() => {
-            if (isResettingBindingForbidden) {
-              return;
-            }
             updateWebstudioData((data) => {
               const instance = data.instances.get(instanceId);
               if (instance) {

--- a/apps/builder/app/builder/features/settings-panel/controls/text-content.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text-content.tsx
@@ -28,7 +28,7 @@ import {
   updateExpressionValue,
   useBindingState,
 } from "../shared";
-import { FieldLabel } from "../property-label";
+import { FieldLabel, useIsResettingBindingForbidden } from "../property-label";
 
 const useInstance = (instanceId: Instance["id"]) => {
   const $store = useMemo(() => {
@@ -78,6 +78,9 @@ export const TextContent = ({
   const { overwritable, variant } = useBindingState(
     child.type === "expression" ? child.value : undefined
   );
+  const isResettingBindingForbidden = useIsResettingBindingForbidden(
+    child.type === "expression"
+  );
 
   return (
     <VerticalLayout
@@ -102,7 +105,11 @@ export const TextContent = ({
             </>
           }
           resettable={hasChildren}
+          resetDisabled={isResettingBindingForbidden}
           onReset={() => {
+            if (isResettingBindingForbidden) {
+              return;
+            }
             updateWebstudioData((data) => {
               const instance = data.instances.get(instanceId);
               if (instance) {

--- a/apps/builder/app/builder/features/settings-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/settings-panel/property-label.tsx
@@ -16,13 +16,23 @@ import { AlertIcon } from "@webstudio-is/icons";
 import type { Prop } from "@webstudio-is/sdk";
 import { showAttribute } from "@webstudio-is/react-sdk";
 import { updateWebstudioData } from "~/shared/instance-utils";
-import { $selectedInstance } from "~/shared/nano-states";
+import {
+  $authPermit,
+  $isContentMode,
+  $selectedInstance,
+} from "~/shared/nano-states";
 import { $props } from "~/shared/sync/data-stores";
 import {
   $selectedInstanceInitialPropNames,
   $selectedInstancePropsMetas,
   humanizeAttribute,
 } from "./shared";
+
+export const useIsResettingBindingForbidden = (isBound: boolean) => {
+  const isContentMode = useStore($isContentMode);
+  const authPermit = useStore($authPermit);
+  return isBound && (isContentMode || authPermit === "edit");
+};
 
 const usePropMeta = (name: string) => {
   const store = useMemo(() => {
@@ -103,6 +113,10 @@ export const PropertyLabel = ({
   // not existing properties cannot be deleted
   const isDeletable = prop !== undefined;
   const isResettable = useIsResettable(name);
+  const isResettingBindingForbidden = useIsResettingBindingForbidden(
+    prop?.type === "expression"
+  );
+  const canDelete = isDeletable && isResettingBindingForbidden === false;
   return (
     <Flex align="center" css={{ gap: theme.spacing[3] }}>
       {/* prevent label growing */}
@@ -114,7 +128,7 @@ export const PropertyLabel = ({
             onClick: (event) => {
               if (event.altKey) {
                 event.preventDefault();
-                if (isDeletable) {
+                if (canDelete) {
                   deleteProp(name);
                 }
                 return;
@@ -144,7 +158,7 @@ export const PropertyLabel = ({
                   </Text>
                 </Flex>
               )}
-              {isDeletable && (
+              {canDelete && (
                 <Button
                   color="dark"
                   // to align button text in the middle
@@ -174,6 +188,7 @@ export const PropertyLabel = ({
 export const FieldLabel = ({
   description,
   resettable = false,
+  resetDisabled = false,
   onReset,
   children,
 }: {
@@ -185,10 +200,12 @@ export const FieldLabel = ({
    * when true means field has value and colored true
    */
   resettable?: boolean;
+  resetDisabled?: boolean;
   onReset?: () => void;
   children: string;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const canReset = resettable && resetDisabled === false;
   if (typeof description === "string") {
     description = (
       <Text
@@ -212,7 +229,7 @@ export const FieldLabel = ({
             onClick: (event) => {
               if (event.altKey) {
                 event.preventDefault();
-                if (resettable) {
+                if (canReset) {
                   onReset?.();
                 }
                 return;
@@ -230,7 +247,7 @@ export const FieldLabel = ({
                 {children}
               </Text>
               {description}
-              {resettable && (
+              {canReset && (
                 <Button
                   color="dark"
                   // to align button text in the middle

--- a/apps/builder/app/builder/features/settings-panel/property-label.tsx
+++ b/apps/builder/app/builder/features/settings-panel/property-label.tsx
@@ -28,10 +28,10 @@ import {
   humanizeAttribute,
 } from "./shared";
 
-export const useIsResettingBindingForbidden = (isBound: boolean) => {
+export const useIsBindingResetForbidden = () => {
   const isContentMode = useStore($isContentMode);
   const authPermit = useStore($authPermit);
-  return isBound && (isContentMode || authPermit === "edit");
+  return isContentMode || authPermit === "edit";
 };
 
 const usePropMeta = (name: string) => {
@@ -113,10 +113,9 @@ export const PropertyLabel = ({
   // not existing properties cannot be deleted
   const isDeletable = prop !== undefined;
   const isResettable = useIsResettable(name);
-  const isResettingBindingForbidden = useIsResettingBindingForbidden(
-    prop?.type === "expression"
-  );
-  const canDelete = isDeletable && isResettingBindingForbidden === false;
+  const isBindingResetForbidden = useIsBindingResetForbidden();
+  const canDelete =
+    isDeletable && !(prop?.type === "expression" && isBindingResetForbidden);
   return (
     <Flex align="center" css={{ gap: theme.spacing[3] }}>
       {/* prevent label growing */}
@@ -205,7 +204,7 @@ export const FieldLabel = ({
   children: string;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const canReset = resettable && resetDisabled === false;
+  const canReset = resettable && !resetDisabled;
   if (typeof description === "string") {
     description = (
       <Text

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.stories.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.stories.tsx
@@ -415,6 +415,7 @@ export const PropsSection = () => {
             instanceId={instanceId}
             propsLogic={logic}
             propValues={new Map()}
+            propValuesByInstanceSelector={new Map()}
             component="Button"
             selectedInstanceKey={instanceId}
           />

--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -34,7 +34,11 @@ import {
 import { $props } from "~/shared/sync/data-stores";
 import { CollapsibleSectionWithAddButton } from "~/builder/shared/collapsible-section";
 import { serverSyncStore } from "~/shared/sync/sync-stores";
-import { $selectedInstance, $selectedInstanceKey } from "~/shared/nano-states";
+import {
+  $selectedInstance,
+  $selectedInstanceKey,
+  getInstanceKey,
+} from "~/shared/nano-states";
 import { renderControl } from "../controls/combined";
 import { usePropsLogic, type PropAndMeta } from "./use-props-logic";
 import { AnimationSection } from "./animation/animation-section";
@@ -77,18 +81,33 @@ const matchOrSuggestToCreate = (
 };
 
 const renderProperty = (
-  { propsLogic: logic, propValues, component, instanceId }: PropsSectionProps,
-  { prop, propName, meta }: PropAndMeta
-) =>
-  renderControl({
-    key: propName,
+  {
+    propsLogic: logic,
+    propValues,
+    propValuesByInstanceSelector,
+    component,
     instanceId,
+  }: PropsSectionProps,
+  item: PropAndMeta
+) => {
+  const { prop, propName, meta } = item;
+  const targetInstanceId = item.instanceId ?? instanceId;
+  const targetPropValues =
+    item.instanceSelector === undefined
+      ? propValues
+      : (propValuesByInstanceSelector.get(
+          getInstanceKey(item.instanceSelector)
+        ) ?? propValues);
+
+  return renderControl({
+    key: propName,
+    instanceId: targetInstanceId,
     meta,
     prop,
     computedValue:
-      propValues.get(propName) ??
+      targetPropValues.get(propName) ??
       // support legacy html props with react names
-      propValues.get(standardAttributesToReactProps[propName]) ??
+      targetPropValues.get(standardAttributesToReactProps[propName]) ??
       meta.defaultValue,
     propName,
     onChange: (propValue) => {
@@ -105,6 +124,7 @@ const renderProperty = (
       }
     },
   });
+};
 
 const forbiddenProperties = new Set(["style"]);
 
@@ -192,6 +212,7 @@ const AddPropertyOrAttribute = ({
 type PropsSectionProps = {
   propsLogic: ReturnType<typeof usePropsLogic>;
   propValues: Map<string, unknown>;
+  propValuesByInstanceSelector: Map<string, Map<string, unknown>>;
   component: Instance["component"];
   instanceId: string;
   selectedInstanceKey: string;
@@ -322,6 +343,7 @@ export const PropsSectionContainer = ({
 }) => {
   const { propsByInstanceId } = useStore($propsIndex);
   const propValues = useStore($propValues);
+  const propValuesByInstanceSelector = useStore($propValuesByInstanceSelector);
 
   const logic = usePropsLogic({
     instance,
@@ -357,6 +379,7 @@ export const PropsSectionContainer = ({
       <PropsSection
         propsLogic={logic}
         propValues={propValues ?? new Map()}
+        propValuesByInstanceSelector={propValuesByInstanceSelector}
         component={instance.component}
         instanceId={instance.id}
         selectedInstanceKey={selectedInstanceKey}

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -163,6 +163,11 @@ const contentModePropertiesByTag: Partial<Record<string, string[]>> = {
   a: ["href"],
 };
 
+const contentModePropertiesByComponent: Partial<Record<string, string[]>> = {
+  YouTube: ["url"],
+  Vimeo: ["url"],
+};
+
 const $selectedInstanceTag = computed(
   [$selectedInstance, $instanceTags],
   (selectedInstance, instanceTags) => {
@@ -190,9 +195,14 @@ export const usePropsLogic = ({
     if (!isContentMode) {
       return true;
     }
-    const allowedProperties =
+    const allowedPropertiesByTag =
       contentModePropertiesByTag[selectedInstanceTag ?? ""] ?? [];
-    return allowedProperties.includes(propName);
+    const allowedPropertiesByComponent =
+      contentModePropertiesByComponent[instance.component] ?? [];
+    return (
+      allowedPropertiesByTag.includes(propName) ||
+      allowedPropertiesByComponent.includes(propName)
+    );
   };
 
   const savedProps = props;

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -16,14 +16,13 @@ import {
 import { $instances } from "~/shared/sync/data-stores";
 import { $props } from "~/shared/sync/data-stores";
 import { isRichText } from "~/shared/content-model";
-import { $selectedInstance, $selectedInstancePath } from "~/shared/nano-states";
+import { $selectedInstancePath } from "~/shared/nano-states";
 import {
   $selectedInstanceInitialPropNames,
   $selectedInstancePropsMetas,
   showAttributeMeta,
   type PropValue,
 } from "../shared";
-import { $instanceTags } from "../../style-panel/shared/model";
 
 type PropOrName = { prop?: Prop; propName: string };
 
@@ -158,26 +157,6 @@ const $canHaveTextContent = computed(
   }
 );
 
-const contentModePropertiesByTag: Partial<Record<string, string[]>> = {
-  img: ["src", "width", "height", "alt"],
-  a: ["href"],
-};
-
-const contentModePropertiesByComponent: Partial<Record<string, string[]>> = {
-  YouTube: ["url"],
-  Vimeo: ["url"],
-};
-
-const $selectedInstanceTag = computed(
-  [$selectedInstance, $instanceTags],
-  (selectedInstance, instanceTags) => {
-    if (selectedInstance === undefined) {
-      return;
-    }
-    return instanceTags.get(selectedInstance.id);
-  }
-);
-
 /** usePropsLogic expects that key={instanceId} is used on the ancestor component */
 export const usePropsLogic = ({
   instance,
@@ -185,32 +164,24 @@ export const usePropsLogic = ({
   updateProp,
 }: UsePropsLogicInput) => {
   const isContentMode = useStore($isContentMode);
-  const selectedInstanceTag = useStore($selectedInstanceTag);
+  const propsMetas = useStore($selectedInstancePropsMetas);
 
   /**
-   * In content edit mode we show only Image and Link props
+   * In content edit mode we show only props marked with contentMode: true
    * In the future I hope the only thing we will show will be Components
    */
   const isPropVisible = (propName: string) => {
     if (!isContentMode) {
       return true;
     }
-    const allowedPropertiesByTag =
-      contentModePropertiesByTag[selectedInstanceTag ?? ""] ?? [];
-    const allowedPropertiesByComponent =
-      contentModePropertiesByComponent[instance.component] ?? [];
-    return (
-      allowedPropertiesByTag.includes(propName) ||
-      allowedPropertiesByComponent.includes(propName)
-    );
+    const propMeta = propsMetas.get(propName);
+    return propMeta?.contentMode === true;
   };
 
   const savedProps = props;
 
   // we will delete items from these maps as we categorize the props
   const unprocessedSaved = new Map(savedProps.map((prop) => [prop.name, prop]));
-
-  const propsMetas = useStore($selectedInstancePropsMetas);
 
   const initialPropNames = useStore($selectedInstanceInitialPropNames);
 

--- a/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/props-section/use-props-logic.ts
@@ -15,7 +15,7 @@ import {
 } from "~/shared/nano-states";
 import { $instances } from "~/shared/sync/data-stores";
 import { $props } from "~/shared/sync/data-stores";
-import { isRichText } from "~/shared/content-model";
+import { isRichText, isRichTextTree } from "~/shared/content-model";
 import { $selectedInstancePath } from "~/shared/nano-states";
 import {
   $selectedInstanceInitialPropNames,
@@ -30,6 +30,8 @@ export type PropAndMeta = {
   prop?: Prop;
   propName: string;
   meta: PropMeta;
+  instanceId?: Instance["id"];
+  instanceSelector?: Instance["id"][];
 };
 
 // The value we set prop to when it's added
@@ -142,12 +144,26 @@ const getAndDelete = <Value>(map: Map<string, Value>, key: string) => {
 };
 
 const $canHaveTextContent = computed(
-  [$instances, $props, $registeredComponentMetas, $selectedInstancePath],
-  (instances, props, metas, instancePath) => {
+  [
+    $instances,
+    $props,
+    $registeredComponentMetas,
+    $selectedInstancePath,
+    $isContentMode,
+  ],
+  (instances, props, metas, instancePath, isContentMode) => {
     if (instancePath === undefined) {
       return false;
     }
     const [{ instanceSelector }] = instancePath;
+    if (isContentMode) {
+      return isRichTextTree({
+        instanceId: instanceSelector[0],
+        instances,
+        props,
+        metas,
+      });
+    }
     return isRichText({
       instances,
       props,
@@ -174,6 +190,9 @@ export const usePropsLogic = ({
     if (!isContentMode) {
       return true;
     }
+    if (propName === textContentAttribute) {
+      return true;
+    }
     const propMeta = propsMetas.get(propName);
     return propMeta?.contentMode === true;
   };
@@ -198,19 +217,57 @@ export const usePropsLogic = ({
   }
 
   const canHaveTextContent = useStore($canHaveTextContent);
+  const instances = useStore($instances);
+  const selectedInstancePath = useStore($selectedInstancePath);
 
-  const hasNoChildren = instance.children.length === 0;
-  const hasOnlyTextChild =
-    instance.children.length === 1 && instance.children[0].type === "text";
-  const hasOnlyExpressionChild =
-    instance.children.length === 1 &&
-    instance.children[0].type === "expression";
-  if (
-    canHaveTextContent &&
-    (hasNoChildren || hasOnlyTextChild || hasOnlyExpressionChild)
-  ) {
+  const getTextContentTarget = () => {
+    const canEditChildren = (target: Instance) => {
+      const hasNoChildren = target.children.length === 0;
+      const hasOnlyTextChild =
+        target.children.length === 1 && target.children[0].type === "text";
+      const hasOnlyExpressionChild =
+        target.children.length === 1 &&
+        target.children[0].type === "expression";
+      return hasNoChildren || hasOnlyTextChild || hasOnlyExpressionChild;
+    };
+
+    if (canHaveTextContent && canEditChildren(instance)) {
+      return {
+        instanceId: instance.id,
+        instanceSelector: selectedInstancePath?.[0].instanceSelector,
+      };
+    }
+
+    if (isContentMode && instance.component === "Link") {
+      const [child] = instance.children;
+      if (child?.type === "id") {
+        const childInstance = instances.get(child.value);
+        if (
+          childInstance?.component === "Text" &&
+          canEditChildren(childInstance)
+        ) {
+          return {
+            instanceId: childInstance.id,
+            instanceSelector:
+              selectedInstancePath === undefined
+                ? undefined
+                : [
+                    childInstance.id,
+                    ...selectedInstancePath[0].instanceSelector,
+                  ],
+          };
+        }
+      }
+    }
+  };
+
+  const textContentTarget = getTextContentTarget();
+
+  if (textContentTarget) {
     systemProps.push({
       propName: textContentAttribute,
+      instanceId: textContentTarget.instanceId,
+      instanceSelector: textContentTarget.instanceSelector,
       meta: {
         required: false,
         control: "textContent",

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -27,7 +27,7 @@ import {
   SYSTEM_VARIABLE_ID,
   systemParameter,
 } from "@webstudio-is/sdk";
-import type { PropMeta, Prop, Asset, WsComponentMeta } from "@webstudio-is/sdk";
+import type { PropMeta, Prop, Asset } from "@webstudio-is/sdk";
 import { InfoCircleIcon } from "@webstudio-is/icons";
 import {
   Label as BaseLabel,
@@ -461,42 +461,54 @@ const attributeToMeta = (attribute: Attribute): PropMeta => {
 // Derive tag → content-mode attribute names from registered component metas,
 // so a prop marked `contentMode: true` in a .ws.ts file also surfaces on
 // `ws:element` instances rendering the same tag.
-const getContentModeAttributesByTag = (metas: Map<string, WsComponentMeta>) => {
-  const byTag = new Map<string, Set<string>>();
-  for (const componentMeta of metas.values()) {
-    const tags = Object.keys(componentMeta.presetStyle ?? {});
-    if (tags.length === 0) {
-      continue;
-    }
-    for (const [propName, propMeta] of Object.entries(
-      componentMeta.props ?? {}
-    )) {
-      if (propMeta.contentMode !== true) {
+const $contentModeAttributesByTag = computed(
+  [$registeredComponentMetas],
+  (metas) => {
+    const byTag = new Map<string, Set<string>>();
+    for (const componentMeta of metas.values()) {
+      const tags = Object.keys(componentMeta.presetStyle ?? {});
+      if (tags.length === 0) {
         continue;
       }
-      for (const tag of tags) {
-        let names = byTag.get(tag);
-        if (names === undefined) {
-          names = new Set();
-          byTag.set(tag, names);
+      for (const [propName, propMeta] of Object.entries(
+        componentMeta.props ?? {}
+      )) {
+        if (propMeta.contentMode !== true) {
+          continue;
         }
-        names.add(propName);
+        for (const tag of tags) {
+          let names = byTag.get(tag);
+          if (names === undefined) {
+            names = new Set();
+            byTag.set(tag, names);
+          }
+          names.add(propName);
+        }
       }
     }
+    return byTag;
   }
-  return byTag;
-};
+);
 
 export const $selectedInstancePropsMetas = computed(
-  [$selectedInstance, $registeredComponentMetas, $instanceTags],
-  (instance, metas, instanceTags): Map<string, PropMeta> => {
+  [
+    $selectedInstance,
+    $registeredComponentMetas,
+    $instanceTags,
+    $contentModeAttributesByTag,
+  ],
+  (
+    instance,
+    metas,
+    instanceTags,
+    contentModeAttributesByTag
+  ): Map<string, PropMeta> => {
     if (instance === undefined) {
       return new Map();
     }
     const meta = metas.get(instance.component);
     const tag = instanceTags.get(instance.id);
     const propsMetas = new Map<Prop["name"], PropMeta>();
-    const contentModeAttributesByTag = getContentModeAttributesByTag(metas);
     const contentModeAttributes =
       tag === undefined ? undefined : contentModeAttributesByTag.get(tag);
     const toAttributeMeta = (attribute: Attribute): PropMeta => {

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -27,7 +27,7 @@ import {
   SYSTEM_VARIABLE_ID,
   systemParameter,
 } from "@webstudio-is/sdk";
-import type { PropMeta, Prop, Asset } from "@webstudio-is/sdk";
+import type { PropMeta, Prop, Asset, WsComponentMeta } from "@webstudio-is/sdk";
 import { InfoCircleIcon } from "@webstudio-is/icons";
 import {
   Label as BaseLabel,
@@ -458,6 +458,35 @@ const attributeToMeta = (attribute: Attribute): PropMeta => {
   throw Error("impossible case");
 };
 
+// Derive tag → content-mode attribute names from registered component metas,
+// so a prop marked `contentMode: true` in a .ws.ts file also surfaces on
+// `ws:element` instances rendering the same tag.
+const getContentModeAttributesByTag = (metas: Map<string, WsComponentMeta>) => {
+  const byTag = new Map<string, Set<string>>();
+  for (const componentMeta of metas.values()) {
+    const tags = Object.keys(componentMeta.presetStyle ?? {});
+    if (tags.length === 0) {
+      continue;
+    }
+    for (const [propName, propMeta] of Object.entries(
+      componentMeta.props ?? {}
+    )) {
+      if (propMeta.contentMode !== true) {
+        continue;
+      }
+      for (const tag of tags) {
+        let names = byTag.get(tag);
+        if (names === undefined) {
+          names = new Set();
+          byTag.set(tag, names);
+        }
+        names.add(propName);
+      }
+    }
+  }
+  return byTag;
+};
+
 export const $selectedInstancePropsMetas = computed(
   [$selectedInstance, $registeredComponentMetas, $instanceTags],
   (instance, metas, instanceTags): Map<string, PropMeta> => {
@@ -467,22 +496,32 @@ export const $selectedInstancePropsMetas = computed(
     const meta = metas.get(instance.component);
     const tag = instanceTags.get(instance.id);
     const propsMetas = new Map<Prop["name"], PropMeta>();
+    const contentModeAttributesByTag = getContentModeAttributesByTag(metas);
+    const contentModeAttributes =
+      tag === undefined ? undefined : contentModeAttributesByTag.get(tag);
+    const toAttributeMeta = (attribute: Attribute): PropMeta => {
+      const propMeta = attributeToMeta(attribute);
+      if (contentModeAttributes?.has(attribute.name)) {
+        return { ...propMeta, contentMode: true };
+      }
+      return propMeta;
+    };
     // add html attributes only when instance has tag
     if (tag) {
       if (elementsByTag[tag].categories.includes("html-element")) {
         for (const attribute of [...ariaAttributes].reverse()) {
-          propsMetas.set(attribute.name, attributeToMeta(attribute));
+          propsMetas.set(attribute.name, toAttributeMeta(attribute));
         }
         // include global attributes only for html elements
         if (attributesByTag["*"]) {
           for (const attribute of [...attributesByTag["*"]].reverse()) {
-            propsMetas.set(attribute.name, attributeToMeta(attribute));
+            propsMetas.set(attribute.name, toAttributeMeta(attribute));
           }
         }
       }
       if (attributesByTag[tag]) {
         for (const attribute of [...attributesByTag[tag]].reverse()) {
-          propsMetas.set(attribute.name, attributeToMeta(attribute));
+          propsMetas.set(attribute.name, toAttributeMeta(attribute));
         }
       }
     }

--- a/packages/sdk-components-react/src/image.ws.ts
+++ b/packages/sdk-components-react/src/image.ws.ts
@@ -53,6 +53,25 @@ export const meta: WsComponentMeta = {
       label: "Source",
       required: false,
       accept: "image/*",
+      contentMode: true,
+    },
+    width: {
+      type: "number",
+      control: "number",
+      required: false,
+      contentMode: true,
+    },
+    height: {
+      type: "number",
+      control: "number",
+      required: false,
+      contentMode: true,
+    },
+    alt: {
+      type: "string",
+      control: "text",
+      required: false,
+      contentMode: true,
     },
   },
 };

--- a/packages/sdk-components-react/src/link.ws.ts
+++ b/packages/sdk-components-react/src/link.ws.ts
@@ -23,6 +23,7 @@ export const meta: WsComponentMeta = {
       type: "string",
       control: "url",
       required: false,
+      contentMode: true,
     },
   },
 };

--- a/packages/sdk-components-react/src/markdown-embed.ws.ts
+++ b/packages/sdk-components-react/src/markdown-embed.ws.ts
@@ -28,6 +28,7 @@ export const meta: WsComponentMeta = {
       control: "code",
       language: "markdown",
       type: "string",
+      contentMode: true,
     },
   },
 };

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -395,7 +395,10 @@ const formatDate = (date: Date, template: string, locale = "en-US"): string => {
   return template.replace(pattern, (match) => String(tokens[match]));
 };
 
-type TimeProps = Pick<ComponentProps<"time">, "dateTime"> & {
+type TimeDateTime = ComponentProps<"time">["dateTime"];
+
+type TimeProps = {
+  datetime?: TimeDateTime;
   language?: Language;
   country?: Country;
   dateStyle?: DateStyle;
@@ -423,8 +426,7 @@ export const Time = forwardRef<ElementRef<"time">, TimeProps>(
       dateStyle = DEFAULT_DATE_STYLE,
       timeStyle = DEFAULT_TIME_STYLE,
       format,
-      // native html attribute in react style
-      dateTime = INITIAL_DATE_STRING,
+      datetime = INITIAL_DATE_STRING,
       ...props
     },
     ref
@@ -439,7 +441,7 @@ export const Time = forwardRef<ElementRef<"time">, TimeProps>(
     };
 
     const datetimeString =
-      dateTime === null ? INVALID_DATE_STRING : dateTime.toString();
+      datetime === null ? INVALID_DATE_STRING : datetime.toString();
 
     const date = parseDate(datetimeString);
     let formattedDate = datetimeString;

--- a/packages/sdk-components-react/src/time.ws.ts
+++ b/packages/sdk-components-react/src/time.ws.ts
@@ -21,5 +21,33 @@ export const meta: WsComponentMeta = {
     "timeStyle",
     "format",
   ],
-  props,
+  props: {
+    ...props,
+    datetime: {
+      type: "string",
+      control: "text",
+      required: false,
+      contentMode: true,
+    },
+    language: {
+      ...props.language,
+      contentMode: true,
+    },
+    country: {
+      ...props.country,
+      contentMode: true,
+    },
+    dateStyle: {
+      ...props.dateStyle,
+      contentMode: true,
+    },
+    timeStyle: {
+      ...props.timeStyle,
+      contentMode: true,
+    },
+    format: {
+      ...props.format,
+      contentMode: true,
+    },
+  },
 };

--- a/packages/sdk-components-react/src/video.ws.ts
+++ b/packages/sdk-components-react/src/video.ws.ts
@@ -39,6 +39,19 @@ export const meta: WsComponentMeta = {
       label: "Source",
       required: false,
       accept: ".mp4,.webm,.mpg,.mpeg,.mov",
+      contentMode: true,
+    },
+    width: {
+      type: "number",
+      control: "number",
+      required: false,
+      contentMode: true,
+    },
+    height: {
+      type: "number",
+      control: "number",
+      required: false,
+      contentMode: true,
     },
   },
 };

--- a/packages/sdk-components-react/src/vimeo-preview-image.ws.ts
+++ b/packages/sdk-components-react/src/vimeo-preview-image.ws.ts
@@ -19,6 +19,7 @@ export const meta: WsComponentMeta = {
       control: "file",
       label: "Source",
       required: false,
+      contentMode: true,
     },
   },
 };

--- a/packages/sdk-components-react/src/vimeo.ws.ts
+++ b/packages/sdk-components-react/src/vimeo.ws.ts
@@ -34,5 +34,11 @@ export const meta: WsComponentMeta = {
   },
   presetStyle: { div },
   initialProps,
-  props,
+  props: {
+    ...props,
+    url: {
+      ...props.url,
+      contentMode: true,
+    },
+  },
 };

--- a/packages/sdk-components-react/src/youtube.ws.ts
+++ b/packages/sdk-components-react/src/youtube.ws.ts
@@ -44,5 +44,11 @@ export const meta: WsComponentMeta = {
   },
   presetStyle: { div },
   initialProps,
-  props,
+  props: {
+    ...props,
+    url: {
+      ...props.url,
+      contentMode: true,
+    },
+  },
 };

--- a/packages/sdk/src/schema/prop-meta.ts
+++ b/packages/sdk/src/schema/prop-meta.ts
@@ -14,6 +14,7 @@ const common = {
   label: z.string().optional(),
   description: z.string().optional(),
   required: z.boolean(),
+  contentMode: z.boolean().optional(),
 };
 
 const Tag = z.object({


### PR DESCRIPTION
## Description

This PR refactors content mode property restrictions to use a declarative, component-based configuration approach. Instead of maintaining hardcoded lists of editable properties in a central location, each component now declares which of its properties should be editable in content mode via the `contentMode: boolean` flag in PropMeta.

### Content Mode Properties Added:

| Component | Properties |
|-----------|-----------|
| Image | src, width, height, alt |
| Video | src, width, height |
| YouTube | url |
| Vimeo | url |
| Vimeo Preview Image | src |
| Link | href |
| Markdown Embed | code |

## Steps for reproduction

1. Create a project and share it with editor-only access
2. Switch to content edit mode
3. Select a YouTube or Vimeo component on the canvas
4. In the Properties panel, the `url` property should now be visible and editable
5. Modify the YouTube/Vimeo URL and verify it updates correctly

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env` file
