### PR TITLE
fix(react-router): exclude same-page hash anchors from NavLink

### DIFF
--- a/packages/sdk-components-react-router/src/link.tsx
+++ b/packages/sdk-components-react-router/src/link.tsx
@@ -26,7 +26,12 @@ export const Link = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
     // remix appends ?index in runtime but not in ssr
     href === "" ||
     href.startsWith("?") ||
-    (href.startsWith("/") && href.startsWith(assetBaseUrl) === false)
+    (href.startsWith("/") &&
+      href.startsWith(assetBaseUrl) === false &&
+      // Same-page hash anchors (e.g. /#section) share pathname "/" with every
+      // root page — NavLink would mark them all as aria-current="page" in SSR.
+      // Use a plain anchor instead; hash navigation doesn't cross page boundaries.
+      href.startsWith("/#") === false)
   ) {
     // In the future, we will switch to the :local-link pseudo-class (https://developer.mozilla.org/en-US/docs/Web/CSS/:local-link). (aria-current="page" is used now)
     // Therefore, we decided to use end={true} (exact route matching) for all links to facilitate easier migration.


### PR DESCRIPTION
## Problem

Links like `/#section` share pathname `/` with the root page. With `end={true}`, React Router's `NavLink` still considers `/` to match `/` regardless of the hash — so every `/#section` link on the homepage gets `aria-current="page"` in SSR.

This causes any CSS rule targeting `[aria-current=page]` (e.g. active nav indicator, underline, color) to apply permanently to all hash anchors on the home page, instead of only the current page link.

## Fix

Exclude `href` values starting with `/#` from the `NavLink` branch and fall through to a plain `<a>`. Hash anchors don't navigate between pages so they should never receive `aria-current="page"`.

## Test

- Nav bar on homepage: only the `/` link should have `aria-current="page"`, not `/#section` links
- On other pages (e.g. `/about`): no hash anchor links should be marked active

@kof if you want to review this one