### PR TITLE
fix: Prevent caching builder user data

### DIFF
--- a/apps/builder/app/dashboard/dashboard.tsx
+++ b/apps/builder/app/dashboard/dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useState, type ReactNode } from "react";
 import {
   Box,
   Flex,
@@ -162,17 +162,21 @@ const $data = atom<DashboardData | undefined>();
 export const DashboardSetup = ({ data }: { data: DashboardData }) => {
   const revalidator = useRevalidator();
   const revalidateVersion = useStore($shouldRevalidateProjects);
-  useEffect(() => {
+  // Apply user-scoped loader data before paint so stale account data is never visible.
+  useLayoutEffect(() => {
     $data.set(data);
     setSharedStores(data);
     $workspaces.set(data.workspaces);
     $user.set(data.user);
-  }, [data]);
-  // Seed notifications from loader data so the indicator renders instantly.
-  // Runs on every revalidation to keep loader → store in sync.
-  useEffect(() => {
     seedNotifications(data.notifications);
-  }, [data.notifications]);
+
+    return () => {
+      $data.set(undefined);
+      $workspaces.set([]);
+      $user.set(undefined);
+      seedNotifications([]);
+    };
+  }, [data]);
   // Revalidate when the polled project count changes (e.g. a transfer was accepted).
   useEffect(() => {
     if (revalidateVersion > 0) {

--- a/apps/builder/app/routes/_ui.(builder).tsx
+++ b/apps/builder/app/routes/_ui.(builder).tsx
@@ -38,6 +38,10 @@ import {
 } from "~/services/destinations.server";
 import { loader as authWsLoader } from "./auth.ws";
 import { getUserById } from "~/shared/db/user.server";
+import {
+  createPrivateNoStoreHeaders,
+  privateNoStoreResponseHeaders,
+} from "~/services/cache-control.server";
 export { ErrorBoundary } from "~/shared/error/error-boundary";
 
 export const links = () => {
@@ -221,7 +225,7 @@ export const loader = async (loaderArgs: LoaderFunctionArgs) => {
       throw new AuthorizationError("Project must have project userId defined");
     }
 
-    const headers = new Headers();
+    const headers = createPrivateNoStoreHeaders();
 
     if (context.authorization.type === "token") {
       // To protect against cookie overwrites, we set a null session cookie if a user is using an authToken.
@@ -287,9 +291,13 @@ export const loader = async (loaderArgs: LoaderFunctionArgs) => {
  *
  */
 export const headers = ({ loaderHeaders }: HeadersArgs) => {
+  const contentSecurityPolicy = loaderHeaders.get("Content-Security-Policy");
+
   return {
-    "Cache-Control": "no-store",
-    "Content-Security-Policy": loaderHeaders.get("Content-Security-Policy"),
+    ...privateNoStoreResponseHeaders,
+    ...(contentSecurityPolicy === null
+      ? {}
+      : { "Content-Security-Policy": contentSecurityPolicy }),
   };
 };
 

--- a/apps/builder/app/routes/_ui.dashboard.tsx
+++ b/apps/builder/app/routes/_ui.dashboard.tsx
@@ -1,17 +1,13 @@
 import { lazy, useEffect } from "react";
 import { preconnect, prefetchDNS } from "react-dom";
-import {
-  Outlet,
-  redirect,
-  type ShouldRevalidateFunction,
-} from "react-router-dom";
+import { Outlet, type ShouldRevalidateFunction } from "react-router-dom";
 import {
   useLoaderData,
   useLocation,
   useNavigate,
   type MetaFunction,
 } from "@remix-run/react";
-import { type LoaderFunctionArgs } from "@remix-run/server-runtime";
+import { json, type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import {
   createCallerFactory,
   AuthorizationError,
@@ -29,6 +25,8 @@ import env from "~/env/env.server";
 import { ClientOnly } from "~/shared/client-only";
 import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import { allowedDestinations } from "~/services/destinations.server";
+import { redirect } from "~/services/no-store-redirect";
+import { privateNoStoreResponseHeaders } from "~/services/cache-control.server";
 export { ErrorBoundary } from "~/shared/error/error-boundary";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import { createContext } from "~/shared/context.server";
@@ -44,17 +42,8 @@ export const meta = () => {
   return metas;
 };
 
-/**
- * When deleting/adding a project, then navigating to a new project and pressing the back button,
- * the dashboard page may display stale data because it’s being retrieved from the browser’s back/forward cache (bfcache).
- *
- * https://web.dev/articles/bfcache
- *
- */
 export const headers = () => {
-  return {
-    "Cache-Control": "no-store",
-  };
+  return privateNoStoreResponseHeaders;
 };
 
 const dashboardProjectCaller = createCallerFactory(dashboardProjectRouter);
@@ -198,19 +187,22 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
   const projectToClone = await getProjectToClone(request, context);
 
-  return {
-    user,
-    projects,
-    planFeatures,
-    purchases,
-    publisherHost: env.PUBLISHER_HOST,
-    origin,
-    projectToClone,
-    workspaces,
-    currentWorkspaceId,
-    role,
-    notifications,
-  };
+  return json(
+    {
+      user,
+      projects,
+      planFeatures,
+      purchases,
+      publisherHost: env.PUBLISHER_HOST,
+      origin,
+      projectToClone,
+      workspaces,
+      currentWorkspaceId,
+      role,
+      notifications,
+    },
+    { headers: privateNoStoreResponseHeaders }
+  );
 };
 
 export const shouldRevalidate: ShouldRevalidateFunction = ({

--- a/apps/builder/app/routes/_ui.login._index.tsx
+++ b/apps/builder/app/routes/_ui.login._index.tsx
@@ -21,6 +21,7 @@ import { lazy } from "react";
 import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import { redirect } from "~/services/no-store-redirect";
 import { allowedDestinations } from "~/services/destinations.server";
+import { createPrivateNoStoreHeaders } from "~/services/cache-control.server";
 export { ErrorBoundary } from "~/shared/error/error-boundary";
 
 export const links: LinksFunction = () => {
@@ -80,7 +81,7 @@ export const loader = async ({
     throw redirect(returnTo);
   }
 
-  const headers = new Headers();
+  const headers = createPrivateNoStoreHeaders();
 
   headers.append("Set-Cookie", await returnToCookie.serialize(returnTo));
 

--- a/apps/builder/app/routes/_ui.logout.tsx
+++ b/apps/builder/app/routes/_ui.logout.tsx
@@ -5,11 +5,12 @@ import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import { createCallerFactory } from "@webstudio-is/trpc-interface/index.server";
 import { logoutRouter } from "~/services/logout-router.server";
 import { createContext } from "~/shared/context.server";
-import { redirect } from "react-router-dom";
+import { redirect } from "~/services/no-store-redirect";
 import { ClientOnly } from "~/shared/client-only";
 import { useLoaderData, type MetaFunction } from "@remix-run/react";
 import { lazy } from "react";
 import { allowedDestinations } from "~/services/destinations.server";
+import { privateNoStoreResponseHeaders } from "~/services/cache-control.server";
 export { ErrorBoundary } from "~/shared/error/error-boundary";
 
 const logoutCaller = createCallerFactory(logoutRouter);
@@ -58,10 +59,13 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         `${builderUrl({ projectId, origin: url.origin })}builder-logout`
     );
 
-    return json({
-      redirectTo,
-      logoutUrls,
-    });
+    return json(
+      {
+        redirectTo,
+        logoutUrls,
+      },
+      { headers: privateNoStoreResponseHeaders }
+    );
   } catch (error) {
     if (error instanceof Response) {
       throw error;

--- a/apps/builder/app/routes/_ui.tsx
+++ b/apps/builder/app/routes/_ui.tsx
@@ -23,6 +23,10 @@ import {
   csrfToken as clientCsrfToken,
   updateCsrfToken,
 } from "~/shared/csrf.client";
+import {
+  createPrivateNoStoreHeaders,
+  privateNoStoreResponseHeaders,
+} from "~/services/cache-control.server";
 
 export const links: LinksFunction = () => {
   // `links` returns an array of objects whose
@@ -57,10 +61,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const [csrfToken, setCookieValue] = await getCsrfTokenAndCookie(request);
 
   if (request.headers.get("sec-fetch-mode") !== "navigate") {
-    return json({ csrfToken: "" });
+    return json({ csrfToken: "" }, { headers: privateNoStoreResponseHeaders });
   }
 
-  const headers = new Headers();
+  const headers = createPrivateNoStoreHeaders();
 
   if (setCookieValue !== undefined) {
     headers.set("Set-Cookie", setCookieValue);

--- a/apps/builder/app/routes/builder-logout.ts
+++ b/apps/builder/app/routes/builder-logout.ts
@@ -4,6 +4,10 @@ import { builderAuthenticator } from "~/services/builder-auth.server";
 import { getAuthorizationServerOrigin } from "~/shared/router-utils/origins";
 import { isBuilder, loginPath } from "~/shared/router-utils";
 import { isRedirectResponse } from "~/services/cookie.server";
+import {
+  appendVaryHeader,
+  createPrivateNoStoreHeaders,
+} from "~/services/cache-control.server";
 
 const debug = createDebug(import.meta.url);
 
@@ -29,11 +33,11 @@ const withCors = (request: Request, response: Response) => {
     return response;
   }
 
-  const headers = new Headers(response.headers);
+  const headers = createPrivateNoStoreHeaders(response.headers);
   for (const [name, value] of Object.entries(corsHeaders)) {
     headers.set(name, value);
   }
-  headers.append("Vary", "Origin");
+  appendVaryHeader(headers, "Origin");
 
   return new Response(response.body, {
     status: response.status,
@@ -62,12 +66,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       });
     }
 
+    const headers = createPrivateNoStoreHeaders(corsHeaders);
+    appendVaryHeader(headers, "Origin");
+
     return new Response(null, {
       status: 204,
-      headers: {
-        ...corsHeaders,
-        Vary: "Origin",
-      },
+      headers,
     });
   }
 

--- a/apps/builder/app/routes/dashboard-logout.ts
+++ b/apps/builder/app/routes/dashboard-logout.ts
@@ -1,10 +1,10 @@
-import { json } from "@remix-run/server-runtime";
+import { json, type ActionFunctionArgs } from "@remix-run/server-runtime";
 import { authenticator } from "~/services/auth.server";
 import { isDashboard, loginPath } from "~/shared/router-utils";
 import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
-import { type ActionFunctionArgs } from "react-router-dom";
 import { checkCsrf } from "~/services/csrf-session.server";
 import { isRedirectResponse } from "@remix-run/server-runtime/dist/responses";
+import { createPrivateNoStoreHeaders } from "~/services/cache-control.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   try {
@@ -24,7 +24,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     });
   } catch (error) {
     if (error instanceof Response && isRedirectResponse(error)) {
-      const headers = new Headers();
+      const headers = createPrivateNoStoreHeaders();
 
       if (error.headers.get("Set-Cookie")) {
         headers.set("Set-Cookie", error.headers.get("Set-Cookie")!);

--- a/apps/builder/app/routes/oauth.ws.authorize.tsx
+++ b/apps/builder/app/routes/oauth.ws.authorize.tsx
@@ -20,6 +20,7 @@ import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import * as session from "~/services/session.server";
 import { redirect } from "~/services/no-store-redirect";
 import { allowedDestinations } from "~/services/destinations.server";
+import { privateNoStoreResponseHeaders } from "~/services/cache-control.server";
 
 const debug = createDebug(import.meta.url);
 
@@ -107,7 +108,7 @@ export const loader: LoaderFunction = async ({ request }) => {
           error_description: "No redirect_uri provided",
           error_uri: "https://tools.ietf.org/html/rfc6749#section-3.1.2",
         },
-        { status: 400 }
+        { status: 400, headers: privateNoStoreResponseHeaders }
       );
     }
 
@@ -131,7 +132,7 @@ export const loader: LoaderFunction = async ({ request }) => {
             "The redirect_uri provided does not match the registered redirect URIs.",
           error_uri: "https://tools.ietf.org/html/rfc6749#section-3.1.2",
         },
-        { status: 400 }
+        { status: 400, headers: privateNoStoreResponseHeaders }
       );
     }
 
@@ -197,7 +198,7 @@ export const loader: LoaderFunction = async ({ request }) => {
               "The redirect_uri provided does not match the registered redirect URIs.",
             error_uri: "https://tools.ietf.org/html/rfc6749#section-3.1.2",
           },
-          { status: 400 }
+          { status: 400, headers: privateNoStoreResponseHeaders }
         );
       }
 
@@ -249,7 +250,7 @@ export const loader: LoaderFunction = async ({ request }) => {
           error instanceof Error ? error.message : "Unknown error",
         error_uri: "",
       },
-      { status: 500 }
+      { status: 500, headers: privateNoStoreResponseHeaders }
     );
   }
 };

--- a/apps/builder/app/routes/oauth.ws.token.ts
+++ b/apps/builder/app/routes/oauth.ws.token.ts
@@ -12,6 +12,7 @@ import {
 import { isUserAuthorizedForProject } from "~/services/builder-access.server";
 import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import { isDashboard } from "~/shared/router-utils";
+import { privateNoStoreResponseHeaders } from "~/services/cache-control.server";
 
 /**
  * OAuth 2.0 Token Request
@@ -57,7 +58,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         error_description: "missing client credentials",
         error_uri: "https://tools.ietf.org/html/rfc6749#section-5.2",
       },
-      { status: 401 }
+      { status: 401, headers: privateNoStoreResponseHeaders }
     );
   }
 
@@ -82,7 +83,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         error_description: "invalid client credentials",
         error_uri: "https://tools.ietf.org/html/rfc6749#section-5.2",
       },
-      { status: 401 }
+      { status: 401, headers: privateNoStoreResponseHeaders }
     );
   }
 
@@ -99,7 +100,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         error_description: fromError(parsedBody.error).toString(),
         error_uri: "https://tools.ietf.org/html/rfc6749#section-5.2",
       },
-      { status: 400 }
+      { status: 400, headers: privateNoStoreResponseHeaders }
     );
   }
 
@@ -116,7 +117,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         error_description: "invalid code",
         error_uri: "https://tools.ietf.org/html/rfc6749#section-5.2",
       },
-      { status: 400 }
+      { status: 400, headers: privateNoStoreResponseHeaders }
     );
   }
 
@@ -133,7 +134,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         error_description: "invalid code_verifier",
         error_uri: "https://tools.ietf.org/html/rfc6749#section-5.2",
       },
-      { status: 400 }
+      { status: 400, headers: privateNoStoreResponseHeaders }
     );
   }
 
@@ -149,7 +150,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         error_description: "user does not have access to the project",
         error_uri: "https://tools.ietf.org/html/rfc6749#section-5.2",
       },
-      { status: 400 }
+      { status: 400, headers: privateNoStoreResponseHeaders }
     );
   }
 
@@ -170,6 +171,6 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       token_type: "Bearer",
       expires_in: Date.now() + maxAge,
     },
-    { status: 200 }
+    { status: 200, headers: privateNoStoreResponseHeaders }
   );
 };

--- a/apps/builder/app/routes/rest.assets.tsx
+++ b/apps/builder/app/routes/rest.assets.tsx
@@ -1,26 +1,16 @@
-import type {
-  ActionFunctionArgs,
-  LoaderFunctionArgs,
-} from "@remix-run/server-runtime";
-import type { Asset } from "@webstudio-is/sdk";
-import {
-  loadAssetsByProject,
-  createUploadName,
-} from "@webstudio-is/asset-uploader/index.server";
+import { json, type ActionFunctionArgs } from "@remix-run/server-runtime";
+import { createUploadName } from "@webstudio-is/asset-uploader/index.server";
 import { createContext } from "~/shared/context.server";
 import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import { checkCsrf } from "~/services/csrf-session.server";
 import { parseError } from "~/shared/error/error-parse";
+import { privateNoStoreResponseHeaders } from "~/services/cache-control.server";
 
-export const loader = async ({
-  params,
-  request,
-}: LoaderFunctionArgs): Promise<Array<Asset>> => {
-  if (params.projectId === undefined) {
-    throw new Error("Project id undefined");
-  }
-  const context = await createContext(request);
-  return await loadAssetsByProject(params.projectId, context);
+export const loader = async () => {
+  return json(
+    { errors: "Method not allowed" },
+    { status: 405, headers: privateNoStoreResponseHeaders }
+  );
 };
 
 export const action = async (props: ActionFunctionArgs) => {
@@ -55,15 +45,19 @@ export const action = async (props: ActionFunctionArgs) => {
         },
         context
       );
-      return {
-        name,
-      };
+      return json({ name }, { headers: privateNoStoreResponseHeaders });
     }
+
+    return json(
+      { errors: "Method not allowed" },
+      { status: 405, headers: privateNoStoreResponseHeaders }
+    );
   } catch (error) {
     console.error(error);
 
-    return {
-      errors: parseError(error).message,
-    };
+    return json(
+      { errors: parseError(error).message },
+      { headers: privateNoStoreResponseHeaders }
+    );
   }
 };

--- a/apps/builder/app/routes/rest.assets_.$name.tsx
+++ b/apps/builder/app/routes/rest.assets_.$name.tsx
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ActionFunctionArgs } from "@remix-run/server-runtime";
+import { json, type ActionFunctionArgs } from "@remix-run/server-runtime";
 import { uploadFile } from "@webstudio-is/asset-uploader/index.server";
 import {
   isAllowedMimeCategory,
@@ -12,14 +12,13 @@ import { createContext } from "~/shared/context.server";
 import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import { checkCsrf } from "~/services/csrf-session.server";
 import { parseError } from "~/shared/error/error-parse";
+import { privateNoStoreResponseHeaders } from "~/services/cache-control.server";
 
 const UrlBody = z.object({
   url: z.string(),
 });
 
-export const action = async (
-  props: ActionFunctionArgs
-): Promise<AssetActionResponse> => {
+export const action = async (props: ActionFunctionArgs) => {
   preventCrossOriginCookie(props.request);
   await checkCsrf(props.request);
 
@@ -121,19 +120,21 @@ export const action = async (
         context,
         assetInfoFallback
       );
-      return {
-        uploadedAssets: [asset],
-      };
+      return json({ uploadedAssets: [asset] } satisfies AssetActionResponse, {
+        headers: privateNoStoreResponseHeaders,
+      });
     }
   } catch (error) {
     console.error(error);
 
-    return {
-      errors: parseError(error).message,
-    };
+    return json(
+      { errors: parseError(error).message } satisfies AssetActionResponse,
+      { headers: privateNoStoreResponseHeaders }
+    );
   }
 
-  return {
-    errors: "Method not allowed",
-  };
+  return json({ errors: "Method not allowed" } satisfies AssetActionResponse, {
+    status: 405,
+    headers: privateNoStoreResponseHeaders,
+  });
 };

--- a/apps/builder/app/routes/rest.data.$projectId.ts
+++ b/apps/builder/app/routes/rest.data.$projectId.ts
@@ -1,13 +1,10 @@
-import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
-import * as projectApi from "@webstudio-is/project/index.server";
-import { loadDevBuildByProjectId } from "@webstudio-is/project-build/index.server";
-import { serializePages } from "@webstudio-is/project-migrations/pages";
-import { loadAssetsByProject } from "@webstudio-is/asset-uploader/index.server";
+import { json, type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { createContext } from "~/shared/context.server";
 import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import { checkCsrf } from "~/services/csrf-session.server";
 import { allowedDestinations } from "~/services/destinations.server";
-import env from "~/env/env.server";
+import { privateNoStoreResponseHeaders } from "~/services/cache-control.server";
+import { loadBuilderDataByProjectId } from "~/services/build-router.server";
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
   preventCrossOriginCookie(request);
@@ -18,20 +15,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     throw new Error("Project id undefined");
   }
   const context = await createContext(request);
-  const project = await projectApi.loadById(params.projectId, context);
-  if (project === null) {
-    throw new Error(`Project "${params.projectId}" not found`);
-  }
-  if (project.userId === null) {
-    throw new Error("Project must have project userId defined");
-  }
-  const build = await loadDevBuildByProjectId(context, project.id);
-  const assets = await loadAssetsByProject(project.id, context);
-  return {
-    ...build,
-    pages: serializePages(build.pages),
-    assets,
-    project,
-    publisherHost: env.PUBLISHER_HOST,
-  };
+  const data = await loadBuilderDataByProjectId(params.projectId, context);
+
+  return json(data, { headers: privateNoStoreResponseHeaders });
 };

--- a/apps/builder/app/routes/rest.resources-loader.ts
+++ b/apps/builder/app/routes/rest.resources-loader.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { type ActionFunctionArgs, data } from "@remix-run/server-runtime";
+import { type ActionFunctionArgs, data, json } from "@remix-run/server-runtime";
 import { ResourceRequest } from "@webstudio-is/sdk";
 import { isLocalResource, loadResource } from "@webstudio-is/sdk/runtime";
 import { loader as siteMapLoader } from "../shared/$resources/sitemap.xml.server";
@@ -8,6 +8,7 @@ import { loader as assetsLoader } from "../shared/$resources/assets.server";
 import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import { checkCsrf } from "~/services/csrf-session.server";
 import { getResourceKey } from "~/shared/resources";
+import { privateNoStoreResponseHeaders } from "~/services/cache-control.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   preventCrossOriginCookie(request);
@@ -41,6 +42,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     console.error("data:", requestJson);
     throw data(requestList.error, {
       status: 400,
+      headers: privateNoStoreResponseHeaders,
     });
   }
 
@@ -65,5 +67,5 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     })
   );
 
-  return output;
+  return json(output, { headers: privateNoStoreResponseHeaders });
 };

--- a/apps/builder/app/routes/trpc.$.ts
+++ b/apps/builder/app/routes/trpc.$.ts
@@ -4,6 +4,7 @@ import { createContext, isServiceAuthorization } from "~/shared/context.server";
 import { appRouter } from "~/services/trcp-router.server";
 import { preventCrossOriginCookie } from "~/services/no-cross-origin-cookie";
 import { checkCsrf } from "~/services/csrf-session.server";
+import { getTrpcResponseMeta } from "~/services/trpc-response-meta.server";
 
 const isServiceRequest = (request: Request) => {
   return isServiceAuthorization(request.headers.get("Authorization"));
@@ -28,50 +29,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     endpoint: "/trpc",
     batching: { enabled: true },
     responseMeta(opts) {
-      // Disable trpc cache
-      if (process.env.NODE_ENV !== "production") {
-        return {};
-      }
-
-      // tRPC batches multiple requests into a single network call.
-      // The `paths` array lists all request paths included in the batch.
-      const { paths, errors, type, ctx } = opts;
-
-      if (paths === undefined) {
-        return {};
-      }
-
-      if (type !== "query") {
-        // Only queries can be cached
-        return {};
-      }
-
-      if (errors.length > 0) {
-        // Errors should not be cached
-        return {};
-      }
-
-      // To enable efficient batching of tRPC requests,
-      // adopt the least max age among all paths for caching, or disable caching entirely if no max-age is set.
-      let minMaxAge = Number.MAX_SAFE_INTEGER;
-      for (const path of paths) {
-        const maxAge = ctx?.trpcCache.getMaxAge(path);
-
-        if (maxAge === undefined) {
-          return {};
-        }
-
-        minMaxAge = Math.min(minMaxAge, maxAge);
-      }
-
-      // Cap the max age at 1 hour
-      minMaxAge = Math.min(minMaxAge, 60 * 60);
-
-      return {
-        headers: {
-          "Cache-Control": `public, max-age=${minMaxAge}, s-maxage=${minMaxAge}`,
-        },
-      };
+      return getTrpcResponseMeta({
+        ...opts,
+        isProduction: process.env.NODE_ENV === "production",
+      });
     },
     async createContext(opts) {
       return await createContext(opts.req);

--- a/apps/builder/app/services/build-router.server.ts
+++ b/apps/builder/app/services/build-router.server.ts
@@ -17,7 +17,11 @@ import {
   toPatchResult,
 } from "~/shared/sync/patch/patch-service.server";
 import { normalizePatchRequest } from "~/shared/sync/patch/patch-normalize.server";
+import * as projectApi from "@webstudio-is/project/index.server";
 import type { BuildPatchTransaction } from "@webstudio-is/project/index.server";
+import { loadDevBuildByProjectId } from "@webstudio-is/project-build/index.server";
+import { serializePages } from "@webstudio-is/project-migrations/pages";
+import { loadAssetsByProject } from "@webstudio-is/asset-uploader/index.server";
 import {
   loadPublishedProjectDataByBuildId,
   loadPublishedProjectDataByProjectId,
@@ -96,7 +100,37 @@ const assertRelayPatchContext = (
   }
 };
 
+export const loadBuilderDataByProjectId = async (
+  projectId: string,
+  ctx: AppContext
+) => {
+  const project = await projectApi.loadById(projectId, ctx);
+  if (project === null) {
+    throw new Error(`Project "${projectId}" not found`);
+  }
+  if (project.userId === null) {
+    throw new Error("Project must have project userId defined");
+  }
+
+  const build = await loadDevBuildByProjectId(ctx, project.id);
+  const assets = await loadAssetsByProject(project.id, ctx);
+
+  return {
+    ...build,
+    pages: serializePages(build.pages),
+    assets,
+    project,
+    publisherHost: env.PUBLISHER_HOST,
+  };
+};
+
 export const buildRouter = router({
+  loadData: procedure
+    .input(z.object({ projectId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      return await loadBuilderDataByProjectId(input.projectId, ctx);
+    }),
+
   loadProjectDataByBuildId: procedure
     .input(z.object({ buildId: z.string() }))
     .query(async ({ ctx, input }) => {

--- a/apps/builder/app/services/cache-control.server.test.ts
+++ b/apps/builder/app/services/cache-control.server.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+import {
+  appendVaryHeader,
+  createPrivateNoStoreHeaders,
+  privateNoStoreResponseHeaders,
+} from "./cache-control.server";
+
+describe("private no-store cache headers", () => {
+  test("marks user-scoped responses as non-cacheable and cookie-varying", () => {
+    expect(privateNoStoreResponseHeaders).toMatchObject({
+      "Cache-Control": "private, no-store, max-age=0",
+      Pragma: "no-cache",
+      Expires: "0",
+      Vary: "Cookie",
+    });
+  });
+
+  test("preserves unrelated headers while enforcing cache policy", () => {
+    const headers = createPrivateNoStoreHeaders({
+      "Cache-Control": "public, max-age=600",
+      "Set-Cookie": "session=value",
+    });
+
+    expect(headers.get("Cache-Control")).toBe(
+      privateNoStoreResponseHeaders["Cache-Control"]
+    );
+    expect(headers.get("Vary")).toBe(privateNoStoreResponseHeaders.Vary);
+    expect(headers.get("Set-Cookie")).toBe("session=value");
+  });
+
+  test("preserves existing vary values while adding cookie", () => {
+    const headers = createPrivateNoStoreHeaders({
+      Vary: "Origin",
+    });
+
+    expect(headers.get("Vary")).toBe("Origin, Cookie");
+  });
+
+  test("does not duplicate vary values", () => {
+    const headers = new Headers({
+      Vary: "Origin, Cookie",
+    });
+
+    appendVaryHeader(headers, "Origin");
+    appendVaryHeader(headers, "Cookie");
+
+    expect(headers.get("Vary")).toBe("Origin, Cookie");
+  });
+});

--- a/apps/builder/app/services/cache-control.server.ts
+++ b/apps/builder/app/services/cache-control.server.ts
@@ -1,0 +1,34 @@
+export const privateNoStoreResponseHeaders = {
+  "Cache-Control": "private, no-store, max-age=0",
+  Pragma: "no-cache",
+  Expires: "0",
+  Vary: "Cookie",
+};
+
+export const appendVaryHeader = (headers: Headers, value: string) => {
+  const vary = headers.get("Vary");
+  if (vary === null || vary.trim() === "") {
+    headers.set("Vary", value);
+    return;
+  }
+
+  const varyValues = vary.split(",").map((item) => item.trim().toLowerCase());
+  if (varyValues.includes(value.toLowerCase()) === false) {
+    headers.set("Vary", `${vary}, ${value}`);
+  }
+};
+
+export const createPrivateNoStoreHeaders = (init?: HeadersInit) => {
+  const headers = new Headers(init);
+
+  for (const [name, value] of Object.entries(privateNoStoreResponseHeaders)) {
+    if (name.toLowerCase() === "vary") {
+      continue;
+    }
+    headers.set(name, value);
+  }
+
+  appendVaryHeader(headers, privateNoStoreResponseHeaders.Vary);
+
+  return headers;
+};

--- a/apps/builder/app/services/no-store-redirect.test.ts
+++ b/apps/builder/app/services/no-store-redirect.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { privateNoStoreResponseHeaders } from "./cache-control.server";
+import { redirect, setNoStoreToRedirect } from "./no-store-redirect";
+
+describe("no-store redirects", () => {
+  test("creates redirects with private no-store headers", () => {
+    const response = redirect("/login");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/login");
+    expect(response.headers.get("Cache-Control")).toBe(
+      privateNoStoreResponseHeaders["Cache-Control"]
+    );
+    expect(response.headers.get("Vary")).toBe(
+      privateNoStoreResponseHeaders.Vary
+    );
+  });
+
+  test("adds private no-store headers to existing redirects without losing headers", () => {
+    const response = new Response(null, {
+      status: 302,
+      headers: {
+        Location: "/dashboard",
+        "Set-Cookie": "session=value",
+        Vary: "Origin",
+      },
+    });
+
+    const result = setNoStoreToRedirect(response);
+
+    expect(result.headers.get("Location")).toBe("/dashboard");
+    expect(result.headers.get("Set-Cookie")).toBe("session=value");
+    expect(result.headers.get("Cache-Control")).toBe(
+      privateNoStoreResponseHeaders["Cache-Control"]
+    );
+    expect(result.headers.get("Vary")).toBe("Origin, Cookie");
+  });
+});

--- a/apps/builder/app/services/no-store-redirect.ts
+++ b/apps/builder/app/services/no-store-redirect.ts
@@ -1,5 +1,9 @@
 import { redirect as remixRedirect } from "@remix-run/server-runtime";
 import { isRedirectResponse } from "./cookie.server";
+import {
+  createPrivateNoStoreHeaders,
+  privateNoStoreResponseHeaders,
+} from "./cache-control.server";
 
 /**
  * Chrome aggressively uses cache when restoring tabs (e.g., using Shift+Command+T or automatic session restore).
@@ -14,10 +18,12 @@ import { isRedirectResponse } from "./cookie.server";
 export const redirect: typeof remixRedirect = (url, init) => {
   const headers =
     typeof init === "object" ? new Headers(init.headers) : new Headers();
-  headers.set("Cache-Control", "no-store");
+  const noStoreHeaders = createPrivateNoStoreHeaders(headers);
 
   const responseInit: ResponseInit =
-    typeof init === "number" ? { status: init, headers } : { ...init, headers };
+    typeof init === "number"
+      ? { status: init, headers: noStoreHeaders }
+      : { ...init, headers: noStoreHeaders };
 
   return remixRedirect(url, responseInit);
 };
@@ -35,7 +41,13 @@ export const redirect: typeof remixRedirect = (url, init) => {
 export const setNoStoreToRedirect = (response: Response) => {
   if (isRedirectResponse(response)) {
     const newResponse = new Response(response.body, response);
-    newResponse.headers.set("Cache-Control", "no-store");
+    const noStoreHeaders = createPrivateNoStoreHeaders(newResponse.headers);
+    for (const name of Object.keys(privateNoStoreResponseHeaders)) {
+      const value = noStoreHeaders.get(name);
+      if (value !== null) {
+        newResponse.headers.set(name, value);
+      }
+    }
     return newResponse;
   }
 

--- a/apps/builder/app/services/trpc-response-meta.server.test.ts
+++ b/apps/builder/app/services/trpc-response-meta.server.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vitest";
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
+import { privateNoStoreResponseHeaders } from "./cache-control.server";
+import { getTrpcResponseMeta } from "./trpc-response-meta.server";
+
+const createContext = (
+  authorization: AppContext["authorization"],
+  maxAges: Record<string, number | undefined> = {}
+): Pick<AppContext, "authorization" | "trpcCache"> => ({
+  authorization,
+  trpcCache: {
+    setMaxAge: () => {},
+    getMaxAge: (path) => maxAges[path],
+  },
+});
+
+describe("tRPC response cache metadata", () => {
+  test("marks development responses as private no-store", () => {
+    expect(
+      getTrpcResponseMeta({
+        isProduction: false,
+        paths: ["marketplace.getItems"],
+        errors: [],
+        type: "query",
+        ctx: createContext(
+          { type: "anonymous" },
+          { "marketplace.getItems": 60 }
+        ),
+      })
+    ).toEqual({ headers: privateNoStoreResponseHeaders });
+  });
+
+  test("marks authenticated responses as private no-store even when procedures opt into public cache", () => {
+    expect(
+      getTrpcResponseMeta({
+        isProduction: true,
+        paths: ["marketplace.getItems"],
+        errors: [],
+        type: "query",
+        ctx: createContext(
+          {
+            type: "user",
+            userId: "user-1",
+            sessionCreatedAt: 0,
+            isLoggedInToBuilder: async () => true,
+          },
+          { "marketplace.getItems": 60 }
+        ),
+      })
+    ).toEqual({ headers: privateNoStoreResponseHeaders });
+  });
+
+  test("marks uncached anonymous queries as private no-store", () => {
+    expect(
+      getTrpcResponseMeta({
+        isProduction: true,
+        paths: ["build.loadData"],
+        errors: [],
+        type: "query",
+        ctx: createContext({ type: "anonymous" }),
+      })
+    ).toEqual({ headers: privateNoStoreResponseHeaders });
+  });
+
+  test("marks empty batches as private no-store", () => {
+    expect(
+      getTrpcResponseMeta({
+        isProduction: true,
+        paths: [],
+        errors: [],
+        type: "query",
+        ctx: createContext({ type: "anonymous" }),
+      })
+    ).toEqual({ headers: privateNoStoreResponseHeaders });
+  });
+
+  test("uses public cache for anonymous queries only when every batched path opts in", () => {
+    expect(
+      getTrpcResponseMeta({
+        isProduction: true,
+        paths: ["marketplace.getItems", "marketplace.getBuildData"],
+        errors: [],
+        type: "query",
+        ctx: createContext(
+          { type: "anonymous" },
+          {
+            "marketplace.getItems": 180,
+            "marketplace.getBuildData": 90,
+          }
+        ),
+      })
+    ).toEqual({
+      headers: {
+        "Cache-Control": "public, max-age=90, s-maxage=90",
+      },
+    });
+  });
+});

--- a/apps/builder/app/services/trpc-response-meta.server.ts
+++ b/apps/builder/app/services/trpc-response-meta.server.ts
@@ -1,0 +1,58 @@
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
+import { privateNoStoreResponseHeaders } from "./cache-control.server";
+
+type TrpcResponseMetaInput = {
+  paths?: readonly string[];
+  errors: readonly unknown[];
+  type: string;
+  ctx?: Pick<AppContext, "authorization" | "trpcCache">;
+  isProduction: boolean;
+};
+
+const privateNoStoreResponse = {
+  headers: privateNoStoreResponseHeaders,
+};
+
+export const getTrpcResponseMeta = ({
+  paths,
+  errors,
+  type,
+  ctx,
+  isProduction,
+}: TrpcResponseMetaInput) => {
+  if (isProduction === false) {
+    return privateNoStoreResponse;
+  }
+
+  if (
+    paths === undefined ||
+    paths.length === 0 ||
+    type !== "query" ||
+    errors.length > 0
+  ) {
+    return privateNoStoreResponse;
+  }
+
+  if (ctx?.authorization.type !== "anonymous") {
+    return privateNoStoreResponse;
+  }
+
+  let minMaxAge = Number.MAX_SAFE_INTEGER;
+  for (const path of paths) {
+    const maxAge = ctx.trpcCache.getMaxAge(path);
+
+    if (maxAge === undefined) {
+      return privateNoStoreResponse;
+    }
+
+    minMaxAge = Math.min(minMaxAge, maxAge);
+  }
+
+  minMaxAge = Math.min(minMaxAge, 60 * 60);
+
+  return {
+    headers: {
+      "Cache-Control": `public, max-age=${minMaxAge}, s-maxage=${minMaxAge}`,
+    },
+  };
+};

--- a/apps/builder/app/shared/builder-data.ts
+++ b/apps/builder/app/shared/builder-data.ts
@@ -2,7 +2,8 @@ import { getStyleDeclKey, type WebstudioData } from "@webstudio-is/sdk";
 import { migratePages } from "@webstudio-is/project-migrations/pages";
 import type { MarketplaceProduct } from "@webstudio-is/project-build";
 import type { Project } from "@webstudio-is/project";
-import type { loader } from "~/routes/rest.data.$projectId";
+import type { inferRouterOutputs } from "@trpc/server";
+import type { AppRouter } from "~/services/trcp-router.server";
 import { $project } from "~/shared/sync/data-stores";
 import {
   $assets,
@@ -17,18 +18,17 @@ import {
   $styleSources,
   $styles,
 } from "~/shared/sync/data-stores";
-import { fetch } from "~/shared/fetch.client";
+import { nativeClient } from "~/shared/trpc/trpc-client";
 
 export type BuilderData = WebstudioData & {
   marketplaceProduct: undefined | MarketplaceProduct;
   project: Project;
 };
 
+type LoadDataOutput = inferRouterOutputs<AppRouter>["build"]["loadData"];
+
 export type LoadedBuilderData = BuilderData &
-  Pick<
-    Awaited<ReturnType<typeof loader>>,
-    "id" | "version" | "publisherHost" | "projectId"
-  >;
+  Pick<LoadDataOutput, "id" | "version" | "publisherHost" | "projectId">;
 
 export const getBuilderData = (): BuilderData => {
   const pages = $pages.get();
@@ -65,14 +65,11 @@ export const loadBuilderData = async ({
   projectId: string;
   signal: AbortSignal;
 }): Promise<LoadedBuilderData> => {
-  const currentUrl = new URL(location.href);
-  const url = new URL(`/rest/data/${projectId}`, currentUrl.origin);
-  const headers = new Headers();
-
-  const response = await fetch(url, { headers, signal });
-
-  if (response.ok) {
-    const data = (await response.json()) as Awaited<ReturnType<typeof loader>>;
+  try {
+    const data = await nativeClient.build.loadData.query(
+      { projectId },
+      { signal }
+    );
     return {
       id: data.id,
       version: data.version,
@@ -93,16 +90,17 @@ export const loadBuilderData = async ({
       styles: new Map(data.styles.map((item) => [getStyleDeclKey(item), item])),
       marketplaceProduct: data.marketplaceProduct,
     };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : JSON.stringify(error);
+
+    if (signal.aborted === false) {
+      // No toasts available in this context
+      alert(`Unable to load builder data. ${message}`);
+    }
+
+    throw new Error(`Unable to load builder data. ${message}`, {
+      cause: error,
+    });
   }
-
-  const text = await response.text();
-
-  // No toasts available in this context
-  alert(
-    `Unable to load builder data. Response status: ${response.status}. Response text: ${text}`
-  );
-
-  throw Error(
-    `Unable to load builder data. Response status: ${response.status}. Response text: ${text}`
-  );
 };

--- a/apps/builder/app/shared/fetch.client.ts
+++ b/apps/builder/app/shared/fetch.client.ts
@@ -42,6 +42,7 @@ export const fetch: typeof globalThis.fetch = async (
 
   const modifiedInit: RequestInit = {
     ...requestInit,
+    cache: requestInit?.cache ?? "no-store",
     headers,
   };
 


### PR DESCRIPTION
**Summary**

Migrates Builder bootstrap data loading from the legacy `/rest/data/:projectId` endpoint to `build.loadData` tRPC, while keeping the old REST route as a no-store compatibility shim.

Hardens authenticated Builder/dashboard responses by explicitly sending:

- `Cache-Control: private, no-store, max-age=0`
- `Pragma: no-cache`
- `Expires: 0`
- `Vary: Cookie`

**Details**

- Added `build.loadData` tRPC query for full Builder state.
- Switched Builder client bootstrap loading to tRPC.
- Added shared cache-control helpers for private no-store responses.
- Made tRPC responses private/no-store by default unless anonymous and explicitly public-cacheable.
- Added no-store headers to Builder/dashboard/auth/resource/asset-related responses.
- Updated redirect handling to preserve headers while enforcing no-store.
- Prevented stale dashboard account data from flashing by applying user-scoped loader data before paint and clearing stores on teardown.
- Added tests for cache headers, tRPC response metadata, and no-store redirects.

**Validation**

- `pnpm --filter @webstudio-is/builder test -- app/services/cache-control.server.test.ts app/services/trpc-response-meta.server.test.ts app/services/no-store-redirect.test.ts app/routes/rest.assets.test.ts app/shared/sync/project-queue.test.ts app/dashboard/dashboard.test.ts`
- `pnpm exec oxlint ...` on touched files
- `git diff --check`

`pnpm --filter @webstudio-is/builder typecheck` still fails on existing unrelated Tailwind/css-engine errors.