### PR TITLE
fix: Fix Time hydration for ISO dates

### DIFF
--- a/packages/sdk-components-react/src/time.test.ts
+++ b/packages/sdk-components-react/src/time.test.ts
@@ -1,7 +1,25 @@
-import { expect, test } from "vitest";
-import { __testing__ } from "./time";
+/**
+ * @vitest-environment jsdom
+ */
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { hydrateRoot, type Root } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { afterEach, expect, test, vi } from "vitest";
+import { Time, __testing__ } from "./time";
 
 const { parseDate, formatDate } = __testing__;
+
+const originalTimeZone = process.env.TZ;
+let root: Root | undefined;
+
+afterEach(() => {
+  root?.unmount();
+  root = undefined;
+  process.env.TZ = originalTimeZone;
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
 
 test("13-digit Unix timestamp", () => {
   expect(parseDate("1724938577059")).toEqual(
@@ -29,6 +47,36 @@ test("parse ISO date string", () => {
   );
 });
 
+test("formats ISO date string in UTC to avoid hydration mismatches", () => {
+  expect(
+    renderToStaticMarkup(
+      createElement(Time, { datetime: "2026-05-06T22:00:00.000Z" })
+    )
+  ).toBe('<time dateTime="2026-05-06T22:00:00.000Z">6 May 2026</time>');
+});
+
+test("hydrates ISO date string without timezone mismatch warnings", async () => {
+  const datetime = "2026-05-06T22:00:00.000Z";
+  const ui = createElement(Time, { datetime });
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  process.env.TZ = "UTC";
+  container.innerHTML = renderToStaticMarkup(ui);
+  expect(container.textContent).toBe("6 May 2026");
+
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  process.env.TZ = "Europe/Berlin";
+  await act(async () => {
+    root = hydrateRoot(container, ui);
+    await Promise.resolve();
+  });
+
+  expect(container.textContent).toBe("6 May 2026");
+  expect(consoleError).not.toHaveBeenCalled();
+});
+
 test.skip("parse short date", () => {
   expect(parseDate("2024.10")).toEqual(new Date("2024-10-01T00:00:00.000Z"));
   expect(parseDate("2024/10")).toEqual(new Date("2024-10-01T00:00:00.000Z"));
@@ -45,94 +93,94 @@ test("invalid date string", () => {
 });
 
 test("formatDate with full template", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "YYYY-MM-DD HH:mm:ss")).toBe("2025-10-31 14:05:09");
 });
 
 test("formatDate with short date", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "DD/MM/YY")).toBe("31/10/25");
 });
 
 test("formatDate with time only", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "H:m:s")).toBe("14:5:9");
 });
 
 test("formatDate with padded values", () => {
-  const date = new Date("2025-01-05T08:03:07");
+  const date = new Date("2025-01-05T08:03:07Z");
   expect(formatDate(date, "YYYY-MM-DD HH:mm:ss")).toBe("2025-01-05 08:03:07");
 });
 
 test("formatDate with unpadded values", () => {
-  const date = new Date("2025-01-05T08:03:07");
+  const date = new Date("2025-01-05T08:03:07Z");
   expect(formatDate(date, "YYYY-M-D H:m:s")).toBe("2025-1-5 8:3:7");
 });
 
 test("formatDate with year only", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "YYYY")).toBe("2025");
 });
 
 test("formatDate with custom separator", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "DD.MM.YYYY")).toBe("31.10.2025");
 });
 
 test("formatDate with full month name in English", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "MMMM D, YYYY", "en-US")).toBe("October 31, 2025");
 });
 
 test("formatDate with short month name in English", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "MMM D, YYYY", "en-US")).toBe("Oct 31, 2025");
 });
 
 test("formatDate with full day name in English", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "DDDD, MMMM D, YYYY", "en-US")).toBe(
     "Friday, October 31, 2025"
   );
 });
 
 test("formatDate with short day name in English", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "DDD, MMM D", "en-US")).toBe("Fri, Oct 31");
 });
 
 test("formatDate with full month name in German", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "D. MMMM YYYY", "de-DE")).toBe("31. Oktober 2025");
 });
 
 test("formatDate with full day name in German", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "DDDD, D. MMMM YYYY", "de-DE")).toBe(
     "Freitag, 31. Oktober 2025"
   );
 });
 
 test("formatDate with short day and month in Spanish", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "DDD, D MMM YYYY", "es-ES")).toBe("vie, 31 oct 2025");
 });
 
 test("formatDate with full day and month in French", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "DDDD D MMMM YYYY", "fr-FR")).toBe(
     "vendredi 31 octobre 2025"
   );
 });
 
 test("formatDate with mixed tokens", () => {
-  const date = new Date("2025-01-15T09:30:45");
+  const date = new Date("2025-01-15T09:30:45Z");
   expect(formatDate(date, "DDDD, MMMM D, YYYY at HH:mm", "en-US")).toBe(
     "Wednesday, January 15, 2025 at 09:30"
   );
 });
 
 test("formatDate preserves non-token text", () => {
-  const date = new Date("2025-10-31T14:05:09");
+  const date = new Date("2025-10-31T14:05:09Z");
   expect(formatDate(date, "Today is DDDD", "en-US")).toBe("Today is Friday");
 });

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -288,6 +288,7 @@ const DEFAULT_LANGUAGE = "en";
 const DEFAULT_COUNTRY = "GB";
 const DEFAULT_DATE_STYLE = "medium";
 const DEFAULT_TIME_STYLE = "none";
+const DEFAULT_TIME_ZONE = "UTC";
 
 const languageOrDefault = (language: unknown): Language => {
   return languages.includes(language as Language)
@@ -356,35 +357,39 @@ const formatDate = (date: Date, template: string, locale = "en-US"): string => {
 
   // Get localized day and month names
   const longDayName = new Intl.DateTimeFormat(locale, {
+    timeZone: DEFAULT_TIME_ZONE,
     weekday: "long",
   }).format(date);
   const shortDayName = new Intl.DateTimeFormat(locale, {
+    timeZone: DEFAULT_TIME_ZONE,
     weekday: "short",
   }).format(date);
   const longMonthName = new Intl.DateTimeFormat(locale, {
+    timeZone: DEFAULT_TIME_ZONE,
     month: "long",
   }).format(date);
   const shortMonthName = new Intl.DateTimeFormat(locale, {
+    timeZone: DEFAULT_TIME_ZONE,
     month: "short",
   }).format(date);
 
   const tokens: Record<string, string | number> = {
-    YYYY: date.getFullYear(),
-    YY: String(date.getFullYear()).slice(-2),
+    YYYY: date.getUTCFullYear(),
+    YY: String(date.getUTCFullYear()).slice(-2),
     MMMM: longMonthName,
     MMM: shortMonthName,
-    MM: pad(date.getMonth() + 1),
-    M: date.getMonth() + 1,
+    MM: pad(date.getUTCMonth() + 1),
+    M: date.getUTCMonth() + 1,
     DDDD: longDayName,
     DDD: shortDayName,
-    DD: pad(date.getDate()),
-    D: date.getDate(),
-    HH: pad(date.getHours()),
-    H: date.getHours(),
-    mm: pad(date.getMinutes()),
-    m: date.getMinutes(),
-    ss: pad(date.getSeconds()),
-    s: date.getSeconds(),
+    DD: pad(date.getUTCDate()),
+    D: date.getUTCDate(),
+    HH: pad(date.getUTCHours()),
+    H: date.getUTCHours(),
+    mm: pad(date.getUTCMinutes()),
+    m: date.getUTCMinutes(),
+    ss: pad(date.getUTCSeconds()),
+    s: date.getUTCSeconds(),
   };
 
   // Sort tokens by length (longest first) to avoid partial replacements
@@ -438,6 +443,7 @@ export const Time = forwardRef<ElementRef<"time">, TimeProps>(
     const options: Intl.DateTimeFormatOptions = {
       dateStyle: dateStyleOrUndefined(dateStyle),
       timeStyle: timeStyleOrUndefined(timeStyle),
+      timeZone: DEFAULT_TIME_ZONE,
     };
 
     const datetimeString =


### PR DESCRIPTION
I’m seeing React hydration errors 418/425/423 in the console when the Time component is used with an ISO date. This was breaking my Klaro cookie banner: it would flash briefly and then disappear. Once I switched to a date-only value (2026-05-06 instead of 2026-05-06T22:00:00.000Z), the issue disappeared, I no longer see console errors, and Klaro works correctly. 