### PR TITLE
feat: Accept transition timing functions in easing input

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/transitions/transition-content.tsx
@@ -225,7 +225,12 @@ export const TransitionContent = ({ index }: { index: number }) => {
             if (value.type === "layers") {
               [value] = value.value;
             }
-            if (value.type === "keyword" || value.type === "var") {
+            if (
+              value.type === "keyword" ||
+              value.type === "function" ||
+              value.type === "unparsed" ||
+              value.type === "var"
+            ) {
               updateIntermediateValue({ timing: value });
               setRepeatedStyleItem(
                 transitionTimingFunction,

--- a/apps/builder/app/builder/shared/css-editor/parse-style-input.test.ts
+++ b/apps/builder/app/builder/shared/css-editor/parse-style-input.test.ts
@@ -54,6 +54,72 @@ describe("parseStyleInput", () => {
     );
   });
 
+  test("parses transition timing functions", () => {
+    expect(
+      parseStyleInput(
+        "transition-timing-function: cubic-bezier(.36,0,.66,-0.56)",
+        new Map()
+      ).styleMap
+    ).toEqual(
+      new Map([
+        [
+          "transition-timing-function",
+          {
+            type: "function",
+            name: "cubic-bezier",
+            args: {
+              type: "layers",
+              value: [
+                { type: "unit", value: 0.36, unit: "number" },
+                { type: "unit", value: 0, unit: "number" },
+                { type: "unit", value: 0.66, unit: "number" },
+                { type: "unit", value: -0.56, unit: "number" },
+              ],
+            },
+          },
+        ],
+      ])
+    );
+
+    expect(
+      parseStyleInput(
+        "transition-timing-function: steps(4, jump-start)",
+        new Map()
+      ).styleMap
+    ).toEqual(
+      new Map([
+        [
+          "transition-timing-function",
+          {
+            type: "function",
+            name: "steps",
+            args: {
+              type: "layers",
+              value: [
+                { type: "unit", value: 4, unit: "number" },
+                { type: "keyword", value: "jump-start" },
+              ],
+            },
+          },
+        ],
+      ])
+    );
+
+    expect(
+      parseStyleInput(
+        "transition-timing-function: linear(0 0%, 1 100%)",
+        new Map()
+      ).styleMap
+    ).toEqual(
+      new Map([
+        [
+          "transition-timing-function",
+          { type: "unparsed", value: "linear(0 0%,1 100%)" },
+        ],
+      ])
+    );
+  });
+
   test("parses multiple property-value pairs", () => {
     const { styleMap: result } = parseStyleInput(
       "color: red; display: block",


### PR DESCRIPTION
Fixes the Transition dialog Easing field so valid CSS timing functions are accepted when typed directly:

cubic-bezier(...)
steps(...)
linear(...)
The parser already accepted these values, but the Transition UI only committed keyword and var values, so parsed function/unparsed timing values were dropped and the input reverted.

Closes https://github.com/webstudio-is/webstudio/issues/5376