### PR TITLE
fix: Fix page template editor permissions

### DIFF
--- a/apps/builder/app/builder/features/address-bar.tsx
+++ b/apps/builder/app/builder/features/address-bar.tsx
@@ -39,13 +39,14 @@ import {
   $stagingPassword,
   $stagingUsername,
 } from "~/shared/nano-states";
-import { isPage } from "@webstudio-is/sdk";
 import { $currentSystem, updateCurrentSystem } from "~/shared/system";
 import { $project, $publisherHost } from "~/shared/sync/data-stores";
 import { getPublishUrl } from "./publish/publish-url";
 
 const $selectedPageHistory = computed($selectedPage, (page): string[] =>
-  page !== undefined && isPage(page) ? (page.history ?? []) : []
+  page !== undefined && "history" in page && Array.isArray(page.history)
+    ? page.history
+    : []
 );
 
 const useCopyUrl = (pageUrl: string) => {

--- a/apps/builder/app/builder/features/command-panel/shared/document-utils.ts
+++ b/apps/builder/app/builder/features/command-panel/shared/document-utils.ts
@@ -1,11 +1,15 @@
-import { isPage, type Page, type PageTemplate } from "@webstudio-is/sdk";
+import {
+  isPageTemplate,
+  type Page,
+  type PageTemplate,
+} from "@webstudio-is/sdk";
 
 // Only html documents accept arbitrary html element/component mutations
 // (insertion, wrapping, conversion). xml documents allow only specific xml
 // components (handled per-item where applicable) and text documents serve
 // plain text content with no insertions.
 export const allowsHtmlMutations = (page: Page | PageTemplate | undefined) => {
-  if (page !== undefined && !isPage(page)) {
+  if (isPageTemplate(page)) {
     return false;
   }
   const documentType = page?.meta.documentType;

--- a/apps/builder/app/builder/features/pages/pages.tsx
+++ b/apps/builder/app/builder/features/pages/pages.tsx
@@ -47,6 +47,7 @@ import {
   $editingTemplateId,
   $creatingPageFromTemplateId,
   $authPermit,
+  $canOpenPageTemplates,
   $isContentMode,
   $isDesignMode,
 } from "~/shared/nano-states";
@@ -889,6 +890,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
   const isDesignMode = useStore($isDesignMode);
   const isContentMode = useStore($isContentMode);
   const authPermit = useStore($authPermit);
+  const canOpenPageTemplates = useStore($canOpenPageTemplates);
   const canCreatePageFromTemplate =
     isDesignMode || (isContentMode && authPermit !== "view");
   const [containerElement, setContainerElement] =
@@ -1024,7 +1026,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
         <>
           <Separator />
           <PanelTitle>Page templates</PanelTitle>
-          {isDesignMode ? (
+          {canOpenPageTemplates ? (
             <TemplateContextMenu
               onRequestDeleteTemplate={setTemplateIdToDelete}
             >
@@ -1066,16 +1068,14 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
             >
               <TemplatesSection
                 selectedPageId={currentPage.id}
-                onSelectTemplate={(id) => {
-                  selectPage(id);
-                }}
+                onSelectTemplate={() => {}}
                 editingTemplateId={editingTemplateItemId}
                 onEditTemplate={() => {}}
                 onCreatePageFromTemplate={(id) => {
                   $creatingPageFromTemplateId.set(id);
                 }}
                 canManageTemplates={false}
-                canSelectTemplate={true}
+                canSelectTemplate={false}
                 canCreatePageFromTemplate={canCreatePageFromTemplate}
               />
             </ScrollAreaNative>
@@ -1123,7 +1123,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
         </FloatingPanel>
       )}
 
-      {isDesignMode && editingTemplateItemId !== undefined && (
+      {canOpenPageTemplates && editingTemplateItemId !== undefined && (
         <FloatingPanel
           content={
             <TemplateEditor

--- a/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
@@ -19,12 +19,7 @@ import {
   NestedInputButton,
   theme,
 } from "@webstudio-is/design-system";
-import {
-  isLiteralExpression,
-  isPage,
-  Resource,
-  type Prop,
-} from "@webstudio-is/sdk";
+import { isLiteralExpression, Resource, type Prop } from "@webstudio-is/sdk";
 import {
   BindingControl,
   BindingPopover,
@@ -99,7 +94,7 @@ const $selectedInstanceResourceScope = computed(
   ],
   (page, instanceKey, variableValuesByInstanceSelector, dataSources) => {
     return getResourceScopeForInstance({
-      page: page !== undefined && isPage(page) ? page : undefined,
+      page,
       instanceKey,
       dataSources,
       variableValuesByInstanceSelector,

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -16,6 +16,7 @@ import {
   Resource,
   type DataSource,
   type Page,
+  type PageTemplate,
 } from "@webstudio-is/sdk";
 import {
   encodeDataVariableId,
@@ -46,7 +47,6 @@ import {
   theme,
 } from "@webstudio-is/design-system";
 import { TrashIcon, InfoCircleIcon, PlusIcon } from "@webstudio-is/icons";
-import { isPage } from "@webstudio-is/sdk";
 import { humanizeString } from "~/shared/string-utils";
 import { $variableValuesByInstanceSelector } from "~/shared/nano-states";
 import { $dataSources } from "~/shared/sync/data-stores";
@@ -525,7 +525,7 @@ export const getResourceScopeForInstance = ({
   dataSources,
   variableValuesByInstanceSelector,
 }: {
-  page: undefined | Page;
+  page: undefined | Page | PageTemplate;
   instanceKey: undefined | string;
   dataSources: DataSources;
   variableValuesByInstanceSelector: Map<string, Map<string, unknown>>;
@@ -608,7 +608,7 @@ export const useResourceScope = ({ variable }: { variable?: DataSource }) => {
           ) => {
             const { scope, aliases, variableValues } =
               getResourceScopeForInstance({
-                page: page !== undefined && isPage(page) ? page : undefined,
+                page,
                 instanceKey: getVariableInstanceKey({
                   variable,
                   instancePath,

--- a/apps/builder/app/builder/shared/topbar.tsx
+++ b/apps/builder/app/builder/shared/topbar.tsx
@@ -13,7 +13,7 @@ import {
   Kbd,
 } from "@webstudio-is/design-system";
 import type { Project } from "@webstudio-is/project";
-import { isPage } from "@webstudio-is/sdk";
+import { isPage, isPageTemplate } from "@webstudio-is/sdk";
 import { $pages } from "~/shared/sync/data-stores";
 import { $editingPageId, $editingTemplateId } from "~/shared/nano-states";
 
@@ -131,7 +131,7 @@ const PagesButton = () => {
             event.altKey && isPage(page) ? page.id : undefined
           );
           $editingTemplateId.set(
-            event.altKey && !isPage(page) ? page.id : undefined
+            event.altKey && isPageTemplate(page) ? page.id : undefined
           );
           toggleActiveSidebarPanel("pages");
         }}

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -35,6 +35,7 @@ import {
   tags,
   blockTemplateComponent,
   isComponentDetachable,
+  isPageTemplate,
 } from "@webstudio-is/sdk";
 import { detectTokenConflicts } from "./style-source-utils";
 import { type ConflictResolution } from "./token-conflict-dialog";
@@ -45,6 +46,7 @@ import {
   $isPreviewMode,
   $textEditingInstanceSelector,
   $isContentMode,
+  $canOpenPageTemplates,
   findBlockSelector,
 } from "./nano-states";
 import { $props } from "~/shared/sync/data-stores";
@@ -112,6 +114,10 @@ export const unwrap = <Value>(value: Value) =>
   isDraft(value) ? current(value) : value;
 
 export const updateWebstudioData = (mutate: (data: WebstudioData) => void) => {
+  const selectedPage = $selectedPage.get();
+  if (isPageTemplate(selectedPage) && $canOpenPageTemplates.get() === false) {
+    return;
+  }
   serverSyncStore.createTransaction(
     [
       $pages,

--- a/apps/builder/app/shared/nano-states/misc.test.ts
+++ b/apps/builder/app/shared/nano-states/misc.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  $authPermit,
+  $builderMode,
+  $canOpenPageTemplates,
+  type BuilderMode,
+} from "./misc";
+
+afterEach(() => {
+  $builderMode.set("design");
+  $authPermit.set("view");
+});
+
+describe("$canOpenPageTemplates", () => {
+  test.each(["build", "admin", "own"] as const)(
+    "allows %s permit in design mode",
+    (authPermit) => {
+      $builderMode.set("design");
+      $authPermit.set(authPermit);
+
+      expect($canOpenPageTemplates.get()).toBe(true);
+    }
+  );
+
+  test.each(["view", "edit"] as const)(
+    "denies %s permit in design mode",
+    (authPermit) => {
+      $builderMode.set("design");
+      $authPermit.set(authPermit);
+
+      expect($canOpenPageTemplates.get()).toBe(false);
+    }
+  );
+
+  test.each(["content", "preview"] as BuilderMode[])(
+    "denies build permit in %s mode",
+    (builderMode) => {
+      $builderMode.set(builderMode);
+      $authPermit.set("build");
+
+      expect($canOpenPageTemplates.get()).toBe(false);
+    }
+  );
+});

--- a/apps/builder/app/shared/nano-states/misc.ts
+++ b/apps/builder/app/shared/nano-states/misc.ts
@@ -329,6 +329,19 @@ export const $isDesignMode = computed(
 );
 
 export const $authPermit = atom<AuthPermit>("view");
+
+export const $canOpenPageTemplates = computed(
+  [$builderMode, $authPermit],
+  (builderMode, authPermit) => {
+    if (builderMode !== "design") {
+      return false;
+    }
+    return (
+      authPermit === "build" || authPermit === "admin" || authPermit === "own"
+    );
+  }
+);
+
 export const $authTokenPermissions = atom<TokenPermissions>({
   canClone: true,
   canCopy: true,

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -4,6 +4,7 @@ import { useNavigate } from "@remix-run/react";
 import { $pages, $project } from "~/shared/sync/data-stores";
 import {
   $authToken,
+  $canOpenPageTemplates,
   $selectedPageHash,
   $builderMode,
   isBuilderMode,
@@ -12,7 +13,7 @@ import {
 import { builderPath } from "~/shared/router-utils";
 import { $selectedPage } from "../nano-states";
 import { selectPage } from "../nano-states";
-import { findPageByIdOrPath } from "@webstudio-is/sdk";
+import { findPageByIdOrPath, isPageTemplate } from "@webstudio-is/sdk";
 
 const setPageStateFromUrl = () => {
   const searchParams = new URLSearchParams(window.location.search);
@@ -32,10 +33,12 @@ const setPageStateFromUrl = () => {
 
   // check the page actually exists
   // to avoid confusing the user with broken state
+  const requestedPageId = searchParams.get("pageId") ?? "";
   const pageId =
-    findPageByIdOrPath(searchParams.get("pageId") ?? "", pages, {
-      includeTemplates: true,
-    })?.id ?? pages.homePageId;
+    ($canOpenPageTemplates.get()
+      ? findPageByIdOrPath(requestedPageId, pages, { includeTemplates: true })
+      : findPageByIdOrPath(requestedPageId, pages)
+    )?.id ?? pages.homePageId;
 
   $selectedPageHash.set({ hash: searchParams.get("pageHash") ?? "" });
   selectPage(pageId);
@@ -55,6 +58,7 @@ export const useSyncPageUrl = () => {
   const page = useStore($selectedPage);
   const pageHash = useStore($selectedPageHash);
   const builderMode = useStore($builderMode);
+  const canOpenPageTemplate = useStore($canOpenPageTemplates);
 
   // Get pageId and pageHash from URL
   // once pages are loaded
@@ -114,14 +118,29 @@ export const useSyncPageUrl = () => {
   }, [builderMode, navigate, page, pageHash]);
 
   useEffect(() => {
+    const pages = $pages.get();
+    if (pages === undefined || page === undefined) {
+      return;
+    }
+    if (isPageTemplate(page) && canOpenPageTemplate === false) {
+      selectPage(pages.homePageId);
+    }
+  }, [canOpenPageTemplate, page]);
+
+  useEffect(() => {
     return $selectedPage.subscribe((page) => {
       // switch to home page when current one does not exist
       // possible when undo creating page
+      const pages = $pages.get();
+      if (pages === undefined) {
+        return;
+      }
       if (page === undefined) {
-        const pages = $pages.get();
-        if (pages) {
-          selectPage(pages.homePageId);
-        }
+        selectPage(pages.homePageId);
+        return;
+      }
+      if (isPageTemplate(page) && $canOpenPageTemplates.get() === false) {
+        selectPage(pages.homePageId);
       }
     });
   });

--- a/apps/builder/app/shared/sync/patch/patch-auth.server.test.ts
+++ b/apps/builder/app/shared/sync/patch/patch-auth.server.test.ts
@@ -37,11 +37,44 @@ import {
 import type { NormalizedPatchRequest } from "./patch-normalize.server";
 
 const createContext = () => {
+  const buildRow = {
+    pages: JSON.stringify({
+      meta: {},
+      homePage: {
+        id: "page-1",
+        name: "Home",
+        path: "",
+        title: "Home",
+        meta: {},
+        rootInstanceId: "body-1",
+      },
+      pages: [],
+      folders: [{ id: "root", name: "Root", slug: "", children: [] }],
+    }),
+    instances: JSON.stringify([
+      { id: "body-1", type: "instance", component: "Body", children: [] },
+    ]),
+    props: JSON.stringify([]),
+  };
   const context = {
     authorization: { type: "anonymous" },
     createTokenContext: vi.fn(async (authToken: string) => ({
       authorization: { type: "token", authToken },
     })),
+    postgrest: {
+      client: {
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({
+                data: buildRow,
+                error: undefined,
+              })),
+            })),
+          })),
+        })),
+      },
+    },
   };
   return context;
 };

--- a/apps/builder/app/shared/system.ts
+++ b/apps/builder/app/shared/system.ts
@@ -103,7 +103,7 @@ export const updateCurrentSystem = (
   update: Partial<Pick<System, "search" | "params">>
 ) => {
   const page = $selectedPage.get();
-  if (page === undefined || !isPage(page)) {
+  if (!isPage(page)) {
     return;
   }
   const systemDataByPage = new Map($systemDataByPage.get());

--- a/packages/project/src/db/build-patch-permissions.test.ts
+++ b/packages/project/src/db/build-patch-permissions.test.ts
@@ -39,6 +39,77 @@ describe("getRequiredPermitForBuildPatchTransaction", () => {
     ).toBe("build");
   });
 
+  test("allows editor page settings changes with edit permit", () => {
+    expect(
+      getRequiredPermitForBuildPatchTransaction(
+        transaction("pages", [
+          { op: "replace", path: ["pages", "page-1", "name"], value: "About" },
+          {
+            op: "replace",
+            path: ["pages", "page-1", "meta", "description"],
+            value: "About us",
+          },
+        ])
+      )
+    ).toBe("edit");
+  });
+
+  test("requires build permit for whole meta replacements", () => {
+    expect(
+      getRequiredPermitForBuildPatchTransaction(
+        transaction("pages", [
+          {
+            op: "replace",
+            path: ["pages", "page-1", "meta"],
+            value: {
+              description: "About us",
+            },
+          },
+        ])
+      )
+    ).toBe("build");
+  });
+
+  test("requires build permit for creating pages", () => {
+    expect(
+      getRequiredPermitForBuildPatchTransaction(
+        transaction("pages", [
+          {
+            op: "add",
+            path: ["pages", "page-1"],
+            value: {
+              id: "page-1",
+              name: "Landing",
+              path: "/landing",
+              title: "Landing",
+              meta: {},
+              rootInstanceId: "root-1",
+            },
+          },
+        ])
+      )
+    ).toBe("build");
+  });
+
+  test("requires build permit for design edits not tied to page creation", () => {
+    expect(
+      getRequiredPermitForBuildPatchTransaction(
+        transaction("styles", [
+          {
+            op: "add",
+            path: ["style-1"],
+            value: {
+              styleSourceId: "style-source-1",
+              breakpointId: "base",
+              property: "color",
+              value: { type: "keyword", value: "red" },
+            },
+          },
+        ])
+      )
+    ).toBe("build");
+  });
+
   test("requires build permit when any change in the transaction is design scoped", () => {
     expect(
       getRequiredPermitForBuildPatchTransaction({
@@ -51,6 +122,12 @@ describe("getRequiredPermitForBuildPatchTransaction", () => {
           },
         ],
       })
+    ).toBe("build");
+  });
+
+  test("requires build permit for unknown namespaces", () => {
+    expect(
+      getRequiredPermitForBuildPatchTransaction(transaction("unknown"))
     ).toBe("build");
   });
 });

--- a/packages/project/src/db/build-patch-permissions.ts
+++ b/packages/project/src/db/build-patch-permissions.ts
@@ -1,18 +1,30 @@
 import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
 import type { BuildPatchTransaction } from "./build-patch-core";
 
-const contentNamespaces = new Set(["instances", "props"]);
+type BuildPatchChange = BuildPatchTransaction["payload"][number];
+
+const isEditorSafeChange = (change: BuildPatchChange) => {
+  if (change.namespace === "instances" || change.namespace === "props") {
+    return true;
+  }
+
+  return (
+    change.namespace === "pages" &&
+    change.patches.every((patch) => {
+      const [collection, pageId, field] = patch.path;
+      return (
+        collection === "pages" &&
+        typeof pageId === "string" &&
+        ((patch.path.length === 3 &&
+          (field === "name" || field === "path" || field === "title")) ||
+          (patch.path.length === 4 && field === "meta"))
+      );
+    })
+  );
+};
 
 export const getRequiredPermitForBuildPatchTransaction = (
   transaction: BuildPatchTransaction
 ): AuthPermit => {
-  for (const change of transaction.payload) {
-    if (change.patches.length === 0) {
-      continue;
-    }
-    if (contentNamespaces.has(change.namespace) === false) {
-      return "build";
-    }
-  }
-  return "edit";
+  return transaction.payload.every(isEditorSafeChange) ? "edit" : "build";
 };

--- a/packages/sdk/src/page-utils.test.ts
+++ b/packages/sdk/src/page-utils.test.ts
@@ -5,6 +5,8 @@ import {
   findParentFolderByChildId,
   getPagePath,
   getStaticSiteMapXml,
+  isPage,
+  isPageTemplate,
 } from "./page-utils";
 
 const pages = {
@@ -74,6 +76,29 @@ const pages = {
     ],
   ]),
 } satisfies Pages;
+
+describe("page type guards", () => {
+  const page = pages.pages.get("page-1");
+  const template = {
+    id: "template-1",
+    name: "Template",
+    title: "Template",
+    rootInstanceId: "rootInstanceId",
+    meta: {},
+  };
+
+  test("detects pages", () => {
+    expect(isPage(page)).toBe(true);
+    expect(isPage(template)).toBe(false);
+    expect(isPage(undefined)).toBe(false);
+  });
+
+  test("detects page templates", () => {
+    expect(isPageTemplate(page)).toBe(false);
+    expect(isPageTemplate(template)).toBe(true);
+    expect(isPageTemplate(undefined)).toBe(false);
+  });
+});
 
 describe("getPagePath", () => {
   test("home page path", () => {

--- a/packages/sdk/src/page-utils.ts
+++ b/packages/sdk/src/page-utils.ts
@@ -8,8 +8,16 @@ export const ROOT_FOLDER_ID = "root";
  * Narrows Page | PageTemplate to Page.
  * Templates have no `path` field; pages always do.
  */
-export const isPage = (page: Page | PageTemplate): page is Page =>
-  "path" in page;
+export const isPage = (page: Page | PageTemplate | undefined): page is Page =>
+  page !== undefined && "path" in page;
+
+/**
+ * Narrows Page | PageTemplate to PageTemplate.
+ */
+export const isPageTemplate = (
+  page: Page | PageTemplate | undefined
+): page is PageTemplate & { path?: never } =>
+  page !== undefined && !("path" in page);
 
 /**
  * Returns true if folder is the root folder.


### PR DESCRIPTION
Adds permission protection around page templates so content editors can create pages from templates without being able to open, edit, or patch template pages directly.