### PR TITLE
feat: Add timezone selection for Time component

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/combined.tsx
@@ -12,6 +12,7 @@ import { JsonControl } from "./json";
 import { TextContent } from "./text-content";
 import { ResourceControl } from "./resource-control";
 import { TagControl } from "./tag-control";
+import { TimeZoneControl } from "./time-zone";
 
 export const renderControl = ({
   meta,
@@ -96,6 +97,10 @@ export const renderControl = ({
 
   if (meta.control === "select") {
     return <SelectControl key={key} meta={meta} prop={prop} {...rest} />;
+  }
+
+  if (meta.control === "timeZone") {
+    return <TimeZoneControl key={key} meta={meta} prop={prop} {...rest} />;
   }
 
   if (meta.control === "file") {

--- a/apps/builder/app/builder/features/settings-panel/controls/time-zone.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/time-zone.tsx
@@ -1,0 +1,303 @@
+import { useId } from "react";
+import { useStore } from "@nanostores/react";
+import { matchSorter } from "match-sorter";
+import { Box, Combobox, Text, theme } from "@webstudio-is/design-system";
+import {
+  BindingControl,
+  BindingPopover,
+  validatePrimitiveValue,
+} from "~/builder/shared/binding-popover";
+import { useDraftValue } from "~/builder/shared/use-draft-value";
+import { $props } from "~/shared/sync/data-stores";
+import {
+  type ControlProps,
+  ResponsiveLayout,
+  updateExpressionValue,
+  $selectedInstanceScope,
+  useBindingState,
+  humanizeAttribute,
+} from "../shared";
+import { PropertyLabel } from "../property-label";
+
+type TimeZoneItem = {
+  value: string;
+  label?: string;
+};
+
+const visitorTimeZone = "visitor";
+const defaultTimeZone = "UTC";
+const defaultDatetime = "dateTime attribute is not set";
+const defaultLanguage = "en";
+const defaultCountry = "GB";
+const defaultDateStyle = "medium";
+const defaultTimeStyle = "none";
+
+const commonTimeZones = [
+  "Europe/Berlin",
+  "Europe/London",
+  "Europe/Paris",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Sao_Paulo",
+  "Asia/Tokyo",
+  "Asia/Shanghai",
+  "Asia/Singapore",
+  "Asia/Dubai",
+  "Australia/Sydney",
+];
+
+const getSupportedTimeZones = () => {
+  const supportedValuesOf = (
+    Intl as typeof Intl & {
+      supportedValuesOf?: (key: "timeZone") => string[];
+    }
+  ).supportedValuesOf;
+  return supportedValuesOf?.("timeZone") ?? [];
+};
+
+const getTimeZoneItem = (value: string): TimeZoneItem => ({
+  value,
+  label: value === visitorTimeZone ? "Visitor's timezone" : value,
+});
+
+const getTimeZoneItems = (options: string[]) => {
+  return Array.from(
+    new Set([...options, ...commonTimeZones, ...getSupportedTimeZones()])
+  ).map(getTimeZoneItem);
+};
+
+const itemToString = (item: TimeZoneItem | null) => {
+  return item?.label ?? item?.value ?? "";
+};
+
+const matchOrSuggestTimeZone = (
+  search: string,
+  items: TimeZoneItem[],
+  itemToString: (item: TimeZoneItem) => string
+) => {
+  if (search.trim() === "") {
+    return items;
+  }
+  const matched = matchSorter(items, search, {
+    keys: [itemToString, "value"],
+  });
+  const trimmed = search.trim();
+  if (
+    matched.some(
+      (item) => item.value.toLocaleLowerCase() === trimmed.toLocaleLowerCase()
+    ) === false
+  ) {
+    matched.unshift({ value: trimmed });
+  }
+  return matched;
+};
+
+const getStringProp = (
+  props: ReturnType<typeof $props.get>,
+  instanceId: string,
+  name: string,
+  defaultValue: string
+) => {
+  for (const prop of props.values()) {
+    if (prop.instanceId === instanceId && prop.name === name) {
+      return prop.type === "string" ? prop.value : defaultValue;
+    }
+  }
+  return defaultValue;
+};
+
+const getDate = (datetime: string) => {
+  const date = new Date(datetime);
+  if (Number.isNaN(date.getTime())) {
+    return;
+  }
+  return date;
+};
+
+const isValidTimeZone = (timeZone: string) => {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const styleOrUndefined = (
+  value: string
+): Intl.DateTimeFormatOptions["dateStyle"] => {
+  return value === "full" ||
+    value === "long" ||
+    value === "medium" ||
+    value === "short"
+    ? value
+    : undefined;
+};
+
+const getTimeZonePreview = ({
+  item,
+  date,
+  locale,
+  dateStyle,
+  timeStyle,
+  format,
+}: {
+  item: TimeZoneItem | null | undefined;
+  date: Date | undefined;
+  locale: string;
+  dateStyle: string;
+  timeStyle: string;
+  format: string;
+}) => {
+  if (item === undefined || item === null) {
+    return;
+  }
+  if (item.value === visitorTimeZone) {
+    return "Uses each visitor's browser timezone after the page loads.";
+  }
+  if (isValidTimeZone(item.value) === false) {
+    return "Unknown timezone. Use an IANA timezone like Europe/Berlin.";
+  }
+  if (date === undefined) {
+    return "Select or type an IANA timezone.";
+  }
+  if (format.trim() !== "") {
+    return "Preview uses the custom format on canvas.";
+  }
+  try {
+    const formatted = new Intl.DateTimeFormat(locale, {
+      dateStyle: styleOrUndefined(dateStyle),
+      timeStyle: styleOrUndefined(timeStyle),
+      timeZone: item.value,
+    }).format(date);
+    const offset = new Intl.DateTimeFormat(locale, {
+      timeZone: item.value,
+      timeZoneName: "shortOffset",
+    })
+      .formatToParts(date)
+      .find((part) => part.type === "timeZoneName")?.value;
+    return [offset, formatted].filter(Boolean).join(" · ");
+  } catch {
+    return "Unable to preview this timezone.";
+  }
+};
+
+export const TimeZoneControl = ({
+  meta,
+  prop,
+  propName,
+  computedValue,
+  instanceId,
+  onChange,
+}: ControlProps<"timeZone">) => {
+  const id = useId();
+  const props = useStore($props);
+  const savedValue = String(
+    computedValue ?? meta.defaultValue ?? defaultTimeZone
+  );
+  const localValue = useDraftValue(savedValue, (value) => {
+    if (prop?.type === "expression") {
+      updateExpressionValue(prop.value, value);
+    } else {
+      onChange({ type: "string", value });
+    }
+  });
+  const timeZoneItems = getTimeZoneItems(meta.options);
+  const selectedItem = getTimeZoneItem(savedValue);
+  const currentItem = getTimeZoneItem(localValue.value);
+  const label = humanizeAttribute(meta.label || propName);
+  const { scope, aliases } = useStore($selectedInstanceScope);
+  const expression =
+    prop?.type === "expression" ? prop.value : JSON.stringify(computedValue);
+  const { overwritable, variant } = useBindingState(
+    prop?.type === "expression" ? prop.value : undefined
+  );
+
+  const datetime = getStringProp(
+    props,
+    instanceId,
+    "datetime",
+    defaultDatetime
+  );
+  const language = getStringProp(
+    props,
+    instanceId,
+    "language",
+    defaultLanguage
+  );
+  const country = getStringProp(props, instanceId, "country", defaultCountry);
+  const dateStyle = getStringProp(
+    props,
+    instanceId,
+    "dateStyle",
+    defaultDateStyle
+  );
+  const timeStyle = getStringProp(
+    props,
+    instanceId,
+    "timeStyle",
+    defaultTimeStyle
+  );
+  const format = getStringProp(props, instanceId, "format", "");
+  const date = getDate(datetime);
+  const locale = `${language}-${country}`;
+
+  return (
+    <ResponsiveLayout
+      label={
+        <PropertyLabel name={propName} readOnly={overwritable === false} />
+      }
+    >
+      <BindingControl>
+        <Combobox<TimeZoneItem>
+          name={id}
+          disabled={overwritable === false}
+          getItems={() => timeZoneItems}
+          itemToString={itemToString}
+          value={currentItem}
+          selectedItem={selectedItem}
+          match={matchOrSuggestTimeZone}
+          onChange={(value) => {
+            if (value !== undefined) {
+              localValue.set(value.trim());
+            }
+          }}
+          onItemSelect={(item) => {
+            localValue.set(item.value.trim());
+            localValue.flush();
+          }}
+          getDescription={(item) => {
+            const preview = getTimeZonePreview({
+              item,
+              date,
+              locale,
+              dateStyle,
+              timeStyle,
+              format,
+            });
+            return (
+              <Box css={{ width: theme.spacing[28] }}>
+                <Text>{preview ?? "Select or type an IANA timezone."}</Text>
+              </Box>
+            );
+          }}
+        />
+        <BindingPopover
+          scope={scope}
+          aliases={aliases}
+          validate={(value) => validatePrimitiveValue(value, label)}
+          variant={variant}
+          value={expression}
+          onChange={(newExpression) =>
+            onChange({ type: "expression", value: newExpression })
+          }
+          onRemove={(evaluatedValue) =>
+            onChange({ type: "string", value: String(evaluatedValue) })
+          }
+        />
+      </BindingControl>
+    </ResponsiveLayout>
+  );
+};

--- a/packages/sdk-components-react/src/__generated__/time.props.ts
+++ b/packages/sdk-components-react/src/__generated__/time.props.ts
@@ -215,9 +215,16 @@ export const props: Record<string, PropMeta> = {
     defaultValue: "medium",
     options: ["full", "long", "medium", "short", "none"],
   },
+  datetime: {
+    required: false,
+    control: "text",
+    type: "string",
+    defaultValue: "dateTime attribute is not set",
+    description: "Machine-readable value",
+  },
   format: {
     description:
-      'Custom format template. Overrides Date Style and Time Style.\n\nTokens: YYYY/YY (year), MMMM/MMM/MM/M (month), DDDD/DDD/DD/D (day), HH/H (hours), mm/m (minutes), ss/s (seconds)\n\nExamples:\n"YYYY-MM-DD" → 2025-11-03\n"DDDD, MMMM D" → Monday, November 3\n"DDD, D. MMM YYYY" → Mon, 3. Nov 2025\n\nDay and month names use the selected language.',
+      'Custom format template. Overrides Date Style and Time Style.\n\nTokens: YYYY/YY (year), MMMM/MMM/MM/M (month), DDDD/DDD/DD/D (day), HH/H (hours), mm/m (minutes), ss/s (seconds)\n\nExamples:\n- "YYYY-MM-DD" → 2025-11-03\n- "DDDD, MMMM D" → Monday, November 3\n- "DDD, D. MMM YYYY" → Mon, 3. Nov 2025\n\nDay and month names use the selected language.',
     required: false,
     control: "text",
     type: "string",
@@ -307,5 +314,13 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     defaultValue: "none",
     options: ["full", "long", "medium", "short", "none"],
+  },
+  timeZone: {
+    description:
+      'Time zone used to format the date.\n\nUse "UTC" for deterministic UTC output, "visitor" to use the browser time\nzone after hydration, or an IANA time zone like "Europe/Berlin".',
+    required: false,
+    control: "text",
+    type: "string",
+    defaultValue: "UTC",
   },
 };

--- a/packages/sdk-components-react/src/time.test.ts
+++ b/packages/sdk-components-react/src/time.test.ts
@@ -8,7 +8,7 @@ import { act } from "react-dom/test-utils";
 import { afterEach, expect, test, vi } from "vitest";
 import { Time, __testing__ } from "./time";
 
-const { parseDate, formatDate } = __testing__;
+const { parseDate, formatDate, timeZoneOrDefault } = __testing__;
 
 const originalTimeZone = process.env.TZ;
 let root: Root | undefined;
@@ -75,6 +75,142 @@ test("hydrates ISO date string without timezone mismatch warnings", async () => 
 
   expect(container.textContent).toBe("6 May 2026");
   expect(consoleError).not.toHaveBeenCalled();
+});
+
+test("formats ISO date string in explicit timezone", () => {
+  expect(
+    renderToStaticMarkup(
+      createElement(Time, {
+        datetime: "2026-06-08T17:45:00.000+00:00",
+        language: "de",
+        country: "DE",
+        timeStyle: "short",
+        dateStyle: "none",
+        timeZone: "Europe/Berlin",
+      })
+    )
+  ).toBe('<time dateTime="2026-06-08T17:45:00.000+00:00">19:45</time>');
+});
+
+test("formats custom template in explicit timezone", () => {
+  expect(
+    formatDate(
+      new Date("2026-06-08T17:45:00.000+00:00"),
+      "YYYY-MM-DD HH:mm",
+      "de-DE",
+      "Europe/Berlin"
+    )
+  ).toBe("2026-06-08 19:45");
+});
+
+test("formats custom template with date rollover in explicit timezone", () => {
+  expect(
+    formatDate(
+      new Date("2026-06-08T23:45:00.000+00:00"),
+      "YYYY-MM-DD HH:mm",
+      "de-DE",
+      "Europe/Berlin"
+    )
+  ).toBe("2026-06-09 01:45");
+});
+
+test("falls back to UTC for invalid timezone", () => {
+  expect(timeZoneOrDefault("Not/A_Timezone")).toBe("UTC");
+});
+
+test("trims timezone before validation", () => {
+  expect(timeZoneOrDefault(" Europe/Berlin ")).toBe("Europe/Berlin");
+});
+
+test("renders UTC fallback for invalid timezone", () => {
+  expect(
+    renderToStaticMarkup(
+      createElement(Time, {
+        datetime: "2026-06-08T17:45:00.000+00:00",
+        language: "de",
+        country: "DE",
+        timeStyle: "short",
+        dateStyle: "none",
+        timeZone: "Not/A_Timezone",
+      })
+    )
+  ).toBe('<time dateTime="2026-06-08T17:45:00.000+00:00">17:45</time>');
+});
+
+test("hydrates visitor timezone without mismatch and updates after hydration", async () => {
+  const datetime = "2026-06-08T17:45:00.000+00:00";
+  const ui = createElement(Time, {
+    datetime,
+    language: "de",
+    country: "DE",
+    timeStyle: "short",
+    dateStyle: "none",
+    timeZone: "visitor",
+  });
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  process.env.TZ = "UTC";
+  container.innerHTML = renderToStaticMarkup(ui);
+  expect(container.textContent).toBe("17:45");
+
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  process.env.TZ = "Europe/Berlin";
+  await act(async () => {
+    root = hydrateRoot(container, ui);
+    await Promise.resolve();
+  });
+
+  expect(container.textContent).toBe("19:45");
+  expect(
+    consoleError.mock.calls.some((call) =>
+      call.some(
+        (message) =>
+          typeof message === "string" &&
+          (message.includes("Text content did not match") ||
+            message.includes("Hydration failed"))
+      )
+    )
+  ).toBe(false);
+});
+
+test("trims visitor timezone mode before hydration update", async () => {
+  const datetime = "2026-06-08T17:45:00.000+00:00";
+  const ui = createElement(Time, {
+    datetime,
+    language: "de",
+    country: "DE",
+    timeStyle: "short",
+    dateStyle: "none",
+    timeZone: " visitor ",
+  });
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  process.env.TZ = "UTC";
+  container.innerHTML = renderToStaticMarkup(ui);
+  expect(container.textContent).toBe("17:45");
+
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  process.env.TZ = "Europe/Berlin";
+  await act(async () => {
+    root = hydrateRoot(container, ui);
+    await Promise.resolve();
+  });
+
+  expect(container.textContent).toBe("19:45");
+  expect(
+    consoleError.mock.calls.some((call) =>
+      call.some(
+        (message) =>
+          typeof message === "string" &&
+          (message.includes("Text content did not match") ||
+            message.includes("Hydration failed"))
+      )
+    )
+  ).toBe(false);
 });
 
 test.skip("parse short date", () => {

--- a/packages/sdk-components-react/src/time.tsx
+++ b/packages/sdk-components-react/src/time.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, type ComponentProps, type ElementRef } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useState,
+  type ComponentProps,
+  type ElementRef,
+} from "react";
 
 const languages = [
   "af",
@@ -289,6 +295,7 @@ const DEFAULT_COUNTRY = "GB";
 const DEFAULT_DATE_STYLE = "medium";
 const DEFAULT_TIME_STYLE = "none";
 const DEFAULT_TIME_ZONE = "UTC";
+const VISITOR_TIME_ZONE = "visitor";
 
 const languageOrDefault = (language: unknown): Language => {
   return languages.includes(language as Language)
@@ -318,6 +325,22 @@ const timeStyleOrUndefined = (
     return value as Intl.DateTimeFormatOptions["timeStyle"];
   }
   return;
+};
+
+const timeZoneOrDefault = (timeZone: unknown): string => {
+  if (typeof timeZone !== "string") {
+    return DEFAULT_TIME_ZONE;
+  }
+  const normalizedTimeZone = timeZone.trim();
+  if (normalizedTimeZone === "" || normalizedTimeZone === VISITOR_TIME_ZONE) {
+    return DEFAULT_TIME_ZONE;
+  }
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: normalizedTimeZone });
+    return normalizedTimeZone;
+  } catch {
+    return DEFAULT_TIME_ZONE;
+  }
 };
 
 const parseDate = (datetimeString: string) => {
@@ -352,44 +375,68 @@ const parseDate = (datetimeString: string) => {
  * Example: formatDate(new Date(), "YYYY-MM-DD HH:mm:ss", "en-US") => "2025-11-03 18:47:25"
  * Example: formatDate(new Date(), "DDDD, MMMM D, YYYY", "en-US") => "Monday, November 3, 2025"
  */
-const formatDate = (date: Date, template: string, locale = "en-US"): string => {
+const formatDate = (
+  date: Date,
+  template: string,
+  locale = "en-US",
+  timeZone = DEFAULT_TIME_ZONE
+): string => {
   const pad = (n: number, length = 2) => String(n).padStart(length, "0");
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const part = (type: Intl.DateTimeFormatPartTypes) => {
+    return parts.find((part) => part.type === type)?.value ?? "";
+  };
+  const year = part("year");
+  const month = Number(part("month"));
+  const day = Number(part("day"));
+  const hour = Number(part("hour"));
+  const minute = Number(part("minute"));
+  const second = Number(part("second"));
 
   // Get localized day and month names
   const longDayName = new Intl.DateTimeFormat(locale, {
-    timeZone: DEFAULT_TIME_ZONE,
+    timeZone,
     weekday: "long",
   }).format(date);
   const shortDayName = new Intl.DateTimeFormat(locale, {
-    timeZone: DEFAULT_TIME_ZONE,
+    timeZone,
     weekday: "short",
   }).format(date);
   const longMonthName = new Intl.DateTimeFormat(locale, {
-    timeZone: DEFAULT_TIME_ZONE,
+    timeZone,
     month: "long",
   }).format(date);
   const shortMonthName = new Intl.DateTimeFormat(locale, {
-    timeZone: DEFAULT_TIME_ZONE,
+    timeZone,
     month: "short",
   }).format(date);
 
   const tokens: Record<string, string | number> = {
-    YYYY: date.getUTCFullYear(),
-    YY: String(date.getUTCFullYear()).slice(-2),
+    YYYY: year,
+    YY: year.slice(-2),
     MMMM: longMonthName,
     MMM: shortMonthName,
-    MM: pad(date.getUTCMonth() + 1),
-    M: date.getUTCMonth() + 1,
+    MM: pad(month),
+    M: month,
     DDDD: longDayName,
     DDD: shortDayName,
-    DD: pad(date.getUTCDate()),
-    D: date.getUTCDate(),
-    HH: pad(date.getUTCHours()),
-    H: date.getUTCHours(),
-    mm: pad(date.getUTCMinutes()),
-    m: date.getUTCMinutes(),
-    ss: pad(date.getUTCSeconds()),
-    s: date.getUTCSeconds(),
+    DD: pad(day),
+    D: day,
+    HH: pad(hour),
+    H: hour,
+    mm: pad(minute),
+    m: minute,
+    ss: pad(second),
+    s: second,
   };
 
   // Sort tokens by length (longest first) to avoid partial replacements
@@ -408,6 +455,13 @@ type TimeProps = {
   country?: Country;
   dateStyle?: DateStyle;
   timeStyle?: TimeStyle;
+  /**
+   * Time zone used to format the date.
+   *
+   * Use "UTC" for deterministic UTC output, "visitor" to use the browser time
+   * zone after hydration, or an IANA time zone like "Europe/Berlin".
+   */
+  timeZone?: string;
   /**
    * Custom format template. Overrides Date Style and Time Style.
    *
@@ -430,21 +484,34 @@ export const Time = forwardRef<ElementRef<"time">, TimeProps>(
       country = DEFAULT_COUNTRY,
       dateStyle = DEFAULT_DATE_STYLE,
       timeStyle = DEFAULT_TIME_STYLE,
+      timeZone = DEFAULT_TIME_ZONE,
       format,
       datetime = INITIAL_DATE_STRING,
       ...props
     },
     ref
   ) => {
+    const [visitorTimeZone, setVisitorTimeZone] = useState<string>();
     const locale = `${languageOrDefault(language)}-${countryOrDefault(
       country
     )}`;
+    const useVisitorTimeZone =
+      typeof timeZone === "string" && timeZone.trim() === VISITOR_TIME_ZONE;
+    const resolvedTimeZone = useVisitorTimeZone
+      ? timeZoneOrDefault(visitorTimeZone)
+      : timeZoneOrDefault(timeZone);
 
     const options: Intl.DateTimeFormatOptions = {
       dateStyle: dateStyleOrUndefined(dateStyle),
       timeStyle: timeStyleOrUndefined(timeStyle),
-      timeZone: DEFAULT_TIME_ZONE,
+      timeZone: resolvedTimeZone,
     };
+
+    useEffect(() => {
+      if (useVisitorTimeZone) {
+        setVisitorTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+      }
+    }, [useVisitorTimeZone]);
 
     const datetimeString =
       datetime === null ? INVALID_DATE_STRING : datetime.toString();
@@ -456,7 +523,7 @@ export const Time = forwardRef<ElementRef<"time">, TimeProps>(
       // Use custom format template if provided
       if (format) {
         try {
-          formattedDate = formatDate(date, format, locale);
+          formattedDate = formatDate(date, format, locale, resolvedTimeZone);
         } catch {
           /* Do Nothing */
         }
@@ -481,4 +548,5 @@ export const Time = forwardRef<ElementRef<"time">, TimeProps>(
 export const __testing__ = {
   parseDate,
   formatDate,
+  timeZoneOrDefault,
 };

--- a/packages/sdk-components-react/src/time.ws.ts
+++ b/packages/sdk-components-react/src/time.ws.ts
@@ -19,6 +19,7 @@ export const meta: WsComponentMeta = {
     "country",
     "dateStyle",
     "timeStyle",
+    "timeZone",
     "format",
   ],
   props: {
@@ -43,6 +44,16 @@ export const meta: WsComponentMeta = {
     },
     timeStyle: {
       ...props.timeStyle,
+      contentMode: true,
+    },
+    timeZone: {
+      required: false,
+      control: "timeZone",
+      type: "string",
+      defaultValue: "UTC",
+      options: ["UTC", "visitor"],
+      description:
+        'Timezone used to display the date. Use "visitor" to display each visitor’s browser timezone after the page loads, or select/type an IANA timezone like "Europe/Berlin".',
       contentMode: true,
     },
     format: {

--- a/packages/sdk/src/schema/prop-meta.ts
+++ b/packages/sdk/src/schema/prop-meta.ts
@@ -111,6 +111,14 @@ const Select = z.object({
   options: z.array(z.string()),
 });
 
+const TimeZone = z.object({
+  ...common,
+  control: z.literal("timeZone"),
+  type: z.literal("string"),
+  defaultValue: z.string().optional(),
+  options: z.array(z.string()),
+});
+
 const Check = z.object({
   ...common,
   control: z.literal("check"),
@@ -203,6 +211,7 @@ export const PropMeta = z.union([
   Radio,
   InlineRadio,
   Select,
+  TimeZone,
   MultiSelect,
   Check,
   InlineCheck,


### PR DESCRIPTION
## Summary

Adds timezone selection support to the Time component.

Users can now choose:

- `UTC` for deterministic server/client rendering
- `visitor` to render UTC during SSR, then update to the browser timezone after hydration
- an IANA timezone such as `Europe/Berlin`

Also adds a timezone combobox control in the settings panel with common timezone options, supported IANA timezone values, typed input, and preview descriptions.

## Changes

- Added `timeZone` prop to the Time component, defaulting to `UTC`
- Updated standard and custom-format date rendering to use the selected timezone
- Added visitor timezone mode with hydration-safe UTC fallback
- Added `timeZone` prop metadata and settings-panel control support
- Added timezone combobox control with previews
- Added tests for:
  - explicit timezone rendering
  - custom format timezone rendering
  - date rollover in another timezone
  - invalid timezone fallback
  - trimmed timezone values
  - visitor timezone hydration behavior

## Verification

- `pnpm --filter @webstudio-is/sdk-components-react test -- time.test.ts`
- `pnpm --filter @webstudio-is/sdk-components-react typecheck`
- `pnpm --filter @webstudio-is/builder typecheck`
- `pnpm exec prettier --check ...`
