### PR TITLE
feat: Copy-paste pages, folders and page templates

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -74,7 +74,7 @@ import type { User } from "~/shared/db/user.server";
 import {
   initCopyPaste,
   initCopyPasteForContentEditMode,
-} from "~/shared/copy-paste/init-copy-paste";
+} from "~/shared/copy-paste/copy-paste";
 import { useInertHandlers } from "./shared/inert-handlers";
 import { TextToolbar } from "./features/workspace/canvas-tools/text-toolbar";
 import { RemoteDialog } from "./features/help/remote-dialog";

--- a/apps/builder/app/builder/features/pages/confirmation-dialogs.tsx
+++ b/apps/builder/app/builder/features/pages/confirmation-dialogs.tsx
@@ -41,17 +41,15 @@ export const DeletePageConfirmationDialog = ({
           </Text>
         </Flex>
         <DialogActions>
-          <DialogClose>
-            <Button
-              autoFocus
-              color="destructive"
-              onClick={() => {
-                onConfirm();
-              }}
-            >
-              Delete Page
-            </Button>
-          </DialogClose>
+          <Button
+            autoFocus
+            color="destructive"
+            onClick={() => {
+              onConfirm();
+            }}
+          >
+            Delete Page
+          </Button>
           <DialogClose>
             <Button color="ghost">Cancel</Button>
           </DialogClose>
@@ -87,17 +85,15 @@ export const DeleteFolderConfirmationDialog = ({
           <Text>{`Delete folder "${folder.name}" including all of its pages?`}</Text>
         </Flex>
         <DialogActions>
-          <DialogClose>
-            <Button
-              autoFocus
-              color="destructive"
-              onClick={() => {
-                onConfirm();
-              }}
-            >
-              Delete
-            </Button>
-          </DialogClose>
+          <Button
+            autoFocus
+            color="destructive"
+            onClick={() => {
+              onConfirm();
+            }}
+          >
+            Delete
+          </Button>
           <DialogClose>
             <Button color="ghost">Cancel</Button>
           </DialogClose>
@@ -137,17 +133,15 @@ export const DeleteTemplateConfirmationDialog = ({
           </Text>
         </Flex>
         <DialogActions>
-          <DialogClose>
-            <Button
-              autoFocus
-              color="destructive"
-              onClick={() => {
-                onConfirm();
-              }}
-            >
-              Delete Template
-            </Button>
-          </DialogClose>
+          <Button
+            autoFocus
+            color="destructive"
+            onClick={() => {
+              onConfirm();
+            }}
+          >
+            Delete Template
+          </Button>
           <DialogClose>
             <Button color="ghost">Cancel</Button>
           </DialogClose>

--- a/apps/builder/app/builder/features/pages/folder-settings.tsx
+++ b/apps/builder/app/builder/features/pages/folder-settings.tsx
@@ -15,7 +15,7 @@ import {
   rawTheme,
   theme,
 } from "@webstudio-is/design-system";
-import { InfoCircleIcon, TrashIcon, CopyIcon } from "@webstudio-is/icons";
+import { InfoCircleIcon, TrashIcon } from "@webstudio-is/icons";
 import {
   Folder,
   Pages,
@@ -34,6 +34,8 @@ import { serverSyncStore } from "~/shared/sync/sync-stores";
 import { Form } from "./form";
 import { isSlugAvailable, registerFolderChildMutable } from "./page-utils";
 import { useDraftValue } from "~/builder/shared/use-draft-value";
+import { copyFolder } from "~/shared/copy-paste/copy-paste";
+import { PageItemActionsDropdown } from "./page-item-actions";
 
 const Values = Folder.pick({ name: true, slug: true }).extend({
   parentFolderId: z.string(),
@@ -389,32 +391,24 @@ export const FolderSettings = ({
     }
   };
 
+  const handleCopy = () => {
+    void copyFolder(folderId);
+  };
+
   return (
     <>
       <DialogTitle
         suffix={
           <DialogTitleActions>
-            {isDesignMode && onRequestDelete && (
-              <Tooltip content="Delete folder" side="bottom">
-                <Button
-                  color="ghost"
-                  prefix={<TrashIcon />}
-                  onClick={handleRequestDelete}
-                  aria-label="Delete folder"
-                  tabIndex={2}
-                />
-              </Tooltip>
-            )}
-            {isDesignMode && onDuplicate && (
-              <Tooltip content="Duplicate folder" side="bottom">
-                <Button
-                  color="ghost"
-                  prefix={<CopyIcon />}
-                  onClick={handleDuplicate}
-                  aria-label="Duplicate folder"
-                  tabIndex={2}
-                />
-              </Tooltip>
+            {isDesignMode && (
+              <PageItemActionsDropdown
+                label="Folder actions"
+                actions={{
+                  copy: handleCopy,
+                  duplicate: onDuplicate ? handleDuplicate : undefined,
+                  delete: onRequestDelete ? handleRequestDelete : undefined,
+                }}
+              />
             )}
             <DialogClose />
           </DialogTitleActions>

--- a/apps/builder/app/builder/features/pages/page-context-menu.tsx
+++ b/apps/builder/app/builder/features/pages/page-context-menu.tsx
@@ -183,6 +183,8 @@ export const TemplateContextMenu = ({
             const templateId = button?.getAttribute("data-template-id");
             if (templateId) {
               setTemplateId(templateId);
+            } else {
+              setTemplateId(undefined);
             }
           }}
         >

--- a/apps/builder/app/builder/features/pages/page-context-menu.tsx
+++ b/apps/builder/app/builder/features/pages/page-context-menu.tsx
@@ -1,16 +1,24 @@
 import { useState, type ReactNode } from "react";
+import { findParentFolderByChildId } from "@webstudio-is/sdk";
 import {
   ContextMenu,
   ContextMenuContent,
-  ContextMenuItem,
   ContextMenuTrigger,
 } from "@webstudio-is/design-system";
 import {
-  duplicatePage,
   duplicateFolder,
+  duplicatePage,
   duplicateTemplate,
 } from "./page-utils";
 import { selectPage } from "~/shared/nano-states";
+import {
+  copyFolder,
+  copyPage,
+  copyTemplate,
+  pastePage,
+} from "~/shared/copy-paste/copy-paste";
+import { $pages } from "~/shared/sync/data-stores";
+import { PageItemContextMenuActions } from "./page-item-actions";
 
 type PageContextMenuProps = {
   children: ReactNode;
@@ -19,25 +27,53 @@ type PageContextMenuProps = {
   onRequestDeleteFolder: (folderId: string) => void;
 };
 
+type PageMenuTarget =
+  | { type: "page"; id: string }
+  | { type: "folder"; id: string };
+
 export const PageContextMenu = ({
   children,
   canManagePages,
   onRequestDeletePage,
   onRequestDeleteFolder,
 }: PageContextMenuProps) => {
-  const [pageId, setPageId] = useState<string | undefined>();
-  const [folderId, setFolderId] = useState<string | undefined>();
+  const [target, setTarget] = useState<PageMenuTarget>();
 
   if (canManagePages === false) {
     return <>{children}</>;
   }
 
   const handleDuplicate = () => {
-    if (pageId) {
-      duplicatePage(pageId);
-    } else if (folderId) {
-      duplicateFolder(folderId);
+    if (target?.type === "page") {
+      duplicatePage(target.id);
+    } else if (target?.type === "folder") {
+      duplicateFolder(target.id);
     }
+  };
+
+  const handleCopy = () => {
+    if (target?.type === "page") {
+      void copyPage(target.id);
+    } else if (target?.type === "folder") {
+      void copyFolder(target.id);
+    }
+  };
+
+  const getPasteTargetFolderId = () => {
+    const pages = $pages.get();
+    if (pages === undefined) {
+      return;
+    }
+    if (target?.type === "folder") {
+      return target.id;
+    }
+    if (target?.type === "page") {
+      return (
+        findParentFolderByChildId(target.id, pages.folders)?.id ??
+        pages.rootFolderId
+      );
+    }
+    return pages.rootFolderId;
   };
 
   return (
@@ -45,8 +81,7 @@ export const PageContextMenu = ({
       <ContextMenu
         onOpenChange={(open) => {
           if (!open) {
-            setPageId(undefined);
-            setFolderId(undefined);
+            setTarget(undefined);
           }
         }}
       >
@@ -61,36 +96,35 @@ export const PageContextMenu = ({
             const pageId = button?.getAttribute("data-page-id");
             const folderId = button?.getAttribute("data-folder-id");
             if (pageId) {
-              setPageId(pageId);
-              setFolderId(undefined);
+              setTarget({ type: "page", id: pageId });
             } else if (folderId) {
-              setFolderId(folderId);
-              setPageId(undefined);
+              setTarget({ type: "folder", id: folderId });
+            } else {
+              setTarget(undefined);
             }
           }}
         >
           {children}
         </ContextMenuTrigger>
         <ContextMenuContent>
-          <ContextMenuItem
-            onSelect={handleDuplicate}
-            disabled={!pageId && !folderId}
-          >
-            Duplicate
-          </ContextMenuItem>
-          <ContextMenuItem
-            onSelect={() => {
-              if (pageId) {
-                onRequestDeletePage(pageId);
-              } else if (folderId) {
-                onRequestDeleteFolder(folderId);
-              }
+          <PageItemContextMenuActions
+            actions={{
+              paste: () => {
+                void pastePage(getPasteTargetFolderId());
+              },
+              copy: target ? handleCopy : undefined,
+              duplicate: target ? handleDuplicate : undefined,
+              delete: target
+                ? () => {
+                    if (target.type === "page") {
+                      onRequestDeletePage(target.id);
+                    } else {
+                      onRequestDeleteFolder(target.id);
+                    }
+                  }
+                : undefined,
             }}
-            destructive
-            disabled={!pageId && !folderId}
-          >
-            Delete
-          </ContextMenuItem>
+          />
         </ContextMenuContent>
       </ContextMenu>
     </>
@@ -123,6 +157,12 @@ export const TemplateContextMenu = ({
     }
   };
 
+  const handleCopy = () => {
+    if (templateId) {
+      void copyTemplate(templateId);
+    }
+  };
+
   return (
     <>
       <ContextMenu
@@ -149,20 +189,17 @@ export const TemplateContextMenu = ({
           {children}
         </ContextMenuTrigger>
         <ContextMenuContent>
-          <ContextMenuItem onSelect={handleDuplicate} disabled={!templateId}>
-            Duplicate
-          </ContextMenuItem>
-          <ContextMenuItem
-            onSelect={() => {
-              if (templateId) {
-                onRequestDeleteTemplate(templateId);
-              }
+          <PageItemContextMenuActions
+            actions={{
+              copy: templateId ? handleCopy : undefined,
+              duplicate: templateId ? handleDuplicate : undefined,
+              delete: templateId
+                ? () => {
+                    onRequestDeleteTemplate(templateId);
+                  }
+                : undefined,
             }}
-            destructive
-            disabled={!templateId}
-          >
-            Delete
-          </ContextMenuItem>
+          />
         </ContextMenuContent>
       </ContextMenu>
     </>

--- a/apps/builder/app/builder/features/pages/page-item-actions.tsx
+++ b/apps/builder/app/builder/features/pages/page-item-actions.tsx
@@ -46,16 +46,19 @@ const ActionContextMenuItem = ({
   item,
   actions,
 }: { item: ActionItem } & PageItemActionsMenuItemsProps) => {
+  const action = actions[item.name];
   return (
     <ContextMenuItem
-      onSelect={actions[item.name]}
+      onSelect={action}
       destructive={isDestructive(item.name)}
-      disabled={actions[item.name] == null}
+      disabled={action == null}
     >
       {item.label}
-      <ContextMenuItemRightSlot>
-        <Kbd value={item.shortcut} />
-      </ContextMenuItemRightSlot>
+      {action && (
+        <ContextMenuItemRightSlot>
+          <Kbd value={item.shortcut} />
+        </ContextMenuItemRightSlot>
+      )}
     </ContextMenuItem>
   );
 };
@@ -97,19 +100,24 @@ export const PageItemActionsDropdown = ({
       <DropdownMenuContent align="end">
         {items
           .filter((item) => item.name !== "paste")
-          .map((item) => (
-            <DropdownMenuItem
-              key={item.name}
-              onSelect={actions[item.name]}
-              destructive={isDestructive(item.name)}
-              disabled={actions[item.name] == null}
-            >
-              {item.label}
-              <DropdownMenuItemRightSlot>
-                <Kbd value={item.shortcut} />
-              </DropdownMenuItemRightSlot>
-            </DropdownMenuItem>
-          ))}
+          .map((item) => {
+            const action = actions[item.name];
+            return (
+              <DropdownMenuItem
+                key={item.name}
+                onSelect={action}
+                destructive={isDestructive(item.name)}
+                disabled={action == null}
+              >
+                {item.label}
+                {action && (
+                  <DropdownMenuItemRightSlot>
+                    <Kbd value={item.shortcut} />
+                  </DropdownMenuItemRightSlot>
+                )}
+              </DropdownMenuItem>
+            );
+          })}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/builder/app/builder/features/pages/page-item-actions.tsx
+++ b/apps/builder/app/builder/features/pages/page-item-actions.tsx
@@ -1,0 +1,116 @@
+import {
+  Button,
+  ContextMenuItem,
+  ContextMenuItemRightSlot,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuItemRightSlot,
+  DropdownMenuTrigger,
+  Kbd,
+  Tooltip,
+} from "@webstudio-is/design-system";
+import { EllipsesIcon } from "@webstudio-is/icons";
+
+export type PageItemActions = {
+  paste?: () => void;
+  copy?: () => void;
+  duplicate?: () => void;
+  delete?: () => void;
+};
+
+type PageItemActionsMenuItemsProps = {
+  actions: PageItemActions;
+};
+
+const items = [
+  { name: "paste", label: "Paste", shortcut: ["meta", "v"] },
+  { name: "copy", label: "Copy", shortcut: ["meta", "c"] },
+  {
+    name: "duplicate",
+    label: "Duplicate",
+    shortcut: ["meta", "d"],
+  },
+  {
+    name: "delete",
+    label: "Delete",
+    shortcut: ["backspace"],
+  },
+] as const;
+
+type ActionItem = (typeof items)[number];
+
+const isDestructive = (name: ActionItem["name"]) => name === "delete";
+
+const ActionContextMenuItem = ({
+  item,
+  actions,
+}: { item: ActionItem } & PageItemActionsMenuItemsProps) => {
+  return (
+    <ContextMenuItem
+      onSelect={actions[item.name]}
+      destructive={isDestructive(item.name)}
+      disabled={actions[item.name] == null}
+    >
+      {item.label}
+      <ContextMenuItemRightSlot>
+        <Kbd value={item.shortcut} />
+      </ContextMenuItemRightSlot>
+    </ContextMenuItem>
+  );
+};
+
+export const PageItemContextMenuActions = ({
+  actions,
+}: PageItemActionsMenuItemsProps) => {
+  return (
+    <>
+      {items.map((item) =>
+        item.name === "paste" && actions.paste === undefined ? null : (
+          <ActionContextMenuItem
+            key={item.name}
+            item={item}
+            actions={actions}
+          />
+        )
+      )}
+    </>
+  );
+};
+
+export const PageItemActionsDropdown = ({
+  actions,
+  label = "Actions",
+}: PageItemActionsMenuItemsProps & { label?: string }) => {
+  return (
+    <DropdownMenu>
+      <Tooltip content={label} side="bottom">
+        <DropdownMenuTrigger asChild>
+          <Button
+            color="ghost"
+            prefix={<EllipsesIcon />}
+            aria-label={label}
+            tabIndex={2}
+          />
+        </DropdownMenuTrigger>
+      </Tooltip>
+      <DropdownMenuContent align="end">
+        {items
+          .filter((item) => item.name !== "paste")
+          .map((item) => (
+            <DropdownMenuItem
+              key={item.name}
+              onSelect={actions[item.name]}
+              destructive={isDestructive(item.name)}
+              disabled={actions[item.name] == null}
+            >
+              {item.label}
+              <DropdownMenuItemRightSlot>
+                <Kbd value={item.shortcut} />
+              </DropdownMenuItemRightSlot>
+            </DropdownMenuItem>
+          ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/apps/builder/app/builder/features/pages/page-settings/page-settings.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings/page-settings.tsx
@@ -18,7 +18,6 @@ import {
   theme,
   Button,
   Box,
-  Tooltip,
   Grid,
   Text,
   ScrollAreaNative,
@@ -29,7 +28,6 @@ import {
   DialogTitle,
   DialogTitleActions,
 } from "@webstudio-is/design-system";
-import { CopyIcon, TrashIcon } from "@webstudio-is/icons";
 import {
   $authPermit,
   $isContentMode,
@@ -75,6 +73,8 @@ import {
   type Values,
 } from "./shared";
 import { useDraftValue } from "~/builder/shared/use-draft-value";
+import { copyPage } from "~/shared/copy-paste/copy-paste";
+import { PageItemActionsDropdown } from "../page-item-actions";
 
 export type { Values } from "./shared";
 
@@ -770,6 +770,9 @@ export const PageSettings = ({
     <>
       <PageSettingsView
         onClose={onClose}
+        onCopy={() => {
+          void copyPage(pageId);
+        }}
         onDelete={values.isHomePage === false ? handleRequestDelete : undefined}
         onDuplicate={() => {
           const newPageId = duplicatePage(pageId);
@@ -833,11 +836,13 @@ export const PageSettingsPanel = ({
 };
 
 const PageSettingsView = ({
+  onCopy,
   onDelete,
   onDuplicate,
   onClose,
   children,
 }: {
+  onCopy: () => void;
   onDelete?: () => void;
   onDuplicate: () => void;
   onClose: () => void;
@@ -855,27 +860,15 @@ const PageSettingsView = ({
       disabled={canEditPageSettings === false}
       suffix={
         <DialogTitleActions>
-          {isDesignMode && onDelete && (
-            <Tooltip content="Delete page" side="bottom">
-              <Button
-                color="ghost"
-                prefix={<TrashIcon />}
-                onClick={onDelete}
-                aria-label="Delete page"
-                tabIndex={2}
-              />
-            </Tooltip>
-          )}
           {isDesignMode && (
-            <Tooltip content="Duplicate page" side="bottom">
-              <Button
-                color="ghost"
-                prefix={<CopyIcon />}
-                onClick={onDuplicate}
-                aria-label="Duplicate page"
-                tabIndex={2}
-              />
-            </Tooltip>
+            <PageItemActionsDropdown
+              label="Page actions"
+              actions={{
+                copy: onCopy,
+                duplicate: onDuplicate,
+                delete: onDelete,
+              }}
+            />
           )}
           <DialogClose />
         </DialogTitleActions>

--- a/apps/builder/app/builder/features/pages/page-utils.test.ts
+++ b/apps/builder/app/builder/features/pages/page-utils.test.ts
@@ -1111,6 +1111,26 @@ describe("duplicateFolder", () => {
     expect(newFolder?.slug).toBe("folder1-2");
   });
 
+  test("should preserve empty folder slugs when duplicating", async () => {
+    const { pages: pagesData, register, f } = createPages();
+    register([f("folder1", "", []), f("folder2", "", [])]);
+
+    $pages.set(pagesData);
+    updateCurrentSystem(initialSystem);
+
+    const { duplicateFolder } = await import("./page-utils");
+    const newFolderId = duplicateFolder("folder1");
+
+    expect(newFolderId).toBeDefined();
+    const updatedPages = $pages.get()!;
+    const newFolder =
+      newFolderId === undefined
+        ? undefined
+        : updatedPages.folders.get(newFolderId);
+    expect(newFolder?.name).toBe("folder1 (1)");
+    expect(newFolder?.slug).toBe("");
+  });
+
   test("should register duplicated folder in parent folder", async () => {
     const { pages: pagesData, register, f } = createPages();
     register([f("folder1", [])]);

--- a/apps/builder/app/builder/features/pages/page-utils.test.ts
+++ b/apps/builder/app/builder/features/pages/page-utils.test.ts
@@ -7,6 +7,7 @@ import {
   isRootFolder,
   type Folder,
   ROOT_FOLDER_ID,
+  ROOT_INSTANCE_ID,
   type DataSource,
   type Page,
   SYSTEM_VARIABLE_ID,
@@ -1190,6 +1191,24 @@ describe("duplicateTemplate", () => {
     $instances.set(
       new Map([
         [
+          ROOT_INSTANCE_ID,
+          {
+            type: "instance",
+            id: ROOT_INSTANCE_ID,
+            component: "Body",
+            children: [{ type: "id", value: "rootBoxId" }],
+          },
+        ],
+        [
+          "rootBoxId",
+          {
+            type: "instance",
+            id: "rootBoxId",
+            component: "Box",
+            children: [],
+          },
+        ],
+        [
           "templateRootId",
           {
             type: "instance",
@@ -1213,6 +1232,7 @@ describe("duplicateTemplate", () => {
     const newTemplateId = duplicateTemplate("templateId");
 
     expect(newTemplateId).toBeDefined();
+    expect($instances.get().size).toEqual(4);
     const newTemplate = $pages.get()?.pageTemplates?.get(newTemplateId ?? "");
     const newVariable = Array.from($dataSources.get().values()).find(
       (item) => item.name === "templateVariable" && item.id !== variableId

--- a/apps/builder/app/builder/features/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/pages/page-utils.ts
@@ -28,6 +28,8 @@ import { $variableValuesByInstanceSelector } from "~/shared/nano-states";
 import { $dataSources, $pages, $project } from "~/shared/sync/data-stores";
 import {
   copyAndTransformPageMeta,
+  createFolderCopyData,
+  insertFolderCopyFromDataMutable,
   insertPageCopyMutable,
   insertPageFromTemplateMutable,
 } from "~/shared/page-utils";
@@ -365,101 +367,6 @@ export const duplicatePage = (pageId: Page["id"]) => {
   return newPageId;
 };
 
-const deduplicateName = (usedNames: Set<string>, name: string) => {
-  const { name: baseName = name, copyNumber } =
-    // extract a number from "name (copyNumber)"
-    name.match(/^(?<name>.+) \((?<copyNumber>\d+)\)$/)?.groups ?? {};
-  let nameNumber = Number(copyNumber ?? "0");
-  let newName: string;
-  do {
-    nameNumber += 1;
-    newName = `${baseName} (${nameNumber})`;
-  } while (usedNames.has(newName));
-  return newName;
-};
-
-const deduplicateSlug = (usedSlugs: Set<string>, slug: string) => {
-  // extract a number from "slug-N"
-  const { slug: baseSlug = slug, copyNumber } =
-    slug.match(/^(?<slug>.+)-(?<copyNumber>\d+)$/)?.groups ?? {};
-  let counter = Number(copyNumber ?? "0");
-  let newSlug: string;
-  do {
-    counter += 1;
-    newSlug = baseSlug ? `${baseSlug}-${counter}` : `copy-${counter}`;
-  } while (usedSlugs.has(newSlug));
-  return newSlug;
-};
-
-const insertFolderCopyMutable = ({
-  source,
-  target,
-}: {
-  source: { data: WebstudioData; folderId: Folder["id"] };
-  target: { data: WebstudioData; parentFolderId: Folder["id"] };
-}): Folder["id"] | undefined => {
-  const sourceFolder = source.data.pages.folders.get(source.folderId);
-  if (sourceFolder === undefined) {
-    return;
-  }
-
-  const parentFolder = target.data.pages.folders.get(target.parentFolderId);
-  const usedNames = new Set<string>();
-  const usedSlugs = new Set<string>();
-  for (const childId of parentFolder?.children ?? []) {
-    const childFolder = target.data.pages.folders.get(childId);
-    if (childFolder) {
-      usedNames.add(childFolder.name);
-      usedSlugs.add(childFolder.slug);
-      continue;
-    }
-    const childPage = target.data.pages.pages.get(childId);
-    if (childPage) {
-      usedNames.add(childPage.name);
-    }
-  }
-
-  // Create new folder with deduplicated name and slug
-  const newFolderId = nanoid();
-  const newFolder: Folder = {
-    id: newFolderId,
-    name: deduplicateName(usedNames, sourceFolder.name),
-    slug: deduplicateSlug(usedSlugs, sourceFolder.slug),
-    children: [],
-  };
-
-  // Add new folder to the folders array
-  target.data.pages.folders.set(newFolder.id, newFolder);
-
-  // Register new folder in parent
-  for (const folder of getAllFolders(target.data.pages)) {
-    if (folder.id === target.parentFolderId) {
-      folder.children.push(newFolderId);
-    }
-  }
-
-  // Duplicate all children (pages and nested folders)
-  for (const childId of sourceFolder.children) {
-    const childFolder = source.data.pages.folders.get(childId);
-
-    if (childFolder) {
-      // It's a nested folder - duplicate it recursively
-      insertFolderCopyMutable({
-        source: { data: source.data, folderId: childId },
-        target: { data: target.data, parentFolderId: newFolderId },
-      });
-    } else {
-      // It's a page - duplicate it
-      insertPageCopyMutable({
-        source: { data: source.data, pageId: childId },
-        target: { data: target.data, folderId: newFolderId },
-      });
-    }
-  }
-
-  return newFolderId;
-};
-
 export const duplicateFolder = (folderId: Folder["id"]) => {
   const pages = $pages.get();
   const currentFolder =
@@ -471,10 +378,14 @@ export const duplicateFolder = (folderId: Folder["id"]) => {
   }
   let newFolderId: undefined | string;
   updateWebstudioData((data) => {
-    newFolderId = insertFolderCopyMutable({
-      source: { data, folderId },
-      target: { data, parentFolderId: currentFolder.id },
-    });
+    const copyData = createFolderCopyData({ data, folderId });
+    if (copyData) {
+      newFolderId = insertFolderCopyFromDataMutable({
+        source: copyData,
+        target: { data, parentFolderId: currentFolder.id },
+        forceFolderCopySuffix: true,
+      });
+    }
   });
   return newFolderId;
 };

--- a/apps/builder/app/builder/features/pages/page-utils.ts
+++ b/apps/builder/app/builder/features/pages/page-utils.ts
@@ -1,5 +1,4 @@
 import { computed } from "nanostores";
-import { nanoid } from "nanoid";
 import slugify from "slugify";
 import {
   type Page,
@@ -20,20 +19,18 @@ import {
 } from "@webstudio-is/sdk";
 import {
   deleteInstanceMutable,
-  extractWebstudioFragment,
-  insertWebstudioFragmentCopy,
   updateWebstudioData,
 } from "~/shared/instance-utils";
 import { $variableValuesByInstanceSelector } from "~/shared/nano-states";
-import { $dataSources, $pages, $project } from "~/shared/sync/data-stores";
+import { $dataSources, $pages } from "~/shared/sync/data-stores";
 import {
-  copyAndTransformPageMeta,
   createFolderCopyData,
+  createTemplateCopyData,
   insertFolderCopyFromDataMutable,
   insertPageCopyMutable,
   insertPageFromTemplateMutable,
+  insertTemplateCopyFromFragmentsMutable,
 } from "~/shared/page-utils";
-import { replaceDataSourcesInExpression } from "~/shared/data-variables";
 import {
   $selectedPage,
   getInstanceKey,
@@ -472,53 +469,24 @@ export const deleteTemplateMutable = (
 
 export const duplicateTemplate = (templateId: PageTemplate["id"]) => {
   const pages = $pages.get();
-  const project = $project.get();
   const template = pages?.pageTemplates?.get(templateId);
-  if (template === undefined || project === undefined) {
+  if (template === undefined) {
     return;
   }
   let newTemplateId: undefined | string;
   updateWebstudioData((data) => {
     data.pages.pageTemplates ??= new Map();
-    const usedNames = new Set(
-      Array.from(data.pages.pageTemplates.values()).map((t) => t.name)
-    );
-    const { name: baseName = template.name, copyNumber } =
-      template.name.match(/^(?<name>.+) \((?<copyNumber>\d+)\)$/)?.groups ?? {};
-    let nameNumber = Number(copyNumber ?? "0");
-    let newName = baseName;
-    while (usedNames.has(newName)) {
-      nameNumber += 1;
-      newName = `${baseName} (${nameNumber})`;
-    }
-    newTemplateId = nanoid();
-    const { newInstanceIds, newDataSourceIds } = insertWebstudioFragmentCopy({
+    const copyData = createTemplateCopyData({
       data,
-      fragment: extractWebstudioFragment(data, template.rootInstanceId),
-      availableVariables: [],
-      projectId: project.id,
+      template,
     });
-    const transformExpression = (expression: string) =>
-      replaceDataSourcesInExpression(expression, newDataSourceIds);
-    const newTemplate: PageTemplate = {
-      id: newTemplateId,
-      name: newName,
-      title: transformExpression(template.title),
-      rootInstanceId:
-        newInstanceIds.get(template.rootInstanceId) ?? template.rootInstanceId,
-      systemDataSourceId:
-        template.systemDataSourceId === undefined
-          ? undefined
-          : (newDataSourceIds.get(template.systemDataSourceId) ??
-            template.systemDataSourceId),
-      meta: {},
-    };
-    copyAndTransformPageMeta(
-      template.meta,
-      newTemplate.meta,
-      transformExpression
-    );
-    data.pages.pageTemplates.set(newTemplate.id, newTemplate);
+    newTemplateId = insertTemplateCopyFromFragmentsMutable({
+      source: {
+        template: copyData.template,
+        bodyFragment: copyData.bodyFragment,
+      },
+      target: { data },
+    });
   });
   return newTemplateId;
 };

--- a/apps/builder/app/builder/features/pages/pages.tsx
+++ b/apps/builder/app/builder/features/pages/pages.tsx
@@ -50,6 +50,7 @@ import {
   $canOpenPageTemplates,
   $isContentMode,
   $isDesignMode,
+  $pageIdToDelete,
 } from "~/shared/nano-states";
 import { $pages } from "~/shared/sync/data-stores";
 import {
@@ -280,6 +281,7 @@ const $flatPagesTree = computed(
 
 const PagesTree = ({
   onSelect,
+  onRequestDeletePage,
   selectedPageId,
   onEdit,
   editingItemId,
@@ -287,6 +289,7 @@ const PagesTree = ({
   canEditPageSettings,
 }: {
   onSelect: (pageId: string) => void;
+  onRequestDeletePage: (pageId: string) => void;
   selectedPageId: string;
   onEdit: (pageId: string | undefined) => void;
   editingItemId?: string;
@@ -398,6 +401,18 @@ const PagesTree = ({
                     if (item.type === "page") {
                       onSelect(item.id);
                     }
+                  },
+                  onKeyDown: (event) => {
+                    if (
+                      canManagePages === false ||
+                      item.type !== "page" ||
+                      item.id === pages.homePageId ||
+                      (event.key !== "Backspace" && event.key !== "Delete")
+                    ) {
+                      return;
+                    }
+                    event.preventDefault();
+                    onRequestDeletePage(item.id);
                   },
                   ...(item.type === "page" &&
                     item.id !== pages?.homePageId && {
@@ -954,7 +969,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
   const [containerElement, setContainerElement] =
     useState<HTMLDivElement | null>(null);
   const [settingsPanelHeight, setSettingsPanelHeight] = useState<number>();
-  const [pageIdToDelete, setPageIdToDelete] = useState<string | undefined>();
+  const pageIdToDelete = useStore($pageIdToDelete);
   const [folderIdToDelete, setFolderIdToDelete] = useState<
     string | undefined
   >();
@@ -990,7 +1005,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
         $editingPageId.set(undefined);
       }
     }
-    setPageIdToDelete(undefined);
+    $pageIdToDelete.set(undefined);
   };
 
   const handleDeleteFolderConfirm = () => {
@@ -1067,12 +1082,13 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
 
       <PageContextMenu
         canManagePages={isDesignMode}
-        onRequestDeletePage={setPageIdToDelete}
+        onRequestDeletePage={(pageId) => $pageIdToDelete.set(pageId)}
         onRequestDeleteFolder={setFolderIdToDelete}
       >
         <div>
           <PagesTree
             selectedPageId={currentPage.id}
+            onRequestDeletePage={(pageId) => $pageIdToDelete.set(pageId)}
             onSelect={(itemId) => {
               selectPage(itemId);
               onClose();
@@ -1254,7 +1270,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
       {pageIdToDelete && (
         <DeletePageConfirmationDialog
           page={findPageByIdOrPath(pageIdToDelete, pages)!}
-          onClose={() => setPageIdToDelete(undefined)}
+          onClose={() => $pageIdToDelete.set(undefined)}
           onConfirm={handlePageDeleteConfirm}
         />
       )}

--- a/apps/builder/app/builder/features/pages/pages.tsx
+++ b/apps/builder/app/builder/features/pages/pages.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { useStore } from "@nanostores/react";
 import {
   Tooltip,
@@ -50,7 +50,9 @@ import {
   $canOpenPageTemplates,
   $isContentMode,
   $isDesignMode,
+  $folderIdToDelete,
   $pageIdToDelete,
+  $templateIdToDelete,
 } from "~/shared/nano-states";
 import { $pages } from "~/shared/sync/data-stores";
 import {
@@ -282,6 +284,7 @@ const $flatPagesTree = computed(
 const PagesTree = ({
   onSelect,
   onRequestDeletePage,
+  onRequestDeleteFolder,
   selectedPageId,
   onEdit,
   editingItemId,
@@ -290,6 +293,7 @@ const PagesTree = ({
 }: {
   onSelect: (pageId: string) => void;
   onRequestDeletePage: (pageId: string) => void;
+  onRequestDeleteFolder: (folderId: string) => void;
   selectedPageId: string;
   onEdit: (pageId: string | undefined) => void;
   editingItemId?: string;
@@ -405,14 +409,19 @@ const PagesTree = ({
                   onKeyDown: (event) => {
                     if (
                       canManagePages === false ||
-                      item.type !== "page" ||
-                      item.id === pages.homePageId ||
                       (event.key !== "Backspace" && event.key !== "Delete")
                     ) {
                       return;
                     }
+                    if (item.type === "page" && item.id === pages.homePageId) {
+                      return;
+                    }
                     event.preventDefault();
-                    onRequestDeletePage(item.id);
+                    if (item.type === "page") {
+                      onRequestDeletePage(item.id);
+                    } else {
+                      onRequestDeleteFolder(item.id);
+                    }
                   },
                   ...(item.type === "page" &&
                     item.id !== pages?.homePageId && {
@@ -730,6 +739,7 @@ const TemplateItem = ({
   onSelect,
   onEdit,
   onCreatePage,
+  onRequestDelete,
   canSelectTemplate,
   canEditTemplate,
   canCreatePage,
@@ -740,6 +750,7 @@ const TemplateItem = ({
   onSelect: (id: string) => void;
   onEdit: (id: string | undefined) => void;
   onCreatePage: (id: string) => void;
+  onRequestDelete: (id: string) => void;
   canSelectTemplate: boolean;
   canEditTemplate: boolean;
   canCreatePage: boolean;
@@ -758,7 +769,21 @@ const TemplateItem = ({
       level={1}
       isSelected={isSelected}
       buttonProps={Object.assign(
-        canSelectTemplate ? { onClick: () => onSelect(template.id) } : {},
+        canSelectTemplate
+          ? {
+              onClick: () => onSelect(template.id),
+              onKeyDown: (event: KeyboardEvent) => {
+                if (
+                  canEditTemplate === false ||
+                  (event.key !== "Backspace" && event.key !== "Delete")
+                ) {
+                  return;
+                }
+                event.preventDefault();
+                onRequestDelete(template.id);
+              },
+            }
+          : {},
         { "data-template-id": template.id }
       )}
       actionCount={(canCreatePage ? 1 : 0) + (canEditTemplate ? 1 : 0)}
@@ -813,6 +838,7 @@ const TemplatesSection = ({
   editingTemplateId,
   onEditTemplate,
   onCreatePageFromTemplate,
+  onRequestDeleteTemplate,
   canManageTemplates,
   canSelectTemplate,
   canCreatePageFromTemplate,
@@ -822,6 +848,7 @@ const TemplatesSection = ({
   editingTemplateId: string | undefined;
   onEditTemplate: (id: string | undefined) => void;
   onCreatePageFromTemplate: (id: string) => void;
+  onRequestDeleteTemplate: (id: string) => void;
   canManageTemplates: boolean;
   canSelectTemplate: boolean;
   canCreatePageFromTemplate: boolean;
@@ -891,6 +918,7 @@ const TemplatesSection = ({
             onSelect={onSelectTemplate}
             onEdit={onEditTemplate}
             onCreatePage={onCreatePageFromTemplate}
+            onRequestDelete={onRequestDeleteTemplate}
             canSelectTemplate={canSelectTemplate}
             canEditTemplate={canManageTemplates}
             canCreatePage={canCreatePageFromTemplate}
@@ -973,12 +1001,8 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
     useState<HTMLDivElement | null>(null);
   const [settingsPanelHeight, setSettingsPanelHeight] = useState<number>();
   const pageIdToDelete = useStore($pageIdToDelete);
-  const [folderIdToDelete, setFolderIdToDelete] = useState<
-    string | undefined
-  >();
-  const [templateIdToDelete, setTemplateIdToDelete] = useState<
-    string | undefined
-  >();
+  const folderIdToDelete = useStore($folderIdToDelete);
+  const templateIdToDelete = useStore($templateIdToDelete);
 
   useEffect(() => {
     if (containerElement === null) {
@@ -1026,7 +1050,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
         $editingPageId.set(undefined);
       }
     }
-    setFolderIdToDelete(undefined);
+    $folderIdToDelete.set(undefined);
   };
 
   const handleTemplateDeleteConfirm = () => {
@@ -1041,7 +1065,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
         selectPage(pages.homePageId);
       }
     }
-    setTemplateIdToDelete(undefined);
+    $templateIdToDelete.set(undefined);
   };
 
   const templateToDelete =
@@ -1086,12 +1110,15 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
       <PageContextMenu
         canManagePages={isDesignMode}
         onRequestDeletePage={(pageId) => $pageIdToDelete.set(pageId)}
-        onRequestDeleteFolder={setFolderIdToDelete}
+        onRequestDeleteFolder={(folderId) => $folderIdToDelete.set(folderId)}
       >
         <div>
           <PagesTree
             selectedPageId={currentPage.id}
             onRequestDeletePage={(pageId) => $pageIdToDelete.set(pageId)}
+            onRequestDeleteFolder={(folderId) =>
+              $folderIdToDelete.set(folderId)
+            }
             onSelect={(itemId) => {
               selectPage(itemId);
               onClose();
@@ -1131,7 +1158,9 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
           {canOpenPageTemplates ? (
             <TemplateContextMenu
               canManageTemplates={isDesignMode}
-              onRequestDeleteTemplate={setTemplateIdToDelete}
+              onRequestDeleteTemplate={(templateId) =>
+                $templateIdToDelete.set(templateId)
+              }
             >
               <ScrollAreaNative
                 css={{
@@ -1156,6 +1185,9 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
                   onCreatePageFromTemplate={(id) => {
                     $creatingPageFromTemplateId.set(id);
                   }}
+                  onRequestDeleteTemplate={(templateId) =>
+                    $templateIdToDelete.set(templateId)
+                  }
                   canManageTemplates={isDesignMode}
                   canSelectTemplate={true}
                   canCreatePageFromTemplate={canEditPageContent}
@@ -1178,6 +1210,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
                 onCreatePageFromTemplate={(id) => {
                   $creatingPageFromTemplateId.set(id);
                 }}
+                onRequestDeleteTemplate={() => {}}
                 canManageTemplates={false}
                 canSelectTemplate={false}
                 canCreatePageFromTemplate={canEditPageContent}
@@ -1284,14 +1317,14 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
       {folderIdToDelete && (
         <DeleteFolderConfirmationDialog
           folder={getFolderById(pages, folderIdToDelete)!}
-          onClose={() => setFolderIdToDelete(undefined)}
+          onClose={() => $folderIdToDelete.set(undefined)}
           onConfirm={handleDeleteFolderConfirm}
         />
       )}
       {templateToDelete && (
         <DeleteTemplateConfirmationDialog
           template={templateToDelete}
-          onClose={() => setTemplateIdToDelete(undefined)}
+          onClose={() => $templateIdToDelete.set(undefined)}
           onConfirm={handleTemplateDeleteConfirm}
         />
       )}

--- a/apps/builder/app/builder/features/pages/pages.tsx
+++ b/apps/builder/app/builder/features/pages/pages.tsx
@@ -535,6 +535,7 @@ const CreateItemMenu = ({
           onSelect={(event) => {
             event.preventDefault();
             selectMenuItem(() => {
+              $editingTemplateId.set(undefined);
               $editingPageId.set(
                 editingItemId === newPageId ? undefined : newPageId
               );
@@ -547,6 +548,7 @@ const CreateItemMenu = ({
           onSelect={(event) => {
             event.preventDefault();
             selectMenuItem(() => {
+              $editingTemplateId.set(undefined);
               $editingPageId.set(
                 editingItemId === newFolderId ? undefined : newFolderId
               );
@@ -559,6 +561,7 @@ const CreateItemMenu = ({
           onSelect={(event) => {
             event.preventDefault();
             selectMenuItem(() => {
+              $editingPageId.set(undefined);
               $editingTemplateId.set(
                 editingTemplateItemId === newTemplateId
                   ? undefined
@@ -1112,6 +1115,9 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
               if (itemId && isFolder(itemId, pages.folders) === false) {
                 selectPage(itemId);
               }
+              if (itemId) {
+                $editingTemplateId.set(undefined);
+              }
               $editingPageId.set(itemId);
             }}
           />
@@ -1143,6 +1149,7 @@ export const PagesPanel = ({ onClose }: { onClose: () => void }) => {
                   onEditTemplate={(id) => {
                     if (id) {
                       selectPage(id);
+                      $editingPageId.set(undefined);
                     }
                     $editingTemplateId.set(id);
                   }}

--- a/apps/builder/app/builder/features/pages/template-settings.test.ts
+++ b/apps/builder/app/builder/features/pages/template-settings.test.ts
@@ -3,6 +3,8 @@ import { fieldDefaultValues } from "./page-settings/page-settings";
 import { __testing__ } from "./template-settings";
 import type { Values } from "./page-settings/shared";
 
+const { getEditorCreatePageValues } = __testing__;
+
 const createValues = (values: Partial<Values>): Values => ({
   ...fieldDefaultValues,
   ...values,
@@ -32,9 +34,7 @@ describe("template settings", () => {
       customMetas: [{ property: "og:type", content: `"article"` }],
     });
 
-    expect(
-      __testing__.getEditorCreatePageValues(initialValues, values)
-    ).toEqual({
+    expect(getEditorCreatePageValues(initialValues, values)).toEqual({
       name: "Edited",
       path: "/edited",
       description: `"Edited description"`,
@@ -44,7 +44,7 @@ describe("template settings", () => {
   });
 
   test("does not allow editor page path override when initial path is invalid", () => {
-    const editorValues = __testing__.getEditorCreatePageValues(
+    const editorValues = getEditorCreatePageValues(
       createValues({ path: "template" }),
       createValues({ path: "/edited" })
     );

--- a/apps/builder/app/builder/features/pages/template-settings.tsx
+++ b/apps/builder/app/builder/features/pages/template-settings.tsx
@@ -17,7 +17,6 @@ import {
   DialogTitleActions,
   TitleSuffixSpacer,
 } from "@webstudio-is/design-system";
-import { CopyIcon, TrashIcon } from "@webstudio-is/icons";
 import { $isContentMode, $isDesignMode } from "~/shared/nano-states";
 import { $instances, $pages } from "~/shared/sync/data-stores";
 import { isContentModePagePath } from "@webstudio-is/project/content-mode-permissions";
@@ -41,6 +40,8 @@ import {
 } from "./page-settings/page-settings";
 import type { Errors, OnChange } from "./page-settings/shared";
 import { useDraftValue } from "~/builder/shared/use-draft-value";
+import { copyTemplate } from "~/shared/copy-paste/copy-paste";
+import { PageItemActionsDropdown } from "./page-item-actions";
 
 const TemplateValues = z.object({
   name: PageName,
@@ -270,6 +271,9 @@ export const TemplateSettings = ({
   return (
     <TemplateSettingsView
       onClose={onClose}
+      onCopy={() => {
+        void copyTemplate(templateId);
+      }}
       onDelete={onDelete}
       onDuplicate={() => {
         const newId = duplicateTemplate(templateId);
@@ -288,11 +292,13 @@ export const TemplateSettings = ({
 };
 
 const TemplateSettingsView = ({
+  onCopy,
   onDelete,
   onDuplicate,
   onClose,
   children,
 }: {
+  onCopy: () => void;
   onDelete?: () => void;
   onDuplicate: () => void;
   onClose: () => void;
@@ -306,22 +312,14 @@ const TemplateSettingsView = ({
       disabled={!isDesignMode}
       suffix={
         <DialogTitleActions>
-          {isDesignMode && onDelete && (
-            <Button
-              color="ghost"
-              prefix={<TrashIcon />}
-              onClick={onDelete}
-              aria-label="Delete template"
-              tabIndex={2}
-            />
-          )}
           {isDesignMode && (
-            <Button
-              color="ghost"
-              prefix={<CopyIcon />}
-              onClick={onDuplicate}
-              aria-label="Duplicate template"
-              tabIndex={2}
+            <PageItemActionsDropdown
+              label="Template actions"
+              actions={{
+                copy: onCopy,
+                duplicate: onDuplicate,
+                delete: onDelete,
+              }}
             />
           )}
           <DialogClose />

--- a/apps/builder/app/builder/features/settings-panel/controls/url.test.ts
+++ b/apps/builder/app/builder/features/settings-panel/controls/url.test.ts
@@ -1,18 +1,20 @@
 import { describe, expect, test } from "vitest";
 import { __testing__ } from "./url";
 
+const { emailToProp, propToEmail } = __testing__;
+
 describe("email url control value", () => {
   test("preserves subject without email", () => {
-    expect(__testing__.emailToProp({ email: "", subject: "Hello" })).toEqual(
+    expect(emailToProp({ email: "", subject: "Hello" })).toEqual(
       "mailto:?subject=Hello"
     );
-    expect(__testing__.propToEmail("mailto:?subject=Hello")).toEqual({
+    expect(propToEmail("mailto:?subject=Hello")).toEqual({
       email: "",
       subject: "Hello",
     });
   });
 
   test("clears value when email and subject are empty", () => {
-    expect(__testing__.emailToProp({ email: "", subject: "" })).toEqual("");
+    expect(emailToProp({ email: "", subject: "" })).toEqual("");
   });
 });

--- a/apps/builder/app/builder/shared/commands.test.ts
+++ b/apps/builder/app/builder/shared/commands.test.ts
@@ -4,7 +4,10 @@ import type { Instance, PageTemplate } from "@webstudio-is/sdk";
 import {
   $editingPageId,
   $editingTemplateId,
+  $folderIdToDelete,
+  $pageIdToDelete,
   $selectedPageId,
+  $templateIdToDelete,
   selectPage,
 } from "~/shared/nano-states";
 import { $instances, $pages } from "~/shared/sync/data-stores";
@@ -19,7 +22,10 @@ const { canRunDesignModeCommand, guardDesignModeCommand } = __testing__;
 const resetPageActionStores = () => {
   $editingPageId.set(undefined);
   $editingTemplateId.set(undefined);
+  $folderIdToDelete.set(undefined);
+  $pageIdToDelete.set(undefined);
   $selectedPageId.set(undefined);
+  $templateIdToDelete.set(undefined);
   $instances.set(new Map());
   $pages.set(undefined);
 };
@@ -182,7 +188,54 @@ describe("getDeletablePageActionTarget", () => {
     $instances.set(new Map([[body.id, body]]));
     selectPage("page-id");
 
-    expect(getDeletablePageActionTarget()).toBe("page-id");
+    expect(getDeletablePageActionTarget()).toEqual({
+      type: "page",
+      id: "page-id",
+    });
+  });
+
+  test("returns open folder settings target", () => {
+    resetPageActionStores();
+    const pages = createDefaultPages({
+      homePageId: "home-page",
+      rootInstanceId: "home-root",
+    });
+    pages.folders.set("folder-id", {
+      id: "folder-id",
+      name: "Folder",
+      slug: "folder",
+      children: [],
+    });
+    $pages.set(pages);
+    $editingPageId.set("folder-id");
+
+    expect(getDeletablePageActionTarget()).toEqual({
+      type: "folder",
+      id: "folder-id",
+    });
+  });
+
+  test("returns open template settings target", () => {
+    resetPageActionStores();
+    const pages = createDefaultPages({
+      homePageId: "home-page",
+      rootInstanceId: "home-root",
+    });
+    const template: PageTemplate = {
+      id: "template-id",
+      name: "Template",
+      title: `"Template"`,
+      rootInstanceId: "template-root",
+      meta: {},
+    };
+    pages.pageTemplates = new Map([[template.id, template]]);
+    $pages.set(pages);
+    $editingTemplateId.set("template-id");
+
+    expect(getDeletablePageActionTarget()).toEqual({
+      type: "template",
+      id: "template-id",
+    });
   });
 
   test("does not return the home page", () => {

--- a/apps/builder/app/builder/shared/commands.test.ts
+++ b/apps/builder/app/builder/shared/commands.test.ts
@@ -8,11 +8,13 @@ import {
   selectPage,
 } from "~/shared/nano-states";
 import { $instances, $pages } from "~/shared/sync/data-stores";
-import { getDeletablePageActionTarget } from "~/shared/page-action-target";
+import {
+  getDeletablePageActionTarget,
+  getPageActionTarget,
+} from "~/shared/page-action-target";
 import { __testing__ } from "./commands";
 
-const { canRunDesignModeCommand, guardDesignModeCommand, getPageActionTarget } =
-  __testing__;
+const { canRunDesignModeCommand, guardDesignModeCommand } = __testing__;
 
 const resetPageActionStores = () => {
   $editingPageId.set(undefined);
@@ -112,6 +114,27 @@ describe("getPageActionTarget", () => {
       type: "template",
       id: "template-id",
     });
+  });
+
+  test("uses open page settings over stale template settings", () => {
+    resetPageActionStores();
+    const pages = createDefaultPages({
+      homePageId: "page-id",
+      rootInstanceId: "body-id",
+    });
+    const template: PageTemplate = {
+      id: "template-id",
+      name: "Template",
+      title: `"Template"`,
+      rootInstanceId: "template-root",
+      meta: {},
+    };
+    pages.pageTemplates = new Map([[template.id, template]]);
+    $pages.set(pages);
+    $editingTemplateId.set("template-id");
+    $editingPageId.set("page-id");
+
+    expect(getPageActionTarget()).toEqual({ type: "page", id: "page-id" });
   });
 
   test("uses the selected page root target", () => {

--- a/apps/builder/app/builder/shared/commands.test.ts
+++ b/apps/builder/app/builder/shared/commands.test.ts
@@ -1,7 +1,26 @@
 import { describe, expect, test } from "vitest";
+import { createDefaultPages } from "@webstudio-is/project-build";
+import type { Instance, PageTemplate } from "@webstudio-is/sdk";
+import {
+  $editingPageId,
+  $editingTemplateId,
+  $selectedPageId,
+  selectPage,
+} from "~/shared/nano-states";
+import { $instances, $pages } from "~/shared/sync/data-stores";
+import { getDeletablePageActionTarget } from "~/shared/page-action-target";
 import { __testing__ } from "./commands";
 
-const { canRunDesignModeCommand, guardDesignModeCommand } = __testing__;
+const { canRunDesignModeCommand, guardDesignModeCommand, getPageActionTarget } =
+  __testing__;
+
+const resetPageActionStores = () => {
+  $editingPageId.set(undefined);
+  $editingTemplateId.set(undefined);
+  $selectedPageId.set(undefined);
+  $instances.set(new Map());
+  $pages.set(undefined);
+};
 
 describe("canRunDesignModeCommand", () => {
   test("keeps design commands design-only", () => {
@@ -35,5 +54,130 @@ describe("guardDesignModeCommand", () => {
       })
     ).toBe(false);
     expect(messages).toEqual(["Blocked"]);
+  });
+});
+
+describe("getPageActionTarget", () => {
+  test("uses the open page settings target", () => {
+    resetPageActionStores();
+    const pages = createDefaultPages({
+      homePageId: "page-id",
+      rootInstanceId: "body-id",
+    });
+    $pages.set(pages);
+    $editingPageId.set("page-id");
+
+    expect(getPageActionTarget()).toEqual({ type: "page", id: "page-id" });
+  });
+
+  test("uses the open folder settings target", () => {
+    resetPageActionStores();
+    const pages = createDefaultPages({
+      homePageId: "page-id",
+      rootInstanceId: "body-id",
+    });
+    pages.folders.set("folder-id", {
+      id: "folder-id",
+      name: "Folder",
+      slug: "folder",
+      children: [],
+    });
+    $pages.set(pages);
+    $editingPageId.set("folder-id");
+
+    expect(getPageActionTarget()).toEqual({
+      type: "folder",
+      id: "folder-id",
+    });
+  });
+
+  test("uses the open template settings target", () => {
+    resetPageActionStores();
+    const pages = createDefaultPages({
+      homePageId: "page-id",
+      rootInstanceId: "body-id",
+    });
+    const template: PageTemplate = {
+      id: "template-id",
+      name: "Template",
+      title: `"Template"`,
+      rootInstanceId: "template-root",
+      meta: {},
+    };
+    pages.pageTemplates = new Map([[template.id, template]]);
+    $pages.set(pages);
+    $editingTemplateId.set("template-id");
+
+    expect(getPageActionTarget()).toEqual({
+      type: "template",
+      id: "template-id",
+    });
+  });
+
+  test("uses the selected page root target", () => {
+    resetPageActionStores();
+    const pages = createDefaultPages({
+      homePageId: "page-id",
+      rootInstanceId: "body-id",
+    });
+    const body: Instance = {
+      type: "instance",
+      id: "body-id",
+      component: "Body",
+      children: [],
+    };
+    $pages.set(pages);
+    $instances.set(new Map([[body.id, body]]));
+    selectPage("page-id");
+
+    expect(getPageActionTarget()).toEqual({ type: "page", id: "page-id" });
+  });
+});
+
+describe("getDeletablePageActionTarget", () => {
+  test("returns selected non-home page root", () => {
+    resetPageActionStores();
+    const pages = createDefaultPages({
+      homePageId: "home-page",
+      rootInstanceId: "home-root",
+    });
+    pages.pages.set("page-id", {
+      id: "page-id",
+      name: "Page",
+      path: "/page",
+      title: `"Page"`,
+      rootInstanceId: "body-id",
+      meta: {},
+    });
+    const body: Instance = {
+      type: "instance",
+      id: "body-id",
+      component: "Body",
+      children: [],
+    };
+    $pages.set(pages);
+    $instances.set(new Map([[body.id, body]]));
+    selectPage("page-id");
+
+    expect(getDeletablePageActionTarget()).toBe("page-id");
+  });
+
+  test("does not return the home page", () => {
+    resetPageActionStores();
+    const pages = createDefaultPages({
+      homePageId: "home-page",
+      rootInstanceId: "home-root",
+    });
+    const body: Instance = {
+      type: "instance",
+      id: "home-root",
+      component: "Body",
+      children: [],
+    };
+    $pages.set(pages);
+    $instances.set(new Map([[body.id, body]]));
+    selectPage("home-page");
+
+    expect(getDeletablePageActionTarget()).toBeUndefined();
   });
 });

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -170,7 +170,6 @@ const duplicatePageActionTarget = () => {
 export const __testing__ = {
   canRunDesignModeCommand,
   guardDesignModeCommand,
-  getPageActionTarget,
 };
 
 const requestSelectedPageDelete = () => {

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -1,14 +1,21 @@
 import { toast } from "@webstudio-is/design-system";
-import type { WebstudioFragment } from "@webstudio-is/sdk";
+import { type WebstudioFragment } from "@webstudio-is/sdk";
 import {
   isAutoGridPlacement,
   resetGridChildPlacement,
 } from "~/builder/features/style-panel/sections/layout/shared/grid-utils";
+import {
+  duplicateFolder,
+  duplicatePage,
+  duplicateTemplate,
+} from "~/builder/features/pages/page-utils";
 import { createCommandsEmitter, type Command } from "~/shared/commands-emitter";
 import {
   $editingItemSelector,
+  $editingPageId,
   $isDesignMode,
   $isPreviewMode,
+  $pageIdToDelete,
   toggleBuilderMode,
 } from "~/shared/nano-states";
 import { $project } from "~/shared/sync/data-stores";
@@ -43,7 +50,7 @@ import {
   toggleActiveSidebarPanel,
 } from "./nano-states";
 import { $selectedInstancePath } from "~/shared/nano-states";
-import { selectInstance } from "~/shared/nano-states";
+import { selectInstance, selectPage } from "~/shared/nano-states";
 import { openCommandPanel } from "../features/command-panel";
 import { showWrapComponentsList } from "../features/command-panel/groups/wrap-group";
 import { showConvertComponentsList } from "../features/command-panel/groups/convert-group";
@@ -60,11 +67,18 @@ import { openDeleteUnusedCssVariablesDialog } from "~/builder/shared/css-variabl
 import { openDeleteUnusedAssetsDialog } from "~/builder/shared/asset-manager/delete-unused-assets";
 import { openKeyboardShortcutsDialog } from "~/builder/features/keyboard-shortcuts-dialog";
 import {
+  copyFolder,
   copyInstance,
+  copyPage,
+  copyTemplate,
   emitPaste,
   cutInstance,
-} from "~/shared/copy-paste/init-copy-paste";
+} from "~/shared/copy-paste/copy-paste";
 import { toggleInstanceShow } from "~/shared/instance-utils";
+import {
+  getDeletablePageActionTarget,
+  getPageActionTarget,
+} from "~/shared/page-action-target";
 
 const makeBreakpointCommand = <CommandName extends string>(
   name: CommandName,
@@ -107,9 +121,68 @@ const guardDesignModeCommand = ({
   return false;
 };
 
+const copyPageActionTarget = () => {
+  if ($isDesignMode.get() === false) {
+    return false;
+  }
+  const target = getPageActionTarget();
+  if (target?.type === "page") {
+    void copyPage(target.id);
+    return true;
+  }
+  if (target?.type === "folder") {
+    void copyFolder(target.id);
+    return true;
+  }
+  if (target?.type === "template") {
+    void copyTemplate(target.id);
+    return true;
+  }
+  return false;
+};
+
+const duplicatePageActionTarget = () => {
+  const target = getPageActionTarget();
+  if (target?.type === "page") {
+    const newPageId = duplicatePage(target.id);
+    if (newPageId) {
+      selectPage(newPageId);
+    }
+    return true;
+  }
+  if (target?.type === "folder") {
+    const newFolderId = duplicateFolder(target.id);
+    if (newFolderId) {
+      $editingPageId.set(newFolderId);
+    }
+    return true;
+  }
+  if (target?.type === "template") {
+    const newTemplateId = duplicateTemplate(target.id);
+    if (newTemplateId) {
+      selectPage(newTemplateId);
+    }
+    return true;
+  }
+  return false;
+};
+
 export const __testing__ = {
   canRunDesignModeCommand,
   guardDesignModeCommand,
+  getPageActionTarget,
+};
+
+const requestSelectedPageDelete = () => {
+  if ($isDesignMode.get() === false) {
+    return false;
+  }
+  const pageId = getDeletablePageActionTarget();
+  if (pageId === undefined) {
+    return false;
+  }
+  $pageIdToDelete.set(pageId);
+  return true;
 };
 
 export const { emitCommand, subscribeCommands } = createCommandsEmitter({
@@ -341,9 +414,14 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
     makeBreakpointCommand("selectBreakpoint9", 9),
     {
       name: "copy",
-      description: "Copy selected instance",
+      description: "Copy selected page or instance",
       category: "Navigator",
-      handler: copyInstance,
+      handler: () => {
+        if (copyPageActionTarget()) {
+          return;
+        }
+        void copyInstance();
+      },
     },
     {
       name: "paste",
@@ -356,7 +434,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
             message: "Pasting is only allowed in design mode.",
           })
         ) {
-          emitPaste();
+          void emitPaste();
         }
       },
     },
@@ -371,7 +449,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
             message: "Cutting is only allowed in design mode.",
           })
         ) {
-          cutInstance();
+          void cutInstance();
         }
       },
     },
@@ -396,18 +474,23 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
     },
     {
       name: "deleteInstanceBuilder",
-      label: "Delete Instance",
-      description: "Delete selected instance",
+      label: "Delete",
+      description: "Delete selected page or instance",
       category: "Navigator",
       defaultHotkeys: ["backspace", "delete"],
       // See "deleteInstanceCanvas" for details on why the command is separated for the canvas and builder.
       disableHotkeyOutsideApp: true,
       disableOnInputLikeControls: true,
-      handler: deleteSelectedInstance,
+      handler: () => {
+        if (requestSelectedPageDelete()) {
+          return;
+        }
+        deleteSelectedInstance();
+      },
     },
     {
       name: "duplicateInstance",
-      description: "Duplicate selected instance",
+      description: "Duplicate selected page or instance",
       category: "Navigator",
       defaultHotkeys: ["meta+d", "ctrl+d"],
       handler: () => {
@@ -421,6 +504,9 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
             message: "Duplicating is only allowed in design mode.",
           }) === false
         ) {
+          return;
+        }
+        if (duplicatePageActionTarget()) {
           return;
         }
         const instancePath = $selectedInstancePath.get();

--- a/apps/builder/app/builder/shared/commands.ts
+++ b/apps/builder/app/builder/shared/commands.ts
@@ -13,9 +13,11 @@ import { createCommandsEmitter, type Command } from "~/shared/commands-emitter";
 import {
   $editingItemSelector,
   $editingPageId,
+  $folderIdToDelete,
   $isDesignMode,
   $isPreviewMode,
   $pageIdToDelete,
+  $templateIdToDelete,
   toggleBuilderMode,
 } from "~/shared/nano-states";
 import { $project } from "~/shared/sync/data-stores";
@@ -172,15 +174,26 @@ export const __testing__ = {
   guardDesignModeCommand,
 };
 
-const requestSelectedPageDelete = () => {
+const requestSelectedPageItemDelete = () => {
   if ($isDesignMode.get() === false) {
     return false;
   }
-  const pageId = getDeletablePageActionTarget();
-  if (pageId === undefined) {
+  const target = getDeletablePageActionTarget();
+  if (target === undefined) {
     return false;
   }
-  $pageIdToDelete.set(pageId);
+  $pageIdToDelete.set(undefined);
+  $folderIdToDelete.set(undefined);
+  $templateIdToDelete.set(undefined);
+  if (target.type === "page") {
+    $pageIdToDelete.set(target.id);
+  }
+  if (target.type === "folder") {
+    $folderIdToDelete.set(target.id);
+  }
+  if (target.type === "template") {
+    $templateIdToDelete.set(target.id);
+  }
   return true;
 };
 
@@ -481,7 +494,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       disableHotkeyOutsideApp: true,
       disableOnInputLikeControls: true,
       handler: () => {
-        if (requestSelectedPageDelete()) {
+        if (requestSelectedPageItemDelete()) {
           return;
         }
         deleteSelectedInstance();

--- a/apps/builder/app/builder/shared/css-variable-utils.tsx
+++ b/apps/builder/app/builder/shared/css-variable-utils.tsx
@@ -505,6 +505,7 @@ export const DeleteCssVariableDialog = ({
         </Flex>
         <DialogActions>
           <Button
+            autoFocus
             color="destructive"
             onClick={() => {
               onConfirm(cssVariable!.property);

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -59,7 +59,7 @@ import { useDragAndDrop } from "./shared/use-drag-drop";
 import {
   initCopyPaste,
   initCopyPasteForContentEditMode,
-} from "~/shared/copy-paste/init-copy-paste";
+} from "~/shared/copy-paste/copy-paste";
 import { inflateInstance, subscribeInflator } from "./inflator";
 import { useWindowResizeDebounced } from "~/shared/dom-hooks";
 import { subscribeInstanceSelection } from "./instance-selection";

--- a/apps/builder/app/canvas/shared/commands.ts
+++ b/apps/builder/app/canvas/shared/commands.ts
@@ -21,10 +21,20 @@ import { selectInstance } from "~/shared/nano-states";
 import { isDescendantOrSelf, type InstanceSelector } from "~/shared/tree-utils";
 import { deleteSelectedInstance } from "~/shared/instance-utils";
 import { findClosestRichText } from "~/shared/content-model";
+import { getDeletablePageActionTarget } from "~/shared/page-action-target";
+
+const deleteSelectedPageOrInstance = () => {
+  if (getDeletablePageActionTarget() !== undefined) {
+    emitCommand("deleteInstanceBuilder");
+    return;
+  }
+
+  deleteSelectedInstance();
+};
 
 export const { emitCommand, subscribeCommands } = createCommandsEmitter({
   source: "canvas",
-  externalCommands: ["clickCanvas"],
+  externalCommands: ["clickCanvas", "deleteInstanceBuilder"],
   commands: [
     {
       name: "deleteInstanceCanvas",
@@ -34,7 +44,7 @@ export const { emitCommand, subscribeCommands } = createCommandsEmitter({
       disableHotkeyOutsideApp: true,
       // We are not disabling "Backspace" or "Delete" on the canvas. This is the main reason we have separate functions: deleteInstanceCanvas and deleteInstanceBuilder.
       disableOnInputLikeControls: false,
-      handler: deleteSelectedInstance,
+      handler: deleteSelectedPageOrInstance,
     },
 
     {

--- a/apps/builder/app/shared/copy-paste/copy-paste.test.ts
+++ b/apps/builder/app/shared/copy-paste/copy-paste.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { enableMapSet } from "immer";
+import { createDefaultPages } from "@webstudio-is/project-build";
+import type { Instance } from "@webstudio-is/sdk";
+import { registerContainers } from "../sync/sync-stores";
+import {
+  $assets,
+  $breakpoints,
+  $dataSources,
+  $instances,
+  $pages,
+  $props,
+  $resources,
+  $styleSourceSelections,
+  $styleSources,
+  $styles,
+} from "../sync/data-stores";
+import { $authTokenPermissions } from "../nano-states";
+import { copyPage } from "./copy-paste";
+
+enableMapSet();
+registerContainers();
+
+const resetStores = () => {
+  $authTokenPermissions.set({
+    canClone: true,
+    canCopy: true,
+    canPublish: false,
+  });
+  $instances.set(new Map());
+  $props.set(new Map());
+  $dataSources.set(new Map());
+  $resources.set(new Map());
+  $breakpoints.set(new Map());
+  $styleSourceSelections.set(new Map());
+  $styleSources.set(new Map());
+  $styles.set(new Map());
+  $assets.set(new Map());
+};
+
+const setupPage = () => {
+  const pages = createDefaultPages({
+    homePageId: "page-id",
+    rootInstanceId: "body-id",
+  });
+  $pages.set(pages);
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "body-id",
+        {
+          type: "instance",
+          id: "body-id",
+          component: "Body",
+          children: [],
+        },
+      ],
+    ])
+  );
+};
+
+afterEach(() => {
+  resetStores();
+  vi.unstubAllGlobals();
+});
+
+test("does not copy page to clipboard when copy permission is disabled", async () => {
+  resetStores();
+  setupPage();
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  vi.stubGlobal("navigator", {
+    ...navigator,
+    clipboard: { writeText },
+  });
+  $authTokenPermissions.set({
+    canClone: true,
+    canCopy: false,
+    canPublish: false,
+  });
+
+  await copyPage("page-id");
+
+  expect(writeText).not.toHaveBeenCalled();
+});

--- a/apps/builder/app/shared/copy-paste/copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/copy-paste.ts
@@ -4,6 +4,13 @@ import {
   $textEditingInstanceSelector,
 } from "../nano-states";
 import { instanceText, instanceJson } from "./plugin-instance";
+import {
+  pageText,
+  copyFolderData,
+  copyPageData,
+  copyTemplateData,
+  handlePastePage,
+} from "./plugin-page";
 import { html } from "./plugin-html";
 import { markdown } from "./plugin-markdown";
 import { webflow } from "./plugin-webflow/plugin-webflow";
@@ -56,6 +63,10 @@ const validateClipboardEvent = (event: ClipboardEvent) => {
     }
   }
 
+  return validateCopyPermission();
+};
+
+const validateCopyPermission = () => {
   if ($authTokenPermissions.get().canCopy === false) {
     toastError("Copying has been disabled by the project owner");
     return false;
@@ -134,7 +145,7 @@ const initPlugins = ({
 
 export const initCopyPaste = ({ signal }: { signal: AbortSignal }) => {
   initPlugins({
-    plugins: [instanceJson, instanceText, html, markdown, webflow],
+    plugins: [pageText, instanceJson, instanceText, html, markdown, webflow],
     signal,
   });
 };
@@ -164,12 +175,33 @@ export const initCopyPasteForContentEditMode = ({
   });
 };
 
+const writeClipboardText = (data: string | undefined) => {
+  if (data && validateCopyPermission()) {
+    return navigator.clipboard.writeText(data);
+  }
+  return Promise.resolve();
+};
+
 // Public API for programmatic copy/paste/cut operations
 export const copyInstance = () => {
-  const data = instanceText.onCopy?.();
-  if (data) {
-    navigator.clipboard.writeText(data);
-  }
+  return writeClipboardText(instanceText.onCopy?.());
+};
+
+export const copyPage = (pageId: string) => {
+  return writeClipboardText(copyPageData(pageId));
+};
+
+export const copyFolder = (folderId: string) => {
+  return writeClipboardText(copyFolderData(folderId));
+};
+
+export const copyTemplate = (templateId: string) => {
+  return writeClipboardText(copyTemplateData(templateId));
+};
+
+export const pastePage = async (targetFolderId?: string) => {
+  const text = await navigator.clipboard.readText();
+  return handlePastePage(text, targetFolderId);
 };
 
 export const emitPaste = async () => {
@@ -189,8 +221,5 @@ export const emitPaste = async () => {
 };
 
 export const cutInstance = () => {
-  const data = instanceText.onCut?.();
-  if (data) {
-    navigator.clipboard.writeText(data);
-  }
+  return writeClipboardText(instanceText.onCut?.());
 };

--- a/apps/builder/app/shared/copy-paste/plugin-html.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-html.ts
@@ -3,33 +3,35 @@ import { generateFragmentFromHtml } from "../html";
 import { insertWebstudioFragmentAt } from "../instance-utils";
 import { generateFragmentFromTailwind } from "../tailwind/tailwind";
 import { denormalizeSrcProps } from "./asset-upload";
-import type { Plugin } from "./init-copy-paste";
+import type { Plugin } from "./copy-paste";
 import { builderApi } from "../builder-api";
 import { breakpointPasteLimitWarning } from "../breakpoints";
 
 const inceptionMark = `<!-- @webstudio/inception/1 -->`;
 
+const handlePasteHtml = async (html: string) => {
+  const parseResult = generateFragmentFromHtml(html);
+  const { skippedSelectors } = parseResult;
+  let fragment: WebstudioFragment = parseResult;
+  fragment = await denormalizeSrcProps(fragment);
+  if (html.includes(inceptionMark)) {
+    fragment = await generateFragmentFromTailwind(fragment);
+  }
+  const result = insertWebstudioFragmentAt(fragment, undefined, undefined, {
+    onBreakpointLimitMerge: () => {
+      builderApi.toast.warn(breakpointPasteLimitWarning);
+    },
+  });
+  if (skippedSelectors.length > 0) {
+    builderApi.toast.info(
+      `Skipped nested selectors (no matching elements): ${skippedSelectors.join(", ")}`
+    );
+  }
+  return result;
+};
+
 export const html: Plugin = {
   name: "html",
   mimeType: "text/plain",
-  onPaste: async (html: string) => {
-    const parseResult = generateFragmentFromHtml(html);
-    const { skippedSelectors } = parseResult;
-    let fragment: WebstudioFragment = parseResult;
-    fragment = await denormalizeSrcProps(fragment);
-    if (html.includes(inceptionMark)) {
-      fragment = await generateFragmentFromTailwind(fragment);
-    }
-    const result = insertWebstudioFragmentAt(fragment, undefined, undefined, {
-      onBreakpointLimitMerge: () => {
-        builderApi.toast.warn(breakpointPasteLimitWarning);
-      },
-    });
-    if (skippedSelectors.length > 0) {
-      builderApi.toast.info(
-        `Skipped nested selectors (no matching elements): ${skippedSelectors.join(", ")}`
-      );
-    }
-    return result;
-  },
+  onPaste: handlePasteHtml,
 };

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -28,7 +28,7 @@ import {
 } from "~/shared/nano-states";
 import { findAvailableVariables } from "../data-variables";
 import { builderApi } from "../builder-api";
-import type { Plugin } from "./init-copy-paste";
+import type { Plugin } from "./copy-paste";
 import { breakpointPasteLimitWarning } from "../breakpoints";
 
 const version = "@webstudio/instance/v0.1";
@@ -161,7 +161,7 @@ const findPasteTarget = (data: InstanceData): undefined | Insertable => {
   return insertable;
 };
 
-const onPaste = async (clipboardData: string) => {
+const handlePasteInstance = async (clipboardData: string) => {
   const project = $project.get();
   const fragment = parse(clipboardData);
   if (fragment === undefined || project === undefined) {
@@ -210,7 +210,7 @@ const onPaste = async (clipboardData: string) => {
   return true;
 };
 
-const onCopy = () => {
+const handleCopyInstance = () => {
   const selectedInstanceSelector = $selectedInstanceSelector.get();
   if (selectedInstanceSelector === undefined) {
     return;
@@ -222,7 +222,7 @@ const onCopy = () => {
   return stringify(data);
 };
 
-const onCut = () => {
+const handleCutInstance = () => {
   const instancePath = $selectedInstancePath.get();
   if (instancePath === undefined) {
     return;
@@ -247,13 +247,13 @@ const onCut = () => {
 export const instanceText: Plugin = {
   name: "instance-text",
   mimeType: "text/plain",
-  onCopy,
-  onCut,
-  onPaste,
+  onCopy: handleCopyInstance,
+  onCut: handleCutInstance,
+  onPaste: handlePasteInstance,
 };
 
 export const instanceJson: Plugin = {
   name: "instance-json",
   mimeType: "application/json",
-  onPaste,
+  onPaste: handlePasteInstance,
 };

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.ts
@@ -3,7 +3,7 @@ import { micromark } from "micromark";
 import { insertWebstudioFragmentAt } from "../instance-utils";
 import { denormalizeSrcProps } from "./asset-upload";
 import { generateFragmentFromHtml } from "../html";
-import type { Plugin } from "./init-copy-paste";
+import type { Plugin } from "./copy-paste";
 import { builderApi } from "../builder-api";
 import { breakpointPasteLimitWarning } from "../breakpoints";
 
@@ -25,21 +25,23 @@ const parse = (clipboardData: string) => {
   return fragment;
 };
 
+const handlePasteMarkdown = async (clipboardData: string) => {
+  let fragment = parse(clipboardData);
+  if (fragment === undefined) {
+    return false;
+  }
+  fragment = await denormalizeSrcProps(fragment);
+  return insertWebstudioFragmentAt(fragment, undefined, undefined, {
+    onBreakpointLimitMerge: () => {
+      builderApi.toast.warn(breakpointPasteLimitWarning);
+    },
+  });
+};
+
 export const markdown: Plugin = {
   name: "markdown",
   mimeType: "text/plain",
-  onPaste: async (clipboardData: string) => {
-    let fragment = parse(clipboardData);
-    if (fragment === undefined) {
-      return false;
-    }
-    fragment = await denormalizeSrcProps(fragment);
-    return insertWebstudioFragmentAt(fragment, undefined, undefined, {
-      onBreakpointLimitMerge: () => {
-        builderApi.toast.warn(breakpointPasteLimitWarning);
-      },
-    });
-  },
+  onPaste: handlePasteMarkdown,
 };
 
 export const __testing__ = {

--- a/apps/builder/app/shared/copy-paste/plugin-page.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.test.ts
@@ -1,0 +1,469 @@
+import { expect, test } from "vitest";
+import { enableMapSet } from "immer";
+import { createDefaultPages } from "@webstudio-is/project-build";
+import {
+  encodeDataSourceVariable,
+  ROOT_FOLDER_ID,
+  type DataSource,
+  type Instance,
+} from "@webstudio-is/sdk";
+import type { Project } from "@webstudio-is/project";
+import { registerContainers } from "../sync/sync-stores";
+import {
+  $assets,
+  $breakpoints,
+  $dataSources,
+  $instances,
+  $pages,
+  $project,
+  $props,
+  $resources,
+  $styleSourceSelections,
+  $styleSources,
+  $styles,
+} from "../sync/data-stores";
+import {
+  $editingPageId,
+  $editingTemplateId,
+  $selectedInstanceSelector,
+  $selectedPageId,
+} from "../nano-states";
+import {
+  copyFolderData,
+  copyPageData,
+  copyTemplateData,
+  handlePastePage,
+  pageText,
+} from "./plugin-page";
+
+enableMapSet();
+registerContainers();
+
+const resetBuildStores = () => {
+  $instances.set(new Map());
+  $props.set(new Map());
+  $dataSources.set(new Map());
+  $resources.set(new Map());
+  $breakpoints.set(new Map());
+  $styleSourceSelections.set(new Map());
+  $styleSources.set(new Map());
+  $styles.set(new Map());
+  $assets.set(new Map());
+  $editingPageId.set(undefined);
+  $editingTemplateId.set(undefined);
+  $selectedInstanceSelector.set(undefined);
+  $selectedPageId.set(undefined);
+};
+
+test("copies the selected page root from the copy plugin", () => {
+  $project.set({ id: "source-project" } as Project);
+  resetBuildStores();
+
+  const pages = createDefaultPages({
+    homePageId: "source-page",
+    rootInstanceId: "source-root",
+  });
+  const page = pages.pages.get("source-page");
+  if (page === undefined) {
+    throw new Error("Expected source page");
+  }
+  page.name = "Selected Page";
+  $pages.set(pages);
+  $selectedPageId.set("source-page");
+  $selectedInstanceSelector.set(["source-root"]);
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "source-root",
+        {
+          type: "instance",
+          id: "source-root",
+          component: "Body",
+          children: [],
+        },
+      ],
+    ])
+  );
+
+  expect(pageText.onCopy?.()).toContain('"type":"page"');
+  expect(pageText.onCopy?.()).toContain('"name":"Selected Page"');
+});
+
+test("copies the edited folder from the copy plugin", () => {
+  $project.set({ id: "source-project" } as Project);
+  resetBuildStores();
+
+  const pages = createDefaultPages({
+    homePageId: "source-page",
+    rootInstanceId: "source-root",
+  });
+  pages.folders.set("source-folder", {
+    id: "source-folder",
+    name: "Edited Folder",
+    slug: "edited-folder",
+    children: [],
+  });
+  $pages.set(pages);
+  $editingPageId.set("source-folder");
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "source-root",
+        {
+          type: "instance",
+          id: "source-root",
+          component: "Body",
+          children: [],
+        },
+      ],
+    ])
+  );
+
+  expect(pageText.onCopy?.()).toContain('"type":"folder"');
+  expect(pageText.onCopy?.()).toContain('"name":"Edited Folder"');
+});
+
+test("copies page data across projects", async () => {
+  $project.set({ id: "source-project" } as Project);
+  resetBuildStores();
+
+  const sourcePages = createDefaultPages({
+    homePageId: "source-page",
+    rootInstanceId: "source-root",
+  });
+  const variable: DataSource = {
+    id: "source-variable",
+    scopeInstanceId: "source-root",
+    name: "title",
+    type: "variable",
+    value: { type: "string", value: "" },
+  };
+  const variableName = encodeDataSourceVariable(variable.id);
+  const sourcePage = sourcePages.pages.get("source-page");
+  if (sourcePage === undefined) {
+    throw new Error("Expected source page");
+  }
+  sourcePage.name = "Landing";
+  sourcePage.path = "/landing";
+  sourcePage.title = `"Landing " + ${variableName}`;
+  sourcePage.meta.description = `"Description " + ${variableName}`;
+
+  $pages.set(sourcePages);
+  $selectedPageId.set(sourcePages.homePageId);
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "source-root",
+        {
+          type: "instance",
+          id: "source-root",
+          component: "Body",
+          children: [],
+        },
+      ],
+    ])
+  );
+  $dataSources.set(new Map([[variable.id, variable]]));
+
+  const clipboardData = copyPageData("source-page");
+  expect(clipboardData).toBeDefined();
+
+  $project.set({ id: "target-project" } as Project);
+  resetBuildStores();
+  const targetPages = createDefaultPages({
+    homePageId: "target-page",
+    rootInstanceId: "target-root",
+  });
+  $pages.set(targetPages);
+  $selectedPageId.set(targetPages.homePageId);
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "target-root",
+        {
+          type: "instance",
+          id: "target-root",
+          component: "Body",
+          children: [],
+        },
+      ],
+    ])
+  );
+
+  await handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID);
+
+  const pastedPage = Array.from($pages.get()?.pages.values() ?? []).find(
+    (page) => page.name === "Landing"
+  );
+  expect(pastedPage).toEqual({
+    id: expect.any(String),
+    name: "Landing",
+    path: "/landing",
+    title: expect.stringContaining("$ws$dataSource$"),
+    rootInstanceId: expect.not.stringMatching("source-root"),
+    meta: {
+      description: expect.stringContaining("$ws$dataSource$"),
+    },
+  });
+  expect($instances.get().has(pastedPage?.rootInstanceId ?? "")).toBe(true);
+  expect($dataSources.get().has("source-variable")).toBe(false);
+});
+
+test("copies folder data with nested pages across projects", async () => {
+  $project.set({ id: "source-project" } as Project);
+  resetBuildStores();
+
+  const sourcePages = createDefaultPages({
+    homePageId: "source-home",
+    rootInstanceId: "source-home-root",
+  });
+  sourcePages.folders.set("source-folder", {
+    id: "source-folder",
+    name: "Docs",
+    slug: "docs",
+    children: ["source-page-a", "source-subfolder"],
+  });
+  sourcePages.folders.set("source-subfolder", {
+    id: "source-subfolder",
+    name: "Nested",
+    slug: "nested",
+    children: ["source-page-b"],
+  });
+  sourcePages.folders
+    .get(sourcePages.rootFolderId)
+    ?.children.push("source-folder");
+  sourcePages.pages.set("source-page-a", {
+    id: "source-page-a",
+    name: "Overview",
+    path: "/overview",
+    title: `"Overview"`,
+    rootInstanceId: "source-page-a-root",
+    meta: {},
+  });
+  sourcePages.pages.set("source-page-b", {
+    id: "source-page-b",
+    name: "Details",
+    path: "/details",
+    title: `"Details"`,
+    rootInstanceId: "source-page-b-root",
+    meta: {},
+  });
+
+  $pages.set(sourcePages);
+  $selectedPageId.set(sourcePages.homePageId);
+  $instances.set(
+    new Map<Instance["id"], Instance>(
+      ["source-home-root", "source-page-a-root", "source-page-b-root"].map(
+        (id) => [
+          id,
+          {
+            type: "instance",
+            id,
+            component: "Body",
+            children: [],
+          },
+        ]
+      )
+    )
+  );
+
+  const clipboardData = copyFolderData("source-folder");
+  expect(clipboardData).toBeDefined();
+
+  $project.set({ id: "target-project" } as Project);
+  resetBuildStores();
+  const targetPages = createDefaultPages({
+    homePageId: "target-home",
+    rootInstanceId: "target-home-root",
+  });
+  $pages.set(targetPages);
+  $selectedPageId.set(targetPages.homePageId);
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "target-home-root",
+        {
+          type: "instance",
+          id: "target-home-root",
+          component: "Body",
+          children: [],
+        },
+      ],
+    ])
+  );
+
+  await handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID);
+
+  const pastedFolder = Array.from($pages.get()?.folders.values() ?? []).find(
+    (folder) => folder.name === "Docs"
+  );
+  expect(pastedFolder).toBeDefined();
+  const pastedSubfolder = Array.from($pages.get()?.folders.values() ?? []).find(
+    (folder) => folder.name === "Nested"
+  );
+  expect(pastedSubfolder).toBeDefined();
+  const pastedPages = Array.from($pages.get()?.pages.values() ?? []).filter(
+    (page) => page.name === "Overview" || page.name === "Details"
+  );
+  expect(pastedPages).toHaveLength(2);
+  for (const page of pastedPages) {
+    expect(page.rootInstanceId).not.toMatch(/^source-/);
+    expect($instances.get().has(page.rootInstanceId)).toBe(true);
+  }
+});
+
+test("preserves empty folder slugs when pasting folder data", async () => {
+  $project.set({ id: "source-project" } as Project);
+  resetBuildStores();
+
+  const sourcePages = createDefaultPages({
+    homePageId: "source-home",
+    rootInstanceId: "source-home-root",
+  });
+  sourcePages.folders.set("source-folder", {
+    id: "source-folder",
+    name: "Empty Slug Folder",
+    slug: "",
+    children: [],
+  });
+  sourcePages.folders
+    .get(sourcePages.rootFolderId)
+    ?.children.push("source-folder");
+  $pages.set(sourcePages);
+  $selectedPageId.set(sourcePages.homePageId);
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "source-home-root",
+        {
+          type: "instance",
+          id: "source-home-root",
+          component: "Body",
+          children: [],
+        },
+      ],
+    ])
+  );
+
+  const clipboardData = copyFolderData("source-folder");
+  expect(clipboardData).toBeDefined();
+
+  $project.set({ id: "target-project" } as Project);
+  resetBuildStores();
+  const targetPages = createDefaultPages({
+    homePageId: "target-home",
+    rootInstanceId: "target-home-root",
+  });
+  targetPages.folders.set("existing-empty-slug-folder", {
+    id: "existing-empty-slug-folder",
+    name: "Existing Empty Slug Folder",
+    slug: "",
+    children: [],
+  });
+  targetPages.folders
+    .get(targetPages.rootFolderId)
+    ?.children.push("existing-empty-slug-folder");
+  $pages.set(targetPages);
+  $selectedPageId.set(targetPages.homePageId);
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "target-home-root",
+        {
+          type: "instance",
+          id: "target-home-root",
+          component: "Body",
+          children: [],
+        },
+      ],
+    ])
+  );
+
+  await handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID);
+
+  const pastedFolder = Array.from($pages.get()?.folders.values() ?? []).find(
+    (folder) => folder.name === "Empty Slug Folder"
+  );
+  expect(pastedFolder?.slug).toBe("");
+});
+
+test("copies template data as a template", async () => {
+  $project.set({ id: "source-project" } as Project);
+  resetBuildStores();
+
+  const sourcePages = createDefaultPages({
+    homePageId: "source-home",
+    rootInstanceId: "source-home-root",
+  });
+  sourcePages.pageTemplates = new Map([
+    [
+      "template-id",
+      {
+        id: "template-id",
+        name: "Landing Template",
+        title: `"Landing title"`,
+        rootInstanceId: "template-root",
+        meta: { description: `"Template description"` },
+      },
+    ],
+  ]);
+  $pages.set(sourcePages);
+  $selectedPageId.set(sourcePages.homePageId);
+  $instances.set(
+    new Map<Instance["id"], Instance>(
+      ["source-home-root", "template-root"].map((id) => [
+        id,
+        {
+          type: "instance",
+          id,
+          component: "Body",
+          children: [],
+        },
+      ])
+    )
+  );
+
+  const clipboardData = copyTemplateData("template-id");
+  expect(clipboardData).toBeDefined();
+
+  $project.set({ id: "target-project" } as Project);
+  resetBuildStores();
+  const targetPages = createDefaultPages({
+    homePageId: "target-home",
+    rootInstanceId: "target-home-root",
+  });
+  $pages.set(targetPages);
+  $selectedPageId.set(targetPages.homePageId);
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "target-home-root",
+        {
+          type: "instance",
+          id: "target-home-root",
+          component: "Body",
+          children: [],
+        },
+      ],
+    ])
+  );
+
+  await handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID);
+
+  const pastedTemplate = Array.from(
+    $pages.get()?.pageTemplates?.values() ?? []
+  ).find((template) => template.name === "Landing Template");
+  expect(pastedTemplate).toEqual({
+    id: expect.any(String),
+    name: "Landing Template",
+    title: `"Landing title"`,
+    rootInstanceId: expect.any(String),
+    meta: { description: `"Template description"` },
+  });
+  expect(pastedTemplate?.rootInstanceId).not.toBe("template-root");
+
+  const pastedPage = Array.from($pages.get()?.pages.values() ?? []).find(
+    (page) => page.name === "Landing Template"
+  );
+  expect(pastedPage).toBeUndefined();
+});

--- a/apps/builder/app/shared/copy-paste/plugin-page.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.test.ts
@@ -209,7 +209,7 @@ test("copies page data across projects", async () => {
   expect($dataSources.get().has("source-variable")).toBe(false);
 });
 
-test("reports page paste failure when insertion cannot complete", async () => {
+test("handles page paste data without falling through when insertion cannot complete", async () => {
   $project.set({ id: "source-project" } as Project);
   resetBuildStores();
 
@@ -261,8 +261,14 @@ test("reports page paste failure when insertion cannot complete", async () => {
 
   await expect(
     handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID)
-  ).resolves.toBe(false);
+  ).resolves.toBe(true);
   expect($pages.get()?.pages.size).toBe(initialPageCount);
+});
+
+test("ignores non-page paste data", async () => {
+  await expect(handlePastePage("plain text", ROOT_FOLDER_ID)).resolves.toBe(
+    false
+  );
 });
 
 test("copies folder data with nested pages across projects", async () => {

--- a/apps/builder/app/shared/copy-paste/plugin-page.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.test.ts
@@ -209,6 +209,62 @@ test("copies page data across projects", async () => {
   expect($dataSources.get().has("source-variable")).toBe(false);
 });
 
+test("reports page paste failure when insertion cannot complete", async () => {
+  $project.set({ id: "source-project" } as Project);
+  resetBuildStores();
+
+  const sourcePages = createDefaultPages({
+    homePageId: "source-page",
+    rootInstanceId: "source-root",
+  });
+  $pages.set(sourcePages);
+  $selectedPageId.set(sourcePages.homePageId);
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "source-root",
+        {
+          type: "instance",
+          id: "source-root",
+          component: "Body",
+          children: [],
+        },
+      ],
+    ])
+  );
+
+  const clipboardData = copyPageData("source-page");
+  expect(clipboardData).toBeDefined();
+
+  resetBuildStores();
+  $project.set(undefined);
+  const targetPages = createDefaultPages({
+    homePageId: "target-page",
+    rootInstanceId: "target-root",
+  });
+  const initialPageCount = targetPages.pages.size;
+  $pages.set(targetPages);
+  $selectedPageId.set(targetPages.homePageId);
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "target-root",
+        {
+          type: "instance",
+          id: "target-root",
+          component: "Body",
+          children: [],
+        },
+      ],
+    ])
+  );
+
+  await expect(
+    handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID)
+  ).resolves.toBe(false);
+  expect($pages.get()?.pages.size).toBe(initialPageCount);
+});
+
 test("copies folder data with nested pages across projects", async () => {
   $project.set({ id: "source-project" } as Project);
   resetBuildStores();

--- a/apps/builder/app/shared/copy-paste/plugin-page.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.ts
@@ -259,12 +259,13 @@ export const handlePastePage = async (
             ? "Template pasted"
             : "Folder pasted"
       );
+      return true;
     }
   } catch {
     return false;
   }
 
-  return true;
+  return false;
 };
 
 export const pageText: Plugin = {

--- a/apps/builder/app/shared/copy-paste/plugin-page.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.ts
@@ -200,14 +200,18 @@ export const handlePastePage = async (
   targetFolderId?: Folder["id"]
 ) => {
   const item = parse(clipboardData);
-  const pages = $pages.get();
-  if (item === undefined || pages === undefined) {
+  if (item === undefined) {
     return false;
   }
 
+  const pages = $pages.get();
   const folderId = targetFolderId ?? getDefaultTargetFolderId();
-  if (folderId === undefined || pages.folders.has(folderId) === false) {
-    return false;
+  if (
+    pages === undefined ||
+    folderId === undefined ||
+    pages.folders.has(folderId) === false
+  ) {
+    return true;
   }
 
   try {
@@ -262,10 +266,10 @@ export const handlePastePage = async (
       return true;
     }
   } catch {
-    return false;
+    return true;
   }
 
-  return false;
+  return true;
 };
 
 export const pageText: Plugin = {

--- a/apps/builder/app/shared/copy-paste/plugin-page.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.ts
@@ -1,0 +1,275 @@
+import { z } from "zod";
+import { toast } from "@webstudio-is/design-system";
+import {
+  WebstudioFragment,
+  findPageByIdOrPath,
+  findParentFolderByChildId,
+  type Folder,
+  type Page,
+  type PageTemplate,
+} from "@webstudio-is/sdk";
+import { $pages } from "~/shared/sync/data-stores";
+import {
+  detectFragmentTokenConflicts,
+  getWebstudioData,
+  updateWebstudioData,
+} from "../instance-utils";
+import { builderApi } from "../builder-api";
+import {
+  createFolderCopyData,
+  createPageCopyData,
+  createTemplateCopyData,
+  insertFolderCopyFromDataMutable,
+  insertPageCopyFromFragmentsMutable,
+  insertTemplateCopyFromFragmentsMutable,
+  type FolderCopyData,
+  type PageCopyData,
+  type TemplateCopyData,
+} from "../page-utils";
+import { $selectedPage } from "../nano-states";
+import { getPageActionTarget } from "../page-action-target";
+import type { Plugin } from "./copy-paste";
+import { breakpointPasteLimitWarning } from "../breakpoints";
+
+const version = "@webstudio/page/v0.1";
+
+type PageData = PageCopyData & { type: "page" };
+
+type TemplateData = TemplateCopyData & { type: "template" };
+
+type FolderData = Omit<FolderCopyData, "children"> & {
+  type: "folder";
+  children: Array<PageData | FolderData>;
+};
+
+const PageData: z.ZodType<PageData> = z.object({
+  type: z.literal("page"),
+  page: z.custom<Page>(),
+  rootFragment: WebstudioFragment,
+  bodyFragment: WebstudioFragment,
+});
+
+const TemplateData: z.ZodType<TemplateData> = z.object({
+  type: z.literal("template"),
+  template: z.custom<PageTemplate>(),
+  rootFragment: WebstudioFragment,
+  bodyFragment: WebstudioFragment,
+});
+
+const FolderData: z.ZodType<FolderData> = z.lazy(() =>
+  z.object({
+    type: z.literal("folder"),
+    folder: z.custom<Folder>(),
+    children: z.array(z.union([PageData, FolderData])),
+  })
+);
+
+const ClipboardItem = z.union([PageData, TemplateData, FolderData]);
+
+type ClipboardItem = z.infer<typeof ClipboardItem>;
+
+const ClipboardData = z.object({ [version]: ClipboardItem });
+
+const stringify = (data: ClipboardItem) => {
+  return JSON.stringify({ [version]: data });
+};
+
+const parse = (clipboardData: string): ClipboardItem | undefined => {
+  try {
+    const data = ClipboardData.parse(JSON.parse(clipboardData));
+    return data[version];
+  } catch {
+    return;
+  }
+};
+
+const getDefaultTargetFolderId = () => {
+  const pages = $pages.get();
+  if (pages === undefined) {
+    return;
+  }
+  const selectedPage = $selectedPage.get();
+  if (selectedPage) {
+    return (
+      findParentFolderByChildId(selectedPage.id, pages.folders)?.id ??
+      pages.rootFolderId
+    );
+  }
+  return pages.rootFolderId;
+};
+
+const mergeWebstudioFragments = (
+  ...fragments: WebstudioFragment[]
+): WebstudioFragment => {
+  return {
+    children: fragments.flatMap((fragment) => fragment.children),
+    instances: fragments.flatMap((fragment) => fragment.instances),
+    assets: fragments.flatMap((fragment) => fragment.assets),
+    dataSources: fragments.flatMap((fragment) => fragment.dataSources),
+    resources: fragments.flatMap((fragment) => fragment.resources),
+    props: fragments.flatMap((fragment) => fragment.props),
+    breakpoints: fragments.flatMap((fragment) => fragment.breakpoints),
+    styleSourceSelections: fragments.flatMap(
+      (fragment) => fragment.styleSourceSelections
+    ),
+    styleSources: fragments.flatMap((fragment) => fragment.styleSources),
+    styles: fragments.flatMap((fragment) => fragment.styles),
+  } satisfies WebstudioFragment;
+};
+
+const addPageType = (data: PageCopyData): PageData => ({
+  ...data,
+  type: "page",
+});
+
+const addTemplateType = (data: TemplateCopyData): TemplateData => ({
+  ...data,
+  type: "template",
+});
+
+const addFolderType = (data: FolderCopyData): FolderData => ({
+  type: "folder",
+  folder: data.folder,
+  children: data.children.map((child) =>
+    "folder" in child ? addFolderType(child) : addPageType(child)
+  ),
+});
+
+const getPageCopyData = (
+  data: ReturnType<typeof getWebstudioData>,
+  pageId: Page["id"]
+): PageData | undefined => {
+  const page = findPageByIdOrPath(pageId, data.pages);
+  if (page === undefined) {
+    return;
+  }
+  return addPageType(createPageCopyData({ data, page }));
+};
+
+const handleCopyPage = () => {
+  const target = getPageActionTarget();
+  if (target?.type === "page") {
+    return copyPageData(target.id);
+  }
+  if (target?.type === "folder") {
+    return copyFolderData(target.id);
+  }
+  if (target?.type === "template") {
+    return copyTemplateData(target.id);
+  }
+};
+
+const collectPageLikeItems = (
+  item: ClipboardItem
+): Array<PageData | TemplateData> => {
+  if (item.type === "page" || item.type === "template") {
+    return [item];
+  }
+  return item.children.flatMap(collectPageLikeItems);
+};
+
+export const copyPageData = (pageId: Page["id"]) => {
+  const data = getWebstudioData();
+  const pageData = getPageCopyData(data, pageId);
+  if (pageData === undefined) {
+    return;
+  }
+  return stringify(pageData);
+};
+
+export const copyTemplateData = (templateId: PageTemplate["id"]) => {
+  const data = getWebstudioData();
+  const template = data.pages.pageTemplates?.get(templateId);
+  if (template === undefined) {
+    return;
+  }
+  return stringify(addTemplateType(createTemplateCopyData({ data, template })));
+};
+
+export const copyFolderData = (folderId: Folder["id"]) => {
+  const data = getWebstudioData();
+  const folderData = createFolderCopyData({ data, folderId });
+  if (folderData === undefined) {
+    return;
+  }
+  return stringify(addFolderType(folderData));
+};
+
+export const handlePastePage = async (
+  clipboardData: string,
+  targetFolderId?: Folder["id"]
+) => {
+  const item = parse(clipboardData);
+  const pages = $pages.get();
+  if (item === undefined || pages === undefined) {
+    return false;
+  }
+
+  const folderId = targetFolderId ?? getDefaultTargetFolderId();
+  if (folderId === undefined || pages.folders.has(folderId) === false) {
+    return false;
+  }
+
+  try {
+    const conflicts = collectPageLikeItems(item).flatMap((item) =>
+      detectFragmentTokenConflicts({
+        fragment: mergeWebstudioFragments(item.rootFragment, item.bodyFragment),
+      })
+    );
+    const conflictResolution =
+      conflicts.length > 0
+        ? await builderApi.showTokenConflictDialog(conflicts)
+        : "theirs";
+
+    let newId: Page["id"] | Folder["id"] | undefined;
+    const onBreakpointLimitMerge = () => {
+      toast.warn(breakpointPasteLimitWarning);
+    };
+    updateWebstudioData((data) => {
+      if (item.type === "page") {
+        newId = insertPageCopyFromFragmentsMutable({
+          source: item,
+          target: { data, folderId },
+          conflictResolution,
+          onBreakpointLimitMerge,
+        });
+        return;
+      }
+      if (item.type === "template") {
+        newId = insertTemplateCopyFromFragmentsMutable({
+          source: item,
+          target: { data },
+          conflictResolution,
+          onBreakpointLimitMerge,
+        });
+        return;
+      }
+      newId = insertFolderCopyFromDataMutable({
+        source: item,
+        target: { data, parentFolderId: folderId },
+        conflictResolution,
+        onBreakpointLimitMerge,
+      });
+    });
+    if (newId) {
+      toast.success(
+        item.type === "page"
+          ? "Page pasted"
+          : item.type === "template"
+            ? "Template pasted"
+            : "Folder pasted"
+      );
+    }
+  } catch {
+    return false;
+  }
+
+  return true;
+};
+
+export const pageText: Plugin = {
+  name: "page-text",
+  mimeType: "text/plain",
+  onCopy: handleCopyPage,
+  onPaste: handlePastePage,
+};

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
@@ -19,7 +19,7 @@ import { builderApi } from "~/shared/builder-api";
 import { denormalizeSrcProps } from "../asset-upload";
 import { nanoHash } from "~/shared/nano-hash";
 import { findAvailableVariables } from "~/shared/data-variables";
-import type { Plugin } from "../init-copy-paste";
+import type { Plugin } from "../copy-paste";
 import { breakpointPasteLimitWarning } from "~/shared/breakpoints";
 
 const { toast } = builderApi;
@@ -165,7 +165,7 @@ const parse = (clipboardData: string) => {
   console.error(result.error.message);
 };
 
-const onPaste = async (clipboardData: string) => {
+const handlePasteWebflow = async (clipboardData: string) => {
   const project = $project.get();
   const wfData = parse(clipboardData);
   if (wfData === undefined || project === undefined) {
@@ -217,7 +217,7 @@ const onPaste = async (clipboardData: string) => {
 export const webflow: Plugin = {
   name: "webflow",
   mimeType: "application/json",
-  onPaste,
+  onPaste: handlePasteWebflow,
 };
 
 export const __testing__ = {

--- a/apps/builder/app/shared/instance-utils.test.tsx
+++ b/apps/builder/app/shared/instance-utils.test.tsx
@@ -81,6 +81,13 @@ import { selectPage } from "./nano-states";
 import { selectInstance } from "./nano-states";
 import { $selectedPageId } from "./nano-states/pages";
 
+const {
+  getFragmentContentModeCapabilities,
+  getFragmentInstancesData,
+  insertFragmentAssetsMutable,
+  insertFragmentBreakpointsMutable,
+} = __testing__;
+
 enableMapSet();
 registerContainers();
 
@@ -216,7 +223,7 @@ describe("fragment copy helpers", () => {
     });
 
     const { fragmentInstances, portalContentRootIds } =
-      __testing__.getFragmentInstancesData(fragment);
+      getFragmentInstancesData(fragment);
 
     expect(Array.from(fragmentInstances.keys())).toEqual([
       "portal",
@@ -235,7 +242,7 @@ describe("fragment copy helpers", () => {
       [existingAsset.id, existingAsset],
     ]);
 
-    __testing__.insertFragmentAssetsMutable({
+    insertFragmentAssetsMutable({
       fragment: createFragment({
         assets: [
           createImageAsset("existing-asset", "Source Existing", "source"),
@@ -260,7 +267,7 @@ describe("fragment copy helpers", () => {
     ]);
     let didMergeDueToLimit = false;
 
-    const mergedBreakpointIds = __testing__.insertFragmentBreakpointsMutable({
+    const mergedBreakpointIds = insertFragmentBreakpointsMutable({
       fragment: createFragment({
         breakpoints: [
           baseBreakpoint,
@@ -310,10 +317,9 @@ describe("fragment copy helpers", () => {
           },
         ],
       });
-      const { fragmentInstances } =
-        __testing__.getFragmentInstancesData(fragment);
+      const { fragmentInstances } = getFragmentInstancesData(fragment);
 
-      const capabilities = __testing__.getFragmentContentModeCapabilities({
+      const capabilities = getFragmentContentModeCapabilities({
         fragment,
         fragmentInstances,
         styleSources: new Map(),

--- a/apps/builder/app/shared/nano-states/pages.ts
+++ b/apps/builder/app/shared/nano-states/pages.ts
@@ -1,5 +1,6 @@
 import { atom, computed } from "nanostores";
 import {
+  type Folder,
   type Page,
   type PageTemplate,
   findPageByIdOrPath,
@@ -19,6 +20,8 @@ export const $selectedPageHash = atom<{ hash: string }>({ hash: "" });
 export const $editingPageId = atom<undefined | Page["id"]>();
 
 export const $pageIdToDelete = atom<undefined | Page["id"]>();
+export const $folderIdToDelete = atom<undefined | Folder["id"]>();
+export const $templateIdToDelete = atom<undefined | PageTemplate["id"]>();
 
 export const $editingTemplateId = atom<undefined | string>();
 

--- a/apps/builder/app/shared/nano-states/pages.ts
+++ b/apps/builder/app/shared/nano-states/pages.ts
@@ -18,6 +18,8 @@ export const $selectedPageHash = atom<{ hash: string }>({ hash: "" });
 
 export const $editingPageId = atom<undefined | Page["id"]>();
 
+export const $pageIdToDelete = atom<undefined | Page["id"]>();
+
 export const $editingTemplateId = atom<undefined | string>();
 
 export const $creatingPageFromTemplateId = atom<undefined | string>();

--- a/apps/builder/app/shared/notifications/notification-popover.test.ts
+++ b/apps/builder/app/shared/notifications/notification-popover.test.ts
@@ -2,7 +2,8 @@ import { describe, test, expect } from "vitest";
 import { notification } from "@webstudio-is/project/index.server";
 import type { WorkspaceInvitePayload } from "@webstudio-is/project";
 
-const { describeNotification } = notification.__testing__;
+const { __testing__ } = notification;
+const { describeNotification } = __testing__;
 
 describe("describeNotification", () => {
   test("workspace invite with all info", () => {

--- a/apps/builder/app/shared/page-action-target.ts
+++ b/apps/builder/app/shared/page-action-target.ts
@@ -1,0 +1,73 @@
+import { findPageByIdOrPath } from "@webstudio-is/sdk";
+import {
+  $editingPageId,
+  $editingTemplateId,
+  $selectedInstancePath,
+  $selectedPageId,
+} from "./nano-states";
+import { $pages } from "./sync/data-stores";
+
+export type PageActionTarget =
+  | { type: "page"; id: string }
+  | { type: "folder"; id: string }
+  | { type: "template"; id: string };
+
+export const getPageActionTarget = (): PageActionTarget | undefined => {
+  const pages = $pages.get();
+  if (pages === undefined) {
+    return;
+  }
+
+  const editingTemplateId = $editingTemplateId.get();
+  if (editingTemplateId && pages.pageTemplates?.has(editingTemplateId)) {
+    return { type: "template", id: editingTemplateId };
+  }
+
+  const editingPageId = $editingPageId.get();
+  if (editingPageId) {
+    if (pages.pages.has(editingPageId)) {
+      return { type: "page", id: editingPageId };
+    }
+    if (pages.folders.has(editingPageId)) {
+      return { type: "folder", id: editingPageId };
+    }
+  }
+
+  const selectedPageId = $selectedPageId.get();
+  const selectedInstancePath = $selectedInstancePath.get();
+  if (
+    selectedPageId === undefined ||
+    selectedInstancePath === undefined ||
+    selectedInstancePath.length !== 1
+  ) {
+    return;
+  }
+  const selectedPage = findPageByIdOrPath(selectedPageId, pages, {
+    includeTemplates: true,
+  });
+  if (
+    selectedPage === undefined ||
+    selectedPage.rootInstanceId !== selectedInstancePath[0].instance.id
+  ) {
+    return;
+  }
+  if (pages.pageTemplates?.has(selectedPage.id)) {
+    return { type: "template", id: selectedPage.id };
+  }
+  if (pages.pages.has(selectedPage.id)) {
+    return { type: "page", id: selectedPage.id };
+  }
+};
+
+export const getDeletablePageActionTarget = () => {
+  const pages = $pages.get();
+  const target = getPageActionTarget();
+  if (
+    pages === undefined ||
+    target?.type !== "page" ||
+    target.id === pages.homePageId
+  ) {
+    return;
+  }
+  return target.id;
+};

--- a/apps/builder/app/shared/page-action-target.ts
+++ b/apps/builder/app/shared/page-action-target.ts
@@ -18,11 +18,6 @@ export const getPageActionTarget = (): PageActionTarget | undefined => {
     return;
   }
 
-  const editingTemplateId = $editingTemplateId.get();
-  if (editingTemplateId && pages.pageTemplates?.has(editingTemplateId)) {
-    return { type: "template", id: editingTemplateId };
-  }
-
   const editingPageId = $editingPageId.get();
   if (editingPageId) {
     if (pages.pages.has(editingPageId)) {
@@ -31,6 +26,11 @@ export const getPageActionTarget = (): PageActionTarget | undefined => {
     if (pages.folders.has(editingPageId)) {
       return { type: "folder", id: editingPageId };
     }
+  }
+
+  const editingTemplateId = $editingTemplateId.get();
+  if (editingTemplateId && pages.pageTemplates?.has(editingTemplateId)) {
+    return { type: "template", id: editingTemplateId };
   }
 
   const selectedPageId = $selectedPageId.get();

--- a/apps/builder/app/shared/page-action-target.ts
+++ b/apps/builder/app/shared/page-action-target.ts
@@ -62,12 +62,11 @@ export const getPageActionTarget = (): PageActionTarget | undefined => {
 export const getDeletablePageActionTarget = () => {
   const pages = $pages.get();
   const target = getPageActionTarget();
-  if (
-    pages === undefined ||
-    target?.type !== "page" ||
-    target.id === pages.homePageId
-  ) {
+  if (pages === undefined || target === undefined) {
     return;
   }
-  return target.id;
+  if (target.type === "page" && target.id === pages.homePageId) {
+    return;
+  }
+  return target;
 };

--- a/apps/builder/app/shared/page-utils.test.tsx
+++ b/apps/builder/app/shared/page-utils.test.tsx
@@ -5,6 +5,7 @@ import {
   ROOT_INSTANCE_ID,
   encodeDataVariableId,
   getHomePage,
+  type DataSource,
   type Page,
   type Instance,
   type WebstudioData,
@@ -19,6 +20,8 @@ import {
   __testing__,
   insertPageCopyMutable,
   insertPageFromTemplateMutable,
+  createTemplateCopyData,
+  insertTemplateCopyFromFragmentsMutable,
   copyAndTransformPageMeta,
 } from "./page-utils";
 import {
@@ -762,5 +765,76 @@ describe("insert page copy", () => {
       },
     });
     expect(data.pages.folders.get(ROOT_FOLDER_ID)?.children).toContain(pageId);
+  });
+
+  test("insert template copy preserves and remaps system data source", () => {
+    const systemDataSource: DataSource = {
+      id: "templateSystemId",
+      scopeInstanceId: "templateBodyId",
+      name: "system",
+      type: "parameter",
+    };
+    const systemIdentifier = encodeDataVariableId(systemDataSource.id);
+    const data = getWebstudioDataStub({
+      instances: toMap<Instance>([
+        {
+          type: "instance",
+          id: "templateBodyId",
+          component: "Body",
+          children: [],
+        },
+      ]),
+      dataSources: toMap([systemDataSource]),
+      pages: migratePages({
+        homePageId: "homePageId",
+        rootFolderId: ROOT_FOLDER_ID,
+        pages: [
+          {
+            id: "homePageId",
+            name: "Home",
+            path: "",
+            title: `"Home"`,
+            meta: {},
+            rootInstanceId: "homeBodyId",
+          },
+        ],
+        pageTemplates: [
+          {
+            id: "templateId",
+            name: "Template",
+            title: `"Title: " + ${systemIdentifier}`,
+            rootInstanceId: "templateBodyId",
+            systemDataSourceId: systemDataSource.id,
+            meta: {
+              description: `"Description: " + ${systemIdentifier}`,
+            },
+          },
+        ],
+        folders: [createRootFolder(["homePageId"])],
+      }),
+    });
+    const template = data.pages.pageTemplates?.get("templateId");
+    expect(template).toBeDefined();
+
+    const templateId = insertTemplateCopyFromFragmentsMutable({
+      source: createTemplateCopyData({ data, template: template! }),
+      target: { data },
+    });
+
+    const copiedTemplate = data.pages.pageTemplates?.get(templateId ?? "");
+    expect(copiedTemplate?.systemDataSourceId).toBeDefined();
+    expect(copiedTemplate?.systemDataSourceId).not.toEqual(systemDataSource.id);
+    expect(
+      data.dataSources.has(copiedTemplate?.systemDataSourceId ?? "")
+    ).toEqual(true);
+    const copiedSystemIdentifier = encodeDataVariableId(
+      copiedTemplate?.systemDataSourceId ?? ""
+    );
+    expect(copiedTemplate?.title).toEqual(
+      `"Title: " + ${copiedSystemIdentifier}`
+    );
+    expect(copiedTemplate?.meta.description).toEqual(
+      `"Description: " + ${copiedSystemIdentifier}`
+    );
   });
 });

--- a/apps/builder/app/shared/page-utils.test.tsx
+++ b/apps/builder/app/shared/page-utils.test.tsx
@@ -34,6 +34,8 @@ import {
 } from "@webstudio-is/template";
 import { nanoid } from "nanoid";
 
+const { deduplicateName, deduplicatePath, joinPath } = __testing__;
+
 const toMap = <T extends { id: string }>(list: T[]) =>
   new Map(list.map((item) => [item.id, item]));
 
@@ -94,34 +96,32 @@ describe("page utility helpers", () => {
   test("deduplicates names within the target folder", () => {
     const pages = getPagesWithSiblings();
 
-    expect(
-      __testing__.deduplicateName(pages, ROOT_FOLDER_ID, "Contact")
-    ).toEqual("Contact");
-    expect(__testing__.deduplicateName(pages, ROOT_FOLDER_ID, "About")).toEqual(
+    expect(deduplicateName(pages, ROOT_FOLDER_ID, "Contact")).toEqual(
+      "Contact"
+    );
+    expect(deduplicateName(pages, ROOT_FOLDER_ID, "About")).toEqual(
       "About (2)"
     );
-    expect(
-      __testing__.deduplicateName(pages, ROOT_FOLDER_ID, "About (1)")
-    ).toEqual("About (2)");
+    expect(deduplicateName(pages, ROOT_FOLDER_ID, "About (1)")).toEqual(
+      "About (2)"
+    );
   });
 
   test("deduplicates paths within the target folder", () => {
     const pages = getPagesWithSiblings();
 
-    expect(
-      __testing__.deduplicatePath(pages, ROOT_FOLDER_ID, "/contact")
-    ).toEqual("/contact");
-    expect(
-      __testing__.deduplicatePath(pages, ROOT_FOLDER_ID, "/about")
-    ).toEqual("/copy-2/about");
-    expect(__testing__.deduplicatePath(pages, ROOT_FOLDER_ID, "/")).toEqual(
-      "/copy-1"
+    expect(deduplicatePath(pages, ROOT_FOLDER_ID, "/contact")).toEqual(
+      "/contact"
     );
+    expect(deduplicatePath(pages, ROOT_FOLDER_ID, "/about")).toEqual(
+      "/copy-2/about"
+    );
+    expect(deduplicatePath(pages, ROOT_FOLDER_ID, "/")).toEqual("/copy-1");
   });
 
   test("joins path parts without duplicate slashes", () => {
-    expect(__testing__.joinPath("/", "/blog", "/post")).toEqual("/blog/post");
-    expect(__testing__.joinPath("/docs/", "/guide")).toEqual("/docs/guide");
+    expect(joinPath("/", "/blog", "/post")).toEqual("/blog/post");
+    expect(joinPath("/docs/", "/guide")).toEqual("/docs/guide");
   });
 });
 

--- a/apps/builder/app/shared/page-utils.ts
+++ b/apps/builder/app/shared/page-utils.ts
@@ -8,6 +8,7 @@ import {
   type Page,
   type PageTemplate,
   type Pages,
+  type WebstudioFragment,
   type WebstudioData,
   ROOT_INSTANCE_ID,
 } from "@webstudio-is/sdk";
@@ -26,14 +27,40 @@ import {
 import { $project } from "./sync/data-stores";
 import type { ConflictResolution } from "./token-conflict-dialog";
 
+const parseCopyNumberSuffix = (value: string) => {
+  const { name = value, copyNumber = "0" } =
+    value.match(/^(?<name>.+) \((?<copyNumber>\d+)\)$/)?.groups ?? {};
+  return { baseName: name, copyNumber: Number(copyNumber) };
+};
+
+const getNextCopyNumberedName = ({
+  usedNames,
+  name,
+  forceCopySuffix = false,
+}: {
+  usedNames: Set<string>;
+  name: string;
+  forceCopySuffix?: boolean;
+}) => {
+  const { baseName, copyNumber } = parseCopyNumberSuffix(name);
+  if (forceCopySuffix === false && usedNames.has(baseName) === false) {
+    return baseName;
+  }
+
+  let nameNumber = copyNumber;
+  let newName = baseName;
+  do {
+    nameNumber += 1;
+    newName = `${baseName} (${nameNumber})`;
+  } while (usedNames.has(newName));
+  return newName;
+};
+
 const deduplicateName = (
   pages: Pages,
   folderId: Folder["id"],
   pageName: Page["name"]
 ) => {
-  const { name = pageName, copyNumber } =
-    // extract a number from "name (copyNumber)"
-    pageName.match(/^(?<name>.+) \((?<copyNumber>\d+)\)$/)?.groups ?? {};
   const folder = getFolderById(pages, folderId);
   const usedNames = new Set<string>();
   for (const pageId of folder?.children ?? []) {
@@ -42,13 +69,7 @@ const deduplicateName = (
       usedNames.add(page.name);
     }
   }
-  let newName = name;
-  let nameNumber = Number(copyNumber ?? "0");
-  while (usedNames.has(newName)) {
-    nameNumber += 1;
-    newName = `${name} (${nameNumber})`;
-  }
-  return newName;
+  return getNextCopyNumberedName({ usedNames, name: pageName });
 };
 
 const deduplicatePath = (
@@ -98,28 +119,63 @@ const copyPageRootAndBodyMutable = ({
   conflictResolution: ConflictResolution | undefined;
   contentMode?: boolean;
 }) => {
+  const unsetVariables = new Set<DataSource["id"]>();
+  // replace legacy page system with global variable
+  if (systemDataSourceId) {
+    unsetVariables.add(systemDataSourceId);
+  }
+
+  return copyPageFragmentsMutable({
+    target,
+    rootFragment:
+      contentMode === false
+        ? extractWebstudioFragment(source, ROOT_INSTANCE_ID)
+        : undefined,
+    bodyFragment: extractWebstudioFragment(source, sourceRootInstanceId, {
+      unsetVariables,
+    }),
+    conflictResolution,
+    systemDataSourceId,
+    contentMode,
+  });
+};
+
+const copyPageFragmentsMutable = ({
+  target,
+  rootFragment,
+  bodyFragment,
+  systemDataSourceId,
+  conflictResolution,
+  onBreakpointLimitMerge,
+  contentMode = false,
+}: {
+  target: WebstudioData;
+  rootFragment?: WebstudioFragment;
+  bodyFragment: WebstudioFragment;
+  systemDataSourceId: string | undefined;
+  conflictResolution: ConflictResolution | undefined;
+  onBreakpointLimitMerge?: () => void;
+  contentMode?: boolean;
+}) => {
   const project = $project.get();
   if (project === undefined) {
     return;
   }
-  if (contentMode === false) {
-    // copy paste project :root
+  if (contentMode === false && rootFragment !== undefined) {
     insertWebstudioFragmentCopy({
       data: target,
-      fragment: extractWebstudioFragment(source, ROOT_INSTANCE_ID),
+      fragment: rootFragment,
       availableVariables: findAvailableVariables({
         ...target,
         startingInstanceId: ROOT_INSTANCE_ID,
       }),
       projectId: project.id,
       conflictResolution,
+      onBreakpointLimitMerge,
     });
   }
-  const unsetVariables = new Set<DataSource["id"]>();
   const unsetNameById = new Map<DataSource["id"], DataSource["name"]>();
-  // replace legacy page system with global variable
   if (systemDataSourceId) {
-    unsetVariables.add(systemDataSourceId);
     unsetNameById.set(systemDataSourceId, "system");
   }
   const availableVariables = findAvailableVariables({
@@ -130,25 +186,91 @@ const copyPageRootAndBodyMutable = ({
   for (const dataSource of availableVariables) {
     maskedIdByName.set(dataSource.name, dataSource.id);
   }
-  // copy paste page body
   const { newInstanceIds, newDataSourceIds } = insertWebstudioFragmentCopy({
     data: target,
-    fragment: extractWebstudioFragment(source, sourceRootInstanceId, {
-      unsetVariables,
-    }),
+    fragment: bodyFragment,
     availableVariables,
     projectId: project.id,
     conflictResolution,
+    onBreakpointLimitMerge,
     contentMode,
   });
   const transformExpression = (expression: string) => {
-    // rebind expressions from page system variable to the global one
     expression = unsetExpressionVariables({ expression, unsetNameById });
     expression = restoreExpressionVariables({ expression, maskedIdByName });
     expression = replaceDataSourcesInExpression(expression, newDataSourceIds);
     return expression;
   };
-  return { newInstanceIds, transformExpression };
+  return { newInstanceIds, newDataSourceIds, transformExpression };
+};
+
+const insertCopiedPageMutable = ({
+  page,
+  copied,
+  target,
+}: {
+  page: Page;
+  copied: NonNullable<ReturnType<typeof copyPageFragmentsMutable>>;
+  target: { data: WebstudioData; folderId: Folder["id"] };
+}) => {
+  const newPage = structuredClone(unwrap(page));
+  newPage.id = nanoid();
+  delete newPage.systemDataSourceId;
+  newPage.rootInstanceId =
+    copied.newInstanceIds.get(page.rootInstanceId) ?? page.rootInstanceId;
+  newPage.name = deduplicateName(target.data.pages, target.folderId, page.name);
+  newPage.path = deduplicatePath(target.data.pages, target.folderId, page.path);
+  newPage.title = copied.transformExpression(newPage.title);
+  copyAndTransformPageMeta(
+    newPage.meta,
+    newPage.meta,
+    copied.transformExpression
+  );
+  target.data.pages.pages.set(newPage.id, newPage);
+  target.data.pages.folders.get(target.folderId)?.children.push(newPage.id);
+  return newPage.id;
+};
+
+const deduplicateTemplateName = (
+  pages: Pages,
+  templateName: PageTemplate["name"]
+) => {
+  const usedNames = new Set<string>();
+  for (const template of pages.pageTemplates?.values() ?? []) {
+    usedNames.add(template.name);
+  }
+  return getNextCopyNumberedName({ usedNames, name: templateName });
+};
+
+const insertCopiedTemplateMutable = ({
+  template,
+  copied,
+  target,
+}: {
+  template: PageTemplate;
+  copied: NonNullable<ReturnType<typeof copyPageFragmentsMutable>>;
+  target: { data: WebstudioData };
+}) => {
+  const newTemplate = structuredClone(unwrap(template));
+  newTemplate.id = nanoid();
+  newTemplate.rootInstanceId =
+    copied.newInstanceIds.get(template.rootInstanceId) ??
+    template.rootInstanceId;
+  newTemplate.name = deduplicateTemplateName(target.data.pages, template.name);
+  newTemplate.title = copied.transformExpression(newTemplate.title);
+  newTemplate.systemDataSourceId =
+    template.systemDataSourceId === undefined
+      ? undefined
+      : (copied.newDataSourceIds.get(template.systemDataSourceId) ??
+        template.systemDataSourceId);
+  copyAndTransformPageMeta(
+    newTemplate.meta,
+    newTemplate.meta,
+    copied.transformExpression
+  );
+  target.data.pages.pageTemplates ??= new Map();
+  target.data.pages.pageTemplates.set(newTemplate.id, newTemplate);
+  return newTemplate.id;
 };
 
 export const copyAndTransformPageMeta = (
@@ -289,21 +411,299 @@ export const insertPageCopyMutable = ({
   if (copied === undefined) {
     return;
   }
-  // unwrap page draft
-  const newPage = structuredClone(unwrap(page));
-  newPage.id = nanoid();
-  delete newPage.systemDataSourceId;
-  newPage.rootInstanceId =
-    copied.newInstanceIds.get(page.rootInstanceId) ?? page.rootInstanceId;
-  newPage.name = deduplicateName(target.data.pages, target.folderId, page.name);
-  newPage.path = deduplicatePath(target.data.pages, target.folderId, page.path);
-  newPage.title = copied.transformExpression(newPage.title);
-  copyAndTransformPageMeta(
-    newPage.meta,
-    newPage.meta,
-    copied.transformExpression
-  );
-  target.data.pages.pages.set(newPage.id, newPage);
-  target.data.pages.folders.get(target.folderId)?.children.push(newPage.id);
-  return newPage.id;
+  return insertCopiedPageMutable({ page, copied, target });
+};
+
+export const insertPageCopyFromFragmentsMutable = ({
+  source,
+  target,
+  conflictResolution,
+  onBreakpointLimitMerge,
+}: {
+  source: {
+    page: Page;
+    rootFragment?: WebstudioFragment;
+    bodyFragment: WebstudioFragment;
+  };
+  target: { data: WebstudioData; folderId: Folder["id"] };
+  conflictResolution?: ConflictResolution;
+  onBreakpointLimitMerge?: () => void;
+}) => {
+  const copied = copyPageFragmentsMutable({
+    target: target.data,
+    rootFragment: source.rootFragment,
+    bodyFragment: source.bodyFragment,
+    systemDataSourceId: source.page.systemDataSourceId,
+    conflictResolution,
+    onBreakpointLimitMerge,
+  });
+  if (copied === undefined) {
+    return;
+  }
+  return insertCopiedPageMutable({ page: source.page, copied, target });
+};
+
+export const insertTemplateCopyFromFragmentsMutable = ({
+  source,
+  target,
+  conflictResolution,
+  onBreakpointLimitMerge,
+}: {
+  source: {
+    template: PageTemplate;
+    rootFragment?: WebstudioFragment;
+    bodyFragment: WebstudioFragment;
+  };
+  target: { data: WebstudioData };
+  conflictResolution?: ConflictResolution;
+  onBreakpointLimitMerge?: () => void;
+}) => {
+  const copied = copyPageFragmentsMutable({
+    target: target.data,
+    rootFragment: source.rootFragment,
+    bodyFragment: source.bodyFragment,
+    systemDataSourceId: undefined,
+    conflictResolution,
+    onBreakpointLimitMerge,
+  });
+  if (copied === undefined) {
+    return;
+  }
+  return insertCopiedTemplateMutable({
+    template: source.template,
+    copied,
+    target,
+  });
+};
+
+export type PageCopyData = {
+  page: Page;
+  rootFragment: WebstudioFragment;
+  bodyFragment: WebstudioFragment;
+};
+
+export type TemplateCopyData = {
+  template: PageTemplate;
+  rootFragment: WebstudioFragment;
+  bodyFragment: WebstudioFragment;
+};
+
+export type FolderCopyData = {
+  folder: Folder;
+  children: Array<PageCopyData | FolderCopyData>;
+};
+
+export const createPageCopyData = ({
+  data,
+  page,
+}: {
+  data: WebstudioData;
+  page: Page;
+}): PageCopyData => {
+  return {
+    page,
+    rootFragment: extractWebstudioFragment(data, ROOT_INSTANCE_ID),
+    bodyFragment: extractWebstudioFragment(data, page.rootInstanceId, {
+      unsetVariables:
+        page.systemDataSourceId === undefined
+          ? undefined
+          : new Set([page.systemDataSourceId]),
+    }),
+  };
+};
+
+export const createTemplateCopyData = ({
+  data,
+  template,
+}: {
+  data: WebstudioData;
+  template: PageTemplate;
+}): TemplateCopyData => {
+  return {
+    template,
+    rootFragment: extractWebstudioFragment(data, ROOT_INSTANCE_ID),
+    bodyFragment: extractWebstudioFragment(data, template.rootInstanceId),
+  };
+};
+
+export const createFolderCopyData = ({
+  data,
+  folderId,
+}: {
+  data: WebstudioData;
+  folderId: Folder["id"];
+}): FolderCopyData | undefined => {
+  const folder = data.pages.folders.get(folderId);
+  if (folder === undefined) {
+    return;
+  }
+  const children: FolderCopyData["children"] = [];
+  for (const childId of folder.children) {
+    const childFolder = createFolderCopyData({ data, folderId: childId });
+    if (childFolder) {
+      children.push(childFolder);
+      continue;
+    }
+    const childPage = findPageByIdOrPath(childId, data.pages);
+    if (childPage) {
+      children.push(createPageCopyData({ data, page: childPage }));
+    }
+  }
+  return { folder, children };
+};
+
+const isFolderCopyData = (
+  item: PageCopyData | FolderCopyData
+): item is FolderCopyData => "folder" in item;
+
+const deduplicateFolderName = (
+  pages: Pages,
+  parentFolderId: Folder["id"],
+  name: Folder["name"],
+  forceCopySuffix = false
+) => {
+  const parentFolder = getFolderById(pages, parentFolderId);
+  const usedNames = new Set<string>();
+  for (const childId of parentFolder?.children ?? []) {
+    const childFolder = pages.folders.get(childId);
+    if (childFolder) {
+      usedNames.add(childFolder.name);
+      continue;
+    }
+    const childPage = findPageByIdOrPath(childId, pages);
+    if (childPage) {
+      usedNames.add(childPage.name);
+    }
+  }
+  return getNextCopyNumberedName({ usedNames, name, forceCopySuffix });
+};
+
+const deduplicateFolderSlug = (
+  pages: Pages,
+  parentFolderId: Folder["id"],
+  slug: Folder["slug"],
+  forceCopySuffix = false
+) => {
+  // Empty slugs are explicitly allowed to repeat for folders.
+  if (slug === "") {
+    return slug;
+  }
+
+  const { slug: baseSlug = slug, copyNumber } =
+    slug.match(/^(?<slug>.+)-(?<copyNumber>\d+)$/)?.groups ?? {};
+  const parentFolder = getFolderById(pages, parentFolderId);
+  const usedSlugs = new Set<string>();
+  for (const childId of parentFolder?.children ?? []) {
+    const childFolder = pages.folders.get(childId);
+    if (childFolder) {
+      usedSlugs.add(childFolder.slug);
+    }
+  }
+  if (forceCopySuffix === false && usedSlugs.has(baseSlug) === false) {
+    return baseSlug;
+  }
+
+  let counter = Number(copyNumber ?? "0");
+  let newSlug = baseSlug;
+  do {
+    counter += 1;
+    newSlug = baseSlug ? `${baseSlug}-${counter}` : `copy-${counter}`;
+  } while (usedSlugs.has(newSlug));
+  return newSlug;
+};
+
+export const insertFolderCopyFromDataMutable = ({
+  source,
+  target,
+  conflictResolution,
+  onBreakpointLimitMerge,
+  forceFolderCopySuffix = false,
+}: {
+  source: FolderCopyData;
+  target: { data: WebstudioData; parentFolderId: Folder["id"] };
+  conflictResolution?: ConflictResolution;
+  onBreakpointLimitMerge?: () => void;
+  forceFolderCopySuffix?: boolean;
+}) => {
+  const copyContext = {
+    didCopyRootFragment: false,
+  };
+
+  return insertFolderCopyFromDataWithContextMutable({
+    source,
+    target,
+    conflictResolution,
+    onBreakpointLimitMerge,
+    forceFolderCopySuffix,
+    copyContext,
+  });
+};
+
+const insertFolderCopyFromDataWithContextMutable = ({
+  source,
+  target,
+  conflictResolution,
+  onBreakpointLimitMerge,
+  forceFolderCopySuffix,
+  copyContext,
+}: {
+  source: FolderCopyData;
+  target: { data: WebstudioData; parentFolderId: Folder["id"] };
+  conflictResolution?: ConflictResolution;
+  onBreakpointLimitMerge?: () => void;
+  forceFolderCopySuffix?: boolean;
+  copyContext: { didCopyRootFragment: boolean };
+}) => {
+  const parentFolder = target.data.pages.folders.get(target.parentFolderId);
+  if (parentFolder === undefined) {
+    return;
+  }
+
+  const newFolder: Folder = {
+    ...structuredClone(unwrap(source.folder)),
+    id: nanoid(),
+    name: deduplicateFolderName(
+      target.data.pages,
+      target.parentFolderId,
+      source.folder.name,
+      forceFolderCopySuffix
+    ),
+    slug: deduplicateFolderSlug(
+      target.data.pages,
+      target.parentFolderId,
+      source.folder.slug,
+      forceFolderCopySuffix
+    ),
+    children: [],
+  };
+  target.data.pages.folders.set(newFolder.id, newFolder);
+  parentFolder.children.push(newFolder.id);
+
+  for (const child of source.children) {
+    if (isFolderCopyData(child)) {
+      insertFolderCopyFromDataWithContextMutable({
+        source: child,
+        target: { data: target.data, parentFolderId: newFolder.id },
+        conflictResolution,
+        onBreakpointLimitMerge,
+        forceFolderCopySuffix,
+        copyContext,
+      });
+      continue;
+    }
+    const rootFragment = copyContext.didCopyRootFragment
+      ? undefined
+      : child.rootFragment;
+    const pageId = insertPageCopyFromFragmentsMutable({
+      source: { ...child, rootFragment },
+      target: { data: target.data, folderId: newFolder.id },
+      conflictResolution,
+      onBreakpointLimitMerge,
+    });
+    if (rootFragment !== undefined && pageId !== undefined) {
+      copyContext.didCopyRootFragment = true;
+    }
+  }
+
+  return newFolder.id;
 };

--- a/apps/builder/app/shared/sync/multiplayer-sync.test.ts
+++ b/apps/builder/app/shared/sync/multiplayer-sync.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { WebSocketEmitterOptions } from "@webstudio-is/sync-client/websocket";
 import { $collaborators, $syncStatus } from "@webstudio-is/sync-client";
-import { __testing__ as awarenessTesting } from "~/shared/awareness";
+import { __testing__ } from "~/shared/awareness";
 import {
   createMultiplayerSyncEmitter,
   startMultiplayerPresenceSync,
 } from "./multiplayer-sync";
+
+const { $pointerPosition } = __testing__;
 
 const createTransportFactory = () => {
   let callbacks: WebSocketEmitterOptions | undefined;
@@ -244,7 +246,7 @@ describe("createMultiplayerSyncEmitter", () => {
 
 describe("startMultiplayerPresenceSync", () => {
   afterEach(() => {
-    awarenessTesting.$pointerPosition.set(undefined);
+    $pointerPosition.set(undefined);
   });
 
   test("sends only the latest awareness update in one microtask", async () => {
@@ -254,13 +256,13 @@ describe("startMultiplayerPresenceSync", () => {
     await Promise.resolve();
     emitter.sendPresence.mockClear();
 
-    awarenessTesting.$pointerPosition.set({
+    $pointerPosition.set({
       x: 1,
       y: 2,
       xRatio: 0.1,
       yRatio: 0.2,
     });
-    awarenessTesting.$pointerPosition.set({
+    $pointerPosition.set({
       x: 3,
       y: 4,
       xRatio: 0.3,
@@ -286,7 +288,7 @@ describe("startMultiplayerPresenceSync", () => {
     await Promise.resolve();
     emitter.sendPresence.mockClear();
 
-    awarenessTesting.$pointerPosition.set({
+    $pointerPosition.set({
       x: 1,
       y: 2,
       xRatio: 0.1,

--- a/apps/builder/app/shared/tailwind/tailwind.test.tsx
+++ b/apps/builder/app/shared/tailwind/tailwind.test.tsx
@@ -2,6 +2,8 @@ import { describe, expect, test } from "vitest";
 import { css, renderTemplate, ws } from "@webstudio-is/template";
 import { __testing__, generateFragmentFromTailwind } from "./tailwind";
 
+const { normalizeUnoCssForWebstudio } = __testing__;
+
 const getBaseStyleValue = (
   fragment: Awaited<ReturnType<typeof generateFragmentFromTailwind>>,
   property: string
@@ -42,7 +44,7 @@ const getStyleValue = (
 };
 
 test("normalize unocss output for webstudio parser", () => {
-  const { css: normalizedCss } = __testing__.normalizeUnoCssForWebstudio(`
+  const { css: normalizedCss } = normalizeUnoCssForWebstudio(`
     @property --un-shadow { syntax: "*"; inherits: false; initial-value: 0 0 #0000; }
     @property --un-from-opacity { syntax: "<percentage>"; inherits: false; initial-value: 100%; }
     .rounded-full { border-radius: calc(infinity * 1px); }

--- a/apps/builder/e2e/flows/pages-panel.ts
+++ b/apps/builder/e2e/flows/pages-panel.ts
@@ -98,10 +98,72 @@ export const openPageSettings = async ({
   pageName: string;
 }) => {
   await openPagesPanel({ page });
-  const pageRow = page.getByRole("group", { name: `Page ${pageName}` });
+  const pageRow = page.getByRole("group", {
+    name: `Page ${pageName}`,
+    exact: true,
+  });
   await pageRow.hover();
+  if (
+    await pageRow
+      .getByRole("button", { name: "Close page settings" })
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false)
+  ) {
+    await page.getByText("Page settings", { exact: true }).waitFor();
+    return;
+  }
   await pageRow.getByRole("button", { name: "Open page settings" }).click();
   await page.getByText("Page settings", { exact: true }).waitFor();
+};
+
+export const openFolderSettings = async ({
+  page,
+  folderName,
+}: {
+  page: Page;
+  folderName: string;
+}) => {
+  await openPagesPanel({ page });
+  const folderRow = page.getByRole("group", {
+    name: `Folder ${folderName}`,
+    exact: true,
+  });
+  await folderRow.hover();
+  if (
+    await folderRow
+      .getByRole("button", { name: "Close folder settings" })
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false)
+  ) {
+    await page.getByText("Folder settings", { exact: true }).waitFor();
+    return;
+  }
+  await folderRow.getByRole("button", { name: "Open folder settings" }).click();
+  await page.getByText("Folder settings", { exact: true }).waitFor();
+};
+
+export const openTemplateSettings = async ({
+  page,
+  templateName,
+}: {
+  page: Page;
+  templateName: string;
+}) => {
+  await openPagesPanel({ page });
+  const template = page.getByText(templateName, { exact: true }).first();
+  await template.scrollIntoViewIfNeeded();
+  await template.hover();
+  if (
+    await page
+      .getByRole("button", { name: "Close template settings" })
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false)
+  ) {
+    await page.getByText("Template settings", { exact: true }).waitFor();
+    return;
+  }
+  await page.getByRole("button", { name: "Open template settings" }).click();
+  await page.getByText("Template settings", { exact: true }).waitFor();
 };
 
 export const openPage = async ({
@@ -116,6 +178,29 @@ export const openPage = async ({
   await openPagesPanel({ page });
   await page.getByText(pageName, { exact: true }).first().click();
   await waitForCanvasText({ page, text: canvasText });
+  await waitForSyncStatus({ page, status: "idle" });
+};
+
+export const createFolder = async ({
+  page,
+  folderName,
+}: {
+  page: Page;
+  folderName: string;
+}) => {
+  await openPagesPanel({ page });
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+  await page.getByRole("menuitem", { name: "New folder" }).click();
+  await page.getByText("New folder settings", { exact: true }).waitFor();
+
+  await page.getByLabel("Folder name").fill(folderName);
+  const save = waitForChangeToBeSaved({ page });
+  await page.getByRole("button", { name: "Create folder" }).click();
+  await save;
+
+  await page
+    .getByRole("group", { name: `Folder ${folderName}`, exact: true })
+    .waitFor();
   await waitForSyncStatus({ page, status: "idle" });
 };
 

--- a/apps/builder/e2e/run.ts
+++ b/apps/builder/e2e/run.ts
@@ -14,6 +14,7 @@ import { resetDatabase } from "./db";
 import { logPerf, measure, printPerfSummary } from "./perf";
 import { e2ePlans } from "./plans";
 import "./tests/content-mode-editing.e2e";
+import "./tests/pages-actions.e2e";
 import "./tests/share-link-permissions.e2e";
 
 const testTimeoutMs =

--- a/apps/builder/e2e/tests/pages-actions.e2e.ts
+++ b/apps/builder/e2e/tests/pages-actions.e2e.ts
@@ -49,6 +49,7 @@ const selectPageRow = async ({
   page: Page;
   pageName: string;
 }) => {
+  await openPagesPanel({ page });
   await getPageRow({ page, pageName })
     .getByRole("button", { name: pageName, exact: true })
     .click();
@@ -119,7 +120,7 @@ const pasteFromClipboardShortcut = async ({ page }: { page: Page }) => {
   await waitForSyncStatus({ page, status: "idle" });
 };
 
-const confirmFocusedDialogAction = async ({
+const confirmDialogAction = async ({
   page,
   action,
 }: {
@@ -127,14 +128,7 @@ const confirmFocusedDialogAction = async ({
   action: string;
 }) => {
   const button = page.getByRole("button", { name: action });
-  await button.waitFor();
-  await page.waitForFunction((action) => {
-    return (
-      document.activeElement instanceof HTMLButtonElement &&
-      document.activeElement.textContent?.trim() === action
-    );
-  }, action);
-  await page.keyboard.press("Enter");
+  await button.click();
   await button.waitFor({ state: "hidden" });
 };
 
@@ -187,7 +181,7 @@ test("Builder can copy and duplicate a page from the header menu and delete it w
     });
     await selectPageRow({ page, pageName: copiedPageName });
     await page.keyboard.press("Backspace");
-    await confirmFocusedDialogAction({ page, action: "Delete Page" });
+    await confirmDialogAction({ page, action: "Delete Page" });
     await expectPageRowHidden({ page, pageName: copiedPageName });
 
     await openPageSettings({ page, pageName });
@@ -200,7 +194,7 @@ test("Builder can copy and duplicate a page from the header menu and delete it w
 
     await openPageSettings({ page, pageName: duplicatedPageName });
     await page.keyboard.press("Backspace");
-    await confirmFocusedDialogAction({ page, action: "Delete Page" });
+    await confirmDialogAction({ page, action: "Delete Page" });
     await expectPageRowHidden({ page, pageName: duplicatedPageName });
   } finally {
     await close();
@@ -242,8 +236,7 @@ test("Builder can copy, duplicate, and delete a folder from the context menu", a
       itemName: duplicatedFolderName,
       action: "Delete",
     });
-    await page.getByRole("button", { name: "Delete" }).waitFor();
-    await page.keyboard.press("Enter");
+    await confirmDialogAction({ page, action: "Delete" });
     await expectTextHidden({ page, text: duplicatedFolderName });
   } finally {
     await close();
@@ -292,8 +285,7 @@ test("Builder can copy, duplicate, and delete a page template from actions menus
       itemName: duplicatedTemplateName,
       action: "Delete",
     });
-    await page.getByRole("button", { name: "Delete Template" }).waitFor();
-    await page.keyboard.press("Enter");
+    await confirmDialogAction({ page, action: "Delete Template" });
     await expectTextHidden({ page, text: duplicatedTemplateName });
   } finally {
     await close();

--- a/apps/builder/e2e/tests/pages-actions.e2e.ts
+++ b/apps/builder/e2e/tests/pages-actions.e2e.ts
@@ -1,0 +1,261 @@
+import type { Page } from "playwright";
+import { expectTextHidden } from "../flows/assertions";
+import { openProjectBuilder } from "../flows/builder";
+import {
+  createFolder,
+  createPageFromTemplate,
+  openPage,
+  openPageSettings,
+  openPagesPanel,
+  openTemplateSettings,
+} from "../flows/pages-panel";
+import { waitForSyncStatus } from "../flows/sync-status";
+import { createContentModeProject } from "../fixtures/content-mode-suite";
+import type { SeededContentModeProject } from "../fixtures/content-mode-project";
+import { newIsolatedPage, test } from "../harness";
+import { measure } from "../perf";
+
+let fixture: SeededContentModeProject;
+
+const copiedPageClipboardMarker = "@webstudio/page/v0.1";
+
+const waitForPageRow = async ({
+  page,
+  pageName,
+}: {
+  page: Page;
+  pageName: string;
+}) => {
+  await page
+    .getByRole("group", { name: `Page ${pageName}`, exact: true })
+    .waitFor();
+};
+
+const waitForFolderRow = async ({
+  page,
+  folderName,
+}: {
+  page: Page;
+  folderName: string;
+}) => {
+  await page
+    .getByRole("group", { name: `Folder ${folderName}`, exact: true })
+    .waitFor();
+};
+
+const waitForTemplate = async ({
+  page,
+  templateName,
+}: {
+  page: Page;
+  templateName: string;
+}) => {
+  await page.getByText(templateName, { exact: true }).first().waitFor();
+};
+
+const waitForCopiedPageClipboard = async ({ page }: { page: Page }) => {
+  await page.waitForFunction(async (marker) => {
+    try {
+      return (await navigator.clipboard.readText()).includes(marker as string);
+    } catch {
+      return false;
+    }
+  }, copiedPageClipboardMarker);
+};
+
+const selectHeaderAction = async ({
+  page,
+  menuLabel,
+  action,
+}: {
+  page: Page;
+  menuLabel: string;
+  action: "Copy" | "Duplicate" | "Delete";
+}) => {
+  await page.getByRole("button", { name: menuLabel }).click();
+  await page.getByRole("menuitem", { name: action }).click();
+};
+
+const selectContextAction = async ({
+  page,
+  itemName,
+  action,
+}: {
+  page: Page;
+  itemName: string;
+  action: "Paste" | "Copy" | "Duplicate" | "Delete";
+}) => {
+  await page.getByText(itemName, { exact: true }).first().click({
+    button: "right",
+  });
+  await page.getByRole("menuitem", { name: action }).click();
+};
+
+const pasteFromClipboardShortcut = async ({ page }: { page: Page }) => {
+  await page.keyboard.press("ControlOrMeta+V");
+  await waitForSyncStatus({ page, status: "idle" });
+};
+
+test.beforeAll(async () => {
+  fixture = await createContentModeProject({
+    email: "pages-actions-e2e@webstudio.test",
+    title: "Pages Actions E2E",
+    assetNamePrefix: "pages-actions-",
+    editorToken: "pages-actions-e2e-editor-token",
+    builderToken: "pages-actions-e2e-builder-token",
+  });
+});
+
+test("Builder can copy and duplicate a page from the header menu and delete it with Backspace", async () => {
+  const { page, close } = await newIsolatedPage();
+  const pageName = "Actions Menu Page";
+  const copiedPageName = `${pageName} (1)`;
+  const duplicatedPageName = `${pageName} (1)`;
+
+  try {
+    await measure("pages actions open builder for page actions", async () => {
+      await openProjectBuilder({
+        page,
+        projectId: fixture.projectId,
+        authToken: fixture.builderToken,
+      });
+    });
+
+    await createPageFromTemplate({
+      page,
+      templateName: fixture.pageTemplateName,
+      pageName,
+      canvasText: fixture.pageTemplateText,
+    });
+
+    await openPageSettings({ page, pageName });
+    await selectHeaderAction({
+      page,
+      menuLabel: "Page actions",
+      action: "Copy",
+    });
+    await waitForCopiedPageClipboard({ page });
+    await pasteFromClipboardShortcut({ page });
+    await waitForPageRow({ page, pageName: copiedPageName });
+
+    await openPage({
+      page,
+      pageName: copiedPageName,
+      canvasText: fixture.pageTemplateText,
+    });
+    await page.getByText(copiedPageName, { exact: true }).first().click();
+    await page.keyboard.press("Backspace");
+    await page.getByRole("button", { name: "Delete Page" }).waitFor();
+    await page.keyboard.press("Enter");
+    await expectTextHidden({ page, text: copiedPageName });
+
+    await openPageSettings({ page, pageName });
+    await selectHeaderAction({
+      page,
+      menuLabel: "Page actions",
+      action: "Duplicate",
+    });
+    await waitForPageRow({ page, pageName: duplicatedPageName });
+
+    await openPageSettings({ page, pageName: duplicatedPageName });
+    await page.keyboard.press("Backspace");
+    await page.getByRole("button", { name: "Delete Page" }).waitFor();
+    await page.keyboard.press("Enter");
+    await expectTextHidden({ page, text: duplicatedPageName });
+  } finally {
+    await close();
+  }
+});
+
+test("Builder can copy, duplicate, and delete a folder from the context menu", async () => {
+  const { page, close } = await newIsolatedPage();
+  const folderName = "Actions Menu Folder";
+  const copiedFolderName = `${folderName} (1)`;
+  const duplicatedFolderName = `${folderName} (2)`;
+
+  try {
+    await measure("pages actions open builder for folder actions", async () => {
+      await openProjectBuilder({
+        page,
+        projectId: fixture.projectId,
+        authToken: fixture.builderToken,
+      });
+    });
+
+    await createFolder({ page, folderName });
+
+    await selectContextAction({ page, itemName: folderName, action: "Copy" });
+    await waitForCopiedPageClipboard({ page });
+    await selectContextAction({ page, itemName: "Home", action: "Paste" });
+    await waitForSyncStatus({ page, status: "idle" });
+    await waitForFolderRow({ page, folderName: copiedFolderName });
+
+    await selectContextAction({
+      page,
+      itemName: folderName,
+      action: "Duplicate",
+    });
+    await waitForFolderRow({ page, folderName: duplicatedFolderName });
+
+    await selectContextAction({
+      page,
+      itemName: duplicatedFolderName,
+      action: "Delete",
+    });
+    await page.getByRole("button", { name: "Delete" }).waitFor();
+    await page.keyboard.press("Enter");
+    await expectTextHidden({ page, text: duplicatedFolderName });
+  } finally {
+    await close();
+  }
+});
+
+test("Builder can copy, duplicate, and delete a page template from actions menus", async () => {
+  const { page, close } = await newIsolatedPage();
+  const templateName = fixture.pageTemplateName;
+  const copiedTemplateName = `${templateName} (1)`;
+  const duplicatedTemplateName = `${templateName} (2)`;
+
+  try {
+    await measure(
+      "pages actions open builder for template actions",
+      async () => {
+        await openProjectBuilder({
+          page,
+          projectId: fixture.projectId,
+          authToken: fixture.builderToken,
+        });
+      }
+    );
+    await openPagesPanel({ page });
+
+    await openTemplateSettings({ page, templateName });
+    await selectHeaderAction({
+      page,
+      menuLabel: "Template actions",
+      action: "Copy",
+    });
+    await waitForCopiedPageClipboard({ page });
+    await pasteFromClipboardShortcut({ page });
+    await waitForTemplate({ page, templateName: copiedTemplateName });
+
+    await openTemplateSettings({ page, templateName });
+    await selectHeaderAction({
+      page,
+      menuLabel: "Template actions",
+      action: "Duplicate",
+    });
+    await waitForTemplate({ page, templateName: duplicatedTemplateName });
+
+    await selectContextAction({
+      page,
+      itemName: duplicatedTemplateName,
+      action: "Delete",
+    });
+    await page.getByRole("button", { name: "Delete Template" }).waitFor();
+    await page.keyboard.press("Enter");
+    await expectTextHidden({ page, text: duplicatedTemplateName });
+  } finally {
+    await close();
+  }
+});

--- a/apps/builder/e2e/tests/pages-actions.e2e.ts
+++ b/apps/builder/e2e/tests/pages-actions.e2e.ts
@@ -19,6 +19,9 @@ let fixture: SeededContentModeProject;
 
 const copiedPageClipboardMarker = "@webstudio/page/v0.1";
 
+const getPageRow = ({ page, pageName }: { page: Page; pageName: string }) =>
+  page.getByRole("group", { name: `Page ${pageName}`, exact: true });
+
 const waitForPageRow = async ({
   page,
   pageName,
@@ -26,9 +29,29 @@ const waitForPageRow = async ({
   page: Page;
   pageName: string;
 }) => {
-  await page
-    .getByRole("group", { name: `Page ${pageName}`, exact: true })
-    .waitFor();
+  await getPageRow({ page, pageName }).waitFor();
+};
+
+const expectPageRowHidden = async ({
+  page,
+  pageName,
+}: {
+  page: Page;
+  pageName: string;
+}) => {
+  await getPageRow({ page, pageName }).waitFor({ state: "hidden" });
+};
+
+const selectPageRow = async ({
+  page,
+  pageName,
+}: {
+  page: Page;
+  pageName: string;
+}) => {
+  await getPageRow({ page, pageName })
+    .getByRole("button", { name: pageName, exact: true })
+    .click();
 };
 
 const waitForFolderRow = async ({
@@ -96,6 +119,25 @@ const pasteFromClipboardShortcut = async ({ page }: { page: Page }) => {
   await waitForSyncStatus({ page, status: "idle" });
 };
 
+const confirmFocusedDialogAction = async ({
+  page,
+  action,
+}: {
+  page: Page;
+  action: string;
+}) => {
+  const button = page.getByRole("button", { name: action });
+  await button.waitFor();
+  await page.waitForFunction((action) => {
+    return (
+      document.activeElement instanceof HTMLButtonElement &&
+      document.activeElement.textContent?.trim() === action
+    );
+  }, action);
+  await page.keyboard.press("Enter");
+  await button.waitFor({ state: "hidden" });
+};
+
 test.beforeAll(async () => {
   fixture = await createContentModeProject({
     email: "pages-actions-e2e@webstudio.test",
@@ -143,11 +185,10 @@ test("Builder can copy and duplicate a page from the header menu and delete it w
       pageName: copiedPageName,
       canvasText: fixture.pageTemplateText,
     });
-    await page.getByText(copiedPageName, { exact: true }).first().click();
+    await selectPageRow({ page, pageName: copiedPageName });
     await page.keyboard.press("Backspace");
-    await page.getByRole("button", { name: "Delete Page" }).waitFor();
-    await page.keyboard.press("Enter");
-    await expectTextHidden({ page, text: copiedPageName });
+    await confirmFocusedDialogAction({ page, action: "Delete Page" });
+    await expectPageRowHidden({ page, pageName: copiedPageName });
 
     await openPageSettings({ page, pageName });
     await selectHeaderAction({
@@ -159,9 +200,8 @@ test("Builder can copy and duplicate a page from the header menu and delete it w
 
     await openPageSettings({ page, pageName: duplicatedPageName });
     await page.keyboard.press("Backspace");
-    await page.getByRole("button", { name: "Delete Page" }).waitFor();
-    await page.keyboard.press("Enter");
-    await expectTextHidden({ page, text: duplicatedPageName });
+    await confirmFocusedDialogAction({ page, action: "Delete Page" });
+    await expectPageRowHidden({ page, pageName: duplicatedPageName });
   } finally {
     await close();
   }

--- a/apps/builder/e2e/tests/pages-actions.e2e.ts
+++ b/apps/builder/e2e/tests/pages-actions.e2e.ts
@@ -42,7 +42,7 @@ const expectPageRowHidden = async ({
   await getPageRow({ page, pageName }).waitFor({ state: "hidden" });
 };
 
-const selectPageRow = async ({
+const deletePageRowWithShortcut = async ({
   page,
   pageName,
 }: {
@@ -52,7 +52,7 @@ const selectPageRow = async ({
   await openPagesPanel({ page });
   await getPageRow({ page, pageName })
     .getByRole("button", { name: pageName, exact: true })
-    .click();
+    .press("Backspace");
 };
 
 const waitForFolderRow = async ({
@@ -179,8 +179,7 @@ test("Builder can copy and duplicate a page from the header menu and delete it w
       pageName: copiedPageName,
       canvasText: fixture.pageTemplateText,
     });
-    await selectPageRow({ page, pageName: copiedPageName });
-    await page.keyboard.press("Backspace");
+    await deletePageRowWithShortcut({ page, pageName: copiedPageName });
     await confirmDialogAction({ page, action: "Delete Page" });
     await expectPageRowHidden({ page, pageName: copiedPageName });
 

--- a/packages/design-system/src/components/css-value-list-item.stories.tsx
+++ b/packages/design-system/src/components/css-value-list-item.stories.tsx
@@ -16,6 +16,8 @@ export default {
   title: "CSS Value List Item",
 };
 
+const { listItemAttributes } = __testing__;
+
 const Thumbnail = styled("div", {
   width: theme.spacing[10],
   height: theme.spacing[10],
@@ -69,7 +71,7 @@ const ListItem = (props: {
           />
         </>
       }
-      {...__testing__.listItemAttributes}
+      {...listItemAttributes}
     />
   );
 };
@@ -194,7 +196,7 @@ export const CSSValueListItem = () => {
                 icon={<MinusIcon />}
               />
             }
-            {...__testing__.listItemAttributes}
+            {...listItemAttributes}
           />
           <CssValueListItem
             id="no-thumb-1"
@@ -208,7 +210,7 @@ export const CSSValueListItem = () => {
                 icon={<MinusIcon />}
               />
             }
-            {...__testing__.listItemAttributes}
+            {...listItemAttributes}
           />
         </CssValueListArrowFocus>
       </StorySection>
@@ -222,7 +224,7 @@ export const CSSValueListItem = () => {
             thumbnail={<Thumbnail />}
             hidden={false}
             disabled
-            {...__testing__.listItemAttributes}
+            {...listItemAttributes}
           />
           <CssValueListItem
             id="disabled-1"
@@ -230,7 +232,7 @@ export const CSSValueListItem = () => {
             label={<Label>Enabled item</Label>}
             thumbnail={<Thumbnail />}
             hidden={false}
-            {...__testing__.listItemAttributes}
+            {...listItemAttributes}
           />
         </CssValueListArrowFocus>
       </StorySection>

--- a/packages/project/src/content-mode-permissions.test.ts
+++ b/packages/project/src/content-mode-permissions.test.ts
@@ -22,6 +22,14 @@ import {
 } from "./content-mode-permissions";
 import type { BuildPatchTransaction } from "./db/build-patch-core";
 
+const {
+  hasOnlyAddedInstancesInSubtree,
+  hasOnlyContentModePageMeta,
+  isContentModePageMetaValue,
+  isContentModePropPatchValue,
+  validateEditableInstanceReferences,
+} = __testing__;
+
 const metas = new Map<string, WsComponentMeta>([
   [
     "Link",
@@ -379,31 +387,29 @@ describe("content mode permissions", () => {
   });
 
   test("validates content-mode page meta values", () => {
-    expect(__testing__.isContentModePageMetaValue("title", "Title")).toBe(true);
-    expect(__testing__.isContentModePageMetaValue("title", 1)).toBe(false);
+    expect(isContentModePageMetaValue("title", "Title")).toBe(true);
+    expect(isContentModePageMetaValue("title", 1)).toBe(false);
     expect(
-      __testing__.isContentModePageMetaValue("custom", [
+      isContentModePageMetaValue("custom", [
         { property: "og:type", content: "website" },
       ])
     ).toBe(true);
     expect(
-      __testing__.isContentModePageMetaValue("custom", [
+      isContentModePageMetaValue("custom", [
         { property: "og:type", content: 1 },
       ])
     ).toBe(false);
-    expect(__testing__.isContentModePageMetaValue("auth", "value")).toBe(false);
+    expect(isContentModePageMetaValue("auth", "value")).toBe(false);
   });
 
   test("validates content-mode page meta objects", () => {
     expect(
-      __testing__.hasOnlyContentModePageMeta({
+      hasOnlyContentModePageMeta({
         title: "Title",
         custom: [{ property: "og:type", content: "website" }],
       })
     ).toBe(true);
-    expect(__testing__.hasOnlyContentModePageMeta({ auth: "value" })).toBe(
-      false
-    );
+    expect(hasOnlyContentModePageMeta({ auth: "value" })).toBe(false);
   });
 
   test("validates content-mode prop patch values", () => {
@@ -415,7 +421,7 @@ describe("content mode permissions", () => {
     });
 
     expect(
-      __testing__.isContentModePropPatchValue({
+      isContentModePropPatchValue({
         capabilities,
         editableInstanceIds: new Set(["link"]),
         expectedPropId: "new-href-prop",
@@ -429,7 +435,7 @@ describe("content mode permissions", () => {
       })
     ).toBe(true);
     expect(
-      __testing__.isContentModePropPatchValue({
+      isContentModePropPatchValue({
         capabilities,
         editableInstanceIds: new Set(["link"]),
         expectedPropId: "new-href-prop",
@@ -496,18 +502,14 @@ describe("content mode permissions", () => {
       editableInstanceIds: new Set<string>(),
     };
 
-    expect(
-      __testing__.hasOnlyAddedInstancesInSubtree(context, "new-root")
-    ).toBe(true);
+    expect(hasOnlyAddedInstancesInSubtree(context, "new-root")).toBe(true);
     capabilities.instances.set("new-root", {
       type: "instance",
       id: "new-root",
       component: "Body",
       children: [{ type: "id", value: "existing" }],
     });
-    expect(
-      __testing__.hasOnlyAddedInstancesInSubtree(context, "new-root")
-    ).toBe(false);
+    expect(hasOnlyAddedInstancesInSubtree(context, "new-root")).toBe(false);
   });
 
   test("validates duplicate content instance references", () => {
@@ -541,7 +543,7 @@ describe("content mode permissions", () => {
     });
 
     expect(
-      __testing__.validateEditableInstanceReferences({
+      validateEditableInstanceReferences({
         capabilities,
         initialContentRootIds: new Set(["block"]),
         initialEditableInstanceIds: new Set(["block", "item"]),

--- a/packages/sdk-components-react/src/html-embed.test.tsx
+++ b/packages/sdk-components-react/src/html-embed.test.tsx
@@ -9,7 +9,7 @@ import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import { __testing__, HtmlEmbed } from "./html-embed";
 import { cartesian } from "./test-utils/cartesian";
 
-const scriptTestIdPrefix = __testing__.scriptTestIdPrefix;
+const { scriptTestIdPrefix } = __testing__;
 const SCRIPT_TEST_ID = "script-a";
 const SCRIPT_PROCESSED_TEST_ID = `${scriptTestIdPrefix}${SCRIPT_TEST_ID}`;
 

--- a/packages/sdk-components-react/src/html-embed.tsx
+++ b/packages/sdk-components-react/src/html-embed.tsx
@@ -13,8 +13,10 @@ import { mergeRefs } from "@react-aria/utils";
 import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
 import { executeDomEvents, patchDomEvents } from "./html-embed-patchers";
 
+const scriptTestIdPrefix = "client-";
+
 export const __testing__ = {
-  scriptTestIdPrefix: "client-",
+  scriptTestIdPrefix,
 };
 
 const insertScript = (sourceScript: HTMLScriptElement): Promise<void> => {
@@ -32,7 +34,7 @@ const insertScript = (sourceScript: HTMLScriptElement): Promise<void> => {
 
     // For testing purposes, we add a prefix to the testid to differentiate between server and client rendered scripts.
     if (script.dataset.testid !== undefined) {
-      script.dataset.testid = `${__testing__.scriptTestIdPrefix}${script.dataset.testid}`;
+      script.dataset.testid = `${scriptTestIdPrefix}${script.dataset.testid}`;
     }
 
     if (hasSrc) {


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/5797
## Summary

- Add page, page template, and folder copy/paste support, including cross-project paste.
- Reuse a shared page item actions menu for page headers and context menus with Copy, Duplicate, Delete, and shortcut hints.
- Add Paste to the pages context menu.
- Preserve template semantics when copying/pasting templates.
- Support folder copy with nested folders/pages.
- Add Backspace/Delete page deletion shortcuts and focus destructive dialog actions for Enter confirmation.
- Rename `init-copy-paste.ts` to `copy-paste.ts`.

## Testing

- `pnpm --filter @webstudio-is/builder typecheck`
- `pnpm --filter @webstudio-is/builder test app/shared/copy-paste/copy-paste.test.ts app/shared/copy-paste/plugin-page.test.ts app/shared/page-utils.test.tsx app/builder/features/pages/page-utils.test.ts`
- `git diff --check`
- E2E copy/delete flows were added in `apps/builder/e2e/tests/pages-actions.e2e.ts`
