### PR TITLE
fix: Prevent outgoing page rerender during navigation

### DIFF
--- a/fixtures/react-router-cloudflare/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-cloudflare/app/routes/[another-page]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/react-router-cloudflare/app/routes/_index.tsx
+++ b/fixtures/react-router-cloudflare/app/routes/_index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/react-router-docker/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-docker/app/routes/[another-page]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/react-router-docker/app/routes/_index.tsx
+++ b/fixtures/react-router-docker/app/routes/_index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/react-router-netlify/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-netlify/app/routes/[another-page]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/react-router-netlify/app/routes/_index.tsx
+++ b/fixtures/react-router-netlify/app/routes/_index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/react-router-vercel/app/routes/[another-page]._index.tsx
+++ b/fixtures/react-router-vercel/app/routes/[another-page]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/react-router-vercel/app/routes/_index.tsx
+++ b/fixtures/react-router-vercel/app/routes/_index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/[another-page]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
@@ -328,20 +329,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/routes/_index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
@@ -328,20 +329,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[_route_with_symbols_]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[animations]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[animations]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[assets1]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[assets1]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[class-names]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[class-names]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[content-block]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[content-block]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[duration]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[duration]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[expressions]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[expressions]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[form]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[form]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[head-tag]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[head-tag]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[heading-with-id]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[nested].[nested-page]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[radix]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[radix]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[resources]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[resources]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/[text-duration]._index.tsx
+++ b/fixtures/webstudio-features/app/routes/[text-duration]._index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/fixtures/webstudio-features/app/routes/_index.tsx
+++ b/fixtures/webstudio-features/app/routes/_index.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/packages/cli/templates/defaults/app/route-templates/html.tsx
+++ b/packages/cli/templates/defaults/app/route-templates/html.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type ServerRuntimeMetaFunction as MetaFunction,
   type LinksFunction,
@@ -328,20 +329,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/packages/cli/templates/react-router/app/route-templates/html.tsx
+++ b/packages/cli/templates/react-router/app/route-templates/html.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import {
   type MetaFunction,
   type LinksFunction,
@@ -327,20 +328,33 @@ export const action = async ({
   }
 };
 
+const PageBoundary = memo(
+  ({ url, system }: ComponentProps<typeof Page> & { url: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={url} system={system} />;
+  },
+  // React Router can rerender the current route while the next route loaders are
+  // still pending. Keep the generated page out of that pending-navigation render
+  // path, but let URL changes remount it.
+  (prevProps, nextProps) => prevProps.url === nextProps.url
+);
+
 const Outlet = () => {
   const { system, resources, url, pageMeta, host } =
     useLoaderData<typeof loader>();
+  const sdkContext = useMemo(
+    () => ({
+      ...constants,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        ...constants,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
-      {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-      <Page key={url} system={system} />
+    <ReactSdkContext.Provider value={sdkContext}>
+      <PageBoundary url={url} system={system} />
       <PageSettingsMeta
         url={url}
         pageMeta={pageMeta}

--- a/packages/sdk-components-react-router/package.json
+++ b/packages/sdk-components-react-router/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "build": "rm -rf lib && esbuild src/components.ts --outdir=lib --bundle --format=esm --packages=external",
     "dts": "tsc --project tsconfig.dts.json",
+    "test": "vitest run",
     "typecheck": "tsgo --noEmit"
   },
   "peerDependencies": {
@@ -39,6 +40,7 @@
     "@types/react-dom": "^18.2.25",
     "@webstudio-is/tsconfig": "workspace:*",
     "react": "18.3.0-canary-14898b6a9-20240318",
-    "react-dom": "18.3.0-canary-14898b6a9-20240318"
+    "react-dom": "18.3.0-canary-14898b6a9-20240318",
+    "vitest": "^3.1.2"
   }
 }

--- a/packages/sdk-components-react-router/src/link.test.tsx
+++ b/packages/sdk-components-react-router/src/link.test.tsx
@@ -1,0 +1,359 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import {
+  createMemoryRouter,
+  RouterProvider,
+  useLoaderData,
+} from "react-router";
+import { afterEach, expect, test, vi } from "vitest";
+import { ReactSdkContext, useResource } from "@webstudio-is/react-sdk/runtime";
+import { HtmlEmbed } from "@webstudio-is/sdk-components-react";
+import { Link } from "./link";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = undefined;
+  document.body.innerHTML = "";
+});
+
+const render = async (children: React.ReactNode) => {
+  const container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(children);
+  });
+};
+
+test("internal link click does not rerender current generated page while destination is pending", async () => {
+  let pageRenderCount = 0;
+  let linkContentRenderCount = 0;
+  let resolveNextLoader: undefined | (() => void);
+
+  const LinkContent = () => {
+    linkContentRenderCount += 1;
+    return <>Next</>;
+  };
+
+  const Page = () => {
+    pageRenderCount += 1;
+    return (
+      <>
+        <div>Home</div>
+        <Link href="/next">
+          <LinkContent />
+        </Link>
+      </>
+    );
+  };
+
+  const PageBoundary = React.memo(
+    ({ url }: { system: { pathname: string }; url: string }) => {
+      return <Page key={url} />;
+    },
+    (prevProps, nextProps) => prevProps.url === nextProps.url
+  );
+
+  const GeneratedRoute = () => {
+    const { resources, system, url } = useLoaderData() as {
+      resources: Record<string, unknown>;
+      system: { pathname: string };
+      url: string;
+    };
+    const sdkContext = React.useMemo(
+      () => ({
+        assetBaseUrl: "/assets/",
+        imageLoader: ({ src }: { src: string }) => src,
+        videoLoader: ({ src }: { src: string }) => src,
+        resources,
+        breakpoints: [],
+        onError: vi.fn(),
+      }),
+      [resources]
+    );
+    return (
+      <ReactSdkContext.Provider value={sdkContext}>
+        <PageBoundary url={url} system={system} />
+      </ReactSdkContext.Provider>
+    );
+  };
+
+  const Next = () => {
+    useLoaderData();
+    return <div>Next page</div>;
+  };
+
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        loader: () => ({
+          resources: {},
+          system: { pathname: "/" },
+          url: "https://example.com/",
+        }),
+        element: <GeneratedRoute />,
+      },
+      {
+        path: "/next",
+        loader: () =>
+          new Promise((resolve) => {
+            resolveNextLoader = () => resolve(null);
+          }),
+        element: <Next />,
+      },
+    ],
+    { initialEntries: ["/"] }
+  );
+
+  await render(<RouterProvider router={router} />);
+
+  expect(pageRenderCount).toBe(1);
+  expect(linkContentRenderCount).toBe(1);
+
+  const link = document.querySelector("a");
+  expect(link).not.toBeNull();
+
+  await act(async () => {
+    link?.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      })
+    );
+    await Promise.resolve();
+  });
+
+  expect(document.body.textContent).toContain("Home");
+  expect(document.body.textContent).not.toContain("Next page");
+  expect(pageRenderCount).toBe(1);
+  expect(linkContentRenderCount).toBe(1);
+
+  await act(async () => {
+    resolveNextLoader?.();
+    await Promise.resolve();
+  });
+
+  expect(document.body.textContent).toContain("Next page");
+});
+
+test("same-url resource changes still update current generated page", async () => {
+  let pageRenderCount = 0;
+  let resources: Record<string, unknown> = { message: "first" };
+
+  const Page = () => {
+    pageRenderCount += 1;
+    const message = useResource("message");
+    return <div>{String(message)}</div>;
+  };
+
+  const PageBoundary = React.memo(
+    ({ url }: { system: { pathname: string }; url: string }) => {
+      return <Page key={url} />;
+    },
+    (prevProps, nextProps) => prevProps.url === nextProps.url
+  );
+
+  const GeneratedRoute = () => {
+    const { resources, system, url } = useLoaderData() as {
+      resources: Record<string, unknown>;
+      system: { pathname: string };
+      url: string;
+    };
+    const sdkContext = React.useMemo(
+      () => ({
+        assetBaseUrl: "/assets/",
+        imageLoader: ({ src }: { src: string }) => src,
+        videoLoader: ({ src }: { src: string }) => src,
+        resources,
+        breakpoints: [],
+        onError: vi.fn(),
+      }),
+      [resources]
+    );
+    return (
+      <ReactSdkContext.Provider value={sdkContext}>
+        <PageBoundary url={url} system={system} />
+      </ReactSdkContext.Provider>
+    );
+  };
+
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        loader: () => ({
+          resources,
+          system: { pathname: "/" },
+          url: "https://example.com/",
+        }),
+        element: <GeneratedRoute />,
+      },
+    ],
+    { initialEntries: ["/"] }
+  );
+
+  await render(<RouterProvider router={router} />);
+
+  expect(pageRenderCount).toBe(1);
+  expect(document.body.textContent).toContain("first");
+
+  resources = { message: "second" };
+
+  await act(async () => {
+    router.revalidate();
+    await Promise.resolve();
+  });
+
+  expect(pageRenderCount).toBe(2);
+  expect(document.body.textContent).toContain("second");
+});
+
+test("html embed scripts are not reprocessed until navigation reaches a new url", async () => {
+  let resolveNextLoader: undefined | (() => void);
+
+  const HomePage = () => {
+    return (
+      <>
+        <HtmlEmbed code={`<script data-testid="home-script"></script>`} />
+        <Link href="/next">Next</Link>
+      </>
+    );
+  };
+
+  const NextPage = () => {
+    return <HtmlEmbed code={`<script data-testid="next-script"></script>`} />;
+  };
+
+  const PageBoundary = React.memo(
+    ({
+      page,
+      url,
+    }: {
+      page: "home" | "next";
+      system: { pathname: string };
+      url: string;
+    }) => {
+      // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+      return (
+        <div key={url}>{page === "home" ? <HomePage /> : <NextPage />}</div>
+      );
+    },
+    (prevProps, nextProps) => prevProps.url === nextProps.url
+  );
+
+  const GeneratedRoute = () => {
+    const { page, resources, system, url } = useLoaderData() as {
+      page: "home" | "next";
+      resources: Record<string, unknown>;
+      system: { pathname: string };
+      url: string;
+    };
+    const sdkContext = React.useMemo(
+      () => ({
+        assetBaseUrl: "/assets/",
+        imageLoader: ({ src }: { src: string }) => src,
+        videoLoader: ({ src }: { src: string }) => src,
+        resources,
+        breakpoints: [],
+        onError: vi.fn(),
+      }),
+      [resources]
+    );
+    return (
+      <ReactSdkContext.Provider value={sdkContext}>
+        <PageBoundary page={page} url={url} system={system} />
+      </ReactSdkContext.Provider>
+    );
+  };
+
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        loader: () => ({
+          page: "home",
+          resources: {},
+          system: { pathname: "/" },
+          url: "https://example.com/",
+        }),
+        element: <GeneratedRoute />,
+      },
+      {
+        path: "/next",
+        loader: () =>
+          new Promise((resolve) => {
+            resolveNextLoader = () =>
+              resolve({
+                page: "next",
+                resources: {},
+                system: { pathname: "/next" },
+                url: "https://example.com/next",
+              });
+          }),
+        element: <GeneratedRoute />,
+      },
+    ],
+    { initialEntries: ["/"] }
+  );
+
+  await render(<RouterProvider router={router} />);
+
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  expect(
+    document.querySelectorAll('[data-testid="client-home-script"]')
+  ).toHaveLength(1);
+  expect(
+    document.querySelector('[data-testid="client-next-script"]')
+  ).toBeNull();
+
+  const link = document.querySelector("a");
+  expect(link).not.toBeNull();
+
+  await act(async () => {
+    link?.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      })
+    );
+    await Promise.resolve();
+  });
+
+  expect(
+    document.querySelectorAll('[data-testid="client-home-script"]')
+  ).toHaveLength(1);
+  expect(
+    document.querySelector('[data-testid="client-next-script"]')
+  ).toBeNull();
+
+  await act(async () => {
+    resolveNextLoader?.();
+    await Promise.resolve();
+  });
+
+  expect(
+    document.querySelector('[data-testid="client-home-script"]')
+  ).toBeNull();
+  expect(
+    document.querySelectorAll('[data-testid="client-next-script"]')
+  ).toHaveLength(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2375,6 +2375,9 @@ importers:
       react-dom:
         specifier: 18.3.0-canary-14898b6a9-20240318
         version: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
+      vitest:
+        specifier: ^3.1.2
+        version: 3.1.2(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.1.2)(jiti@2.4.2)(jsdom@20.0.3)(msw@2.13.2(@types/node@22.13.10)(typescript@5.8.2))(tsx@4.19.3)
 
   packages/sync-client:
     dependencies:


### PR DESCRIPTION
**Description**

Prevents published pages from rerendering the outgoing generated page during pending internal navigation.

React Router can rerender the current route while the next route loader is pending. The generated `Page` was rendered directly inside that route, so the entire outgoing page could rerender before the next page appeared.

This adds a memoized `PageBoundary` keyed by `url`, so the generated page only rerenders/remounts when the actual page URL changes. The SDK context value is memoized by `resources`, preserving same-URL resource updates without exposing the full page tree to unrelated pending-navigation rerenders.

**Changes**
- Added `PageBoundary` to React Router and Remix/default HTML route templates.
- Kept `key={url}` behavior for HTML Embed script reloads on dynamic pages.
- Added regression tests for:
  - no outgoing page rerender while destination navigation is pending
  - same-URL resource changes still update generated page content
- Added Vitest setup for `sdk-components-react-router`.

**Verification**
```txt
pnpm --filter @webstudio-is/sdk-components-react-router test src/link.test.tsx
pnpm --filter @webstudio-is/sdk-components-react-router typecheck
pnpm --filter @webstudio-is/sdk-cli typecheck
```