### PR TITLE
fix: Fix local link matching when query params are used

### DIFF
--- a/packages/sdk-components-react-remix/src/link.tsx
+++ b/packages/sdk-components-react-remix/src/link.tsx
@@ -3,7 +3,7 @@ import {
   useLocation,
   useResolvedPath,
 } from "@remix-run/react";
-import { createLocalLink } from "@webstudio-is/sdk-components-react";
+import { createLocalLink } from "@webstudio-is/sdk-components-react/local-link";
 
 export const Link = createLocalLink({
   Link: RemixLink,

--- a/packages/sdk-components-react-remix/src/link.tsx
+++ b/packages/sdk-components-react-remix/src/link.tsx
@@ -1,42 +1,12 @@
-import { forwardRef, type ComponentPropsWithoutRef, useContext } from "react";
-import { NavLink as RemixLink } from "@remix-run/react";
-import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
-import { Link as BaseLink } from "@webstudio-is/sdk-components-react";
+import {
+  Link as RemixLink,
+  useLocation,
+  useResolvedPath,
+} from "@remix-run/react";
+import { createLocalLink } from "@webstudio-is/sdk-components-react";
 
-type Props = Omit<ComponentPropsWithoutRef<typeof BaseLink>, "target"> & {
-  // override (string & {}) in target to generate keywords
-  target?: "_self" | "_blank" | "_parent" | "_top";
-
-  // useful remix props
-  prefetch?: "none" | "intent" | "render" | "viewport";
-  reloadDocument?: boolean;
-  replace?: boolean;
-  preventScrollReset?: boolean;
-};
-
-export const Link = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
-  const { assetBaseUrl } = useContext(ReactSdkContext);
-  // cast to string when invalid value type is provided with binding
-  const href = String(props.href ?? "");
-
-  // use remix link for self reference and all relative urls
-  // ignore asset paths which can be relative too
-  // urls starting with # should be handled natively to not override search params
-  if (
-    // remix appends ?index in runtime but not in ssr
-    href === "" ||
-    href.startsWith("?") ||
-    (href.startsWith("/") && href.startsWith(assetBaseUrl) === false)
-  ) {
-    // In the future, we will switch to the :local-link pseudo-class (https://developer.mozilla.org/en-US/docs/Web/CSS/:local-link). (aria-current="page" is used now)
-    // Therefore, we decided to use end={true} (exact route matching) for all links to facilitate easier migration.
-    return <RemixLink {...props} to={href} ref={ref} end />;
-  }
-
-  const { prefetch, reloadDocument, replace, preventScrollReset, ...rest } =
-    props;
-
-  return <BaseLink {...rest} ref={ref} />;
+export const Link = createLocalLink({
+  Link: RemixLink,
+  useLocation,
+  useResolvedPath,
 });
-
-Link.displayName = BaseLink.displayName;

--- a/packages/sdk-components-react-router/src/link.test.tsx
+++ b/packages/sdk-components-react-router/src/link.test.tsx
@@ -38,6 +38,356 @@ const render = async (children: React.ReactNode) => {
   });
 };
 
+const sdkContext = {
+  assetBaseUrl: "/assets/",
+  imageLoader: ({ src }: { src: string }) => src,
+  videoLoader: ({ src }: { src: string }) => src,
+  resources: {},
+  breakpoints: [],
+  onError: vi.fn(),
+};
+
+test("local link is current only when pathname, search, and hash match", async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/path",
+        element: (
+          <ReactSdkContext.Provider value={sdkContext}>
+            <Link href="/path?tag=bla#section">Exact</Link>
+            <Link href="/path">Path only</Link>
+            <Link href="/path?tag=bla">Missing hash</Link>
+            <Link href="/path?tag=other#section">Different query</Link>
+            <Link href="/path#section">Missing query</Link>
+            <Link href="#section">Hash only</Link>
+            <Link href="?tag=bla#section">Search only</Link>
+            <Link href="">Empty</Link>
+            <Link href="/path?tag=bla#section" className="custom">
+              Active class
+            </Link>
+            <Link href="/path" className="custom">
+              Inactive class
+            </Link>
+            <Link href="/path?tag=bla#section" aria-current="location">
+              Aria override
+            </Link>
+          </ReactSdkContext.Provider>
+        ),
+      },
+    ],
+    { initialEntries: ["/path?tag=bla#section"] }
+  );
+
+  await render(<RouterProvider router={router} />);
+
+  const links = Array.from(document.querySelectorAll("a"));
+
+  expect(links.map((link) => link.getAttribute("aria-current"))).toEqual([
+    "page",
+    null,
+    null,
+    null,
+    null,
+    "page",
+    "page",
+    "page",
+    "page",
+    null,
+    "location",
+  ]);
+
+  expect(links[0]?.getAttribute("class")).toBe("active");
+  expect(links[1]?.hasAttribute("class")).toBe(false);
+  expect(links[8]?.getAttribute("class")).toBe("custom active");
+  expect(links[9]?.getAttribute("class")).toBe("custom");
+});
+
+test("local link preserves exact pathname behavior", async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/path/*",
+        element: (
+          <ReactSdkContext.Provider value={sdkContext}>
+            <Link href="/path">Parent</Link>
+            <Link href="/path/child">Child</Link>
+            <Link href="/path/">Trailing slash</Link>
+            <Link href="/Path/child">Different case</Link>
+          </ReactSdkContext.Provider>
+        ),
+      },
+    ],
+    { initialEntries: ["/path/child"] }
+  );
+
+  await render(<RouterProvider router={router} />);
+
+  const links = Array.from(document.querySelectorAll("a"));
+
+  expect(links.map((link) => link.getAttribute("aria-current"))).toEqual([
+    null,
+    "page",
+    null,
+    null,
+  ]);
+});
+
+test("external link renders as plain anchor without router context", async () => {
+  await render(
+    <Link
+      href="https://example.com/page"
+      prefetch="intent"
+      preventScrollReset
+      reloadDocument
+      replace
+      target="_blank"
+    >
+      External
+    </Link>
+  );
+
+  const link = document.querySelector("a");
+
+  expect(link?.getAttribute("href")).toBe("https://example.com/page");
+  expect(link?.getAttribute("target")).toBe("_blank");
+  expect(link?.hasAttribute("prefetch")).toBe(false);
+  expect(link?.hasAttribute("preventscrollreset")).toBe(false);
+  expect(link?.hasAttribute("reloaddocument")).toBe(false);
+  expect(link?.hasAttribute("replace")).toBe(false);
+});
+
+test("protocol-relative link renders as plain anchor without router context", async () => {
+  await render(<Link href="//example.com/page">Protocol relative</Link>);
+
+  const link = document.querySelector("a");
+
+  expect(link?.getAttribute("href")).toBe("//example.com/page");
+});
+
+test("protocol links render as plain anchors without router context", async () => {
+  await render(
+    <>
+      <Link href="mailto:hello@example.com">Email</Link>
+      <Link href="tel:+15555555555">Phone</Link>
+    </>
+  );
+
+  const links = Array.from(document.querySelectorAll("a"));
+
+  expect(links[0]?.getAttribute("href")).toBe("mailto:hello@example.com");
+  expect(links[1]?.getAttribute("href")).toBe("tel:+15555555555");
+});
+
+test("asset link renders as plain anchor without router context", async () => {
+  await render(
+    <ReactSdkContext.Provider value={sdkContext}>
+      <Link href="/assets/file.pdf">Asset</Link>
+    </ReactSdkContext.Provider>
+  );
+
+  const link = document.querySelector("a");
+
+  expect(link?.getAttribute("href")).toBe("/assets/file.pdf");
+  expect(link?.getAttribute("aria-current")).toBeNull();
+});
+
+test("asset base url only excludes matching root-relative asset paths", async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/path",
+        element: (
+          <ReactSdkContext.Provider
+            value={{ ...sdkContext, assetBaseUrl: "/assets/" }}
+          >
+            <Link href="/assets">Asset-looking page</Link>
+            <Link href="/assets2/file.pdf">Similar prefix page</Link>
+          </ReactSdkContext.Provider>
+        ),
+      },
+    ],
+    { initialEntries: ["/path"] }
+  );
+
+  await render(<RouterProvider router={router} />);
+
+  const links = Array.from(document.querySelectorAll("a"));
+
+  expect(links[0]?.getAttribute("data-discover")).toBe("true");
+  expect(links[1]?.getAttribute("data-discover")).toBe("true");
+});
+
+test("hash-only link does not start router navigation", async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/path",
+        element: (
+          <ReactSdkContext.Provider value={sdkContext}>
+            <Link href="#section">Hash</Link>
+          </ReactSdkContext.Provider>
+        ),
+      },
+      {
+        path: "/other",
+        element: <div>Other page</div>,
+      },
+    ],
+    { initialEntries: ["/path?tag=bla#section"] }
+  );
+
+  await render(<RouterProvider router={router} />);
+
+  const link = document.querySelector("a");
+
+  expect(link?.getAttribute("href")).toBe("#section");
+  expect(link?.getAttribute("aria-current")).toBe("page");
+
+  await act(async () => {
+    link?.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      })
+    );
+    await Promise.resolve();
+  });
+
+  expect(router.state.location.pathname).toBe("/path");
+  expect(router.state.location.search).toBe("?tag=bla");
+  expect(router.state.location.hash).toBe("#section");
+});
+
+test("empty local link preserves the current search and hash", async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/path",
+        element: (
+          <ReactSdkContext.Provider value={sdkContext}>
+            <Link href="">Empty</Link>
+          </ReactSdkContext.Provider>
+        ),
+      },
+      {
+        path: "/other",
+        element: <div>Other page</div>,
+      },
+    ],
+    { initialEntries: ["/path?tag=bla#section"] }
+  );
+
+  await render(<RouterProvider router={router} />);
+
+  const link = document.querySelector("a");
+
+  expect(link?.getAttribute("href")).toBe("/path?tag=bla#section");
+  expect(link?.getAttribute("aria-current")).toBe("page");
+
+  await act(async () => {
+    link?.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      })
+    );
+    await Promise.resolve();
+  });
+
+  expect(router.state.location.pathname).toBe("/path");
+  expect(router.state.location.search).toBe("?tag=bla");
+  expect(router.state.location.hash).toBe("#section");
+});
+
+test("router link forwards navigation props and resolves relative href", async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/parent/child",
+        element: (
+          <ReactSdkContext.Provider value={sdkContext}>
+            <Link href="../next?tab=1#section" preventScrollReset replace>
+              Relative
+            </Link>
+          </ReactSdkContext.Provider>
+        ),
+      },
+      {
+        path: "/next",
+        element: <div>Next route</div>,
+      },
+    ],
+    { initialEntries: ["/parent/child"] }
+  );
+
+  await render(<RouterProvider router={router} />);
+
+  const link = document.querySelector("a");
+
+  expect(link?.getAttribute("href")).toBe("/next?tab=1#section");
+  expect(link?.getAttribute("data-discover")).toBe("true");
+
+  await act(async () => {
+    link?.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      })
+    );
+    await Promise.resolve();
+  });
+
+  expect(router.state.location.pathname).toBe("/next");
+  expect(router.state.location.search).toBe("?tab=1");
+  expect(router.state.location.hash).toBe("#section");
+});
+
+test("router link calls onClick and respects preventDefault", async () => {
+  const onClick = vi.fn((event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+  });
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        element: (
+          <ReactSdkContext.Provider value={sdkContext}>
+            <Link href="/next" onClick={onClick}>
+              Next
+            </Link>
+          </ReactSdkContext.Provider>
+        ),
+      },
+      {
+        path: "/next",
+        element: <div>Next page</div>,
+      },
+    ],
+    { initialEntries: ["/"] }
+  );
+
+  await render(<RouterProvider router={router} />);
+
+  const link = document.querySelector("a");
+
+  await act(async () => {
+    link?.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      })
+    );
+    await Promise.resolve();
+  });
+
+  expect(onClick).toHaveBeenCalledTimes(1);
+  expect(router.state.location.pathname).toBe("/");
+});
+
 test("internal link click does not rerender current generated page while destination is pending", async () => {
   let pageRenderCount = 0;
   let linkContentRenderCount = 0;

--- a/packages/sdk-components-react-router/src/link.test.tsx
+++ b/packages/sdk-components-react-router/src/link.test.tsx
@@ -60,6 +60,7 @@ test("local link is current only when pathname, search, and hash match", async (
             <Link href="/path?tag=other#section">Different query</Link>
             <Link href="/path#section">Missing query</Link>
             <Link href="#section">Hash only</Link>
+            <Link href="#">Bare hash</Link>
             <Link href="?tag=bla#section">Search only</Link>
             <Link href="">Empty</Link>
             <Link href="/path?tag=bla#section" className="custom">
@@ -89,8 +90,9 @@ test("local link is current only when pathname, search, and hash match", async (
     null,
     null,
     "page",
+    null,
     "page",
-    "page",
+    null,
     "page",
     null,
     "location",
@@ -98,8 +100,8 @@ test("local link is current only when pathname, search, and hash match", async (
 
   expect(links[0]?.getAttribute("class")).toBe("active");
   expect(links[1]?.hasAttribute("class")).toBe(false);
-  expect(links[8]?.getAttribute("class")).toBe("custom active");
-  expect(links[9]?.getAttribute("class")).toBe("custom");
+  expect(links[9]?.getAttribute("class")).toBe("custom active");
+  expect(links[10]?.getAttribute("class")).toBe("custom");
 });
 
 test("local link preserves exact pathname behavior", async () => {
@@ -224,7 +226,15 @@ test("hash-only link does not start router navigation", async () => {
         path: "/path",
         element: (
           <ReactSdkContext.Provider value={sdkContext}>
-            <Link href="#section">Hash</Link>
+            <Link
+              href="#section"
+              prefetch="intent"
+              preventScrollReset
+              reloadDocument
+              replace
+            >
+              Hash
+            </Link>
           </ReactSdkContext.Provider>
         ),
       },
@@ -242,6 +252,10 @@ test("hash-only link does not start router navigation", async () => {
 
   expect(link?.getAttribute("href")).toBe("#section");
   expect(link?.getAttribute("aria-current")).toBe("page");
+  expect(link?.hasAttribute("prefetch")).toBe(false);
+  expect(link?.hasAttribute("preventscrollreset")).toBe(false);
+  expect(link?.hasAttribute("reloaddocument")).toBe(false);
+  expect(link?.hasAttribute("replace")).toBe(false);
 
   await act(async () => {
     link?.dispatchEvent(
@@ -259,7 +273,30 @@ test("hash-only link does not start router navigation", async () => {
   expect(router.state.location.hash).toBe("#section");
 });
 
-test("empty local link preserves the current search and hash", async () => {
+test("bare hash link targets the current page without the current hash", async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/path",
+        element: (
+          <ReactSdkContext.Provider value={sdkContext}>
+            <Link href="#">Hash</Link>
+          </ReactSdkContext.Provider>
+        ),
+      },
+    ],
+    { initialEntries: ["/path?tag=bla#section"] }
+  );
+
+  await render(<RouterProvider router={router} />);
+
+  const link = document.querySelector("a");
+
+  expect(link?.getAttribute("href")).toBe("#");
+  expect(link?.getAttribute("aria-current")).toBeNull();
+});
+
+test("empty local link preserves the current search and clears the hash", async () => {
   const router = createMemoryRouter(
     [
       {
@@ -282,8 +319,8 @@ test("empty local link preserves the current search and hash", async () => {
 
   const link = document.querySelector("a");
 
-  expect(link?.getAttribute("href")).toBe("/path?tag=bla#section");
-  expect(link?.getAttribute("aria-current")).toBe("page");
+  expect(link?.getAttribute("href")).toBe("/path?tag=bla");
+  expect(link?.getAttribute("aria-current")).toBeNull();
 
   await act(async () => {
     link?.dispatchEvent(
@@ -298,7 +335,7 @@ test("empty local link preserves the current search and hash", async () => {
 
   expect(router.state.location.pathname).toBe("/path");
   expect(router.state.location.search).toBe("?tag=bla");
-  expect(router.state.location.hash).toBe("#section");
+  expect(router.state.location.hash).toBe("");
 });
 
 test("router link forwards navigation props and resolves relative href", async () => {

--- a/packages/sdk-components-react-router/src/link.tsx
+++ b/packages/sdk-components-react-router/src/link.tsx
@@ -1,42 +1,8 @@
-import { type ComponentPropsWithoutRef, forwardRef, useContext } from "react";
-import { NavLink as RemixLink } from "react-router";
-import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
-import { Link as BaseLink } from "@webstudio-is/sdk-components-react";
+import { Link as RemixLink, useLocation, useResolvedPath } from "react-router";
+import { createLocalLink } from "@webstudio-is/sdk-components-react";
 
-type Props = Omit<ComponentPropsWithoutRef<typeof BaseLink>, "target"> & {
-  // override (string & {}) in target to generate keywords
-  target?: "_self" | "_blank" | "_parent" | "_top";
-
-  // useful remix props
-  prefetch?: "none" | "intent" | "render" | "viewport";
-  reloadDocument?: boolean;
-  replace?: boolean;
-  preventScrollReset?: boolean;
-};
-
-export const Link = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
-  const { assetBaseUrl } = useContext(ReactSdkContext);
-  // cast to string when invalid value type is provided with binding
-  const href = String(props.href ?? "");
-
-  // use remix link for self reference and all relative urls
-  // ignore asset paths which can be relative too
-  // urls starting with # should be handled natively to not override search params
-  if (
-    // remix appends ?index in runtime but not in ssr
-    href === "" ||
-    href.startsWith("?") ||
-    (href.startsWith("/") && href.startsWith(assetBaseUrl) === false)
-  ) {
-    // In the future, we will switch to the :local-link pseudo-class (https://developer.mozilla.org/en-US/docs/Web/CSS/:local-link). (aria-current="page" is used now)
-    // Therefore, we decided to use end={true} (exact route matching) for all links to facilitate easier migration.
-    return <RemixLink {...props} to={href} ref={ref} end />;
-  }
-
-  const { prefetch, reloadDocument, replace, preventScrollReset, ...rest } =
-    props;
-
-  return <BaseLink {...rest} ref={ref} />;
+export const Link = createLocalLink({
+  Link: RemixLink,
+  useLocation,
+  useResolvedPath,
 });
-
-Link.displayName = BaseLink.displayName;

--- a/packages/sdk-components-react-router/src/link.tsx
+++ b/packages/sdk-components-react-router/src/link.tsx
@@ -1,5 +1,5 @@
 import { Link as RemixLink, useLocation, useResolvedPath } from "react-router";
-import { createLocalLink } from "@webstudio-is/sdk-components-react";
+import { createLocalLink } from "@webstudio-is/sdk-components-react/local-link";
 
 export const Link = createLocalLink({
   Link: RemixLink,

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -28,6 +28,11 @@
       "types": "./lib/types/hooks.d.ts",
       "import": "./lib/hooks.js"
     },
+    "./local-link": {
+      "webstudio": "./src/local-link.tsx",
+      "types": "./lib/types/local-link.d.ts",
+      "import": "./lib/local-link.js"
+    },
     "./templates": {
       "webstudio": "./src/templates.ts",
       "types": "./lib/types/templates.d.ts",

--- a/packages/sdk-components-react/src/components.ts
+++ b/packages/sdk-components-react/src/components.ts
@@ -8,7 +8,6 @@ export { Text } from "./text";
 export { Heading } from "./heading";
 export { Paragraph } from "./paragraph";
 export { Link } from "./link";
-export { createLocalLink, type LocalLinkProps } from "./local-link";
 export { RichTextLink } from "./rich-text-link";
 export { Span } from "./span";
 export { Bold } from "./bold";

--- a/packages/sdk-components-react/src/components.ts
+++ b/packages/sdk-components-react/src/components.ts
@@ -8,6 +8,8 @@ export { Text } from "./text";
 export { Heading } from "./heading";
 export { Paragraph } from "./paragraph";
 export { Link } from "./link";
+export { createLocalLink, type LocalLinkProps } from "./local-link";
+export { isLocalLinkActive, resolveLocalLinkUrl } from "./link-utils";
 export { RichTextLink } from "./rich-text-link";
 export { Span } from "./span";
 export { Bold } from "./bold";

--- a/packages/sdk-components-react/src/components.ts
+++ b/packages/sdk-components-react/src/components.ts
@@ -9,7 +9,6 @@ export { Heading } from "./heading";
 export { Paragraph } from "./paragraph";
 export { Link } from "./link";
 export { createLocalLink, type LocalLinkProps } from "./local-link";
-export { isLocalLinkActive, resolveLocalLinkUrl } from "./link-utils";
 export { RichTextLink } from "./rich-text-link";
 export { Span } from "./span";
 export { Bold } from "./bold";

--- a/packages/sdk-components-react/src/link-utils.test.ts
+++ b/packages/sdk-components-react/src/link-utils.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "vitest";
+import { isLocalLinkActive, resolveLocalLinkUrl } from "./link-utils";
+
+test("local link matches exact pathname, search, and hash", () => {
+  expect(
+    isLocalLinkActive(
+      { pathname: "/path", search: "?tag=bla", hash: "#section" },
+      { pathname: "/path", search: "?tag=bla", hash: "#section" }
+    )
+  ).toBe(true);
+});
+
+test("local link does not match when pathname, search, or hash differ", () => {
+  const current = { pathname: "/path", search: "?tag=bla", hash: "#section" };
+
+  expect(
+    isLocalLinkActive(current, {
+      pathname: "/path/child",
+      search: "?tag=bla",
+      hash: "#section",
+    })
+  ).toBe(false);
+  expect(
+    isLocalLinkActive(current, {
+      pathname: "/path",
+      search: "?tag=other",
+      hash: "#section",
+    })
+  ).toBe(false);
+  expect(
+    isLocalLinkActive(current, {
+      pathname: "/path",
+      search: "?tag=bla",
+      hash: "#other",
+    })
+  ).toBe(false);
+});
+
+test("local link matching is case-sensitive like concrete URLs", () => {
+  expect(
+    isLocalLinkActive(
+      { pathname: "/Path", search: "?Tag=bla", hash: "#Section" },
+      { pathname: "/path", search: "?tag=bla", hash: "#section" }
+    )
+  ).toBe(false);
+});
+
+test("local link matching preserves trailing slash exactness", () => {
+  expect(
+    isLocalLinkActive(
+      { pathname: "/path/", search: "", hash: "" },
+      { pathname: "/path", search: "", hash: "" }
+    )
+  ).toBe(false);
+});
+
+test("empty local link resolves to full current location", () => {
+  const current = { pathname: "/path", search: "?tag=bla", hash: "#section" };
+
+  expect(
+    resolveLocalLinkUrl("", current, {
+      pathname: "/path",
+      search: "",
+      hash: "",
+    })
+  ).toEqual(current);
+});
+
+test("hash local link resolves against current pathname and search", () => {
+  const current = { pathname: "/path", search: "?tag=bla", hash: "" };
+
+  expect(
+    resolveLocalLinkUrl("#section", current, {
+      pathname: "/other",
+      search: "?tag=other",
+      hash: "#section",
+    })
+  ).toEqual({
+    pathname: "/path",
+    search: "?tag=bla",
+    hash: "#section",
+  });
+});
+
+test("path local link uses router resolved path", () => {
+  const resolvedPath = {
+    pathname: "/resolved",
+    search: "?tag=bla",
+    hash: "#section",
+  };
+
+  expect(
+    resolveLocalLinkUrl(
+      "/resolved?tag=bla#section",
+      { pathname: "/path", search: "", hash: "" },
+      resolvedPath
+    )
+  ).toBe(resolvedPath);
+});

--- a/packages/sdk-components-react/src/link-utils.test.ts
+++ b/packages/sdk-components-react/src/link-utils.test.ts
@@ -54,7 +54,7 @@ test("local link matching preserves trailing slash exactness", () => {
   ).toBe(false);
 });
 
-test("empty local link resolves to full current location", () => {
+test("empty local link resolves to current pathname and search without hash", () => {
   const current = { pathname: "/path", search: "?tag=bla", hash: "#section" };
 
   expect(
@@ -63,7 +63,11 @@ test("empty local link resolves to full current location", () => {
       search: "",
       hash: "",
     })
-  ).toEqual(current);
+  ).toEqual({
+    pathname: "/path",
+    search: "?tag=bla",
+    hash: "",
+  });
 });
 
 test("hash local link resolves against current pathname and search", () => {
@@ -79,6 +83,22 @@ test("hash local link resolves against current pathname and search", () => {
     pathname: "/path",
     search: "?tag=bla",
     hash: "#section",
+  });
+});
+
+test("bare hash local link resolves to current pathname and search without hash", () => {
+  const current = { pathname: "/path", search: "?tag=bla", hash: "#section" };
+
+  expect(
+    resolveLocalLinkUrl("#", current, {
+      pathname: "/other",
+      search: "?tag=other",
+      hash: "#section",
+    })
+  ).toEqual({
+    pathname: "/path",
+    search: "?tag=bla",
+    hash: "",
   });
 });
 

--- a/packages/sdk-components-react/src/link-utils.ts
+++ b/packages/sdk-components-react/src/link-utils.ts
@@ -5,10 +5,10 @@ export type UrlParts = {
 };
 
 /**
- * React Router resolves href="" and href="#section" without preserving the full
- * browser URL shape Webstudio uses for :local-link-like matching. Normalize those
- * cases before comparing so aria-current follows browser-local-link semantics
- * instead of route-only semantics.
+ * React Router resolves href="" and hash-only hrefs without preserving the
+ * concrete browser URL shape Webstudio uses for :local-link-like matching.
+ * Normalize those cases before comparing so aria-current follows anchor URL
+ * semantics instead of route-only semantics.
  */
 export const resolveLocalLinkUrl = (
   href: string,
@@ -16,14 +16,18 @@ export const resolveLocalLinkUrl = (
   resolvedPath: UrlParts
 ): UrlParts => {
   if (href === "") {
-    return location;
+    return {
+      pathname: location.pathname,
+      search: location.search,
+      hash: "",
+    };
   }
 
   if (href.startsWith("#")) {
     return {
       pathname: location.pathname,
       search: location.search,
-      hash: href,
+      hash: href === "#" ? "" : href,
     };
   }
 

--- a/packages/sdk-components-react/src/link-utils.ts
+++ b/packages/sdk-components-react/src/link-utils.ts
@@ -1,0 +1,44 @@
+export type UrlParts = {
+  pathname: string;
+  search: string;
+  hash: string;
+};
+
+/**
+ * React Router resolves href="" and href="#section" without preserving the full
+ * browser URL shape Webstudio uses for :local-link-like matching. Normalize those
+ * cases before comparing so aria-current follows browser-local-link semantics
+ * instead of route-only semantics.
+ */
+export const resolveLocalLinkUrl = (
+  href: string,
+  location: UrlParts,
+  resolvedPath: UrlParts
+): UrlParts => {
+  if (href === "") {
+    return location;
+  }
+
+  if (href.startsWith("#")) {
+    return {
+      pathname: location.pathname,
+      search: location.search,
+      hash: href,
+    };
+  }
+
+  return resolvedPath;
+};
+
+/**
+ * Webstudio's local link styles target the concrete URL, not just the matched
+ * route. This intentionally preserves the old NavLink end/exact behavior while
+ * also requiring query string and fragment equality.
+ */
+export const isLocalLinkActive = (current: UrlParts, target: UrlParts) => {
+  return (
+    current.pathname === target.pathname &&
+    current.search === target.search &&
+    current.hash === target.hash
+  );
+};

--- a/packages/sdk-components-react/src/local-link.tsx
+++ b/packages/sdk-components-react/src/local-link.tsx
@@ -2,6 +2,7 @@ import {
   type ComponentPropsWithoutRef,
   type ComponentType,
   type ForwardRefExoticComponent,
+  type LegacyRef,
   type RefAttributes,
   forwardRef,
   useContext,
@@ -31,6 +32,14 @@ export type LocalLinkProps = Omit<
 type LocalLinkComponent = ForwardRefExoticComponent<
   LocalLinkProps & RefAttributes<HTMLAnchorElement>
 >;
+
+type RouterTo = string | Partial<UrlParts>;
+
+type RouterLinkComponentProps = Omit<LocalLinkProps, "href" | "target"> & {
+  target?: ComponentPropsWithoutRef<"a">["target"];
+  to: RouterTo;
+  ref?: LegacyRef<HTMLAnchorElement>;
+};
 
 const absoluteUrlPattern = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
 
@@ -70,11 +79,24 @@ const getLocalLinkProps = (
 
 const getRouterHref = (href: string, location: UrlParts) => {
   if (href === "") {
-    return `${location.pathname}${location.search}${location.hash}`;
+    return `${location.pathname}${location.search}`;
   }
 
   return href;
 };
+
+const stripRouterOnlyProps = <
+  Props extends Pick<
+    LocalLinkProps,
+    "prefetch" | "reloadDocument" | "replace" | "preventScrollReset"
+  >,
+>({
+  prefetch,
+  reloadDocument,
+  replace,
+  preventScrollReset,
+  ...props
+}: Props) => props;
 
 /**
  * Remix and React Router expose compatible navigation hooks but from different
@@ -87,9 +109,9 @@ export const createLocalLink = ({
   useResolvedPath,
 }: {
   // Remix v2 and React Router v7 expose compatible Link behavior but different
-  // public prop types. Keep the injected component loose while the returned
-  // Webstudio component stays typed through LocalLinkProps.
-  Link: ComponentType<any>;
+  // public prop types. This adapter boundary captures only the props Webstudio
+  // actually forwards.
+  Link: ComponentType<RouterLinkComponentProps>;
   useLocation: () => UrlParts;
   useResolvedPath: (href: string) => UrlParts;
 }): LocalLinkComponent => {
@@ -126,7 +148,7 @@ export const createLocalLink = ({
     );
     return (
       <BaseLink
-        {...linkProps}
+        {...stripRouterOnlyProps(linkProps)}
         {...localLinkProps}
         href={props.href}
         ref={ref}
@@ -153,10 +175,7 @@ export const createLocalLink = ({
         return <HashLink {...props} href={href} ref={ref} />;
       }
 
-      const { prefetch, reloadDocument, replace, preventScrollReset, ...rest } =
-        props;
-
-      return <BaseLink {...rest} ref={ref} />;
+      return <BaseLink {...stripRouterOnlyProps(props)} ref={ref} />;
     }
   );
 

--- a/packages/sdk-components-react/src/local-link.tsx
+++ b/packages/sdk-components-react/src/local-link.tsx
@@ -1,0 +1,166 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentType,
+  type ForwardRefExoticComponent,
+  type RefAttributes,
+  forwardRef,
+  useContext,
+} from "react";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
+import { Link as BaseLink } from "./link";
+import {
+  isLocalLinkActive,
+  resolveLocalLinkUrl,
+  type UrlParts,
+} from "./link-utils";
+
+export type LocalLinkProps = Omit<
+  ComponentPropsWithoutRef<typeof BaseLink>,
+  "target"
+> & {
+  // override (string & {}) in target to generate keywords
+  target?: "_self" | "_blank" | "_parent" | "_top";
+
+  // useful remix props
+  prefetch?: "none" | "intent" | "render" | "viewport";
+  reloadDocument?: boolean;
+  replace?: boolean;
+  preventScrollReset?: boolean;
+};
+
+type LocalLinkComponent = ForwardRefExoticComponent<
+  LocalLinkProps & RefAttributes<HTMLAnchorElement>
+>;
+
+const absoluteUrlPattern = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+
+const shouldUseRouterLink = (href: string, assetBaseUrl: string) => {
+  if (href.startsWith("#") || absoluteUrlPattern.test(href)) {
+    return false;
+  }
+
+  if (href.startsWith("/") && href.startsWith(assetBaseUrl)) {
+    return false;
+  }
+
+  return true;
+};
+
+const getLocalLinkProps = (
+  props: LocalLinkProps & { href: string },
+  location: UrlParts,
+  resolvedPath: UrlParts
+) => {
+  const { href, "aria-current": ariaCurrent, className, ...linkProps } = props;
+  const target = resolveLocalLinkUrl(href, location, resolvedPath);
+  const isActive = isLocalLinkActive(location, target);
+  const classNameValue = [className, isActive ? "active" : undefined]
+    .filter(Boolean)
+    .join(" ");
+
+  return {
+    href,
+    linkProps,
+    localLinkProps: {
+      ...(isActive ? { "aria-current": ariaCurrent ?? "page" } : {}),
+      ...(classNameValue === "" ? {} : { className: classNameValue }),
+    },
+  };
+};
+
+const getRouterHref = (href: string, location: UrlParts) => {
+  if (href === "") {
+    return `${location.pathname}${location.search}${location.hash}`;
+  }
+
+  return href;
+};
+
+/**
+ * Remix and React Router expose compatible navigation hooks but from different
+ * packages. This factory keeps Webstudio's local-link semantics in one place
+ * while each integration supplies its own router primitives.
+ */
+export const createLocalLink = ({
+  Link,
+  useLocation,
+  useResolvedPath,
+}: {
+  // Remix v2 and React Router v7 expose compatible Link behavior but different
+  // public prop types. Keep the injected component loose while the returned
+  // Webstudio component stays typed through LocalLinkProps.
+  Link: ComponentType<any>;
+  useLocation: () => UrlParts;
+  useResolvedPath: (href: string) => UrlParts;
+}): LocalLinkComponent => {
+  const RouterLink = forwardRef<
+    HTMLAnchorElement,
+    LocalLinkProps & { href: string }
+  >((props, ref) => {
+    const location = useLocation();
+    const { href, linkProps, localLinkProps } = getLocalLinkProps(
+      props,
+      location,
+      useResolvedPath(props.href)
+    );
+
+    return (
+      <Link
+        {...linkProps}
+        {...localLinkProps}
+        to={getRouterHref(href, location)}
+        ref={ref}
+      />
+    );
+  });
+
+  const HashLink = forwardRef<
+    HTMLAnchorElement,
+    LocalLinkProps & { href: string }
+  >((props, ref) => {
+    const location = useLocation();
+    const { linkProps, localLinkProps } = getLocalLinkProps(
+      props,
+      location,
+      location
+    );
+    return (
+      <BaseLink
+        {...linkProps}
+        {...localLinkProps}
+        href={props.href}
+        ref={ref}
+      />
+    );
+  });
+
+  const LocalLink = forwardRef<HTMLAnchorElement, LocalLinkProps>(
+    (props, ref) => {
+      const { assetBaseUrl } = useContext(ReactSdkContext);
+      // cast to string when invalid value type is provided with binding
+      const href = String(props.href ?? "");
+
+      if (shouldUseRouterLink(href, assetBaseUrl)) {
+        // Route through the framework only for navigations it should own. Asset
+        // paths can also be root-relative, so they must stay plain anchors.
+        return <RouterLink {...props} href={href} ref={ref} />;
+      }
+
+      if (href.startsWith("#")) {
+        // Hash-only links should preserve the current search params. React Router
+        // navigation rewrites them, so keep native anchor behavior and only add
+        // Webstudio's aria-current state.
+        return <HashLink {...props} href={href} ref={ref} />;
+      }
+
+      const { prefetch, reloadDocument, replace, preventScrollReset, ...rest } =
+        props;
+
+      return <BaseLink {...rest} ref={ref} />;
+    }
+  );
+
+  LocalLink.displayName = BaseLink.displayName;
+
+  return LocalLink;
+};

--- a/packages/sdk-components-react/tsconfig.dts.json
+++ b/packages/sdk-components-react/tsconfig.dts.json
@@ -1,6 +1,11 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/components.ts", "src/metas.ts", "src/hooks.ts"],
+  "include": [
+    "src/components.ts",
+    "src/metas.ts",
+    "src/hooks.ts",
+    "src/local-link.tsx"
+  ],
   "compilerOptions": {
     "declarationDir": "lib/types"
   }

--- a/vite.sdk-components.config.ts
+++ b/vite.sdk-components.config.ts
@@ -5,6 +5,9 @@ import path from "node:path";
 const hasPrivateFolders = existsSync(
   path.join(process.cwd(), "private-src", "README.md")
 );
+const maybeEntry = (entry: string) => {
+  return existsSync(path.join(process.cwd(), entry)) ? entry : undefined;
+};
 
 const isBareImport = (id: string) =>
   id.startsWith("@") || id.includes(".") === false;
@@ -16,9 +19,9 @@ export default defineConfig({
         hasPrivateFolders ? "private-src/components.ts" : "src/components.ts",
         "src/metas.ts",
         "src/hooks.ts",
-        "src/local-link.tsx",
+        maybeEntry("src/local-link.tsx"),
         "src/templates.ts",
-      ],
+      ].filter((entry) => entry !== undefined),
       formats: ["es"],
     },
     rollupOptions: {

--- a/vite.sdk-components.config.ts
+++ b/vite.sdk-components.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
         hasPrivateFolders ? "private-src/components.ts" : "src/components.ts",
         "src/metas.ts",
         "src/hooks.ts",
+        "src/local-link.tsx",
         "src/templates.ts",
       ],
       formats: ["es"],


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/5377


## Summary

Fixes local link matching so links are marked current only when the full URL matches: pathname, search query, and hash.

## Changes

- Replaced duplicated Remix/React Router `Link` logic with a shared `createLocalLink` helper.
- Switched from `NavLink` route-only active matching to explicit full URL matching.
- Preserved exact `end`-style behavior while also requiring query/hash equality.
- Kept hash-only links as native anchors so current search params are not rewritten.
- Preserved browser-like behavior for `href=""` by resolving it to the full current URL.
- Kept asset/external/protocol links as plain anchors.
- Added comments explaining why the shared local-link code exists and why specific edge cases avoid router navigation.

## Tests

- Added URL matching unit tests for pathname/search/hash, case sensitivity, trailing slash, empty href, hash href, and router-resolved paths.
- Added React Router integration coverage for:
  - exact active/current matching
  - query/hash mismatches
  - active class and `aria-current`
  - hash-only links
  - empty links preserving search/hash
  - external/protocol/asset links
  - relative route links
  - `preventDefault`
  - pending navigation/render behavior
  - same-url resource updates
  - HTML embed navigation behavior

## Verification

- `pnpm --filter @webstudio-is/sdk-components-react test`
- `pnpm --filter @webstudio-is/sdk-components-react-router test`
- `pnpm --filter @webstudio-is/sdk-components-react typecheck`
- `pnpm --filter @webstudio-is/sdk-components-react-router typecheck`
- `pnpm --filter @webstudio-is/sdk-components-react-remix typecheck`
- `pnpm --filter @webstudio-is/sdk-components-react dts`
- `pnpm --filter @webstudio-is/sdk-components-react-router dts`
- `pnpm --filter @webstudio-is/sdk-components-react-remix dts`
