### PR TITLE
fix: Fix text binding rendering for non-text values

### DIFF
--- a/fixtures/react-router-cloudflare/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/react-router-cloudflare/app/__generated__/[another-page]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/react-router-cloudflare/app/__generated__/_index.tsx
+++ b/fixtures/react-router-cloudflare/app/__generated__/_index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/react-router-docker/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/react-router-docker/app/__generated__/[another-page]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/react-router-docker/app/__generated__/_index.tsx
+++ b/fixtures/react-router-docker/app/__generated__/_index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/react-router-netlify/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/react-router-netlify/app/__generated__/[another-page]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/react-router-netlify/app/__generated__/_index.tsx
+++ b/fixtures/react-router-netlify/app/__generated__/_index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/react-router-vercel/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/react-router-vercel/app/__generated__/[another-page]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/react-router-vercel/app/__generated__/_index.tsx
+++ b/fixtures/react-router-vercel/app/__generated__/_index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/ssg-cloudflare-pages/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/ssg-cloudflare-pages/app/__generated__/[another-page]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Heading as Heading,

--- a/fixtures/ssg-cloudflare-pages/app/__generated__/_index.tsx
+++ b/fixtures/ssg-cloudflare-pages/app/__generated__/_index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Heading as Heading,

--- a/fixtures/ssg-netlify-by-project-id/app/__generated__/[redirect]._index.tsx
+++ b/fixtures/ssg-netlify-by-project-id/app/__generated__/[redirect]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 
 export const projectId = "8a7358b1-7de3-459d-b7b1-56dddfb6ce1e";
 

--- a/fixtures/ssg-netlify-by-project-id/app/__generated__/_index.tsx
+++ b/fixtures/ssg-netlify-by-project-id/app/__generated__/_index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Heading as Heading,

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/[another-page]._index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/[another-page]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-remix";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/_index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/webstudio-features/app/__generated__/[_route_with_symbols_]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[_route_with_symbols_]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Image as Image } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-features/app/__generated__/[animations]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[animations]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import {
   Box as Box,

--- a/fixtures/webstudio-features/app/__generated__/[assets1]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[assets1]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 
 export const projectId = "cddc1d44-af37-4cb6-a430-d300cf6f932d";

--- a/fixtures/webstudio-features/app/__generated__/[class-names]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[class-names]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Box as Box } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-features/app/__generated__/[content-block]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[content-block]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import {
   Box as Box,

--- a/fixtures/webstudio-features/app/__generated__/[duration]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[duration]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { AnimateChildren as AnimateChildren } from "@webstudio-is/sdk-components-animation";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";

--- a/fixtures/webstudio-features/app/__generated__/[expressions]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[expressions]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import {
   Heading as Heading,
@@ -40,7 +44,7 @@ const Page = (_props: { system: any }) => {
   return (
     <Body className={`w-body`}>
       <Heading className={`w-heading`}>
-        {`${jsonResourceVariable?.data?.args}`}
+        {renderText(`${jsonResourceVariable?.data?.args}`)}
       </Heading>
       <HtmlEmbed
         code={`<script>
@@ -52,7 +56,7 @@ console.log(a, b);
 </script>`}
         className={`w-html-embed`}
       />
-      <Box className={`w-box`}>{globalVariable}</Box>
+      <Box className={`w-box`}>{renderText(globalVariable)}</Box>
     </Body>
   );
 };

--- a/fixtures/webstudio-features/app/__generated__/[form]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[form]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Form as Form,

--- a/fixtures/webstudio-features/app/__generated__/[head-tag]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[head-tag]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/fixtures/webstudio-features/app/__generated__/[heading-with-id]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[heading-with-id]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-features/app/__generated__/[nested].[nested-page]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[nested].[nested-page]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import { Heading as Heading } from "@webstudio-is/sdk-components-react";
 

--- a/fixtures/webstudio-features/app/__generated__/[radix]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[radix]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import {
   Accordion as Accordion,

--- a/fixtures/webstudio-features/app/__generated__/[resources]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[resources]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import {
   Box as Box,

--- a/fixtures/webstudio-features/app/__generated__/[sitemap.xml]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[sitemap.xml]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   XmlNode as XmlNode,
   XmlTime as XmlTime,
@@ -67,9 +71,9 @@ const Page = (_props: { system: any }) => {
           <Fragment key={index}>
             <XmlNode tag={"url"}>
               <XmlNode tag={"loc"}>
-                {`${system?.origin ?? "${ORIGIN}"}${url?.path}`}
+                {renderText(`${system?.origin ?? "${ORIGIN}"}${url?.path}`)}
               </XmlNode>
-              <XmlNode tag={"lastmod"}>{url?.lastModified}</XmlNode>
+              <XmlNode tag={"lastmod"}>{renderText(url?.lastModified)}</XmlNode>
               <XmlNode
                 tag={"xhtml:link"}
                 rel={"alternate"}

--- a/fixtures/webstudio-features/app/__generated__/[text-duration]._index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/[text-duration]._index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import { Body as Body } from "@webstudio-is/sdk-components-react-router";
 import {
   AnimateChildren as AnimateChildren,

--- a/fixtures/webstudio-features/app/__generated__/_index.tsx
+++ b/fixtures/webstudio-features/app/__generated__/_index.tsx
@@ -2,7 +2,11 @@
 /* This is a auto generated file for building the project */
 
 import { Fragment, useState } from "react";
-import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+import {
+  renderText,
+  useResource,
+  useVariableState,
+} from "@webstudio-is/react-sdk/runtime";
 import {
   Body as Body,
   Link as Link,

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -635,7 +635,7 @@ export const prebuild = async (options: {
       /* This is a auto generated file for building the project */ \n
 
       import { Fragment, useState } from "react";
-      import { useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
+      import { renderText, useResource, useVariableState } from "@webstudio-is/react-sdk/runtime";
       ${importsString}
 
       export const projectId = "${siteData.build.projectId}";

--- a/packages/react-sdk/src/component-generator.test.tsx
+++ b/packages/react-sdk/src/component-generator.test.tsx
@@ -381,7 +381,7 @@ test("generate jsx children with expression", () => {
   ).toEqual(
     validateJSX(
       clear(`
-      {'Hello ' + myvar}
+      {renderText('Hello ' + myvar)}
     `)
     )
   );
@@ -515,7 +515,7 @@ test("generate collection component with itemKey", () => {
       return (
     <Fragment key={key}>
     <Label>
-    {key}
+    {renderText(key)}
     </Label>
     <Button
     aria-label={element} />
@@ -1148,13 +1148,13 @@ test("generate unset variables as undefined", () => {
   ).toEqual(
     validateJSX(
       clear(`
-      const Page = () => {
-      return <Body>
-      <Box>
-      {undefined + undefined}
-      </Box>
-      </Body>
-      }
+    const Page = () => {
+    return <Body>
+    <Box>
+    {renderText(undefined + undefined)}
+    </Box>
+    </Body>
+    }
     `)
     )
   );
@@ -1187,7 +1187,7 @@ test("generate global variables", () => {
       let [rootVariable, set$rootVariable] = useVariableState<any>("root")
       return <Body>
       <Box>
-      {rootVariable}
+      {renderText(rootVariable)}
       </Box>
       </Body>
       }

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -400,7 +400,7 @@ export const generateJsxChildren = ({
         usedDataSources,
         scope,
       });
-      generatedChildren = `{${expression}}\n`;
+      generatedChildren = `{renderText(${expression})}\n`;
       continue;
     }
     if (child.type === "id") {

--- a/packages/react-sdk/src/context.test.tsx
+++ b/packages/react-sdk/src/context.test.tsx
@@ -1,0 +1,55 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, test } from "vitest";
+
+import { renderText } from "./context";
+
+const renderTextBinding = (value: unknown) =>
+  renderToStaticMarkup(<div>{renderText(value)}</div>);
+
+test("failed resource status binding renders the status code", () => {
+  const resource = {
+    ok: false,
+    status: 500,
+    statusText: "Internal Server Error",
+    data: { message: "Internal Server Error" },
+  };
+  const html = renderTextBinding(resource.status);
+
+  expect(html).toBe("<div>500</div>");
+});
+
+test("application error field binding renders the error message", () => {
+  const resource = {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    data: { error: "permission denied" },
+  };
+  const html = renderTextBinding(resource.data.error);
+
+  expect(html).toBe("<div>permission denied</div>");
+});
+
+test("failed resource object binding renders empty text instead of crashing", () => {
+  const resource = {
+    ok: false,
+    status: 500,
+    statusText: "Internal Server Error",
+    data: { message: "Internal Server Error" },
+  };
+  const html = renderTextBinding(resource);
+
+  expect(html).toBe("<div></div>");
+});
+
+test("object-valued data binding renders empty text instead of crashing", () => {
+  const resource = {
+    data: { title: "Changed shape" },
+    ok: true,
+    status: 200,
+    statusText: "OK",
+  };
+  const html = renderTextBinding(resource.data);
+
+  expect(html).toBe("<div></div>");
+});

--- a/packages/react-sdk/src/context.tsx
+++ b/packages/react-sdk/src/context.tsx
@@ -65,3 +65,7 @@ export const useResource = (name: string) => {
 
   return resourceMemozied;
 };
+
+export const renderText = (value: unknown) => {
+  return typeof value === "string" || typeof value === "number" ? value : "";
+};


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio/issues/2966

## Description

Fixes visitor-facing crashes when a text binding resolves to a non-text value, such as an object returned from a resource.

Generated expression children now render through `renderText`, which preserves strings and numbers and renders other runtime values as empty text. This prevents React SSR from throwing `Objects are not valid as a React child` when resource data shape changes unexpectedly.

## Changes

- Added `renderText(value)` runtime helper.
- Wrapped generated expression children with `renderText(...)`.
- Updated generated page imports to include `renderText`.
- Added rendering tests for resource status/error fields and object-shaped bindings.

## Tests

```bash
pnpm --filter @webstudio-is/react-sdk test -- context.test.tsx component-generator.test.tsx
pnpm --filter @webstudio-is/react-sdk typecheck
pnpm --filter ./packages/cli typecheck