### PR TITLE
fix: prevent self-hosted animation rerenders

### DIFF
--- a/fixtures/ssg-cloudflare-pages/pages/another-page/+Page.tsx
+++ b/fixtures/ssg-cloudflare-pages/pages/another-page/+Page.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import type { PageContext } from "vike/types";
 import {
   PageSettingsMeta,
@@ -12,21 +13,40 @@ import {
   siteName,
 } from "../../app/__generated__/[another-page]._index";
 
+const getPageKey = (url: string) => {
+  const { origin, pathname, search } = new URL(url);
+  return `${origin}${pathname}${search}`;
+};
+
+const PageBoundary = memo(
+  ({ pageKey, system }: ComponentProps<typeof Page> & { pageKey: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={pageKey} system={system} />;
+  },
+  // Vike can rerender the current page during client-side navigation and
+  // hash-only URL updates. Keep the generated page out of that render path,
+  // but let actual page URL changes remount it.
+  (prevProps, nextProps) => prevProps.pageKey === nextProps.pageKey
+);
+
 const PageComponent = ({ data }: { data: PageContext["data"] }) => {
   const { system, resources, url, pageMeta } = data;
+  const pageKey = getPageKey(url);
+  const sdkContext = useMemo(
+    () => ({
+      imageLoader,
+      assetBaseUrl,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        imageLoader,
-        assetBaseUrl,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
+    <ReactSdkContext.Provider value={sdkContext}>
       <LinkCurrentUrlContext.Provider value={url}>
-        {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-        <Page key={url} system={system} />
+        <PageBoundary pageKey={pageKey} system={system} />
       </LinkCurrentUrlContext.Provider>
       <PageSettingsMeta
         url={url}

--- a/fixtures/ssg-cloudflare-pages/pages/index/+Page.tsx
+++ b/fixtures/ssg-cloudflare-pages/pages/index/+Page.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import type { PageContext } from "vike/types";
 import {
   PageSettingsMeta,
@@ -8,21 +9,40 @@ import { LinkCurrentUrlContext } from "@webstudio-is/sdk-components-react";
 import { assetBaseUrl, imageLoader } from "../../app/constants.mjs";
 import { Page, breakpoints, siteName } from "../../app/__generated__/_index";
 
+const getPageKey = (url: string) => {
+  const { origin, pathname, search } = new URL(url);
+  return `${origin}${pathname}${search}`;
+};
+
+const PageBoundary = memo(
+  ({ pageKey, system }: ComponentProps<typeof Page> & { pageKey: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={pageKey} system={system} />;
+  },
+  // Vike can rerender the current page during client-side navigation and
+  // hash-only URL updates. Keep the generated page out of that render path,
+  // but let actual page URL changes remount it.
+  (prevProps, nextProps) => prevProps.pageKey === nextProps.pageKey
+);
+
 const PageComponent = ({ data }: { data: PageContext["data"] }) => {
   const { system, resources, url, pageMeta } = data;
+  const pageKey = getPageKey(url);
+  const sdkContext = useMemo(
+    () => ({
+      imageLoader,
+      assetBaseUrl,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        imageLoader,
-        assetBaseUrl,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
+    <ReactSdkContext.Provider value={sdkContext}>
       <LinkCurrentUrlContext.Provider value={url}>
-        {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-        <Page key={url} system={system} />
+        <PageBoundary pageKey={pageKey} system={system} />
       </LinkCurrentUrlContext.Provider>
       <PageSettingsMeta
         url={url}

--- a/fixtures/ssg-cloudflare-pages/renderer/+onRenderClient.tsx
+++ b/fixtures/ssg-cloudflare-pages/renderer/+onRenderClient.tsx
@@ -1,4 +1,4 @@
-import { type Root, createRoot } from "react-dom/client";
+import { type Root, hydrateRoot } from "react-dom/client";
 import type { OnRenderClientSync } from "vike/types";
 
 let root: Root;
@@ -19,7 +19,8 @@ export const onRenderClient: OnRenderClientSync = (pageContext) => {
     </>
   );
   if (root === undefined) {
-    root = createRoot(document.documentElement);
+    root = hydrateRoot(document.documentElement, htmlContent);
+    return;
   }
   document.documentElement.lang = lang;
   root.render(htmlContent);

--- a/fixtures/ssg-netlify-by-project-id/pages/index/+Page.tsx
+++ b/fixtures/ssg-netlify-by-project-id/pages/index/+Page.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import type { PageContext } from "vike/types";
 import {
   PageSettingsMeta,
@@ -8,21 +9,40 @@ import { LinkCurrentUrlContext } from "@webstudio-is/sdk-components-react";
 import { assetBaseUrl, imageLoader } from "../../app/constants.mjs";
 import { Page, breakpoints, siteName } from "../../app/__generated__/_index";
 
+const getPageKey = (url: string) => {
+  const { origin, pathname, search } = new URL(url);
+  return `${origin}${pathname}${search}`;
+};
+
+const PageBoundary = memo(
+  ({ pageKey, system }: ComponentProps<typeof Page> & { pageKey: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={pageKey} system={system} />;
+  },
+  // Vike can rerender the current page during client-side navigation and
+  // hash-only URL updates. Keep the generated page out of that render path,
+  // but let actual page URL changes remount it.
+  (prevProps, nextProps) => prevProps.pageKey === nextProps.pageKey
+);
+
 const PageComponent = ({ data }: { data: PageContext["data"] }) => {
   const { system, resources, url, pageMeta } = data;
+  const pageKey = getPageKey(url);
+  const sdkContext = useMemo(
+    () => ({
+      imageLoader,
+      assetBaseUrl,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        imageLoader,
-        assetBaseUrl,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
+    <ReactSdkContext.Provider value={sdkContext}>
       <LinkCurrentUrlContext.Provider value={url}>
-        {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-        <Page key={url} system={system} />
+        <PageBoundary pageKey={pageKey} system={system} />
       </LinkCurrentUrlContext.Provider>
       <PageSettingsMeta
         url={url}

--- a/fixtures/ssg-netlify-by-project-id/pages/redirect/+Page.tsx
+++ b/fixtures/ssg-netlify-by-project-id/pages/redirect/+Page.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import type { PageContext } from "vike/types";
 import {
   PageSettingsMeta,
@@ -12,21 +13,40 @@ import {
   siteName,
 } from "../../app/__generated__/[redirect]._index";
 
+const getPageKey = (url: string) => {
+  const { origin, pathname, search } = new URL(url);
+  return `${origin}${pathname}${search}`;
+};
+
+const PageBoundary = memo(
+  ({ pageKey, system }: ComponentProps<typeof Page> & { pageKey: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={pageKey} system={system} />;
+  },
+  // Vike can rerender the current page during client-side navigation and
+  // hash-only URL updates. Keep the generated page out of that render path,
+  // but let actual page URL changes remount it.
+  (prevProps, nextProps) => prevProps.pageKey === nextProps.pageKey
+);
+
 const PageComponent = ({ data }: { data: PageContext["data"] }) => {
   const { system, resources, url, pageMeta } = data;
+  const pageKey = getPageKey(url);
+  const sdkContext = useMemo(
+    () => ({
+      imageLoader,
+      assetBaseUrl,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        imageLoader,
-        assetBaseUrl,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
+    <ReactSdkContext.Provider value={sdkContext}>
       <LinkCurrentUrlContext.Provider value={url}>
-        {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-        <Page key={url} system={system} />
+        <PageBoundary pageKey={pageKey} system={system} />
       </LinkCurrentUrlContext.Provider>
       <PageSettingsMeta
         url={url}

--- a/fixtures/ssg-netlify-by-project-id/renderer/+onRenderClient.tsx
+++ b/fixtures/ssg-netlify-by-project-id/renderer/+onRenderClient.tsx
@@ -1,4 +1,4 @@
-import { type Root, createRoot } from "react-dom/client";
+import { type Root, hydrateRoot } from "react-dom/client";
 import type { OnRenderClientSync } from "vike/types";
 
 let root: Root;
@@ -19,7 +19,8 @@ export const onRenderClient: OnRenderClientSync = (pageContext) => {
     </>
   );
   if (root === undefined) {
-    root = createRoot(document.documentElement);
+    root = hydrateRoot(document.documentElement, htmlContent);
+    return;
   }
   document.documentElement.lang = lang;
   root.render(htmlContent);

--- a/packages/cli/templates/ssg/app/route-templates/html/+Page.tsx
+++ b/packages/cli/templates/ssg/app/route-templates/html/+Page.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, memo, useMemo } from "react";
 import type { PageContext } from "vike/types";
 import {
   PageSettingsMeta,
@@ -8,21 +9,40 @@ import { LinkCurrentUrlContext } from "@webstudio-is/sdk-components-react";
 import { assetBaseUrl, imageLoader } from "__CONSTANTS__";
 import { Page, breakpoints, siteName } from "__CLIENT__";
 
+const getPageKey = (url: string) => {
+  const { origin, pathname, search } = new URL(url);
+  return `${origin}${pathname}${search}`;
+};
+
+const PageBoundary = memo(
+  ({ pageKey, system }: ComponentProps<typeof Page> & { pageKey: string }) => {
+    // Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages
+    return <Page key={pageKey} system={system} />;
+  },
+  // Vike can rerender the current page during client-side navigation and
+  // hash-only URL updates. Keep the generated page out of that render path,
+  // but let actual page URL changes remount it.
+  (prevProps, nextProps) => prevProps.pageKey === nextProps.pageKey
+);
+
 const PageComponent = ({ data }: { data: PageContext["data"] }) => {
   const { system, resources, url, pageMeta } = data;
+  const pageKey = getPageKey(url);
+  const sdkContext = useMemo(
+    () => ({
+      imageLoader,
+      assetBaseUrl,
+      resources,
+      breakpoints,
+      onError: console.error,
+    }),
+    [resources]
+  );
+
   return (
-    <ReactSdkContext.Provider
-      value={{
-        imageLoader,
-        assetBaseUrl,
-        resources,
-        breakpoints,
-        onError: console.error,
-      }}
-    >
+    <ReactSdkContext.Provider value={sdkContext}>
       <LinkCurrentUrlContext.Provider value={url}>
-        {/* Use the URL as the key to force scripts in HTML Embed to reload on dynamic pages */}
-        <Page key={url} system={system} />
+        <PageBoundary pageKey={pageKey} system={system} />
       </LinkCurrentUrlContext.Provider>
       <PageSettingsMeta
         url={url}

--- a/packages/cli/templates/ssg/renderer/+onRenderClient.tsx
+++ b/packages/cli/templates/ssg/renderer/+onRenderClient.tsx
@@ -1,4 +1,4 @@
-import { type Root, createRoot } from "react-dom/client";
+import { type Root, hydrateRoot } from "react-dom/client";
 import type { OnRenderClientSync } from "vike/types";
 
 let root: Root;
@@ -19,7 +19,8 @@ export const onRenderClient: OnRenderClientSync = (pageContext) => {
     </>
   );
   if (root === undefined) {
-    root = createRoot(document.documentElement);
+    root = hydrateRoot(document.documentElement, htmlContent);
+    return;
   }
   document.documentElement.lang = lang;
   root.render(htmlContent);


### PR DESCRIPTION
User reported:

The repeated animation issue has been fixed on Webstudio Cloud hosting, but the bug still exists — and is actually even worse — on self-hosted deployments, whether it's on Netlify or Vercel.

Animations sometimes play twice on the initial page load. They also replay before navigating to another page and when clicking an anchor link that points to a section on the same page.

 Additionally, on the very first visit to the website, the first interaction with Radix components causes all animations to replay again. As far as I can tell, this no longer happens after assets are cached, but the initial glitch is still noticeable and doesn't look very polished from a user experience perspective.