### PR TITLE
fix: Make accordion forceMount template-scoped

### DIFF
--- a/packages/sdk-components-react-radix/src/__generated__/accordion.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/accordion.props.ts
@@ -70,6 +70,5 @@ export const propsAccordionContent: Record<string, PropMeta> = {
     required: false,
     control: "boolean",
     type: "boolean",
-    defaultValue: true,
   },
 };

--- a/packages/sdk-components-react-radix/src/accordion.template.tsx
+++ b/packages/sdk-components-react-radix/src/accordion.template.tsx
@@ -76,9 +76,11 @@ const createAccordionItem = (triggerText: string, contentText: string) => {
           font-size: ${fontSize.sm};
           line-height: ${fontSizeLineHeight.sm};
           transition: ${transition.all};
-          height: var(--radix-collapsible-content-height);
           &[data-state="closed"] {
             height: 0;
+          }
+          &[data-state="open"] {
+            height: var(--radix-accordion-content-height);
           }
         `}
       >

--- a/packages/sdk-components-react-radix/src/accordion.tsx
+++ b/packages/sdk-components-react-radix/src/accordion.tsx
@@ -57,15 +57,10 @@ export const AccordionTrigger: ForwardRefExoticComponent<
     RefAttributes<HTMLButtonElement>
 > = Trigger;
 
-export const AccordionContent = forwardRef<
-  HTMLDivElement,
-  Omit<ComponentPropsWithoutRef<typeof Content>, "asChild" | "forceMount"> & {
-    forceMount?: boolean;
-  }
->(({ forceMount = true, ...props }, ref) => {
-  const contentProps = forceMount ? { forceMount: true as const } : {};
-  return <Content ref={ref} {...contentProps} {...props} />;
-});
+export const AccordionContent: ForwardRefExoticComponent<
+  Omit<ComponentProps<typeof Content>, "asChild"> &
+    RefAttributes<HTMLDivElement>
+> = Content;
 
 /* BUILDER HOOKS */
 


### PR DESCRIPTION
We changed forceMount by default to true in the component, which broke existing instances.