### PR TITLE
fix: Fix insertion into legacy slots

### DIFF
--- a/apps/builder/app/shared/instance-utils.test.tsx
+++ b/apps/builder/app/shared/instance-utils.test.tsx
@@ -428,6 +428,39 @@ describe("insert instance children", () => {
     );
   });
 
+  test("insert instance children into legacy slot with direct children", () => {
+    const data = renderData(
+      <$.Body ws:id="bodyId">
+        <$.Slot ws:id="slotId">
+          <$.Box ws:id="boxId"></$.Box>
+        </$.Slot>
+      </$.Body>
+    );
+    const [div] = renderTemplate(
+      <ws.element ws:tag="div" ws:id="divId"></ws.element>
+    ).instances;
+    data.instances.set(div.id, div);
+
+    insertInstanceChildrenMutable(data, [{ type: "id", value: "divId" }], {
+      parentSelector: ["slotId", "bodyId"],
+      position: "end",
+    });
+
+    const fragmentId = data.instances.get("slotId")?.children[0]?.value;
+    expect(data).toEqual(
+      renderData(
+        <$.Body ws:id="bodyId">
+          <$.Slot ws:id="slotId">
+            <$.Fragment ws:id={fragmentId}>
+              <$.Box ws:id="boxId"></$.Box>
+              <ws.element ws:tag="div" ws:id="divId"></ws.element>
+            </$.Fragment>
+          </$.Slot>
+        </$.Body>
+      )
+    );
+  });
+
   test("insert instance children into the start of target", () => {
     const data = renderData(
       <ws.element ws:tag="body" ws:id="bodyId">
@@ -641,6 +674,47 @@ describe("insert webstudio element at", () => {
           <ws.element ws:id="divId" ws:tag="div">
             <ws.element ws:id={newInstanceId} ws:tag="div" />
           </ws.element>
+        </$.Body>
+      ).instances
+    );
+  });
+
+  test("insert element into selected legacy slot with direct children", () => {
+    $pages.set(
+      createDefaultPages({ homePageId: "homePageId", rootInstanceId: "bodyId" })
+    );
+    $instances.set(
+      renderData(
+        <$.Body ws:id="bodyId">
+          <$.Slot ws:id="slotId">
+            <$.Box ws:id="boxId"></$.Box>
+          </$.Slot>
+        </$.Body>
+      ).instances
+    );
+    selectPage("homePageId");
+    selectInstance(["slotId", "bodyId"]);
+
+    insertWebstudioElementAt();
+
+    const instances = $instances.get();
+    const fragmentId = instances.get("slotId")?.children[0]?.value;
+    const newInstanceId = Array.from(instances.keys()).find(
+      (id) =>
+        id !== "bodyId" &&
+        id !== "slotId" &&
+        id !== "boxId" &&
+        id !== fragmentId
+    );
+    expect(instances).toEqual(
+      renderData(
+        <$.Body ws:id="bodyId">
+          <$.Slot ws:id="slotId">
+            <$.Fragment ws:id={fragmentId}>
+              <$.Box ws:id="boxId"></$.Box>
+              <ws.element ws:id={newInstanceId} ws:tag="div" />
+            </$.Fragment>
+          </$.Slot>
         </$.Body>
       ).instances
     );

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -79,6 +79,21 @@ export const getInstanceOrCreateFragmentIfNecessary = (
   // otherwise multiple slots will have to maintain own children
   // here all slot children are wrapped with fragment instance
   if (instance.component === "Slot") {
+    const wrapSlotChildrenWithFragment = () => {
+      const id = nanoid();
+      instances.set(id, {
+        type: "instance",
+        id,
+        component: "Fragment",
+        children: instance.children,
+      });
+      instance.children = [{ type: "id", value: id }];
+      return {
+        parentSelector: [id, ...dropTarget.parentSelector],
+        position: dropTarget.position,
+      };
+    };
+
     if (instance.children.length === 0) {
       const id = nanoid();
       const fragment: Instance = {
@@ -94,14 +109,20 @@ export const getInstanceOrCreateFragmentIfNecessary = (
         position: dropTarget.position,
       };
     }
-    // first slot child is always fragment
     if (instance.children[0].type === "id") {
       const fragmentId = instance.children[0].value;
+      const fragment = instances.get(fragmentId);
+      if (fragment?.component !== "Fragment") {
+        // Legacy slots stored content directly under Slot. Normalize before
+        // inserting so the first content child is not mistaken for Fragment.
+        return wrapSlotChildrenWithFragment();
+      }
       return {
         parentSelector: [fragmentId, ...dropTarget.parentSelector],
         position: dropTarget.position,
       };
     }
+    return wrapSlotChildrenWithFragment();
   }
   return;
 };


### PR DESCRIPTION
## Summary

Fixes insertion into legacy Slot instances whose children are stored directly under the Slot instead of under the newer hidden Fragment wrapper.

Previously, adding an element to an old Slot could insert the new element into the first existing Slot child. The insertion path assumed the first Slot child was always a Fragment.

## Changes

- Normalize legacy Slot children during insertion by wrapping direct Slot children in a Fragment.
- Preserve the existing behavior for valid `Slot -> Fragment -> children` structures.
- Add regression tests for:
  - low-level `insertInstanceChildrenMutable`
  - UI-facing `insertWebstudioElementAt`

## Validation

```bash
pnpm --filter @webstudio-is/builder test -- app/shared/instance-utils.test.tsx
pnpm --filter @webstudio-is/builder typecheck
```
