### PR TITLE
fix(storybook): update color import after Figma token pipeline removal

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { setEnv } from "../packages/feature-flags/src/index";
 import { theme, globalCss } from "../packages/design-system/src/index";
-import { color } from "../packages/design-system/src/__generated__/figma-design-tokens";
+import { color } from "../packages/design-system/src/design-tokens";
 
 // this adds <style> tags to the <head> of the document
 import "@fontsource-variable/inter";


### PR DESCRIPTION
Commit db78ae4 (`feat: Bring back blue token color and remove Figma token sync pipeline`) deleted `packages/design-system/src/__generated__/figma-design-tokens` but `.storybook/preview.tsx` still imports `color` from it, breaking Chromatic/Storybook builds.

The same `color` export already exists in `design-tokens.ts` (the source that was previously used to generate the deleted file).

```diff
- import { color } from "../packages/design-system/src/__generated__/figma-design-tokens";
+ import { color } from "../packages/design-system/src/design-tokens";
```