### PR TITLE
fix: Fix Builder paste transfer data handling and publish sync edge cases

### DIFF
--- a/apps/builder/app/shared/copy-paste/copy-paste.test.ts
+++ b/apps/builder/app/shared/copy-paste/copy-paste.test.ts
@@ -131,6 +131,13 @@ const setupToastInfo = () => {
   return toastInfo;
 };
 
+const setupToastError = () => {
+  initBuilderApi();
+  const toastError = vi.fn();
+  window.__webstudio__$__builderApi.toast.error = toastError;
+  return toastError;
+};
+
 const waitForClipboardEvent = () =>
   new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -456,6 +463,80 @@ test("pastes multi-selected instance clipboard data through clipboard event", as
   abortController.abort();
 });
 
+test("does not paste malformed webstudio instance json as plain text", async () => {
+  resetStores();
+  const abortController = new AbortController();
+  const toastError = setupToastError();
+  initCopyPaste({ signal: abortController.signal });
+  $project.set({ id: "project-id" } as Project);
+  setupPage();
+  selectInstance(["body-id"]);
+  const { clipboardData, event } = createClipboardEvent("paste");
+  clipboardData.setData(
+    "text/plain",
+    `{"@webstudio/instance/v0.1":{"instanceSelector":["missing-id","body-id"]`
+  );
+
+  document.dispatchEvent(event);
+  await waitForClipboardEvent();
+
+  expect(event.defaultPrevented).toBe(true);
+  expect($instances.get().get("body-id")?.children).toEqual([]);
+  expect(toastError).toHaveBeenCalledWith(
+    "Could not paste Webstudio instance data. The clipboard data appears to be incomplete or invalid."
+  );
+  abortController.abort();
+});
+
+test("reports malformed Webflow json through generic paste", async () => {
+  resetStores();
+  const abortController = new AbortController();
+  const toastError = setupToastError();
+  initCopyPaste({ signal: abortController.signal });
+  setupPage();
+  selectInstance(["body-id"]);
+  const { clipboardData, event } = createClipboardEvent("paste");
+  clipboardData.setData(
+    "application/json",
+    JSON.stringify({ type: "@webflow/XscpData" })
+  );
+
+  document.dispatchEvent(event);
+  await waitForClipboardEvent();
+
+  expect(event.defaultPrevented).toBe(true);
+  expect($instances.get().get("body-id")?.children).toEqual([]);
+  expect(toastError).toHaveBeenCalledWith(expect.any(String));
+  abortController.abort();
+});
+
+test("does not intercept native paste while editing text", async () => {
+  resetStores();
+  const abortController = new AbortController();
+  const toastError = setupToastError();
+  initCopyPaste({ signal: abortController.signal });
+  setupPage();
+  $textEditingInstanceSelector.set({
+    selector: ["text-id", "body-id"],
+    reason: "click",
+    mouseX: 0,
+    mouseY: 0,
+  });
+  const { clipboardData, event } = createClipboardEvent("paste");
+  clipboardData.setData(
+    "text/plain",
+    `{"@webstudio/instance/v0.1":{"instanceSelector":["missing-id","body-id"]`
+  );
+
+  document.dispatchEvent(event);
+  await waitForClipboardEvent();
+
+  expect(event.defaultPrevented).toBe(false);
+  expect($instances.get().get("body-id")?.children).toEqual([]);
+  expect(toastError).not.toHaveBeenCalled();
+  abortController.abort();
+});
+
 test("cuts multi-selected instances through clipboard event", () => {
   resetStores();
   const abortController = new AbortController();
@@ -543,6 +624,31 @@ test("content mode reports unsupported paste clipboard data", async () => {
 
   expect(event.defaultPrevented).toBe(true);
   expect(toastInfo).toHaveBeenCalledWith(
+    "This clipboard data cannot be pasted here."
+  );
+  abortController.abort();
+});
+
+test("content mode reports malformed webstudio instance clipboard data", async () => {
+  resetStores();
+  const abortController = new AbortController();
+  const toastInfo = setupToastInfo();
+  const toastError = setupToastError();
+  initCopyPasteForContentEditMode({ signal: abortController.signal });
+  const { clipboardData, event } = createClipboardEvent("paste");
+  clipboardData.setData(
+    "text/plain",
+    `{"@webstudio/instance/v0.1":{"instanceSelector":["missing-id","body-id"]`
+  );
+
+  document.dispatchEvent(event);
+  await waitForClipboardEvent();
+
+  expect(event.defaultPrevented).toBe(true);
+  expect(toastError).toHaveBeenCalledWith(
+    "Could not paste Webstudio instance data. The clipboard data appears to be incomplete or invalid."
+  );
+  expect(toastInfo).not.toHaveBeenCalledWith(
     "This clipboard data cannot be pasted here."
   );
   abortController.abort();

--- a/apps/builder/app/shared/copy-paste/copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/copy-paste.ts
@@ -80,7 +80,31 @@ export type Plugin = {
   mimeType: string;
   onCopy?: () => undefined | string;
   onCut?: () => undefined | string;
-  onPaste?: (data: string) => boolean | Promise<boolean>;
+  onPaste?: (data: string) => PasteResult | Promise<PasteResult>;
+};
+
+export type PasteResult =
+  | { success: true; data: { handled: false } }
+  | { success: true; data: { handled: true } }
+  | { success: false; error: string };
+
+export const pasteIgnored: PasteResult = {
+  success: true,
+  data: { handled: false },
+};
+
+export const pasteHandled: PasteResult = {
+  success: true,
+  data: { handled: true },
+};
+
+const isPasteHandled = (result: PasteResult) =>
+  result.success === false || result.data.handled;
+
+const reportPasteResult = (result: PasteResult) => {
+  if (result.success === false) {
+    builderApi.toast.error(result.error);
+  }
 };
 
 const initPlugins = ({
@@ -126,12 +150,19 @@ const initPlugins = ({
     if (validateClipboardEvent(event) === false) {
       return;
     }
+    event.preventDefault();
 
     for (const { mimeType, onPaste } of plugins) {
-      // this shouldn't matter, but just in case
-      event.preventDefault();
+      if (onPaste === undefined) {
+        continue;
+      }
       const data = event.clipboardData?.getData(mimeType).trim();
-      if (data && (await onPaste?.(data))) {
+      if (data === undefined || data === "") {
+        continue;
+      }
+      const result = await onPaste(data);
+      if (isPasteHandled(result)) {
+        reportPasteResult(result);
         break;
       }
     }
@@ -196,7 +227,9 @@ export const initCopyPasteForContentEditMode = ({
     const jsonData = event.clipboardData?.getData(instanceJson.mimeType).trim();
     if (jsonData) {
       event.preventDefault();
-      if (await instanceJson.onPaste?.(jsonData)) {
+      const result = await instanceJson.onPaste(jsonData);
+      if (isPasteHandled(result)) {
+        reportPasteResult(result);
         return;
       }
       showUnsupportedPasteMessage();
@@ -205,7 +238,9 @@ export const initCopyPasteForContentEditMode = ({
     const textData = event.clipboardData?.getData(instanceText.mimeType).trim();
     if (textData) {
       event.preventDefault();
-      if (await instanceText.onPaste?.(textData)) {
+      const result = await instanceText.onPaste(textData);
+      if (isPasteHandled(result)) {
+        reportPasteResult(result);
         return;
       }
       showUnsupportedPasteMessage();
@@ -257,7 +292,9 @@ export const copyTemplate = (templateId: string) => {
 
 export const pastePage = async (targetFolderId?: string) => {
   const text = await navigator.clipboard.readText();
-  return handlePastePage(text, targetFolderId);
+  const result = await handlePastePage(text, targetFolderId);
+  reportPasteResult(result);
+  return isPasteHandled(result);
 };
 
 export const emitPaste = async () => {

--- a/apps/builder/app/shared/copy-paste/fragment-utils.ts
+++ b/apps/builder/app/shared/copy-paste/fragment-utils.ts
@@ -1,0 +1,20 @@
+import type { WebstudioFragment } from "@webstudio-is/sdk";
+import { breakpointPasteLimitWarning } from "@webstudio-is/project-build/runtime/breakpoints";
+import {
+  insertWebstudioFragmentAt,
+  type Insertable,
+} from "../instance-utils/insert";
+import { builderApi } from "../builder-api";
+
+export const hasFragmentData = (fragment: WebstudioFragment) =>
+  fragment.children.length > 0 || fragment.styleSources.length > 0;
+
+export const insertFragmentWithBreakpointWarning = (
+  fragment: WebstudioFragment,
+  insertable?: Insertable
+) =>
+  insertWebstudioFragmentAt(fragment, insertable, undefined, {
+    onBreakpointLimitMerge: () => {
+      builderApi.toast.warn(breakpointPasteLimitWarning);
+    },
+  });

--- a/apps/builder/app/shared/copy-paste/plugin-html.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-html.test.tsx
@@ -14,6 +14,7 @@ import {
   selectInstance,
 } from "../nano-states";
 import { html } from "./plugin-html";
+import { pasteHandled, pasteIgnored } from "./copy-paste";
 
 setEnv("*");
 registerContainers();
@@ -40,7 +41,7 @@ test("paste html fragment", async () => {
         <h1>It works</h1>
       </section>
     `)
-  ).toEqual(true);
+  ).toEqual(pasteHandled);
   const [_bodyId, _divId, sectionId, headingId] = $instances.get().keys();
   expect(sectionId).toBeTruthy();
   expect(headingId).toBeTruthy();
@@ -72,7 +73,7 @@ test("ignore html without any tags", async () => {
   );
   $selectedPageId.set("pageId");
   selectInstance(["divId", "bodyId"]);
-  expect(await html.onPaste?.(`It works`)).toEqual(false);
+  expect(await html.onPaste?.(`It works`)).toEqual(pasteIgnored);
   expect($instances.get()).toEqual(data.instances);
 });
 
@@ -95,7 +96,7 @@ test("skip whitespace-only text nodes between element siblings", async () => {
   // This ensures the second span gets text-content control in settings panel
   expect(
     await html.onPaste?.(`<div><span>✓</span> <span>text</span></div>`)
-  ).toEqual(true);
+  ).toEqual(pasteHandled);
 
   const instances = Array.from($instances.get().values()).filter(
     (i) => i.id !== "bodyId" && i.id !== "divId"

--- a/apps/builder/app/shared/copy-paste/plugin-html.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-html.ts
@@ -1,11 +1,13 @@
 import type { WebstudioFragment } from "@webstudio-is/sdk";
 import { generateFragmentFromHtml } from "@webstudio-is/project-build/runtime/html";
-import { insertWebstudioFragmentAt } from "../instance-utils/insert";
 import { generateFragmentFromTailwind } from "../tailwind/tailwind";
 import { denormalizeSrcProps } from "./asset-upload";
-import type { Plugin } from "./copy-paste";
+import { pasteHandled, pasteIgnored, type Plugin } from "./copy-paste";
 import { builderApi } from "../builder-api";
-import { breakpointPasteLimitWarning } from "@webstudio-is/project-build/runtime/breakpoints";
+import {
+  hasFragmentData,
+  insertFragmentWithBreakpointWarning,
+} from "./fragment-utils";
 
 const inceptionMark = `<!-- @webstudio/inception/1 -->`;
 
@@ -13,26 +15,20 @@ const handlePasteHtml = async (html: string) => {
   const parseResult = generateFragmentFromHtml(html);
   const { skippedSelectors } = parseResult;
   let fragment: WebstudioFragment = parseResult;
+  if (hasFragmentData(fragment) === false) {
+    return pasteIgnored;
+  }
   fragment = await denormalizeSrcProps(fragment);
   if (html.includes(inceptionMark)) {
     fragment = await generateFragmentFromTailwind(fragment);
   }
-  const result = await insertWebstudioFragmentAt(
-    fragment,
-    undefined,
-    undefined,
-    {
-      onBreakpointLimitMerge: () => {
-        builderApi.toast.warn(breakpointPasteLimitWarning);
-      },
-    }
-  );
+  insertFragmentWithBreakpointWarning(fragment);
   if (skippedSelectors.length > 0) {
     builderApi.toast.info(
       `Skipped nested selectors (no matching elements): ${skippedSelectors.join(", ")}`
     );
   }
-  return result;
+  return pasteHandled;
 };
 
 export const html: Plugin = {

--- a/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
@@ -1,5 +1,6 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import { enableMapSet } from "immer";
+import { toast } from "@webstudio-is/design-system";
 import type {
   Instance,
   Instances,
@@ -20,6 +21,7 @@ import {
 } from "@webstudio-is/sdk";
 import type { Project } from "@webstudio-is/project";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
+import { componentMetas } from "@webstudio-is/sdk-components-registry/metas";
 import { registerContainers } from "../sync/sync-stores";
 import { $registeredComponentMetas } from "../nano-states";
 import { $instances } from "~/shared/sync/data-stores";
@@ -40,6 +42,7 @@ import {
   expectSlotTreeIntegrity,
   expectSlotsShareFragment,
 } from "../slot-test-utils";
+import { pasteHandled } from "./copy-paste";
 
 const expectString = expect.any(String) as unknown as string;
 
@@ -182,7 +185,8 @@ describe("copy and cut guards", () => {
     const clipboardData = instanceText.onCopy?.() ?? "";
     selectInstance(["body0"]);
 
-    expect(await instanceText.onPaste?.(clipboardData)).toBe(true);
+    const result = await instanceText.onPaste?.(clipboardData);
+    expect(result).toEqual(pasteHandled);
 
     const bodyChildren = $instances.get().get("body0")?.children;
     const pastedRootIds = bodyChildren?.slice(2).map((child) => child.value);
@@ -224,8 +228,8 @@ describe("copy and cut guards", () => {
     ];
     selectInstance(["body0"]);
 
-    expect(await instanceText.onPaste?.(JSON.stringify(clipboardData))).toBe(
-      true
+    expect(await instanceText.onPaste?.(JSON.stringify(clipboardData))).toEqual(
+      pasteHandled
     );
 
     const bodyChildren = $instances.get().get("body0")?.children;
@@ -236,8 +240,8 @@ describe("copy and cut guards", () => {
     ]);
 
     clipboardData["@webstudio/instances/v0.1"].rootInstanceIds = ["missing"];
-    expect(await instanceText.onPaste?.(JSON.stringify(clipboardData))).toBe(
-      false
+    expect(await instanceText.onPaste?.(JSON.stringify(clipboardData))).toEqual(
+      pasteHandled
     );
     expect($instances.get().get("body0")?.children).toEqual(bodyChildren);
   });
@@ -371,6 +375,96 @@ describe("copy and cut guards", () => {
 });
 
 describe("paste target", () => {
+  test("pastes radix navigation menu fragment with viewport wrapper", async () => {
+    const previousMetas = $registeredComponentMetas.get();
+    $registeredComponentMetas.set(componentMetas);
+    $instances.set(toMap([createInstance("body0", "Body", [])]));
+    selectInstance(["body0"]);
+
+    const clipboardData = JSON.stringify({
+      "@webstudio/instance/v0.1": {
+        instanceSelector: ["nav", "source-parent"],
+        children: [{ type: "id", value: "nav" }],
+        instances: [
+          createInstance(
+            "nav",
+            "@webstudio-is/sdk-components-react-radix:NavigationMenu",
+            [
+              { type: "id", value: "list" },
+              { type: "id", value: "viewport-container" },
+            ]
+          ),
+          createInstance(
+            "list",
+            "@webstudio-is/sdk-components-react-radix:NavigationMenuList",
+            [{ type: "id", value: "item" }]
+          ),
+          createInstance(
+            "item",
+            "@webstudio-is/sdk-components-react-radix:NavigationMenuItem",
+            [
+              { type: "id", value: "trigger" },
+              { type: "id", value: "content" },
+            ]
+          ),
+          createInstance(
+            "trigger",
+            "@webstudio-is/sdk-components-react-radix:NavigationMenuTrigger",
+            [{ type: "id", value: "button" }]
+          ),
+          createInstance("button", "Button", [{ type: "id", value: "text" }]),
+          createInstance("text", "Text", [{ type: "text", value: "About" }]),
+          createInstance(
+            "content",
+            "@webstudio-is/sdk-components-react-radix:NavigationMenuContent",
+            [{ type: "id", value: "content-box" }]
+          ),
+          createInstance("content-box", "Box", [
+            { type: "id", value: "content-link" },
+          ]),
+          createInstance("content-link", "Link", [
+            { type: "text", value: "Documentation" },
+          ]),
+          {
+            ...createInstance("viewport-container", "Box", [
+              { type: "id", value: "viewport" },
+            ]),
+            label: "Viewport Container",
+          },
+          createInstance(
+            "viewport",
+            "@webstudio-is/sdk-components-react-radix:NavigationMenuViewport",
+            []
+          ),
+        ],
+        assets: [],
+        dataSources: [],
+        resources: [],
+        props: [],
+        breakpoints: [],
+        styleSourceSelections: [],
+        styleSources: [],
+        styles: [],
+      },
+    });
+
+    const warn = vi.spyOn(toast, "warn").mockImplementation(() => "");
+    const result = await instanceText.onPaste?.(clipboardData);
+    expect(result).toEqual(pasteHandled);
+    expect(warn).not.toHaveBeenCalled();
+
+    const [pastedNavId] =
+      $instances
+        .get()
+        .get("body0")
+        ?.children.map((child) => child.value) ?? [];
+    expect($instances.get().get(pastedNavId ?? "")?.component).toBe(
+      "@webstudio-is/sdk-components-react-radix:NavigationMenu"
+    );
+    warn.mockRestore();
+    $registeredComponentMetas.set(previousMetas);
+  });
+
   // body0
   //   box1
   //   box2

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -6,6 +6,13 @@ import {
   getPasteRootInstanceIds,
   mergeWebstudioFragments,
 } from "@webstudio-is/project-build/runtime/fragment";
+import {
+  instanceTransferDataVersion,
+  instancesTransferDataVersion,
+  parseInstanceTransferData,
+  type InstanceTransferData,
+  type InstancesTransferData,
+} from "@webstudio-is/project-build/runtime/data-formats/instance-transfer";
 import { findClosestInsertable } from "../instance-utils/insert";
 import {
   executeRuntimeMutationAsync,
@@ -13,11 +20,10 @@ import {
 } from "../instance-utils/data";
 import { type Insertable } from "../instance-utils/insert";
 import { shallowEqual } from "shallow-equal";
-import { z } from "zod";
 import { toast } from "@webstudio-is/design-system";
 import {
+  type Instance,
   type WebstudioFragment,
-  webstudioFragment,
   isComponentDetachable,
 } from "@webstudio-is/sdk";
 import { $instances } from "~/shared/sync/data-stores";
@@ -36,24 +42,11 @@ import {
 } from "~/shared/nano-states";
 import { getInstancePath } from "@webstudio-is/project-build/runtime/lookup";
 import { builderApi } from "../builder-api";
-import type { Plugin } from "./copy-paste";
+import { pasteHandled, pasteIgnored, type Plugin } from "./copy-paste";
 import { breakpointPasteLimitWarning } from "@webstudio-is/project-build/runtime/breakpoints";
 
-const version = "@webstudio/instance/v0.1";
-const multiRootVersion = "@webstudio/instances/v0.1";
-
-const instanceData = webstudioFragment.extend({
-  instanceSelector: z.array(z.string()),
-});
-
-type InstanceData = z.infer<typeof instanceData>;
-
-const multiRootInstanceData = z.object({
-  rootInstanceIds: z.array(z.string()),
-  fragment: webstudioFragment,
-});
-
-type MultiRootInstanceData = z.infer<typeof multiRootInstanceData>;
+const invalidPasteDataMessage =
+  "Could not paste Webstudio instance data. The clipboard data appears to be incomplete or invalid.";
 
 const getTreeData = (
   instanceSelector: InstanceSelector,
@@ -82,45 +75,20 @@ const getTreeData = (
   };
 };
 
-const stringify = (data: InstanceData) => {
-  return JSON.stringify({ [version]: data });
+const stringify = (data: InstanceTransferData) => {
+  return JSON.stringify({ [instanceTransferDataVersion]: data });
 };
 
-const stringifyMultiRoot = (data: MultiRootInstanceData) => {
-  return JSON.stringify({ [multiRootVersion]: data });
+const stringifyMultiRoot = (data: InstancesTransferData) => {
+  return JSON.stringify({ [instancesTransferDataVersion]: data });
 };
 
-const stringifyMultiRootSelection = (selectedData: InstanceData[]) => {
+const stringifyMultiRootSelection = (selectedData: InstanceTransferData[]) => {
   const rootInstanceIds = selectedData.map((data) => data.instanceSelector[0]);
   return stringifyMultiRoot({
     rootInstanceIds,
     fragment: mergeWebstudioFragments(rootInstanceIds, selectedData),
   });
-};
-
-const clipboard = z.object({ [version]: instanceData });
-const multiRootClipboard = z.object({
-  [multiRootVersion]: multiRootInstanceData,
-});
-
-const parse = (clipboardData: string): InstanceData | undefined => {
-  try {
-    const data = clipboard.parse(JSON.parse(clipboardData));
-    return data[version];
-  } catch {
-    return;
-  }
-};
-
-const parseMultiRoot = (
-  clipboardData: string
-): MultiRootInstanceData | undefined => {
-  try {
-    const data = multiRootClipboard.parse(JSON.parse(clipboardData));
-    return data[multiRootVersion];
-  } catch {
-    return;
-  }
 };
 
 const reportSkippedSelectedInstances = (operation: "copied" | "cut") => {
@@ -199,7 +167,9 @@ const findPasteTargetForFragment = (
   });
 };
 
-const findPasteTarget = (data: InstanceData): undefined | Insertable => {
+const findPasteTarget = (
+  data: InstanceTransferData
+): undefined | Insertable => {
   const instances = $instances.get();
 
   const instanceSelector = $selectedInstanceSelector.get();
@@ -238,68 +208,15 @@ const resolveFragmentTokenConflicts = async (fragment: WebstudioFragment) => {
     : "theirs";
 };
 
-const handlePasteInstance = async (clipboardData: string) => {
-  const multiRootFragment = parseMultiRoot(clipboardData);
-  if (multiRootFragment !== undefined) {
-    const pasteRootInstanceIds = getPasteRootInstanceIds(multiRootFragment);
-    if (pasteRootInstanceIds.length === 0) {
-      return false;
-    }
-    const fragment: WebstudioFragment = {
-      ...multiRootFragment.fragment,
-      children: pasteRootInstanceIds.map((instanceId) => ({
-        type: "id",
-        value: instanceId,
-      })),
-    };
-    const pasteTarget = findSelectionPasteTarget(fragment);
-    if (pasteTarget === undefined) {
-      return false;
-    }
-
-    try {
-      const conflictResolution = await resolveFragmentTokenConflicts(fragment);
-      const result = await executeRuntimeMutationAsync({
-        id: "instances.insertFragment",
-        input: {
-          parentInstanceId: pasteTarget.parentSelector[0],
-          fragment,
-          conflictResolution,
-          insertIndex:
-            typeof pasteTarget.position === "number"
-              ? pasteTarget.position
-              : undefined,
-        },
-      });
-      if (result === undefined || result.result.rootInstanceIds.length === 0) {
-        return false;
-      }
-      if (result.result.didMergeBreakpointsDueToLimit === true) {
-        toast.warn(breakpointPasteLimitWarning);
-      }
-      selectInstances(
-        result.result.rootInstanceIds.map((newRootInstanceId) => [
-          newRootInstanceId,
-          ...pasteTarget.parentSelector,
-        ])
-      );
-    } catch (error) {
-      // User cancelled
-      return false;
-    }
-
-    return true;
-  }
-  const fragment = parse(clipboardData);
-  if (fragment === undefined) {
-    return false;
-  }
-
-  const pasteTarget = findPasteTarget(fragment);
-  if (pasteTarget === undefined) {
-    return false;
-  }
-
+const insertPastedFragment = async ({
+  fragment,
+  pasteTarget,
+  selectRootInstances,
+}: {
+  fragment: WebstudioFragment;
+  pasteTarget: Insertable;
+  selectRootInstances: (rootInstanceIds: Instance["id"][]) => void;
+}) => {
   try {
     const conflictResolution = await resolveFragmentTokenConflicts(fragment);
     const result = await executeRuntimeMutationAsync({
@@ -314,20 +231,77 @@ const handlePasteInstance = async (clipboardData: string) => {
             : undefined,
       },
     });
-    const [newRootInstanceId] = result?.result.rootInstanceIds ?? [];
-    if (newRootInstanceId === undefined) {
+    const rootInstanceIds = result?.result.rootInstanceIds;
+    if (rootInstanceIds === undefined || rootInstanceIds.length === 0) {
       return false;
     }
     if (result?.result.didMergeBreakpointsDueToLimit === true) {
       toast.warn(breakpointPasteLimitWarning);
     }
-    selectInstances([[newRootInstanceId, ...pasteTarget.parentSelector]]);
+    selectRootInstances(rootInstanceIds);
   } catch (error) {
     // User cancelled
     return false;
   }
-
   return true;
+};
+
+const handlePasteInstance = async (clipboardData: string) => {
+  const transferData = parseInstanceTransferData(clipboardData);
+  if (transferData.owned === false) {
+    return pasteIgnored;
+  }
+  if (transferData.valid === false) {
+    return { success: false, error: invalidPasteDataMessage } as const;
+  }
+  if (transferData.type === "multi-root") {
+    const pasteRootInstanceIds = getPasteRootInstanceIds(transferData.data);
+    if (pasteRootInstanceIds.length === 0) {
+      return pasteHandled;
+    }
+    const fragment: WebstudioFragment = {
+      ...transferData.data.fragment,
+      children: pasteRootInstanceIds.map((instanceId) => ({
+        type: "id",
+        value: instanceId,
+      })),
+    };
+    const pasteTarget = findSelectionPasteTarget(fragment);
+    if (pasteTarget === undefined) {
+      return pasteHandled;
+    }
+    await insertPastedFragment({
+      fragment,
+      pasteTarget,
+      selectRootInstances: (rootInstanceIds) => {
+        selectInstances(
+          rootInstanceIds.map((newRootInstanceId) => [
+            newRootInstanceId,
+            ...pasteTarget.parentSelector,
+          ])
+        );
+      },
+    });
+    return pasteHandled;
+  }
+  const fragment = transferData.data;
+
+  const pasteTarget = findPasteTarget(fragment);
+  if (pasteTarget === undefined) {
+    return pasteHandled;
+  }
+  await insertPastedFragment({
+    fragment,
+    pasteTarget,
+    selectRootInstances: (rootInstanceIds) => {
+      const newRootInstanceId = rootInstanceIds[0];
+      if (newRootInstanceId === undefined) {
+        return;
+      }
+      selectInstances([[newRootInstanceId, ...pasteTarget.parentSelector]]);
+    },
+  });
+  return pasteHandled;
 };
 
 const handleCopyInstance = () => {
@@ -347,7 +321,7 @@ const handleCopyInstance = () => {
     .map((instanceSelector) =>
       getTreeData(instanceSelector, { showToast: false })
     )
-    .filter((data): data is InstanceData => data !== undefined);
+    .filter((data): data is InstanceTransferData => data !== undefined);
   if (selectedData.length === 0) {
     return;
   }
@@ -377,7 +351,7 @@ const handleCutInstance = () => {
         (
           item
         ): item is {
-          data: InstanceData;
+          data: InstanceTransferData;
           instancePath: NonNullable<ReturnType<typeof getInstancePath>>;
         } => item !== undefined
       );
@@ -417,16 +391,16 @@ const handleCutInstance = () => {
   return stringify(data);
 };
 
-export const instanceText: Plugin = {
+export const instanceText = {
   name: "instance-text",
   mimeType: "text/plain",
   onCopy: handleCopyInstance,
   onCut: handleCutInstance,
   onPaste: handlePasteInstance,
-};
+} satisfies Plugin;
 
-export const instanceJson: Plugin = {
+export const instanceJson = {
   name: "instance-json",
   mimeType: "application/json",
   onPaste: handlePasteInstance,
-};
+} satisfies Plugin;

--- a/apps/builder/app/shared/copy-paste/plugin-jsx.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-jsx.test.ts
@@ -3,6 +3,7 @@ import { createEmptyWebstudioFragment } from "@webstudio-is/project-build/runtim
 import { inspectWebstudioJsxFragmentSyntax } from "@webstudio-is/project-build/runtime/jsx/syntax";
 import { isLikelyWebstudioJsx, jsx } from "./plugin-jsx";
 import { $project } from "../sync/data-stores";
+import { pasteHandled, pasteIgnored } from "./copy-paste";
 
 const mocks = vi.hoisted(() => ({
   createJsxFragment: vi.fn(),
@@ -65,7 +66,7 @@ describe("jsx paste plugin", () => {
     mocks.createJsxFragment.mockResolvedValue(fragment);
     mocks.insertWebstudioFragmentAt.mockReturnValue(true);
 
-    await expect(jsx.onPaste?.("<$.Box />")).resolves.toBe(true);
+    await expect(jsx.onPaste?.("<$.Box />")).resolves.toEqual(pasteHandled);
 
     expect(mocks.createJsxFragment).toHaveBeenCalledWith({
       projectId: "project-id",
@@ -82,7 +83,9 @@ describe("jsx paste plugin", () => {
   });
 
   test("does not claim non-Webstudio JSX text", async () => {
-    await expect(jsx.onPaste?.("<section>HTML</section>")).resolves.toBe(false);
+    await expect(jsx.onPaste?.("<section>HTML</section>")).resolves.toEqual(
+      pasteIgnored
+    );
 
     expect(mocks.createJsxFragment).not.toHaveBeenCalled();
     expect(mocks.insertWebstudioFragmentAt).not.toHaveBeenCalled();
@@ -91,7 +94,7 @@ describe("jsx paste plugin", () => {
   test("does not claim JSX without a current project", async () => {
     $project.set(undefined);
 
-    await expect(jsx.onPaste?.("<$.Box />")).resolves.toBe(false);
+    await expect(jsx.onPaste?.("<$.Box />")).resolves.toEqual(pasteIgnored);
 
     expect(mocks.createJsxFragment).not.toHaveBeenCalled();
     expect(mocks.insertWebstudioFragmentAt).not.toHaveBeenCalled();
@@ -100,9 +103,12 @@ describe("jsx paste plugin", () => {
   test("reports conversion errors and stops paste fallback", async () => {
     mocks.createJsxFragment.mockRejectedValue(new Error("Invalid JSX"));
 
-    await expect(jsx.onPaste?.('<$.Box ws:id="0" />')).resolves.toBe(true);
+    await expect(jsx.onPaste?.('<$.Box ws:id="0" />')).resolves.toEqual({
+      success: false,
+      error: "Invalid JSX",
+    });
 
-    expect(mocks.toastError).toHaveBeenCalledWith("Invalid JSX");
+    expect(mocks.toastError).not.toHaveBeenCalled();
     expect(mocks.insertWebstudioFragmentAt).not.toHaveBeenCalled();
   });
 });

--- a/apps/builder/app/shared/copy-paste/plugin-jsx.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-jsx.ts
@@ -1,38 +1,34 @@
 import { nativeClient } from "../trpc/trpc-client";
-import { insertWebstudioFragmentAt } from "../instance-utils/insert";
-import { builderApi } from "../builder-api";
 import { $project } from "../sync/data-stores";
-import { breakpointPasteLimitWarning } from "@webstudio-is/project-build/runtime/breakpoints";
 import { isLikelyWebstudioJsxFragment } from "@webstudio-is/project-build/runtime/jsx/utils";
-import type { Plugin } from "./copy-paste";
+import { pasteHandled, pasteIgnored, type Plugin } from "./copy-paste";
+import { insertFragmentWithBreakpointWarning } from "./fragment-utils";
 
 export const isLikelyWebstudioJsx = isLikelyWebstudioJsxFragment;
 
 const handlePasteJsx = async (source: string) => {
   if (isLikelyWebstudioJsx(source) === false) {
-    return false;
+    return pasteIgnored;
   }
   const project = $project.get();
   if (project === undefined) {
-    return false;
+    return pasteIgnored;
   }
   try {
     const fragment = await nativeClient.build.createJsxFragment.query({
       projectId: project.id,
       source,
     });
-    return await insertWebstudioFragmentAt(fragment, undefined, undefined, {
-      onBreakpointLimitMerge: () => {
-        builderApi.toast.warn(breakpointPasteLimitWarning);
-      },
-    });
+    insertFragmentWithBreakpointWarning(fragment);
+    return pasteHandled;
   } catch (error) {
-    builderApi.toast.error(
-      error instanceof Error
-        ? error.message
-        : "Could not paste Webstudio JSX fragment."
-    );
-    return true;
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Could not paste Webstudio JSX fragment.",
+    } as const;
   }
 };
 

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.ts
@@ -1,11 +1,12 @@
 import { gfm, gfmHtml } from "micromark-extension-gfm";
 import { micromark } from "micromark";
-import { insertWebstudioFragmentAt } from "../instance-utils/insert";
 import { denormalizeSrcProps } from "./asset-upload";
 import { generateFragmentFromHtml } from "@webstudio-is/project-build/runtime/html";
-import type { Plugin } from "./copy-paste";
-import { builderApi } from "../builder-api";
-import { breakpointPasteLimitWarning } from "@webstudio-is/project-build/runtime/breakpoints";
+import { pasteHandled, pasteIgnored, type Plugin } from "./copy-paste";
+import {
+  hasFragmentData,
+  insertFragmentWithBreakpointWarning,
+} from "./fragment-utils";
 
 const parse = (clipboardData: string) => {
   const html = micromark(clipboardData, "utf-8", {
@@ -27,15 +28,12 @@ const parse = (clipboardData: string) => {
 
 const handlePasteMarkdown = async (clipboardData: string) => {
   let fragment = parse(clipboardData);
-  if (fragment === undefined) {
-    return false;
+  if (hasFragmentData(fragment) === false) {
+    return pasteIgnored;
   }
   fragment = await denormalizeSrcProps(fragment);
-  return await insertWebstudioFragmentAt(fragment, undefined, undefined, {
-    onBreakpointLimitMerge: () => {
-      builderApi.toast.warn(breakpointPasteLimitWarning);
-    },
-  });
+  insertFragmentWithBreakpointWarning(fragment);
+  return pasteHandled;
 };
 
 export const markdown: Plugin = {

--- a/apps/builder/app/shared/copy-paste/plugin-page.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.test.ts
@@ -35,6 +35,7 @@ import {
   handlePastePage,
   pageText,
 } from "./plugin-page";
+import { pasteHandled, pasteIgnored } from "./copy-paste";
 
 enableMapSet();
 registerContainers();
@@ -261,13 +262,13 @@ test("handles page paste data without falling through when insertion cannot comp
 
   await expect(
     handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID)
-  ).resolves.toBe(true);
+  ).resolves.toEqual(pasteHandled);
   expect($pages.get()?.pages.size).toBe(initialPageCount);
 });
 
 test("ignores non-page paste data", async () => {
-  await expect(handlePastePage("plain text", ROOT_FOLDER_ID)).resolves.toBe(
-    false
+  await expect(handlePastePage("plain text", ROOT_FOLDER_ID)).resolves.toEqual(
+    pasteIgnored
   );
 });
 

--- a/apps/builder/app/shared/copy-paste/plugin-page.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.ts
@@ -2,7 +2,6 @@ import {
   executeRuntimeMutation,
   getWebstudioData,
 } from "../instance-utils/data";
-import { z } from "zod";
 import { toast } from "@webstudio-is/design-system";
 import {
   type WebstudioFragment,
@@ -19,32 +18,25 @@ import {
   createFolderCopyData,
   createPageCopyData,
   createTemplateCopyData,
-  pageClipboardItemInput,
-  type FolderClipboardData,
-  type PageClipboardData,
-  type PageClipboardItem,
-  type TemplateClipboardData,
 } from "@webstudio-is/project-build/runtime/page-copy";
+import {
+  pageTransferDataVersion,
+  parsePageTransferData,
+  type FolderTransferData,
+  type PageTransferData,
+  type PageTransferItem,
+  type TemplateTransferData,
+} from "@webstudio-is/project-build/runtime/data-formats/page-transfer";
 import { $selectedPage } from "../nano-states";
 import { getPageActionTarget } from "../page-action-target";
-import type { Plugin } from "./copy-paste";
+import { pasteHandled, pasteIgnored, type Plugin } from "./copy-paste";
 import { breakpointPasteLimitWarning } from "@webstudio-is/project-build/runtime/breakpoints";
 
-const version = "@webstudio/page/v0.1";
+const invalidPasteDataMessage =
+  "Could not paste Webstudio page data. The clipboard data appears to be incomplete or invalid.";
 
-const clipboard = z.object({ [version]: pageClipboardItemInput });
-
-const stringify = (data: PageClipboardItem) => {
-  return JSON.stringify({ [version]: data });
-};
-
-const parse = (clipboardData: string): PageClipboardItem | undefined => {
-  try {
-    const data = clipboard.parse(JSON.parse(clipboardData));
-    return data[version];
-  } catch {
-    return;
-  }
+const stringify = (data: PageTransferItem) => {
+  return JSON.stringify({ [pageTransferDataVersion]: data });
 };
 
 const getDefaultTargetFolderId = () => {
@@ -83,21 +75,21 @@ const mergeWebstudioFragments = (
 
 const addPageType = (
   data: ReturnType<typeof createPageCopyData>
-): PageClipboardData => ({
+): PageTransferData => ({
   ...data,
   type: "page",
 });
 
 const addTemplateType = (
   data: ReturnType<typeof createTemplateCopyData>
-): TemplateClipboardData => ({
+): TemplateTransferData => ({
   ...data,
   type: "template",
 });
 
 const addFolderType = (
   data: NonNullable<ReturnType<typeof createFolderCopyData>>
-): FolderClipboardData => ({
+): FolderTransferData => ({
   type: "folder",
   folder: data.folder,
   children: data.children.map((child) =>
@@ -108,7 +100,7 @@ const addFolderType = (
 const getPageCopyData = (
   data: ReturnType<typeof getWebstudioData>,
   pageId: Page["id"]
-): PageClipboardData | undefined => {
+): PageTransferData | undefined => {
   const page = findPageByIdOrPath(pageId, data.pages);
   if (page === undefined) {
     return;
@@ -130,8 +122,8 @@ const handleCopyPage = () => {
 };
 
 const collectPageLikeItems = (
-  item: PageClipboardItem
-): Array<PageClipboardData | TemplateClipboardData> => {
+  item: PageTransferItem
+): Array<PageTransferData | TemplateTransferData> => {
   if (item.type === "page" || item.type === "template") {
     return [item];
   }
@@ -169,10 +161,14 @@ export const handlePastePage = async (
   clipboardData: string,
   targetFolderId?: Folder["id"]
 ) => {
-  const item = parse(clipboardData);
-  if (item === undefined) {
-    return false;
+  const transferData = parsePageTransferData(clipboardData);
+  if (transferData.owned === false) {
+    return pasteIgnored;
   }
+  if (transferData.valid === false) {
+    return { success: false, error: invalidPasteDataMessage } as const;
+  }
+  const item = transferData.data;
 
   const pages = $pages.get();
   const folderId = targetFolderId ?? getDefaultTargetFolderId();
@@ -181,14 +177,14 @@ export const handlePastePage = async (
     folderId === undefined ||
     pages.folders.has(folderId) === false
   ) {
-    return true;
+    return pasteHandled;
   }
 
   try {
     const targetData = getWebstudioData();
     const projectId = $project.get()?.id;
     if (projectId === undefined) {
-      return true;
+      return pasteHandled;
     }
     const conflicts = collectPageLikeItems(item).flatMap((item) =>
       detectFragmentTokenConflicts({
@@ -202,7 +198,7 @@ export const handlePastePage = async (
         : "theirs";
 
     const result = executeRuntimeMutation({
-      id: "pageClipboard.paste",
+      id: "pageTransfer.insert",
       input: {
         item,
         targetFolderId: folderId,
@@ -222,18 +218,18 @@ export const handlePastePage = async (
             ? "Template pasted"
             : "Folder pasted"
       );
-      return true;
+      return pasteHandled;
     }
   } catch {
-    return true;
+    return pasteHandled;
   }
 
-  return true;
+  return pasteHandled;
 };
 
 export const pageText: Plugin = {
   name: "page-text",
   mimeType: "text/plain",
   onCopy: handleCopyPage,
-  onPaste: handlePastePage,
+  onPaste: (clipboardData) => handlePastePage(clipboardData),
 };

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.test.tsx
@@ -12,12 +12,13 @@ import {
 } from "@webstudio-is/sdk";
 import { $, renderData } from "@webstudio-is/template";
 import * as defaultMetas from "@webstudio-is/sdk-components-react/metas";
-import { __testing__ } from "./plugin-webflow";
+import { __testing__, webflow } from "./plugin-webflow";
 import { $registeredComponentMetas } from "../../nano-states";
 import { $breakpoints } from "~/shared/sync/data-stores";
 import { $project, $styleSources, $styles } from "~/shared/sync/data-stores";
 import invariant from "tiny-invariant";
 import { wfData } from "@webstudio-is/project-build/runtime/webflow/schema";
+import { pasteIgnored } from "../copy-paste";
 
 const { toWebstudioFragment } = __testing__;
 
@@ -113,6 +114,21 @@ beforeEach(() => {
       })
     )
   );
+});
+
+test("ignores non-Webflow paste data", async () => {
+  await expect(webflow.onPaste?.(`{"type":"other"}`)).resolves.toEqual(
+    pasteIgnored
+  );
+});
+
+test("reports malformed Webflow-owned paste data", async () => {
+  await expect(
+    webflow.onPaste?.(JSON.stringify({ type: "@webflow/XscpData" }))
+  ).resolves.toMatchObject({
+    success: false,
+    error: expect.any(String),
+  });
 });
 
 test("Heading", async () => {

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
@@ -1,8 +1,5 @@
 import type { Instance, WebstudioFragment } from "@webstudio-is/sdk";
-import {
-  findClosestInsertable,
-  insertWebstudioFragmentAt,
-} from "../../instance-utils/insert";
+import { findClosestInsertable } from "../../instance-utils/insert";
 import { $project, $styleSources } from "~/shared/sync/data-stores";
 import {
   type WfData,
@@ -17,9 +14,12 @@ import { addStyles } from "@webstudio-is/project-build/runtime/webflow/styles";
 import { builderApi } from "~/shared/builder-api";
 import { denormalizeSrcProps } from "../asset-upload";
 import { nanoHash } from "~/shared/nano-hash";
-import type { Plugin } from "../copy-paste";
-import { breakpointPasteLimitWarning } from "@webstudio-is/project-build/runtime/breakpoints";
+import { pasteHandled, pasteIgnored, type Plugin } from "../copy-paste";
 import { builderRuntimeContext } from "@webstudio-is/project-build/runtime/context";
+import {
+  hasFragmentData,
+  insertFragmentWithBreakpointWarning,
+} from "../fragment-utils";
 
 const { toast } = builderApi;
 
@@ -106,20 +106,28 @@ const toWebstudioFragment = async (
   return fragment;
 };
 
-const parse = (clipboardData: string) => {
+type WebflowParseResult =
+  | { owned: false }
+  | { owned: true; success: false; error: string }
+  | { owned: true; success: true; data: WfData };
+
+const parse = (clipboardData: string): WebflowParseResult => {
   let data;
   try {
     data = JSON.parse(clipboardData);
   } catch {
-    return;
+    return { owned: false };
   }
 
   if (data.type !== "@webflow/XscpData") {
-    return;
+    return { owned: false };
   }
 
+  const payloadNodes = Array.isArray(data.payload?.nodes)
+    ? data.payload.nodes
+    : [];
   const unsupportedNodeTypes: Set<string> = new Set(
-    data.payload.nodes
+    payloadNodes
       .filter((node: { type: string }) => {
         return (
           node.type !== undefined &&
@@ -139,7 +147,7 @@ const parse = (clipboardData: string) => {
   const result = wfData.safeParse(data);
 
   if (result.success) {
-    const unpasedTypes = new Set<string>();
+    const unparsedTypes = new Set<string>();
 
     for (let i = 0; i !== result.data.payload.nodes.length; ++i) {
       if ("type" in result.data.payload.nodes[i]) {
@@ -156,45 +164,47 @@ const parse = (clipboardData: string) => {
         continue;
       }
 
-      unpasedTypes.add(probablyUnparsedType);
+      unparsedTypes.add(probablyUnparsedType);
     }
 
-    if (unpasedTypes.size !== 0) {
-      const message = `The following types were skipped due to a parsing error: ${[...unpasedTypes.values()].join(", ")}`;
+    if (unparsedTypes.size !== 0) {
+      const message = `The following types were skipped due to a parsing error: ${[...unparsedTypes.values()].join(", ")}`;
       toast.info(message);
       console.info(message);
     }
 
-    return result.data;
+    return { owned: true, success: true, data: result.data };
   }
 
-  toast.error(result.error.message);
-  console.error(result.error.message);
+  return { owned: true, success: false, error: result.error.message };
 };
 
 const handlePasteWebflow = async (clipboardData: string) => {
   const project = $project.get();
-  const wfData = parse(clipboardData);
-  if (wfData === undefined || project === undefined) {
-    return false;
+  const result = parse(clipboardData);
+  if (result.owned === false) {
+    return pasteIgnored;
+  }
+  if (result.success === false) {
+    return { success: false, error: result.error } as const;
+  }
+  if (project === undefined) {
+    return pasteHandled;
   }
 
-  let fragment = await toWebstudioFragment(wfData);
-  if (fragment === undefined) {
-    return false;
+  let fragment = await toWebstudioFragment(result.data);
+  if (hasFragmentData(fragment) === false) {
+    return pasteHandled;
   }
   fragment = await denormalizeSrcProps(fragment);
 
   const insertable = findClosestInsertable(fragment);
   if (insertable === undefined) {
-    return false;
+    return pasteHandled;
   }
 
-  return insertWebstudioFragmentAt(fragment, insertable, undefined, {
-    onBreakpointLimitMerge: () => {
-      toast.warn(breakpointPasteLimitWarning);
-    },
-  });
+  insertFragmentWithBreakpointWarning(fragment, insertable);
+  return pasteHandled;
 };
 
 export const webflow: Plugin = {

--- a/apps/builder/e2e/flows/content-editing.ts
+++ b/apps/builder/e2e/flows/content-editing.ts
@@ -119,6 +119,36 @@ export const replaceCanvasText = async ({
   }
 };
 
+export const pasteCanvasText = async ({
+  page,
+  currentText,
+  text,
+}: {
+  page: Page;
+  currentText: string;
+  text: string;
+}) => {
+  const { canvas, editable } = await startCanvasTextEditingByText({
+    page,
+    currentText,
+  });
+  await page.evaluate(async (text) => {
+    await navigator.clipboard.writeText(text);
+  }, text);
+  await page.keyboard.press("ControlOrMeta+A");
+  const save = waitForChangeToBeSaved({ page });
+  try {
+    await page.keyboard.press("ControlOrMeta+V");
+    await canvas.locator("body").click({ position: { x: 1, y: 1 } });
+    await editable.waitFor({ state: "hidden", timeout: 1_000 });
+    await waitForCanvasText({ page, text });
+    await save;
+  } catch (error) {
+    await save.catch(() => undefined);
+    throw error;
+  }
+};
+
 export const replaceCanvasTextAndApplyInlineFormats = async ({
   page,
   currentText,

--- a/apps/builder/e2e/tests/content-mode-editing.[shard-2].e2e.ts
+++ b/apps/builder/e2e/tests/content-mode-editing.[shard-2].e2e.ts
@@ -15,6 +15,7 @@ import {
   waitForCanvasVideoSource,
 } from "../flows/canvas-media";
 import {
+  pasteCanvasText,
   replaceCanvasText,
   replaceCanvasTextAndApplyInlineFormats,
 } from "../flows/content-editing";
@@ -365,6 +366,46 @@ test("Editor can edit text and content props but not design props", async () => 
       value: editedVideoSrc,
     });
     await waitForCanvasText({ page, text: editedContent });
+  } finally {
+    await close();
+  }
+});
+
+test("Editor can paste text while editing canvas content", async () => {
+  const fixture = getSharedContentModeProject();
+  const pastedContent = "Pasted editable content";
+  const { page, close } = await newIsolatedPage();
+
+  try {
+    await measure("content mode open editor for text paste", async () => {
+      await openProjectBuilder({
+        page,
+        projectId: fixture.projectId,
+        authToken: fixture.editorToken,
+        mode: "content",
+      });
+    });
+    await waitForCanvasText({ page, text: "Initial content" });
+    await waitForSyncStatus({ page, status: "idle" });
+
+    await insertTemplateAfterCanvasText({
+      page,
+      anchorText: "Initial content",
+      templateName: fixture.editableTextTemplateName,
+    });
+    await waitForCanvasText({
+      page,
+      text: fixture.editableTextTemplateText,
+    });
+
+    await measure("content mode native paste text", async () => {
+      await pasteCanvasText({
+        page,
+        currentText: fixture.editableTextTemplateText,
+        text: pastedContent,
+      });
+    });
+    await waitForCanvasText({ page, text: pastedContent });
   } finally {
     await close();
   }

--- a/apps/builder/e2e/tests/pages-actions.[shard-2].e2e.ts
+++ b/apps/builder/e2e/tests/pages-actions.[shard-2].e2e.ts
@@ -1,5 +1,9 @@
 import type { Page } from "playwright";
-import { openProjectBuilder, waitForCanvasText } from "../flows/builder";
+import {
+  openProjectBuilder,
+  waitForCanvasText,
+  waitForCanvasTextHidden,
+} from "../flows/builder";
 import { selectCanvasTextInstance } from "../flows/canvas-selection";
 import {
   waitForChangeToBeSaved,
@@ -14,104 +18,30 @@ import { loadDevBuild } from "../db";
 let fixture: SeededContentModeProject;
 let navigatorStructuralFixture: SeededContentModeProject;
 
-const getInstanceComponentCount = async ({
-  fixture,
-  component,
-}: {
-  fixture: SeededContentModeProject;
-  component: string;
-}) => {
-  const build = await loadDevBuild({ projectId: fixture.projectId });
-  const instances = JSON.parse(build.instances) as Array<{
-    component: string;
-  }>;
-  return instances.filter((instance) => instance.component === component)
-    .length;
+type BuildInstanceChild = {
+  type: string;
+  value?: string;
 };
 
-const getElementTagCount = async ({
-  fixture,
-  tag,
-}: {
-  fixture: SeededContentModeProject;
-  tag: string;
-}) => {
-  const build = await loadDevBuild({ projectId: fixture.projectId });
-  const instances = JSON.parse(build.instances) as Array<{
-    component: string;
-    tag?: string;
-  }>;
-  return instances.filter(
-    (instance) => instance.component === "ws:element" && instance.tag === tag
-  ).length;
+type BuildInstance = {
+  id: string;
+  component?: string;
+  tag?: string;
+  label?: string;
+  children?: BuildInstanceChild[];
 };
 
-const getElementTagWithTextCount = async ({
-  fixture,
-  tag,
-  text,
-}: {
-  fixture: SeededContentModeProject;
-  tag: string;
-  text: string;
-}) => {
+const loadBuildInstances = async (fixture: SeededContentModeProject) => {
   const build = await loadDevBuild({ projectId: fixture.projectId });
-  const instances = JSON.parse(build.instances) as Array<{
-    id: string;
-    component: string;
-    tag?: string;
-    children?: Array<{ type: string; value?: string }>;
-  }>;
-  const instancesById = new Map(
-    instances.map((instance) => [instance.id, instance])
-  );
-
-  const instanceContainsText = (instanceId: string): boolean => {
-    const instance = instancesById.get(instanceId);
-    if (instance === undefined) {
-      return false;
-    }
-    return (
-      instance.children?.some((child) => {
-        if (child.type === "text") {
-          return child.value?.includes(text);
-        }
-        if (child.type === "id" && child.value !== undefined) {
-          return instanceContainsText(child.value);
-        }
-        return false;
-      }) ?? false
-    );
-  };
-
-  return instances.filter(
-    (instance) =>
-      instance.component === "ws:element" &&
-      instance.tag === tag &&
-      instanceContainsText(instance.id)
-  ).length;
+  return JSON.parse(build.instances) as BuildInstance[];
 };
 
-const getElementWithTextParentTag = async ({
-  fixture,
-  tag,
-  text,
-}: {
-  fixture: SeededContentModeProject;
-  tag: string;
-  text: string;
-}) => {
-  const build = await loadDevBuild({ projectId: fixture.projectId });
-  const instances = JSON.parse(build.instances) as Array<{
-    id: string;
-    component: string;
-    tag?: string;
-    children?: Array<{ type: string; value?: string }>;
-  }>;
+const createBuildInspector = (instances: BuildInstance[]) => {
   const instancesById = new Map(
     instances.map((instance) => [instance.id, instance])
   );
   const parentByChildId = new Map<string, string>();
+
   for (const instance of instances) {
     for (const child of instance.children ?? []) {
       if (child.type === "id" && child.value !== undefined) {
@@ -120,7 +50,7 @@ const getElementWithTextParentTag = async ({
     }
   }
 
-  const instanceContainsText = (instanceId: string): boolean => {
+  const instanceContainsText = (instanceId: string, text: string): boolean => {
     const instance = instancesById.get(instanceId);
     if (instance === undefined) {
       return false;
@@ -131,48 +61,12 @@ const getElementWithTextParentTag = async ({
           return child.value?.includes(text);
         }
         if (child.type === "id" && child.value !== undefined) {
-          return instanceContainsText(child.value);
+          return instanceContainsText(child.value, text);
         }
         return false;
       }) ?? false
     );
   };
-
-  const instance = instances.find(
-    (instance) =>
-      instance.component === "ws:element" &&
-      instance.tag === tag &&
-      instanceContainsText(instance.id)
-  );
-  if (instance === undefined) {
-    return;
-  }
-  const parentId = parentByChildId.get(instance.id);
-  if (parentId === undefined) {
-    return;
-  }
-  return instancesById.get(parentId)?.tag;
-};
-
-const getDirectChildTextOrder = async ({
-  fixture,
-  parentTag,
-  texts,
-}: {
-  fixture: SeededContentModeProject;
-  parentTag: string;
-  texts: string[];
-}) => {
-  const build = await loadDevBuild({ projectId: fixture.projectId });
-  const instances = JSON.parse(build.instances) as Array<{
-    id: string;
-    component: string;
-    tag?: string;
-    children?: Array<{ type: string; value?: string }>;
-  }>;
-  const instancesById = new Map(
-    instances.map((instance) => [instance.id, instance])
-  );
 
   const collectText = (instanceId: string): string => {
     const instance = instancesById.get(instanceId);
@@ -192,25 +86,167 @@ const getDirectChildTextOrder = async ({
       .join(" ");
   };
 
-  const parent = instances.find(
-    (instance) =>
-      instance.component === "ws:element" && instance.tag === parentTag
-  );
-  if (parent === undefined) {
-    return [];
-  }
-  return (parent.children ?? [])
-    .flatMap((child, index) => {
-      if (child.type !== "id" || child.value === undefined) {
+  return {
+    countComponent: (component: string) =>
+      instances.filter((instance) => instance.component === component).length,
+    countElementTag: (tag: string) =>
+      instances.filter(
+        (instance) =>
+          instance.component === "ws:element" && instance.tag === tag
+      ).length,
+    countElementTagWithText: ({ tag, text }: { tag: string; text: string }) =>
+      instances.filter(
+        (instance) =>
+          instance.component === "ws:element" &&
+          instance.tag === tag &&
+          instanceContainsText(instance.id, text)
+      ).length,
+    countInstancesWithText: (text: string) =>
+      instances.filter((instance) => instanceContainsText(instance.id, text))
+        .length,
+    countExactTextChildren: (text: string) =>
+      instances.reduce((count, instance) => {
+        return (
+          count +
+          (instance.children?.filter(
+            (child) => child.type === "text" && child.value === text
+          ).length ?? 0)
+        );
+      }, 0),
+    getElementWithTextParentTag: ({
+      tag,
+      text,
+    }: {
+      tag: string;
+      text: string;
+    }) => {
+      const instance = instances.find(
+        (instance) =>
+          instance.component === "ws:element" &&
+          instance.tag === tag &&
+          instanceContainsText(instance.id, text)
+      );
+      const parentId =
+        instance === undefined ? undefined : parentByChildId.get(instance.id);
+      return parentId === undefined
+        ? undefined
+        : instancesById.get(parentId)?.tag;
+    },
+    getDirectChildTextOrder: ({
+      parentTag,
+      texts,
+    }: {
+      parentTag: string;
+      texts: string[];
+    }) => {
+      const parent = instances.find(
+        (instance) =>
+          instance.component === "ws:element" && instance.tag === parentTag
+      );
+      if (parent === undefined) {
         return [];
       }
-      const content = collectText(child.value);
-      return texts
-        .filter((text) => content.includes(text))
-        .map((text) => ({ text, index }));
-    })
-    .sort((left, right) => left.index - right.index)
-    .map(({ text }) => text);
+      return (parent.children ?? [])
+        .flatMap((child, index) => {
+          if (child.type !== "id" || child.value === undefined) {
+            return [];
+          }
+          const content = collectText(child.value);
+          return texts
+            .filter((text) => content.includes(text))
+            .map((text) => ({ text, index }));
+        })
+        .sort((left, right) => left.index - right.index)
+        .map(({ text }) => text);
+    },
+    countLabel: (label: string) =>
+      instances.filter((instance) => instance.label === label).length,
+  };
+};
+
+const inspectBuild = async (fixture: SeededContentModeProject) =>
+  createBuildInspector(await loadBuildInstances(fixture));
+
+const getInstanceComponentCount = async ({
+  fixture,
+  component,
+}: {
+  fixture: SeededContentModeProject;
+  component: string;
+}) => {
+  return (await inspectBuild(fixture)).countComponent(component);
+};
+
+const getElementTagCount = async ({
+  fixture,
+  tag,
+}: {
+  fixture: SeededContentModeProject;
+  tag: string;
+}) => {
+  return (await inspectBuild(fixture)).countElementTag(tag);
+};
+
+const getElementTagWithTextCount = async ({
+  fixture,
+  tag,
+  text,
+}: {
+  fixture: SeededContentModeProject;
+  tag: string;
+  text: string;
+}) => {
+  return (await inspectBuild(fixture)).countElementTagWithText({ tag, text });
+};
+
+const getInstanceWithTextCount = async ({
+  fixture,
+  text,
+}: {
+  fixture: SeededContentModeProject;
+  text: string;
+}) => {
+  return (await inspectBuild(fixture)).countInstancesWithText(text);
+};
+
+const getExactTextChildCount = async ({
+  fixture,
+  text,
+}: {
+  fixture: SeededContentModeProject;
+  text: string;
+}) => {
+  return (await inspectBuild(fixture)).countExactTextChildren(text);
+};
+
+const getElementWithTextParentTag = async ({
+  fixture,
+  tag,
+  text,
+}: {
+  fixture: SeededContentModeProject;
+  tag: string;
+  text: string;
+}) => {
+  return (await inspectBuild(fixture)).getElementWithTextParentTag({
+    tag,
+    text,
+  });
+};
+
+const getDirectChildTextOrder = async ({
+  fixture,
+  parentTag,
+  texts,
+}: {
+  fixture: SeededContentModeProject;
+  parentTag: string;
+  texts: string[];
+}) => {
+  return (await inspectBuild(fixture)).getDirectChildTextOrder({
+    parentTag,
+    texts,
+  });
 };
 
 const getInstanceLabelCount = async ({
@@ -220,11 +256,7 @@ const getInstanceLabelCount = async ({
   fixture: SeededContentModeProject;
   label: string;
 }) => {
-  const build = await loadDevBuild({ projectId: fixture.projectId });
-  const instances = JSON.parse(build.instances) as Array<{
-    label?: string;
-  }>;
-  return instances.filter((instance) => instance.label === label).length;
+  return (await inspectBuild(fixture)).countLabel(label);
 };
 
 const pastePlainTextFromClipboardShortcut = async ({
@@ -239,6 +271,77 @@ const pastePlainTextFromClipboardShortcut = async ({
   }, text);
   const save = waitForChangeToBeSaved({ page });
   await page.keyboard.press("ControlOrMeta+V");
+  await save;
+  await waitForSyncStatus({ page, status: "idle" });
+};
+
+const pasteFromClipboardShortcut = async ({ page }: { page: Page }) => {
+  const save = waitForChangeToBeSaved({ page }).catch(() => undefined);
+  await page.keyboard.press("ControlOrMeta+V");
+  await save;
+  await waitForSyncStatus({ page, status: "idle" });
+};
+
+const cutSelectedInstanceShortcut = async ({ page }: { page: Page }) => {
+  const save = waitForChangeToBeSaved({ page });
+  await page.keyboard.press("ControlOrMeta+X");
+  await save;
+  await waitForSyncStatus({ page, status: "idle" });
+};
+
+const pasteTextFromClipboardShortcutWithoutSave = async ({
+  page,
+  text,
+}: {
+  page: Page;
+  text: string;
+}) => {
+  await page.evaluate(async (text) => {
+    await navigator.clipboard.writeText(text);
+  }, text);
+  await page.keyboard.press("ControlOrMeta+V");
+  await waitForSyncStatus({ page, status: "idle" });
+};
+
+const waitForClipboardTextIncludes = async ({
+  page,
+  text,
+}: {
+  page: Page;
+  text: string;
+}) => {
+  await page.waitForFunction(async (text) => {
+    try {
+      return (await navigator.clipboard.readText()).includes(text as string);
+    } catch {
+      return false;
+    }
+  }, text);
+};
+
+const pasteClipboardData = async ({
+  page,
+  data,
+  waitForSave = true,
+}: {
+  page: Page;
+  data: Record<string, string>;
+  waitForSave?: boolean;
+}) => {
+  const save = waitForSave ? waitForChangeToBeSaved({ page }) : undefined;
+  await page.evaluate((data) => {
+    const clipboardData = new DataTransfer();
+    for (const [mimeType, value] of Object.entries(data)) {
+      clipboardData.setData(mimeType, value);
+    }
+    document.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData,
+      })
+    );
+  }, data);
   await save;
   await waitForSyncStatus({ page, status: "idle" });
 };
@@ -393,6 +496,11 @@ const selectNavigatorItem = async ({
   await item.waitFor({ state: "visible" });
   await item.click();
   await item.click();
+};
+
+const selectBodyInNavigator = async ({ page }: { page: Page }) => {
+  await openNavigatorPanel({ page });
+  await selectNavigatorItem({ page, itemName: "Body" });
 };
 
 const editSelectedNavigatorLabel = async ({
@@ -977,6 +1085,294 @@ test("Builder pastes external HTML fragments through clipboard and reloads them"
     if (reloadedArticleCount !== initialArticleCount + 1) {
       throw new Error(
         `Expected reload to preserve pasted article. Before ${initialArticleCount}, after ${reloadedArticleCount}`
+      );
+    }
+  } finally {
+    await close();
+  }
+});
+
+test("Builder copies, pastes, and cuts instances through browser shortcuts", async () => {
+  const { page, close } = await newIsolatedPage();
+  const text = "Initial content";
+
+  try {
+    await measure(
+      "pages actions open builder for instance clipboard shortcuts",
+      async () => {
+        await openProjectBuilder({
+          page,
+          projectId: fixture.projectId,
+          authToken: fixture.builderToken,
+        });
+      }
+    );
+    await waitForCanvasText({ page, text });
+    await waitForSyncStatus({ page, status: "idle" });
+
+    const initialTextCount = await getExactTextChildCount({ fixture, text });
+    await selectCanvasTextInstance({ page, text });
+    await page.keyboard.press("ControlOrMeta+C");
+    await waitForClipboardTextIncludes({
+      page,
+      text: "@webstudio/instance/v0.1",
+    });
+
+    await pasteFromClipboardShortcut({ page });
+    const pastedFromCanvasSelectionCount = await getExactTextChildCount({
+      fixture,
+      text,
+    });
+    if (pastedFromCanvasSelectionCount !== initialTextCount + 1) {
+      throw new Error(
+        `Expected paste from canvas selection to duplicate text. Before ${initialTextCount}, after ${pastedFromCanvasSelectionCount}`
+      );
+    }
+
+    await cutSelectedInstanceShortcut({ page });
+    const afterCutCount = await getExactTextChildCount({ fixture, text });
+    if (afterCutCount !== initialTextCount) {
+      throw new Error(
+        `Expected cut shortcut to remove selected pasted instance. Before ${initialTextCount}, after ${afterCutCount}`
+      );
+    }
+  } finally {
+    await close();
+  }
+});
+
+test("Builder does not insert malformed Webstudio paste data as text", async () => {
+  const { page, close } = await newIsolatedPage();
+  const malformedData =
+    '{"@webstudio/instance/v0.1":{"instanceSelector":["missing","body"]';
+
+  try {
+    await measure(
+      "pages actions open builder for malformed paste",
+      async () => {
+        await openProjectBuilder({
+          page,
+          projectId: fixture.projectId,
+          authToken: fixture.builderToken,
+        });
+      }
+    );
+    await waitForCanvasText({ page, text: "Initial content" });
+    await selectBodyInNavigator({ page });
+
+    await pasteTextFromClipboardShortcutWithoutSave({
+      page,
+      text: malformedData,
+    });
+    await waitForCanvasTextHidden({ page, text: malformedData });
+    const malformedTextCount = await getExactTextChildCount({
+      fixture,
+      text: malformedData,
+    });
+    if (malformedTextCount !== 0) {
+      throw new Error(
+        `Expected malformed Webstudio data not to be inserted as text, found ${malformedTextCount}`
+      );
+    }
+  } finally {
+    await close();
+  }
+});
+
+test("Builder allows native paste inside focused builder inputs", async () => {
+  const { page, close } = await newIsolatedPage();
+  const pastedText = "<section>Native input paste</section>";
+
+  try {
+    await measure(
+      "pages actions open builder for native input paste",
+      async () => {
+        await openProjectBuilder({
+          page,
+          projectId: fixture.projectId,
+          authToken: fixture.builderToken,
+        });
+      }
+    );
+    await waitForCanvasText({ page, text: "Initial content" });
+
+    await openCommandPanel({ page });
+    const commandInput = page.getByPlaceholder("Type a command or search...", {
+      exact: true,
+    });
+    await page.evaluate(async (text) => {
+      await navigator.clipboard.writeText(text);
+    }, pastedText);
+    await page.keyboard.press("ControlOrMeta+V");
+    await commandInput.waitFor();
+    const value = await commandInput.inputValue();
+    if (value !== pastedText) {
+      throw new Error(
+        `Expected native input paste to preserve text "${pastedText}", got "${value}"`
+      );
+    }
+    await page.keyboard.press("Escape");
+    await waitForCanvasTextHidden({ page, text: pastedText });
+  } finally {
+    await close();
+  }
+});
+
+test("Builder runs paste plugins through generic browser paste events", async () => {
+  const { page, close } = await newIsolatedPage();
+  const instanceJsonText = "Instance JSON paste heading";
+  const instanceTextText = "Instance text paste heading";
+  const jsxText = "JSX paste heading";
+  const htmlText = "HTML paste heading";
+  const markdownText = "Markdown paste heading";
+  const webflowText = "Webflow paste heading";
+
+  const fragmentArrays = {
+    assets: [],
+    dataSources: [],
+    resources: [],
+    props: [],
+    breakpoints: [],
+    styleSourceSelections: [],
+    styleSources: [],
+    styles: [],
+  };
+
+  const createInstanceTransfer = ({ id, text }: { id: string; text: string }) =>
+    JSON.stringify({
+      "@webstudio/instance/v0.1": {
+        instanceSelector: [id, "source-body"],
+        children: [{ type: "id", value: id }],
+        instances: [
+          {
+            type: "instance",
+            id,
+            component: "ws:element",
+            tag: "p",
+            children: [{ type: "text", value: text }],
+          },
+        ],
+        ...fragmentArrays,
+      },
+    });
+
+  const webflowData = JSON.stringify({
+    type: "@webflow/XscpData",
+    payload: {
+      nodes: [
+        {
+          _id: "webflow-heading",
+          type: "Heading",
+          tag: "h1",
+          children: ["webflow-heading-text"],
+          classes: [],
+        },
+        {
+          _id: "webflow-heading-text",
+          v: webflowText,
+          text: true,
+        },
+      ],
+      styles: [],
+      assets: [],
+    },
+  });
+
+  try {
+    await measure(
+      "pages actions open builder for generic paste plugins",
+      async () => {
+        await openProjectBuilder({
+          page,
+          projectId: fixture.projectId,
+          authToken: fixture.builderToken,
+        });
+      }
+    );
+    await waitForCanvasText({ page, text: "Initial content" });
+
+    await selectBodyInNavigator({ page });
+    await pasteClipboardData({
+      page,
+      data: {
+        "application/json": createInstanceTransfer({
+          id: "instance-json-paste",
+          text: instanceJsonText,
+        }),
+      },
+    });
+    await waitForCanvasText({ page, text: instanceJsonText });
+
+    await selectBodyInNavigator({ page });
+    await pasteClipboardData({
+      page,
+      data: {
+        "text/plain": createInstanceTransfer({
+          id: "instance-text-paste",
+          text: instanceTextText,
+        }),
+      },
+    });
+    await waitForCanvasText({ page, text: instanceTextText });
+
+    await selectBodyInNavigator({ page });
+    await pasteClipboardData({
+      page,
+      data: {
+        "text/plain": `<ws.element ws:tag="h2">${jsxText}</ws.element>`,
+      },
+    });
+    await waitForCanvasText({ page, text: jsxText });
+
+    await selectBodyInNavigator({ page });
+    await pasteClipboardData({
+      page,
+      data: {
+        "text/plain": `<section><h2>${htmlText}</h2></section>`,
+      },
+    });
+    await waitForCanvasText({ page, text: htmlText });
+
+    await selectBodyInNavigator({ page });
+    await pasteClipboardData({
+      page,
+      data: {
+        "text/plain": `## ${markdownText}`,
+      },
+    });
+    await waitForCanvasText({ page, text: markdownText });
+
+    await selectBodyInNavigator({ page });
+    await pasteClipboardData({
+      page,
+      data: {
+        "application/json": webflowData,
+      },
+    });
+    await waitForCanvasText({ page, text: webflowText });
+
+    const expectedPastes = [
+      ["p", instanceJsonText],
+      ["p", instanceTextText],
+      ["h2", jsxText],
+      ["h2", htmlText],
+      ["h2", markdownText],
+    ] as const;
+    for (const [tag, text] of expectedPastes) {
+      const count = await getElementTagWithTextCount({ fixture, tag, text });
+      if (count !== 1) {
+        throw new Error(
+          `Expected generic paste to create one ${tag} containing "${text}", found ${count}`
+        );
+      }
+    }
+    const webflowTextCount = await getInstanceWithTextCount({
+      fixture,
+      text: webflowText,
+    });
+    if (webflowTextCount === 0) {
+      throw new Error(
+        `Expected generic Webflow paste to persist text "${webflowText}"`
       );
     }
   } finally {

--- a/apps/builder/e2e/tests/pages-actions.[shard-3].e2e.ts
+++ b/apps/builder/e2e/tests/pages-actions.[shard-3].e2e.ts
@@ -22,7 +22,7 @@ import { loadDevBuild } from "../db";
 
 let fixture: SeededContentModeProject;
 
-const copiedPageClipboardMarker = "@webstudio/page/v0.1";
+const copiedPageTransferMarker = "@webstudio/page/v0.1";
 
 const getPageRow = ({ page, pageName }: { page: Page; pageName: string }) =>
   page.getByRole("group", { name: `Page ${pageName}`, exact: true });
@@ -69,14 +69,14 @@ const waitForTemplate = async ({
   await page.getByText(templateName, { exact: true }).first().waitFor();
 };
 
-const waitForCopiedPageClipboard = async ({ page }: { page: Page }) => {
+const waitForCopiedPageTransferData = async ({ page }: { page: Page }) => {
   await page.waitForFunction(async (marker) => {
     try {
       return (await navigator.clipboard.readText()).includes(marker as string);
     } catch {
       return false;
     }
-  }, copiedPageClipboardMarker);
+  }, copiedPageTransferMarker);
 };
 
 const getDataResourceCounts = async (fixture: SeededContentModeProject) => {
@@ -253,7 +253,7 @@ test("Builder can copy, duplicate, and delete a page from the header menu", asyn
       menuLabel: "Page actions",
       action: "Copy",
     });
-    await waitForCopiedPageClipboard({ page });
+    await waitForCopiedPageTransferData({ page });
     await pasteFromClipboardShortcut({ page });
     await waitForPageRow({ page, pageName: copiedPageName });
 
@@ -355,7 +355,7 @@ test("Builder can copy, duplicate, and delete a folder from the context menu", a
       itemName: renamedFolderName,
       action: "Copy",
     });
-    await waitForCopiedPageClipboard({ page });
+    await waitForCopiedPageTransferData({ page });
     await selectContextAction({ page, itemName: "Home", action: "Paste" });
     await waitForSyncStatus({ page, status: "idle" });
     await waitForFolderRow({ page, folderName: copiedFolderName });
@@ -431,7 +431,7 @@ test("Builder can copy, duplicate, and delete a page template from actions menus
       menuLabel: "Template actions",
       action: "Copy",
     });
-    await waitForCopiedPageClipboard({ page });
+    await waitForCopiedPageTransferData({ page });
     await pasteFromClipboardShortcut({ page });
     await waitForTemplate({ page, templateName: copiedTemplateName });
 

--- a/fixtures/react-router-cloudflare/.webstudio/data.json
+++ b/fixtures/react-router-cloudflare/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-1svfrul",
+  "bundleVersion": "bundle-a4rjtk",
   "build": {
     "id": "f565d527-32e7-4731-bc71-aca9e9574587",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/react-router-docker/.webstudio/data.json
+++ b/fixtures/react-router-docker/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-1svfrul",
+  "bundleVersion": "bundle-a4rjtk",
   "build": {
     "id": "f565d527-32e7-4731-bc71-aca9e9574587",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/react-router-netlify/.webstudio/data.json
+++ b/fixtures/react-router-netlify/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-1svfrul",
+  "bundleVersion": "bundle-a4rjtk",
   "build": {
     "id": "f565d527-32e7-4731-bc71-aca9e9574587",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/react-router-vercel/.webstudio/data.json
+++ b/fixtures/react-router-vercel/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-1svfrul",
+  "bundleVersion": "bundle-a4rjtk",
   "build": {
     "id": "f565d527-32e7-4731-bc71-aca9e9574587",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/ssg-cloudflare-pages/.webstudio/data.json
+++ b/fixtures/ssg-cloudflare-pages/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-1svfrul",
+  "bundleVersion": "bundle-a4rjtk",
   "build": {
     "id": "a2e8de30-03d5-4514-a3a6-406b3266a3af",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/ssg-netlify-by-project-id/.webstudio/data.json
+++ b/fixtures/ssg-netlify-by-project-id/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-1svfrul",
+  "bundleVersion": "bundle-a4rjtk",
   "build": {
     "id": "8f0fdff2-e76b-4f86-9203-ea7df5f1143c",
     "projectId": "8a7358b1-7de3-459d-b7b1-56dddfb6ce1e",

--- a/fixtures/webstudio-cloudflare-template/.webstudio/data.json
+++ b/fixtures/webstudio-cloudflare-template/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-1svfrul",
+  "bundleVersion": "bundle-a4rjtk",
   "build": {
     "id": "a2e8de30-03d5-4514-a3a6-406b3266a3af",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/webstudio-features/.webstudio/data.json
+++ b/fixtures/webstudio-features/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-1svfrul",
+  "bundleVersion": "bundle-a4rjtk",
   "build": {
     "id": "1b66ee06-8ea5-4420-9a0e-e0d3a67aca32",
     "projectId": "cddc1d44-af37-4cb6-a430-d300cf6f932d",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
     "@webstudio-is/project-migrations": "workspace:*",
     "@webstudio-is/protocol": "workspace:*",
     "@webstudio-is/sdk-components-registry": "workspace:*",
+    "@webstudio-is/sync-client": "workspace:*",
     "acorn": "^8.14.1",
     "acorn-jsx": "^5.3.2",
     "acorn-walk": "^8.3.4",

--- a/packages/cli/src/asset-files.test.ts
+++ b/packages/cli/src/asset-files.test.ts
@@ -98,6 +98,25 @@ test("downloads asset files when they are missing from the synced asset cache", 
   );
 });
 
+test("retries asset download once after a server error", async () => {
+  const fetch = vi
+    .fn()
+    .mockResolvedValueOnce(new Response("failed", { status: 500 }))
+    .mockResolvedValueOnce(new Response("downloaded"));
+  globalThis.fetch = fetch;
+
+  await materializeAssetFile({
+    asset,
+    origin: "https://example.com",
+    targetAssetsDirectory: "public/assets",
+  });
+
+  await expect(readFile("public/assets/image.png", "utf8")).resolves.toBe(
+    "downloaded"
+  );
+  expect(fetch).toHaveBeenCalledTimes(2);
+});
+
 test("removes temporary files when asset download fails", async () => {
   const fetch = vi.fn(
     async () =>

--- a/packages/cli/src/asset-files.ts
+++ b/packages/cli/src/asset-files.ts
@@ -2,14 +2,20 @@ import { constants, createWriteStream } from "node:fs";
 import { copyFile, rename, rm } from "node:fs/promises";
 import { dirname, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
+import { setTimeout } from "node:timers/promises";
 import pLimit from "p-limit";
 import { getAssetUrl, type Asset } from "@webstudio-is/sdk";
+import { createBackoff } from "@webstudio-is/sync-client/backoff";
 import { createFolderIfNotExists, isFileExists } from "./fs-utils";
 import { isAssetFileName } from "@webstudio-is/protocol";
 
 export const LOCAL_ASSETS_DIR = ".webstudio/assets";
 
 const limit = pLimit(10);
+const assetDownloadMaxAttempts = 2;
+
+const isRetryableStatus = (status: number) =>
+  status === 408 || status === 429 || status >= 500;
 
 const runAssetTasks = async ({
   assets,
@@ -87,20 +93,19 @@ export const createLocalUploadAssetsInput = <Asset extends { name: string }>({
   readAssetData: createLocalAssetDataReader(readFile, assetsDir),
 });
 
-const downloadUrlToFile = async (url: string, filePath: string) => {
+const downloadUrlToFileOnce = async (url: string, filePath: string) => {
   const tempFilePath = `${filePath}.tmp`;
   let writableStream: ReturnType<typeof createWriteStream> | undefined;
-
-  if (await isFileExists(filePath)) {
-    return;
-  }
-
-  await createFolderIfNotExists(dirname(filePath));
 
   try {
     const response = await fetch(url);
     if (!response.ok) {
-      throw new Error(`Failed to fetch ${url}: ${response.statusText}`);
+      throw Object.assign(
+        new Error(
+          `Failed to fetch ${url}: ${response.status} ${response.statusText}`
+        ),
+        { status: response.status }
+      );
     }
     if (response.body === null) {
       throw new Error(`Failed to fetch ${url}: response body is empty`);
@@ -123,6 +128,41 @@ const downloadUrlToFile = async (url: string, filePath: string) => {
     await rm(tempFilePath, { force: true });
     throw error;
   }
+};
+
+const downloadUrlToFile = async (url: string, filePath: string) => {
+  if (await isFileExists(filePath)) {
+    return;
+  }
+
+  await createFolderIfNotExists(dirname(filePath));
+
+  let lastError: unknown;
+  const backoff = createBackoff({
+    baseDelay: 500,
+    jitter: false,
+    maxDelay: 500,
+    multiplier: 1,
+  });
+  for (let attempt = 1; attempt <= assetDownloadMaxAttempts; attempt += 1) {
+    try {
+      await downloadUrlToFileOnce(url, filePath);
+      return;
+    } catch (error) {
+      lastError = error;
+      const status =
+        typeof error === "object" && error !== null && "status" in error
+          ? error.status
+          : undefined;
+      const isRetryable =
+        typeof status === "number" ? isRetryableStatus(status) : true;
+      if (attempt === assetDownloadMaxAttempts || isRetryable === false) {
+        throw error;
+      }
+      await setTimeout(backoff.next());
+    }
+  }
+  throw lastError;
 };
 
 export const downloadAssetFile = async ({

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -816,8 +816,8 @@ export const reorderPageTemplate = runtimeProjectMutation(
 
 export const duplicateFolder = runtimeProjectMutation("duplicate-folder");
 
-export const pastePageClipboardItem = runtimeProjectMutation(
-  "paste-page-clipboard-item"
+export const insertPageTransferItem = runtimeProjectMutation(
+  "insert-page-transfer-item"
 );
 
 export const movePageTreeItem = runtimeProjectMutation("move-page-tree-item");

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -107,6 +107,21 @@
       "import": "./src/runtime/data.ts",
       "default": "./src/runtime/data.ts"
     },
+    "./runtime/data-formats/data-envelope": {
+      "webstudio": "./src/runtime/data-formats/data-envelope.ts",
+      "import": "./src/runtime/data-formats/data-envelope.ts",
+      "default": "./src/runtime/data-formats/data-envelope.ts"
+    },
+    "./runtime/data-formats/instance-transfer": {
+      "webstudio": "./src/runtime/data-formats/instance-transfer.ts",
+      "import": "./src/runtime/data-formats/instance-transfer.ts",
+      "default": "./src/runtime/data-formats/instance-transfer.ts"
+    },
+    "./runtime/data-formats/page-transfer": {
+      "webstudio": "./src/runtime/data-formats/page-transfer.ts",
+      "import": "./src/runtime/data-formats/page-transfer.ts",
+      "default": "./src/runtime/data-formats/page-transfer.ts"
+    },
     "./runtime/errors": {
       "webstudio": "./src/runtime/errors.ts",
       "import": "./src/runtime/errors.ts",

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -1865,9 +1865,9 @@ export const runtimeOperationContractData = [
     requiresAssets: true,
   },
   {
-    id: "pageClipboard.paste",
-    command: "paste-page-clipboard-item",
-    client: "pastePageClipboardItem",
+    id: "pageTransfer.insert",
+    command: "insert-page-transfer-item",
+    client: "insertPageTransferItem",
     kind: "mutation",
     inputSchema: {
       type: "object",

--- a/packages/project-build/src/runtime/components.test.ts
+++ b/packages/project-build/src/runtime/components.test.ts
@@ -655,48 +655,59 @@ test("inspects webstudio jsx fragment syntax without evaluation", () => {
   ).not.toThrow();
 });
 
-test("rejects bare template-backed components in webstudio jsx fragments", async () => {
+test("inserts bare template-backed components from webstudio jsx fragments", async () => {
   const parent = createParent();
   const fragment = await parseWebstudioJsxFragment(`<radix.Switch />`);
 
-  expect(() =>
-    insertFragment(
-      createState(parent),
-      {
-        parentInstanceId: parent.id,
-        fragment,
-      },
-      {
-        createId: createIdFactory(),
-        projectId: "project-id",
-      }
-    )
-  ).toThrow(
-    'use insert-component with component "@webstudio-is/sdk-components-react-radix:Switch"'
+  const mutation = insertFragment(
+    createState(parent),
+    {
+      parentInstanceId: parent.id,
+      fragment,
+    },
+    {
+      createId: createIdFactory(),
+      projectId: "project-id",
+    }
   );
+
+  expect(getAddedValues<Instance>(mutation, "instances")).toEqual([
+    expect.objectContaining({
+      component: "@webstudio-is/sdk-components-react-radix:Switch",
+    }),
+  ]);
 });
 
-test("rejects misplaced required template parts in webstudio jsx fragments", async () => {
+test("inserts authored template part structure from webstudio jsx fragments", async () => {
   const parent = createParent();
   const fragment = await parseWebstudioJsxFragment(
     `<radix.Switch><ws.element ws:tag="div"><radix.SwitchThumb /></ws.element></radix.Switch>`
   );
 
-  expect(() =>
-    insertFragment(
-      createState(parent),
-      {
-        parentInstanceId: parent.id,
-        fragment,
-      },
-      {
-        createId: createIdFactory(),
-        projectId: "project-id",
-      }
-    )
-  ).toThrow(
-    '"@webstudio-is/sdk-components-react-radix:Switch" > "@webstudio-is/sdk-components-react-radix:SwitchThumb"'
+  const mutation = insertFragment(
+    createState(parent),
+    {
+      parentInstanceId: parent.id,
+      fragment,
+    },
+    {
+      createId: createIdFactory(),
+      projectId: "project-id",
+    }
   );
+
+  expect(getAddedValues<Instance>(mutation, "instances")).toEqual([
+    expect.objectContaining({
+      component: "@webstudio-is/sdk-components-react-radix:Switch",
+    }),
+    expect.objectContaining({
+      component: elementComponent,
+      tag: "div",
+    }),
+    expect.objectContaining({
+      component: "@webstudio-is/sdk-components-react-radix:SwitchThumb",
+    }),
+  ]);
 });
 
 test("supports react style props in webstudio jsx fragments", async () => {

--- a/packages/project-build/src/runtime/components.ts
+++ b/packages/project-build/src/runtime/components.ts
@@ -446,12 +446,10 @@ const createTokenFragmentInsertPayload = ({
 
 const validateFragmentComponent = ({
   instance,
-  instancesById,
   templates,
   page,
 }: {
   instance: Instance;
-  instancesById: ReadonlyMap<Instance["id"], Instance>;
   templates: ComponentTemplateRegistry;
   page: Page;
 }) => {
@@ -488,37 +486,6 @@ const validateFragmentComponent = ({
   if (meta === undefined && insertCategory === undefined) {
     return;
   }
-  const requiredStructure = getTemplateRequiredStructure(component, templates);
-  if (requiredStructure.parts.length > 0) {
-    const subtreeComponents = getSubtreeComponents(instance, instancesById);
-    const missingParts = requiredStructure.parts.filter(
-      (part) => subtreeComponents.has(part) === false
-    );
-    if (missingParts.length > 0) {
-      return throwBuilderRuntimeError(
-        "BAD_REQUEST",
-        `Component "${component}" has a registered template with required child/part components ${missingParts
-          .map((part) => `"${part}"`)
-          .join(
-            ", "
-          )}. In JSX fragments, include the required parts explicitly, or use insert-component with component "${component}" when you want Webstudio to apply the template automatically.`
-      );
-    }
-    const subtreeEdges = getSubtreeComponentEdges(instance, instancesById);
-    const missingEdges = requiredStructure.edges.filter(
-      (edge) => subtreeEdges.has(edge) === false
-    );
-    if (missingEdges.length > 0) {
-      return throwBuilderRuntimeError(
-        "BAD_REQUEST",
-        `Component "${component}" has a registered template with required child/part structure ${missingEdges
-          .map(formatComponentEdge)
-          .join(
-            ", "
-          )}. In JSX fragments, keep required parts under the same parent components as the template, or use insert-component with component "${component}" when you want Webstudio to apply the template automatically.`
-      );
-    }
-  }
 };
 
 const getSubtreeComponents = (
@@ -550,11 +517,6 @@ const createComponentEdge = (
 export const parseComponentEdge = (edge: string) => {
   const [parentComponent, childComponent] = edge.split("\0");
   return { parentComponent, childComponent };
-};
-
-const formatComponentEdge = (edge: string) => {
-  const [parentComponent, childComponent] = edge.split("\0");
-  return `"${parentComponent}" > "${childComponent}"`;
 };
 
 const getSubtreeComponentEdges = (
@@ -661,13 +623,9 @@ const createInsertFragmentMutation = ({
   }
 
   const page = getInsertionPage(mutationState, originalParent);
-  const fragmentInstancesById = new Map(
-    fragment.instances.map((instance) => [instance.id, instance])
-  );
   for (const instance of fragment.instances) {
     validateFragmentComponent({
       instance,
-      instancesById: fragmentInstancesById,
       templates,
       page,
     });

--- a/packages/project-build/src/runtime/cutover.ts
+++ b/packages/project-build/src/runtime/cutover.ts
@@ -267,10 +267,10 @@ export const builderRuntimeCutoverManifests = [
     callers: ["appRouter.api.variables"] as const,
   },
   {
-    family: "page-tree-and-clipboard-mutations",
+    family: "page-tree-and-transfer-mutations",
     operationIds: [
       "pages.copy",
-      "pageClipboard.paste",
+      "pageTransfer.insert",
       "pageTree.move",
       "pageTree.reparentOrphans",
     ] as const,

--- a/packages/project-build/src/runtime/data-formats/data-envelope.ts
+++ b/packages/project-build/src/runtime/data-formats/data-envelope.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+
+/**
+ * A Webstudio data envelope is a serialized single-key object whose key is a
+ * versioned Webstudio data marker, for example
+ * `{ "@webstudio/instance/v0.1": data }`.
+ *
+ * The envelope is transport-agnostic. Runtime only validates the envelope and
+ * returns the domain transfer data inside it.
+ */
+type DataEnvelopeSchemas = readonly (readonly [string, z.ZodTypeAny])[];
+
+type DataEnvelopeValidResult<Schemas extends DataEnvelopeSchemas> = {
+  [Index in keyof Schemas]: Schemas[Index] extends readonly [
+    infer Version extends string,
+    infer Schema extends z.ZodTypeAny,
+  ]
+    ? { owned: true; valid: true; version: Version; data: z.output<Schema> }
+    : never;
+}[number];
+
+export type DataEnvelopeParseResult<Schemas extends DataEnvelopeSchemas> =
+  | { owned: false; valid: false }
+  | { owned: true; valid: false }
+  | DataEnvelopeValidResult<Schemas>;
+
+const ownsDataEnvelope = (serializedData: string, versions: string[]) => {
+  const data = serializedData.trimStart();
+  const objectContent =
+    data.startsWith("{") === false ? undefined : data.slice(1).trimStart();
+  if (
+    objectContent !== undefined &&
+    versions.some((version) => objectContent.startsWith(`"${version}"`))
+  ) {
+    return true;
+  }
+  try {
+    const data = JSON.parse(serializedData);
+    return (
+      data != null &&
+      typeof data === "object" &&
+      versions.some((version) => version in data)
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const parseDataEnvelope = <Schemas extends DataEnvelopeSchemas>({
+  serializedData,
+  schemas,
+}: {
+  serializedData: string;
+  schemas: Schemas;
+}): DataEnvelopeParseResult<Schemas> => {
+  const versions = schemas.map(([version]) => version);
+  const owned = ownsDataEnvelope(serializedData, versions);
+  if (owned === false) {
+    return { owned: false, valid: false };
+  }
+  try {
+    const data = JSON.parse(serializedData);
+    if (data == null || typeof data !== "object") {
+      return { owned: true, valid: false };
+    }
+    for (const [version, schema] of schemas) {
+      const result = schema.safeParse(
+        (data as Record<string, unknown>)[version]
+      );
+      if (result.success) {
+        return {
+          owned: true,
+          valid: true,
+          version,
+          data: result.data,
+        } as DataEnvelopeValidResult<Schemas>;
+      }
+    }
+  } catch {
+    return { owned: true, valid: false };
+  }
+  return { owned: true, valid: false };
+};

--- a/packages/project-build/src/runtime/data-formats/instance-transfer.test.ts
+++ b/packages/project-build/src/runtime/data-formats/instance-transfer.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "vitest";
+import { parseInstanceTransferData } from "./instance-transfer";
+
+test("validates instance transfer data", () => {
+  const valid = parseInstanceTransferData(
+    JSON.stringify({
+      "@webstudio/instance/v0.1": {
+        instanceSelector: ["box", "body"],
+        children: [{ type: "id", value: "box" }],
+        instances: [
+          { type: "instance", id: "box", component: "Box", children: [] },
+        ],
+        assets: [],
+        dataSources: [],
+        resources: [],
+        props: [],
+        breakpoints: [],
+        styleSourceSelections: [],
+        styleSources: [],
+        styles: [],
+      },
+    })
+  );
+
+  expect(valid).toMatchObject({
+    owned: true,
+    valid: true,
+    type: "single-root",
+  });
+
+  expect(
+    parseInstanceTransferData(
+      `{  "@webstudio/instance/v0.1":{"instanceSelector":["box","body"]`
+    )
+  ).toEqual({ owned: true, valid: false });
+
+  expect(parseInstanceTransferData("plain text")).toEqual({
+    owned: false,
+    valid: false,
+  });
+});

--- a/packages/project-build/src/runtime/data-formats/instance-transfer.ts
+++ b/packages/project-build/src/runtime/data-formats/instance-transfer.ts
@@ -1,0 +1,35 @@
+import { webstudioFragment } from "@webstudio-is/sdk";
+import { z } from "zod";
+import { parseDataEnvelope } from "./data-envelope";
+
+export const instanceTransferDataVersion = "@webstudio/instance/v0.1";
+export const instancesTransferDataVersion = "@webstudio/instances/v0.1";
+
+export const instanceTransferData = webstudioFragment.extend({
+  instanceSelector: z.array(z.string()),
+});
+
+export const instancesTransferData = z.object({
+  rootInstanceIds: z.array(z.string()),
+  fragment: webstudioFragment,
+});
+
+export type InstanceTransferData = z.infer<typeof instanceTransferData>;
+export type InstancesTransferData = z.infer<typeof instancesTransferData>;
+
+export const parseInstanceTransferData = (serializedData: string) => {
+  const transferData = parseDataEnvelope({
+    serializedData,
+    schemas: [
+      [instanceTransferDataVersion, instanceTransferData],
+      [instancesTransferDataVersion, instancesTransferData],
+    ] as const,
+  });
+  if (transferData.valid === false) {
+    return transferData;
+  }
+  if (transferData.version === instanceTransferDataVersion) {
+    return { ...transferData, type: "single-root" } as const;
+  }
+  return { ...transferData, type: "multi-root" } as const;
+};

--- a/packages/project-build/src/runtime/data-formats/page-transfer.test.ts
+++ b/packages/project-build/src/runtime/data-formats/page-transfer.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "vitest";
+import { parsePageTransferData } from "./page-transfer";
+
+test("validates page transfer data", () => {
+  const fragment = {
+    children: [],
+    instances: [],
+    assets: [],
+    dataSources: [],
+    resources: [],
+    props: [],
+    breakpoints: [],
+    styleSourceSelections: [],
+    styleSources: [],
+    styles: [],
+  };
+  const valid = parsePageTransferData(
+    JSON.stringify({
+      "@webstudio/page/v0.1": {
+        type: "page",
+        page: {
+          id: "page",
+          name: "Page",
+          path: "/page",
+          title: `"Page"`,
+          meta: {},
+          rootInstanceId: "body",
+        },
+        rootFragment: fragment,
+        bodyFragment: fragment,
+      },
+    })
+  );
+
+  expect(valid).toMatchObject({
+    owned: true,
+    valid: true,
+    data: { type: "page" },
+  });
+
+  expect(
+    parsePageTransferData(`{  "@webstudio/page/v0.1":{"type":"page"`)
+  ).toEqual({ owned: true, valid: false });
+
+  expect(parsePageTransferData("plain text")).toEqual({
+    owned: false,
+    valid: false,
+  });
+});

--- a/packages/project-build/src/runtime/data-formats/page-transfer.ts
+++ b/packages/project-build/src/runtime/data-formats/page-transfer.ts
@@ -1,0 +1,89 @@
+import {
+  type Folder,
+  type Page,
+  type PageTemplate,
+  type WebstudioFragment,
+  webstudioFragment,
+} from "@webstudio-is/sdk";
+import { z } from "zod";
+import { parseDataEnvelope } from "./data-envelope";
+
+export type PageCopyData = {
+  page: Page;
+  rootFragment: WebstudioFragment;
+  bodyFragment: WebstudioFragment;
+};
+
+export type TemplateCopyData = {
+  template: PageTemplate;
+  rootFragment: WebstudioFragment;
+  bodyFragment: WebstudioFragment;
+};
+
+export type FolderCopyData = {
+  folder: Folder;
+  children: Array<PageCopyData | FolderCopyData>;
+};
+
+export type PageTransferData = PageCopyData & { type: "page" };
+
+export type TemplateTransferData = TemplateCopyData & { type: "template" };
+
+export type FolderTransferData = Omit<FolderCopyData, "children"> & {
+  type: "folder";
+  children: Array<PageTransferData | FolderTransferData>;
+};
+
+export type PageTransferItem =
+  | PageTransferData
+  | TemplateTransferData
+  | FolderTransferData;
+
+export const pageTransferPageInput: z.ZodType<PageTransferData> = z.object({
+  type: z.literal("page"),
+  page: z.custom<Page>(),
+  rootFragment: webstudioFragment,
+  bodyFragment: webstudioFragment,
+});
+
+export const pageTransferTemplateInput: z.ZodType<TemplateTransferData> =
+  z.object({
+    type: z.literal("template"),
+    template: z.custom<PageTemplate>(),
+    rootFragment: webstudioFragment,
+    bodyFragment: webstudioFragment,
+  });
+
+export const pageTransferFolderInput: z.ZodType<FolderTransferData> = z.lazy(
+  () =>
+    z.object({
+      type: z.literal("folder"),
+      folder: z.custom<Folder>(),
+      children: z.array(
+        z.union([pageTransferPageInput, pageTransferFolderInput])
+      ),
+    })
+);
+
+export const pageTransferItemInput = z.union([
+  pageTransferPageInput,
+  pageTransferTemplateInput,
+  pageTransferFolderInput,
+]);
+
+export const pageTransferDataVersion = "@webstudio/page/v0.1";
+
+export const parsePageTransferData = (serializedData: string) => {
+  const transferData = parseDataEnvelope({
+    serializedData,
+    schemas: [[pageTransferDataVersion, pageTransferItemInput]] as const,
+  });
+  if (transferData.valid === false) {
+    return transferData;
+  }
+  return {
+    owned: true,
+    valid: true,
+    data: transferData.data,
+  } as const;
+};

--- a/packages/project-build/src/runtime/data.test.tsx
+++ b/packages/project-build/src/runtime/data.test.tsx
@@ -230,6 +230,22 @@ test("creates data variable values from form input values", () => {
   ).toEqual({ type: "json", value: { enabled: true } });
   expect(
     createDataVariableValueFromInput({
+      type: "json",
+      value: null,
+    })
+  ).toEqual({ type: "json", value: null });
+  expect(
+    JSON.parse(
+      JSON.stringify(
+        createDataVariableValueFromInput({
+          type: "json",
+          value: null,
+        })
+      )
+    )
+  ).toEqual({ type: "json", value: null });
+  expect(
+    createDataVariableValueFromInput({
       type: "string[]",
       value: '["Draft", "Connected", "Published"]',
     })

--- a/packages/project-build/src/runtime/data.ts
+++ b/packages/project-build/src/runtime/data.ts
@@ -307,9 +307,10 @@ export const createDataVariableValueFromInput = ({
       value: value === null ? [] : parseDataVariableJsonExpression(value),
     });
   }
+  const parsedValue = value ? parseDataVariableJsonExpression(value) : null;
   return {
     type: "json",
-    value: value ? parseDataVariableJsonExpression(value) : undefined,
+    value: parsedValue ?? null,
   };
 };
 

--- a/packages/project-build/src/runtime/page-copy.ts
+++ b/packages/project-build/src/runtime/page-copy.ts
@@ -29,7 +29,6 @@ import {
   type WsComponentMeta,
   type WebstudioFragment,
   type WebstudioData,
-  webstudioFragment,
   ROOT_INSTANCE_ID,
 } from "@webstudio-is/sdk";
 import type { ConflictResolution } from "./style-copy";
@@ -49,6 +48,12 @@ import {
 } from "./pages";
 import { unwrap } from "./unwrap";
 import { componentMetas } from "@webstudio-is/sdk-components-registry/metas";
+import {
+  pageTransferItemInput,
+  type FolderCopyData,
+  type PageCopyData,
+  type TemplateCopyData,
+} from "./data-formats/page-transfer";
 
 type CreateId = () => string;
 
@@ -1195,73 +1200,10 @@ export const insertTemplateCopyFromFragmentsMutable = ({
   });
 };
 
-export type PageCopyData = {
-  page: Page;
-  rootFragment: WebstudioFragment;
-  bodyFragment: WebstudioFragment;
-};
-
-export type TemplateCopyData = {
-  template: PageTemplate;
-  rootFragment: WebstudioFragment;
-  bodyFragment: WebstudioFragment;
-};
-
-export type FolderCopyData = {
-  folder: Folder;
-  children: Array<PageCopyData | FolderCopyData>;
-};
-
-export type PageClipboardData = PageCopyData & { type: "page" };
-
-export type TemplateClipboardData = TemplateCopyData & { type: "template" };
-
-export type FolderClipboardData = Omit<FolderCopyData, "children"> & {
-  type: "folder";
-  children: Array<PageClipboardData | FolderClipboardData>;
-};
-
-export type PageClipboardItem =
-  | PageClipboardData
-  | TemplateClipboardData
-  | FolderClipboardData;
-
-export const pageClipboardPageInput: z.ZodType<PageClipboardData> = z.object({
-  type: z.literal("page"),
-  page: z.custom<Page>(),
-  rootFragment: webstudioFragment,
-  bodyFragment: webstudioFragment,
-});
-
-export const pageClipboardTemplateInput: z.ZodType<TemplateClipboardData> =
-  z.object({
-    type: z.literal("template"),
-    template: z.custom<PageTemplate>(),
-    rootFragment: webstudioFragment,
-    bodyFragment: webstudioFragment,
-  });
-
-export const pageClipboardFolderInput: z.ZodType<FolderClipboardData> = z.lazy(
-  () =>
-    z.object({
-      type: z.literal("folder"),
-      folder: z.custom<Folder>(),
-      children: z.array(
-        z.union([pageClipboardPageInput, pageClipboardFolderInput])
-      ),
-    })
-);
-
-export const pageClipboardItemInput = z.union([
-  pageClipboardPageInput,
-  pageClipboardTemplateInput,
-  pageClipboardFolderInput,
-]);
-
-export const pageClipboardPasteInput = z.object({
+export const pageTransferInsertInput = z.object({
   projectId: z.string(),
   targetFolderId: z.string(),
-  item: pageClipboardItemInput,
+  item: pageTransferItemInput,
   conflictResolution: z.enum(["ours", "theirs", "merge"]).optional(),
 });
 
@@ -1420,9 +1362,9 @@ export const insertFolderCopyFromDataMutable = ({
   });
 };
 
-export const pastePageClipboardItem = (
+export const insertPageTransferItem = (
   state: BuilderState,
-  input: z.infer<typeof pageClipboardPasteInput>,
+  input: z.infer<typeof pageTransferInsertInput>,
   context: { createId: CreateId }
 ) => {
   const data = getRequiredWebstudioData(state);
@@ -1471,7 +1413,7 @@ export const pastePageClipboardItem = (
   if (id === undefined) {
     return throwBuilderRuntimeError(
       "BAD_REQUEST",
-      "Clipboard item was not pasted"
+      "Transfer item was not inserted"
     );
   }
   return createRuntimeMutation({

--- a/packages/project-build/src/runtime/registry.test.ts
+++ b/packages/project-build/src/runtime/registry.test.ts
@@ -1125,7 +1125,7 @@ describe("builder runtime registry", () => {
       ["folders.update", {}],
       ["folders.delete", {}],
       ["folders.duplicate", {}],
-      ["pageClipboard.paste", {}],
+      ["pageTransfer.insert", {}],
       ["pageTree.move", {}],
       ["pageTree.reparentOrphans", "invalid"],
       ["instances.insertComponent", { parentInstanceId: "body" }],

--- a/packages/project-build/src/runtime/registry.ts
+++ b/packages/project-build/src/runtime/registry.ts
@@ -606,15 +606,15 @@ export const builderRuntimeOperations = [
       pageCopy.duplicateFolder(state, input, context)
   ),
   runtimeOperation(
-    "pageClipboard.paste",
-    api("paste-page-clipboard-item", "pastePageClipboardItem"),
+    "pageTransfer.insert",
+    api("insert-page-transfer-item", "insertPageTransferItem"),
     mutationContract({
       readNamespaces: pageCopyNamespaces,
       writeNamespaces: pageCopyNamespaces,
     }),
-    pageCopy.pageClipboardPasteInput,
+    pageCopy.pageTransferInsertInput,
     ({ state, input, context }) =>
-      pageCopy.pastePageClipboardItem(state, input, context)
+      pageCopy.insertPageTransferItem(state, input, context)
   ),
   runtimeOperation(
     "pageTree.move",

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -10,3 +10,25 @@ bundle compatibility/version helpers.
 Domain models such as pages, assets, and serialized builds remain owned by
 their domain packages and are composed here through schema-only entrypoints.
 Do not copy those schemas into this package.
+
+## Terminology
+
+**Project bundle** is the authoritative external project artifact. It is used by
+sync, `.webstudio/data.json`, project import, transferred asset files, and
+prebuild.
+
+**Data envelope** is a serialized single-key object whose key is a versioned
+Webstudio marker, for example `{ "@webstudio/instance/v0.1": data }`. The
+envelope identifies the payload version and lets consumers detect malformed
+Webstudio-owned data before falling back to other formats.
+
+**Transfer data** is the domain payload inside a data envelope. Examples include
+`InstanceTransferData`, `InstancesTransferData`, and `PageTransferData`.
+Transfer data is portable and detached from a project; insertion/import remaps
+ids and merges it into authoritative project state. Runtime-owned transfer
+formats live in `@webstudio-is/project-build/runtime/data-formats/*`.
+
+**Clipboard data** is a UI transport concern. Builder copy/paste may serialize
+transfer data into a data envelope and place it on the browser clipboard, but
+runtime and protocol code should name the reusable format as data envelope or
+transfer data, not clipboard.

--- a/packages/sdk/src/schema/data-sources.test.ts
+++ b/packages/sdk/src/schema/data-sources.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "vitest";
+import { dataSource } from "./data-sources";
+
+test("normalizes legacy json data variables without value", () => {
+  expect(
+    dataSource.parse({
+      id: "data-source-id",
+      type: "variable",
+      name: "data",
+      value: { type: "json" },
+    })
+  ).toEqual({
+    id: "data-source-id",
+    type: "variable",
+    name: "data",
+    value: { type: "json", value: null },
+  });
+});

--- a/packages/sdk/src/schema/data-sources.ts
+++ b/packages/sdk/src/schema/data-sources.ts
@@ -20,10 +20,12 @@ export const dataSourceVariableValue = z.union([
     type: z.literal("string[]"),
     value: z.array(z.string()),
   }),
-  z.object({
-    type: z.literal("json"),
-    value: z.unknown(),
-  }),
+  z
+    .object({
+      type: z.literal("json"),
+      value: z.unknown().optional(),
+    })
+    .transform((value) => ({ ...value, value: value.value ?? null })),
 ]);
 
 export const dataSource = z.union([

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -11,6 +11,11 @@
       "import": "./src/index.ts",
       "default": "./src/index.ts"
     },
+    "./backoff": {
+      "webstudio": "./src/backoff.ts",
+      "import": "./src/backoff.ts",
+      "default": "./src/backoff.ts"
+    },
     "./websocket": {
       "webstudio": "./src/multiplayer/websocket-emitter.ts",
       "import": "./src/multiplayer/websocket-emitter.ts",

--- a/packages/template/src/jsx.ts
+++ b/packages/template/src/jsx.ts
@@ -390,7 +390,7 @@ export const renderTemplate = (
       } else if (typeof variable.initialValue === "boolean") {
         value = { type: "boolean", value: variable.initialValue };
       } else {
-        value = { type: "json", value: variable.initialValue };
+        value = { type: "json", value: variable.initialValue ?? null };
       }
       dataSources.set(variable, {
         type: "variable",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1170,6 +1170,9 @@ importers:
       '@webstudio-is/sdk-components-registry':
         specifier: workspace:*
         version: link:../sdk-components-registry
+      '@webstudio-is/sync-client':
+        specifier: workspace:*
+        version: link:../sync-client
       acorn:
         specifier: ^8.14.1
         version: 8.14.1


### PR DESCRIPTION

- Fix publish sync for empty JSON data variables
- Retry transient asset downloads once with shared sync-client backoff
- Fix Builder paste handling for Webstudio transfer data
- Add transfer/data-envelope terminology and colocated runtime data-format modules
- Rename page clipboard runtime operation to page transfer semantics
- Report malformed Webstudio/Webflow paste data through paste results instead of inserting it as text
- Add browser-level E2E coverage for instance, page, folder, template, generic plugin, malformed data, native input, and content-mode paste flows

## Details

- Allows empty JSON data variables to sync/publish correctly.
- Adds asset download retry coverage and uses shared backoff logic.
- Introduces runtime `data-formats` modules for data envelopes, instance transfer data, and page transfer data.
- Removes stale clipboard aliases and `validateTemplateStructure`.
- Keeps clipboard as a Builder UI transport concern while runtime/protocol use transfer-data terminology.
- Changes paste plugins to return expressive success/error results so callers can show toast errors and stop fallback insertion.
- Prevents malformed Webstudio transfer payloads from falling through to text/HTML/markdown insertion.
- Handles malformed Webflow-owned paste data without throwing.
- Adds shared copy-paste fragment insertion helpers to reduce duplicated breakpoint-warning/fragment-data logic.
