### PR TITLE
feat: Add complete, client-compatible MCP output schemas

### DIFF
--- a/fixtures/react-router-docker/vite.config.ts
+++ b/fixtures/react-router-docker/vite.config.ts
@@ -1,14 +1,17 @@
 import { defineConfig } from "vite";
 import { reactRouter } from "@react-router/dev/vite";
 
+const sourceConditions =
+  process.env.WEBSTUDIO_LOCAL_CLI_BOOTSTRAPPED === "1" ? ["webstudio"] : [];
+
 export default defineConfig({
   plugins: [reactRouter()],
   resolve: {
-    conditions: ["browser", "development|production"],
+    conditions: [...sourceConditions, "browser", "development|production"],
   },
   ssr: {
     resolve: {
-      conditions: ["node", "development|production"],
+      conditions: [...sourceConditions, "node", "development|production"],
     },
   },
 });

--- a/fixtures/react-router-vercel/vite.config.ts
+++ b/fixtures/react-router-vercel/vite.config.ts
@@ -1,14 +1,17 @@
 import { defineConfig } from "vite";
 import { reactRouter } from "@react-router/dev/vite";
 
+const sourceConditions =
+  process.env.WEBSTUDIO_LOCAL_CLI_BOOTSTRAPPED === "1" ? ["webstudio"] : [];
+
 export default defineConfig({
   plugins: [reactRouter()],
   resolve: {
-    conditions: ["browser", "development|production"],
+    conditions: [...sourceConditions, "browser", "development|production"],
   },
   ssr: {
     resolve: {
-      conditions: ["node", "development|production"],
+      conditions: [...sourceConditions, "node", "development|production"],
     },
   },
 });

--- a/packages/cli/src/prebuild.test.ts
+++ b/packages/cli/src/prebuild.test.ts
@@ -367,6 +367,12 @@ describe("prebuild", () => {
     await expect(readFile("app/routes/_index.tsx", "utf8")).resolves.toContain(
       'from "react-router"'
     );
+    await expect(readFile("vite.config.ts", "utf8")).resolves.toContain(
+      'process.env.WEBSTUDIO_LOCAL_CLI_BOOTSTRAPPED === "1"'
+    );
+    await expect(readFile("vite.config.ts", "utf8")).resolves.toContain(
+      '["webstudio"]'
+    );
     await expect(
       readFile("app/__generated__/$resources.redirects.ts", "utf8")
     ).resolves.toContain("/dl.php?filename=file.pdf");

--- a/packages/cli/templates/react-router/vite.config.ts
+++ b/packages/cli/templates/react-router/vite.config.ts
@@ -1,14 +1,17 @@
 import { defineConfig } from "vite";
 import { reactRouter } from "@react-router/dev/vite";
 
+const sourceConditions =
+  process.env.WEBSTUDIO_LOCAL_CLI_BOOTSTRAPPED === "1" ? ["webstudio"] : [];
+
 export default defineConfig({
   plugins: [reactRouter()],
   resolve: {
-    conditions: ["browser", "development|production"],
+    conditions: [...sourceConditions, "browser", "development|production"],
   },
   ssr: {
     resolve: {
-      conditions: ["node", "development|production"],
+      conditions: [...sourceConditions, "node", "development|production"],
     },
   },
 });

--- a/packages/project-build/scripts/generate-runtime-operation-contracts.ts
+++ b/packages/project-build/scripts/generate-runtime-operation-contracts.ts
@@ -32,9 +32,7 @@ const contractData = builderRuntimeOperations.map(
     permit,
     kind,
     inputSchema: inputJsonSchema,
-    ...(outputJsonSchema === undefined
-      ? {}
-      : { outputSchema: outputJsonSchema }),
+    outputSchema: outputJsonSchema,
     readNamespaces,
     writeNamespaces,
     invalidatesNamespaces,

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -16,6 +16,83 @@ export const runtimeOperationContractData = [
       },
       required: [],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        pages: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              path: {
+                type: "string",
+              },
+              localPath: {
+                type: "string",
+              },
+              title: {
+                type: "string",
+              },
+              rootInstanceId: {
+                type: "string",
+              },
+              parentFolderId: {
+                type: "string",
+              },
+              isHome: {
+                type: "boolean",
+              },
+            },
+            required: [
+              "id",
+              "name",
+              "path",
+              "localPath",
+              "title",
+              "rootInstanceId",
+              "isHome",
+            ],
+            additionalProperties: {},
+          },
+        },
+        folders: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              slug: {
+                type: "string",
+              },
+              parentFolderId: {
+                type: "string",
+              },
+              children: {
+                type: "array",
+                items: {
+                  type: "string",
+                },
+              },
+            },
+            required: ["id", "name", "slug", "children"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["pages"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages"],
     writeNamespaces: [],
     invalidatesNamespaces: [],
@@ -35,6 +112,133 @@ export const runtimeOperationContractData = [
       },
       required: ["pageId"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+        },
+        name: {
+          type: "string",
+        },
+        path: {
+          type: "string",
+        },
+        localPath: {
+          type: "string",
+        },
+        title: {
+          type: "string",
+        },
+        rootInstanceId: {
+          type: "string",
+        },
+        parentFolderId: {
+          type: "string",
+        },
+        isHome: {
+          type: "boolean",
+        },
+        meta: {
+          type: "object",
+          properties: {
+            description: {
+              type: "string",
+            },
+            language: {
+              type: "string",
+            },
+            redirect: {
+              type: "string",
+            },
+            status: {
+              type: "string",
+            },
+            socialImageUrl: {
+              type: "string",
+            },
+            socialImageAssetId: {
+              type: "string",
+            },
+            excludePageFromSearch: {
+              type: "boolean",
+            },
+            documentType: {
+              type: "string",
+              enum: ["html", "xml", "text"],
+            },
+            content: {
+              type: "string",
+            },
+            auth: {
+              anyOf: [
+                {
+                  type: "object",
+                  properties: {
+                    method: {
+                      type: "string",
+                      const: "basic",
+                    },
+                    login: {
+                      type: "string",
+                    },
+                    password: {
+                      type: "string",
+                    },
+                  },
+                  required: ["method", "login", "password"],
+                },
+                {
+                  type: "object",
+                  properties: {
+                    type: {
+                      type: "string",
+                      const: "basic",
+                    },
+                    login: {
+                      type: "string",
+                    },
+                    password: {
+                      type: "string",
+                    },
+                  },
+                  required: ["type", "login", "password"],
+                },
+              ],
+            },
+            custom: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  property: {
+                    type: "string",
+                  },
+                  content: {
+                    type: "string",
+                  },
+                },
+                required: ["property", "content"],
+                additionalProperties: {},
+              },
+            },
+          },
+          required: ["documentType"],
+          additionalProperties: {},
+        },
+      },
+      required: [
+        "id",
+        "name",
+        "path",
+        "localPath",
+        "title",
+        "rootInstanceId",
+        "isHome",
+        "meta",
+      ],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages", "instances"],
     writeNamespaces: [],
     invalidatesNamespaces: [],
@@ -53,6 +257,317 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["path"],
+    },
+    outputSchema: {
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+            },
+            name: {
+              type: "string",
+            },
+            path: {
+              type: "string",
+            },
+            localPath: {
+              type: "string",
+            },
+            title: {
+              type: "string",
+            },
+            rootInstanceId: {
+              type: "string",
+            },
+            parentFolderId: {
+              type: "string",
+            },
+            isHome: {
+              type: "boolean",
+            },
+            meta: {
+              type: "object",
+              properties: {
+                description: {
+                  type: "string",
+                },
+                language: {
+                  type: "string",
+                },
+                redirect: {
+                  type: "string",
+                },
+                status: {
+                  type: "string",
+                },
+                socialImageUrl: {
+                  type: "string",
+                },
+                socialImageAssetId: {
+                  type: "string",
+                },
+                excludePageFromSearch: {
+                  type: "boolean",
+                },
+                documentType: {
+                  type: "string",
+                  enum: ["html", "xml", "text"],
+                },
+                content: {
+                  type: "string",
+                },
+                auth: {
+                  anyOf: [
+                    {
+                      type: "object",
+                      properties: {
+                        method: {
+                          type: "string",
+                          const: "basic",
+                        },
+                        login: {
+                          type: "string",
+                        },
+                        password: {
+                          type: "string",
+                        },
+                      },
+                      required: ["method", "login", "password"],
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "basic",
+                        },
+                        login: {
+                          type: "string",
+                        },
+                        password: {
+                          type: "string",
+                        },
+                      },
+                      required: ["type", "login", "password"],
+                    },
+                  ],
+                },
+                custom: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      property: {
+                        type: "string",
+                      },
+                      content: {
+                        type: "string",
+                      },
+                    },
+                    required: ["property", "content"],
+                    additionalProperties: {},
+                  },
+                },
+              },
+              required: ["documentType"],
+              additionalProperties: {},
+            },
+            requestedPath: {
+              type: "string",
+            },
+            found: {
+              type: "boolean",
+            },
+            exactMatch: {
+              type: "boolean",
+            },
+            matchedPattern: {
+              type: "boolean",
+            },
+            matchedFallback: {
+              type: "boolean",
+            },
+          },
+          required: [
+            "id",
+            "name",
+            "path",
+            "localPath",
+            "title",
+            "rootInstanceId",
+            "isHome",
+            "meta",
+            "requestedPath",
+            "found",
+            "exactMatch",
+            "matchedPattern",
+            "matchedFallback",
+          ],
+          additionalProperties: {},
+        },
+        {
+          type: "object",
+          properties: {
+            requestedPath: {
+              type: "string",
+            },
+            found: {
+              type: "boolean",
+            },
+            exactMatch: {
+              type: "boolean",
+            },
+            matchedPattern: {
+              type: "boolean",
+            },
+            matchedFallback: {
+              type: "boolean",
+            },
+            fallbackPage: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                },
+                name: {
+                  type: "string",
+                },
+                path: {
+                  type: "string",
+                },
+                localPath: {
+                  type: "string",
+                },
+                title: {
+                  type: "string",
+                },
+                rootInstanceId: {
+                  type: "string",
+                },
+                parentFolderId: {
+                  type: "string",
+                },
+                isHome: {
+                  type: "boolean",
+                },
+                meta: {
+                  type: "object",
+                  properties: {
+                    description: {
+                      type: "string",
+                    },
+                    language: {
+                      type: "string",
+                    },
+                    redirect: {
+                      type: "string",
+                    },
+                    status: {
+                      type: "string",
+                    },
+                    socialImageUrl: {
+                      type: "string",
+                    },
+                    socialImageAssetId: {
+                      type: "string",
+                    },
+                    excludePageFromSearch: {
+                      type: "boolean",
+                    },
+                    documentType: {
+                      type: "string",
+                      enum: ["html", "xml", "text"],
+                    },
+                    content: {
+                      type: "string",
+                    },
+                    auth: {
+                      anyOf: [
+                        {
+                          type: "object",
+                          properties: {
+                            method: {
+                              type: "string",
+                              const: "basic",
+                            },
+                            login: {
+                              type: "string",
+                            },
+                            password: {
+                              type: "string",
+                            },
+                          },
+                          required: ["method", "login", "password"],
+                        },
+                        {
+                          type: "object",
+                          properties: {
+                            type: {
+                              type: "string",
+                              const: "basic",
+                            },
+                            login: {
+                              type: "string",
+                            },
+                            password: {
+                              type: "string",
+                            },
+                          },
+                          required: ["type", "login", "password"],
+                        },
+                      ],
+                    },
+                    custom: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          property: {
+                            type: "string",
+                          },
+                          content: {
+                            type: "string",
+                          },
+                        },
+                        required: ["property", "content"],
+                        additionalProperties: {},
+                      },
+                    },
+                  },
+                  required: ["documentType"],
+                  additionalProperties: {},
+                },
+              },
+              required: [
+                "id",
+                "name",
+                "path",
+                "localPath",
+                "title",
+                "rootInstanceId",
+                "isHome",
+                "meta",
+              ],
+              additionalProperties: {},
+            },
+            guidance: {
+              type: "string",
+            },
+          },
+          required: [
+            "requestedPath",
+            "found",
+            "exactMatch",
+            "matchedPattern",
+            "matchedFallback",
+            "fallbackPage",
+            "guidance",
+          ],
+          additionalProperties: {},
+        },
+      ],
     },
     readNamespaces: ["pages", "instances"],
     writeNamespaces: [],
@@ -194,6 +709,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["name", "path"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        pageId: {
+          type: "string",
+        },
+        rootInstanceId: {
+          type: "string",
+        },
+      },
+      required: ["pageId", "rootInstanceId"],
+      additionalProperties: {},
     },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages", "instances"],
@@ -352,6 +880,16 @@ export const runtimeOperationContractData = [
       },
       required: ["pageId", "values"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        pageId: {
+          type: "string",
+        },
+      },
+      required: ["pageId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
     invalidatesNamespaces: ["pages"],
@@ -462,6 +1000,16 @@ export const runtimeOperationContractData = [
       },
       required: ["pageId", "values"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        pageId: {
+          type: "string",
+        },
+      },
+      required: ["pageId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
     invalidatesNamespaces: ["pages"],
@@ -496,6 +1044,32 @@ export const runtimeOperationContractData = [
       },
       required: ["pageId", "marketplace"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        pageId: {
+          type: "string",
+        },
+        marketplace: {
+          type: "object",
+          properties: {
+            include: {
+              type: "boolean",
+            },
+            category: {
+              type: "string",
+            },
+            thumbnailAssetId: {
+              type: "string",
+            },
+          },
+          additionalProperties: {},
+          required: [],
+        },
+      },
+      required: ["pageId", "marketplace"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
     invalidatesNamespaces: ["pages"],
@@ -518,6 +1092,12 @@ export const runtimeOperationContractData = [
       },
       required: ["pageId", "path"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: {},
+      required: [],
+    },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
     invalidatesNamespaces: ["pages"],
@@ -537,6 +1117,16 @@ export const runtimeOperationContractData = [
       },
       required: ["pageId"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        pageId: {
+          type: "string",
+        },
+      },
+      required: ["pageId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
     invalidatesNamespaces: ["pages"],
@@ -552,6 +1142,69 @@ export const runtimeOperationContractData = [
       properties: {},
       required: [],
       additionalProperties: true,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        meta: {
+          type: "object",
+          properties: {
+            siteName: {
+              type: "string",
+            },
+            contactEmail: {
+              type: "string",
+            },
+            faviconAssetId: {
+              type: "string",
+            },
+            code: {
+              type: "string",
+            },
+            agentInstructions: {
+              type: "string",
+            },
+            auth: {
+              type: "string",
+            },
+          },
+          additionalProperties: {},
+          required: [],
+        },
+        compiler: {
+          type: "object",
+          properties: {
+            atomicStyles: {
+              type: "boolean",
+            },
+          },
+          additionalProperties: {},
+          required: [],
+        },
+        redirects: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              old: {
+                type: "string",
+              },
+              new: {
+                type: "string",
+                minLength: 1,
+              },
+              status: {
+                type: "string",
+                enum: ["301", "302"],
+              },
+            },
+            required: ["old", "new"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["meta", "compiler", "redirects"],
+      additionalProperties: {},
     },
     readNamespaces: ["pages", "projectSettings"],
     writeNamespaces: [],
@@ -656,6 +1309,16 @@ export const runtimeOperationContractData = [
         "Update at least one supported project meta or compiler setting. Null removes a setting.",
       required: [],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        updated: {
+          type: "boolean",
+        },
+      },
+      required: ["updated"],
+      additionalProperties: {},
+    },
     readNamespaces: ["projectSettings"],
     writeNamespaces: ["projectSettings"],
     invalidatesNamespaces: ["projectSettings"],
@@ -671,6 +1334,94 @@ export const runtimeOperationContractData = [
       properties: {},
       required: [],
       additionalProperties: true,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        marketplaceProduct: {
+          type: "object",
+          properties: {
+            category: {
+              anyOf: [
+                {
+                  type: "string",
+                  const: "sectionTemplates",
+                },
+                {
+                  type: "string",
+                  const: "pageTemplates",
+                },
+                {
+                  type: "string",
+                  const: "integrationTemplates",
+                },
+              ],
+            },
+            name: {
+              type: "string",
+              minLength: 2,
+              maxLength: 200,
+            },
+            thumbnailAssetId: {
+              type: "string",
+            },
+            author: {
+              type: "string",
+              minLength: 2,
+              maxLength: 200,
+            },
+            email: {
+              type: "string",
+              maxLength: 200,
+              format: "email",
+              pattern:
+                "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+            },
+            website: {
+              anyOf: [
+                {
+                  type: "string",
+                  maxLength: 200,
+                  format: "uri",
+                },
+                {
+                  type: "string",
+                  const: "",
+                },
+              ],
+            },
+            issues: {
+              anyOf: [
+                {
+                  type: "string",
+                  maxLength: 200,
+                  format: "uri",
+                },
+                {
+                  type: "string",
+                  const: "",
+                },
+              ],
+            },
+            description: {
+              type: "string",
+              minLength: 10,
+              maxLength: 1000,
+            },
+          },
+          required: [
+            "category",
+            "name",
+            "thumbnailAssetId",
+            "author",
+            "email",
+            "description",
+          ],
+          additionalProperties: {},
+        },
+      },
+      required: ["marketplaceProduct"],
+      additionalProperties: {},
     },
     readNamespaces: ["marketplaceProduct"],
     writeNamespaces: [],
@@ -762,6 +1513,16 @@ export const runtimeOperationContractData = [
         "description",
       ],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        updated: {
+          type: "boolean",
+        },
+      },
+      required: ["updated"],
+      additionalProperties: {},
+    },
     readNamespaces: ["marketplaceProduct"],
     writeNamespaces: ["marketplaceProduct"],
     invalidatesNamespaces: ["marketplaceProduct"],
@@ -777,6 +1538,34 @@ export const runtimeOperationContractData = [
       properties: {},
       required: [],
       additionalProperties: true,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        redirects: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              old: {
+                type: "string",
+              },
+              new: {
+                type: "string",
+                minLength: 1,
+              },
+              status: {
+                type: "string",
+                enum: ["301", "302"],
+              },
+            },
+            required: ["old", "new"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["redirects"],
+      additionalProperties: {},
     },
     readNamespaces: ["pages"],
     writeNamespaces: [],
@@ -803,6 +1592,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["old", "new"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        old: {
+          type: "string",
+        },
+      },
+      required: ["old"],
+      additionalProperties: {},
     },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
@@ -846,6 +1645,16 @@ export const runtimeOperationContractData = [
       },
       required: ["old", "values"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        old: {
+          type: "string",
+        },
+      },
+      required: ["old"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
     invalidatesNamespaces: ["pages"],
@@ -864,6 +1673,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["old"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        old: {
+          type: "string",
+        },
+      },
+      required: ["old"],
+      additionalProperties: {},
     },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
@@ -900,6 +1719,18 @@ export const runtimeOperationContractData = [
       },
       required: ["redirects"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        count: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+      },
+      required: ["count"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
     invalidatesNamespaces: ["pages"],
@@ -915,6 +1746,38 @@ export const runtimeOperationContractData = [
       properties: {},
       required: [],
       additionalProperties: true,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        breakpoints: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              label: {
+                type: "string",
+              },
+              minWidth: {
+                type: "number",
+              },
+              maxWidth: {
+                type: "number",
+              },
+              condition: {
+                type: "string",
+              },
+            },
+            required: ["id", "label"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["breakpoints"],
+      additionalProperties: {},
     },
     readNamespaces: ["breakpoints"],
     writeNamespaces: [],
@@ -945,6 +1808,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["label"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        breakpointId: {
+          type: "string",
+        },
+      },
+      required: ["breakpointId"],
+      additionalProperties: {},
     },
     readNamespaces: ["breakpoints"],
     writeNamespaces: ["breakpoints"],
@@ -1006,6 +1879,16 @@ export const runtimeOperationContractData = [
       },
       required: ["breakpointId", "values"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        breakpointId: {
+          type: "string",
+        },
+      },
+      required: ["breakpointId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["breakpoints"],
     writeNamespaces: ["breakpoints"],
     invalidatesNamespaces: ["breakpoints"],
@@ -1025,6 +1908,16 @@ export const runtimeOperationContractData = [
       },
       required: ["breakpointId"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        breakpointId: {
+          type: "string",
+        },
+      },
+      required: ["breakpointId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["breakpoints", "styles"],
     writeNamespaces: ["breakpoints", "styles"],
     invalidatesNamespaces: ["breakpoints", "styles"],
@@ -1043,6 +1936,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["pageId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        pageId: {
+          type: "string",
+        },
+      },
+      required: ["pageId"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -1099,6 +2002,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["pageId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        pageId: {
+          type: "string",
+        },
+      },
+      required: ["pageId"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -1166,6 +2079,16 @@ export const runtimeOperationContractData = [
       },
       required: ["sourceData", "pageId"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        pageId: {
+          type: "string",
+        },
+      },
+      required: ["pageId"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "pages",
       "assets",
@@ -1215,6 +2138,127 @@ export const runtimeOperationContractData = [
       properties: {},
       required: [],
       additionalProperties: true,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        templates: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              title: {
+                type: "string",
+              },
+              rootInstanceId: {
+                type: "string",
+              },
+              systemDataSourceId: {
+                type: "string",
+              },
+              meta: {
+                type: "object",
+                properties: {
+                  description: {
+                    type: "string",
+                  },
+                  title: {
+                    type: "string",
+                  },
+                  excludePageFromSearch: {
+                    type: "string",
+                  },
+                  language: {
+                    type: "string",
+                  },
+                  socialImageAssetId: {
+                    type: "string",
+                  },
+                  socialImageUrl: {
+                    type: "string",
+                  },
+                  status: {
+                    type: "string",
+                  },
+                  redirect: {
+                    type: "string",
+                  },
+                  documentType: {
+                    type: "string",
+                    enum: ["html", "xml", "text"],
+                  },
+                  content: {
+                    type: "string",
+                  },
+                  auth: {
+                    anyOf: [
+                      {
+                        type: "object",
+                        properties: {
+                          method: {
+                            type: "string",
+                            const: "basic",
+                          },
+                          login: {
+                            type: "string",
+                          },
+                          password: {
+                            type: "string",
+                          },
+                        },
+                        required: ["method", "login", "password"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "basic",
+                          },
+                          login: {
+                            type: "string",
+                          },
+                          password: {
+                            type: "string",
+                          },
+                        },
+                        required: ["type", "login", "password"],
+                      },
+                    ],
+                  },
+                  custom: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        property: {
+                          type: "string",
+                        },
+                        content: {
+                          type: "string",
+                        },
+                      },
+                      required: ["property", "content"],
+                    },
+                  },
+                },
+                additionalProperties: {},
+                required: [],
+              },
+            },
+            required: ["id", "name", "title", "rootInstanceId", "meta"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["templates"],
+      additionalProperties: {},
     },
     readNamespaces: ["pages"],
     writeNamespaces: [],
@@ -1348,6 +2392,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["name"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        templateId: {
+          type: "string",
+        },
+        rootInstanceId: {
+          type: "string",
+        },
+      },
+      required: ["templateId", "rootInstanceId"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -1525,6 +2582,16 @@ export const runtimeOperationContractData = [
       },
       required: ["templateId", "values"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        templateId: {
+          type: "string",
+        },
+      },
+      required: ["templateId"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "pages",
       "assets",
@@ -1578,6 +2645,16 @@ export const runtimeOperationContractData = [
       },
       required: ["templateId"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        templateId: {
+          type: "string",
+        },
+      },
+      required: ["templateId"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "pages",
       "assets",
@@ -1630,6 +2707,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["templateId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        templateId: {
+          type: "string",
+        },
+      },
+      required: ["templateId"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -1691,6 +2778,16 @@ export const runtimeOperationContractData = [
       },
       required: ["sourceTemplateId", "targetTemplateId", "position"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        templateId: {
+          type: "string",
+        },
+      },
+      required: ["templateId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
     invalidatesNamespaces: ["pages"],
@@ -1722,6 +2819,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["templateId", "name", "path"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        pageId: {
+          type: "string",
+        },
+      },
+      required: ["pageId"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -1776,6 +2883,83 @@ export const runtimeOperationContractData = [
       },
       required: [],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        folders: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              slug: {
+                type: "string",
+              },
+              parentFolderId: {
+                type: "string",
+              },
+              children: {
+                type: "array",
+                items: {
+                  type: "string",
+                },
+              },
+            },
+            required: ["id", "name", "slug", "children"],
+            additionalProperties: {},
+          },
+        },
+        pages: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              path: {
+                type: "string",
+              },
+              localPath: {
+                type: "string",
+              },
+              title: {
+                type: "string",
+              },
+              rootInstanceId: {
+                type: "string",
+              },
+              parentFolderId: {
+                type: "string",
+              },
+              isHome: {
+                type: "boolean",
+              },
+            },
+            required: [
+              "id",
+              "name",
+              "path",
+              "localPath",
+              "title",
+              "rootInstanceId",
+              "isHome",
+            ],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["folders"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages"],
     writeNamespaces: [],
     invalidatesNamespaces: [],
@@ -1800,6 +2984,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["name", "slug"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        folderId: {
+          type: "string",
+        },
+      },
+      required: ["folderId"],
+      additionalProperties: {},
     },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
@@ -1835,6 +3029,16 @@ export const runtimeOperationContractData = [
       },
       required: ["folderId", "values"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        folderId: {
+          type: "string",
+        },
+      },
+      required: ["folderId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
     invalidatesNamespaces: ["pages"],
@@ -1853,6 +3057,28 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["folderId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        folderId: {
+          type: "string",
+        },
+        pageIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        folderIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["folderId", "pageIds", "folderIds"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -1902,6 +3128,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["folderId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        folderId: {
+          type: "string",
+        },
+      },
+      required: ["folderId"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -23821,6 +25057,23 @@ export const runtimeOperationContractData = [
         },
       },
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+        },
+        type: {
+          type: "string",
+          enum: ["page", "folder", "template"],
+        },
+        didReachBreakpointLimit: {
+          type: "boolean",
+        },
+      },
+      required: ["id", "type", "didReachBreakpointLimit"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "pages",
       "assets",
@@ -23882,6 +25135,16 @@ export const runtimeOperationContractData = [
       },
       required: ["childId", "parentFolderId", "position"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        childId: {
+          type: "string",
+        },
+      },
+      required: ["childId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
     invalidatesNamespaces: ["pages"],
@@ -23897,6 +25160,12 @@ export const runtimeOperationContractData = [
       properties: {},
       required: [],
       additionalProperties: true,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: {},
+      required: [],
     },
     readNamespaces: ["pages"],
     writeNamespaces: ["pages"],
@@ -23944,6 +25213,53 @@ export const runtimeOperationContractData = [
       },
       required: [],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instances: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              component: {
+                type: "string",
+              },
+              tag: {
+                type: "string",
+              },
+              label: {
+                type: "string",
+              },
+              childCount: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+              depth: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+              parentId: {
+                type: "string",
+              },
+              indexWithinParent: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+            },
+            required: ["id", "component", "childCount", "depth"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["instances"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages", "instances", "props"],
     writeNamespaces: [],
     invalidatesNamespaces: [],
@@ -23981,6 +25297,7305 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["instanceId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+        },
+        component: {
+          type: "string",
+        },
+        tag: {
+          type: "string",
+        },
+        label: {
+          type: "string",
+        },
+        childCount: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+        depth: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+        parentId: {
+          type: "string",
+        },
+        indexWithinParent: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+        ancestors: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              component: {
+                type: "string",
+              },
+              tag: {
+                type: "string",
+              },
+              label: {
+                type: "string",
+              },
+              childCount: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+              depth: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+              parentId: {
+                type: "string",
+              },
+              indexWithinParent: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+            },
+            required: ["id", "component", "childCount", "depth"],
+            additionalProperties: {},
+          },
+        },
+        props: {
+          type: "array",
+          items: {
+            anyOf: [
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "number",
+                  },
+                  value: {
+                    type: "number",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "string",
+                  },
+                  value: {
+                    type: "string",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "boolean",
+                  },
+                  value: {
+                    type: "boolean",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "json",
+                  },
+                  value: {},
+                },
+                required: ["id", "instanceId", "name", "type"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "asset",
+                  },
+                  value: {
+                    type: "string",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "page",
+                  },
+                  value: {
+                    anyOf: [
+                      {
+                        type: "string",
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          pageId: {
+                            type: "string",
+                          },
+                          instanceId: {
+                            type: "string",
+                          },
+                        },
+                        required: ["pageId", "instanceId"],
+                      },
+                    ],
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "string[]",
+                  },
+                  value: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                    },
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "parameter",
+                  },
+                  value: {
+                    type: "string",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "resource",
+                  },
+                  value: {
+                    type: "string",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "expression",
+                  },
+                  value: {
+                    type: "string",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "action",
+                  },
+                  value: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "execute",
+                        },
+                        args: {
+                          type: "array",
+                          items: {
+                            type: "string",
+                          },
+                        },
+                        code: {
+                          type: "string",
+                        },
+                      },
+                      required: ["type", "args", "code"],
+                    },
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "animationAction",
+                  },
+                  value: {
+                    oneOf: [
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "scroll",
+                          },
+                          source: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "closest",
+                              },
+                              {
+                                type: "string",
+                                const: "nearest",
+                              },
+                              {
+                                type: "string",
+                                const: "root",
+                              },
+                            ],
+                          },
+                          axis: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "block",
+                              },
+                              {
+                                type: "string",
+                                const: "inline",
+                              },
+                              {
+                                type: "string",
+                                const: "x",
+                              },
+                              {
+                                type: "string",
+                                const: "y",
+                              },
+                            ],
+                          },
+                          animations: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                name: {
+                                  type: "string",
+                                },
+                                description: {
+                                  type: "string",
+                                },
+                                enabled: {
+                                  type: "array",
+                                  items: {
+                                    type: "array",
+                                    prefixItems: [
+                                      {
+                                        type: "string",
+                                        description: "breakpointId",
+                                      },
+                                      {
+                                        type: "boolean",
+                                      },
+                                    ],
+                                    minItems: 2,
+                                    maxItems: 2,
+                                  },
+                                },
+                                keyframes: {
+                                  type: "array",
+                                  items: {
+                                    type: "object",
+                                    properties: {
+                                      offset: {
+                                        type: "number",
+                                      },
+                                      styles: {
+                                        type: "object",
+                                        propertyNames: {
+                                          type: "string",
+                                        },
+                                        additionalProperties: {
+                                          $ref: "#/$defs/__schema0",
+                                        },
+                                      },
+                                    },
+                                    required: ["styles"],
+                                  },
+                                },
+                                timing: {
+                                  type: "object",
+                                  properties: {
+                                    easing: {
+                                      type: "string",
+                                    },
+                                    fill: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                          const: "none",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "forwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "backwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "both",
+                                        },
+                                      ],
+                                    },
+                                    duration: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    delay: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    iterations: {
+                                      anyOf: [
+                                        {
+                                          type: "number",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "infinite",
+                                        },
+                                      ],
+                                    },
+                                    rangeStart: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "start",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "end",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                    rangeEnd: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "start",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "end",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                  },
+                                  required: [],
+                                },
+                              },
+                              required: ["keyframes", "timing"],
+                            },
+                          },
+                          isPinned: {
+                            type: "boolean",
+                          },
+                          debug: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "animations"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "view",
+                          },
+                          subject: {
+                            type: "string",
+                          },
+                          axis: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "block",
+                              },
+                              {
+                                type: "string",
+                                const: "inline",
+                              },
+                              {
+                                type: "string",
+                                const: "x",
+                              },
+                              {
+                                type: "string",
+                                const: "y",
+                              },
+                            ],
+                          },
+                          animations: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                name: {
+                                  type: "string",
+                                },
+                                description: {
+                                  type: "string",
+                                },
+                                enabled: {
+                                  type: "array",
+                                  items: {
+                                    type: "array",
+                                    prefixItems: [
+                                      {
+                                        type: "string",
+                                        description: "breakpointId",
+                                      },
+                                      {
+                                        type: "boolean",
+                                      },
+                                    ],
+                                    minItems: 2,
+                                    maxItems: 2,
+                                  },
+                                },
+                                keyframes: {
+                                  type: "array",
+                                  items: {
+                                    type: "object",
+                                    properties: {
+                                      offset: {
+                                        type: "number",
+                                      },
+                                      styles: {
+                                        type: "object",
+                                        propertyNames: {
+                                          type: "string",
+                                        },
+                                        additionalProperties: {
+                                          $ref: "#/$defs/__schema0",
+                                        },
+                                      },
+                                    },
+                                    required: ["styles"],
+                                  },
+                                },
+                                timing: {
+                                  type: "object",
+                                  properties: {
+                                    easing: {
+                                      type: "string",
+                                    },
+                                    fill: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                          const: "none",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "forwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "backwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "both",
+                                        },
+                                      ],
+                                    },
+                                    duration: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    delay: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    iterations: {
+                                      anyOf: [
+                                        {
+                                          type: "number",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "infinite",
+                                        },
+                                      ],
+                                    },
+                                    rangeStart: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "contain",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "cover",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry-crossing",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit-crossing",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                    rangeEnd: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "contain",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "cover",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry-crossing",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit-crossing",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                  },
+                                  required: [],
+                                },
+                              },
+                              required: ["keyframes", "timing"],
+                            },
+                          },
+                          insetStart: {
+                            anyOf: [
+                              {
+                                anyOf: [
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unit",
+                                      },
+                                      value: {
+                                        type: "number",
+                                      },
+                                      unit: {
+                                        anyOf: [
+                                          {
+                                            type: "string",
+                                            const: "%",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "px",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "mm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "q",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "in",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pt",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pc",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "em",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rem",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rcap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rlh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmax",
+                                          },
+                                        ],
+                                      },
+                                    },
+                                    required: ["type", "value", "unit"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unparsed",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "var",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                ],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "keyword",
+                                  },
+                                  value: {
+                                    type: "string",
+                                    const: "auto",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                            ],
+                          },
+                          insetEnd: {
+                            anyOf: [
+                              {
+                                anyOf: [
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unit",
+                                      },
+                                      value: {
+                                        type: "number",
+                                      },
+                                      unit: {
+                                        anyOf: [
+                                          {
+                                            type: "string",
+                                            const: "%",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "px",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "mm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "q",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "in",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pt",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pc",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "em",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rem",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rcap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rlh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmax",
+                                          },
+                                        ],
+                                      },
+                                    },
+                                    required: ["type", "value", "unit"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unparsed",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "var",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                ],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "keyword",
+                                  },
+                                  value: {
+                                    type: "string",
+                                    const: "auto",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                            ],
+                          },
+                          isPinned: {
+                            type: "boolean",
+                          },
+                          debug: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "animations"],
+                      },
+                    ],
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+            ],
+          },
+        },
+        styles: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              instanceId: {
+                type: "string",
+              },
+              styleSourceId: {
+                type: "string",
+              },
+              property: {
+                type: "string",
+              },
+              value: {},
+              breakpoint: {
+                type: "string",
+              },
+              state: {
+                type: "string",
+              },
+              source: {
+                type: "string",
+                enum: ["local", "token"],
+              },
+            },
+            required: [
+              "instanceId",
+              "styleSourceId",
+              "property",
+              "breakpoint",
+              "source",
+            ],
+            additionalProperties: {},
+          },
+        },
+        children: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              component: {
+                type: "string",
+              },
+              tag: {
+                type: "string",
+              },
+              label: {
+                type: "string",
+              },
+              childCount: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+              depth: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+              parentId: {
+                type: "string",
+              },
+              indexWithinParent: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+            },
+            required: ["id", "component", "childCount", "depth"],
+            additionalProperties: {},
+          },
+        },
+        bindings: {
+          type: "array",
+          items: {
+            anyOf: [
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "number",
+                  },
+                  value: {
+                    type: "number",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "string",
+                  },
+                  value: {
+                    type: "string",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "boolean",
+                  },
+                  value: {
+                    type: "boolean",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "json",
+                  },
+                  value: {},
+                },
+                required: ["id", "instanceId", "name", "type"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "asset",
+                  },
+                  value: {
+                    type: "string",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "page",
+                  },
+                  value: {
+                    anyOf: [
+                      {
+                        type: "string",
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          pageId: {
+                            type: "string",
+                          },
+                          instanceId: {
+                            type: "string",
+                          },
+                        },
+                        required: ["pageId", "instanceId"],
+                      },
+                    ],
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "string[]",
+                  },
+                  value: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                    },
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "parameter",
+                  },
+                  value: {
+                    type: "string",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "resource",
+                  },
+                  value: {
+                    type: "string",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "expression",
+                  },
+                  value: {
+                    type: "string",
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "action",
+                  },
+                  value: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "execute",
+                        },
+                        args: {
+                          type: "array",
+                          items: {
+                            type: "string",
+                          },
+                        },
+                        code: {
+                          type: "string",
+                        },
+                      },
+                      required: ["type", "args", "code"],
+                    },
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+              {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "string",
+                  },
+                  instanceId: {
+                    type: "string",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  required: {
+                    type: "boolean",
+                  },
+                  type: {
+                    type: "string",
+                    const: "animationAction",
+                  },
+                  value: {
+                    oneOf: [
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "scroll",
+                          },
+                          source: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "closest",
+                              },
+                              {
+                                type: "string",
+                                const: "nearest",
+                              },
+                              {
+                                type: "string",
+                                const: "root",
+                              },
+                            ],
+                          },
+                          axis: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "block",
+                              },
+                              {
+                                type: "string",
+                                const: "inline",
+                              },
+                              {
+                                type: "string",
+                                const: "x",
+                              },
+                              {
+                                type: "string",
+                                const: "y",
+                              },
+                            ],
+                          },
+                          animations: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                name: {
+                                  type: "string",
+                                },
+                                description: {
+                                  type: "string",
+                                },
+                                enabled: {
+                                  type: "array",
+                                  items: {
+                                    type: "array",
+                                    prefixItems: [
+                                      {
+                                        type: "string",
+                                        description: "breakpointId",
+                                      },
+                                      {
+                                        type: "boolean",
+                                      },
+                                    ],
+                                    minItems: 2,
+                                    maxItems: 2,
+                                  },
+                                },
+                                keyframes: {
+                                  type: "array",
+                                  items: {
+                                    type: "object",
+                                    properties: {
+                                      offset: {
+                                        type: "number",
+                                      },
+                                      styles: {
+                                        type: "object",
+                                        propertyNames: {
+                                          type: "string",
+                                        },
+                                        additionalProperties: {
+                                          $ref: "#/$defs/__schema0",
+                                        },
+                                      },
+                                    },
+                                    required: ["styles"],
+                                  },
+                                },
+                                timing: {
+                                  type: "object",
+                                  properties: {
+                                    easing: {
+                                      type: "string",
+                                    },
+                                    fill: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                          const: "none",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "forwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "backwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "both",
+                                        },
+                                      ],
+                                    },
+                                    duration: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    delay: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    iterations: {
+                                      anyOf: [
+                                        {
+                                          type: "number",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "infinite",
+                                        },
+                                      ],
+                                    },
+                                    rangeStart: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "start",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "end",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                    rangeEnd: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "start",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "end",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                  },
+                                  required: [],
+                                },
+                              },
+                              required: ["keyframes", "timing"],
+                            },
+                          },
+                          isPinned: {
+                            type: "boolean",
+                          },
+                          debug: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "animations"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "view",
+                          },
+                          subject: {
+                            type: "string",
+                          },
+                          axis: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "block",
+                              },
+                              {
+                                type: "string",
+                                const: "inline",
+                              },
+                              {
+                                type: "string",
+                                const: "x",
+                              },
+                              {
+                                type: "string",
+                                const: "y",
+                              },
+                            ],
+                          },
+                          animations: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                name: {
+                                  type: "string",
+                                },
+                                description: {
+                                  type: "string",
+                                },
+                                enabled: {
+                                  type: "array",
+                                  items: {
+                                    type: "array",
+                                    prefixItems: [
+                                      {
+                                        type: "string",
+                                        description: "breakpointId",
+                                      },
+                                      {
+                                        type: "boolean",
+                                      },
+                                    ],
+                                    minItems: 2,
+                                    maxItems: 2,
+                                  },
+                                },
+                                keyframes: {
+                                  type: "array",
+                                  items: {
+                                    type: "object",
+                                    properties: {
+                                      offset: {
+                                        type: "number",
+                                      },
+                                      styles: {
+                                        type: "object",
+                                        propertyNames: {
+                                          type: "string",
+                                        },
+                                        additionalProperties: {
+                                          $ref: "#/$defs/__schema0",
+                                        },
+                                      },
+                                    },
+                                    required: ["styles"],
+                                  },
+                                },
+                                timing: {
+                                  type: "object",
+                                  properties: {
+                                    easing: {
+                                      type: "string",
+                                    },
+                                    fill: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                          const: "none",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "forwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "backwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "both",
+                                        },
+                                      ],
+                                    },
+                                    duration: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    delay: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    iterations: {
+                                      anyOf: [
+                                        {
+                                          type: "number",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "infinite",
+                                        },
+                                      ],
+                                    },
+                                    rangeStart: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "contain",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "cover",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry-crossing",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit-crossing",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                    rangeEnd: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "contain",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "cover",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry-crossing",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit-crossing",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                  },
+                                  required: [],
+                                },
+                              },
+                              required: ["keyframes", "timing"],
+                            },
+                          },
+                          insetStart: {
+                            anyOf: [
+                              {
+                                anyOf: [
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unit",
+                                      },
+                                      value: {
+                                        type: "number",
+                                      },
+                                      unit: {
+                                        anyOf: [
+                                          {
+                                            type: "string",
+                                            const: "%",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "px",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "mm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "q",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "in",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pt",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pc",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "em",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rem",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rcap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rlh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmax",
+                                          },
+                                        ],
+                                      },
+                                    },
+                                    required: ["type", "value", "unit"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unparsed",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "var",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                ],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "keyword",
+                                  },
+                                  value: {
+                                    type: "string",
+                                    const: "auto",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                            ],
+                          },
+                          insetEnd: {
+                            anyOf: [
+                              {
+                                anyOf: [
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unit",
+                                      },
+                                      value: {
+                                        type: "number",
+                                      },
+                                      unit: {
+                                        anyOf: [
+                                          {
+                                            type: "string",
+                                            const: "%",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "px",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "mm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "q",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "in",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pt",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pc",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "em",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rem",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rcap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rlh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmax",
+                                          },
+                                        ],
+                                      },
+                                    },
+                                    required: ["type", "value", "unit"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unparsed",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "var",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                ],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "keyword",
+                                  },
+                                  value: {
+                                    type: "string",
+                                    const: "auto",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                            ],
+                          },
+                          isPinned: {
+                            type: "boolean",
+                          },
+                          debug: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "animations"],
+                      },
+                    ],
+                  },
+                },
+                required: ["id", "instanceId", "name", "type", "value"],
+              },
+            ],
+          },
+        },
+        sources: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["id", "component", "childCount", "depth"],
+      additionalProperties: {},
+      $defs: {
+        __schema0: {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "image",
+                },
+                value: {
+                  anyOf: [
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "asset",
+                        },
+                        value: {
+                          type: "string",
+                        },
+                      },
+                      required: ["type", "value"],
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "url",
+                        },
+                        url: {
+                          type: "string",
+                        },
+                      },
+                      required: ["type", "url"],
+                    },
+                  ],
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "value"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "layers",
+                },
+                value: {
+                  type: "array",
+                  items: {
+                    anyOf: [
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "unit",
+                          },
+                          unit: {
+                            type: "string",
+                          },
+                          value: {
+                            type: "number",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "unit", "value"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "keyword",
+                          },
+                          value: {
+                            type: "string",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "value"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "unparsed",
+                          },
+                          value: {
+                            type: "string",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "value"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "image",
+                          },
+                          value: {
+                            anyOf: [
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "asset",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "url",
+                                  },
+                                  url: {
+                                    type: "string",
+                                  },
+                                },
+                                required: ["type", "url"],
+                              },
+                            ],
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "value"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "tuple",
+                          },
+                          value: {
+                            type: "array",
+                            items: {
+                              anyOf: [
+                                {
+                                  type: "object",
+                                  properties: {
+                                    type: {
+                                      type: "string",
+                                      const: "unit",
+                                    },
+                                    unit: {
+                                      type: "string",
+                                    },
+                                    value: {
+                                      type: "number",
+                                    },
+                                    hidden: {
+                                      type: "boolean",
+                                    },
+                                  },
+                                  required: ["type", "unit", "value"],
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    type: {
+                                      type: "string",
+                                      const: "keyword",
+                                    },
+                                    value: {
+                                      type: "string",
+                                    },
+                                    hidden: {
+                                      type: "boolean",
+                                    },
+                                  },
+                                  required: ["type", "value"],
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    type: {
+                                      type: "string",
+                                      const: "unparsed",
+                                    },
+                                    value: {
+                                      type: "string",
+                                    },
+                                    hidden: {
+                                      type: "boolean",
+                                    },
+                                  },
+                                  required: ["type", "value"],
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    type: {
+                                      type: "string",
+                                      const: "image",
+                                    },
+                                    value: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "asset",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "url",
+                                            },
+                                            url: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "url"],
+                                        },
+                                      ],
+                                    },
+                                    hidden: {
+                                      type: "boolean",
+                                    },
+                                  },
+                                  required: ["type", "value"],
+                                },
+                                {
+                                  $ref: "#/$defs/__schema1",
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    type: {
+                                      type: "string",
+                                      const: "rgb",
+                                    },
+                                    r: {
+                                      type: "number",
+                                    },
+                                    g: {
+                                      type: "number",
+                                    },
+                                    b: {
+                                      type: "number",
+                                    },
+                                    alpha: {
+                                      type: "number",
+                                    },
+                                    hidden: {
+                                      type: "boolean",
+                                    },
+                                  },
+                                  required: ["type", "r", "g", "b", "alpha"],
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    type: {
+                                      type: "string",
+                                      const: "function",
+                                    },
+                                    name: {
+                                      type: "string",
+                                    },
+                                    args: {
+                                      $ref: "#/$defs/__schema0",
+                                    },
+                                    hidden: {
+                                      type: "boolean",
+                                    },
+                                  },
+                                  required: ["type", "name", "args"],
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    type: {
+                                      type: "string",
+                                      const: "var",
+                                    },
+                                    value: {
+                                      type: "string",
+                                    },
+                                    fallback: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unparsed",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                            hidden: {
+                                              type: "boolean",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "keyword",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                            hidden: {
+                                              type: "boolean",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            unit: {
+                                              type: "string",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            hidden: {
+                                              type: "boolean",
+                                            },
+                                          },
+                                          required: ["type", "unit", "value"],
+                                        },
+                                        {
+                                          $ref: "#/$defs/__schema1",
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "rgb",
+                                            },
+                                            r: {
+                                              type: "number",
+                                            },
+                                            g: {
+                                              type: "number",
+                                            },
+                                            b: {
+                                              type: "number",
+                                            },
+                                            alpha: {
+                                              type: "number",
+                                            },
+                                            hidden: {
+                                              type: "boolean",
+                                            },
+                                          },
+                                          required: [
+                                            "type",
+                                            "r",
+                                            "g",
+                                            "b",
+                                            "alpha",
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                    hidden: {
+                                      type: "boolean",
+                                    },
+                                  },
+                                  required: ["type", "value"],
+                                },
+                              ],
+                            },
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "value"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "shadow",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                          position: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "inset",
+                              },
+                              {
+                                type: "string",
+                                const: "outset",
+                              },
+                            ],
+                          },
+                          offsetX: {
+                            anyOf: [
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "unit",
+                                  },
+                                  unit: {
+                                    type: "string",
+                                  },
+                                  value: {
+                                    type: "number",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "unit", "value"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "var",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                  fallback: {
+                                    anyOf: [
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "unparsed",
+                                          },
+                                          value: {
+                                            type: "string",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "value"],
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "keyword",
+                                          },
+                                          value: {
+                                            type: "string",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "value"],
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "unit",
+                                          },
+                                          unit: {
+                                            type: "string",
+                                          },
+                                          value: {
+                                            type: "number",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "unit", "value"],
+                                      },
+                                      {
+                                        $ref: "#/$defs/__schema1",
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "rgb",
+                                          },
+                                          r: {
+                                            type: "number",
+                                          },
+                                          g: {
+                                            type: "number",
+                                          },
+                                          b: {
+                                            type: "number",
+                                          },
+                                          alpha: {
+                                            type: "number",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: [
+                                          "type",
+                                          "r",
+                                          "g",
+                                          "b",
+                                          "alpha",
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                            ],
+                          },
+                          offsetY: {
+                            anyOf: [
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "unit",
+                                  },
+                                  unit: {
+                                    type: "string",
+                                  },
+                                  value: {
+                                    type: "number",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "unit", "value"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "var",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                  fallback: {
+                                    anyOf: [
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "unparsed",
+                                          },
+                                          value: {
+                                            type: "string",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "value"],
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "keyword",
+                                          },
+                                          value: {
+                                            type: "string",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "value"],
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "unit",
+                                          },
+                                          unit: {
+                                            type: "string",
+                                          },
+                                          value: {
+                                            type: "number",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "unit", "value"],
+                                      },
+                                      {
+                                        $ref: "#/$defs/__schema1",
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "rgb",
+                                          },
+                                          r: {
+                                            type: "number",
+                                          },
+                                          g: {
+                                            type: "number",
+                                          },
+                                          b: {
+                                            type: "number",
+                                          },
+                                          alpha: {
+                                            type: "number",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: [
+                                          "type",
+                                          "r",
+                                          "g",
+                                          "b",
+                                          "alpha",
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                            ],
+                          },
+                          blur: {
+                            anyOf: [
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "unit",
+                                  },
+                                  unit: {
+                                    type: "string",
+                                  },
+                                  value: {
+                                    type: "number",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "unit", "value"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "var",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                  fallback: {
+                                    anyOf: [
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "unparsed",
+                                          },
+                                          value: {
+                                            type: "string",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "value"],
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "keyword",
+                                          },
+                                          value: {
+                                            type: "string",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "value"],
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "unit",
+                                          },
+                                          unit: {
+                                            type: "string",
+                                          },
+                                          value: {
+                                            type: "number",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "unit", "value"],
+                                      },
+                                      {
+                                        $ref: "#/$defs/__schema1",
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "rgb",
+                                          },
+                                          r: {
+                                            type: "number",
+                                          },
+                                          g: {
+                                            type: "number",
+                                          },
+                                          b: {
+                                            type: "number",
+                                          },
+                                          alpha: {
+                                            type: "number",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: [
+                                          "type",
+                                          "r",
+                                          "g",
+                                          "b",
+                                          "alpha",
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                            ],
+                          },
+                          spread: {
+                            anyOf: [
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "unit",
+                                  },
+                                  unit: {
+                                    type: "string",
+                                  },
+                                  value: {
+                                    type: "number",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "unit", "value"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "var",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                  fallback: {
+                                    anyOf: [
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "unparsed",
+                                          },
+                                          value: {
+                                            type: "string",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "value"],
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "keyword",
+                                          },
+                                          value: {
+                                            type: "string",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "value"],
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "unit",
+                                          },
+                                          unit: {
+                                            type: "string",
+                                          },
+                                          value: {
+                                            type: "number",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "unit", "value"],
+                                      },
+                                      {
+                                        $ref: "#/$defs/__schema1",
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "rgb",
+                                          },
+                                          r: {
+                                            type: "number",
+                                          },
+                                          g: {
+                                            type: "number",
+                                          },
+                                          b: {
+                                            type: "number",
+                                          },
+                                          alpha: {
+                                            type: "number",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: [
+                                          "type",
+                                          "r",
+                                          "g",
+                                          "b",
+                                          "alpha",
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                            ],
+                          },
+                          color: {
+                            anyOf: [
+                              {
+                                $ref: "#/$defs/__schema1",
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "rgb",
+                                  },
+                                  r: {
+                                    type: "number",
+                                  },
+                                  g: {
+                                    type: "number",
+                                  },
+                                  b: {
+                                    type: "number",
+                                  },
+                                  alpha: {
+                                    type: "number",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "r", "g", "b", "alpha"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "keyword",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "var",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                  fallback: {
+                                    anyOf: [
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "unparsed",
+                                          },
+                                          value: {
+                                            type: "string",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "value"],
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "keyword",
+                                          },
+                                          value: {
+                                            type: "string",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "value"],
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "unit",
+                                          },
+                                          unit: {
+                                            type: "string",
+                                          },
+                                          value: {
+                                            type: "number",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: ["type", "unit", "value"],
+                                      },
+                                      {
+                                        $ref: "#/$defs/__schema1",
+                                      },
+                                      {
+                                        type: "object",
+                                        properties: {
+                                          type: {
+                                            type: "string",
+                                            const: "rgb",
+                                          },
+                                          r: {
+                                            type: "number",
+                                          },
+                                          g: {
+                                            type: "number",
+                                          },
+                                          b: {
+                                            type: "number",
+                                          },
+                                          alpha: {
+                                            type: "number",
+                                          },
+                                          hidden: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        required: [
+                                          "type",
+                                          "r",
+                                          "g",
+                                          "b",
+                                          "alpha",
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                            ],
+                          },
+                        },
+                        required: ["type", "position", "offsetX", "offsetY"],
+                      },
+                      {
+                        $ref: "#/$defs/__schema1",
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "rgb",
+                          },
+                          r: {
+                            type: "number",
+                          },
+                          g: {
+                            type: "number",
+                          },
+                          b: {
+                            type: "number",
+                          },
+                          alpha: {
+                            type: "number",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "r", "g", "b", "alpha"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "invalid",
+                          },
+                          value: {
+                            type: "string",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "value"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "function",
+                          },
+                          name: {
+                            type: "string",
+                          },
+                          args: {
+                            $ref: "#/$defs/__schema0",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "name", "args"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "var",
+                          },
+                          value: {
+                            type: "string",
+                          },
+                          fallback: {
+                            anyOf: [
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "unparsed",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "keyword",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "unit",
+                                  },
+                                  unit: {
+                                    type: "string",
+                                  },
+                                  value: {
+                                    type: "number",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "unit", "value"],
+                              },
+                              {
+                                $ref: "#/$defs/__schema1",
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "rgb",
+                                  },
+                                  r: {
+                                    type: "number",
+                                  },
+                                  g: {
+                                    type: "number",
+                                  },
+                                  b: {
+                                    type: "number",
+                                  },
+                                  alpha: {
+                                    type: "number",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "r", "g", "b", "alpha"],
+                              },
+                            ],
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "value"],
+                      },
+                    ],
+                  },
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "value"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "unit",
+                },
+                unit: {
+                  type: "string",
+                },
+                value: {
+                  type: "number",
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "unit", "value"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "keyword",
+                },
+                value: {
+                  type: "string",
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "value"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "fontFamily",
+                },
+                value: {
+                  type: "array",
+                  items: {
+                    type: "string",
+                  },
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "value"],
+            },
+            {
+              $ref: "#/$defs/__schema1",
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "rgb",
+                },
+                r: {
+                  type: "number",
+                },
+                g: {
+                  type: "number",
+                },
+                b: {
+                  type: "number",
+                },
+                alpha: {
+                  type: "number",
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "r", "g", "b", "alpha"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "unparsed",
+                },
+                value: {
+                  type: "string",
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "value"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "tuple",
+                },
+                value: {
+                  type: "array",
+                  items: {
+                    anyOf: [
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "unit",
+                          },
+                          unit: {
+                            type: "string",
+                          },
+                          value: {
+                            type: "number",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "unit", "value"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "keyword",
+                          },
+                          value: {
+                            type: "string",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "value"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "unparsed",
+                          },
+                          value: {
+                            type: "string",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "value"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "image",
+                          },
+                          value: {
+                            anyOf: [
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "asset",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "url",
+                                  },
+                                  url: {
+                                    type: "string",
+                                  },
+                                },
+                                required: ["type", "url"],
+                              },
+                            ],
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "value"],
+                      },
+                      {
+                        $ref: "#/$defs/__schema1",
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "rgb",
+                          },
+                          r: {
+                            type: "number",
+                          },
+                          g: {
+                            type: "number",
+                          },
+                          b: {
+                            type: "number",
+                          },
+                          alpha: {
+                            type: "number",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "r", "g", "b", "alpha"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "function",
+                          },
+                          name: {
+                            type: "string",
+                          },
+                          args: {
+                            $ref: "#/$defs/__schema0",
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "name", "args"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "var",
+                          },
+                          value: {
+                            type: "string",
+                          },
+                          fallback: {
+                            anyOf: [
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "unparsed",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "keyword",
+                                  },
+                                  value: {
+                                    type: "string",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "unit",
+                                  },
+                                  unit: {
+                                    type: "string",
+                                  },
+                                  value: {
+                                    type: "number",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "unit", "value"],
+                              },
+                              {
+                                $ref: "#/$defs/__schema1",
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "rgb",
+                                  },
+                                  r: {
+                                    type: "number",
+                                  },
+                                  g: {
+                                    type: "number",
+                                  },
+                                  b: {
+                                    type: "number",
+                                  },
+                                  alpha: {
+                                    type: "number",
+                                  },
+                                  hidden: {
+                                    type: "boolean",
+                                  },
+                                },
+                                required: ["type", "r", "g", "b", "alpha"],
+                              },
+                            ],
+                          },
+                          hidden: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "value"],
+                      },
+                    ],
+                  },
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "value"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "function",
+                },
+                name: {
+                  type: "string",
+                },
+                args: {
+                  $ref: "#/$defs/__schema0",
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "name", "args"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "guaranteedInvalid",
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "invalid",
+                },
+                value: {
+                  type: "string",
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "value"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "unset",
+                },
+                value: {
+                  type: "string",
+                  const: "",
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "value"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "var",
+                },
+                value: {
+                  type: "string",
+                },
+                fallback: {
+                  anyOf: [
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "unparsed",
+                        },
+                        value: {
+                          type: "string",
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "value"],
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "keyword",
+                        },
+                        value: {
+                          type: "string",
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "value"],
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "unit",
+                        },
+                        unit: {
+                          type: "string",
+                        },
+                        value: {
+                          type: "number",
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "unit", "value"],
+                    },
+                    {
+                      $ref: "#/$defs/__schema1",
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "rgb",
+                        },
+                        r: {
+                          type: "number",
+                        },
+                        g: {
+                          type: "number",
+                        },
+                        b: {
+                          type: "number",
+                        },
+                        alpha: {
+                          type: "number",
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "r", "g", "b", "alpha"],
+                    },
+                  ],
+                },
+                hidden: {
+                  type: "boolean",
+                },
+              },
+              required: ["type", "value"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "shadow",
+                },
+                hidden: {
+                  type: "boolean",
+                },
+                position: {
+                  anyOf: [
+                    {
+                      type: "string",
+                      const: "inset",
+                    },
+                    {
+                      type: "string",
+                      const: "outset",
+                    },
+                  ],
+                },
+                offsetX: {
+                  anyOf: [
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "unit",
+                        },
+                        unit: {
+                          type: "string",
+                        },
+                        value: {
+                          type: "number",
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "unit", "value"],
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "var",
+                        },
+                        value: {
+                          type: "string",
+                        },
+                        fallback: {
+                          anyOf: [
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "unparsed",
+                                },
+                                value: {
+                                  type: "string",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "value"],
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "keyword",
+                                },
+                                value: {
+                                  type: "string",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "value"],
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "unit",
+                                },
+                                unit: {
+                                  type: "string",
+                                },
+                                value: {
+                                  type: "number",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "unit", "value"],
+                            },
+                            {
+                              $ref: "#/$defs/__schema1",
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "rgb",
+                                },
+                                r: {
+                                  type: "number",
+                                },
+                                g: {
+                                  type: "number",
+                                },
+                                b: {
+                                  type: "number",
+                                },
+                                alpha: {
+                                  type: "number",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "r", "g", "b", "alpha"],
+                            },
+                          ],
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "value"],
+                    },
+                  ],
+                },
+                offsetY: {
+                  anyOf: [
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "unit",
+                        },
+                        unit: {
+                          type: "string",
+                        },
+                        value: {
+                          type: "number",
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "unit", "value"],
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "var",
+                        },
+                        value: {
+                          type: "string",
+                        },
+                        fallback: {
+                          anyOf: [
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "unparsed",
+                                },
+                                value: {
+                                  type: "string",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "value"],
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "keyword",
+                                },
+                                value: {
+                                  type: "string",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "value"],
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "unit",
+                                },
+                                unit: {
+                                  type: "string",
+                                },
+                                value: {
+                                  type: "number",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "unit", "value"],
+                            },
+                            {
+                              $ref: "#/$defs/__schema1",
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "rgb",
+                                },
+                                r: {
+                                  type: "number",
+                                },
+                                g: {
+                                  type: "number",
+                                },
+                                b: {
+                                  type: "number",
+                                },
+                                alpha: {
+                                  type: "number",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "r", "g", "b", "alpha"],
+                            },
+                          ],
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "value"],
+                    },
+                  ],
+                },
+                blur: {
+                  anyOf: [
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "unit",
+                        },
+                        unit: {
+                          type: "string",
+                        },
+                        value: {
+                          type: "number",
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "unit", "value"],
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "var",
+                        },
+                        value: {
+                          type: "string",
+                        },
+                        fallback: {
+                          anyOf: [
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "unparsed",
+                                },
+                                value: {
+                                  type: "string",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "value"],
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "keyword",
+                                },
+                                value: {
+                                  type: "string",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "value"],
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "unit",
+                                },
+                                unit: {
+                                  type: "string",
+                                },
+                                value: {
+                                  type: "number",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "unit", "value"],
+                            },
+                            {
+                              $ref: "#/$defs/__schema1",
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "rgb",
+                                },
+                                r: {
+                                  type: "number",
+                                },
+                                g: {
+                                  type: "number",
+                                },
+                                b: {
+                                  type: "number",
+                                },
+                                alpha: {
+                                  type: "number",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "r", "g", "b", "alpha"],
+                            },
+                          ],
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "value"],
+                    },
+                  ],
+                },
+                spread: {
+                  anyOf: [
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "unit",
+                        },
+                        unit: {
+                          type: "string",
+                        },
+                        value: {
+                          type: "number",
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "unit", "value"],
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "var",
+                        },
+                        value: {
+                          type: "string",
+                        },
+                        fallback: {
+                          anyOf: [
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "unparsed",
+                                },
+                                value: {
+                                  type: "string",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "value"],
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "keyword",
+                                },
+                                value: {
+                                  type: "string",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "value"],
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "unit",
+                                },
+                                unit: {
+                                  type: "string",
+                                },
+                                value: {
+                                  type: "number",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "unit", "value"],
+                            },
+                            {
+                              $ref: "#/$defs/__schema1",
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "rgb",
+                                },
+                                r: {
+                                  type: "number",
+                                },
+                                g: {
+                                  type: "number",
+                                },
+                                b: {
+                                  type: "number",
+                                },
+                                alpha: {
+                                  type: "number",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "r", "g", "b", "alpha"],
+                            },
+                          ],
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "value"],
+                    },
+                  ],
+                },
+                color: {
+                  anyOf: [
+                    {
+                      $ref: "#/$defs/__schema1",
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "rgb",
+                        },
+                        r: {
+                          type: "number",
+                        },
+                        g: {
+                          type: "number",
+                        },
+                        b: {
+                          type: "number",
+                        },
+                        alpha: {
+                          type: "number",
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "r", "g", "b", "alpha"],
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "keyword",
+                        },
+                        value: {
+                          type: "string",
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "value"],
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        type: {
+                          type: "string",
+                          const: "var",
+                        },
+                        value: {
+                          type: "string",
+                        },
+                        fallback: {
+                          anyOf: [
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "unparsed",
+                                },
+                                value: {
+                                  type: "string",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "value"],
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "keyword",
+                                },
+                                value: {
+                                  type: "string",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "value"],
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "unit",
+                                },
+                                unit: {
+                                  type: "string",
+                                },
+                                value: {
+                                  type: "number",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "unit", "value"],
+                            },
+                            {
+                              $ref: "#/$defs/__schema1",
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                type: {
+                                  type: "string",
+                                  const: "rgb",
+                                },
+                                r: {
+                                  type: "number",
+                                },
+                                g: {
+                                  type: "number",
+                                },
+                                b: {
+                                  type: "number",
+                                },
+                                alpha: {
+                                  type: "number",
+                                },
+                                hidden: {
+                                  type: "boolean",
+                                },
+                              },
+                              required: ["type", "r", "g", "b", "alpha"],
+                            },
+                          ],
+                        },
+                        hidden: {
+                          type: "boolean",
+                        },
+                      },
+                      required: ["type", "value"],
+                    },
+                  ],
+                },
+              },
+              required: ["type", "position", "offsetX", "offsetY"],
+            },
+          ],
+        },
+        __schema1: {
+          type: "object",
+          properties: {
+            type: {
+              type: "string",
+              const: "color",
+            },
+            colorSpace: {
+              anyOf: [
+                {
+                  type: "string",
+                  const: "hex",
+                },
+                {
+                  type: "string",
+                  const: "srgb",
+                },
+                {
+                  type: "string",
+                  const: "p3",
+                },
+                {
+                  type: "string",
+                  const: "srgb-linear",
+                },
+                {
+                  type: "string",
+                  const: "hsl",
+                },
+                {
+                  type: "string",
+                  const: "hwb",
+                },
+                {
+                  type: "string",
+                  const: "lab",
+                },
+                {
+                  type: "string",
+                  const: "lch",
+                },
+                {
+                  type: "string",
+                  const: "oklab",
+                },
+                {
+                  type: "string",
+                  const: "oklch",
+                },
+                {
+                  type: "string",
+                  const: "a98rgb",
+                },
+                {
+                  type: "string",
+                  const: "prophoto",
+                },
+                {
+                  type: "string",
+                  const: "rec2020",
+                },
+                {
+                  type: "string",
+                  const: "xyz-d65",
+                },
+                {
+                  type: "string",
+                  const: "xyz-d50",
+                },
+              ],
+            },
+            components: {
+              type: "array",
+              prefixItems: [
+                {
+                  type: "number",
+                },
+                {
+                  type: "number",
+                },
+                {
+                  type: "number",
+                },
+              ],
+              minItems: 3,
+              maxItems: 3,
+            },
+            alpha: {
+              anyOf: [
+                {
+                  type: "number",
+                },
+                {
+                  type: "object",
+                  properties: {
+                    type: {
+                      type: "string",
+                      const: "var",
+                    },
+                    value: {
+                      type: "string",
+                    },
+                    fallback: {
+                      anyOf: [
+                        {
+                          type: "object",
+                          properties: {
+                            type: {
+                              type: "string",
+                              const: "unparsed",
+                            },
+                            value: {
+                              type: "string",
+                            },
+                            hidden: {
+                              type: "boolean",
+                            },
+                          },
+                          required: ["type", "value"],
+                        },
+                        {
+                          type: "object",
+                          properties: {
+                            type: {
+                              type: "string",
+                              const: "keyword",
+                            },
+                            value: {
+                              type: "string",
+                            },
+                            hidden: {
+                              type: "boolean",
+                            },
+                          },
+                          required: ["type", "value"],
+                        },
+                        {
+                          type: "object",
+                          properties: {
+                            type: {
+                              type: "string",
+                              const: "unit",
+                            },
+                            unit: {
+                              type: "string",
+                            },
+                            value: {
+                              type: "number",
+                            },
+                            hidden: {
+                              type: "boolean",
+                            },
+                          },
+                          required: ["type", "unit", "value"],
+                        },
+                        {
+                          $ref: "#/$defs/__schema1",
+                        },
+                        {
+                          type: "object",
+                          properties: {
+                            type: {
+                              type: "string",
+                              const: "rgb",
+                            },
+                            r: {
+                              type: "number",
+                            },
+                            g: {
+                              type: "number",
+                            },
+                            b: {
+                              type: "number",
+                            },
+                            alpha: {
+                              type: "number",
+                            },
+                            hidden: {
+                              type: "boolean",
+                            },
+                          },
+                          required: ["type", "r", "g", "b", "alpha"],
+                        },
+                      ],
+                    },
+                    hidden: {
+                      type: "boolean",
+                    },
+                  },
+                  required: ["type", "value"],
+                },
+              ],
+            },
+            hidden: {
+              type: "boolean",
+            },
+          },
+          required: ["type", "colorSpace", "components", "alpha"],
+        },
+      },
     },
     readNamespaces: [
       "instances",
@@ -24034,6 +32649,43 @@ export const runtimeOperationContractData = [
       },
       required: ["query"],
       additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+        },
+        scopes: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        total: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+        truncated: {
+          type: "boolean",
+        },
+        matches: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              kind: {
+                type: "string",
+              },
+            },
+            required: ["kind"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["query", "scopes", "total", "truncated", "matches"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -25932,6 +34584,37 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["parentInstanceId", "component"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        rootInstanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        removedInstanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        parentInstanceId: {
+          type: "string",
+        },
+        didMergeBreakpointsDueToLimit: {
+          type: "boolean",
+        },
+      },
+      required: ["instanceIds", "rootInstanceIds", "removedInstanceIds"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -37443,6 +46126,37 @@ export const runtimeOperationContractData = [
         },
       },
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        rootInstanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        removedInstanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        parentInstanceId: {
+          type: "string",
+        },
+        didMergeBreakpointsDueToLimit: {
+          type: "boolean",
+        },
+      },
+      required: ["instanceIds", "rootInstanceIds", "removedInstanceIds"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "pages",
       "instances",
@@ -37521,6 +46235,19 @@ export const runtimeOperationContractData = [
       },
       required: ["moves"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["instanceIds"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages", "instances", "props", "dataSources", "resources"],
     writeNamespaces: [
       "pages",
@@ -37581,6 +46308,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["sourceInstanceSelector", "dropTarget"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceSelector: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      additionalProperties: {},
+      required: [],
     },
     readNamespaces: [
       "pages",
@@ -37643,6 +46383,25 @@ export const runtimeOperationContractData = [
       },
       required: ["parentInstanceId", "totalCells", "breakpointId"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        styleSourceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["instanceIds", "styleSourceIds"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "pages",
       "instances",
@@ -37695,6 +46454,19 @@ export const runtimeOperationContractData = [
       },
       required: ["instanceSelector", "component"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceSelector: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["instanceSelector"],
+      additionalProperties: {},
+    },
     readNamespaces: ["instances", "props"],
     writeNamespaces: ["instances"],
     invalidatesNamespaces: ["instances"],
@@ -37731,6 +46503,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["instanceSelector", "component"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceId: {
+          type: "string",
+        },
+      },
+      additionalProperties: {},
+      required: [],
     },
     readNamespaces: [
       "pages",
@@ -37789,6 +46571,19 @@ export const runtimeOperationContractData = [
       },
       required: ["instanceSelector"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceSelector: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["instanceSelector"],
+      additionalProperties: {},
+    },
     readNamespaces: ["instances", "props"],
     writeNamespaces: ["instances"],
     invalidatesNamespaces: ["instances"],
@@ -37815,6 +46610,22 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["sourceInstanceId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceId: {
+          type: "string",
+        },
+        instanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["instanceId", "instanceIds"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -37864,6 +46675,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["sourceInstanceId", "parentInstanceId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceId: {
+          type: "string",
+        },
+        parentInstanceId: {
+          type: "string",
+        },
+      },
+      required: ["instanceId"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -37922,6 +46746,19 @@ export const runtimeOperationContractData = [
       },
       required: ["instanceIds"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["instanceIds"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "pages",
       "instances",
@@ -37971,6 +46808,25 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["instanceSelector"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        instanceSelector: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["instanceIds"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -38366,6 +47222,19 @@ export const runtimeOperationContractData = [
       },
       required: ["updates"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        propIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["propIds"],
+      additionalProperties: {},
+    },
     readNamespaces: ["instances", "props", "dataSources"],
     writeNamespaces: ["props"],
     invalidatesNamespaces: ["props"],
@@ -38423,6 +47292,51 @@ export const runtimeOperationContractData = [
       },
       required: ["find", "replace"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        changedCount: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+        matchingPropCount: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+        truncated: {
+          type: "boolean",
+        },
+        matches: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              propId: {
+                type: "string",
+              },
+              instanceId: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              before: {
+                type: "string",
+              },
+              after: {
+                type: "string",
+              },
+            },
+            required: ["propId", "instanceId", "name", "before", "after"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["changedCount", "matchingPropCount", "truncated", "matches"],
+      additionalProperties: {},
+    },
     readNamespaces: ["instances", "props"],
     writeNamespaces: ["props"],
     invalidatesNamespaces: ["props"],
@@ -38455,6 +47369,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["deletions"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        propIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["propIds"],
+      additionalProperties: {},
     },
     readNamespaces: ["instances", "props"],
     writeNamespaces: ["props", "resources"],
@@ -38565,6 +47492,19 @@ export const runtimeOperationContractData = [
       },
       required: ["bindings"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        propIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["propIds"],
+      additionalProperties: {},
+    },
     readNamespaces: ["instances", "props", "dataSources", "resources"],
     writeNamespaces: ["props"],
     invalidatesNamespaces: ["props"],
@@ -38601,6 +47541,50 @@ export const runtimeOperationContractData = [
         },
       },
       required: [],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        texts: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              instanceId: {
+                type: "string",
+              },
+              childIndex: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+              component: {
+                type: "string",
+              },
+              label: {
+                type: "string",
+              },
+              mode: {
+                type: "string",
+                enum: ["text", "expression"],
+              },
+              value: {
+                type: "string",
+              },
+            },
+            required: [
+              "instanceId",
+              "childIndex",
+              "component",
+              "mode",
+              "value",
+            ],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["texts"],
+      additionalProperties: {},
     },
     readNamespaces: ["pages", "instances"],
     writeNamespaces: [],
@@ -38640,6 +47624,25 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["instanceId", "childIndex", "text"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceId: {
+          type: "string",
+        },
+        childIndex: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+        mode: {
+          type: "string",
+          enum: ["text", "expression"],
+        },
+      },
+      required: ["instanceId", "childIndex", "mode"],
+      additionalProperties: {},
     },
     readNamespaces: ["instances", "dataSources"],
     writeNamespaces: ["instances"],
@@ -38686,6 +47689,50 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["find", "replace"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        changedCount: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+        matchingChildCount: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+        truncated: {
+          type: "boolean",
+        },
+        matches: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              instanceId: {
+                type: "string",
+              },
+              childIndex: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+              before: {
+                type: "string",
+              },
+              after: {
+                type: "string",
+              },
+            },
+            required: ["instanceId", "childIndex", "before", "after"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["changedCount", "matchingChildCount", "truncated", "matches"],
+      additionalProperties: {},
     },
     readNamespaces: ["pages", "instances"],
     writeNamespaces: ["instances"],
@@ -38741,6 +47788,24 @@ export const runtimeOperationContractData = [
           required: ["operation", "instanceId"],
         },
       ],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceId: {
+          type: "string",
+        },
+        operation: {
+          type: "string",
+          enum: ["set", "reset"],
+        },
+        mode: {
+          type: "string",
+          enum: ["text", "expression"],
+        },
+      },
+      required: ["instanceId", "operation"],
+      additionalProperties: {},
     },
     readNamespaces: ["instances", "dataSources"],
     writeNamespaces: ["instances"],
@@ -38843,6 +47908,31 @@ export const runtimeOperationContractData = [
       },
       required: ["rootInstanceId", "instances"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        rootInstanceId: {
+          type: "string",
+        },
+        instanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        idMap: {
+          type: "object",
+          propertyNames: {
+            type: "string",
+          },
+          additionalProperties: {
+            type: "string",
+          },
+        },
+      },
+      required: ["rootInstanceId", "instanceIds", "idMap"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "instances",
       "props",
@@ -38892,6 +47982,19 @@ export const runtimeOperationContractData = [
       },
       required: ["instanceId", "tag"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceId: {
+          type: "string",
+        },
+        tag: {
+          type: "string",
+        },
+      },
+      required: ["instanceId", "tag"],
+      additionalProperties: {},
+    },
     readNamespaces: ["instances", "props"],
     writeNamespaces: ["instances", "props"],
     invalidatesNamespaces: ["instances", "props"],
@@ -38914,6 +48017,22 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["instanceId", "label"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        label: {
+          type: "string",
+        },
+      },
+      required: ["instanceIds", "label"],
+      additionalProperties: {},
     },
     readNamespaces: ["instances"],
     writeNamespaces: ["instances"],
@@ -38957,6 +48076,49 @@ export const runtimeOperationContractData = [
         },
       },
       required: [],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        declarations: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              instanceId: {
+                type: "string",
+              },
+              styleSourceId: {
+                type: "string",
+              },
+              property: {
+                type: "string",
+              },
+              value: {},
+              breakpoint: {
+                type: "string",
+              },
+              state: {
+                type: "string",
+              },
+              source: {
+                type: "string",
+                enum: ["local", "token"],
+              },
+            },
+            required: [
+              "instanceId",
+              "styleSourceId",
+              "property",
+              "breakpoint",
+              "source",
+            ],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["declarations"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "instances",
@@ -39009,6 +48171,19 @@ export const runtimeOperationContractData = [
       },
       required: ["updates"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["styleKeys"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "instances",
       "styles",
@@ -39052,6 +48227,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["deletions"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["styleKeys"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "instances",
@@ -39104,6 +48292,19 @@ export const runtimeOperationContractData = [
       },
       required: ["updates"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["styleKeys"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "instances",
       "styles",
@@ -39151,6 +48352,19 @@ export const runtimeOperationContractData = [
       },
       required: ["deletions"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["styleKeys"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "instances",
       "styles",
@@ -39183,6 +48397,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["property"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["styleKeys"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -39220,6 +48447,46 @@ export const runtimeOperationContractData = [
         },
       },
       required: [],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        tokens: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              declarationCount: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+              styles: {
+                type: "object",
+                propertyNames: {
+                  type: "string",
+                },
+                additionalProperties: {},
+              },
+              usageCount: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+            },
+            required: ["id", "name", "declarationCount"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["tokens"],
+      additionalProperties: {},
     },
     readNamespaces: ["styles", "styleSources", "styleSourceSelections"],
     writeNamespaces: [],
@@ -39276,6 +48543,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["tokens"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        tokenIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["tokenIds"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "styles",
@@ -39349,6 +48629,19 @@ export const runtimeOperationContractData = [
       },
       required: ["tokens", "instanceIds"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        tokenIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["tokenIds"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "instances",
       "styles",
@@ -39394,6 +48687,22 @@ export const runtimeOperationContractData = [
       },
       required: ["designTokenId", "updates"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        designTokenId: {
+          type: "string",
+        },
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["designTokenId", "styleKeys"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "styles",
       "styleSources",
@@ -39437,6 +48746,22 @@ export const runtimeOperationContractData = [
       },
       required: ["designTokenId", "deletions"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        designTokenId: {
+          type: "string",
+        },
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["designTokenId", "styleKeys"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "styles",
       "styleSources",
@@ -39472,6 +48797,16 @@ export const runtimeOperationContractData = [
       },
       required: ["designTokenId", "instanceIds"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        designTokenId: {
+          type: "string",
+        },
+      },
+      required: ["designTokenId"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "instances",
       "styles",
@@ -39502,6 +48837,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["designTokenId", "instanceIds"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        designTokenId: {
+          type: "string",
+        },
+      },
+      required: ["designTokenId"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "instances",
@@ -39541,6 +48886,22 @@ export const runtimeOperationContractData = [
       },
       required: ["instanceIds", "name"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        designTokenId: {
+          type: "string",
+        },
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["designTokenId", "styleKeys"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "instances",
       "styles",
@@ -39568,6 +48929,16 @@ export const runtimeOperationContractData = [
       },
       required: ["styleSourceId", "name"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleSourceId: {
+          type: "string",
+        },
+      },
+      required: ["styleSourceId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["styleSources"],
     writeNamespaces: ["styleSources"],
     invalidatesNamespaces: ["styleSources"],
@@ -39591,6 +48962,19 @@ export const runtimeOperationContractData = [
       },
       required: ["styleSourceIds"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleSourceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["styleSourceIds"],
+      additionalProperties: {},
+    },
     readNamespaces: ["styles", "styleSources", "styleSourceSelections"],
     writeNamespaces: ["styles", "styleSources", "styleSourceSelections"],
     invalidatesNamespaces: ["styles", "styleSources", "styleSourceSelections"],
@@ -39612,6 +48996,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["styleSourceId", "locked"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleSourceId: {
+          type: "string",
+        },
+        locked: {
+          type: "boolean",
+        },
+      },
+      required: ["styleSourceId", "locked"],
+      additionalProperties: {},
     },
     readNamespaces: ["styleSources"],
     writeNamespaces: ["styleSources"],
@@ -39638,6 +49035,22 @@ export const runtimeOperationContractData = [
       },
       required: ["instanceId", "styleSourceIds"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        instanceId: {
+          type: "string",
+        },
+        styleSourceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["instanceId", "styleSourceIds"],
+      additionalProperties: {},
+    },
     readNamespaces: ["instances", "styleSources", "styleSourceSelections"],
     writeNamespaces: ["styleSourceSelections"],
     invalidatesNamespaces: ["styleSourceSelections"],
@@ -39656,6 +49069,22 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["styleSourceId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleSourceId: {
+          type: "string",
+        },
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["styleSourceId", "styleKeys"],
+      additionalProperties: {},
     },
     readNamespaces: ["styles", "styleSources"],
     writeNamespaces: ["styles"],
@@ -39680,6 +49109,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["instanceId", "styleSourceId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleSourceId: {
+          type: "string",
+        },
+      },
+      required: ["styleSourceId"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "instances",
@@ -39712,6 +49151,16 @@ export const runtimeOperationContractData = [
       },
       required: ["instanceId", "styleSourceId"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleSourceId: {
+          type: "string",
+        },
+      },
+      required: ["styleSourceId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["instances", "styleSources", "styleSourceSelections"],
     writeNamespaces: ["styleSources", "styleSourceSelections"],
     invalidatesNamespaces: ["styleSources", "styleSourceSelections"],
@@ -39733,6 +49182,37 @@ export const runtimeOperationContractData = [
         },
       },
       required: [],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        vars: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              name: {
+                type: "string",
+              },
+              value: {
+                type: "string",
+              },
+              scope: {
+                type: "string",
+              },
+              usageCount: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+            },
+            required: ["name", "value", "scope"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["vars"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "styles",
@@ -42436,6 +51916,19 @@ export const runtimeOperationContractData = [
         },
       },
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        names: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["names"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "pages",
       "styles",
@@ -42467,6 +51960,25 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["names"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        names: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["names", "styleKeys"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "styles",
@@ -42502,6 +52014,25 @@ export const runtimeOperationContractData = [
       },
       required: ["map"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        propIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["styleKeys", "propIds"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "styles",
       "styleSources",
@@ -42529,6 +52060,31 @@ export const runtimeOperationContractData = [
       },
       required: ["oldName", "newName"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        oldName: {
+          type: "string",
+        },
+        newName: {
+          type: "string",
+        },
+        styleKeys: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        propIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["oldName", "newName", "styleKeys", "propIds"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "styles",
       "styleSources",
@@ -42552,6 +52108,33 @@ export const runtimeOperationContractData = [
         },
       },
       required: [],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        variables: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              scopeInstanceId: {
+                type: "string",
+              },
+              value: {},
+            },
+            required: ["id", "name"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["variables"],
+      additionalProperties: {},
     },
     readNamespaces: ["dataSources"],
     writeNamespaces: [],
@@ -42645,6 +52228,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["scopeInstanceId", "name", "value"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        dataSourceId: {
+          type: "string",
+        },
+      },
+      required: ["dataSourceId"],
+      additionalProperties: {},
     },
     readNamespaces: ["pages", "instances", "props", "dataSources", "resources"],
     writeNamespaces: [
@@ -42760,6 +52353,16 @@ export const runtimeOperationContractData = [
       },
       required: ["dataSourceId", "values"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        dataSourceId: {
+          type: "string",
+        },
+      },
+      required: ["dataSourceId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages", "instances", "props", "dataSources", "resources"],
     writeNamespaces: [
       "pages",
@@ -42791,6 +52394,16 @@ export const runtimeOperationContractData = [
       },
       required: ["dataSourceId"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        dataSourceId: {
+          type: "string",
+        },
+      },
+      required: ["dataSourceId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["pages", "instances", "props", "dataSources", "resources"],
     writeNamespaces: [
       "pages",
@@ -42818,6 +52431,24 @@ export const runtimeOperationContractData = [
       properties: {},
       required: [],
       additionalProperties: true,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        dataSourceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        deletedCount: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+      },
+      required: ["dataSourceIds", "deletedCount"],
+      additionalProperties: {},
     },
     readNamespaces: ["pages", "instances", "props", "dataSources", "resources"],
     writeNamespaces: [
@@ -42849,6 +52480,45 @@ export const runtimeOperationContractData = [
         },
       },
       required: [],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        resources: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              method: {
+                type: "string",
+                enum: ["get", "post", "put", "delete"],
+              },
+              url: {
+                type: "string",
+              },
+              scopeInstanceId: {
+                type: "string",
+              },
+              exposedAsDataSource: {
+                type: "boolean",
+              },
+              dataSourceId: {
+                type: "string",
+              },
+            },
+            required: ["id", "name", "method", "url", "exposedAsDataSource"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["resources"],
+      additionalProperties: {},
     },
     readNamespaces: ["dataSources", "resources"],
     writeNamespaces: [],
@@ -43002,6 +52672,25 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["resource"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        resourceId: {
+          type: "string",
+        },
+        dataSourceId: {
+          type: "string",
+        },
+        warnings: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["resourceId", "warnings"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -43189,6 +52878,25 @@ export const runtimeOperationContractData = [
       },
       required: ["resourceId", "values"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        resourceId: {
+          type: "string",
+        },
+        dataSourceId: {
+          type: "string",
+        },
+        warnings: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["resourceId"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "pages",
       "instances",
@@ -43275,6 +52983,49 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["find", "replace"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        changedCount: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+        matchingFieldCount: {
+          type: "integer",
+          minimum: -9007199254740991,
+          maximum: 9007199254740991,
+        },
+        truncated: {
+          type: "boolean",
+        },
+        matches: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              resourceId: {
+                type: "string",
+              },
+              field: {
+                type: "string",
+                enum: ["name", "url"],
+              },
+              before: {
+                type: "string",
+              },
+              after: {
+                type: "string",
+              },
+            },
+            required: ["resourceId", "field", "before", "after"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["changedCount", "matchingFieldCount", "truncated", "matches"],
+      additionalProperties: {},
     },
     readNamespaces: ["resources"],
     writeNamespaces: ["resources"],
@@ -43429,6 +53180,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["resource", "scopeInstanceId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        resourceId: {
+          type: "string",
+        },
+        dataSourceId: {
+          type: "string",
+        },
+      },
+      required: ["resourceId", "dataSourceId"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "pages",
@@ -43617,6 +53381,25 @@ export const runtimeOperationContractData = [
       },
       required: ["instanceId", "propName", "resource"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        resourceId: {
+          type: "string",
+        },
+        dataSourceId: {
+          type: "string",
+        },
+        propIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["resourceId", "dataSourceId", "propIds"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "pages",
       "instances",
@@ -43669,6 +53452,28 @@ export const runtimeOperationContractData = [
       },
       required: ["resourceId"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        resourceId: {
+          type: "string",
+        },
+        dataSourceIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        propIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["resourceId", "dataSourceIds", "propIds"],
+      additionalProperties: {},
+    },
     readNamespaces: ["dataSources", "resources", "props"],
     writeNamespaces: ["dataSources", "resources", "props"],
     invalidatesNamespaces: ["dataSources", "resources", "props"],
@@ -43704,6 +53509,77 @@ export const runtimeOperationContractData = [
       },
       required: [],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        items: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              filename: {
+                type: "string",
+              },
+              description: {
+                anyOf: [
+                  {
+                    type: "string",
+                  },
+                  {
+                    type: "null",
+                  },
+                ],
+              },
+              type: {
+                type: "string",
+                enum: ["font", "image", "file"],
+              },
+              size: {
+                type: "number",
+              },
+              contentType: {
+                type: "string",
+              },
+              createdAt: {
+                type: "string",
+              },
+              usageCount: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+            },
+            required: [
+              "id",
+              "name",
+              "type",
+              "size",
+              "contentType",
+              "createdAt",
+            ],
+            additionalProperties: {},
+          },
+        },
+        nextCursor: {
+          anyOf: [
+            {
+              type: "string",
+            },
+            {
+              type: "null",
+            },
+          ],
+        },
+      },
+      required: ["items", "nextCursor"],
+      additionalProperties: {},
+    },
     readNamespaces: [
       "assets",
       "pages",
@@ -43734,6 +53610,88 @@ export const runtimeOperationContractData = [
       },
       required: [],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        uploaded: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              family: {
+                type: "string",
+              },
+              source: {
+                type: "string",
+                const: "uploaded",
+              },
+              assets: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    assetId: {
+                      type: "string",
+                    },
+                    format: {
+                      type: "string",
+                    },
+                    style: {
+                      type: "string",
+                    },
+                    weight: {
+                      anyOf: [
+                        {
+                          type: "string",
+                        },
+                        {
+                          type: "number",
+                        },
+                      ],
+                    },
+                    variable: {
+                      type: "boolean",
+                    },
+                  },
+                  required: ["assetId", "format", "variable"],
+                  additionalProperties: {},
+                },
+              },
+            },
+            required: ["family", "source", "assets"],
+            additionalProperties: {},
+          },
+        },
+        system: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              family: {
+                type: "string",
+              },
+              source: {
+                type: "string",
+                const: "system",
+              },
+              stack: {
+                type: "array",
+                items: {
+                  type: "string",
+                },
+              },
+              description: {
+                type: "string",
+              },
+            },
+            required: ["family", "source", "stack", "description"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["uploaded", "system"],
+      additionalProperties: {},
+    },
     readNamespaces: ["assets"],
     writeNamespaces: [],
     invalidatesNamespaces: [],
@@ -43753,6 +53711,53 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["assetId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        usages: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              namespace: {
+                type: "string",
+                enum: [
+                  "props",
+                  "styles",
+                  "resources",
+                  "dataSources",
+                  "pages",
+                  "project",
+                ],
+              },
+              pageId: {
+                type: "string",
+              },
+              instanceId: {
+                type: "string",
+              },
+              path: {
+                type: "array",
+                items: {
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "number",
+                    },
+                  ],
+                },
+              },
+            },
+            required: ["namespace", "path"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["usages"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "assets",
@@ -43802,6 +53807,16 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["assetId", "values"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        assetId: {
+          type: "string",
+        },
+      },
+      required: ["assetId"],
+      additionalProperties: {},
     },
     readNamespaces: ["assets"],
     writeNamespaces: ["assets"],
@@ -43865,6 +53880,29 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["updates"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        updated: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              assetId: {
+                type: "string",
+              },
+              decorative: {
+                type: "boolean",
+              },
+            },
+            required: ["assetId", "decorative"],
+            additionalProperties: {},
+          },
+        },
+      },
+      required: ["updated"],
+      additionalProperties: {},
     },
     readNamespaces: ["assets"],
     writeNamespaces: ["assets"],
@@ -44125,6 +54163,16 @@ export const runtimeOperationContractData = [
       },
       required: ["asset"],
     },
+    outputSchema: {
+      type: "object",
+      properties: {
+        assetId: {
+          type: "string",
+        },
+      },
+      required: ["assetId"],
+      additionalProperties: {},
+    },
     readNamespaces: ["assets"],
     writeNamespaces: ["assets"],
     invalidatesNamespaces: ["assets"],
@@ -44147,6 +54195,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["fromAssetId", "toAssetId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        fromAssetId: {
+          type: "string",
+        },
+        toAssetId: {
+          type: "string",
+        },
+      },
+      required: ["fromAssetId", "toAssetId"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "assets",
@@ -44188,6 +54249,19 @@ export const runtimeOperationContractData = [
         },
       },
       required: ["assetIdsOrPrefixes"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        assetIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["assetIds"],
+      additionalProperties: {},
     },
     readNamespaces: [
       "assets",

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -34611,10 +34611,15 @@ export const runtimeOperationContractData = [
         },
         didMergeBreakpointsDueToLimit: {
           type: "boolean",
+          const: true,
         },
       },
-      required: ["instanceIds", "rootInstanceIds", "removedInstanceIds"],
-      additionalProperties: {},
+      required: [
+        "instanceIds",
+        "rootInstanceIds",
+        "removedInstanceIds",
+        "parentInstanceId",
+      ],
     },
     readNamespaces: [
       "pages",
@@ -46152,10 +46157,10 @@ export const runtimeOperationContractData = [
         },
         didMergeBreakpointsDueToLimit: {
           type: "boolean",
+          const: true,
         },
       },
       required: ["instanceIds", "rootInstanceIds", "removedInstanceIds"],
-      additionalProperties: {},
     },
     readNamespaces: [
       "pages",

--- a/packages/project-build/src/contracts/builder-runtime.ts
+++ b/packages/project-build/src/contracts/builder-runtime.ts
@@ -17,7 +17,7 @@ export type RuntimeOperationStateContract = {
   id: string;
   kind: RuntimeOperationKind;
   inputSchema: InputJsonSchema;
-  outputSchema?: InputJsonSchema;
+  outputSchema: InputJsonSchema;
   readNamespaces: readonly BuilderNamespace[];
   writeNamespaces: readonly BuilderNamespace[];
   invalidatesNamespaces: readonly BuilderNamespace[];

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -49,6 +49,11 @@ type TestPublicMcpOperation = Pick<
 > &
   Partial<PublicMcpOperation>;
 
+const runtimeContractById = new Map<
+  string,
+  (typeof runtimeOperationContracts)[number]
+>(runtimeOperationContracts.map((contract) => [contract.id, contract]));
+
 const publicOperation = (
   operation: TestPublicMcpOperation
 ): PublicMcpOperation => {
@@ -63,6 +68,7 @@ const publicOperation = (
     writeNamespaces: [],
     invalidatesNamespaces: [],
     retryOnConflict: false,
+    outputSchema: runtimeContractById.get(operation.id)?.outputSchema,
     ...operationFields,
   };
   return { ...merged, inputSchema };
@@ -574,6 +580,18 @@ describe("project session mcp adapter", () => {
     ]);
     expect(toolNames).toContain("insert-fragment");
     expect(toolNames).not.toContain("copy-page");
+    for (const operation of publicMcpOperations) {
+      if (
+        hiddenMcpOperationCommands.has(operation.command) ||
+        runtimeContractById.has(operation.id) === false
+      ) {
+        continue;
+      }
+      expect(
+        tools.find((tool) => tool.name === operation.command)?.outputSchema,
+        `Missing MCP output schema for ${operation.command}`
+      ).toBeDefined();
+    }
     const imageDescriptionsTool = tools.find(
       (tool) => tool.name === "set-image-descriptions"
     );

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -80,6 +80,16 @@ const getTestInputSchema = (inputSchema: z.ZodTypeAny) =>
 const getSchemaProperties = (schema: unknown) =>
   (schema as { properties?: Record<string, unknown> }).properties ?? {};
 
+const getSuccessfulOutputDataSchema = (schema: unknown) => {
+  const variants = (schema as { oneOf?: unknown[] }).oneOf ?? [];
+  const success = variants.find(
+    (variant) =>
+      getSchemaProperties(variant).ok !== undefined &&
+      (getSchemaProperties(variant).ok as { const?: unknown }).const === true
+  );
+  return getSchemaProperties(success).data;
+};
+
 const optionalArrayFieldInputSchema = (field: string) =>
   getTestInputSchema(
     z.object({
@@ -623,6 +633,20 @@ describe("project session mcp adapter", () => {
     expect(JSON.stringify(imageDescriptionsTool?.inputSchema)).toContain(
       "rendered image in context"
     );
+    expect(
+      getSuccessfulOutputDataSchema(
+        tools.find((tool) => tool.name === "refresh")?.outputSchema
+      )
+    ).toMatchObject({
+      type: "object",
+      required: ["refreshedNamespaces"],
+      properties: {
+        refreshedNamespaces: {
+          type: "array",
+          items: { type: "string", enum: expect.any(Array) },
+        },
+      },
+    });
     const auditOutputSchema = tools.find(
       (tool) => tool.name === "audit"
     )?.outputSchema;
@@ -664,6 +688,22 @@ describe("project session mcp adapter", () => {
         ),
       })
     ).not.toThrow();
+    for (const command of ["preview.start", "preview.status", "preview.stop"]) {
+      expect(
+        getSuccessfulOutputDataSchema(
+          visualTools.find((tool) => tool.name === command)?.outputSchema
+        ),
+        `Missing MCP output schema for ${command}`
+      ).toMatchObject({
+        type: "object",
+        required: ["url", "running"],
+        properties: {
+          url: { type: "string" },
+          pid: { type: "integer" },
+          running: { type: "boolean" },
+        },
+      });
+    }
     for (const command of hiddenMcpOperationCommands) {
       expect(toolNames).not.toContain(command);
     }

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -90,6 +90,40 @@ const getSuccessfulOutputDataSchema = (schema: unknown) => {
   return getSchemaProperties(success).data;
 };
 
+const getUnresolvedLocalSchemaRefs = (
+  schema: unknown,
+  root = schema,
+  path: readonly string[] = []
+): string[] => {
+  if (schema === null || typeof schema !== "object") {
+    return [];
+  }
+  const object = schema as Record<string, unknown>;
+  const ref = object.$ref;
+  const unresolved =
+    typeof ref === "string" && ref.startsWith("#/")
+      ? ref
+          .slice(2)
+          .split("/")
+          .map((segment) => segment.replaceAll("~1", "/").replaceAll("~0", "~"))
+          .reduce<unknown>(
+            (value, segment) =>
+              value !== null && typeof value === "object"
+                ? (value as Record<string, unknown>)[segment]
+                : undefined,
+            root
+          ) === undefined
+        ? [`${path.join(".")}: ${ref}`]
+        : []
+      : [];
+  return [
+    ...unresolved,
+    ...Object.entries(object).flatMap(([key, value]) =>
+      getUnresolvedLocalSchemaRefs(value, root, [...path, key])
+    ),
+  ];
+};
+
 const optionalArrayFieldInputSchema = (field: string) =>
   getTestInputSchema(
     z.object({
@@ -638,6 +672,10 @@ describe("project session mcp adapter", () => {
           tool.outputSchema.type,
           `MCP output schema must be object-typed for ${tool.name}`
         ).toBe("object");
+        expect(
+          getUnresolvedLocalSchemaRefs(tool.outputSchema),
+          `MCP output schema has unresolved local references for ${tool.name}`
+        ).toEqual([]);
       }
     }
     expect(

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -625,6 +625,21 @@ describe("project session mcp adapter", () => {
       includeScreenshot: true,
       includePreview: true,
     });
+    const completeTools = listProjectSessionMcpTools(publicMcpOperations, {
+      includeImport: true,
+      includeScreenshot: true,
+      includeScreenshotDiff: true,
+      includeInstallOcr: true,
+      includePreview: true,
+    });
+    for (const tool of completeTools) {
+      if (tool.outputSchema !== undefined) {
+        expect(
+          tool.outputSchema.type,
+          `MCP output schema must be object-typed for ${tool.name}`
+        ).toBe("object");
+      }
+    }
     expect(
       getSchemaProperties(
         visualTools.find((tool) => tool.name === "audit")?.inputSchema

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -1650,6 +1650,42 @@ export const mcpArgumentExamples: Record<string, readonly unknown[]> = {
 const getMcpExamples = (command: string): readonly unknown[] =>
   mcpArgumentExamples[command] ?? [];
 
+const getMcpOutputSchema = (dataSchema: InputJsonSchema): InputJsonSchema => ({
+  type: "object",
+  oneOf: [
+    {
+      type: "object",
+      properties: {
+        ok: { type: "boolean", const: true },
+        data: dataSchema,
+        meta: { type: "object", additionalProperties: true },
+      },
+      required: ["ok", "data", "meta"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      properties: {
+        ok: { type: "boolean", const: false },
+        data: dataSchema,
+        error: {
+          type: "object",
+          properties: {
+            code: { type: "string" },
+            message: { type: "string" },
+            issues: semanticValidationIssuesJsonSchema,
+          },
+          required: ["code", "message"],
+          additionalProperties: true,
+        },
+        meta: { type: "object", additionalProperties: true },
+      },
+      required: ["ok", "error", "meta"],
+      additionalProperties: false,
+    },
+  ],
+});
+
 const sessionStatusDataSchema = {
   type: "object",
   properties: { loaded: { type: "boolean" } },
@@ -2299,44 +2335,6 @@ export const hiddenMcpOperationCommands = new Set<string>([
   // MCP callers use duplicate-page or serializable page-transfer workflows.
   "copy-page",
 ]);
-
-function getMcpOutputSchema(dataSchema: InputJsonSchema): InputJsonSchema {
-  return {
-    type: "object",
-    oneOf: [
-      {
-        type: "object",
-        properties: {
-          ok: { type: "boolean", const: true },
-          data: dataSchema,
-          meta: { type: "object", additionalProperties: true },
-        },
-        required: ["ok", "data", "meta"],
-        additionalProperties: false,
-      },
-      {
-        type: "object",
-        properties: {
-          ok: { type: "boolean", const: false },
-          data: dataSchema,
-          error: {
-            type: "object",
-            properties: {
-              code: { type: "string" },
-              message: { type: "string" },
-              issues: semanticValidationIssuesJsonSchema,
-            },
-            required: ["code", "message"],
-            additionalProperties: true,
-          },
-          meta: { type: "object", additionalProperties: true },
-        },
-        required: ["ok", "error", "meta"],
-        additionalProperties: false,
-      },
-    ],
-  };
-}
 
 export const listProjectSessionMcpTools = (
   operations: readonly PublicMcpOperation[],

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -1650,6 +1650,36 @@ export const mcpArgumentExamples: Record<string, readonly unknown[]> = {
 const getMcpExamples = (command: string): readonly unknown[] =>
   mcpArgumentExamples[command] ?? [];
 
+const sessionStatusDataSchema = {
+  type: "object",
+  properties: { loaded: { type: "boolean" } },
+  required: ["loaded"],
+  additionalProperties: false,
+} as const satisfies InputJsonSchema;
+
+const refreshDataSchema = {
+  type: "object",
+  properties: {
+    refreshedNamespaces: {
+      type: "array",
+      items: { type: "string", enum: builderNamespaces },
+    },
+  },
+  required: ["refreshedNamespaces"],
+  additionalProperties: false,
+} as const satisfies InputJsonSchema;
+
+const previewDataSchema = {
+  type: "object",
+  properties: {
+    url: { type: "string" },
+    pid: { type: "integer" },
+    running: { type: "boolean" },
+  },
+  required: ["url", "running"],
+  additionalProperties: false,
+} as const satisfies InputJsonSchema;
+
 const sessionTools: readonly ProjectSessionMcpTool[] = [
   createProjectSessionMcpTool({
     name: "meta.index",
@@ -1994,6 +2024,7 @@ const sessionTools: readonly ProjectSessionMcpTool[] = [
     description:
       "Read the current local ProjectSession status. Pass verbose true only when debugging namespace, compatibility, freshness, or diagnostic details.",
     inputSchema: statusInputSchema,
+    outputSchema: getMcpOutputSchema(sessionStatusDataSchema),
     annotations: {
       command: "status",
       operationId: "project-session.status",
@@ -2022,6 +2053,7 @@ const sessionTools: readonly ProjectSessionMcpTool[] = [
         },
       },
     },
+    outputSchema: getMcpOutputSchema(refreshDataSchema),
     annotations: {
       command: "refresh",
       operationId: "project-session.refresh",
@@ -2039,6 +2071,7 @@ const sessionTools: readonly ProjectSessionMcpTool[] = [
     name: "reset-session",
     description: "Delete the persisted local ProjectSession snapshot.",
     inputSchema: emptyInputSchema,
+    outputSchema: getMcpOutputSchema(sessionStatusDataSchema),
     annotations: {
       command: "reset-session",
       operationId: "project-session.reset",
@@ -2140,6 +2173,7 @@ const previewTools: readonly ProjectSessionMcpTool[] = [
     description:
       "Regenerate local project files when needed, build them, then start or restart a production-like generated-site preview server for fast visual verification while MCP is running.",
     inputSchema: previewInputSchema,
+    outputSchema: getMcpOutputSchema(previewDataSchema),
     mcpExamples: getMcpExamples("preview.start"),
     annotations: {
       command: "preview.start",
@@ -2159,6 +2193,7 @@ const previewTools: readonly ProjectSessionMcpTool[] = [
     description:
       "Return the active generated-site preview server URL and process state for screenshot-based verification.",
     inputSchema: emptyInputSchema,
+    outputSchema: getMcpOutputSchema(previewDataSchema),
     mcpExamples: getMcpExamples("preview.status"),
     annotations: {
       command: "preview.status",
@@ -2178,6 +2213,7 @@ const previewTools: readonly ProjectSessionMcpTool[] = [
     description:
       "Stop the active generated-site preview server owned by this MCP session.",
     inputSchema: emptyInputSchema,
+    outputSchema: getMcpOutputSchema(previewDataSchema),
     mcpExamples: getMcpExamples("preview.stop"),
     annotations: {
       command: "preview.stop",
@@ -2264,40 +2300,42 @@ export const hiddenMcpOperationCommands = new Set<string>([
   "copy-page",
 ]);
 
-const getMcpOutputSchema = (dataSchema: InputJsonSchema): InputJsonSchema => ({
-  oneOf: [
-    {
-      type: "object",
-      properties: {
-        ok: { type: "boolean", const: true },
-        data: dataSchema,
-        meta: { type: "object", additionalProperties: true },
-      },
-      required: ["ok", "data", "meta"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: {
-        ok: { type: "boolean", const: false },
-        data: dataSchema,
-        error: {
-          type: "object",
-          properties: {
-            code: { type: "string" },
-            message: { type: "string" },
-            issues: semanticValidationIssuesJsonSchema,
-          },
-          required: ["code", "message"],
-          additionalProperties: true,
+function getMcpOutputSchema(dataSchema: InputJsonSchema): InputJsonSchema {
+  return {
+    oneOf: [
+      {
+        type: "object",
+        properties: {
+          ok: { type: "boolean", const: true },
+          data: dataSchema,
+          meta: { type: "object", additionalProperties: true },
         },
-        meta: { type: "object", additionalProperties: true },
+        required: ["ok", "data", "meta"],
+        additionalProperties: false,
       },
-      required: ["ok", "error", "meta"],
-      additionalProperties: false,
-    },
-  ],
-});
+      {
+        type: "object",
+        properties: {
+          ok: { type: "boolean", const: false },
+          data: dataSchema,
+          error: {
+            type: "object",
+            properties: {
+              code: { type: "string" },
+              message: { type: "string" },
+              issues: semanticValidationIssuesJsonSchema,
+            },
+            required: ["code", "message"],
+            additionalProperties: true,
+          },
+          meta: { type: "object", additionalProperties: true },
+        },
+        required: ["ok", "error", "meta"],
+        additionalProperties: false,
+      },
+    ],
+  };
+}
 
 export const listProjectSessionMcpTools = (
   operations: readonly PublicMcpOperation[],

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -2302,6 +2302,7 @@ export const hiddenMcpOperationCommands = new Set<string>([
 
 function getMcpOutputSchema(dataSchema: InputJsonSchema): InputJsonSchema {
   return {
+    type: "object",
     oneOf: [
       {
         type: "object",

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -1650,41 +1650,45 @@ export const mcpArgumentExamples: Record<string, readonly unknown[]> = {
 const getMcpExamples = (command: string): readonly unknown[] =>
   mcpArgumentExamples[command] ?? [];
 
-const getMcpOutputSchema = (dataSchema: InputJsonSchema): InputJsonSchema => ({
-  type: "object",
-  oneOf: [
-    {
-      type: "object",
-      properties: {
-        ok: { type: "boolean", const: true },
-        data: dataSchema,
-        meta: { type: "object", additionalProperties: true },
-      },
-      required: ["ok", "data", "meta"],
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      properties: {
-        ok: { type: "boolean", const: false },
-        data: dataSchema,
-        error: {
-          type: "object",
-          properties: {
-            code: { type: "string" },
-            message: { type: "string" },
-            issues: semanticValidationIssuesJsonSchema,
-          },
-          required: ["code", "message"],
-          additionalProperties: true,
+const getMcpOutputSchema = (dataSchema: InputJsonSchema): InputJsonSchema => {
+  const { $defs, ...data } = dataSchema;
+  return {
+    type: "object",
+    ...($defs === undefined ? {} : { $defs }),
+    oneOf: [
+      {
+        type: "object",
+        properties: {
+          ok: { type: "boolean", const: true },
+          data,
+          meta: { type: "object", additionalProperties: true },
         },
-        meta: { type: "object", additionalProperties: true },
+        required: ["ok", "data", "meta"],
+        additionalProperties: false,
       },
-      required: ["ok", "error", "meta"],
-      additionalProperties: false,
-    },
-  ],
-});
+      {
+        type: "object",
+        properties: {
+          ok: { type: "boolean", const: false },
+          data,
+          error: {
+            type: "object",
+            properties: {
+              code: { type: "string" },
+              message: { type: "string" },
+              issues: semanticValidationIssuesJsonSchema,
+            },
+            required: ["code", "message"],
+            additionalProperties: true,
+          },
+          meta: { type: "object", additionalProperties: true },
+        },
+        required: ["ok", "error", "meta"],
+        additionalProperties: false,
+      },
+    ],
+  };
+};
 
 const sessionStatusDataSchema = {
   type: "object",

--- a/packages/project-build/src/project-session.test.ts
+++ b/packages/project-build/src/project-session.test.ts
@@ -259,6 +259,23 @@ describe("project session", () => {
     expect(storage.cleared).toBe(true);
   });
 
+  test("identifies session control operations in their envelopes", async () => {
+    const session = createSession({
+      storage: createStorage(),
+      transport: createTransport(),
+    });
+
+    await expect(session.initialize()).resolves.toMatchObject({
+      operationId: "project-session.status",
+    });
+    await expect(session.refresh(["pages"])).resolves.toMatchObject({
+      operationId: "project-session.refresh",
+    });
+    await expect(session.reset()).resolves.toMatchObject({
+      operationId: "project-session.reset",
+    });
+  });
+
   test("refreshes missing namespaces from remote and persists atomically", async () => {
     const storage = createStorage();
     const transport = createTransport();

--- a/packages/project-build/src/project-session.ts
+++ b/packages/project-build/src/project-session.ts
@@ -564,10 +564,16 @@ export class ProjectSession {
     await this.#options.storage.clear();
     this.#snapshot = undefined;
     this.#revision = undefined;
-    return this.status(["Project session snapshot was reset."]);
+    return this.status(
+      ["Project session snapshot was reset."],
+      "project-session.reset"
+    );
   }
 
-  status(messages: string[] = []): ProjectSessionEnvelope<{
+  status(
+    messages: string[] = [],
+    operationId = "project-session.status"
+  ): ProjectSessionEnvelope<{
     loaded: boolean;
   }> {
     const diagnostics = messages.map(
@@ -581,7 +587,7 @@ export class ProjectSession {
       source: "local",
       result: { loaded: this.#snapshot !== undefined },
       committed: false,
-      contract: emptyContract,
+      contract: { ...emptyContract, id: operationId },
       diagnostics,
     });
   }
@@ -596,6 +602,7 @@ export class ProjectSession {
       committed: false,
       contract: {
         ...emptyContract,
+        id: "project-session.refresh",
         readNamespaces: namespaces,
       },
       snapshot,

--- a/packages/project-build/src/project-session.ts
+++ b/packages/project-build/src/project-session.ts
@@ -2,14 +2,12 @@ import hash from "@emotion/hash";
 import type {
   RuntimeOperationContract,
   RuntimeOperationId,
-  RuntimeOperationStateContract,
 } from "./contracts/builder-runtime";
 import { runtimeOperationContracts } from "./contracts/builder-runtime";
 import type { BuilderNamespace } from "./contracts/namespaces";
 import type { BuilderPatchTransaction } from "./contracts/patch";
 import { hasGeneratedRecordWritePatch } from "./contracts/patch";
 import type { BuilderApiCapability } from "./contracts/permissions";
-import { emptyInputJsonSchema } from "./contracts/input-schema";
 import {
   builderRuntimeContext,
   type BuilderRuntimeContext,
@@ -34,6 +32,10 @@ import {
 import { applyBuilderPatchTransactions } from "./state/patch";
 
 type ProjectSessionSource = "local" | "remote" | "dry-run" | "server";
+type ProjectSessionEnvelopeContract = Pick<
+  RuntimeOperationContract,
+  "id" | "readNamespaces" | "writeNamespaces" | "invalidatesNamespaces"
+>;
 type ProjectSessionDiagnosticLevel = "info" | "warning" | "error";
 
 export type ProjectSessionDiagnostic = {
@@ -1133,10 +1135,7 @@ export class ProjectSession {
     source: ProjectSessionSource;
     result: Result;
     committed: boolean;
-    contract: Pick<
-      RuntimeOperationContract,
-      "id" | "readNamespaces" | "writeNamespaces" | "invalidatesNamespaces"
-    >;
+    contract: ProjectSessionEnvelopeContract;
     snapshot?: ProjectSessionSnapshot;
     diagnostics?: ProjectSessionDiagnostic[];
     transaction?: BuilderPatchTransaction;
@@ -1171,16 +1170,11 @@ export class ProjectSession {
   }
 }
 
-const emptyContract: RuntimeOperationStateContract = {
+const emptyContract: ProjectSessionEnvelopeContract = {
   id: "project-session.status",
-  kind: "read",
-  inputSchema: emptyInputJsonSchema,
   readNamespaces: [],
   writeNamespaces: [],
   invalidatesNamespaces: [],
-  retryOnConflict: false,
-  requiresAssets: false,
-  requiresConfirm: false,
 };
 
 export const createProjectSession = (options: ProjectSessionOptions) =>

--- a/packages/project-build/src/runtime/instances.ts
+++ b/packages/project-build/src/runtime/instances.ts
@@ -3548,6 +3548,15 @@ export const listTextInstances = (
   };
 };
 
+type InstanceInspection = ReturnType<typeof serializeInstanceSummary> & {
+  ancestors?: ReturnType<typeof getInstanceAncestors>;
+  props?: Prop[];
+  styles?: ReturnType<typeof serializeStyleDeclarations>;
+  children?: Array<ReturnType<typeof serializeInstanceSummary>>;
+  bindings?: Prop[];
+  sources?: string[];
+};
+
 export const inspectInstance = (
   state: Pick<
     BuilderState,
@@ -3569,7 +3578,7 @@ export const inspectInstance = (
   const depths = getInstanceDepths(instances, [input.instanceId]);
   const parents = getInstanceParents(instances);
   const include = new Set(input.include ?? []);
-  const details: Record<string, unknown> = serializeInstanceSummary(
+  const details: InstanceInspection = serializeInstanceSummary(
     instance,
     depths.get(instance.id) ?? 0,
     parents.get(instance.id)

--- a/packages/project-build/src/runtime/output-schemas.ts
+++ b/packages/project-build/src/runtime/output-schemas.ts
@@ -14,6 +14,7 @@ import { builderPatchSchema } from "../contracts/patch";
 import { marketplaceProduct } from "../shared/marketplace";
 import { auditResult } from "./audit";
 import { insertCollectionResult } from "./collection";
+import { componentInsertResult } from "./component-insert-contract";
 
 const looseObject = <Shape extends z.ZodRawShape>(shape: Shape) =>
   z.looseObject(shape);
@@ -204,12 +205,8 @@ const systemFont = looseObject({
   description: z.string(),
 });
 
-const insertedInstances = looseObject({
-  instanceIds: stringArray,
-  rootInstanceIds: stringArray,
-  removedInstanceIds: stringArray,
+const fragmentInsertResult = componentInsertResult.extend({
   parentInstanceId: id.optional(),
-  didMergeBreakpointsDueToLimit: z.boolean().optional(),
 });
 const instanceIdsResult = looseObject({ instanceIds: stringArray });
 const pageIdResult = looseObject({ pageId: id });
@@ -334,9 +331,9 @@ export const runtimeOutputSchemas = {
     matches: z.array(looseObject({ kind: z.string() })),
   }),
   "project.audit": auditResult,
-  "instances.insertComponent": insertedInstances,
+  "instances.insertComponent": componentInsertResult,
   "instances.insertCollection": insertCollectionResult,
-  "instances.insertFragment": insertedInstances,
+  "instances.insertFragment": fragmentInsertResult,
   "instances.move": instanceIdsResult,
   "instances.reparent": looseObject({
     instanceSelector: stringArray.optional(),

--- a/packages/project-build/src/runtime/output-schemas.ts
+++ b/packages/project-build/src/runtime/output-schemas.ts
@@ -13,6 +13,7 @@ import { builderNamespaces } from "../contracts/namespaces";
 import { builderPatchSchema } from "../contracts/patch";
 import { marketplaceProduct } from "../shared/marketplace";
 import { auditResult } from "./audit";
+import { insertCollectionResult } from "./collection";
 
 const looseObject = <Shape extends z.ZodRawShape>(shape: Shape) =>
   z.looseObject(shape);
@@ -334,6 +335,7 @@ export const runtimeOutputSchemas = {
   }),
   "project.audit": auditResult,
   "instances.insertComponent": insertedInstances,
+  "instances.insertCollection": insertCollectionResult,
   "instances.insertFragment": insertedInstances,
   "instances.move": instanceIdsResult,
   "instances.reparent": looseObject({

--- a/packages/project-build/src/runtime/output-schemas.ts
+++ b/packages/project-build/src/runtime/output-schemas.ts
@@ -1,0 +1,516 @@
+import { z } from "zod";
+import {
+  assetType,
+  compilerSettings,
+  documentTypes,
+  pageAuth,
+  pageRedirect,
+  pageTemplate as sdkPageTemplate,
+  projectMeta,
+  prop,
+} from "@webstudio-is/sdk";
+import { builderNamespaces } from "../contracts/namespaces";
+import { builderPatchSchema } from "../contracts/patch";
+import { marketplaceProduct } from "../shared/marketplace";
+import { auditResult } from "./audit";
+
+const looseObject = <Shape extends z.ZodRawShape>(shape: Shape) =>
+  z.looseObject(shape);
+const id = z.string();
+const stringArray = z.array(z.string());
+const unknownRecord = z.record(z.string(), z.unknown());
+
+const patchChange = z.object({
+  namespace: z.enum(builderNamespaces),
+  patches: z.array(builderPatchSchema),
+});
+
+export const createRuntimeMutationExecutionSchema = <
+  Result extends z.ZodTypeAny,
+>(
+  result: Result
+) =>
+  z.object({
+    kind: z.literal("mutation"),
+    payload: z.array(patchChange),
+    result,
+    invalidatesNamespaces: z.array(z.enum(builderNamespaces)),
+    noop: z.boolean(),
+  });
+
+const pageSummary = looseObject({
+  id,
+  name: z.string(),
+  path: z.string(),
+  localPath: z.string(),
+  title: z.string(),
+  rootInstanceId: id,
+  parentFolderId: id.optional(),
+  isHome: z.boolean(),
+});
+const pageDetails = pageSummary.extend({
+  meta: looseObject({
+    description: z.string().optional(),
+    language: z.string().optional(),
+    redirect: z.string().optional(),
+    status: z.string().optional(),
+    socialImageUrl: z.string().optional(),
+    socialImageAssetId: id.optional(),
+    excludePageFromSearch: z.boolean().optional(),
+    documentType: z.enum(documentTypes),
+    content: z.string().optional(),
+    auth: pageAuth.optional(),
+    custom: z
+      .array(
+        looseObject({
+          property: z.string(),
+          content: z.string(),
+        })
+      )
+      .optional(),
+  }),
+});
+const pagePathLookup = {
+  requestedPath: z.string(),
+  found: z.boolean(),
+  exactMatch: z.boolean(),
+  matchedPattern: z.boolean(),
+  matchedFallback: z.boolean(),
+};
+const folder = looseObject({
+  id,
+  name: z.string(),
+  slug: z.string(),
+  parentFolderId: id.optional(),
+  children: stringArray,
+});
+const pageTemplate = looseObject({
+  id,
+  name: z.string(),
+  title: z.string(),
+  rootInstanceId: id,
+  systemDataSourceId: id.optional(),
+  meta: looseObject(sdkPageTemplate.shape.meta.shape),
+});
+const instanceSummary = looseObject({
+  id,
+  component: z.string(),
+  tag: z.string().optional(),
+  label: z.string().optional(),
+  childCount: z.number().int(),
+  depth: z.number().int(),
+  parentId: id.optional(),
+  indexWithinParent: z.number().int().optional(),
+});
+const breakpoint = looseObject({
+  id,
+  label: z.string(),
+  minWidth: z.number().optional(),
+  maxWidth: z.number().optional(),
+  condition: z.string().optional(),
+});
+const redirect = looseObject(pageRedirect.shape);
+const pageMarketplace = looseObject({
+  include: z.boolean().optional(),
+  category: z.string().optional(),
+  thumbnailAssetId: id.optional(),
+});
+const textMatch = looseObject({
+  instanceId: id,
+  childIndex: z.number().int(),
+  component: z.string(),
+  label: z.string().optional(),
+  mode: z.enum(["text", "expression"]),
+  value: z.string(),
+});
+const declaration = looseObject({
+  instanceId: id,
+  styleSourceId: id,
+  property: z.string(),
+  value: z.unknown(),
+  breakpoint: id,
+  state: z.string().optional(),
+  source: z.enum(["local", "token"]),
+});
+const token = looseObject({
+  id,
+  name: z.string(),
+  declarationCount: z.number().int(),
+  styles: unknownRecord.optional(),
+  usageCount: z.number().int().optional(),
+});
+const cssVariable = looseObject({
+  name: z.string(),
+  value: z.string(),
+  scope: z.string(),
+  usageCount: z.number().int().optional(),
+});
+const variable = looseObject({
+  id,
+  name: z.string(),
+  scopeInstanceId: id.optional(),
+  value: z.unknown(),
+});
+const resource = looseObject({
+  id,
+  name: z.string(),
+  method: z.enum(["get", "post", "put", "delete"]),
+  url: z.string(),
+  scopeInstanceId: id.optional(),
+  exposedAsDataSource: z.boolean(),
+  dataSourceId: id.optional(),
+});
+const asset = looseObject({
+  id,
+  name: z.string(),
+  filename: z.string().optional(),
+  description: z.string().nullable().optional(),
+  type: assetType,
+  size: z.number(),
+  contentType: z.string(),
+  createdAt: z.string(),
+  usageCount: z.number().int().optional(),
+});
+const assetUsage = looseObject({
+  namespace: z.enum([
+    "props",
+    "styles",
+    "resources",
+    "dataSources",
+    "pages",
+    "project",
+  ]),
+  pageId: id.optional(),
+  instanceId: id.optional(),
+  path: z.array(z.string().or(z.number())),
+});
+const uploadedFontAsset = looseObject({
+  assetId: id,
+  format: z.string(),
+  style: z.string().optional(),
+  weight: z.string().or(z.number()).optional(),
+  variable: z.boolean(),
+});
+const uploadedFont = looseObject({
+  family: z.string(),
+  source: z.literal("uploaded"),
+  assets: z.array(uploadedFontAsset),
+});
+const systemFont = looseObject({
+  family: z.string(),
+  source: z.literal("system"),
+  stack: stringArray,
+  description: z.string(),
+});
+
+const insertedInstances = looseObject({
+  instanceIds: stringArray,
+  rootInstanceIds: stringArray,
+  removedInstanceIds: stringArray,
+  parentInstanceId: id.optional(),
+  didMergeBreakpointsDueToLimit: z.boolean().optional(),
+});
+const instanceIdsResult = looseObject({ instanceIds: stringArray });
+const pageIdResult = looseObject({ pageId: id });
+const folderIdResult = looseObject({ folderId: id });
+const templateIdResult = looseObject({ templateId: id });
+const breakpointIdResult = looseObject({ breakpointId: id });
+const dataSourceIdResult = looseObject({ dataSourceId: id });
+const assetIdResult = looseObject({ assetId: id });
+const styleKeysResult = looseObject({ styleKeys: stringArray });
+const textReplacementMatch = looseObject({
+  instanceId: id,
+  childIndex: z.number().int(),
+  before: z.string(),
+  after: z.string(),
+});
+const propReplacementMatch = looseObject({
+  propId: id,
+  instanceId: id,
+  name: z.string(),
+  before: z.string(),
+  after: z.string(),
+});
+const resourceReplacementMatch = looseObject({
+  resourceId: id,
+  field: z.enum(["name", "url"]),
+  before: z.string(),
+  after: z.string(),
+});
+const resourceMutationResult = looseObject({
+  resourceId: id,
+  dataSourceId: id.optional(),
+  warnings: stringArray,
+});
+
+export const runtimeOutputSchemas = {
+  "pages.list": looseObject({
+    pages: z.array(pageSummary),
+    folders: z.array(folder).optional(),
+  }),
+  "pages.get": pageDetails,
+  "pages.getByPath": z.union([
+    pageDetails.extend(pagePathLookup),
+    looseObject({
+      ...pagePathLookup,
+      fallbackPage: pageDetails,
+      guidance: z.string(),
+    }),
+  ]),
+  "pages.create": looseObject({ pageId: id, rootInstanceId: id }),
+  "pages.update": pageIdResult,
+  "pages.updateSettings": pageIdResult,
+  "pages.updateMarketplace": looseObject({
+    pageId: id,
+    marketplace: pageMarketplace,
+  }),
+  "pages.savePathInHistory": looseObject({}),
+  "pages.setHome": pageIdResult,
+  "projectSettings.get": looseObject({
+    meta: looseObject(projectMeta.shape),
+    compiler: looseObject(compilerSettings.shape),
+    redirects: z.array(redirect),
+  }),
+  "projectSettings.update": looseObject({ updated: z.boolean() }),
+  "projectSettings.getMarketplaceProduct": looseObject({
+    marketplaceProduct: looseObject(marketplaceProduct.shape),
+  }),
+  "projectSettings.updateMarketplaceProduct": looseObject({
+    updated: z.boolean(),
+  }),
+  "redirects.list": looseObject({ redirects: z.array(redirect) }),
+  "redirects.create": looseObject({ old: z.string() }),
+  "redirects.update": looseObject({ old: z.string() }),
+  "redirects.delete": looseObject({ old: z.string() }),
+  "redirects.setAll": looseObject({ count: z.number().int() }),
+  "breakpoints.list": looseObject({ breakpoints: z.array(breakpoint) }),
+  "breakpoints.create": breakpointIdResult,
+  "breakpoints.update": breakpointIdResult,
+  "breakpoints.delete": breakpointIdResult,
+  "pages.delete": pageIdResult,
+  "pages.duplicate": pageIdResult,
+  "pages.copy": pageIdResult,
+  "pageTemplates.list": looseObject({ templates: z.array(pageTemplate) }),
+  "pageTemplates.create": looseObject({ templateId: id, rootInstanceId: id }),
+  "pageTemplates.update": templateIdResult,
+  "pageTemplates.delete": templateIdResult,
+  "pageTemplates.duplicate": templateIdResult,
+  "pageTemplates.reorder": templateIdResult,
+  "pageTemplates.createPage": pageIdResult,
+  "folders.list": looseObject({
+    folders: z.array(folder),
+    pages: z.array(pageSummary).optional(),
+  }),
+  "folders.create": folderIdResult,
+  "folders.update": folderIdResult,
+  "folders.delete": looseObject({
+    folderId: id,
+    pageIds: stringArray,
+    folderIds: stringArray,
+  }),
+  "folders.duplicate": folderIdResult,
+  "pageTransfer.insert": looseObject({
+    id,
+    type: z.enum(["page", "folder", "template"]),
+    didReachBreakpointLimit: z.boolean(),
+  }),
+  "pageTree.move": looseObject({ childId: id }),
+  "pageTree.reparentOrphans": looseObject({}),
+  "instances.list": looseObject({ instances: z.array(instanceSummary) }),
+  "instances.inspect": instanceSummary.extend({
+    ancestors: z.array(instanceSummary).optional(),
+    props: z.array(prop).optional(),
+    styles: z.array(declaration).optional(),
+    children: z.array(instanceSummary).optional(),
+    bindings: z.array(prop).optional(),
+    sources: stringArray.optional(),
+  }),
+  "project.search": looseObject({
+    query: z.string(),
+    scopes: stringArray,
+    total: z.number().int(),
+    truncated: z.boolean(),
+    matches: z.array(looseObject({ kind: z.string() })),
+  }),
+  "project.audit": auditResult,
+  "instances.insertComponent": insertedInstances,
+  "instances.insertFragment": insertedInstances,
+  "instances.move": instanceIdsResult,
+  "instances.reparent": looseObject({
+    instanceSelector: stringArray.optional(),
+  }),
+  "instances.fillGrid": looseObject({
+    instanceIds: stringArray,
+    styleSourceIds: stringArray,
+  }),
+  "instances.wrap": looseObject({ instanceSelector: stringArray }),
+  "instances.convert": looseObject({ instanceId: id.optional() }),
+  "instances.unwrap": looseObject({ instanceSelector: stringArray }),
+  "instances.clone": looseObject({ instanceId: id, instanceIds: stringArray }),
+  "instances.duplicateAfterItself": looseObject({
+    instanceId: id,
+    parentInstanceId: id.optional(),
+  }),
+  "instances.delete": instanceIdsResult,
+  "instances.deleteBySelector": looseObject({
+    instanceIds: stringArray,
+    instanceSelector: stringArray.optional(),
+  }),
+  "instances.updateProps": looseObject({ propIds: stringArray }),
+  "instances.replacePropText": looseObject({
+    changedCount: z.number().int(),
+    matchingPropCount: z.number().int(),
+    truncated: z.boolean(),
+    matches: z.array(propReplacementMatch),
+  }),
+  "instances.deleteProps": looseObject({ propIds: stringArray }),
+  "instances.bindProps": looseObject({ propIds: stringArray }),
+  "instances.listTexts": looseObject({ texts: z.array(textMatch) }),
+  "instances.updateText": looseObject({
+    instanceId: id,
+    childIndex: z.number().int(),
+    mode: z.enum(["text", "expression"]),
+  }),
+  "instances.replaceText": looseObject({
+    changedCount: z.number().int(),
+    matchingChildCount: z.number().int(),
+    truncated: z.boolean(),
+    matches: z.array(textReplacementMatch),
+  }),
+  "instances.setTextContent": looseObject({
+    instanceId: id,
+    operation: z.enum(["set", "reset"]),
+    mode: z.enum(["text", "expression"]).optional(),
+  }),
+  "instances.updateTextTree": looseObject({
+    rootInstanceId: id,
+    instanceIds: stringArray,
+    idMap: z.record(z.string(), z.string()),
+  }),
+  "instances.setTag": looseObject({ instanceId: id, tag: z.string() }),
+  "instances.setLabel": looseObject({
+    instanceIds: stringArray,
+    label: z.string(),
+  }),
+  "styles.getDeclarations": looseObject({
+    declarations: z.array(declaration),
+  }),
+  "styles.updateDeclarations": styleKeysResult,
+  "styles.deleteDeclarations": styleKeysResult,
+  "styles.updateSelectedDeclarations": styleKeysResult,
+  "styles.deleteSelectedDeclarations": styleKeysResult,
+  "styles.replaceValues": styleKeysResult,
+  "designTokens.list": looseObject({ tokens: z.array(token) }),
+  "designTokens.create": looseObject({ tokenIds: stringArray }),
+  "designTokens.createAttached": looseObject({ tokenIds: stringArray }),
+  "designTokens.updateStyles": looseObject({
+    designTokenId: id,
+    styleKeys: stringArray,
+  }),
+  "designTokens.deleteStyles": looseObject({
+    designTokenId: id,
+    styleKeys: stringArray,
+  }),
+  "designTokens.attach": looseObject({ designTokenId: id }),
+  "designTokens.detach": looseObject({ designTokenId: id }),
+  "designTokens.extract": looseObject({
+    designTokenId: id,
+    styleKeys: stringArray,
+  }),
+  "styleSources.rename": looseObject({ styleSourceId: id }),
+  "styleSources.delete": looseObject({ styleSourceIds: stringArray }),
+  "styleSources.setLock": looseObject({
+    styleSourceId: id,
+    locked: z.boolean(),
+  }),
+  "styleSources.reorder": looseObject({
+    instanceId: id,
+    styleSourceIds: stringArray,
+  }),
+  "styleSources.clearStyles": looseObject({
+    styleSourceId: id,
+    styleKeys: stringArray,
+  }),
+  "styleSources.duplicate": looseObject({ styleSourceId: id }),
+  "styleSources.convertLocalToToken": looseObject({ styleSourceId: id }),
+  "cssVariables.list": looseObject({ vars: z.array(cssVariable) }),
+  "cssVariables.define": looseObject({ names: stringArray }),
+  "cssVariables.delete": looseObject({
+    names: stringArray,
+    styleKeys: stringArray,
+  }),
+  "cssVariables.rewriteRefs": looseObject({
+    styleKeys: stringArray,
+    propIds: stringArray,
+  }),
+  "cssVariables.rename": looseObject({
+    oldName: z.string(),
+    newName: z.string(),
+    styleKeys: stringArray,
+    propIds: stringArray,
+  }),
+  "variables.list": looseObject({ variables: z.array(variable) }),
+  "variables.create": dataSourceIdResult,
+  "variables.update": dataSourceIdResult,
+  "variables.delete": dataSourceIdResult,
+  "variables.deleteUnused": looseObject({
+    dataSourceIds: stringArray,
+    deletedCount: z.number().int(),
+  }),
+  "resources.list": looseObject({ resources: z.array(resource) }),
+  "resources.create": resourceMutationResult,
+  "resources.update": resourceMutationResult.partial({ warnings: true }),
+  "resources.replaceText": looseObject({
+    changedCount: z.number().int(),
+    matchingFieldCount: z.number().int(),
+    truncated: z.boolean(),
+    matches: z.array(resourceReplacementMatch),
+  }),
+  "resources.upsert": looseObject({ resourceId: id, dataSourceId: id }),
+  "resources.upsertProp": looseObject({
+    resourceId: id,
+    dataSourceId: id,
+    propIds: stringArray,
+  }),
+  "resources.delete": looseObject({
+    resourceId: id,
+    dataSourceIds: stringArray,
+    propIds: stringArray,
+  }),
+  "assets.list": looseObject({
+    items: z.array(asset),
+    nextCursor: z.string().nullable(),
+  }),
+  "fonts.list": looseObject({
+    uploaded: z.array(uploadedFont),
+    system: z.array(systemFont),
+  }),
+  "assets.findUsage": looseObject({ usages: z.array(assetUsage) }),
+  "assets.update": assetIdResult,
+  "assets.setImageDescriptions": looseObject({
+    updated: z.array(looseObject({ assetId: id, decorative: z.boolean() })),
+  }),
+  "assets.add": assetIdResult,
+  "assets.replace": looseObject({ fromAssetId: id, toAssetId: id }),
+  "assets.delete": looseObject({ assetIds: stringArray }),
+  "system.migrateLoadedData": looseObject({ didBreakCycles: z.boolean() }),
+} satisfies Record<string, z.ZodTypeAny>;
+
+export type RuntimeOutputSchemaId = keyof typeof runtimeOutputSchemas;
+export type RuntimeOperationOutput<Id extends RuntimeOutputSchemaId> = z.output<
+  (typeof runtimeOutputSchemas)[Id]
+>;
+
+export function getRuntimeOutputSchema<Id extends RuntimeOutputSchemaId>(
+  operationId: Id
+): (typeof runtimeOutputSchemas)[Id];
+export function getRuntimeOutputSchema(operationId: string): z.ZodTypeAny;
+export function getRuntimeOutputSchema(operationId: string) {
+  const schema = runtimeOutputSchemas[operationId as RuntimeOutputSchemaId];
+  if (schema === undefined) {
+    throw new Error(
+      `Missing runtime output schema for operation "${operationId}".`
+    );
+  }
+  return schema;
+}

--- a/packages/project-build/src/runtime/registry.test.ts
+++ b/packages/project-build/src/runtime/registry.test.ts
@@ -14,6 +14,7 @@ import {
   getBuilderRuntimeOperation,
 } from "./registry";
 import { runtimeGeneratedIdInput } from "./generated-id-input";
+import { getRuntimeOutputSchema, runtimeOutputSchemas } from "./output-schemas";
 import { getPage, listFolders, listPages } from "./pages";
 import {
   getStyleDeclarations,
@@ -161,9 +162,7 @@ test("keeps generated runtime contracts in sync with the registry", () => {
         permit,
         kind,
         inputSchema: inputJsonSchema,
-        ...(outputJsonSchema === undefined
-          ? {}
-          : { outputSchema: outputJsonSchema }),
+        outputSchema: outputJsonSchema,
         readNamespaces,
         writeNamespaces,
         invalidatesNamespaces,
@@ -175,131 +174,55 @@ test("keeps generated runtime contracts in sync with the registry", () => {
   );
 });
 
-test("tracks public runtime operations without output schemas", () => {
+test("requires an output schema for every runtime operation", () => {
   expect(
     builderRuntimeOperations
-      .filter(
-        (operation) =>
-          operation.command !== undefined &&
-          operation.outputSchema === undefined
-      )
+      .filter((operation) => operation.outputSchema === undefined)
       .map((operation) => operation.id)
-  ).toMatchInlineSnapshot(`
-    [
-      "pages.list",
-      "pages.get",
-      "pages.getByPath",
-      "pages.create",
-      "pages.update",
-      "pages.updateSettings",
-      "pages.updateMarketplace",
-      "pages.savePathInHistory",
-      "pages.setHome",
-      "projectSettings.get",
-      "projectSettings.update",
-      "projectSettings.getMarketplaceProduct",
-      "projectSettings.updateMarketplaceProduct",
-      "redirects.list",
-      "redirects.create",
-      "redirects.update",
-      "redirects.delete",
-      "redirects.setAll",
-      "breakpoints.list",
-      "breakpoints.create",
-      "breakpoints.update",
-      "breakpoints.delete",
-      "pages.delete",
-      "pages.duplicate",
-      "pages.copy",
-      "pageTemplates.list",
-      "pageTemplates.create",
-      "pageTemplates.update",
-      "pageTemplates.delete",
-      "pageTemplates.duplicate",
-      "pageTemplates.reorder",
-      "pageTemplates.createPage",
-      "folders.list",
-      "folders.create",
-      "folders.update",
-      "folders.delete",
-      "folders.duplicate",
-      "pageTransfer.insert",
-      "pageTree.move",
-      "pageTree.reparentOrphans",
-      "instances.list",
-      "instances.inspect",
-      "project.search",
-      "instances.insertComponent",
-      "instances.insertFragment",
-      "instances.move",
-      "instances.reparent",
-      "instances.fillGrid",
-      "instances.wrap",
-      "instances.convert",
-      "instances.unwrap",
-      "instances.clone",
-      "instances.duplicateAfterItself",
-      "instances.delete",
-      "instances.deleteBySelector",
-      "instances.updateProps",
-      "instances.replacePropText",
-      "instances.deleteProps",
-      "instances.bindProps",
-      "instances.listTexts",
-      "instances.updateText",
-      "instances.replaceText",
-      "instances.setTextContent",
-      "instances.updateTextTree",
-      "instances.setTag",
-      "instances.setLabel",
-      "styles.getDeclarations",
-      "styles.updateDeclarations",
-      "styles.deleteDeclarations",
-      "styles.updateSelectedDeclarations",
-      "styles.deleteSelectedDeclarations",
-      "styles.replaceValues",
-      "designTokens.list",
-      "designTokens.create",
-      "designTokens.createAttached",
-      "designTokens.updateStyles",
-      "designTokens.deleteStyles",
-      "designTokens.attach",
-      "designTokens.detach",
-      "designTokens.extract",
-      "styleSources.rename",
-      "styleSources.delete",
-      "styleSources.setLock",
-      "styleSources.reorder",
-      "styleSources.clearStyles",
-      "styleSources.duplicate",
-      "styleSources.convertLocalToToken",
-      "cssVariables.list",
-      "cssVariables.define",
-      "cssVariables.delete",
-      "cssVariables.rewriteRefs",
-      "cssVariables.rename",
-      "variables.list",
-      "variables.create",
-      "variables.update",
-      "variables.delete",
-      "variables.deleteUnused",
-      "resources.list",
-      "resources.create",
-      "resources.update",
-      "resources.replaceText",
-      "resources.upsert",
-      "resources.upsertProp",
-      "resources.delete",
-      "assets.list",
-      "fonts.list",
-      "assets.findUsage",
-      "assets.update",
-      "assets.setImageDescriptions",
-      "assets.add",
-      "assets.replace",
-      "assets.delete",
-    ]
-  `);
+  ).toEqual([]);
+  expect(
+    Object.keys(runtimeOutputSchemas)
+      .filter((operationId) => operationId.startsWith("system.") === false)
+      .sort()
+  ).toEqual(builderRuntimeOperations.map((operation) => operation.id).sort());
+  expect(() => getRuntimeOutputSchema("missing.operation")).toThrow(
+    'Missing runtime output schema for operation "missing.operation".'
+  );
+});
+
+test("validates structured runtime operation results", () => {
+  expect(
+    getRuntimeOutputSchema("resources.update").parse({ resourceId: "resource" })
+  ).toEqual({ resourceId: "resource" });
+  expect(
+    getRuntimeOutputSchema("resources.update").parse({
+      resourceId: "resource",
+      dataSourceId: "data-source",
+      warnings: ["warning"],
+    })
+  ).toMatchObject({ dataSourceId: "data-source", warnings: ["warning"] });
+
+  expect(
+    getRuntimeOutputSchema("instances.deleteBySelector").safeParse({
+      instanceSelector: ["instance", "parent"],
+    }).success
+  ).toBe(false);
+  expect(
+    getRuntimeOutputSchema("instances.replacePropText").parse({
+      changedCount: 1,
+      matchingPropCount: 1,
+      truncated: false,
+      matches: [
+        {
+          propId: "prop",
+          instanceId: "instance",
+          name: "title",
+          before: "Before",
+          after: "After",
+        },
+      ],
+    }).matches
+  ).toHaveLength(1);
 });
 
 describe("builder runtime pages", () => {

--- a/packages/project-build/src/runtime/registry.ts
+++ b/packages/project-build/src/runtime/registry.ts
@@ -27,6 +27,13 @@ import * as search from "./search";
 import * as audit from "./audit";
 import * as styles from "./styles";
 import { getZodValidationIssues, throwBuilderValidationError } from "./errors";
+import {
+  createRuntimeMutationExecutionSchema,
+  getRuntimeOutputSchema,
+  type RuntimeOperationOutput,
+  type RuntimeOutputSchemaId,
+} from "./output-schemas";
+import type { BuilderRuntimeMutation } from "./mutation";
 
 export type BuilderRuntimeOperation<
   Id extends string = string,
@@ -40,8 +47,8 @@ export type BuilderRuntimeOperation<
   kind: "read" | "mutation";
   inputSchema: z.ZodTypeAny;
   inputJsonSchema: InputJsonSchema;
-  outputSchema?: z.ZodTypeAny;
-  outputJsonSchema?: InputJsonSchema;
+  outputSchema: z.ZodTypeAny;
+  outputJsonSchema: InputJsonSchema;
   readNamespaces: readonly BuilderNamespace[];
   writeNamespaces: readonly BuilderNamespace[];
   invalidatesNamespaces: readonly BuilderNamespace[];
@@ -78,6 +85,18 @@ type RuntimeOperationContractInput =
       requiresAssets?: boolean;
       requiresConfirm?: boolean;
     };
+
+type ReadContract = Extract<RuntimeOperationContractInput, { kind: "read" }>;
+type MutationContract = Extract<
+  RuntimeOperationContractInput,
+  { kind: "mutation" }
+>;
+type RuntimeExecutionOutput<
+  Id extends RuntimeOutputSchemaId,
+  Contract extends RuntimeOperationContractInput,
+> = Contract extends MutationContract
+  ? BuilderRuntimeMutation<RuntimeOperationOutput<Id>>
+  : RuntimeOperationOutput<Id>;
 
 const throwInvalidOperationInput = (
   error: z.ZodError,
@@ -139,26 +158,36 @@ const bindExpressionInput = (
 };
 
 const runtimeOperation = <
-  Id extends string,
+  Id extends RuntimeOutputSchemaId,
   Schema extends z.ZodTypeAny,
-  Result,
+  Contract extends RuntimeOperationContractInput,
 >(
   id: Id,
   publicApi: RuntimeOperationPublicApi,
-  contract: RuntimeOperationContractInput,
+  contract: Contract,
   inputSchema: Schema,
   execute: (args: {
     state: BuilderState;
     input: z.output<Schema>;
     context: BuilderRuntimeContext;
-  }) => Result | Promise<Result>,
-  outputSchema?: z.ZodTypeAny
-): BuilderRuntimeOperation<Id, z.input<Schema>, Result> => {
+  }) =>
+    | RuntimeExecutionOutput<Id, Contract>
+    | Promise<RuntimeExecutionOutput<Id, Contract>>
+): BuilderRuntimeOperation<
+  Id,
+  z.input<Schema>,
+  RuntimeExecutionOutput<Id, Contract>
+> => {
   const writeNamespaces =
     contract.kind === "mutation" ? contract.writeNamespaces : [];
   const inputJsonSchema = getInputSchemaMetadata(inputSchema, {
     isHiddenField: isHiddenPublicApiInputField,
   }).inputJsonSchema;
+  const outputSchema = getRuntimeOutputSchema(id);
+  const executionOutputSchema =
+    contract.kind === "mutation"
+      ? createRuntimeMutationExecutionSchema(outputSchema)
+      : outputSchema;
   return {
     id,
     ...publicApi,
@@ -166,10 +195,7 @@ const runtimeOperation = <
     inputSchema,
     inputJsonSchema,
     outputSchema,
-    outputJsonSchema:
-      outputSchema === undefined
-        ? undefined
-        : getInputSchemaMetadata(outputSchema).inputJsonSchema,
+    outputJsonSchema: getInputSchemaMetadata(outputSchema).inputJsonSchema,
     readNamespaces: contract.readNamespaces,
     writeNamespaces,
     invalidatesNamespaces:
@@ -194,31 +220,19 @@ const runtimeOperation = <
         input: parseOperationInput(inputSchema, input, inputJsonSchema),
         context,
       });
-      if (outputSchema === undefined) {
-        return result;
-      }
-      const parseOutput = (value: Result) => {
-        if (contract.kind === "mutation") {
-          if (
-            typeof value !== "object" ||
-            value === null ||
-            "result" in value === false
-          ) {
-            throw new Error(
-              `Mutation runtime operation "${id}" must return a mutation envelope with a result.`
-            );
-          }
-          return {
-            ...value,
-            result: outputSchema.parse(value.result),
-          } as Result;
-        }
-        return outputSchema.parse(value) as Result;
-      };
       if (result instanceof Promise) {
-        return result.then(parseOutput);
+        return result.then(
+          (value) =>
+            executionOutputSchema.parse(value) as RuntimeExecutionOutput<
+              Id,
+              Contract
+            >
+        );
       }
-      return parseOutput(result);
+      return executionOutputSchema.parse(result) as RuntimeExecutionOutput<
+        Id,
+        Contract
+      >;
     },
   };
 };
@@ -232,7 +246,7 @@ const api = (
 const readContract = (
   readNamespaces: readonly BuilderNamespace[],
   options: { requiresAssets?: boolean } = {}
-): RuntimeOperationContractInput => ({
+): ReadContract => ({
   kind: "read",
   readNamespaces,
   ...options,
@@ -245,7 +259,7 @@ const mutationContract = (input: {
   retryOnConflict?: boolean;
   requiresAssets?: boolean;
   requiresConfirm?: boolean;
-}): RuntimeOperationContractInput => ({ kind: "mutation", ...input });
+}): MutationContract => ({ kind: "mutation", ...input });
 
 const pageNamespaces = ["pages", "instances"] as const;
 const instanceReadNamespaces = ["pages", "instances", "props"] as const;
@@ -814,8 +828,7 @@ export const builderRuntimeOperations = [
       "breakpoints",
     ]),
     audit.auditInput,
-    ({ state, input, context }) => audit.audit(state, input, context),
-    audit.auditResult
+    ({ state, input, context }) => audit.audit(state, input, context)
   ),
   runtimeOperation(
     "instances.insertComponent",

--- a/packages/project-build/src/runtime/registry.ts
+++ b/packages/project-build/src/runtime/registry.ts
@@ -850,8 +850,7 @@ export const builderRuntimeOperations = [
     }),
     collection.insertCollectionInput,
     ({ state, input, context }) =>
-      components.insertCollection(state, input, context),
-    collection.insertCollectionResult
+      components.insertCollection(state, input, context)
   ),
   runtimeOperation(
     "instances.insertFragment",

--- a/packages/project-build/src/runtime/search.ts
+++ b/packages/project-build/src/runtime/search.ts
@@ -367,7 +367,7 @@ export const analyzeProject = (
     instanceIds ?? getRelatedPageInstanceIds(instanceId, pageInstanceIds);
   const isInScope = (instanceId: string) =>
     instanceIds === undefined || instanceIds.has(instanceId);
-  const matches: Array<Record<string, unknown>> = [];
+  const matches: Array<Record<string, unknown> & { kind: string }> = [];
 
   if (scopes.has("instances")) {
     for (const instance of state.instances.values()) {
@@ -1474,4 +1474,4 @@ export const analyzeProject = (
 export const searchProject = (
   state: Parameters<typeof analyzeProject>[0],
   input: z.infer<typeof projectSearchInput>
-) => analyzeProject(state, input);
+) => ({ ...analyzeProject(state, input), query: input.query });

--- a/packages/protocol/src/builder-api/runtime-contracts.test.ts
+++ b/packages/protocol/src/builder-api/runtime-contracts.test.ts
@@ -18,9 +18,7 @@ test("exposes public runtime contracts without private metadata", () => {
       permit: contract.permit,
       kind: contract.kind,
       inputSchema: contract.inputSchema,
-      ...("outputSchema" in contract
-        ? { outputSchema: contract.outputSchema }
-        : {}),
+      outputSchema: contract.outputSchema,
       readNamespaces: contract.readNamespaces,
       writeNamespaces: contract.writeNamespaces,
       invalidatesNamespaces: contract.invalidatesNamespaces,
@@ -40,6 +38,53 @@ test("exposes the audit output schema and stable rule ids", () => {
   expect(outputSchema).toContain('"missing-aria-reference"');
   expect(outputSchema).toContain('"contractVersion"');
   expect(outputSchema).toContain('"const":1');
+});
+
+test("exposes complete output schemas for every public runtime operation", () => {
+  expect(
+    publicRuntimeOperationContracts
+      .filter((contract) => contract.outputSchema === undefined)
+      .map((contract) => contract.id)
+  ).toEqual([]);
+
+  const byId = new Map(
+    publicRuntimeOperationContracts.map((contract) => [contract.id, contract])
+  );
+  expect(byId.get("pages.list")?.outputSchema.properties?.pages).toBeDefined();
+  expect(
+    byId.get("instances.inspect")?.outputSchema.properties?.ancestors
+  ).toBeDefined();
+  expect(
+    byId.get("instances.inspect")?.outputSchema.properties?.props
+  ).toMatchObject({ type: "array" });
+  expect(
+    byId.get("instances.inspect")?.outputSchema.properties?.children
+  ).toMatchObject({ type: "array" });
+  expect(byId.get("assets.update")?.outputSchema).toMatchObject({
+    required: ["assetId"],
+  });
+  expect(byId.get("resources.update")?.outputSchema).toMatchObject({
+    properties: {
+      resourceId: { type: "string" },
+      dataSourceId: { type: "string" },
+      warnings: { type: "array" },
+    },
+    required: ["resourceId"],
+  });
+  expect(byId.get("instances.deleteBySelector")?.outputSchema).toMatchObject({
+    properties: {
+      instanceIds: { type: "array" },
+      instanceSelector: { type: "array" },
+    },
+    required: ["instanceIds"],
+  });
+  expect(byId.get("projectSettings.get")?.outputSchema).toMatchObject({
+    properties: {
+      meta: { properties: { siteName: { type: "string" } } },
+      compiler: { properties: { atomicStyles: { type: "boolean" } } },
+      redirects: { type: "array" },
+    },
+  });
 });
 
 test("exposes public operation namespaces from builder namespaces", () => {

--- a/packages/protocol/src/builder-api/runtime-contracts.ts
+++ b/packages/protocol/src/builder-api/runtime-contracts.ts
@@ -23,7 +23,7 @@ export type PublicRuntimeOperationContract = {
   permit?: PublicApiOperationPermit;
   kind: PublicApiOperationKind;
   inputSchema: InputJsonSchema;
-  outputSchema?: InputJsonSchema;
+  outputSchema: InputJsonSchema;
   readNamespaces: readonly PublicApiOperationNamespace[];
   writeNamespaces: readonly PublicApiOperationNamespace[];
   invalidatesNamespaces: readonly PublicApiOperationNamespace[];
@@ -55,9 +55,7 @@ export const publicRuntimeOperationContracts: readonly PublicRuntimeOperationCon
       permit,
       kind,
       inputSchema,
-      ...("outputSchema" in contract
-        ? { outputSchema: contract.outputSchema }
-        : {}),
+      outputSchema: contract.outputSchema,
       readNamespaces,
       writeNamespaces,
       invalidatesNamespaces,


### PR DESCRIPTION
## What changed\n\n- Define concrete output schemas for every public runtime operation.\n- Expose output schemas through generated runtime contracts and MCP tool discovery.\n- Validate runtime results against their declared schemas, including mutation result envelopes.\n- Add output contracts for project-session status, refresh, reset, Collection insertion, and generated-preview tools.\n- Make every advertised MCP output schema explicitly object-shaped for strict clients.\n- Keep generated schema definitions at the correct root so local references resolve during tool discovery.\n- Report the correct session operation metadata for refresh and reset.\n- Preserve local workspace package resolution when the local CLI builds a generated React Router preview.\n\n## Why\n\nAgents could discover input requirements, but several tools did not describe their returned data. Strict MCP clients could also reject the complete tool catalog during reconnect because output schemas were not consistently object-shaped or contained unresolved local references.\n\n## User impact\n\n- Agents can plan calls from complete input and output contracts.\n- MCP clients can fetch the full Webstudio tool catalog without schema-validation failures.\n- Agents can reliably parse and validate command results.\n- Local generated previews continue to work for visual verification.\n\n## Validation\n\n- Every public runtime operation has an output schema.\n- Every advertised MCP output schema is object-shaped and has resolvable local references.\n- A real stdio MCP client connected through the local CLI and fetched 154 tools, including 119 valid output schemas.\n- Runtime output contracts validate representative query and mutation results.\n- A fresh subagent refreshed a real project session, built and started the generated site, captured the target route with HTTP 200, checked preview status, and stopped the server.\n- Focused project-build tests, project-build and CLI typechecks, lint, formatting, and generated-doc checks passed.\n