### PR TITLE
fix: wait for db over TCP in dev/backend.sh to avoid false-positive readiness

### DIFF
--- a/apps/builder/dev/backend.sh
+++ b/apps/builder/dev/backend.sh
@@ -57,8 +57,12 @@ builder_backend_wait_for_db() {
   local timeout_at
   timeout_at="$(($(date +%s) + timeout_seconds))"
 
+  # Connect over TCP, not the unix socket: the postgres image's entrypoint
+  # runs a temporary socket-only server (listen_addresses='') during init,
+  # which lets a socket probe pass while host clients (prisma migrate,
+  # postgrest) still get connection refused.
   until builder_compose exec -T db \
-    sh -c 'psql -q -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c "SELECT 1"' \
+    sh -c 'PGPASSWORD="$POSTGRES_PASSWORD" psql -q -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c "SELECT 1"' \
     >/dev/null 2>&1; do
     if [ "$(date +%s)" -ge "$timeout_at" ]; then
       echo "Timed out waiting for database" >&2


### PR DESCRIPTION
## Description

`builder_backend_wait_for_db` checks readiness by running `psql` inside the `db` container, which connects over the **unix socket**. The official `postgres` image's entrypoint starts a temporary server with `listen_addresses=''` (socket only) while it runs its init phase. During that window the socket probe succeeds, but host-side clients (prisma migrate, postgrest) connecting over TCP still get `connection refused` . so the wait can return before the database is actually reachable.

It's a timing race: it rarely bites with a fast init, but it's reproducible with slower images/machines (we hit it consistently in our fork's CI, which uses a pg image with a longer init phase).

Fix: make the readiness probe connect the same way real clients do. Over TCP (`psql -h 127.0.0.1`). `PGPASSWORD` is needed because host connections use password auth, unlike the socket which is `trust`.

Same one-line change to the probe in `builder_backend_wait_for_db`; behavior is otherwise identical.

## Steps for reproduction

1. `docker compose down -v` in `apps/builder` (force a fresh initdb)
2. run `dev/run-local.sh` (or anything using `builder_backend_wait_for_db`)
3. on a slow machine the wait returns during the init phase and the following `prisma migrate` / postgrest startup fails with `connection refused`; with this patch the wait only returns once TCP is accepting connections

## Code Review

- [ ] hi @kof, I need you to do
  - detailed review (it's a one-line probe change in `dev/backend.sh`)

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated test cases document n/a (dev tooling only)
- [ ] added tests -> n/a (shell dev script)
- [x] if any new env variables are added, added them to `.env` file -> none added
