### PR TITLE
fix: render head slot JSON-LD in document head

### DIFF
--- a/packages/sdk-components-react/src/head-slot-context.ts
+++ b/packages/sdk-components-react/src/head-slot-context.ts
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const HeadSlotContext = createContext(false);

--- a/packages/sdk-components-react/src/head-slot.tsx
+++ b/packages/sdk-components-react/src/head-slot.tsx
@@ -4,6 +4,7 @@ import {
   type Hook,
 } from "@webstudio-is/react-sdk/runtime";
 import { forwardRef, type ElementRef, useContext, type ReactNode } from "react";
+import { HeadSlotContext } from "./head-slot-context";
 import { XmlNode } from "./xml-node";
 
 export const defaultTag = "head";
@@ -15,7 +16,11 @@ export const HeadSlot = forwardRef<
   const { renderer } = useContext(ReactSdkContext);
 
   if (renderer === undefined) {
-    return children;
+    return (
+      <HeadSlotContext.Provider value={true}>
+        {children}
+      </HeadSlotContext.Provider>
+    );
   }
 
   if (props["data-ws-expand"] !== true) {

--- a/packages/sdk-components-react/src/json-ld-head.test.tsx
+++ b/packages/sdk-components-react/src/json-ld-head.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, expect, test } from "vitest";
+import { HeadSlot } from "./head-slot";
+import { JsonLd } from "./json-ld";
+
+afterEach(cleanup);
+
+test("renders JSON-LD in the document head when nested in Head Slot", async () => {
+  const { container } = render(
+    <HeadSlot>
+      <JsonLd code={{ "@context": "https://schema.org", name: "Acme" }} />
+    </HeadSlot>
+  );
+
+  await waitFor(() => {
+    expect(
+      document.head.querySelector('script[type="application/ld+json"]')
+    ).not.toBeNull();
+  });
+  expect(
+    container.querySelector('script[type="application/ld+json"]')
+  ).toBeNull();
+});
+
+test("keeps JSON-LD in page flow when it is outside Head Slot", () => {
+  const { container } = render(
+    <JsonLd code={{ "@context": "https://schema.org", name: "Acme" }} />
+  );
+
+  expect(
+    container.querySelector('script[type="application/ld+json"]')
+  ).not.toBeNull();
+  expect(
+    document.head.querySelector('script[type="application/ld+json"]')
+  ).toBeNull();
+});

--- a/packages/sdk-components-react/src/json-ld.tsx
+++ b/packages/sdk-components-react/src/json-ld.tsx
@@ -3,7 +3,16 @@ import {
   escapeJsonLdScriptText,
   validateJsonLd,
 } from "@webstudio-is/sdk/runtime";
-import { forwardRef, type ElementRef, type Ref, useContext } from "react";
+import {
+  forwardRef,
+  type ElementRef,
+  type Ref,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { HeadSlotContext } from "./head-slot-context";
 import { XmlNode } from "./xml-node";
 
 export const defaultTag = "script";
@@ -19,7 +28,15 @@ const serializeJsonLd = (code: unknown) => {
 export const JsonLd = forwardRef<ElementRef<"script">, { code?: unknown }>(
   ({ code = "" }, ref) => {
     const { renderer } = useContext(ReactSdkContext);
+    const isInHeadSlot = useContext(HeadSlotContext);
+    const [isMounted, setIsMounted] = useState(false);
     const serialized = serializeJsonLd(code);
+
+    useEffect(() => {
+      if (isInHeadSlot) {
+        setIsMounted(true);
+      }
+    }, [isInHeadSlot]);
 
     if (renderer === "canvas") {
       return (
@@ -44,13 +61,19 @@ export const JsonLd = forwardRef<ElementRef<"script">, { code?: unknown }>(
       return null;
     }
 
-    return (
+    const script = (
       <script
         ref={ref}
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: content }}
       />
     );
+
+    if (isInHeadSlot && isMounted) {
+      return createPortal(script, document.head);
+    }
+
+    return script;
   }
 );
 


### PR DESCRIPTION
## What changed

- mark published Head Slot descendants with an internal context
- portal JSON-LD scripts nested in Head Slot into `document.head`
- preserve page-flow rendering for JSON-LD used outside Head Slot
- add browser-DOM regression coverage for both placements

## Root cause

React hoists `title`, `meta`, and `link` elements rendered by Head Slot, but it does not hoist inline `script type="application/ld+json"` elements. As a result, JSON-LD nested in Head Slot remained under the page body.

## Impact

JSON-LD placed in Head Slot now appears in the document head after the published page mounts. JSON-LD intentionally placed outside Head Slot remains in its original page position.

## Validation

- `pnpm --filter @webstudio-is/sdk-components-react test`
- `pnpm --filter @webstudio-is/sdk-components-react typecheck`
- targeted oxlint on changed files
- `pnpm --filter @webstudio-is/sdk-components-react build`
- `pnpm build`
