### PR TITLE
fix: remap conflicting pasted breakpoint ids

### DIFF
--- a/apps/builder/app/shared/instance-utils/fragment.test.tsx
+++ b/apps/builder/app/shared/instance-utils/fragment.test.tsx
@@ -242,6 +242,7 @@ describe("fragment copy helpers", () => {
         ],
       }),
       breakpoints,
+      createId: () => "generated-breakpoint",
       onBreakpointLimitMerge: () => {
         didMergeDueToLimit = true;
       },

--- a/packages/project-build/src/runtime/components.test.ts
+++ b/packages/project-build/src/runtime/components.test.ts
@@ -786,6 +786,60 @@ test("inserts webstudio jsx fragment with styles", async () => {
   ]);
 });
 
+test("remaps fragment breakpoint ids that conflict with existing breakpoints", () => {
+  const parent = createParent();
+  const state = createState(parent);
+  state.breakpoints.set("1", {
+    id: "1",
+    label: "Desktop",
+    minWidth: 1280,
+  });
+
+  const mutation = insertFragment(
+    state,
+    {
+      parentInstanceId: parent.id,
+      fragment: {
+        ...createEmptyWebstudioFragment(),
+        children: [{ type: "id", value: "fragment-instance" }],
+        instances: [
+          {
+            type: "instance",
+            id: "fragment-instance",
+            component: elementComponent,
+            tag: "div",
+            children: [],
+          },
+        ],
+        styleSourceSelections: [
+          { instanceId: "fragment-instance", values: ["local-style"] },
+        ],
+        styleSources: [{ type: "local", id: "local-style" }],
+        breakpoints: [{ id: "1", label: "Tablet", maxWidth: 991 }],
+        styles: [
+          {
+            styleSourceId: "local-style",
+            breakpointId: "1",
+            property: "display",
+            value: { type: "keyword", value: "grid" },
+          },
+        ],
+      },
+    },
+    {
+      createId: createIdFactory(),
+      projectId: "project-id",
+    }
+  );
+
+  expect(getAddedValues<{ id: string }>(mutation, "breakpoints")).toEqual([
+    expect.objectContaining({ id: "generated-0", maxWidth: 991 }),
+  ]);
+  expect(getAddedValues<StyleDecl>(mutation, "styles")).toContainEqual(
+    expect.objectContaining({ breakpointId: "generated-0" })
+  );
+});
+
 test("inserts fragment into legacy Slot content by normalizing shared Fragment", async () => {
   const state = createState({
     type: "instance",

--- a/packages/project-build/src/runtime/fragment.ts
+++ b/packages/project-build/src/runtime/fragment.ts
@@ -493,10 +493,12 @@ const insertFragmentAssetsMutable = ({
 const insertFragmentBreakpointsMutable = ({
   fragment,
   breakpoints,
+  createId,
   onBreakpointLimitMerge,
 }: {
   fragment: WebstudioFragment;
   breakpoints: Breakpoints;
+  createId: () => string;
   onBreakpointLimitMerge?: () => void;
 }) => {
   let didMergeBreakpointsDueToLimit = false;
@@ -515,7 +517,17 @@ const insertFragmentBreakpointsMutable = ({
   }
   for (const newBreakpoint of fragment.breakpoints) {
     if (mergedBreakpointIds.has(newBreakpoint.id) === false) {
-      breakpoints.set(newBreakpoint.id, newBreakpoint);
+      let newBreakpointId = newBreakpoint.id;
+      while (breakpoints.has(newBreakpointId)) {
+        newBreakpointId = createId();
+      }
+      breakpoints.set(newBreakpointId, {
+        ...newBreakpoint,
+        id: newBreakpointId,
+      });
+      if (newBreakpointId !== newBreakpoint.id) {
+        mergedBreakpointIds.set(newBreakpoint.id, newBreakpointId);
+      }
     }
   }
   return { mergedBreakpointIds, didMergeBreakpointsDueToLimit };
@@ -591,6 +603,7 @@ export const insertWebstudioFragmentCopy = ({
       ? insertFragmentBreakpointsMutable({
           fragment,
           breakpoints,
+          createId,
           onBreakpointLimitMerge,
         })
       : {


### PR DESCRIPTION
## What changed

- Remap pasted breakpoint IDs when the same ID already belongs to a different breakpoint in the destination project.
- Carry the remapped ID into pasted style declarations.
- Add a regression test for inserting a fragment whose breakpoint ID conflicts with an existing project breakpoint.

## Why

HTML and Tailwind conversion uses compact fragment-local breakpoint IDs such as `"0"` and `"1"`. In non-empty projects, one of those IDs can already identify a different breakpoint. The fragment copy path previously retained the incoming ID, causing the runtime to reject the mutation with `Generated record id "1" already exists`.

## Impact

Pasting HTML with Tailwind classes now works in existing projects even when generated fragment breakpoint IDs overlap project breakpoint IDs. Matching breakpoints continue to be reused.

## Validation

- `pnpm --filter @webstudio-is/project-build test -- src/runtime/components.test.ts`
- `pnpm --filter @webstudio-is/project-build test -- src/runtime/fragment.test.tsx src/runtime/breakpoints.test.ts`
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm exec oxlint packages/project-build/src/runtime/fragment.ts packages/project-build/src/runtime/components.test.ts`
- `pnpm exec oxfmt --check packages/project-build/src/runtime/fragment.ts packages/project-build/src/runtime/components.test.ts`
- `git diff --check`