### PR TITLE
fix: Fix insertion of content-model component parts

### DIFF
--- a/packages/project-build/src/runtime/components.test.ts
+++ b/packages/project-build/src/runtime/components.test.ts
@@ -1933,6 +1933,63 @@ test("rejects known provider child components without standalone templates", asy
   );
 });
 
+test.each(["AnimateText", "StaggerAnimation"])(
+  "inserts animation part %s into an Animation Group",
+  (name) => {
+    const parent: Instance = {
+      type: "instance",
+      id: "animation-group",
+      component: "@webstudio-is/sdk-components-animation:AnimateChildren",
+      children: [],
+    };
+    const component = `@webstudio-is/sdk-components-animation:${name}`;
+
+    const mutation = insertComponent(
+      createState(parent),
+      {
+        parentInstanceId: parent.id,
+        component,
+      },
+      {
+        createId: createIdFactory(),
+      }
+    );
+
+    expect(getAddedValues<Instance>(mutation, "instances")).toContainEqual(
+      expect.objectContaining({ component })
+    );
+  }
+);
+
+test("inserts a component part allowed by an ancestor content model", () => {
+  const parent = createParent();
+  const ancestor: Instance = {
+    type: "instance",
+    id: "checkbox",
+    component: "@webstudio-is/sdk-components-react-radix:Checkbox",
+    children: [{ type: "id", value: parent.id }],
+  };
+  const component =
+    "@webstudio-is/sdk-components-react-radix:CheckboxIndicator";
+  const state = createState(ancestor);
+  state.instances.set(parent.id, parent);
+
+  const mutation = insertComponent(
+    state,
+    {
+      parentInstanceId: parent.id,
+      component,
+    },
+    {
+      createId: createIdFactory(),
+    }
+  );
+
+  expect(getAddedValues<Instance>(mutation, "instances")).toContainEqual(
+    expect.objectContaining({ component })
+  );
+});
+
 test("rejects native option outside select and suggests select", async () => {
   const parent = createParent();
 

--- a/packages/project-build/src/runtime/components.ts
+++ b/packages/project-build/src/runtime/components.ts
@@ -56,6 +56,7 @@ import {
 import { createRuntimeMutation, type BuilderRuntimeMutation } from "./mutation";
 import { getSlotFragmentDropTargetMutable } from "./slot";
 import type { ConflictResolution } from "./style-copy";
+import { findPageAndSelectorByInstanceId } from "./lookup";
 import { z } from "zod";
 
 const conflictResolutionInput = z.enum(["ours", "theirs", "merge"]);
@@ -142,9 +143,28 @@ const canContainDescendant = (
   );
 };
 
-const getStandaloneInsertError = (component: Instance["component"]) => {
-  const meta = componentMetas.get(component);
-  if (meta?.contentModel?.category !== "none") {
+const getComponentPartInsertError = ({
+  component,
+  ancestors,
+}: {
+  component: Instance["component"];
+  ancestors: readonly Instance[];
+}) => {
+  const [parent] = ancestors;
+  const allowedChildren =
+    parent === undefined
+      ? []
+      : (componentMetas.get(parent.component)?.contentModel?.children ?? []);
+  const allowedByAncestor = ancestors.some((ancestor) => {
+    const descendants =
+      componentMetas.get(ancestor.component)?.contentModel?.descendants ?? [];
+    return descendants.includes(component) || descendants.includes("none");
+  });
+  if (
+    allowedChildren.includes(component) ||
+    allowedChildren.includes("none") ||
+    allowedByAncestor
+  ) {
     return;
   }
   const suggestions = Array.from(componentMetas.entries())
@@ -884,7 +904,21 @@ export const insertComponent = (
   const fragment = createComponentTemplateFragment({
     component: input.component,
     templates,
-    getFallbackError: getStandaloneInsertError,
+    getFallbackError: (component) => {
+      if (componentMetas.get(component)?.contentModel?.category !== "none") {
+        return;
+      }
+      const { instanceSelector } = findPageAndSelectorByInstanceId(
+        mutationState.pages,
+        mutationState.instances,
+        parent.id
+      );
+      const ancestors = instanceSelector.flatMap((instanceId) => {
+        const instance = mutationState.instances.get(instanceId);
+        return instance === undefined ? [] : [instance];
+      });
+      return getComponentPartInsertError({ component, ancestors });
+    },
     createId: context.createId,
   });
   if (input.component === elementComponent) {

--- a/packages/project-build/src/runtime/lookup.test.ts
+++ b/packages/project-build/src/runtime/lookup.test.ts
@@ -72,6 +72,29 @@ describe("getInstancePath", () => {
 });
 
 describe("findPageAndSelectorByInstanceId", () => {
+  test("supports legacy instances without a children field", () => {
+    const pages = createDefaultPages({
+      homePageId: "homePageId",
+      rootInstanceId: "root",
+    });
+    const legacyRoot = {
+      type: "instance",
+      id: "root",
+      component: "Body",
+    } as Instance;
+
+    expect(
+      findPageAndSelectorByInstanceId(
+        pages,
+        new Map([[legacyRoot.id, legacyRoot]]),
+        legacyRoot.id
+      )
+    ).toEqual({
+      pageId: "homePageId",
+      instanceSelector: [legacyRoot.id],
+    });
+  });
+
   test("returns page id and selector for instances in nested pages", () => {
     const pages = createDefaultPages({
       homePageId: "homePageId",

--- a/packages/project-build/src/runtime/lookup.ts
+++ b/packages/project-build/src/runtime/lookup.ts
@@ -57,7 +57,7 @@ export const findPageAndSelectorByInstanceId = (
   if (parentInstanceById === undefined) {
     parentInstanceById = new Map<Instance["id"], Instance["id"]>();
     for (const instance of instances.values()) {
-      for (const child of instance.children) {
+      for (const child of instance.children ?? []) {
         if (child.type === "id") {
           parentInstanceById.set(child.value, instance.id);
         }


### PR DESCRIPTION
## What changed

- Allow template-less component parts to be inserted when the target parent explicitly permits them through `children`.
- Honor component parts permitted by an ancestor through `descendants`.
- Keep invalid standalone insertion blocked.
- Support legacy instances without a `children` field while resolving ancestor selectors.
- Add regression coverage for Text Animation, Stagger Animation, nested Radix parts, and legacy instances.

## Why

Text Animation and Stagger Animation were valid direct children of Animation Group according to their content models, but the runtime rejected every template-less component with `contentModel.category: "none"` before considering its target parent.

The registry audit also found that hidden base and Radix component parts could hit the same rejection through direct internal or MCP insertion, even when an ancestor explicitly allowed them.

## Impact

Text Animation and Stagger Animation can now be inserted into Animation Group. Programmatic insertion of hidden component parts also follows the same content-model rules consistently.

## Validation

- `pnpm --filter @webstudio-is/project-build test` — 1,984 tests passed
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm lint`
- `pnpm check:package-boundaries`
- Formatting and diff checks
