### PR TITLE
fix: make the page Status code field robust (#5913)

### DIFF
--- a/packages/project-build/src/runtime/pages.test.ts
+++ b/packages/project-build/src/runtime/pages.test.ts
@@ -1203,6 +1203,18 @@ describe("page input schemas", () => {
     expect(() => pageMetaInput.parse({ documentType: "json" })).toThrow();
   });
 
+  test("stores a numeric status code as a number literal", () => {
+    // A plain numeric status must become the number literal `302`, not the
+    // string literal `"302"` that would trip the Builder's numeric validation.
+    expect(pageFieldsInput.parse({ meta: { status: "302" } })).toEqual({
+      meta: { status: "302" },
+    });
+    // Non-numeric status stays an expression for dynamic status handling.
+    expect(
+      pageFieldsInput.parse({ meta: { status: "system.status" } }).meta?.status
+    ).toBe("system.status");
+  });
+
   test("reports page expression errors", () => {
     expect(
       getPageExpressionErrors({

--- a/packages/project-build/src/runtime/pages.test.ts
+++ b/packages/project-build/src/runtime/pages.test.ts
@@ -241,6 +241,40 @@ describe("page settings values", () => {
       shouldSetHomePage: true,
     });
   });
+
+  test("forwards a cleared status code so the patch removes it", () => {
+    const pages = createPages();
+    const page = pages.pages.get("page")!;
+    page.meta.status = "302";
+
+    // The Builder clears the numeric Status code input to `undefined`; the
+    // cleared key must be forwarded (not skipped like an untouched field).
+    const result = getPageSettingsUpdateData({
+      page,
+      pages,
+      values: { status: undefined },
+    });
+    expect(Object.hasOwn(result.pageValues.meta ?? {}, "status")).toBe(true);
+    expect(result.pageValues.meta?.status).toBeUndefined();
+
+    // ...so the resulting patch removes the existing status.
+    expect(
+      createPageUpdatePatches({ input: result.pageValues, page, pages })
+    ).toEqual([{ op: "remove", path: ["pages", "page", "meta", "status"] }]);
+  });
+
+  test("does not touch status when it is not part of the update", () => {
+    const pages = createPages();
+    const page = pages.pages.get("page")!;
+    page.meta.status = "302";
+
+    const result = getPageSettingsUpdateData({
+      page,
+      pages,
+      values: { title: "Landing" },
+    });
+    expect(Object.hasOwn(result.pageValues.meta ?? {}, "status")).toBe(false);
+  });
 });
 
 describe("page drop targets", () => {

--- a/packages/project-build/src/runtime/pages.ts
+++ b/packages/project-build/src/runtime/pages.ts
@@ -860,10 +860,38 @@ const normalizePageExpressionInput = (value: string) => {
   return JSON.stringify(value);
 };
 
+// The status code is validated as a number, so a plain numeric value must be
+// stored as a number literal (`302`), not the string literal (`"302"`) that the
+// generic normalizer would produce and the Builder then rejects as "invalid
+// input". Non-numeric values stay expressions for dynamic status handling.
+// Mirrors the Builder Status code input (features/pages Status field).
+const normalizePageStatusInput = (value: string) => {
+  const number = Number(value);
+  if (Number.isNaN(number) === false && String(number) === value) {
+    return value;
+  }
+  return normalizePageExpressionInput(value);
+};
+
 const pageExpressionStringInput = z
   .preprocess(
     (value) =>
       typeof value === "string" ? normalizePageExpressionInput(value) : value,
+    z.string({
+      error: (issue) =>
+        issue.input !== null &&
+        typeof issue.input === "object" &&
+        Array.isArray(issue.input) === false
+          ? `${pageExpressionFieldHint} Pass it as a string, not as a prop value object like {"type":"string","value":"..."}.`
+          : undefined,
+    })
+  )
+  .describe(pageExpressionFieldHint);
+
+const pageStatusExpressionInput = z
+  .preprocess(
+    (value) =>
+      typeof value === "string" ? normalizePageStatusInput(value) : value,
     z.string({
       error: (issue) =>
         issue.input !== null &&
@@ -930,7 +958,10 @@ const normalizePageMetaExpressionInputs = (
   for (const name of pageMetaExpressionFields) {
     const value = normalized[name];
     if (typeof value === "string" && value !== "") {
-      normalized[name] = normalizePageExpressionInput(value);
+      normalized[name] =
+        name === "status"
+          ? normalizePageStatusInput(value)
+          : normalizePageExpressionInput(value);
     }
   }
   normalized.custom = normalized.custom?.map((customMeta) => ({
@@ -964,7 +995,7 @@ const pageMetaInputBase = z.object({
     .optional(),
   documentType: z.enum(["html", "xml", "text"]).optional(),
   content: pageExpressionStringInput.optional(),
-  status: pageExpressionStringInput.optional(),
+  status: pageStatusExpressionInput.optional(),
   auth: pageAuth.optional(),
   custom: z
     .array(

--- a/packages/project-build/src/runtime/pages.ts
+++ b/packages/project-build/src/runtime/pages.ts
@@ -1980,7 +1980,11 @@ export const getPageSettingsUpdateData = ({
   if (values.language !== undefined) {
     meta.language = values.language;
   }
-  if (values.status !== undefined) {
+  // Unlike the other string meta fields, the Builder's Status code input
+  // clears to `undefined` (it is numeric; empty means "no status"). We must
+  // forward that cleared key so the patch removes `meta.status`, instead of
+  // skipping it like an untouched field and leaving the old status stuck.
+  if (Object.hasOwn(values, "status")) {
     meta.status = values.status;
   }
   if (values.redirect !== undefined) {


### PR DESCRIPTION
## Description

Fixes #5913.

Two related defects in the page **Status code** meta field (`page.meta.status`):

**1. Numeric status stored as a string → "invalid input"**
When a status is written through the CLI/MCP (`create-page`, `update-page-settings`), the generic page-meta normalizer wraps every plain value in quotes, so `302` is stored as the **string** literal `"302"` instead of the **number** literal `302`. The Builder validates the status as a number (`z.number()`), so the stored string surfaces as a red **"invalid input"** and the field can't be fixed from the UI because typing re-triggers the same wrapping.

This is inconsistent with everything that consumes the status, which all expect a number literal:
- the published runtime: `pageMeta.status === 301 || pageMeta.status === 302` and `new Response(..., { status: pageMeta.status })` (`route-templates/*.tsx`);
- the internal 404-page detection: `page.meta.status === "404"` compares against the numeric-literal source (`packages/project-build/src/runtime/pages.ts`);
- the Builder's own Status input, which already stores typed numbers as number literals.

Fix: a status-specific normalizer that **mirrors the Builder's Status input**. A plain numeric value becomes a number literal (`302`), while non-numeric values stay expressions for dynamic status handling (e.g. `system.status`). String meta fields (title, description, language, redirect, content, …) are unchanged and stay quoted, since the API expects text for those.

**2. A status code can't be cleared from the Builder**
Once set, the status can't be removed: the Status input clears to `undefined`, which `getPageSettingsUpdateData` skipped like an untouched field, so the old value stayed stuck. Forward the explicitly-cleared key so the resulting patch removes `meta.status`. (Symptom: clearing the Redirect but leaving a `302` behind makes the page serve a `302` with no `Location` header.)

Note: the project-level redirects table (`pageRedirect.status`, a `z.enum(["301","302"])`) is a different field and is intentionally left untouched.

## Steps for reproduction

Invalid input:
1. Set a page's status code via the CLI/MCP (or import a project where it was), e.g. `302`.
2. Open the page settings in the Builder → Status code shows a red **"invalid input"**.
3. Expected: the status is accepted as a valid number.

Can't clear:
1. On a page that has a status code, clear the Status code input in the Builder.
2. Reopen the settings → the old status is still there.
3. Expected: the status is removed.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 0000)
- [ ] updated test cases document
- [x] added tests (`packages/project-build/src/runtime/pages.test.ts`)
- [ ] if any new env variables are added, added them to `.env` file
