### PR TITLE
ci: deduplicate builder E2E setup

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -3,6 +3,11 @@ name: CI setup
 description: |
   Sets up the CI environment for the project.
 
+inputs:
+  run-scripts:
+    description: Run dependency lifecycle scripts during installation.
+    default: "false"
+
 runs:
   using: "composite"
 
@@ -12,5 +17,10 @@ runs:
       with:
         node-version: 22
         cache: pnpm
-    - run: pnpm install --frozen-lockfile --ignore-scripts
+    - run: |
+        install_args=(--frozen-lockfile)
+        if [ "${{ inputs.run-scripts }}" != "true" ]; then
+          install_args+=(--ignore-scripts)
+        fi
+        pnpm install "${install_args[@]}"
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,24 +189,16 @@ jobs:
         with:
           submodules-ssh-key: ${{ secrets.PRIVATE_GITHUB_DEPLOY_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/ci-setup
         with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Pnpm install
-        run: pnpm install
+          run-scripts: "true"
 
       - name: Discover builder e2e shards
         id: shards
         run: echo "value=$(pnpm --dir apps/builder exec tsx ./e2e/print-shards.ts)" >> "$GITHUB_OUTPUT"
 
       - name: Build builder and generated preview dependencies
-        run: |
-          pnpm --filter=@webstudio-is/builder build
-          pnpm --filter=@webstudio-is/sdk-components-react-router build
+        run: pnpm e2e:builder:build
 
       # Generate this from the current migrations for this workflow run only.
       # Shards consume the snapshot as a fast, disposable schema cache.
@@ -257,15 +249,9 @@ jobs:
         with:
           submodules-ssh-key: ${{ secrets.PRIVATE_GITHUB_DEPLOY_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/ci-setup
         with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Pnpm install
-        run: pnpm install
+          run-scripts: "true"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/apps/builder/e2e/harness.ts
+++ b/apps/builder/e2e/harness.ts
@@ -9,6 +9,7 @@ import {
   type LaunchOptions,
 } from "playwright";
 import env from "../app/env/env.server";
+import { getE2eSuiteName } from "./test-modules";
 
 const builderPort = process.env.PORT ?? "3000";
 
@@ -45,12 +46,6 @@ type TestApi = ((name: string, run: () => Promise<void>) => void) & {
 const suites: Suite[] = [];
 const suitesByFile = new Map<string, Suite>();
 
-const formatSuiteName = (filePath: string) => {
-  return basename(filePath, ".e2e.ts")
-    .replace(/(\.\[shard-\d+\])+$/, "")
-    .replaceAll("-", " ");
-};
-
 const getCallerFile = () => {
   const stack = new Error().stack ?? "";
   const callerLine = stack
@@ -75,9 +70,10 @@ const getFileSuite = () => {
     return suite;
   }
 
+  const fileName = basename(filePath);
   suite = {
-    name: formatSuiteName(filePath),
-    fileName: basename(filePath),
+    name: getE2eSuiteName(fileName),
+    fileName,
     filePath,
     tests: [],
   };

--- a/apps/builder/e2e/run-local.sh
+++ b/apps/builder/e2e/run-local.sh
@@ -127,9 +127,8 @@ build_e2e_apps() {
 verify_e2e_apps_built() {
   local builder_server="$ROOT_DIR/apps/builder/build/server"
   local builder_assets="$ROOT_DIR/apps/builder/build/client/assets"
-  local preview_router="$ROOT_DIR/packages/sdk-components-react-router/lib/components.js"
 
-  if [ ! -d "$builder_server" ] || [ ! -d "$builder_assets" ] || [ ! -f "$preview_router" ]; then
+  if [ ! -d "$builder_server" ] || [ ! -d "$builder_assets" ]; then
     echo "E2E_SKIP_BUILDER_BUILD requires prebuilt Builder artifacts" >&2
     return 1
   fi

--- a/apps/builder/e2e/run-local.sh
+++ b/apps/builder/e2e/run-local.sh
@@ -121,8 +121,7 @@ install_playwright_chromium() {
 }
 
 build_e2e_apps() {
-  pnpm --dir "$ROOT_DIR" --filter=@webstudio-is/builder build
-  pnpm --dir "$ROOT_DIR" --filter=@webstudio-is/sdk-components-react-router build
+  pnpm --dir "$ROOT_DIR" e2e:builder:build
 }
 
 verify_e2e_apps_built() {

--- a/apps/builder/e2e/run.ts
+++ b/apps/builder/e2e/run.ts
@@ -204,36 +204,29 @@ const stopBuilder = async (child: ChildProcess | undefined) => {
 };
 
 const getRunnableSuites = () => {
-  const suites = getSuites()
-    .filter((suite) => {
-      if (testShard === undefined || testShard === "") {
+  const suites = getSuites().map((suite, suiteIndex) => ({
+    suite,
+    tests: suite.tests.filter((test, testIndex) => {
+      // Offset each suite so odd test counts do not always give the extra
+      // test to the same worker.
+      if (
+        isE2eTestInShard({
+          fileName: suite.fileName,
+          shard: testShard,
+          distributionIndex: testIndex + suiteIndex,
+        }) === false
+      ) {
+        return false;
+      }
+      if (testFilters.length === 0) {
         return true;
       }
-      return suite.fileName.includes(`[${testShard}]`);
-    })
-    .map((suite, suiteIndex) => ({
-      suite,
-      tests: suite.tests.filter((test, testIndex) => {
-        // Offset each suite so odd test counts do not always give the extra
-        // test to the same worker.
-        if (
-          isE2eTestInShard({
-            fileName: suite.fileName,
-            shard: testShard,
-            distributionIndex: testIndex + suiteIndex,
-          }) === false
-        ) {
-          return false;
-        }
-        if (testFilters.length === 0) {
-          return true;
-        }
-        const fullName = `${suite.name} › ${test.name}`;
-        return testFilters.some(
-          (filter) => test.name.includes(filter) || fullName.includes(filter)
-        );
-      }),
-    }));
+      const fullName = `${suite.name} › ${test.name}`;
+      return testFilters.some(
+        (filter) => test.name.includes(filter) || fullName.includes(filter)
+      );
+    }),
+  }));
 
   const runnableSuites = suites.filter(({ tests }) => tests.length > 0);
 

--- a/apps/builder/e2e/test-modules.test.ts
+++ b/apps/builder/e2e/test-modules.test.ts
@@ -2,9 +2,19 @@ import { expect, test } from "vitest";
 import {
   getE2eFileShards,
   getE2eShards,
+  getE2eSuiteName,
   getE2eTestModules,
   isE2eTestInShard,
 } from "./test-modules";
+
+test("formats suite names using the shared shard filename syntax", () => {
+  expect(
+    getE2eSuiteName("pages-actions.[shard-2].[shard-5].[shard-6].e2e.ts")
+  ).toBe("pages actions");
+  expect(getE2eSuiteName("asset-canvas-drag.[shard-4].e2e.ts")).toBe(
+    "asset canvas drag"
+  );
+});
 
 test("discovers every e2e module and filters ownership by shard tag", () => {
   const files = [

--- a/apps/builder/e2e/test-modules.ts
+++ b/apps/builder/e2e/test-modules.ts
@@ -1,23 +1,32 @@
 const e2eFileSuffix = ".e2e.ts";
-const shardTagPattern = /\[(shard-\d+)\]/g;
+const shardNamePattern = "shard-\\d+";
+const shardTagPattern = new RegExp(`\\[(${shardNamePattern})\\]`, "g");
+const trailingShardTagsPattern = new RegExp(`(\\.\\[${shardNamePattern}\\])+$`);
 
 export const getE2eFileShards = (fileName: string) =>
   [...fileName.matchAll(shardTagPattern)].map((match) => match[1]);
 
+export const getE2eSuiteName = (fileName: string) => {
+  const name = fileName.endsWith(e2eFileSuffix)
+    ? fileName.slice(0, -e2eFileSuffix.length)
+    : fileName;
+  return name.replace(trailingShardTagsPattern, "").replaceAll("-", " ");
+};
+
 export const getE2eShards = (fileNames: readonly string[]) => {
-  const e2eFiles = fileNames.filter((fileName) =>
-    fileName.endsWith(e2eFileSuffix)
-  );
-  const unassignedFiles = e2eFiles.filter(
-    (fileName) => getE2eFileShards(fileName).length === 0
-  );
+  const e2eFiles = fileNames
+    .filter((fileName) => fileName.endsWith(e2eFileSuffix))
+    .map((fileName) => ({ fileName, shards: getE2eFileShards(fileName) }));
+  const unassignedFiles = e2eFiles
+    .filter(({ shards }) => shards.length === 0)
+    .map(({ fileName }) => fileName);
   if (unassignedFiles.length > 0) {
     throw new Error(
       `Every e2e file must have a shard tag: ${unassignedFiles.join(", ")}`
     );
   }
-  return [...new Set(e2eFiles.flatMap(getE2eFileShards))].sort((left, right) =>
-    left.localeCompare(right, undefined, { numeric: true })
+  return [...new Set(e2eFiles.flatMap(({ shards }) => shards))].sort(
+    (left, right) => left.localeCompare(right, undefined, { numeric: true })
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "fixtures": "pnpm -r fixtures:link && pnpm -r fixtures:sync && pnpm -r fixtures:build",
     "checks": "pnpm -r test && pnpm -r typecheck && pnpm lint && pnpm check:package-boundaries && pnpm check:generated-api && pnpm check:generated-docs && pnpm fixtures",
     "e2e:builder": "bash ./apps/builder/e2e/run-local.sh",
-    "e2e:builder:build": "pnpm --filter=@webstudio-is/builder build && pnpm --filter=@webstudio-is/sdk-components-react-router build",
+    "e2e:builder:build": "pnpm --filter=@webstudio-is/builder build",
     "e2e:builder:dev:backend": "E2E_SKIP_CLEANUP=true E2E_RUN_TESTS=false E2E_START_POSTGREST=true E2E_DB_BOOTSTRAP=if-empty E2E_INSTALL_PLAYWRIGHT=false bash ./apps/builder/e2e/run-local.sh",
     "e2e:builder:dev": "E2E_SKIP_CLEANUP=true E2E_DB_BOOTSTRAP=if-empty E2E_INSTALL_PLAYWRIGHT=false E2E_BUILDER_URL=${E2E_BUILDER_URL:-https://127.0.0.1:3000} bash ./apps/builder/e2e/run-local.sh",
     "e2e:builder:refresh-schema-cache": "E2E_DB_BOOTSTRAP=migrations E2E_WRITE_SCHEMA_SNAPSHOT=true E2E_RUN_TESTS=false bash ./apps/builder/e2e/run-local.sh",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "fixtures": "pnpm -r fixtures:link && pnpm -r fixtures:sync && pnpm -r fixtures:build",
     "checks": "pnpm -r test && pnpm -r typecheck && pnpm lint && pnpm check:package-boundaries && pnpm check:generated-api && pnpm check:generated-docs && pnpm fixtures",
     "e2e:builder": "bash ./apps/builder/e2e/run-local.sh",
+    "e2e:builder:build": "pnpm --filter=@webstudio-is/builder build && pnpm --filter=@webstudio-is/sdk-components-react-router build",
     "e2e:builder:dev:backend": "E2E_SKIP_CLEANUP=true E2E_RUN_TESTS=false E2E_START_POSTGREST=true E2E_DB_BOOTSTRAP=if-empty E2E_INSTALL_PLAYWRIGHT=false bash ./apps/builder/e2e/run-local.sh",
     "e2e:builder:dev": "E2E_SKIP_CLEANUP=true E2E_DB_BOOTSTRAP=if-empty E2E_INSTALL_PLAYWRIGHT=false E2E_BUILDER_URL=${E2E_BUILDER_URL:-https://127.0.0.1:3000} bash ./apps/builder/e2e/run-local.sh",
     "e2e:builder:refresh-schema-cache": "E2E_DB_BOOTSTRAP=migrations E2E_WRITE_SCHEMA_SNAPSHOT=true E2E_RUN_TESTS=false bash ./apps/builder/e2e/run-local.sh",


### PR DESCRIPTION
## What changed

- reuse the shared CI setup action in both Builder E2E jobs
- use one build command for CI and local E2E runs
- centralize shard filename parsing and suite-name formatting
- remove redundant suite-level shard filtering
- parse each E2E filename's shard metadata once

## Why

The merged image-asset PR introduced multiple owners for Builder E2E setup, build dependencies, and shard filename semantics. Consolidating them prevents CI and local behavior from drifting as the shard layout evolves.

## Validation

- `pnpm --filter=@webstudio-is/builder test -- e2e/test-modules.test.ts`
- `pnpm --filter=@webstudio-is/builder typecheck`
- `pnpm lint`
- `pnpm e2e:builder:build`
- shell syntax and YAML parsing
- shard discovery returned shards 1–6
