### PR TITLE
fix: preserve legacy content through validation

### DIFF
--- a/apps/builder/app/builder/features/command-panel/groups/wrap-group.test.tsx
+++ b/apps/builder/app/builder/features/command-panel/groups/wrap-group.test.tsx
@@ -94,20 +94,19 @@ describe("canWrapInstance for components", () => {
     expect(result).toBe(true);
   });
 
-  test("should reject invalid wrapping (text in CodeText)", () => {
+  test("should allow wrapping text in a legacy CodeText", () => {
     $instances.set(
       renderData(
         <$.Body ws:id="body">
-          <$.Box ws:id="box"></$.Box>
+          <$.Text ws:id="text">Hello</$.Text>
         </$.Body>
       ).instances
     );
-    selectInstance(["box", "body"]);
+    selectInstance(["text", "body"]);
 
-    // CodeText only accepts text content, not boxes
     const result = canWrapInstance(
-      "box",
-      ["box", "body"],
+      "text",
+      ["text", "body"],
       "body",
       "CodeText",
       undefined,
@@ -115,7 +114,7 @@ describe("canWrapInstance for components", () => {
       $props.get(),
       $registeredComponentMetas.get()
     );
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 });
 

--- a/apps/builder/app/builder/features/publish/publish.tsx
+++ b/apps/builder/app/builder/features/publish/publish.tsx
@@ -469,6 +469,9 @@ const Publish = ({
   const [publishError, setPublishError] = useState<
     undefined | JSX.Element | string
   >();
+  const [publishWarning, setPublishWarning] = useState<
+    undefined | JSX.Element | string
+  >();
   const [isPublishing, setIsPublishing] = useOptimistic(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [hasSelectedDomains, setHasSelectedDomains] = useState(false);
@@ -519,6 +522,7 @@ const Publish = ({
 
   const handlePublish = async (formData: FormData) => {
     setPublishError(undefined);
+    setPublishWarning(undefined);
 
     const { error: auditError, warning: auditWarning } =
       getPrePublishAuditMessages();
@@ -528,7 +532,8 @@ const Publish = ({
       return;
     }
     if (auditWarning !== undefined) {
-      toast.info(auditWarning);
+      toast.warn(auditWarning);
+      setPublishWarning(auditWarning);
     }
 
     // Custom domain checkboxes are disabled on free plan so they are never
@@ -649,6 +654,9 @@ const Publish = ({
   return (
     <Flex gap={2} shrink={false} direction={"column"}>
       {publishError && <Text color="destructive">{publishError}</Text>}
+      {publishWarning && (
+        <PanelBanner variant="warning">{publishWarning}</PanelBanner>
+      )}
 
       <Tooltip
         content={
@@ -722,6 +730,7 @@ const PublishStatic = ({
   const project = useStore($project);
   const [_, startTransition] = useTransition();
   const [publishError, setPublishError] = useState<JSX.Element | string>();
+  const [publishWarning, setPublishWarning] = useState<JSX.Element | string>();
 
   if (project == null) {
     throw new Error("Project not found");
@@ -739,6 +748,9 @@ const PublishStatic = ({
   return (
     <Flex gap={2} shrink={false} direction={"column"}>
       {publishError && <Text color="destructive">{publishError}</Text>}
+      {publishWarning && (
+        <PanelBanner variant="warning">{publishWarning}</PanelBanner>
+      )}
       {status === "FAILED" && <Text color="destructive">{statusText}</Text>}
 
       <Tooltip
@@ -752,6 +764,7 @@ const PublishStatic = ({
             startTransition(async () => {
               try {
                 setPublishError(undefined);
+                setPublishWarning(undefined);
                 const { error: auditError, warning: auditWarning } =
                   getPrePublishAuditMessages();
                 if (auditError !== undefined) {
@@ -760,7 +773,8 @@ const PublishStatic = ({
                   return;
                 }
                 if (auditWarning !== undefined) {
-                  toast.info(auditWarning);
+                  toast.warn(auditWarning);
+                  setPublishWarning(auditWarning);
                 }
 
                 setIsPendingOptimistic(true);

--- a/apps/builder/app/builder/features/publish/publish.tsx
+++ b/apps/builder/app/builder/features/publish/publish.tsx
@@ -103,7 +103,7 @@ import {
   type PrePublishAuditFinding,
 } from "@webstudio-is/project-build/runtime";
 
-const PrePublishAuditError = ({
+const PrePublishAuditMessage = ({
   finding,
 }: {
   finding: PrePublishAuditFinding;
@@ -164,7 +164,7 @@ const PrePublishAuditError = ({
   );
 };
 
-const getPrePublishAuditError = () => {
+const getPrePublishAuditMessages = () => {
   const findings = runPrePublishAudit({
     pages: $pages.get(),
     instances: $instances.get(),
@@ -173,8 +173,14 @@ const getPrePublishAuditError = () => {
     resources: $resources.get(),
     metas: $registeredComponentMetas.get(),
   });
-  const finding = findings.find(({ severity }) => severity === "error");
-  return finding && <PrePublishAuditError finding={finding} />;
+  const getMessage = (severity: PrePublishAuditFinding["severity"]) => {
+    const finding = findings.find((item) => item.severity === severity);
+    return finding && <PrePublishAuditMessage finding={finding} />;
+  };
+  return {
+    error: getMessage("error"),
+    warning: getMessage("warning"),
+  };
 };
 
 type ChangeProjectDomainProps = {
@@ -514,11 +520,15 @@ const Publish = ({
   const handlePublish = async (formData: FormData) => {
     setPublishError(undefined);
 
-    const auditError = getPrePublishAuditError();
+    const { error: auditError, warning: auditWarning } =
+      getPrePublishAuditMessages();
     if (auditError !== undefined) {
       toast.error(auditError);
       setPublishError(auditError);
       return;
+    }
+    if (auditWarning !== undefined) {
+      toast.info(auditWarning);
     }
 
     // Custom domain checkboxes are disabled on free plan so they are never
@@ -742,11 +752,15 @@ const PublishStatic = ({
             startTransition(async () => {
               try {
                 setPublishError(undefined);
-                const auditError = getPrePublishAuditError();
+                const { error: auditError, warning: auditWarning } =
+                  getPrePublishAuditMessages();
                 if (auditError !== undefined) {
                   toast.error(auditError);
                   setPublishError(auditError);
                   return;
+                }
+                if (auditWarning !== undefined) {
+                  toast.info(auditWarning);
                 }
 
                 setIsPendingOptimistic(true);

--- a/apps/builder/app/shared/copy-paste/fragment-utils.ts
+++ b/apps/builder/app/shared/copy-paste/fragment-utils.ts
@@ -1,5 +1,8 @@
 import type { WebstudioFragment } from "@webstudio-is/sdk";
-import { breakpointPasteLimitWarning } from "@webstudio-is/project-build/runtime";
+import {
+  breakpointPasteLimitWarning,
+  type FragmentContentModelWarning,
+} from "@webstudio-is/project-build/runtime";
 import {
   insertWebstudioFragmentAt,
   type Insertable,
@@ -10,6 +13,23 @@ import { resolveFragmentTokenConflicts } from "../resolve-token-conflicts";
 export const hasFragmentData = (fragment: WebstudioFragment) =>
   fragment.children.length > 0 || fragment.styleSources.length > 0;
 
+export const reportFragmentContentModelWarnings = (
+  warnings: FragmentContentModelWarning[]
+) => {
+  const [firstWarning] = warnings;
+  if (firstWarning === undefined) {
+    return;
+  }
+  const remainingCount = warnings.length - 1;
+  const suffix =
+    remainingCount === 0
+      ? ""
+      : ` (${remainingCount} more validation ${remainingCount === 1 ? "warning" : "warnings"})`;
+  builderApi.toast.warn(
+    `Pasted with warning: ${firstWarning.message}${suffix}`
+  );
+};
+
 export const insertFragmentWithBreakpointWarning = async (
   fragment: WebstudioFragment,
   insertable?: Insertable
@@ -19,6 +39,8 @@ export const insertFragmentWithBreakpointWarning = async (
     return false;
   }
   return insertWebstudioFragmentAt(fragment, insertable, conflictResolution, {
+    allowContentModelWarnings: true,
+    onContentModelWarnings: reportFragmentContentModelWarnings,
     onBreakpointLimitMerge: () => {
       builderApi.toast.warn(breakpointPasteLimitWarning);
     },

--- a/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
@@ -43,6 +43,7 @@ import {
   expectSlotsShareFragment,
 } from "../slot-test-utils";
 import { pasteHandled } from "./copy-paste";
+import { initBuilderApi } from "../builder-api";
 
 const expectString = expect.any(String) as unknown as string;
 
@@ -202,6 +203,40 @@ describe("copy and cut guards", () => {
       [pastedRootIds?.[0], "body0"],
       [pastedRootIds?.[1], "body0"],
     ]);
+  });
+
+  test("pastes a legacy invalid subtree with a warning", async () => {
+    $instances.set(
+      toMap([
+        createInstance("body0", "Body", [
+          { type: "id", value: "legacy-button" },
+        ]),
+        {
+          ...createInstance("legacy-button", elementComponent, [
+            { type: "id", value: "legacy-heading" },
+          ]),
+          tag: "button",
+        },
+        {
+          ...createInstance("legacy-heading", elementComponent, []),
+          tag: "h3",
+        },
+      ] satisfies Instance[])
+    );
+    selectInstance(["legacy-button", "body0"]);
+    const clipboardData = instanceText.onCopy?.() ?? "";
+    selectInstance(["body0"]);
+    initBuilderApi();
+    const previousWarn = window.__webstudio__$__builderApi.toast.warn;
+    const warn = vi.fn();
+    window.__webstudio__$__builderApi.toast.warn = warn;
+
+    expect(await instanceText.onPaste?.(clipboardData)).toEqual(pasteHandled);
+    expect($instances.get().get("body0")?.children).toHaveLength(2);
+    expect(warn).toHaveBeenCalledWith(
+      "Pasted with warning: Placing <h3> element inside a <button> violates HTML spec."
+    );
+    window.__webstudio__$__builderApi.toast.warn = previousWarn;
   });
 
   test("sanitizes multi-root clipboard root ids before paste", async () => {

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -3,6 +3,7 @@ import {
   findSafeFragmentPasteTarget,
   getCommonAncestorSelector,
   getPasteRootInstanceIds,
+  getFragmentContentModelWarnings,
   mergeWebstudioFragments,
 } from "@webstudio-is/project-build/runtime";
 import {
@@ -37,6 +38,7 @@ import {
   clearInstanceSelection,
   $selectedInstancePath,
   $selectedInstanceSelector,
+  $registeredComponentMetas,
   selectInstances,
 } from "~/shared/nano-states";
 import { getInstancePath } from "@webstudio-is/project-build/runtime";
@@ -44,6 +46,7 @@ import { builderApi } from "../builder-api";
 import { pasteHandled, pasteIgnored, type Plugin } from "./copy-paste";
 import { breakpointPasteLimitWarning } from "@webstudio-is/project-build/runtime";
 import { resolveFragmentTokenConflicts } from "../resolve-token-conflicts";
+import { reportFragmentContentModelWarnings } from "./fragment-utils";
 
 const invalidPasteDataMessage =
   "Could not paste Webstudio instance data. The clipboard data appears to be incomplete or invalid.";
@@ -156,7 +159,9 @@ const findPasteTargetForFragment = (
 ): undefined | Insertable => {
   const instances = $instances.get();
 
-  insertable = findClosestInsertable(fragment, insertable);
+  insertable = findClosestInsertable(fragment, insertable, {
+    allowContentModelWarnings: true,
+  });
   if (insertable === undefined) {
     return;
   }
@@ -208,6 +213,10 @@ const insertPastedFragment = async ({
   selectRootInstances: (rootInstanceIds: Instance["id"][]) => void;
 }) => {
   try {
+    const contentModelWarnings = getFragmentContentModelWarnings({
+      fragment,
+      metas: $registeredComponentMetas.get(),
+    });
     const conflictResolution = await resolveFragmentTokenConflicts(fragment);
     if (conflictResolution === "cancel") {
       return;
@@ -231,6 +240,7 @@ const insertPastedFragment = async ({
     if (result?.result.didMergeBreakpointsDueToLimit === true) {
       toast.warn(breakpointPasteLimitWarning);
     }
+    reportFragmentContentModelWarnings(contentModelWarnings);
     selectRootInstances(rootInstanceIds);
   } catch (error) {
     // User cancelled

--- a/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-webflow/plugin-webflow.ts
@@ -198,7 +198,9 @@ const handlePasteWebflow = async (clipboardData: string) => {
   }
   fragment = await denormalizeSrcProps(fragment);
 
-  const insertable = findClosestInsertable(fragment);
+  const insertable = findClosestInsertable(fragment, undefined, {
+    allowContentModelWarnings: true,
+  });
   if (insertable === undefined) {
     return pasteHandled;
   }

--- a/apps/builder/app/shared/instance-utils/insert.ts
+++ b/apps/builder/app/shared/instance-utils/insert.ts
@@ -12,6 +12,8 @@ import {
 import {
   builderRuntimeContext,
   createComponentTemplateFragment,
+  getFragmentContentModelWarnings,
+  type FragmentContentModelWarning,
   type ConflictResolution,
   resolveComponentInsertTarget,
   resolveFragmentInsertTarget,
@@ -55,7 +57,8 @@ const onNoComponentInsertMatch = (component: string) => {
 
 const getFragmentInsertTarget = (
   fragment: WebstudioFragment,
-  from?: Insertable
+  from?: Insertable,
+  options?: { allowContentModelWarnings?: boolean }
 ) => {
   const rootInstanceId = getRootInstanceId();
   if (rootInstanceId === undefined) {
@@ -73,6 +76,7 @@ const getFragmentInsertTarget = (
     onRootTarget,
     onMissingTarget,
     onNoMatch: onNoInsertMatch(fragment),
+    allowFragmentContentModelWarnings: options?.allowContentModelWarnings,
   });
 };
 
@@ -161,7 +165,12 @@ export const insertWebstudioFragmentAt = (
   fragment: WebstudioFragment,
   insertable?: Insertable,
   conflictResolution?: ConflictResolution,
-  options?: { contentMode?: boolean; onBreakpointLimitMerge?: () => void }
+  options?: {
+    contentMode?: boolean;
+    onBreakpointLimitMerge?: () => void;
+    allowContentModelWarnings?: boolean;
+    onContentModelWarnings?: (warnings: FragmentContentModelWarning[]) => void;
+  }
 ): boolean => {
   const hasChildren = fragment.children.length > 0;
   const hasTokens = fragment.styleSources.length > 0;
@@ -187,7 +196,7 @@ export const insertWebstudioFragmentAt = (
     }
     return result !== undefined;
   }
-  const target = getFragmentInsertTarget(fragment, insertable);
+  const target = getFragmentInsertTarget(fragment, insertable, options);
   if ($project.get() === undefined || target === undefined) {
     return false;
   }
@@ -216,6 +225,15 @@ export const insertWebstudioFragmentAt = (
   }
   if (result?.result.didMergeBreakpointsDueToLimit === true) {
     options?.onBreakpointLimitMerge?.();
+  }
+  if (result !== undefined && options?.allowContentModelWarnings === true) {
+    const warnings = getFragmentContentModelWarnings({
+      fragment,
+      metas: $registeredComponentMetas.get(),
+    });
+    if (warnings.length > 0) {
+      options.onContentModelWarnings?.(warnings);
+    }
   }
   return result !== undefined;
 };
@@ -264,7 +282,8 @@ export type Insertable = InsertTarget;
 
 export const findClosestInsertable = (
   fragment: WebstudioFragment,
-  from?: Insertable
+  from?: Insertable,
+  options?: { allowContentModelWarnings?: boolean }
 ): undefined | Insertable => {
   const rootInstanceId = getRootInstanceId();
   if (rootInstanceId === undefined) {
@@ -281,6 +300,7 @@ export const findClosestInsertable = (
     onRootTarget,
     onMissingTarget,
     onNoMatch: onNoInsertMatch(fragment),
+    allowFragmentContentModelWarnings: options?.allowContentModelWarnings,
   });
   if (target === undefined) {
     return;

--- a/packages/project-build/src/runtime/insert-target.test.tsx
+++ b/packages/project-build/src/runtime/insert-target.test.tsx
@@ -93,6 +93,27 @@ describe("insert target", () => {
     ).toEqual({ parentSelector: ["body"], position: "end" });
   });
 
+  test("does not restore an incompatible explicit paste target", () => {
+    const data = renderData(
+      <$.Body ws:id="body">
+        <ws.element ws:id="button" ws:tag="button" />
+      </$.Body>
+    );
+    const fragment = renderTemplate(<$.ListItem ws:id="item" />);
+
+    expect(
+      resolveFragmentInsertTarget({
+        fragment,
+        instances: data.instances,
+        props: data.props,
+        metas: componentMetas,
+        rootInstanceId: "body",
+        from: { parentSelector: ["button", "body"], position: "end" },
+        allowFragmentContentModelWarnings: true,
+      })
+    ).toBeUndefined();
+  });
+
   test("reports global root target", () => {
     const data = renderData(<$.Body ws:id="body"></$.Body>);
     const fragment = renderTemplate(

--- a/packages/project-build/src/runtime/insert-target.ts
+++ b/packages/project-build/src/runtime/insert-target.ts
@@ -156,6 +156,7 @@ export const findClosestInsertTarget = ({
   from,
   onRootTarget,
   onNoMatch,
+  allowFragmentContentModelWarnings,
 }: {
   fragment: Pick<WebstudioFragment, "children" | "instances" | "props">;
   instances: Instances;
@@ -166,6 +167,7 @@ export const findClosestInsertTarget = ({
   from?: InsertTarget;
   onRootTarget?: () => void;
   onNoMatch?: (message: string) => void;
+  allowFragmentContentModelWarnings?: boolean;
 }): undefined | InsertTarget => {
   const instanceSelector = from?.parentSelector ??
     selectedInstanceSelector ?? [rootInstanceId];
@@ -191,6 +193,7 @@ export const findClosestInsertTarget = ({
     instanceSelector: instanceSelector.slice(closestContainerIndex),
     fragment,
     onError: onNoMatch,
+    allowFragmentContentModelWarnings,
   });
   if (insertableIndex === -1) {
     return;
@@ -232,6 +235,7 @@ export const resolveFragmentInsertTarget = ({
   onRootTarget,
   onNoMatch,
   onMissingTarget,
+  allowFragmentContentModelWarnings,
 }: {
   fragment: Pick<WebstudioFragment, "children" | "instances" | "props">;
   instances: Instances;
@@ -243,19 +247,23 @@ export const resolveFragmentInsertTarget = ({
   onRootTarget?: () => void;
   onNoMatch?: (message: string) => void;
   onMissingTarget?: () => void;
+  allowFragmentContentModelWarnings?: boolean;
 }): undefined | ResolvedInsertTarget => {
+  const matchedTarget = findClosestInsertTarget({
+    fragment,
+    instances,
+    props,
+    metas,
+    rootInstanceId,
+    selectedInstanceSelector,
+    from,
+    onRootTarget,
+    onNoMatch,
+    allowFragmentContentModelWarnings,
+  });
   const closestTarget =
-    findClosestInsertTarget({
-      fragment,
-      instances,
-      props,
-      metas,
-      rootInstanceId,
-      selectedInstanceSelector,
-      from,
-      onRootTarget,
-      onNoMatch,
-    }) ?? from;
+    matchedTarget ??
+    (allowFragmentContentModelWarnings === true ? undefined : from);
   if (closestTarget === undefined) {
     return;
   }

--- a/packages/project-build/src/runtime/matcher.test.tsx
+++ b/packages/project-build/src/runtime/matcher.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, test, vi } from "vitest";
-import { $, renderData, renderTemplate } from "@webstudio-is/template";
+import { $, renderData, renderTemplate, ws } from "@webstudio-is/template";
 import { componentMetas } from "@webstudio-is/sdk-components-registry/metas";
-import { findClosestInstanceMatchingFragment } from "./matcher";
+import {
+  findClosestInstanceMatchingFragment,
+  getFragmentContentModelWarnings,
+} from "./matcher";
 
 describe("findClosestInstanceMatchingFragment", () => {
   test("finds closest list with list item fragment", () => {
@@ -98,5 +101,63 @@ describe("findClosestInstanceMatchingFragment", () => {
     expect(onError).toHaveBeenLastCalledWith(
       "Placing <li> element inside a <body> violates HTML spec."
     );
+  });
+
+  test("allows fragment-internal warnings without allowing new placement violations", () => {
+    const { instances, props } = renderData(
+      <$.Body ws:id="body">
+        <ws.element ws:id="button" ws:tag="button" />
+      </$.Body>
+    );
+    const legacyFragment = renderTemplate(
+      <ws.element ws:id="legacy-button" ws:tag="button">
+        <ws.element ws:id="legacy-heading" ws:tag="h3" />
+      </ws.element>
+    );
+
+    expect(
+      getFragmentContentModelWarnings({
+        fragment: legacyFragment,
+        metas: componentMetas,
+      })
+    ).toEqual([
+      {
+        instanceId: "legacy-heading",
+        message: "Placing <h3> element inside a <button> violates HTML spec.",
+      },
+    ]);
+    expect(
+      findClosestInstanceMatchingFragment({
+        metas: componentMetas,
+        instances,
+        props,
+        instanceSelector: ["body"],
+        fragment: legacyFragment,
+      })
+    ).toBe(-1);
+    expect(
+      findClosestInstanceMatchingFragment({
+        metas: componentMetas,
+        instances,
+        props,
+        instanceSelector: ["body"],
+        fragment: legacyFragment,
+        allowFragmentContentModelWarnings: true,
+      })
+    ).toBe(0);
+
+    const headingFragment = renderTemplate(
+      <ws.element ws:id="new-heading" ws:tag="h3" />
+    );
+    expect(
+      findClosestInstanceMatchingFragment({
+        metas: componentMetas,
+        instances,
+        props,
+        instanceSelector: ["button", "body"],
+        fragment: headingFragment,
+        allowFragmentContentModelWarnings: true,
+      })
+    ).toBe(1);
   });
 });

--- a/packages/project-build/src/runtime/matcher.ts
+++ b/packages/project-build/src/runtime/matcher.ts
@@ -7,6 +7,44 @@ import type {
 } from "@webstudio-is/sdk";
 import { isTreeSatisfyingContentModel } from "./content-model";
 
+export type FragmentContentModelWarning = {
+  instanceId: Instance["id"];
+  message: string;
+};
+
+const getWarningKey = ({ instanceId, message }: FragmentContentModelWarning) =>
+  `${instanceId}\0${message}`;
+
+export const getFragmentContentModelWarnings = ({
+  fragment,
+  metas,
+}: {
+  fragment: Pick<WebstudioFragment, "children" | "instances" | "props">;
+  metas: Map<string, WsComponentMeta>;
+}): FragmentContentModelWarning[] => {
+  const instances: Instances = new Map(
+    fragment.instances.map((instance) => [instance.id, instance])
+  );
+  const props: Props = new Map(fragment.props.map((prop) => [prop.id, prop]));
+  const warnings = new Map<string, FragmentContentModelWarning>();
+  for (const child of fragment.children) {
+    if (child.type !== "id") {
+      continue;
+    }
+    isTreeSatisfyingContentModel({
+      instances,
+      props,
+      metas,
+      instanceSelector: [child.value],
+      onError: (message, instanceSelector) => {
+        const warning = { message, instanceId: instanceSelector[0] };
+        warnings.set(getWarningKey(warning), warning);
+      },
+    });
+  }
+  return Array.from(warnings.values());
+};
+
 export const findClosestInstanceMatchingFragment = ({
   instances,
   props,
@@ -14,6 +52,7 @@ export const findClosestInstanceMatchingFragment = ({
   instanceSelector,
   fragment,
   onError,
+  allowFragmentContentModelWarnings = false,
 }: {
   instances: Instances;
   props: Props;
@@ -21,6 +60,7 @@ export const findClosestInstanceMatchingFragment = ({
   instanceSelector: Instance["id"][];
   fragment: Pick<WebstudioFragment, "children" | "instances" | "props">;
   onError?: (message: string) => void;
+  allowFragmentContentModelWarnings?: boolean;
 }) => {
   const mergedInstances = new Map(instances);
   for (const instance of fragment.instances) {
@@ -30,6 +70,11 @@ export const findClosestInstanceMatchingFragment = ({
   for (const prop of fragment.props) {
     mergedProps.set(prop.id, prop);
   }
+  const allowedWarningKeys = new Set(
+    allowFragmentContentModelWarnings
+      ? getFragmentContentModelWarnings({ fragment, metas }).map(getWarningKey)
+      : []
+  );
   let firstError = "";
   for (let index = 0; index < instanceSelector.length; index += 1) {
     const instanceId = instanceSelector[index];
@@ -46,17 +91,26 @@ export const findClosestInstanceMatchingFragment = ({
       if (child.type !== "id") {
         continue;
       }
-      matches &&= isTreeSatisfyingContentModel({
+      let hasNewViolation = false;
+      const isValid = isTreeSatisfyingContentModel({
         instances: mergedInstances,
         props: mergedProps,
         metas,
         instanceSelector: [child.value, ...instanceSelector.slice(index)],
-        onError: (message) => {
+        onError: (message, errorSelector) => {
           if (firstError === "") {
             firstError = message;
           }
+          if (
+            allowedWarningKeys.has(
+              getWarningKey({ instanceId: errorSelector[0], message })
+            ) === false
+          ) {
+            hasNewViolation = true;
+          }
         },
       });
+      matches &&= isValid || hasNewViolation === false;
     }
     if (matches) {
       return index;

--- a/packages/project-build/src/runtime/pre-publish-audit.test.tsx
+++ b/packages/project-build/src/runtime/pre-publish-audit.test.tsx
@@ -6,7 +6,7 @@ import {
   type Pages,
 } from "@webstudio-is/sdk";
 import { componentMetas } from "@webstudio-is/sdk-components-registry/metas";
-import { $, renderData } from "@webstudio-is/template";
+import { $, renderData, ws } from "@webstudio-is/template";
 import {
   formatPrePublishAuditFinding,
   runPrePublishAudit,
@@ -122,6 +122,19 @@ test("allows valid legacy CodeText children", () => {
       <$.CodeText>
         <$.Text ws:tag="span">Legacy code text</$.Text>
       </$.CodeText>
+    </$.Body>
+  );
+
+  expect(runAudit({ instances, props })).toEqual([]);
+});
+
+test("allows valid Video children", () => {
+  const { instances, props } = renderData(
+    <$.Body ws:id="body">
+      <$.Video>
+        <ws.element ws:tag="source" />
+        <ws.element ws:tag="track" />
+      </$.Video>
     </$.Body>
   );
 

--- a/packages/project-build/src/runtime/pre-publish-audit.test.tsx
+++ b/packages/project-build/src/runtime/pre-publish-audit.test.tsx
@@ -116,6 +116,18 @@ test("allows valid publishable pages and ignores invalid drafts", () => {
   ).toEqual([]);
 });
 
+test("allows valid legacy CodeText children", () => {
+  const { instances, props } = renderData(
+    <$.Body ws:id="body">
+      <$.CodeText>
+        <$.Text ws:tag="span">Legacy code text</$.Text>
+      </$.CodeText>
+    </$.Body>
+  );
+
+  expect(runAudit({ instances, props })).toEqual([]);
+});
+
 test("blocks publishing when required audit input is unavailable", () => {
   const { instances, props } = renderData(<$.Body ws:id="body"></$.Body>);
 

--- a/packages/project-build/src/runtime/pre-publish-audit.test.tsx
+++ b/packages/project-build/src/runtime/pre-publish-audit.test.tsx
@@ -52,14 +52,14 @@ const runAudit = ({
     metas: componentMetas,
   });
 
-test("returns a blocking finding with the page and instance identity", () => {
+test("warns without blocking legacy invalid HTML", () => {
   const { instances, props } = renderData(
     <$.Body ws:id="body">
-      <$.Paragraph>
-        <$.Heading ws:id="heading" ws:tag="h2">
-          Analyze Global Markets
+      <ws.element ws:tag="button">
+        <$.Heading ws:id="heading" ws:tag="h3">
+          Legacy accordion trigger
         </$.Heading>
-      </$.Paragraph>
+      </ws.element>
     </$.Body>
   );
 
@@ -68,8 +68,8 @@ test("returns a blocking finding with the page and instance identity", () => {
   expect(findings).toEqual([
     {
       ruleId: "html-content-model",
-      severity: "error",
-      message: "Placing <h2> element inside a <p> violates HTML spec.",
+      severity: "warning",
+      message: "Placing <h3> element inside a <button> violates HTML spec.",
       location: {
         pageId: "marketedge",
         pageName: "MarketEdge",
@@ -79,7 +79,7 @@ test("returns a blocking finding with the page and instance identity", () => {
     },
   ]);
   expect(formatPrePublishAuditFinding(findings[0]!)).toBe(
-    'Cannot publish "MarketEdge" (/marketedge): Placing <h2> element inside a <p> violates HTML spec.'
+    'Publish warning for "MarketEdge" (/marketedge): Placing <h3> element inside a <button> violates HTML spec.'
   );
 });
 

--- a/packages/project-build/src/runtime/pre-publish-audit.ts
+++ b/packages/project-build/src/runtime/pre-publish-audit.ts
@@ -67,7 +67,7 @@ const checkHtmlContentModel: PrePublishAuditCheck = ({
     if (isValid === false) {
       findings.push({
         ruleId: "html-content-model",
-        severity: "error",
+        severity: "warning",
         message: message ?? "The page contains invalid element nesting.",
         location: {
           pageId: page.id,
@@ -133,8 +133,10 @@ export const formatPrePublishAuditFinding = (
   finding: PrePublishAuditFinding
 ) => {
   const { pageName, pagePath } = finding.location;
+  const prefix =
+    finding.severity === "error" ? "Cannot publish" : "Publish warning";
   if (pageName === undefined || pagePath === undefined) {
-    return `Cannot publish: ${finding.message}`;
+    return `${prefix}: ${finding.message}`;
   }
-  return `Cannot publish "${pageName}" (${pagePath}): ${finding.message}`;
+  return `${prefix} for "${pageName}" (${pagePath}): ${finding.message}`;
 };

--- a/packages/sdk-components-react/src/code-text.ws.ts
+++ b/packages/sdk-components-react/src/code-text.ws.ts
@@ -37,10 +37,6 @@ const presetStyle = {
 export const meta: WsComponentMeta = {
   deprecated: true,
   icon: BracesIcon,
-  contentModel: {
-    category: "instance",
-    children: [],
-  },
   presetStyle,
   initialProps: ["id", "class", "lang", "code"],
   props: {

--- a/packages/sdk-components-react/src/video.ws.ts
+++ b/packages/sdk-components-react/src/video.ws.ts
@@ -5,10 +5,6 @@ import { props } from "./__generated__/video.props";
 
 export const meta: WsComponentMeta = {
   icon: VideoIcon,
-  contentModel: {
-    category: "instance",
-    children: [],
-  },
   presetStyle: {
     video: [
       {


### PR DESCRIPTION
## Summary

- Keep the shared content-model validator strict during normal Builder authoring.
- Report HTML and component nesting violations as publish warnings instead of blocking legacy projects.
- Allow paste operations to retain violations already contained inside legacy fragments and surface them as warnings.
- Continue rejecting new violations introduced at the paste destination boundary.
- Remove obsolete empty content models from CodeText and Video so their runtime-supported, HTML-valid children pass validation.

## Root cause

The new pre-publish audit applied current authoring constraints to historical project trees. Some legacy structures, including old Accordion triggers containing an h3 inside a button, were created by earlier Webstudio templates and cannot satisfy the current HTML model without migration. Blocking publish or paste would make untouched legacy content unusable.

CodeText and Video also had metadata that rejected children their renderers intentionally support. Those verified metadata mismatches are corrected independently of the compatibility policy.

## Behavior

- New invalid nesting remains prevented by normal authoring operations.
- Existing invalid nesting produces a Publish warning and does not abort publishing.
- Webstudio instance, HTML, JSX, and Webflow paste retain fragment-internal violations and show a paste warning.
- Paste still validates the destination and cannot introduce a new invalid parent-child relationship.
- Resource integrity and missing audit inputs still prevent publishing.

## Verification

- [x] Legacy button containing h3 reports a publish warning
- [x] Legacy invalid subtree pastes successfully with a warning
- [x] New paste destination violations remain rejected or use the closest valid target
- [x] Valid legacy CodeText children pass validation
- [x] Valid Video source and track children pass validation
- [x] Project-build matcher and insert-target tests
- [x] Builder instance, HTML, JSX, and Webflow paste tests
- [x] Project-build and Builder typechecks
- [x] Focused oxlint and formatting checks