### PR TITLE
fix: Preserve tokens when pasting Slot content

### DIFF
--- a/packages/project-build/src/runtime/fragment.test.tsx
+++ b/packages/project-build/src/runtime/fragment.test.tsx
@@ -33,6 +33,7 @@ import {
   ActionValue,
   renderTemplate,
   Parameter,
+  token,
 } from "@webstudio-is/template";
 import { findAvailableVariables } from "./data";
 
@@ -336,6 +337,41 @@ test("insert instances with slots", () => {
     expect.objectContaining({ component: "Slot" }),
     expect.objectContaining({ component: "Slot" }),
   ]);
+});
+
+test("remap token selections in inserted slot content", () => {
+  const data = renderData(<$.Body ws:id="bodyId"></$.Body>);
+  const fragment = renderTemplate(
+    <$.Slot ws:id="slotId">
+      <$.Fragment ws:id="fragmentId">
+        <$.HtmlEmbed
+          ws:id="iconId"
+          ws:tokens={[
+            token(
+              "Accordion Icon",
+              css`
+                color: red;
+              `
+            ),
+          ]}
+        />
+      </$.Fragment>
+    </$.Slot>
+  );
+
+  insertWebstudioFragmentCopy({
+    data,
+    fragment,
+    availableVariables: [],
+    projectId: "",
+  });
+
+  const [insertedTokenId] =
+    data.styleSourceSelections.get("iconId")?.values ?? [];
+  expect(data.styleSources.get(insertedTokenId)).toMatchObject({
+    type: "token",
+    name: "Accordion Icon",
+  });
 });
 
 test("insert instances with multiple roots", () => {

--- a/packages/project-build/src/runtime/fragment.ts
+++ b/packages/project-build/src/runtime/fragment.ts
@@ -702,6 +702,7 @@ export const insertWebstudioFragmentCopy = ({
         styleSources,
         styleSourceSelections,
         styles,
+        styleSourceIdMap,
         mergedBreakpointIds,
       });
     }

--- a/packages/project-build/src/runtime/style-copy.test.ts
+++ b/packages/project-build/src/runtime/style-copy.test.ts
@@ -191,13 +191,14 @@ describe("style source insertion", () => {
       styleSources,
       styleSourceSelections,
       styles,
+      styleSourceIdMap: new Map([["token", "mapped-token"]]),
       mergedBreakpointIds: new Map([["old-base", "base"]]),
     });
 
     expect(styleSources.get("local")).toEqual(local("local"));
     expect(styleSourceSelections.get("portal")).toEqual({
       instanceId: "portal",
-      values: ["local", "token"],
+      values: ["local", "mapped-token"],
     });
     expect(Array.from(styles.values())).toEqual([
       style("local", "base", "color", red),

--- a/packages/project-build/src/runtime/style-copy.ts
+++ b/packages/project-build/src/runtime/style-copy.ts
@@ -392,6 +392,7 @@ export const insertPortalLocalStyleSources = ({
   styleSources,
   styleSourceSelections,
   styles,
+  styleSourceIdMap,
   mergedBreakpointIds,
 }: {
   fragmentStyleSources: StyleSource[];
@@ -401,6 +402,7 @@ export const insertPortalLocalStyleSources = ({
   styleSources: StyleSources;
   styleSourceSelections: StyleSourceSelections;
   styles: Styles;
+  styleSourceIdMap: Map<StyleSource["id"], StyleSource["id"]>;
   mergedBreakpointIds: Map<Breakpoint["id"], Breakpoint["id"]>;
 }): void => {
   const instanceStyleSourceIds = new Set<StyleSource["id"]>();
@@ -409,8 +411,11 @@ export const insertPortalLocalStyleSources = ({
     if (instanceIds.has(instanceId) === false) {
       continue;
     }
-    styleSourceSelections.set(instanceId, styleSourceSelection);
-    for (const styleSourceId of styleSourceSelection.values) {
+    const values = styleSourceSelection.values.map(
+      (styleSourceId) => styleSourceIdMap.get(styleSourceId) ?? styleSourceId
+    );
+    styleSourceSelections.set(instanceId, { instanceId, values });
+    for (const styleSourceId of values) {
       instanceStyleSourceIds.add(styleSourceId);
     }
   }


### PR DESCRIPTION
## Summary

Preserve design-token selections on instances nested inside pasted Slot content.

## Root cause

Token style sources receive new or reused IDs during fragment insertion. Regular copied instances applied that token ID mapping to their style-source selections, but preserved Slot/portal content copied selections with the stale clipboard IDs. As a result, an Accordion's shared HtmlEmbed icon could lose its visible token after pasting the whole Accordion even though pasting the icon alone worked.

## Changes

- Pass the token style-source ID map into Slot/portal style insertion.
- Remap token IDs while preserving local style-source IDs.
- Add unit coverage for portal selection remapping.
- Add a fragment-level regression test using a tokenized HtmlEmbed inside a Slot.

## Checklist

- [x] Remap token selections in pasted Slot content
- [x] Add regression coverage
- [x] Run project-build tests
- [x] Run project-build typecheck
- [x] Run lint and formatting checks

## Verification

- `pnpm --filter @webstudio-is/project-build test` — 1,993 tests passed
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm exec oxlint --deny-warnings packages/project-build/src/runtime/style-copy.ts packages/project-build/src/runtime/fragment.ts packages/project-build/src/runtime/style-copy.test.ts packages/project-build/src/runtime/fragment.test.tsx`
- `pnpm exec oxfmt packages/project-build/src/runtime/style-copy.ts packages/project-build/src/runtime/fragment.ts packages/project-build/src/runtime/style-copy.test.ts packages/project-build/src/runtime/fragment.test.tsx`
