### PR TITLE
fix: Show publish warnings immediately

### DIFF
--- a/apps/builder/app/builder/features/publish/publish.tsx
+++ b/apps/builder/app/builder/features/publish/publish.tsx
@@ -520,33 +520,7 @@ const Publish = ({
     };
   }, [project.domain]);
 
-  const handlePublish = async (formData: FormData) => {
-    setPublishError(undefined);
-    setPublishWarning(undefined);
-
-    const { error: auditError, warning: auditWarning } =
-      getPrePublishAuditMessages();
-    if (auditError !== undefined) {
-      toast.error(auditError);
-      setPublishError(auditError);
-      return;
-    }
-    if (auditWarning !== undefined) {
-      toast.warn(auditWarning);
-      setPublishWarning(auditWarning);
-    }
-
-    // Custom domain checkboxes are disabled on free plan so they are never
-    // submitted — only the staging (wstd.io) domain can appear in formData.
-    const domains = formData
-      .getAll(domainToPublishName)
-      .map((domainEntry) => domainEntry.toString());
-
-    if (domains.length === 0) {
-      toast.error("Please select at least one domain to publish");
-      return;
-    }
-
+  const publish = async (domains: string[]) => {
     setIsPublishing(true);
 
     const publishResult = await nativeClient.domain.publish.mutate({
@@ -643,6 +617,38 @@ const Publish = ({
     }
   };
 
+  const handlePublish = (formData: FormData) => {
+    setPublishError(undefined);
+    setPublishWarning(undefined);
+
+    const { error: auditError, warning: auditWarning } =
+      getPrePublishAuditMessages();
+    if (auditError !== undefined) {
+      toast.error(auditError);
+      setPublishError(auditError);
+      return;
+    }
+    if (auditWarning !== undefined) {
+      toast.warn(auditWarning);
+      setPublishWarning(auditWarning);
+    }
+
+    // Custom domain checkboxes are disabled on free plan so they are never
+    // submitted — only the staging (wstd.io) domain can appear in formData.
+    const domains = formData
+      .getAll(domainToPublishName)
+      .map((domainEntry) => domainEntry.toString());
+
+    if (domains.length === 0) {
+      toast.error("Please select at least one domain to publish");
+      return;
+    }
+
+    startTransition(async () => {
+      await publish(domains);
+    });
+  };
+
   const hasPendingState = project.latestBuildVirtual
     ? getPublishStatusAndText(project.latestBuildVirtual).status === "PENDING"
     : false;
@@ -655,7 +661,9 @@ const Publish = ({
     <Flex gap={2} shrink={false} direction={"column"}>
       {publishError && <Text color="destructive">{publishError}</Text>}
       {publishWarning && (
-        <PanelBanner variant="warning">{publishWarning}</PanelBanner>
+        <PanelBanner variant="warning">
+          <Text>{publishWarning}</Text>
+        </PanelBanner>
       )}
 
       <Tooltip
@@ -669,7 +677,13 @@ const Publish = ({
       >
         <Button
           ref={buttonRef}
-          formAction={handlePublish}
+          type="button"
+          onClick={() => {
+            const form = buttonRef.current?.closest("form");
+            if (form) {
+              handlePublish(new FormData(form));
+            }
+          }}
           color="positive"
           state={showPendingState ? "pending" : undefined}
           disabled={
@@ -749,7 +763,9 @@ const PublishStatic = ({
     <Flex gap={2} shrink={false} direction={"column"}>
       {publishError && <Text color="destructive">{publishError}</Text>}
       {publishWarning && (
-        <PanelBanner variant="warning">{publishWarning}</PanelBanner>
+        <PanelBanner variant="warning">
+          <Text>{publishWarning}</Text>
+        </PanelBanner>
       )}
       {status === "FAILED" && <Text color="destructive">{statusText}</Text>}
 
@@ -761,22 +777,22 @@ const PublishStatic = ({
           color="positive"
           state={isPublishInProgress ? "pending" : undefined}
           onClick={() => {
+            setPublishError(undefined);
+            setPublishWarning(undefined);
+            const { error: auditError, warning: auditWarning } =
+              getPrePublishAuditMessages();
+            if (auditError !== undefined) {
+              toast.error(auditError);
+              setPublishError(auditError);
+              return;
+            }
+            if (auditWarning !== undefined) {
+              toast.warn(auditWarning);
+              setPublishWarning(auditWarning);
+            }
+
             startTransition(async () => {
               try {
-                setPublishError(undefined);
-                setPublishWarning(undefined);
-                const { error: auditError, warning: auditWarning } =
-                  getPrePublishAuditMessages();
-                if (auditError !== undefined) {
-                  toast.error(auditError);
-                  setPublishError(auditError);
-                  return;
-                }
-                if (auditWarning !== undefined) {
-                  toast.warn(auditWarning);
-                  setPublishWarning(auditWarning);
-                }
-
                 setIsPendingOptimistic(true);
 
                 const result = await nativeClient.domain.publish.mutate({


### PR DESCRIPTION
## Summary

Show client-side pre-publish audit findings as soon as the user starts publishing, and apply the Builder's standard text styling to warning banners.

## Root cause

The cloud publish audit ran inside an async form action, while the static export audit ran inside an async transition. React deferred their ordinary state updates until those async operations completed, so warnings could appear only after publishing or export finished even though validation itself ran synchronously on the client.

## Changes

- Run the cloud publish audit in the synchronous button click handler before starting the async publish transition.
- Run the static export audit before starting its async transition.
- Keep warnings non-blocking while preserving blocking audit errors.
- Render warning-banner content with the design-system `Text` component.

## Checklist

- [x] Show cloud publish warnings before publishing starts
- [x] Show static export warnings before export starts
- [x] Style warning text consistently
- [x] Run Builder tests
- [x] Run Builder typecheck
- [x] Run lint and formatting checks

## Verification

- `pnpm --filter @webstudio-is/builder test` — 2,351 tests passed
- `pnpm --filter @webstudio-is/builder typecheck`
- `pnpm exec oxlint --deny-warnings apps/builder/app/builder/features/publish/publish.tsx`
- `pnpm exec oxfmt apps/builder/app/builder/features/publish/publish.tsx`
