### PR TITLE
fix: remove unsupported TIFF assets

### DIFF
--- a/apps/builder/app/builder/shared/asset-manager/asset-filters.tsx
+++ b/apps/builder/app/builder/shared/asset-manager/asset-filters.tsx
@@ -81,8 +81,6 @@ const EXTENSION_TO_DISPLAY_CATEGORY: Record<
   avif: "Images",
   ico: "Images",
   bmp: "Images",
-  tif: "Images",
-  tiff: "Images",
 
   // Fonts
   woff: "Fonts",

--- a/packages/sdk/src/assets.test.ts
+++ b/packages/sdk/src/assets.test.ts
@@ -600,7 +600,7 @@ describe("allowed-file-types", () => {
       expect(url.search).toBe("?format=raw");
     });
 
-    test.each(["tiff", "tif", "bmp", "ico", "avif"])(
+    test.each(["bmp", "ico", "avif"])(
       "serves %s images directly without resizing",
       (format) => {
         const url = getAssetUrl(

--- a/packages/sdk/src/assets.ts
+++ b/packages/sdk/src/assets.ts
@@ -162,7 +162,7 @@ const assetFileTypes = {
 
   // Images
   // Note: Cloudflare Image Resizing supports: jpg, jpeg, png, gif, webp, svg, avif
-  // Other formats (bmp, ico, tif, tiff) are served as-is without optimization
+  // Other formats (bmp, ico) are served as-is without optimization
   jpg: binaryFile("image/jpeg"),
   jpeg: binaryFile("image/jpeg"),
   png: binaryFile("image/png"),
@@ -172,8 +172,6 @@ const assetFileTypes = {
   avif: binaryFile("image/avif"),
   ico: binaryFile("image/vnd.microsoft.icon"),
   bmp: binaryFile("image/bmp"),
-  tif: binaryFile("image/tiff"),
-  tiff: binaryFile("image/tiff"),
 
   // Fonts
   woff: binaryFile("font/woff"),


### PR DESCRIPTION
## Summary

- Remove `.tif` and `.tiff` from supported asset extensions.
- Stop categorizing TIFF files as images in the asset manager.
- Update SDK URL coverage to reflect the supported direct-served image formats.

## Why

The asset manager classified TIFF files as images, but the browser and image optimization pipeline cannot reliably render TIFF thumbnails. Treating TIFF as supported created broken previews.

## Verification

- SDK asset tests: 95 passed
- Formatting completed
- Diff checked against `main`