### PR TITLE
fix: preserve asset folders during upload and selection

### DIFF
--- a/apps/builder/app/builder/features/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.tsx
+++ b/apps/builder/app/builder/features/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.tsx
@@ -86,6 +86,13 @@ const additionalShortcuts = [
     category: "Top bar",
     defaultHotkeys: ["1-9"],
   },
+  {
+    name: "selectAllAssets",
+    label: "Select all assets and folders",
+    description: "Select all currently rendered assets and folders",
+    category: "Panels",
+    defaultHotkeys: ["meta+a", "ctrl+a"],
+  },
 ];
 
 const leftCategoryOrder = ["General", "Top bar", "Panels", "Style panel"];
@@ -188,6 +195,7 @@ export const KeyboardShortcutsDialog = () => {
       "toggleComponentsPanel",
       "toggleNavigatorPanel",
       "openStylePanel",
+      "selectAllAssets",
       "openSettingsPanel",
     ],
 

--- a/apps/builder/app/builder/shared/asset-manager/asset-manager-marquee.ts
+++ b/apps/builder/app/builder/shared/asset-manager/asset-manager-marquee.ts
@@ -48,6 +48,10 @@ export const startAssetManagerMarquee = ({
   const scrollViewport = listbox.closest<HTMLElement>(
     "[data-asset-manager-scroll-area]"
   );
+  const initialScroll = {
+    left: scrollViewport?.scrollLeft ?? 0,
+    top: scrollViewport?.scrollTop ?? 0,
+  };
   const getBounds = () =>
     scrollViewport?.getBoundingClientRect() ?? panel.getBoundingClientRect();
 
@@ -100,7 +104,18 @@ export const startAssetManagerMarquee = ({
       x: Math.min(Math.max(event.clientX, bounds.left), bounds.right),
       y: Math.min(Math.max(event.clientY, bounds.top), bounds.bottom),
     };
-    const selectionRect = createAssetManagerSelectionRect(start, end);
+    const scrollDelta = {
+      left:
+        (scrollViewport?.scrollLeft ?? initialScroll.left) - initialScroll.left,
+      top: (scrollViewport?.scrollTop ?? initialScroll.top) - initialScroll.top,
+    };
+    const selectionRect = createAssetManagerSelectionRect(
+      {
+        x: start.x - scrollDelta.left,
+        y: start.y - scrollDelta.top,
+      },
+      end
+    );
     const intersectingItems = items.filter((item) => {
       const element = getItemElement(item);
       return (

--- a/apps/builder/app/builder/shared/asset-manager/asset-manager.test.tsx
+++ b/apps/builder/app/builder/shared/asset-manager/asset-manager.test.tsx
@@ -699,6 +699,27 @@ describe("Asset Manager shortcuts", () => {
     });
   });
 
+  test("selects all rendered assets and folders with Command or Control + A", () => {
+    const asset = createAsset("asset");
+    act(() => $assets.set(new Map([[asset.id, asset]])));
+    const container = renderManager();
+    const options = getOptions(container);
+    const folderButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Folder Alpha"]'
+    )!;
+    const folderOption = folderButton.closest<HTMLElement>('[role="option"]')!;
+
+    keyDown(options[0]!.button, "a", { metaKey: true });
+    expect(
+      [folderOption, ...options.map(({ option }) => option)].map((item) =>
+        item.getAttribute("aria-selected")
+      )
+    ).toEqual(["true", "true", "true", "true", "true"]);
+
+    keyDown(options[0]!.button, "a", { ctrlKey: true });
+    expect(document.body.textContent).toContain("4 items selected.");
+  });
+
   test("applies copy and duplicate shortcuts to the complete multiselection", () => {
     const asset = createAsset("asset");
     act(() => $assets.set(new Map([[asset.id, asset]])));

--- a/apps/builder/app/builder/shared/asset-manager/asset-manager.tsx
+++ b/apps/builder/app/builder/shared/asset-manager/asset-manager.tsx
@@ -727,13 +727,32 @@ export const AssetManager = ({
       event.altKey === false &&
       event.shiftKey === false &&
       ["backspace", "delete"].includes(key);
-    if (isItemCommand === false && isDeleteCommand === false) {
+    const isSelectAllCommand =
+      hasCommandModifier &&
+      event.altKey === false &&
+      event.shiftKey === false &&
+      key === "a";
+    if (
+      isItemCommand === false &&
+      isDeleteCommand === false &&
+      isSelectAllCommand === false
+    ) {
       return;
     }
     event.preventDefault();
     event.stopPropagation();
 
-    if (key === "c" && shortcutItems.length > 0) {
+    if (isSelectAllCommand) {
+      const renderedItems = navigableItems.filter((item) =>
+        itemElements.current.has(getAssetManagerSelectionKey(item))
+      );
+      if (renderedItems.length > 0) {
+        setForcedSelection(renderedItems);
+        setSelectionAnchor(renderedItems[0]);
+        setSelection(renderedItems[0]);
+        announceSelection(renderedItems);
+      }
+    } else if (key === "c" && shortcutItems.length > 0) {
       copyItems(shortcutItems);
     } else if (key === "x" && shortcutItems.length > 0) {
       cutItems(shortcutItems);

--- a/apps/builder/app/builder/shared/assets/directory-drop.test.ts
+++ b/apps/builder/app/builder/shared/assets/directory-drop.test.ts
@@ -83,6 +83,19 @@ test("falls back to regular files when directory entries are unavailable", async
   });
 });
 
+test("ignores directory items when getAsFile throws NotFoundError", async () => {
+  const item = {
+    getAsFile: () => {
+      throw new DOMException("directory", "NotFoundError");
+    },
+  } as unknown as DataTransferItem;
+
+  await expect(readDroppedAssetItems([item])).resolves.toEqual({
+    files: [],
+    directories: [],
+  });
+});
+
 test("creates every folder before returning files grouped by destination", async () => {
   const readme = new File(["readme"], "readme.md");
   const logo = new File(["logo"], "logo.svg");

--- a/apps/builder/app/builder/shared/assets/directory-drop.ts
+++ b/apps/builder/app/builder/shared/assets/directory-drop.ts
@@ -21,6 +21,17 @@ const getEntry = (item: DataTransferItem) => {
 const readFileEntry = (entry: FileSystemFileEntry) =>
   new Promise<File>((resolve, reject) => entry.file(resolve, reject));
 
+const getDroppedFile = (item: DataTransferItem) => {
+  try {
+    return item.getAsFile();
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "NotFoundError") {
+      return null;
+    }
+    throw error;
+  }
+};
+
 const readDirectoryEntries = async (entry: FileSystemDirectoryEntry) => {
   const reader = entry.createReader();
   const entries: FileSystemEntry[] = [];
@@ -73,7 +84,7 @@ export const readDroppedAssetItems = async (
       files.push(await readFileEntry(entry as FileSystemFileEntry));
       continue;
     }
-    const file = item.getAsFile();
+    const file = getDroppedFile(item);
     if (file !== null) {
       files.push(file);
     }

--- a/apps/builder/app/builder/shared/assets/upload-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/upload-assets.tsx
@@ -13,7 +13,7 @@ import {
   $uploadingFilesDataStore,
   type UploadingFileData,
 } from "~/shared/nano-states";
-import { $assetFolders, $assets } from "~/shared/sync/data-stores";
+import { $assets } from "~/shared/sync/data-stores";
 import { $project } from "~/shared/sync/data-stores";
 import { onNextTransactionComplete } from "~/shared/sync/project-queue";
 import { invalidateAssets } from "~/shared/resources";
@@ -55,13 +55,9 @@ const safeSetAsset = (asset: Asset, projectId: string) => {
     return;
   }
 
-  const folderId =
-    asset.folderId !== undefined && $assetFolders.get().has(asset.folderId)
-      ? asset.folderId
-      : undefined;
   executeRuntimeMutation({
     id: "assets.add",
-    input: { asset: { ...asset, folderId } },
+    input: { asset },
   });
 
   onNextTransactionComplete(() => {

--- a/apps/builder/app/builder/shared/assets/upload-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/upload-assets.tsx
@@ -121,6 +121,22 @@ const deleteUploadingFileData = (id: UploadingFileData["assetId"]) => {
   );
 };
 
+const moveExistingAsset = (asset: Asset, folderId: string | undefined) => {
+  if (asset.folderId === folderId) {
+    return;
+  }
+  executeRuntimeMutation({
+    id: "assets.update",
+    input: {
+      assetId: asset.id,
+      values: { folderId: folderId ?? null },
+    },
+  });
+  onNextTransactionComplete(() => {
+    invalidateAssets();
+  });
+};
+
 const getUniqueFilesData = (
   filesData: UploadingFileData[],
   revokeObjectURL = URL.revokeObjectURL
@@ -399,6 +415,10 @@ const processUpload = async (
       const assetId = fileData.assetId;
 
       if ($assets.get().has(assetId)) {
+        const existingAsset = $assets.get().get(assetId);
+        if (existingAsset !== undefined) {
+          moveExistingAsset(existingAsset, fileData.folderId);
+        }
         toast.info("Asset already exists", {
           icon: <ToastImageInfo objectURL={fileData.objectURL} />,
         });

--- a/apps/builder/app/builder/shared/assets/upload-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/upload-assets.tsx
@@ -514,11 +514,11 @@ export const uploadAssets = async <T extends File | URL>(
       uploadTickets.set(fileData.fingerprintId, ticket);
       if (ticket.deduplicated) {
         URL.revokeObjectURL(fileData.objectURL);
-        moveExistingAsset(ticket.asset, fileData.folderId);
         safeSetAsset(
           { ...ticket.asset, folderId: fileData.folderId },
           projectId
         );
+        moveExistingAsset(ticket.asset, fileData.folderId);
         toast.info("Asset already exists");
         continue;
       }

--- a/apps/builder/app/builder/shared/assets/upload-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/upload-assets.tsx
@@ -482,6 +482,10 @@ export const uploadAssets = async <T extends File | URL>(
     }
     uniqueFilesDataByFingerprint.delete(fingerprintId);
     URL.revokeObjectURL(fileData.objectURL);
+    const existingAsset = $assets.get().get(existingFileData.assetId);
+    if (existingAsset !== undefined) {
+      moveExistingAsset(existingAsset, fileData.folderId);
+    }
     toast.info("Asset already exists", {
       icon: <ToastImageInfo objectURL={existingFileData.objectURL} />,
     });
@@ -510,7 +514,11 @@ export const uploadAssets = async <T extends File | URL>(
       uploadTickets.set(fileData.fingerprintId, ticket);
       if (ticket.deduplicated) {
         URL.revokeObjectURL(fileData.objectURL);
-        safeSetAsset(ticket.asset, projectId);
+        moveExistingAsset(ticket.asset, fileData.folderId);
+        safeSetAsset(
+          { ...ticket.asset, folderId: fileData.folderId },
+          projectId
+        );
         toast.info("Asset already exists");
         continue;
       }


### PR DESCRIPTION
## Summary

Fix asset folder uploads and improve asset-manager selection behavior.

## Changes

- Preserve destination folder IDs for newly uploaded assets.
- Move duplicate assets into the dropped folder, including server-side deduplication and assets already in the upload queue.
- Register deduplicated assets before applying folder moves to avoid “Asset not found” errors.
- Handle browser `NotFoundError` cases while reading dropped directories.
- Keep lasso selection anchored correctly while scrolling.
- Add `Cmd/Ctrl+A` to select all currently rendered assets and folders.
- Document the select-all shortcut in the keyboard shortcuts dialog.

## Verification

- [x] Asset upload and directory-drop tests
- [x] Asset-manager tests
- [x] Keyboard shortcuts dialog tests
- [x] Builder typecheck
- [x] Formatting and diff checks