### PR TITLE
fix: expand CSS shorthands in MCP style updates

### DIFF
--- a/packages/project-build/src/runtime/styles.test.ts
+++ b/packages/project-build/src/runtime/styles.test.ts
@@ -85,6 +85,7 @@ import {
   createLocalStyleSourcePlan,
   createStyleDecl as createStyleDeclValue,
   createStyleDeclFromInput,
+  createStyleDeclsFromInput,
   deleteLocalStyleSourcesMutable,
   deleteStyleDeclMutable,
   deleteStyleSourceMutable,
@@ -2089,6 +2090,27 @@ describe("style declaration helpers", () => {
     });
   });
 
+  test("expands shorthand style input into editable longhands", () => {
+    expect(
+      createStyleDeclsFromInput({
+        styleSourceId: "token",
+        property: "inset",
+        value: { type: "unparsed", value: "0" },
+        breakpoint: "desktop",
+        state: ":hover",
+      })
+    ).toEqual(
+      ["top", "right", "bottom", "left"].map((property) => ({
+        styleSourceId: "token",
+        breakpointId: "desktop",
+        listed: undefined,
+        property,
+        value: { type: "unit", value: 0, unit: "number" },
+        state: ":hover",
+      }))
+    );
+  });
+
   test("creates style declaration keys from user input with base breakpoint default", () => {
     expect(
       getStyleDeclKeyFromInput({
@@ -2617,6 +2639,35 @@ describe("createStyleDeclarationUpdatePayload", () => {
     expect(missingLocalStyleSourceInstanceIds).toEqual([]);
   });
 
+  test("expands shorthand updates into local longhand patches", () => {
+    const { payload, styleKeys } = createStyleDeclarationUpdatePayload({
+      styleSources: sources([local("local")]),
+      styleSourceSelections: [{ instanceId: "box", values: ["local"] }],
+      styles: [],
+      createId,
+      updates: [
+        {
+          instanceId: "box",
+          property: "inset",
+          value: { type: "unparsed", value: "0" },
+        },
+      ],
+    });
+
+    expect(payload[0]?.patches.map((patch) => patch.path[0])).toEqual([
+      "local:base:top:",
+      "local:base:right:",
+      "local:base:bottom:",
+      "local:base:left:",
+    ]);
+    expect(styleKeys).toEqual([
+      "local:base:top:",
+      "local:base:right:",
+      "local:base:bottom:",
+      "local:base:left:",
+    ]);
+  });
+
   test("reports missing local style source when creation is disabled", () => {
     const result = createStyleDeclarationUpdatePayload({
       styleSources: new Map(),
@@ -2942,6 +2993,23 @@ describe("design token patch helpers", () => {
       },
     ]);
     expect(styleKeys).toEqual(["token:base:color:", "token:base:color:"]);
+  });
+
+  test("expands shorthand updates for design tokens", () => {
+    const { payload } = createDesignTokenStyleUpdatePayload({
+      designTokenId: "token",
+      styles: [],
+      updates: [
+        { property: "gridArea", value: { type: "unparsed", value: "1 / 1" } },
+      ],
+    });
+
+    expect(payload[0]?.patches.map((patch) => patch.path[0])).toEqual([
+      "token:base:gridRowStart:",
+      "token:base:gridColumnStart:",
+      "token:base:gridRowEnd:",
+      "token:base:gridColumnEnd:",
+    ]);
   });
 
   test("returns empty payload when token style updates are empty", () => {

--- a/packages/project-build/src/runtime/styles.test.ts
+++ b/packages/project-build/src/runtime/styles.test.ts
@@ -84,7 +84,6 @@ import {
   createLocalStyleSourcePatchPlan,
   createLocalStyleSourcePlan,
   createStyleDecl as createStyleDeclValue,
-  createStyleDeclFromInput,
   createStyleDeclsFromInput,
   deleteLocalStyleSourcesMutable,
   deleteStyleDeclMutable,
@@ -2073,21 +2072,23 @@ describe("style declaration helpers", () => {
     });
   });
 
-  test("creates style declarations from user input with base breakpoint default", () => {
+  test("creates a longhand style declaration with base breakpoint default", () => {
     expect(
-      createStyleDeclFromInput({
+      createStyleDeclsFromInput({
         styleSourceId: "token",
         property: "color",
         value: { type: "keyword", value: "red" },
         state: ":hover",
       })
-    ).toEqual({
-      styleSourceId: "token",
-      breakpointId: "base",
-      property: "color",
-      value: { type: "keyword", value: "red" },
-      state: ":hover",
-    });
+    ).toEqual([
+      {
+        styleSourceId: "token",
+        breakpointId: "base",
+        property: "color",
+        value: { type: "keyword", value: "red" },
+        state: ":hover",
+      },
+    ]);
   });
 
   test("expands shorthand style input into editable longhands", () => {
@@ -2098,17 +2099,28 @@ describe("style declaration helpers", () => {
         value: { type: "unparsed", value: "0" },
         breakpoint: "desktop",
         state: ":hover",
+        listed: true,
       })
     ).toEqual(
       ["top", "right", "bottom", "left"].map((property) => ({
         styleSourceId: "token",
         breakpointId: "desktop",
-        listed: undefined,
+        listed: true,
         property,
         value: { type: "unit", value: 0, unit: "number" },
         state: ":hover",
       }))
     );
+  });
+
+  test("rejects invalid shorthand values", () => {
+    expect(() =>
+      createStyleDeclsFromInput({
+        styleSourceId: "token",
+        property: "inset",
+        value: { type: "unparsed", value: "1px /" },
+      })
+    ).toThrow('Invalid value for shorthand CSS property "inset"');
   });
 
   test("creates style declaration keys from user input with base breakpoint default", () => {

--- a/packages/project-build/src/runtime/styles.ts
+++ b/packages/project-build/src/runtime/styles.ts
@@ -1844,7 +1844,7 @@ export const createStyleDeclsFromInput = ({
   state?: StyleDecl["state"];
   listed?: StyleDecl["listed"];
 }): StyleDecl[] => {
-  const createSingleStyleDecl = () => [
+  const createStyleDeclWithInput = (property: unknown, value: unknown) =>
     createStyleDecl({
       styleSourceId,
       breakpointId: breakpoint,
@@ -1852,8 +1852,7 @@ export const createStyleDeclsFromInput = ({
       value,
       state,
       listed,
-    }),
-  ];
+    });
   const normalizedProperty = normalizeStyleProperty(property);
   const cssProperty = hyphenateProperty(String(normalizedProperty));
   if (
@@ -1861,12 +1860,12 @@ export const createStyleDeclsFromInput = ({
       cssProperty as (typeof shorthandProperties)[number]
     ) === false
   ) {
-    return createSingleStyleDecl();
+    return [createStyleDeclWithInput(property, value)];
   }
 
   const parsedValue = styleValue.safeParse(value);
   if (parsedValue.success === false) {
-    return createSingleStyleDecl();
+    return [createStyleDeclWithInput(property, value)];
   }
   const parsed = parseCss(
     `.styles{${cssProperty}:${toValue(parsedValue.data)}}`,
@@ -1885,14 +1884,7 @@ export const createStyleDeclsFromInput = ({
     );
   }
   return parsed.styles.map((style) =>
-    createStyleDecl({
-      styleSourceId,
-      breakpointId: breakpoint,
-      property: style.property,
-      value: style.value,
-      state,
-      listed,
-    })
+    createStyleDeclWithInput(style.property, style.value)
   );
 };
 

--- a/packages/project-build/src/runtime/styles.ts
+++ b/packages/project-build/src/runtime/styles.ts
@@ -3,7 +3,9 @@ import { nanoid } from "nanoid";
 import deepEqual from "fast-deep-equal";
 import {
   camelCaseProperty,
+  parseCss,
   parseCssValue,
+  shorthandProperties,
   validateSelector,
 } from "@webstudio-is/css-data";
 import {
@@ -1851,6 +1853,73 @@ export const createStyleDeclFromInput = ({
     listed,
   });
 
+export const createStyleDeclsFromInput = ({
+  styleSourceId,
+  property,
+  value,
+  breakpoint = DEFAULT_BREAKPOINT_ID,
+  state,
+  listed,
+}: {
+  styleSourceId: StyleSource["id"];
+  property: unknown;
+  value: unknown;
+  breakpoint?: string;
+  state?: StyleDecl["state"];
+  listed?: StyleDecl["listed"];
+}): StyleDecl[] => {
+  const createSingleStyleDecl = () => [
+    createStyleDeclFromInput({
+      styleSourceId,
+      property,
+      value,
+      breakpoint,
+      state,
+      listed,
+    }),
+  ];
+  const normalizedProperty = normalizeStyleProperty(property);
+  const cssProperty = hyphenateProperty(String(normalizedProperty));
+  if (
+    shorthandProperties.includes(
+      cssProperty as (typeof shorthandProperties)[number]
+    ) === false
+  ) {
+    return createSingleStyleDecl();
+  }
+
+  const parsedValue = styleValue.safeParse(value);
+  if (parsedValue.success === false) {
+    return createSingleStyleDecl();
+  }
+  const parsed = parseCss(
+    `.styles{${cssProperty}:${toValue(parsedValue.data)}}`,
+    new Map()
+  );
+  if (
+    parsed.errors.length > 0 ||
+    parsed.styles.length === 0 ||
+    parsed.styles.some(({ value: parsedStyleValue }) =>
+      ["invalid", "guaranteedInvalid"].includes(parsedStyleValue.type)
+    )
+  ) {
+    return throwBuilderRuntimeError(
+      "BAD_REQUEST",
+      `Invalid value for shorthand CSS property "${cssProperty}"`
+    );
+  }
+  return parsed.styles.map((style) =>
+    createStyleDeclFromInput({
+      styleSourceId,
+      breakpoint,
+      property: style.property,
+      value: style.value,
+      state,
+      listed,
+    })
+  );
+};
+
 export const getStyleDeclKeyFromInput = ({
   styleSourceId,
   property,
@@ -2609,18 +2678,19 @@ export const createDesignTokenCreatePayload = ({
       value: styleSource,
     });
     for (const declaration of createDesignTokenStyleInputs(token)) {
-      const style = createStyleDeclFromInput({
+      for (const style of createStyleDeclsFromInput({
         styleSourceId: tokenId,
         breakpoint: declaration.breakpoint,
         property: declaration.property,
         value: declaration.value,
         state: declaration.state,
-      });
-      stylePatches.push({
-        op: "add" as const,
-        path: [getStyleDeclKey(style)],
-        value: style,
-      });
+      })) {
+        stylePatches.push({
+          op: "add" as const,
+          path: [getStyleDeclKey(style)],
+          value: style,
+        });
+      }
     }
   }
 
@@ -2655,23 +2725,24 @@ export const createDesignTokenStyleUpdatePayload = ({
   const styleKeys = new Set(
     Array.from(styles, (styleDecl) => getStyleDeclKey(styleDecl))
   );
-  const patches = updates.map((update) => {
-    const style = createStyleDeclFromInput({
+  const patches = updates.flatMap((update) =>
+    createStyleDeclsFromInput({
       styleSourceId: designTokenId,
       breakpoint: update.breakpoint,
       property: update.property,
       value: update.value,
       state: update.state,
-    });
-    const key = getStyleDeclKey(style);
-    const patch = {
-      op: styleKeys.has(key) ? ("replace" as const) : ("add" as const),
-      path: [key],
-      value: style,
-    };
-    styleKeys.add(key);
-    return patch;
-  });
+    }).map((style) => {
+      const key = getStyleDeclKey(style);
+      const patch = {
+        op: styleKeys.has(key) ? ("replace" as const) : ("add" as const),
+        path: [key],
+        value: style,
+      };
+      styleKeys.add(key);
+      return patch;
+    })
+  );
 
   return {
     payload:
@@ -2869,20 +2940,21 @@ export const createStyleDeclarationUpdatePayload = ({
       continue;
     }
     payload.push(...result.payload);
-    const nextStyleDecl = createStyleDeclFromInput({
+    for (const nextStyleDecl of createStyleDeclsFromInput({
       styleSourceId: result.styleSourceId,
       breakpoint: update.breakpoint,
       property: update.property,
       value: update.value,
       state: update.state,
       listed: update.listed,
-    });
-    const key = getStyleDeclKey(nextStyleDecl);
-    stylePatches.set(key, {
-      op: existingStyleKeys.has(key) ? "replace" : "add",
-      path: [key],
-      value: nextStyleDecl,
-    });
+    })) {
+      const key = getStyleDeclKey(nextStyleDecl);
+      stylePatches.set(key, {
+        op: existingStyleKeys.has(key) ? "replace" : "add",
+        path: [key],
+        value: nextStyleDecl,
+      });
+    }
   }
 
   const patches = Array.from(stylePatches.values());
@@ -3028,23 +3100,24 @@ export const createSelectedStyleDeclarationUpdatePayload = ({
       ]);
     }
 
-    const styleDecl = createStyleDeclFromInput({
+    for (const styleDecl of createStyleDeclsFromInput({
       styleSourceId: update.styleSourceId,
       breakpoint: update.breakpoint,
       property: update.property,
       value: update.value,
       state: update.state,
       listed: update.listed,
-    });
-    const styleKey = getStyleDeclKey(styleDecl);
-    stylePatches.push({
-      op: existingStyleKeys.has(styleKey)
-        ? ("replace" as const)
-        : ("add" as const),
-      path: [styleKey],
-      value: styleDecl,
-    });
-    existingStyleKeys.add(styleKey);
+    })) {
+      const styleKey = getStyleDeclKey(styleDecl);
+      stylePatches.push({
+        op: existingStyleKeys.has(styleKey)
+          ? ("replace" as const)
+          : ("add" as const),
+        path: [styleKey],
+        value: styleDecl,
+      });
+      existingStyleKeys.add(styleKey);
+    }
   }
 
   if (styleSourcePatches.length > 0) {

--- a/packages/project-build/src/runtime/styles.ts
+++ b/packages/project-build/src/runtime/styles.ts
@@ -1829,30 +1829,6 @@ export const createStyleDecl = ({
     listed,
   });
 
-export const createStyleDeclFromInput = ({
-  styleSourceId,
-  property,
-  value,
-  breakpoint = DEFAULT_BREAKPOINT_ID,
-  state,
-  listed,
-}: {
-  styleSourceId: StyleSource["id"];
-  property: unknown;
-  value: unknown;
-  breakpoint?: string;
-  state?: StyleDecl["state"];
-  listed?: StyleDecl["listed"];
-}): StyleDecl =>
-  createStyleDecl({
-    styleSourceId,
-    breakpointId: breakpoint,
-    state,
-    property,
-    value,
-    listed,
-  });
-
 export const createStyleDeclsFromInput = ({
   styleSourceId,
   property,
@@ -1869,11 +1845,11 @@ export const createStyleDeclsFromInput = ({
   listed?: StyleDecl["listed"];
 }): StyleDecl[] => {
   const createSingleStyleDecl = () => [
-    createStyleDeclFromInput({
+    createStyleDecl({
       styleSourceId,
+      breakpointId: breakpoint,
       property,
       value,
-      breakpoint,
       state,
       listed,
     }),
@@ -1909,9 +1885,9 @@ export const createStyleDeclsFromInput = ({
     );
   }
   return parsed.styles.map((style) =>
-    createStyleDeclFromInput({
+    createStyleDecl({
       styleSourceId,
-      breakpoint,
+      breakpointId: breakpoint,
       property: style.property,
       value: style.value,
       state,


### PR DESCRIPTION
Closes #5940

## What changed

- Route shorthand properties from `update-styles`, `update-design-token-styles`, and shared style mutation helpers through the existing CSS parser.
- Store expanded longhand declarations so generated CSS and Builder editing use the same data model as JSX fragment insertion.
- Preserve breakpoint, pseudo-state, and listed metadata across generated declarations.

## User impact

MCP-authored shorthands such as `inset` and `grid-area` no longer disappear from generated CSS or remain as declarations the Builder cannot edit. The three style authoring paths now produce consistent, editable project data.

## Verification

- `pnpm --filter @webstudio-is/project-build test` (2,015 tests)
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm oxfmt --check packages/project-build/src/runtime/styles.ts packages/project-build/src/runtime/styles.test.ts`
- `pnpm oxlint --deny-warnings packages/project-build/src/runtime/styles.ts packages/project-build/src/runtime/styles.test.ts`
- `git diff --check`