### PR TITLE
fix: prevent mixed router dependencies in MCP previews

### DIFF
--- a/packages/cli/src/commands/preview.test.ts
+++ b/packages/cli/src/commands/preview.test.ts
@@ -34,8 +34,8 @@ test("rejects empty preview host", async () => {
   ).rejects.toThrow("--host must not be empty.");
 });
 
-test("defaults preview generation to the app template", () => {
-  expect(previewDefaultTemplate).toEqual(["defaults", "react-router"]);
+test("defaults preview generation to one compatible router template", () => {
+  expect(previewDefaultTemplate).toEqual(["react-router"]);
 });
 
 test("uses Node module search paths to discover installed dependencies", () => {
@@ -169,7 +169,7 @@ test("prepares preview by syncing missing data and generating the app template",
   expect(syncDependencies.loadProjectBundleByProjectId).toHaveBeenCalled();
   expect(prebuildProject).toHaveBeenCalledWith({
     assets: true,
-    template: ["defaults", "react-router"],
+    template: ["react-router"],
   });
   expect(result.cwd).toBe(getPreviewProjectDir());
 });
@@ -197,7 +197,7 @@ test("prepares local verification previews with draft routes", async () => {
   });
   expect(prebuildProject).toHaveBeenCalledWith({
     assets: true,
-    template: ["defaults", "react-router"],
+    template: ["react-router"],
     includeDraftPages: true,
   });
 });
@@ -259,7 +259,7 @@ test("generates preview project in isolated directory", async () => {
 
   expect(prebuildProject).toHaveBeenCalledWith({
     assets: true,
-    template: ["defaults", "react-router"],
+    template: ["react-router"],
   });
   expect(ensureDependencies).toHaveBeenCalledOnce();
 });
@@ -335,7 +335,7 @@ test("regenerates a production cache before using it for iterative preview", asy
 
   expect(prebuildProject).toHaveBeenCalledWith({
     assets: true,
-    template: ["defaults", "react-router"],
+    template: ["react-router"],
     preserveRouteTemplates: true,
   });
 });
@@ -534,7 +534,7 @@ test("materializes session data before previewing from session source", async ()
   expect(prepareSessionDataFile).toHaveBeenCalledOnce();
   expect(prebuildProject).toHaveBeenCalledWith({
     assets: true,
-    template: ["defaults", "react-router"],
+    template: ["react-router"],
   });
 });
 
@@ -600,7 +600,7 @@ test("uses current project directory when generation is disabled", async () => {
   expect(prebuildProject).not.toHaveBeenCalled();
 });
 
-test("adds defaults when previewing the direct React Router template", async () => {
+test("keeps the standalone React Router preview template", async () => {
   const prebuildProject = vi.fn(async () => undefined);
 
   await preparePreviewProject({
@@ -614,7 +614,7 @@ test("adds defaults when previewing the direct React Router template", async () 
 
   expect(prebuildProject).toHaveBeenCalledWith({
     assets: true,
-    template: ["defaults", "react-router"],
+    template: ["react-router"],
   });
 });
 

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -47,20 +47,12 @@ import { LOCAL_ASSETS_DIR } from "../asset-files";
 import packageJson from "../../package.json" with { type: "json" };
 import { createExclusiveAsyncRunner } from "../async-utils";
 
-export const previewDefaultTemplate = ["defaults", "react-router"] as const;
+export const previewDefaultTemplate = ["react-router"] as const;
 export const previewSources = projectPreviewSources;
 export type PreviewSource = ProjectPreviewSource;
 
 const getPreviewTemplates = (template: string[]) => {
-  const templates =
-    template.length === 0 ? [...previewDefaultTemplate] : [...template];
-  if (
-    templates.includes("react-router") &&
-    templates.includes("defaults") === false
-  ) {
-    templates.unshift("defaults");
-  }
-  return templates;
+  return template.length === 0 ? [...previewDefaultTemplate] : [...template];
 };
 
 export const previewOptions = (yargs: CommonYargsArgv) =>

--- a/packages/cli/src/commands/screenshot.test.ts
+++ b/packages/cli/src/commands/screenshot.test.ts
@@ -139,7 +139,7 @@ test("captures a project route through a temporary production preview", async ()
 
   expect(preparePreviewProject).toHaveBeenCalledWith({
     assets: true,
-    template: ["defaults", "react-router"],
+    template: ["react-router"],
     generate: true,
     silent: true,
   });


### PR DESCRIPTION
## Summary

- generate MCP previews from the standalone React Router template
- prevent Remix and React Router runtimes from being merged into one dependency graph
- keep the normal Remix build path unchanged

## Root cause

The preview generator combined the complete React Router template with the Remix defaults template. That installed React Router 7 alongside Remix-provided React Router DOM 6, causing Vite to fail on incompatible exports before the iterative preview server became ready.

## User impact

`preview.start({ source: "session", mode: "iterative" })` can now start successfully, so agents can reuse the preview for fast edit, reload, screenshot, and vision cycles.

## Verification

- [x] Generated a preview from production-size project data and received HTTP 200
- [x] Verified the generated package contains React Router and no Remix router dependencies
- [x] 55 targeted CLI preview, screenshot, and MCP preview tests
- [x] CLI typecheck and formatting
- [x] `pnpm checks`
- [x] `pnpm evaluations` (all three real agent fixtures passed)