### PR TITLE
fix: Sort style sources with temporary local source

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
@@ -322,3 +322,23 @@ test("reorders and clears styles through runtime mutations", () => {
   expect($styles.get().has("token1:base:color:")).toEqual(false);
   expect($styles.get().get("local1:base:color:")).toEqual(localStyle);
 });
+
+test("reorders style sources while local style source is temporary", () => {
+  setupSelectedBody();
+  $styleSources.set(
+    new Map([
+      ["token1", { id: "token1", type: "token", name: "Primary" }],
+      ["token2", { id: "token2", type: "token", name: "Secondary" }],
+    ])
+  );
+  $styleSourceSelections.set(
+    new Map([["body", { instanceId: "body", values: ["token1", "token2"] }]])
+  );
+
+  reorderStyleSources(["token2", "token1", "temporary-local"]);
+
+  expect($styleSourceSelections.get().get("body")?.values).toEqual([
+    "token2",
+    "token1",
+  ]);
+});

--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -159,11 +159,18 @@ const reorderStyleSources = (styleSourceIds: StyleSource["id"][]) => {
   if (instanceId === undefined) {
     return;
   }
+  const attachedStyleSourceIds = new Set(
+    $styleSourceSelections.get().get(instanceId)?.values
+  );
   executeRuntimeMutation({
     id: "styleSources.reorder",
     input: {
       instanceId,
-      styleSourceIds,
+      // The style panel adds a temporary local source until local styles are
+      // persisted. Exclude it because the runtime only accepts attached IDs.
+      styleSourceIds: styleSourceIds.filter((id) =>
+        attachedStyleSourceIds.has(id)
+      ),
     },
   });
 };


### PR DESCRIPTION
## Summary

- Allow style sources to be reordered when the displayed local source has not been persisted yet.
- Submit only attached style source IDs to the runtime reorder operation.
- Add regression coverage for reordering tokens alongside a temporary local source.

## Root cause

The style panel displays a temporary local style source until local styles are persisted. Sorting included that temporary ID in the runtime mutation, but the runtime accepts only attached style source IDs and rejected the entire reorder.

## Todo

- [x] Filter temporary style source IDs from reorder mutations.
- [x] Add regression coverage.
- [x] Run targeted tests, lint, formatting, and Builder typecheck.

## Verification

- `pnpm --filter @webstudio-is/builder test -- app/builder/features/style-panel/style-source-section.test.ts` — 12 tests passed
- `pnpm exec oxlint --deny-warnings apps/builder/app/builder/features/style-panel/style-source-section.tsx apps/builder/app/builder/features/style-panel/style-source-section.test.ts`
- `pnpm exec oxfmt --check apps/builder/app/builder/features/style-panel/style-source-section.tsx apps/builder/app/builder/features/style-panel/style-source-section.test.ts`
- `pnpm --filter @webstudio-is/builder typecheck`