### PR TITLE
fix: Allow publishing projects with custom elements

### DIFF
--- a/packages/project-build/src/runtime/content-model.ts
+++ b/packages/project-build/src/runtime/content-model.ts
@@ -60,9 +60,11 @@ const isTagInteractive = (tag: string) => {
 
 const isTagSatisfyingContentModel = ({
   tag,
+  component,
   allowedCategories,
 }: {
   tag: undefined | string;
+  component: Instance["component"];
   allowedCategories: undefined | string[];
 }) => {
   // slot or collection does not have tag and should pass through allowed categories
@@ -84,9 +86,10 @@ const isTagSatisfyingContentModel = ({
     return true;
   }
   const elementContentModel = getElementContentModel(tag);
-  // Custom and legacy elements missing from our HTML data cannot be validated.
+  // Preserve legacy components whose rendered tags are missing from HTML data.
+  // Explicit tags on the generic Element must still be known and valid.
   if (elementContentModel === undefined) {
-    return true;
+    return component !== elementComponent;
   }
   // interactive exception, label > input or label > button are considered
   // valid way to nest interactive elements
@@ -356,6 +359,7 @@ export const isTreeSatisfyingContentModel = ({
   const tag = getTag({ instance, metas, props, htmlTagsByInstanceId });
   const isTagSatisfying = isTagSatisfyingContentModel({
     tag,
+    component: instance.component,
     allowedCategories,
   });
   if (isTagSatisfying === false) {

--- a/packages/project-build/src/runtime/content-model.ts
+++ b/packages/project-build/src/runtime/content-model.ts
@@ -39,13 +39,23 @@ const isIntersected = (arrayA: string[], arrayB: string[]) => {
   return arrayA.some((item) => arrayB.includes(item));
 };
 
+const getElementContentModel = (tag: undefined | string) => {
+  if (tag === undefined) {
+    return;
+  }
+  return elementsByTag[tag] as (typeof elementsByTag)[string] | undefined;
+};
+
 /**
  * checks if tag has interactive category
  * though img is an exception and historically its interactivity ignored
  * so img can be put into links and buttons
  */
 const isTagInteractive = (tag: string) => {
-  return tag !== "img" && elementsByTag[tag].categories.includes("interactive");
+  return (
+    tag !== "img" &&
+    getElementContentModel(tag)?.categories.includes("interactive") === true
+  );
 };
 
 const isTagSatisfyingContentModel = ({
@@ -73,11 +83,16 @@ const isTagSatisfyingContentModel = ({
   if (allowedCategories.includes("phrasing") && tag === "div") {
     return true;
   }
+  const elementContentModel = getElementContentModel(tag);
+  // Custom and legacy elements missing from our HTML data cannot be validated.
+  if (elementContentModel === undefined) {
+    return true;
+  }
   // interactive exception, label > input or label > button are considered
   // valid way to nest interactive elements
   if (
     allowedCategories.includes("labelable") &&
-    elementsByTag[tag].categories.includes("labelable")
+    elementContentModel.categories.includes("labelable")
   ) {
     return true;
   }
@@ -92,7 +107,7 @@ const isTagSatisfyingContentModel = ({
     return false;
   }
   // instance matches parent constraints
-  return isIntersected(allowedCategories, elementsByTag[tag].categories);
+  return isIntersected(allowedCategories, elementContentModel.categories);
 };
 
 /**
@@ -108,8 +123,9 @@ const getElementChildren = (
   }
   // components without tag behave like transparent category
   // and pass through parent constraints
-  let elementChildren: string[] =
-    tag === undefined ? ["transparent"] : elementsByTag[tag].children;
+  let elementChildren = getElementContentModel(tag)?.children ?? [
+    "transparent",
+  ];
   if (elementChildren.includes("transparent") && allowedCategories) {
     // merge categories from parent and current element when transparent occured
     elementChildren = elementChildren.flatMap((category) =>
@@ -130,7 +146,10 @@ const getElementChildren = (
   if (tag === "label" || allowedCategories?.includes("labelable")) {
     // stop passing through labelable to control children
     // to prevent label > button > input
-    if (tag && elementsByTag[tag].categories.includes("labelable") === false) {
+    if (
+      tag &&
+      getElementContentModel(tag)?.categories.includes("labelable") === false
+    ) {
       elementChildren = [...elementChildren, "labelable"];
     }
   }
@@ -546,7 +565,7 @@ export const isRichTextTree = ({
     return false;
   }
   const tag = getTag({ instance, metas, props, htmlTagsByInstanceId });
-  const elementContentModel = tag ? elementsByTag[tag] : undefined;
+  const elementContentModel = getElementContentModel(tag);
   const componentContentModel = getComponentContentModel(
     metas.get(instance.component)
   );
@@ -693,7 +712,7 @@ export const findClosestContainer = ({
     }
     const tag = getTag({ instance, props, metas, htmlTagsByInstanceId });
     const meta = metas.get(instance.component);
-    const elementChildren = tag ? elementsByTag[tag].children : undefined;
+    const elementChildren = getElementContentModel(tag)?.children;
     const componentChildren = getComponentContentModel(meta).children;
     if (
       componentChildren.length === 0 ||
@@ -732,7 +751,7 @@ export const findClosestNonTextualContainer = ({
     }
     const tag = getTag({ instance, props, metas, htmlTagsByInstanceId });
     const meta = metas.get(instance.component);
-    const elementChildren = tag ? elementsByTag[tag].children : undefined;
+    const elementChildren = getElementContentModel(tag)?.children;
     const componentChildren = getComponentContentModel(meta).children;
     if (
       componentChildren.length === 0 ||

--- a/packages/project-build/src/runtime/pre-publish-audit.test.tsx
+++ b/packages/project-build/src/runtime/pre-publish-audit.test.tsx
@@ -141,14 +141,42 @@ test("allows valid Video children", () => {
   expect(runAudit({ instances, props })).toEqual([]);
 });
 
-test("allows custom elements", () => {
+test("warns about unknown element tags without throwing", () => {
   const { instances, props } = renderData(
     <$.Body ws:id="body">
-      <ws.element ws:tag="custom-element">
+      <ws.element ws:id="custom" ws:tag="custom-element">
         <$.Paragraph>Custom element content</$.Paragraph>
       </ws.element>
     </$.Body>
   );
+
+  expect(runAudit({ instances, props })).toEqual([
+    {
+      ruleId: "html-content-model",
+      severity: "warning",
+      message:
+        "Placing <custom-element> element inside a <body> violates HTML spec.",
+      location: {
+        pageId: "marketedge",
+        pageName: "MarketEdge",
+        pagePath: "/marketedge",
+        instanceId: "custom",
+      },
+    },
+  ]);
+});
+
+test("allows legacy components with unknown tags", () => {
+  const { instances, props } = renderData(
+    <$.Body ws:id="body">
+      <ws.element ws:id="legacy" ws:tag="legacy-element" />
+    </$.Body>
+  );
+  const legacyInstance = instances.get("legacy");
+  if (legacyInstance === undefined) {
+    throw new Error("Expected legacy instance");
+  }
+  legacyInstance.component = "LegacyComponent";
 
   expect(runAudit({ instances, props })).toEqual([]);
 });

--- a/packages/project-build/src/runtime/pre-publish-audit.test.tsx
+++ b/packages/project-build/src/runtime/pre-publish-audit.test.tsx
@@ -141,6 +141,18 @@ test("allows valid Video children", () => {
   expect(runAudit({ instances, props })).toEqual([]);
 });
 
+test("allows custom elements", () => {
+  const { instances, props } = renderData(
+    <$.Body ws:id="body">
+      <ws.element ws:tag="custom-element">
+        <$.Paragraph>Custom element content</$.Paragraph>
+      </ws.element>
+    </$.Body>
+  );
+
+  expect(runAudit({ instances, props })).toEqual([]);
+});
+
 test("blocks publishing when required audit input is unavailable", () => {
   const { instances, props } = renderData(<$.Body ws:id="body"></$.Body>);
 


### PR DESCRIPTION
## Summary

Prevent the pre-publish HTML content-model audit from crashing when a project contains a tag that is not present in the generated HTML metadata.

Unknown tags on generic Element instances now produce a non-blocking publish warning. Legacy component instances remain permitted for backward compatibility. Known HTML elements continue to use their existing category and child constraints.

## Root cause

The content-model validator indexed `elementsByTag` and immediately read `categories` or `children`. A project tag absent from that dataset returned `undefined`, causing the publishing audit to throw before publishing could continue.

## Impact

Projects containing unsupported tags can complete the pre-publish audit instead of failing with an uncaught `categories` error. Invalid generic element tags are still reported, and legacy components are not rejected solely because their rendered tag is absent from current HTML metadata.

## Todo

- [x] Safely resolve HTML content-model metadata
- [x] Preserve validation for known HTML elements
- [x] Warn for unknown generic Element tags
- [x] Preserve legacy component compatibility
- [x] Add pre-publish audit regressions
- [x] Run project-build and builder formatting, lint, typecheck, and tests

## Verification

- `pnpm exec oxfmt --check packages/project-build/src/runtime/content-model.ts packages/project-build/src/runtime/pre-publish-audit.test.tsx`
- `pnpm exec oxlint --deny-warnings packages/project-build/src/runtime/content-model.ts packages/project-build/src/runtime/pre-publish-audit.test.tsx`
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm --filter @webstudio-is/builder typecheck`
- `pnpm --filter @webstudio-is/project-build test` — 81 files, 2,021 tests passed
- `pnpm --filter @webstudio-is/builder test` — 189 files, 2,356 tests passed
