### PR TITLE
fix: Accept CSS strings in animation keyframes

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/animation/animation-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/animation/animation-section.tsx
@@ -18,11 +18,12 @@ import {
 import {
   type AnimationAction,
   type AnimationActionScroll,
-  animationAction,
+  createAnimationActionInput,
   type InsetUnitValue,
   insetUnitValue,
   RANGE_UNITS,
 } from "@webstudio-is/sdk";
+import { parseCssValue } from "@webstudio-is/css-data";
 import {
   ArrowDownIcon,
   ArrowRightIcon,
@@ -56,6 +57,8 @@ const defaultActionValue: AnimationAction = {
   type: "view",
   animations: [],
 };
+
+const animationActionInput = createAnimationActionInput({ parseCssValue });
 
 const animationAxisDescription: Record<
   Exclude<NonNullable<AnimationAction["axis"]>, "block" | "inline">,
@@ -382,7 +385,7 @@ export const AnimationSection = ({
       return;
     }
 
-    const parsedValue = animationAction.safeParse(value);
+    const parsedValue = animationActionInput.safeParse(value);
     if (parsedValue.success) {
       onChange(parsedValue.data, isEphemeral);
       return;

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -58813,10 +58813,1941 @@ export const runtimeOperationContractData = [
                   },
                   value: {
                     description:
-                      "Animation action payload. Prefer existing animation tools.",
+                      "Animation action payload. Keyframe styles accept CSS strings or Webstudio style data; omitted timing defaults to an empty options object.",
+                    oneOf: [
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "scroll",
+                          },
+                          source: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "closest",
+                              },
+                              {
+                                type: "string",
+                                const: "nearest",
+                              },
+                              {
+                                type: "string",
+                                const: "root",
+                              },
+                            ],
+                          },
+                          axis: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "block",
+                              },
+                              {
+                                type: "string",
+                                const: "inline",
+                              },
+                              {
+                                type: "string",
+                                const: "x",
+                              },
+                              {
+                                type: "string",
+                                const: "y",
+                              },
+                            ],
+                          },
+                          animations: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                name: {
+                                  type: "string",
+                                },
+                                description: {
+                                  type: "string",
+                                },
+                                enabled: {
+                                  type: "array",
+                                  items: {
+                                    type: "array",
+                                    prefixItems: [
+                                      {
+                                        type: "string",
+                                        description: "breakpointId",
+                                      },
+                                      {
+                                        type: "boolean",
+                                      },
+                                    ],
+                                    minItems: 2,
+                                    maxItems: 2,
+                                  },
+                                },
+                                keyframes: {
+                                  type: "array",
+                                  items: {
+                                    type: "object",
+                                    properties: {
+                                      offset: {
+                                        type: "number",
+                                      },
+                                      styles: {
+                                        type: "object",
+                                        propertyNames: {
+                                          type: "string",
+                                        },
+                                        additionalProperties: {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              description:
+                                                'CSS value such as "translateX(-75%)". The value is parsed into Webstudio style data before it is stored.',
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type"],
+                                              additionalProperties: {},
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                    required: ["styles"],
+                                  },
+                                },
+                                timing: {
+                                  default: {},
+                                  type: "object",
+                                  properties: {
+                                    easing: {
+                                      type: "string",
+                                    },
+                                    fill: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                          const: "none",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "forwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "backwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "both",
+                                        },
+                                      ],
+                                    },
+                                    duration: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    delay: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    iterations: {
+                                      anyOf: [
+                                        {
+                                          type: "number",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "infinite",
+                                        },
+                                      ],
+                                    },
+                                    rangeStart: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "start",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "end",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                    rangeEnd: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "start",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "end",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                  },
+                                  required: [],
+                                },
+                              },
+                              required: ["keyframes"],
+                            },
+                          },
+                          isPinned: {
+                            type: "boolean",
+                          },
+                          debug: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "animations"],
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          type: {
+                            type: "string",
+                            const: "view",
+                          },
+                          subject: {
+                            type: "string",
+                          },
+                          axis: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "block",
+                              },
+                              {
+                                type: "string",
+                                const: "inline",
+                              },
+                              {
+                                type: "string",
+                                const: "x",
+                              },
+                              {
+                                type: "string",
+                                const: "y",
+                              },
+                            ],
+                          },
+                          animations: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                name: {
+                                  type: "string",
+                                },
+                                description: {
+                                  type: "string",
+                                },
+                                enabled: {
+                                  type: "array",
+                                  items: {
+                                    type: "array",
+                                    prefixItems: [
+                                      {
+                                        type: "string",
+                                        description: "breakpointId",
+                                      },
+                                      {
+                                        type: "boolean",
+                                      },
+                                    ],
+                                    minItems: 2,
+                                    maxItems: 2,
+                                  },
+                                },
+                                keyframes: {
+                                  type: "array",
+                                  items: {
+                                    type: "object",
+                                    properties: {
+                                      offset: {
+                                        type: "number",
+                                      },
+                                      styles: {
+                                        type: "object",
+                                        propertyNames: {
+                                          type: "string",
+                                        },
+                                        additionalProperties: {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              description:
+                                                'CSS value such as "translateX(-75%)". The value is parsed into Webstudio style data before it is stored.',
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type"],
+                                              additionalProperties: {},
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                    required: ["styles"],
+                                  },
+                                },
+                                timing: {
+                                  default: {},
+                                  type: "object",
+                                  properties: {
+                                    easing: {
+                                      type: "string",
+                                    },
+                                    fill: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                          const: "none",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "forwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "backwards",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "both",
+                                        },
+                                      ],
+                                    },
+                                    duration: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    delay: {
+                                      anyOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "unit",
+                                            },
+                                            value: {
+                                              type: "number",
+                                            },
+                                            unit: {
+                                              anyOf: [
+                                                {
+                                                  type: "string",
+                                                  const: "ms",
+                                                },
+                                                {
+                                                  type: "string",
+                                                  const: "s",
+                                                },
+                                              ],
+                                            },
+                                          },
+                                          required: ["type", "value", "unit"],
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            type: {
+                                              type: "string",
+                                              const: "var",
+                                            },
+                                            value: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["type", "value"],
+                                        },
+                                      ],
+                                    },
+                                    iterations: {
+                                      anyOf: [
+                                        {
+                                          type: "number",
+                                        },
+                                        {
+                                          type: "string",
+                                          const: "infinite",
+                                        },
+                                      ],
+                                    },
+                                    rangeStart: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "contain",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "cover",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry-crossing",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit-crossing",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                    rangeEnd: {
+                                      type: "array",
+                                      prefixItems: [
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "string",
+                                              const: "contain",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "cover",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "entry-crossing",
+                                            },
+                                            {
+                                              type: "string",
+                                              const: "exit-crossing",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          anyOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unit",
+                                                },
+                                                value: {
+                                                  type: "number",
+                                                },
+                                                unit: {
+                                                  anyOf: [
+                                                    {
+                                                      type: "string",
+                                                      const: "%",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "px",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "mm",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "q",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "in",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pt",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "pc",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "em",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rem",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rex",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "cap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rcap",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "ch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rch",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "rlh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvw",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvh",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvi",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvb",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmin",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "vmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "svmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "lvmax",
+                                                    },
+                                                    {
+                                                      type: "string",
+                                                      const: "dvmax",
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              required: [
+                                                "type",
+                                                "value",
+                                                "unit",
+                                              ],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "unparsed",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                type: {
+                                                  type: "string",
+                                                  const: "var",
+                                                },
+                                                value: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["type", "value"],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                  },
+                                  required: [],
+                                },
+                              },
+                              required: ["keyframes"],
+                            },
+                          },
+                          insetStart: {
+                            anyOf: [
+                              {
+                                anyOf: [
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unit",
+                                      },
+                                      value: {
+                                        type: "number",
+                                      },
+                                      unit: {
+                                        anyOf: [
+                                          {
+                                            type: "string",
+                                            const: "%",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "px",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "mm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "q",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "in",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pt",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pc",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "em",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rem",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rcap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rlh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmax",
+                                          },
+                                        ],
+                                      },
+                                    },
+                                    required: ["type", "value", "unit"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unparsed",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "var",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                ],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "keyword",
+                                  },
+                                  value: {
+                                    type: "string",
+                                    const: "auto",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                            ],
+                          },
+                          insetEnd: {
+                            anyOf: [
+                              {
+                                anyOf: [
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unit",
+                                      },
+                                      value: {
+                                        type: "number",
+                                      },
+                                      unit: {
+                                        anyOf: [
+                                          {
+                                            type: "string",
+                                            const: "%",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "px",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "mm",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "q",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "in",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pt",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "pc",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "em",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rem",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rex",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "cap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rcap",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "ch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rch",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "rlh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvw",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvh",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvi",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvb",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmin",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "vmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "svmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "lvmax",
+                                          },
+                                          {
+                                            type: "string",
+                                            const: "dvmax",
+                                          },
+                                        ],
+                                      },
+                                    },
+                                    required: ["type", "value", "unit"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "unparsed",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      type: {
+                                        type: "string",
+                                        const: "var",
+                                      },
+                                      value: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["type", "value"],
+                                  },
+                                ],
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  type: {
+                                    type: "string",
+                                    const: "keyword",
+                                  },
+                                  value: {
+                                    type: "string",
+                                    const: "auto",
+                                  },
+                                },
+                                required: ["type", "value"],
+                              },
+                            ],
+                          },
+                          isPinned: {
+                            type: "boolean",
+                          },
+                          debug: {
+                            type: "boolean",
+                          },
+                        },
+                        required: ["type", "animations"],
+                      },
+                    ],
                   },
                 },
-                required: ["instanceId", "name", "type"],
+                required: ["instanceId", "name", "type", "value"],
               },
             ],
             description:

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -3912,7 +3912,7 @@ const animationComponentGuidanceByComponent = new Map<string, string>([
       'Set the action prop to an animationAction. Use type:"view" for visibility-driven entry/exit animations and type:"scroll" for scroll-progress animations.',
       "For view actions, common settings are axis, subject, insetStart, insetEnd, isPinned, debug, and animations. Use subject only when another element should drive progress.",
       "For scroll actions, common settings are axis, source (nearest, root, or closest), isPinned, debug, and animations.",
-      "Each animation needs timing and keyframes. Timing can use rangeStart/rangeEnd, fill, easing, duration, delay, and iterations. Duration makes Range End unnecessary because duration defines when the animation ends.",
+      'Each animation needs keyframes; timing is optional and defaults to {}. In keyframes[].styles, use CSS property names with raw CSS strings such as transform:"translateX(-75%)"; update-props parses them into Webstudio style data. Timing can use rangeStart/rangeEnd, fill, easing, duration, delay, and iterations. Duration makes Range End unnecessary because duration defines when the animation ends.',
       'Use fill:"backwards" for in animations from animation styles to canvas styles, and fill:"forwards" for out animations from canvas styles to animation styles.',
       "Direct child animations expose --index and --total to support staggered formulas such as calc(var(--index) * 20%).",
       "For polished pages, design the element's normal canvas styles as the final state, then set the Animation Group keyframes to the starting or ending animated state.",

--- a/packages/project-build/src/runtime/props.test.ts
+++ b/packages/project-build/src/runtime/props.test.ts
@@ -501,6 +501,80 @@ describe("createPropUpsertPayload", () => {
 });
 
 describe("updateProps", () => {
+  test("parses CSS strings in animation action keyframes", () => {
+    const input = propUpdatesInput.parse({
+      updates: [
+        {
+          instanceId: "animation-id",
+          name: "action",
+          type: "animationAction",
+          value: {
+            type: "scroll",
+            axis: "y",
+            source: "closest",
+            animations: [
+              {
+                keyframes: [
+                  { offset: 0, styles: { transform: "translateX(0%)" } },
+                  { offset: 1, styles: { transform: "translateX(-75%)" } },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(input.updates[0].value).toEqual({
+      type: "scroll",
+      axis: "y",
+      source: "closest",
+      animations: [
+        {
+          timing: {},
+          keyframes: [
+            {
+              offset: 0,
+              styles: {
+                transform: {
+                  type: "tuple",
+                  value: [
+                    {
+                      type: "function",
+                      name: "translateX",
+                      args: {
+                        type: "layers",
+                        value: [{ type: "unit", unit: "%", value: 0 }],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              offset: 1,
+              styles: {
+                transform: {
+                  type: "tuple",
+                  value: [
+                    {
+                      type: "function",
+                      name: "translateX",
+                      args: {
+                        type: "layers",
+                        value: [{ type: "unit", unit: "%", value: -75 }],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   test("rejects invalid HtmlEmbed code updates", () => {
     const htmlEmbed: Instance = {
       type: "instance",

--- a/packages/project-build/src/runtime/props.ts
+++ b/packages/project-build/src/runtime/props.ts
@@ -1,9 +1,15 @@
 import { z } from "zod";
+import { parseCssValue } from "@webstudio-is/css-data";
+import { hyphenateProperty } from "@webstudio-is/css-engine";
 import {
+  animationAction,
+  animationKeyframe,
   prop as propSchema,
+  scrollAnimation,
   type Instance,
   type Prop,
   type PropMeta,
+  viewAnimation,
 } from "@webstudio-is/sdk";
 import { validateJsonLd } from "@webstudio-is/sdk/runtime";
 import type { BuilderState } from "../state/builder-state";
@@ -170,6 +176,54 @@ const propValueBaseInput = {
   required: z.boolean().optional(),
 };
 
+const animationStyleInput = z.union([
+  z
+    .string()
+    .describe(
+      'CSS value such as "translateX(-75%)". The value is parsed into Webstudio style data before it is stored.'
+    ),
+  z.object({ type: z.string() }).passthrough(),
+]);
+
+const animationKeyframeInput = animationKeyframe.extend({
+  styles: z.record(z.string(), animationStyleInput),
+});
+
+const scrollAnimationInput = scrollAnimation.extend({
+  timing: scrollAnimation.shape.timing.optional().default({}),
+  keyframes: z.array(animationKeyframeInput),
+});
+
+const viewAnimationInput = viewAnimation.extend({
+  timing: viewAnimation.shape.timing.optional().default({}),
+  keyframes: z.array(animationKeyframeInput),
+});
+
+const [scrollActionSchema, viewActionSchema] = animationAction.options;
+
+const animationActionInput = z
+  .discriminatedUnion("type", [
+    scrollActionSchema.extend({ animations: z.array(scrollAnimationInput) }),
+    viewActionSchema.extend({ animations: z.array(viewAnimationInput) }),
+  ])
+  .transform((action) => ({
+    ...action,
+    animations: action.animations.map((animation) => ({
+      ...animation,
+      keyframes: animation.keyframes.map((keyframe) => ({
+        ...keyframe,
+        styles: Object.fromEntries(
+          Object.entries(keyframe.styles).map(([property, value]) => [
+            property,
+            typeof value === "string"
+              ? parseCssValue(hyphenateProperty(property), value)
+              : value,
+          ])
+        ),
+      })),
+    })),
+  }));
+
 const propValueInputVariants = [
   z.object({
     ...propValueBaseInput,
@@ -245,9 +299,9 @@ const propValueInputVariants = [
   z.object({
     ...propValueBaseInput,
     type: z.literal("animationAction"),
-    value: z
-      .unknown()
-      .describe("Animation action payload. Prefer existing animation tools."),
+    value: animationActionInput.describe(
+      "Animation action payload. Keyframe styles accept CSS strings or Webstudio style data; omitted timing defaults to an empty options object."
+    ),
   }),
 ] as const;
 

--- a/packages/project-build/src/runtime/props.ts
+++ b/packages/project-build/src/runtime/props.ts
@@ -1,15 +1,11 @@
 import { z } from "zod";
 import { parseCssValue } from "@webstudio-is/css-data";
-import { hyphenateProperty } from "@webstudio-is/css-engine";
 import {
-  animationAction,
-  animationKeyframe,
+  createAnimationActionInput,
   prop as propSchema,
-  scrollAnimation,
   type Instance,
   type Prop,
   type PropMeta,
-  viewAnimation,
 } from "@webstudio-is/sdk";
 import { validateJsonLd } from "@webstudio-is/sdk/runtime";
 import type { BuilderState } from "../state/builder-state";
@@ -176,53 +172,7 @@ const propValueBaseInput = {
   required: z.boolean().optional(),
 };
 
-const animationStyleInput = z.union([
-  z
-    .string()
-    .describe(
-      'CSS value such as "translateX(-75%)". The value is parsed into Webstudio style data before it is stored.'
-    ),
-  z.object({ type: z.string() }).passthrough(),
-]);
-
-const animationKeyframeInput = animationKeyframe.extend({
-  styles: z.record(z.string(), animationStyleInput),
-});
-
-const scrollAnimationInput = scrollAnimation.extend({
-  timing: scrollAnimation.shape.timing.optional().default({}),
-  keyframes: z.array(animationKeyframeInput),
-});
-
-const viewAnimationInput = viewAnimation.extend({
-  timing: viewAnimation.shape.timing.optional().default({}),
-  keyframes: z.array(animationKeyframeInput),
-});
-
-const [scrollActionSchema, viewActionSchema] = animationAction.options;
-
-const animationActionInput = z
-  .discriminatedUnion("type", [
-    scrollActionSchema.extend({ animations: z.array(scrollAnimationInput) }),
-    viewActionSchema.extend({ animations: z.array(viewAnimationInput) }),
-  ])
-  .transform((action) => ({
-    ...action,
-    animations: action.animations.map((animation) => ({
-      ...animation,
-      keyframes: animation.keyframes.map((keyframe) => ({
-        ...keyframe,
-        styles: Object.fromEntries(
-          Object.entries(keyframe.styles).map(([property, value]) => [
-            property,
-            typeof value === "string"
-              ? parseCssValue(hyphenateProperty(property), value)
-              : value,
-          ])
-        ),
-      })),
-    })),
-  }));
+const animationActionInput = createAnimationActionInput({ parseCssValue });
 
 const propValueInputVariants = [
   z.object({

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -62,6 +62,7 @@ export type {
 
 export {
   animationAction,
+  createAnimationActionInput,
   scrollAnimation,
   viewAnimation,
   rangeUnitValue,

--- a/packages/sdk/src/schema/animation-schema.test.ts
+++ b/packages/sdk/src/schema/animation-schema.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "vitest";
+import { parseCssValue } from "@webstudio-is/css-data";
+import { createAnimationActionInput } from "./animation-schema";
+
+test("normalizes authored animation actions", () => {
+  const animationActionInput = createAnimationActionInput({ parseCssValue });
+
+  expect(
+    animationActionInput.parse({
+      type: "scroll",
+      animations: [
+        {
+          keyframes: [
+            {
+              styles: {
+                transform: "translateX(-75%)",
+              },
+            },
+          ],
+        },
+      ],
+    })
+  ).toEqual({
+    type: "scroll",
+    animations: [
+      {
+        timing: {},
+        keyframes: [
+          {
+            styles: {
+              transform: parseCssValue("transform", "translateX(-75%)"),
+            },
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/packages/sdk/src/schema/animation-schema.ts
+++ b/packages/sdk/src/schema/animation-schema.ts
@@ -1,4 +1,9 @@
-import { styleValue } from "@webstudio-is/css-engine";
+import {
+  hyphenateProperty,
+  styleValue,
+  type CssProperty,
+  type StyleValue,
+} from "@webstudio-is/css-engine";
 import { z } from "zod";
 
 // Helper for creating union of string literals from array
@@ -219,6 +224,74 @@ export const animationAction = z.discriminatedUnion("type", [
   scrollAction,
   viewAction,
 ]);
+
+const animationStyleInput = z.union([
+  z
+    .string()
+    .describe(
+      'CSS value such as "translateX(-75%)". The value is parsed into Webstudio style data before it is stored.'
+    ),
+  z
+    .object({ type: z.string() })
+    .passthrough()
+    .superRefine((value, context) => {
+      const result = styleValue.safeParse(value);
+      if (result.success === false) {
+        for (const issue of result.error.issues) {
+          context.addIssue({
+            code: "custom",
+            path: issue.path,
+            message: issue.message,
+          });
+        }
+      }
+    }),
+]);
+
+const animationKeyframeInput = animationKeyframe.extend({
+  styles: z.record(z.string(), animationStyleInput),
+});
+
+const scrollAnimationInput = scrollAnimation.extend({
+  timing: scrollAnimation.shape.timing.optional().default({}),
+  keyframes: z.array(animationKeyframeInput),
+});
+
+const viewAnimationInput = viewAnimation.extend({
+  timing: viewAnimation.shape.timing.optional().default({}),
+  keyframes: z.array(animationKeyframeInput),
+});
+
+export const createAnimationActionInput = ({
+  parseCssValue,
+}: {
+  parseCssValue: (property: CssProperty, value: string) => StyleValue;
+}) =>
+  z
+    .discriminatedUnion("type", [
+      scrollAction.extend({ animations: z.array(scrollAnimationInput) }),
+      viewAction.extend({ animations: z.array(viewAnimationInput) }),
+    ])
+    .transform(
+      (action): AnimationAction =>
+        ({
+          ...action,
+          animations: action.animations.map((animation) => ({
+            ...animation,
+            keyframes: animation.keyframes.map((keyframe) => ({
+              ...keyframe,
+              styles: Object.fromEntries(
+                Object.entries(keyframe.styles).map(([property, value]) => [
+                  property,
+                  typeof value === "string"
+                    ? parseCssValue(hyphenateProperty(property), value)
+                    : value,
+                ])
+              ),
+            })),
+          })),
+        }) as AnimationAction
+    );
 
 // Helper function to check if a value is a valid range unit
 export const isRangeUnit = (


### PR DESCRIPTION
## Summary

Allow MCP `update-props` callers to configure `animationAction` keyframes with normal CSS strings, including values such as `transform: "translateX(-75%)"`.

Use one SDK-owned animation authoring schema in both the Builder UI and MCP so CSS parsing, timing defaults, and validation cannot drift between entry points.

## Root cause

The Builder UI and MCP did not share an authoring contract. Builder controls produced Webstudio's structured style values and animation factories supplied timing objects, while MCP passed its input directly toward the persisted prop schema. As a result, normal CSS strings failed deep Zod validation and omitted timing objects were rejected.

## Implementation

- Add a shared `createAnimationActionInput` schema factory to the SDK.
- Inject the CSS parser into the schema factory to avoid adding an `sdk` → `css-data` dependency cycle.
- Use the shared schema in both Builder animation validation and MCP `update-props`.
- Accept raw CSS strings or existing structured Webstudio values in `keyframes[].styles`.
- Parse string values before persistence and default omitted animation `timing` to an empty options object.
- Update Animation Group guidance and regenerate the runtime operation contract.
- Preserve strict validation for existing structured animation style values.

## Checklist

- [x] Add regression coverage for the reported horizontal scroll payload.
- [x] Verify the regression fails before implementation and passes after it.
- [x] Add SDK coverage for shared animation authoring normalization.
- [x] Use the shared authoring schema in Builder and MCP.
- [x] Verify package boundaries and generated runtime contracts.
- [x] Run affected typechecks, targeted tests, lint, and formatting.
- [x] Run the complete agent evaluation suite.
- [ ] Resolve evaluation read-budget failures: `authenticated-page-v1` and `design-input-v1` failed only `boundedReads`.

## Validation

Passed:

- `pnpm --filter @webstudio-is/sdk test -- src/schema/animation-schema.test.ts`
- `pnpm --filter @webstudio-is/project-build test -- src/runtime/props.test.ts src/mcp.test.ts`
- `pnpm --filter @webstudio-is/sdk typecheck`
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm --filter @webstudio-is/builder typecheck`
- `pnpm check:package-boundaries`
- `pnpm exec oxlint --deny-warnings <changed source and test files>`
- `pnpm exec oxfmt --check <changed source and test files>`
- `pnpm check:generated-api`
- `font-assets-v1` agent evaluation

Agent evaluation findings:

- `authenticated-page-v1`: failed only `boundedReads`; all functional, audit, binding, privacy, and visual checks passed.
- `design-input-v1`: failed only `boundedReads`; all functional, audit, responsive, design-system, privacy, and visual checks passed.
- `font-assets-v1`: passed all checks.

