### PR TITLE
fix: Reuse npm launcher for generated previews

### DIFF
--- a/packages/cli/src/commands/preview.test.ts
+++ b/packages/cli/src/commands/preview.test.ts
@@ -458,6 +458,42 @@ test("installs isolated generated dependencies when the cli does not ship them",
   );
 });
 
+test("reuses the npm cli that launched webstudio on windows", async () => {
+  let installed = false;
+  const execFile = vi.fn(async () => {
+    installed = true;
+    return { stdout: "", stderr: "" };
+  });
+
+  await ensurePreviewDependencies("/tmp/project/.webstudio/preview", {
+    access: vi.fn(async (path) => {
+      if (installed && path.startsWith("/tmp/project/.webstudio/preview")) {
+        return;
+      }
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    }),
+    execFile,
+    lstat: vi.fn(async () => {
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    }),
+    readFile: vi.fn(async () => '{"dependencies":{"vite":"1.0.0"}}'),
+    nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
+    npmExecPath:
+      "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+    platform: "win32",
+    writeFile: vi.fn(async () => undefined),
+  });
+
+  expect(execFile).toHaveBeenCalledWith(
+    "C:\\Program Files\\nodejs\\node.exe",
+    expect.arrayContaining([
+      "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+      "install",
+    ]),
+    { cwd: "/tmp/project/.webstudio/preview" }
+  );
+});
+
 test("reports an actionable error when generated dependencies cannot install", async () => {
   const access = vi.fn(async () => {
     throw Object.assign(new Error("missing"), { code: "ENOENT" });

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -27,6 +27,7 @@ import { LOCAL_CONFIG_FILE, LOCAL_DATA_FILE } from "../config";
 import { HandledCliError } from "../errors";
 import {
   getPreviewUrl,
+  getNpmInvocation,
   previewBuildCacheMarker,
   runPreviewBuild,
   startPreviewServer,
@@ -177,6 +178,8 @@ type PreviewDependencyOperations = {
     type: "dir" | "junction"
   ) => Promise<void>;
   writeFile: (path: string, data: string) => Promise<void>;
+  nodeExecPath: string;
+  npmExecPath?: string;
   platform: NodeJS.Platform;
 };
 
@@ -195,6 +198,8 @@ export const ensurePreviewDependencies = async (
     rm,
     symlink,
     writeFile,
+    nodeExecPath: process.execPath,
+    npmExecPath: process.env.npm_execpath,
     platform: process.platform,
     ...dependencies,
   };
@@ -260,19 +265,20 @@ export const ensurePreviewDependencies = async (
     }
   }
 
+  const installArgs = [
+    "install",
+    "--legacy-peer-deps",
+    "--no-audit",
+    "--no-fund",
+    "--package-lock=false",
+    "--loglevel=error",
+  ];
+  const invocation = getNpmInvocation(installArgs, operations);
+
   try {
-    await operations.execFile(
-      operations.platform === "win32" ? "npm.cmd" : "npm",
-      [
-        "install",
-        "--legacy-peer-deps",
-        "--no-audit",
-        "--no-fund",
-        "--package-lock=false",
-        "--loglevel=error",
-      ],
-      { cwd: previewProjectDir }
-    );
+    await operations.execFile(invocation.command, invocation.args, {
+      cwd: previewProjectDir,
+    });
   } catch (error) {
     throw new Error(
       "PREVIEW_DEPENDENCY_INSTALL_FAILED: Could not install the generated preview dependencies. Check the npm/network configuration, then reinstall or update webstudio if the problem persists.",

--- a/packages/cli/src/preview-server.test.ts
+++ b/packages/cli/src/preview-server.test.ts
@@ -7,6 +7,7 @@ import {
   findAvailablePort,
   getPreviewBuildArgs,
   getPreviewCommand,
+  getNpmInvocation,
   getPreviewStartArgs,
   getPreviewUrl,
   materializePreviewAssets,
@@ -34,6 +35,8 @@ const createDependencies = (
   readFile: vi.fn(async () => "") as never,
   writeFile: vi.fn(async () => undefined) as never,
   sleep: vi.fn(async () => undefined),
+  nodeExecPath: "/usr/bin/node",
+  npmExecPath: undefined,
   platform: "linux",
   ...overrides,
 });
@@ -107,6 +110,24 @@ test("uses the platform npm executable for preview commands", () => {
   expect(getPreviewCommand("linux")).toBe("npm");
   expect(getPreviewCommand("darwin")).toBe("npm");
   expect(getPreviewCommand("win32")).toBe("npm.cmd");
+});
+
+test("reuses the npm cli that launched webstudio for preview commands", () => {
+  expect(
+    getNpmInvocation(["run", "build"], {
+      nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
+      npmExecPath:
+        "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+      platform: "win32",
+    })
+  ).toEqual({
+    command: "C:\\Program Files\\nodejs\\node.exe",
+    args: [
+      "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+      "run",
+      "build",
+    ],
+  });
 });
 
 test("runs generated project production build", async () => {

--- a/packages/cli/src/preview-server.ts
+++ b/packages/cli/src/preview-server.ts
@@ -5,7 +5,7 @@ import {
 } from "node:child_process";
 import { cp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { createServer as createTcpServer } from "node:net";
-import { delimiter, dirname, join, parse } from "node:path";
+import { basename, delimiter, dirname, join, parse, win32 } from "node:path";
 import { parse as parseHtml, type DefaultTreeAdapterMap } from "parse5";
 import type { ProjectPreviewMode } from "@webstudio-is/project-build/visual";
 
@@ -33,6 +33,8 @@ export type PreviewServerDependencies = {
   readFile: typeof readFile;
   writeFile: typeof writeFile;
   sleep: (ms: number) => Promise<void>;
+  nodeExecPath: string;
+  npmExecPath?: string;
   platform: typeof process.platform;
 };
 
@@ -45,6 +47,8 @@ export const defaultPreviewServerDependencies: PreviewServerDependencies = {
   readFile,
   writeFile,
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  nodeExecPath: process.execPath,
+  npmExecPath: process.env.npm_execpath,
   platform: process.platform,
 };
 
@@ -132,23 +136,44 @@ export const getPreviewCommand = (
   platform: typeof process.platform = process.platform
 ) => (platform === "win32" ? "npm.cmd" : "npm");
 
+export const getNpmInvocation = (
+  args: string[],
+  {
+    nodeExecPath = process.execPath,
+    npmExecPath = process.env.npm_execpath,
+    platform = process.platform,
+  }: {
+    nodeExecPath?: string;
+    npmExecPath?: string;
+    platform?: typeof process.platform;
+  } = {}
+) => {
+  const npmCliName =
+    npmExecPath === undefined
+      ? undefined
+      : platform === "win32"
+        ? win32.basename(npmExecPath)
+        : basename(npmExecPath);
+  if (npmExecPath !== undefined && npmCliName === "npm-cli.js") {
+    return { command: nodeExecPath, args: [npmExecPath, ...args] };
+  }
+  return { command: getPreviewCommand(platform), args };
+};
+
 export const runPreviewBuild = async (
   dependencies = defaultPreviewServerDependencies,
   cwd?: string,
   stdio: StdioOptions = "inherit"
 ) => {
-  const buildProcess = dependencies.spawn(
-    getPreviewCommand(dependencies.platform),
-    getPreviewBuildArgs(),
-    {
-      cwd,
-      stdio,
-      env: getPreviewEnv(cwd, {
-        ...processEnv(),
-        NODE_ENV: "production",
-      }),
-    }
-  );
+  const invocation = getNpmInvocation(getPreviewBuildArgs(), dependencies);
+  const buildProcess = dependencies.spawn(invocation.command, invocation.args, {
+    cwd,
+    stdio,
+    env: getPreviewEnv(cwd, {
+      ...processEnv(),
+      NODE_ENV: "production",
+    }),
+  });
   let output = "";
   const appendOutput = (chunk: unknown) => {
     output = `${output}${String(chunk)}`.slice(-4000);
@@ -196,9 +221,13 @@ export const startPreviewServer = (
   options: PreviewServerOptions & { stdio?: StdioOptions },
   dependencies = defaultPreviewServerDependencies
 ): PreviewServerResult => {
-  const previewProcess = dependencies.spawn(
-    getPreviewCommand(dependencies.platform),
+  const invocation = getNpmInvocation(
     getPreviewStartArgs(options),
+    dependencies
+  );
+  const previewProcess = dependencies.spawn(
+    invocation.command,
+    invocation.args,
     {
       cwd: options.cwd,
       stdio: options.stdio ?? "inherit",


### PR DESCRIPTION
## Summary

Generated previews now reuse the npm CLI path supplied by the npx launcher instead of rediscovering npm or npm.cmd through the MCP subprocess PATH. The same invocation is used for dependency installation, production builds, and preview server startup, with the existing platform command retained as a fallback for direct launches.

## Technical choices

- Invoke npm-cli.js with the current Node executable when npm_execpath identifies npm as the launcher.
- Parse Windows paths with the platform path implementation.
- Keep npm and npm.cmd fallback behavior when Webstudio was not launched through npm.
- Inject executable paths in tests so launcher behavior is deterministic.

## Todo

- [x] Reuse the npx npm launcher during generated dependency installation.
- [x] Apply the same launcher to generated build and server commands.
- [x] Cover Windows launcher paths and direct-launch fallbacks.
- [x] Run focused tests, typecheck, lint, formatting, and production build.

## Verification

- pnpm --filter webstudio test -- src/commands/preview.test.ts src/preview-server.test.ts
- pnpm --filter webstudio typecheck
- pnpm exec oxlint --deny-warnings on the four changed files
- pnpm --filter webstudio build
- git diff --check

All checks passed. The build emitted the existing Radix use-client bundling warnings. Agent evaluations were not run because they require separate explicit approval.