### PR TITLE
fix: Clarify published content database size

### DIFF
--- a/apps/builder/app/builder/features/publish/content-database-publish-warning-view.test.tsx
+++ b/apps/builder/app/builder/features/publish/content-database-publish-warning-view.test.tsx
@@ -1,0 +1,61 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import type { ContentDatabasePublishDiagnostics } from "~/services/content-database.server";
+import { ContentDatabasePublishWarning } from "./content-database-publish-warning-view";
+
+const renderWarning = (diagnostics: ContentDatabasePublishDiagnostics) =>
+  renderToStaticMarkup(
+    <ContentDatabasePublishWarning diagnostics={diagnostics} />
+  );
+
+describe("ContentDatabasePublishWarning", () => {
+  test("explains a size omission using the full database size", () => {
+    expect(
+      renderWarning({
+        stats: {
+          format: "webstudio-content-database",
+          version: 1,
+          revision:
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          usedBytes: 21 * 1024,
+          maxBytes: 500 * 1024,
+          unboundedBytes: 939_661,
+          includedDocumentCount: 5,
+          omittedDocumentCount: 1,
+          omissionReason: "size",
+          truncated: true,
+        },
+        affectedResources: [
+          { name: "post", kind: "dynamic" },
+          { name: "posts", kind: "static" },
+          { name: "featuredPost", kind: "static" },
+        ],
+      })
+    ).toBe(
+      "The complete content database is 918 KiB, exceeding the 500 KiB publish limit. Publishing will include 5 of 6 files (21 KiB) and omit 1 file. Resources that may return incomplete results: posts, featuredPost. Resource with route or variable values cannot be checked in advance and may also return incomplete results: post."
+    );
+  });
+
+  test("explains when required content is unavailable", () => {
+    expect(
+      renderWarning({
+        stats: {
+          format: "webstudio-content-database",
+          version: 1,
+          revision:
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          usedBytes: 10 * 1024,
+          maxBytes: 500 * 1024,
+          unboundedBytes: 10 * 1024,
+          includedDocumentCount: 1,
+          omittedDocumentCount: 2,
+          omissionReason: "unavailable",
+          truncated: true,
+        },
+        affectedResources: [],
+      })
+    ).toBe(
+      "Publishing will include 1 of 3 files (10 KiB) and omit 2 files because their required content is unavailable."
+    );
+  });
+});

--- a/apps/builder/app/builder/features/publish/content-database-publish-warning-view.tsx
+++ b/apps/builder/app/builder/features/publish/content-database-publish-warning-view.tsx
@@ -15,29 +15,36 @@ export const ContentDatabasePublishWarning = ({
   const staticResourceNames = diagnostics.affectedResources.flatMap(
     ({ name, kind }) => (kind === "static" ? [name] : [])
   );
+  const includedSize = `${Math.ceil(stats.usedBytes / 1024)} KiB`;
+  const fullSize = `${Math.ceil(stats.unboundedBytes / 1024)} KiB`;
+  const sizeLimit = `${Math.ceil(stats.maxBytes / 1024)} KiB`;
   return (
     <>
-      The merged published content database will include{" "}
-      {stats.includedDocumentCount} of {totalDocumentCount} files (
-      {Math.ceil(stats.usedBytes / 1024)} of {Math.ceil(stats.maxBytes / 1024)}{" "}
-      KiB). {stats.omittedDocumentCount} {omittedFileLabel} will be omitted{" "}
-      {stats.omissionReason === "size"
-        ? "because the complete database exceeds the size limit"
-        : "because the required content could not be embedded"}
-      .
-      {dynamicResourceNames.length > 0 && (
+      {stats.omissionReason === "size" && (
         <>
-          {" "}
-          Assets resources with route or variable values cannot be checked
-          exactly and may return incomplete results:{" "}
-          {dynamicResourceNames.join(", ")}.
+          The complete content database is {fullSize}, exceeding the {sizeLimit}{" "}
+          publish limit.{" "}
         </>
       )}
+      Publishing will include {stats.includedDocumentCount} of{" "}
+      {totalDocumentCount} files ({includedSize}) and omit{" "}
+      {stats.omittedDocumentCount} {omittedFileLabel}
+      {stats.omissionReason === "unavailable"
+        ? ` because ${stats.omittedDocumentCount === 1 ? "its" : "their"} required content is unavailable.`
+        : "."}
       {staticResourceNames.length > 0 && (
         <>
           {" "}
-          Potentially affected Assets resources:{" "}
-          {staticResourceNames.join(", ")}.
+          {staticResourceNames.length === 1 ? "Resource" : "Resources"} that may
+          return incomplete results: {staticResourceNames.join(", ")}.
+        </>
+      )}
+      {dynamicResourceNames.length > 0 && (
+        <>
+          {" "}
+          {dynamicResourceNames.length === 1 ? "Resource" : "Resources"} with
+          route or variable values cannot be checked in advance and may also
+          return incomplete results: {dynamicResourceNames.join(", ")}.
         </>
       )}
     </>


### PR DESCRIPTION
## Problem

The publish warning compared the already-truncated database size with the publish limit. For example, it reported 21 of 500 KiB while saying the complete database exceeded the limit, even though truncation is decided from the separate full database size.

## Changes

- Compare the complete pre-truncation database size with the publish limit.
- Report the retained published subset separately.
- Clarify unavailable-content and potentially incomplete-resource messages.
- Add regression coverage for size-based and unavailable-content omissions.

## Investigation

The compiler correctly uses `unboundedBytes` to decide whether truncation is required and `usedBytes` for the serialized artifact after files are omitted. The warning only displayed `usedBytes`, making correct truncation look contradictory.

Exact static-resource attribution remains conservative because the published artifact does not retain the compiler’s omitted-file/query mapping.

## Todo

- [x] Show the complete database size and publish limit.
- [x] Separate the retained database size from the limit comparison.
- [x] Cover size and unavailable-content warnings.
- [x] Run focused verification.

## Verification

- `pnpm --filter @webstudio-is/builder test -- content-database-publish-warning-view.test.tsx`
- `pnpm --filter @webstudio-is/content-engine test -- asset-index.test.ts`
- `pnpm --filter @webstudio-is/builder typecheck`
- `pnpm exec oxfmt --check ...`
- `pnpm exec oxlint --deny-warnings ...`
- `git diff --check`

Fixture inputs and outputs are unaffected.