### PR TITLE
fix: Confirm conflicting root styles on page paste

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -68,6 +68,7 @@ import { DeleteUnusedCssVariablesDialog } from "~/builder/shared/css-variable-ut
 import { DeleteUnusedAssetsDialog } from "~/builder/shared/asset-manager/delete-unused-assets";
 import { KeyboardShortcutsDialog } from "./features/keyboard-shortcuts-dialog";
 import { TokenConflictDialog } from "~/shared/token-conflict-dialog";
+import { RootStyleConflictDialog } from "~/shared/root-style-conflict-dialog";
 import { DesignTokenImportDialog } from "~/shared/design-token-import-dialog";
 import type { User } from "~/shared/db/user.server";
 
@@ -527,6 +528,7 @@ export const Builder = (props: BuilderProps) => {
         <KeyboardShortcutsDialog />
         <DesignTokenImportDialog />
         <TokenConflictDialog />
+        <RootStyleConflictDialog />
         <RemoteDialog />
         <Toaster />
       </div>

--- a/apps/builder/app/builder/features/marketplace/templates.tsx
+++ b/apps/builder/app/builder/features/marketplace/templates.tsx
@@ -23,6 +23,7 @@ import {
   getAllPages,
   type Instance,
   ROOT_FOLDER_ID,
+  ROOT_INSTANCE_ID,
   type Asset,
   type Page,
   type WebstudioData,
@@ -40,6 +41,7 @@ import {
   resolveFragmentTokenConflicts,
   resolveTokenConflicts,
 } from "~/shared/resolve-token-conflicts";
+import { resolveRootStyleConflicts } from "~/shared/resolve-root-style-conflicts";
 
 const isBody = (instance: Instance) =>
   instance.component === "Body" ||
@@ -88,13 +90,22 @@ const insertPage = async ({
   data: WebstudioData;
   pageId: Page["id"];
 }) => {
+  const targetData = getWebstudioData();
   const conflicts = detectPageTokenConflicts({
     sourceData,
-    targetData: getWebstudioData(),
+    targetData,
     pageId,
   });
   const conflictResolution = await resolveTokenConflicts(conflicts);
   if (conflictResolution === "cancel") {
+    return;
+  }
+  const rootFragment = extractWebstudioFragment(sourceData, ROOT_INSTANCE_ID);
+  const rootStyleConflictResolution = await resolveRootStyleConflicts({
+    fragment: rootFragment,
+    targetData,
+  });
+  if (rootStyleConflictResolution === "cancel") {
     return;
   }
   const projectId = $project.get()?.id;
@@ -109,6 +120,7 @@ const insertPage = async ({
       parentFolderId: ROOT_FOLDER_ID,
       projectId,
       conflictResolution,
+      rootStyleConflictResolution,
     },
   });
   const newPageId = result?.result.pageId;

--- a/apps/builder/app/builder/features/marketplace/templates.tsx
+++ b/apps/builder/app/builder/features/marketplace/templates.tsx
@@ -90,20 +90,21 @@ const insertPage = async ({
   data: WebstudioData;
   pageId: Page["id"];
 }) => {
-  const targetData = getWebstudioData();
+  const tokenTargetData = getWebstudioData();
   const conflicts = detectPageTokenConflicts({
     sourceData,
-    targetData,
+    targetData: tokenTargetData,
     pageId,
   });
   const conflictResolution = await resolveTokenConflicts(conflicts);
   if (conflictResolution === "cancel") {
     return;
   }
+  const rootStyleTargetData = getWebstudioData();
   const rootFragment = extractWebstudioFragment(sourceData, ROOT_INSTANCE_ID);
   const rootStyleConflictResolution = await resolveRootStyleConflicts({
     fragment: rootFragment,
-    targetData,
+    targetData: rootStyleTargetData,
   });
   if (rootStyleConflictResolution === "cancel") {
     return;

--- a/apps/builder/app/shared/builder-api.ts
+++ b/apps/builder/app/shared/builder-api.ts
@@ -3,6 +3,7 @@ import invariant from "tiny-invariant";
 import { toast } from "@webstudio-is/design-system";
 import { uploadAssets } from "~/builder/shared/assets/upload-assets";
 import { showTokenConflictDialog } from "./token-conflict-dialog";
+import { showRootStyleConflictDialog } from "./root-style-conflict-dialog";
 import { showDesignTokenImportDialog } from "./design-token-import-dialog";
 
 const apiWindowNamespace = "__webstudio__$__builderApi";
@@ -35,6 +36,7 @@ const _builderApi = {
   },
   showDesignTokenImportDialog,
   showTokenConflictDialog,
+  showRootStyleConflictDialog,
 };
 
 declare global {

--- a/apps/builder/app/shared/conflict-resolution-dialog.tsx
+++ b/apps/builder/app/shared/conflict-resolution-dialog.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  Flex,
+  Text,
+  theme,
+} from "@webstudio-is/design-system";
+import { DialogRadioOptions } from "./dialog-radio-options";
+
+export const ConflictResolutionDialog = <Resolution extends string>({
+  title,
+  description,
+  detailsLabel,
+  details,
+  resolution,
+  options,
+  onResolutionChange,
+  onResolve,
+  onCancel,
+}: {
+  title: string;
+  description: string;
+  detailsLabel: string;
+  details: ReactNode;
+  resolution: Resolution;
+  options: ReadonlyArray<{
+    value: Resolution;
+    label: string;
+    description: string;
+  }>;
+  onResolutionChange: (resolution: Resolution) => void;
+  onResolve: () => void;
+  onCancel: () => void;
+}) => (
+  <Dialog
+    open={true}
+    onOpenChange={(open) => {
+      if (open === false) {
+        onCancel();
+      }
+    }}
+  >
+    <DialogContent css={{ minWidth: "40ch" }}>
+      <DialogTitle>{title}</DialogTitle>
+      <Flex direction="column" gap="2" css={{ padding: theme.panel.padding }}>
+        <DialogDescription asChild>
+          <Text as="p">{description}</Text>
+        </DialogDescription>
+        <DialogRadioOptions
+          value={resolution}
+          options={options}
+          onValueChange={onResolutionChange}
+        />
+        <Flex as="details" direction="column" gap="1">
+          <Text as="summary">{detailsLabel}</Text>
+          <Text color="subtle" css={{ maxHeight: 150, overflow: "auto" }}>
+            {details}
+          </Text>
+        </Flex>
+      </Flex>
+      <DialogActions>
+        <Button autoFocus color="positive" onClick={onResolve}>
+          Continue
+        </Button>
+        <Button color="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+      </DialogActions>
+    </DialogContent>
+  </Dialog>
+);

--- a/apps/builder/app/shared/copy-paste/plugin-page.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.test.ts
@@ -1,9 +1,10 @@
-import { expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 import { enableMapSet } from "immer";
 import { createDefaultPages } from "@webstudio-is/project-build";
 import {
   encodeDataSourceVariable,
   ROOT_FOLDER_ID,
+  ROOT_INSTANCE_ID,
   type DataSource,
   type Instance,
 } from "@webstudio-is/sdk";
@@ -36,9 +37,15 @@ import {
   pageText,
 } from "./plugin-page";
 import { pasteHandled, pasteIgnored } from "./copy-paste";
+import { initBuilderApi } from "../builder-api";
 
 enableMapSet();
 registerContainers();
+initBuilderApi();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const resetBuildStores = () => {
   $instances.set(new Map());
@@ -54,6 +61,88 @@ const resetBuildStores = () => {
   $editingTemplateId.set(undefined);
   selectInstance(undefined);
   $selectedPageId.set(undefined);
+};
+
+const setRootLocalStyle = ({
+  styleSourceId,
+  value,
+}: {
+  styleSourceId: string;
+  value: string;
+}) => {
+  $instances.set(
+    new Map([
+      ...$instances.get(),
+      [
+        ROOT_INSTANCE_ID,
+        {
+          type: "instance",
+          id: ROOT_INSTANCE_ID,
+          component: "Box",
+          children: [],
+        } satisfies Instance,
+      ],
+    ])
+  );
+  $breakpoints.set(new Map([["base", { id: "base", label: "Base" }]]));
+  $styleSources.set(
+    new Map([[styleSourceId, { id: styleSourceId, type: "local" }]])
+  );
+  $styleSourceSelections.set(
+    new Map([
+      [
+        ROOT_INSTANCE_ID,
+        { instanceId: ROOT_INSTANCE_ID, values: [styleSourceId] },
+      ],
+    ])
+  );
+  $styles.set(
+    new Map([
+      [
+        `${styleSourceId}:base:color:`,
+        {
+          styleSourceId,
+          breakpointId: "base",
+          property: "color",
+          value: { type: "keyword", value },
+        },
+      ],
+    ])
+  );
+};
+
+const setupProjectWithRootStyle = ({
+  projectId,
+  pageId,
+  rootInstanceId,
+  styleSourceId,
+  color,
+}: {
+  projectId: string;
+  pageId: string;
+  rootInstanceId: string;
+  styleSourceId: string;
+  color: string;
+}) => {
+  $project.set({ id: projectId } as Project);
+  resetBuildStores();
+  const pages = createDefaultPages({ homePageId: pageId, rootInstanceId });
+  $pages.set(pages);
+  $instances.set(
+    new Map([
+      [
+        rootInstanceId,
+        {
+          type: "instance",
+          id: rootInstanceId,
+          component: "Body",
+          children: [],
+        } satisfies Instance,
+      ],
+    ])
+  );
+  setRootLocalStyle({ styleSourceId, value: color });
+  return pages;
 };
 
 test("copies the selected page root from the copy plugin", () => {
@@ -210,6 +299,81 @@ test("copies page data across projects", async () => {
   expect($dataSources.get().has("source-variable")).toBe(false);
 });
 
+test.each([
+  ["ours", "blue"],
+  ["theirs", "red"],
+] as const)(
+  "resolves conflicting global root styles with %s",
+  async (resolution, expectedColor) => {
+    setupProjectWithRootStyle({
+      projectId: "source-project",
+      pageId: "source-page",
+      rootInstanceId: "source-body",
+      styleSourceId: "source-local",
+      color: "red",
+    });
+    const clipboardData = copyPageData("source-page");
+
+    setupProjectWithRootStyle({
+      projectId: "target-project",
+      pageId: "target-page",
+      rootInstanceId: "target-body",
+      styleSourceId: "target-local",
+      color: "blue",
+    });
+    const conflictDialog = vi
+      .spyOn(window.__webstudio__$__builderApi, "showRootStyleConflictDialog")
+      .mockResolvedValue(resolution);
+
+    await handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID);
+
+    expect(conflictDialog).toHaveBeenCalledWith([
+      expect.objectContaining({
+        incomingStyle: expect.objectContaining({
+          property: "color",
+          value: { type: "keyword", value: "red" },
+        }),
+      }),
+    ]);
+    expect($styles.get().get("target-local:base:color:")?.value).toEqual({
+      type: "keyword",
+      value: expectedColor,
+    });
+  }
+);
+
+test("cancels page paste when global root style resolution is cancelled", async () => {
+  setupProjectWithRootStyle({
+    projectId: "source-project",
+    pageId: "source-page",
+    rootInstanceId: "source-body",
+    styleSourceId: "source-local",
+    color: "red",
+  });
+  const clipboardData = copyPageData("source-page");
+
+  const targetPages = setupProjectWithRootStyle({
+    projectId: "target-project",
+    pageId: "target-page",
+    rootInstanceId: "target-body",
+    styleSourceId: "target-local",
+    color: "blue",
+  });
+  const initialPageCount = targetPages.pages.size;
+  vi.spyOn(
+    window.__webstudio__$__builderApi,
+    "showRootStyleConflictDialog"
+  ).mockResolvedValue("cancel");
+
+  await handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID);
+
+  expect($pages.get()?.pages.size).toBe(initialPageCount);
+  expect($styles.get().get("target-local:base:color:")?.value).toEqual({
+    type: "keyword",
+    value: "blue",
+  });
+});
+
 test("handles page paste data without falling through when insertion cannot complete", async () => {
   $project.set({ id: "source-project" } as Project);
   resetBuildStores();
@@ -329,6 +493,7 @@ test("copies folder data with nested pages across projects", async () => {
       )
     )
   );
+  setRootLocalStyle({ styleSourceId: "source-local", value: "red" });
 
   const clipboardData = copyFolderData("source-folder");
   expect(clipboardData).toBeDefined();
@@ -354,9 +519,18 @@ test("copies folder data with nested pages across projects", async () => {
       ],
     ])
   );
+  setRootLocalStyle({ styleSourceId: "target-local", value: "blue" });
+  const conflictDialog = vi
+    .spyOn(window.__webstudio__$__builderApi, "showRootStyleConflictDialog")
+    .mockResolvedValue("ours");
 
   await handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID);
 
+  expect(conflictDialog).toHaveBeenCalledOnce();
+  expect($styles.get().get("target-local:base:color:")?.value).toEqual({
+    type: "keyword",
+    value: "blue",
+  });
   const pastedFolder = Array.from($pages.get()?.folders.values() ?? []).find(
     (folder) => folder.name === "Docs"
   );

--- a/apps/builder/app/shared/copy-paste/plugin-page.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.test.ts
@@ -312,6 +312,12 @@ test.each([
       styleSourceId: "source-local",
       color: "red",
     });
+    $styles.get().set("source-local:base:fontSize:", {
+      styleSourceId: "source-local",
+      breakpointId: "base",
+      property: "fontSize",
+      value: { type: "keyword", value: "medium" },
+    });
     const clipboardData = copyPageData("source-page");
 
     setupProjectWithRootStyle({
@@ -338,6 +344,10 @@ test.each([
     expect($styles.get().get("target-local:base:color:")?.value).toEqual({
       type: "keyword",
       value: expectedColor,
+    });
+    expect($styles.get().get("target-local:base:fontSize:")?.value).toEqual({
+      type: "keyword",
+      value: "medium",
     });
   }
 );
@@ -659,6 +669,7 @@ test("copies template data as a template", async () => {
       ])
     )
   );
+  setRootLocalStyle({ styleSourceId: "source-local", value: "red" });
 
   const clipboardData = copyTemplateData("template-id");
   expect(clipboardData).toBeDefined();
@@ -684,9 +695,18 @@ test("copies template data as a template", async () => {
       ],
     ])
   );
+  setRootLocalStyle({ styleSourceId: "target-local", value: "blue" });
+  const conflictDialog = vi
+    .spyOn(window.__webstudio__$__builderApi, "showRootStyleConflictDialog")
+    .mockResolvedValue("theirs");
 
   await handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID);
 
+  expect(conflictDialog).toHaveBeenCalledOnce();
+  expect($styles.get().get("target-local:base:color:")?.value).toEqual({
+    type: "keyword",
+    value: "red",
+  });
   const pastedTemplate = Array.from(
     $pages.get()?.pageTemplates?.values() ?? []
   ).find((template) => template.name === "Landing Template");

--- a/apps/builder/app/shared/copy-paste/plugin-page.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.test.ts
@@ -111,6 +111,56 @@ const setRootLocalStyle = ({
   );
 };
 
+const addRootTokenStyle = ({
+  styleSourceId,
+  value,
+}: {
+  styleSourceId: string;
+  value: string;
+}) => {
+  const styleSources = new Map($styleSources.get());
+  styleSources.set(styleSourceId, {
+    id: styleSourceId,
+    type: "token",
+    name: "primary",
+  });
+  $styleSources.set(styleSources);
+
+  const rootSelection = $styleSourceSelections.get().get(ROOT_INSTANCE_ID);
+  const selections = new Map($styleSourceSelections.get());
+  selections.set(ROOT_INSTANCE_ID, {
+    instanceId: ROOT_INSTANCE_ID,
+    values: [...(rootSelection?.values ?? []), styleSourceId],
+  });
+  $styleSourceSelections.set(selections);
+
+  const styles = new Map($styles.get());
+  styles.set(`${styleSourceId}:base:color:`, {
+    styleSourceId,
+    breakpointId: "base",
+    property: "color",
+    value: { type: "keyword", value },
+  });
+  $styles.set(styles);
+};
+
+const updateRootLocalStyle = (value: string) => {
+  const rootLocalStyle = Array.from($styles.get().values()).find(
+    (style) =>
+      $styleSources.get().get(style.styleSourceId)?.type === "local" &&
+      style.property === "color"
+  );
+  if (rootLocalStyle === undefined) {
+    throw new Error("Expected root local color style");
+  }
+  const styles = new Map($styles.get());
+  styles.set(`${rootLocalStyle.styleSourceId}:base:color:`, {
+    ...rootLocalStyle,
+    value: { type: "keyword", value },
+  });
+  $styles.set(styles);
+};
+
 const setupProjectWithRootStyle = ({
   projectId,
   pageId,
@@ -378,6 +428,45 @@ test("cancels page paste when global root style resolution is cancelled", async 
   await handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID);
 
   expect($pages.get()?.pages.size).toBe(initialPageCount);
+  expect($styles.get().get("target-local:base:color:")?.value).toEqual({
+    type: "keyword",
+    value: "blue",
+  });
+});
+
+test("checks current root styles after resolving token conflicts", async () => {
+  setupProjectWithRootStyle({
+    projectId: "source-project",
+    pageId: "source-page",
+    rootInstanceId: "source-body",
+    styleSourceId: "source-local",
+    color: "red",
+  });
+  addRootTokenStyle({ styleSourceId: "source-token", value: "red" });
+  const clipboardData = copyPageData("source-page");
+
+  setupProjectWithRootStyle({
+    projectId: "target-project",
+    pageId: "target-page",
+    rootInstanceId: "target-body",
+    styleSourceId: "target-local",
+    color: "red",
+  });
+  addRootTokenStyle({ styleSourceId: "target-token", value: "blue" });
+  vi.spyOn(
+    window.__webstudio__$__builderApi,
+    "showTokenConflictDialog"
+  ).mockImplementation(async () => {
+    updateRootLocalStyle("blue");
+    return "ours";
+  });
+  const rootConflictDialog = vi
+    .spyOn(window.__webstudio__$__builderApi, "showRootStyleConflictDialog")
+    .mockResolvedValue("ours");
+
+  await handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID);
+
+  expect(rootConflictDialog).toHaveBeenCalledOnce();
   expect($styles.get().get("target-local:base:color:")?.value).toEqual({
     type: "keyword",
     value: "blue",

--- a/apps/builder/app/shared/copy-paste/plugin-page.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.ts
@@ -190,13 +190,14 @@ export const handlePastePage = async (
     if (conflictResolution === "cancel") {
       return pasteHandled;
     }
+    const rootStyleTargetData = getWebstudioData();
     const firstPageLikeItem = pageItems[0];
     const rootStyleConflictResolution =
       firstPageLikeItem === undefined
-        ? "theirs"
+        ? undefined
         : await resolveRootStyleConflicts({
             fragment: firstPageLikeItem.rootFragment,
-            targetData,
+            targetData: rootStyleTargetData,
           });
     if (rootStyleConflictResolution === "cancel") {
       return pasteHandled;

--- a/apps/builder/app/shared/copy-paste/plugin-page.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.ts
@@ -12,8 +12,12 @@ import {
   type PageTemplate,
 } from "@webstudio-is/sdk";
 import { $pages, $project } from "~/shared/sync/data-stores";
-import { detectFragmentTokenConflicts } from "@webstudio-is/project-build/runtime";
+import {
+  detectFragmentRootStyleConflicts,
+  detectFragmentTokenConflicts,
+} from "@webstudio-is/project-build/runtime";
 import { resolveTokenConflicts } from "../resolve-token-conflicts";
+import { builderApi } from "../builder-api";
 import {
   createFolderCopyData,
   createPageCopyData,
@@ -196,6 +200,21 @@ export const handlePastePage = async (
     if (conflictResolution === "cancel") {
       return pasteHandled;
     }
+    const firstPageLikeItem = collectPageLikeItems(item)[0];
+    const rootStyleConflicts =
+      firstPageLikeItem === undefined
+        ? []
+        : detectFragmentRootStyleConflicts({
+            fragment: firstPageLikeItem.rootFragment,
+            targetData,
+          });
+    const rootStyleConflictResolution =
+      rootStyleConflicts.length === 0
+        ? "theirs"
+        : await builderApi.showRootStyleConflictDialog(rootStyleConflicts);
+    if (rootStyleConflictResolution === "cancel") {
+      return pasteHandled;
+    }
 
     const result = executeRuntimeMutation({
       id: "pageTransfer.insert",
@@ -204,6 +223,7 @@ export const handlePastePage = async (
         targetFolderId: folderId,
         projectId,
         conflictResolution,
+        rootStyleConflictResolution,
       },
     });
     if (result?.result.didReachBreakpointLimit) {

--- a/apps/builder/app/shared/copy-paste/plugin-page.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.ts
@@ -12,12 +12,9 @@ import {
   type PageTemplate,
 } from "@webstudio-is/sdk";
 import { $pages, $project } from "~/shared/sync/data-stores";
-import {
-  detectFragmentRootStyleConflicts,
-  detectFragmentTokenConflicts,
-} from "@webstudio-is/project-build/runtime";
+import { detectFragmentTokenConflicts } from "@webstudio-is/project-build/runtime";
 import { resolveTokenConflicts } from "../resolve-token-conflicts";
-import { builderApi } from "../builder-api";
+import { resolveRootStyleConflicts } from "../resolve-root-style-conflicts";
 import {
   createFolderCopyData,
   createPageCopyData,
@@ -194,24 +191,13 @@ export const handlePastePage = async (
       return pasteHandled;
     }
     const firstPageLikeItem = pageItems[0];
-    const rootStyleConflicts =
+    const rootStyleConflictResolution =
       firstPageLikeItem === undefined
-        ? []
-        : detectFragmentRootStyleConflicts({
+        ? "theirs"
+        : await resolveRootStyleConflicts({
             fragment: firstPageLikeItem.rootFragment,
             targetData,
           });
-    const rootStyleConflictResolution =
-      rootStyleConflicts.length === 0
-        ? "theirs"
-        : await builderApi.showRootStyleConflictDialog(
-            rootStyleConflicts.map((conflict) => ({
-              ...conflict,
-              breakpointLabel:
-                targetData.breakpoints.get(conflict.existingStyle.breakpointId)
-                  ?.label ?? conflict.existingStyle.breakpointId,
-            }))
-          );
     if (rootStyleConflictResolution === "cancel") {
       return pasteHandled;
     }

--- a/apps/builder/app/shared/copy-paste/plugin-page.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.ts
@@ -26,6 +26,7 @@ import {
 import {
   pageTransferDataVersion,
   parsePageTransferData,
+  collectPageTransferItems,
   type FolderTransferData,
   type PageTransferData,
   type PageTransferItem,
@@ -125,15 +126,6 @@ const handleCopyPage = () => {
   }
 };
 
-const collectPageLikeItems = (
-  item: PageTransferItem
-): Array<PageTransferData | TemplateTransferData> => {
-  if (item.type === "page" || item.type === "template") {
-    return [item];
-  }
-  return item.children.flatMap(collectPageLikeItems);
-};
-
 export const copyPageData = (pageId: Page["id"]) => {
   const data = getWebstudioData();
   const pageData = getPageCopyData(data, pageId);
@@ -190,7 +182,8 @@ export const handlePastePage = async (
     if (projectId === undefined) {
       return pasteHandled;
     }
-    const conflicts = collectPageLikeItems(item).flatMap((item) =>
+    const pageItems = collectPageTransferItems(item);
+    const conflicts = pageItems.flatMap((item) =>
       detectFragmentTokenConflicts({
         fragment: mergeWebstudioFragments(item.rootFragment, item.bodyFragment),
         targetData,
@@ -200,7 +193,7 @@ export const handlePastePage = async (
     if (conflictResolution === "cancel") {
       return pasteHandled;
     }
-    const firstPageLikeItem = collectPageLikeItems(item)[0];
+    const firstPageLikeItem = pageItems[0];
     const rootStyleConflicts =
       firstPageLikeItem === undefined
         ? []
@@ -211,7 +204,14 @@ export const handlePastePage = async (
     const rootStyleConflictResolution =
       rootStyleConflicts.length === 0
         ? "theirs"
-        : await builderApi.showRootStyleConflictDialog(rootStyleConflicts);
+        : await builderApi.showRootStyleConflictDialog(
+            rootStyleConflicts.map((conflict) => ({
+              ...conflict,
+              breakpointLabel:
+                targetData.breakpoints.get(conflict.existingStyle.breakpointId)
+                  ?.label ?? conflict.existingStyle.breakpointId,
+            }))
+          );
     if (rootStyleConflictResolution === "cancel") {
       return pasteHandled;
     }

--- a/apps/builder/app/shared/resolve-root-style-conflicts.ts
+++ b/apps/builder/app/shared/resolve-root-style-conflicts.ts
@@ -1,0 +1,24 @@
+import type { WebstudioFragment, WebstudioData } from "@webstudio-is/sdk";
+import { detectFragmentRootStyleConflicts } from "@webstudio-is/project-build/runtime";
+import { builderApi } from "./builder-api";
+
+export const resolveRootStyleConflicts = async ({
+  fragment,
+  targetData,
+}: {
+  fragment: WebstudioFragment;
+  targetData: WebstudioData;
+}) => {
+  const conflicts = detectFragmentRootStyleConflicts({ fragment, targetData });
+  if (conflicts.length === 0) {
+    return "theirs" as const;
+  }
+  return builderApi.showRootStyleConflictDialog(
+    conflicts.map((conflict) => ({
+      ...conflict,
+      breakpointLabel:
+        targetData.breakpoints.get(conflict.existingStyle.breakpointId)
+          ?.label ?? conflict.existingStyle.breakpointId,
+    }))
+  );
+};

--- a/apps/builder/app/shared/resolve-root-style-conflicts.ts
+++ b/apps/builder/app/shared/resolve-root-style-conflicts.ts
@@ -11,7 +11,7 @@ export const resolveRootStyleConflicts = async ({
 }) => {
   const conflicts = detectFragmentRootStyleConflicts({ fragment, targetData });
   if (conflicts.length === 0) {
-    return "theirs" as const;
+    return;
   }
   return builderApi.showRootStyleConflictDialog(
     conflicts.map((conflict) => ({

--- a/apps/builder/app/shared/root-style-conflict-dialog.test.tsx
+++ b/apps/builder/app/shared/root-style-conflict-dialog.test.tsx
@@ -1,0 +1,108 @@
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import {
+  RootStyleConflictDialog,
+  showRootStyleConflictDialog,
+} from "./root-style-conflict-dialog";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    }
+  );
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});
+
+const renderDialog = () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root?.render(createElement(RootStyleConflictDialog)));
+};
+
+const conflict = {
+  incomingStyle: {
+    styleSourceId: "incoming-local",
+    breakpointId: "base",
+    property: "backgroundColor",
+    value: { type: "keyword", value: "red" },
+  },
+} as const;
+
+test("keeps existing global styles by default", async () => {
+  const result = showRootStyleConflictDialog([conflict]);
+  renderDialog();
+
+  expect(document.body.textContent).toContain("background-color");
+  const continueButton = Array.from(document.querySelectorAll("button")).find(
+    (button) => button.textContent === "Continue"
+  );
+  if (continueButton === undefined) {
+    throw new Error("Expected global style conflict continue button");
+  }
+  act(() => {
+    continueButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+
+  await expect(result).resolves.toBe("ours");
+});
+
+test("uses incoming global styles when selected", async () => {
+  const result = showRootStyleConflictDialog([conflict]);
+  renderDialog();
+
+  const incomingRadio = Array.from(
+    document.querySelectorAll('[role="radio"]')
+  ).find((radio) => radio.parentElement?.textContent?.includes("Use incoming"));
+  if (incomingRadio === undefined) {
+    throw new Error("Expected use incoming resolution option");
+  }
+  act(() => {
+    incomingRadio.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  const continueButton = Array.from(document.querySelectorAll("button")).find(
+    (button) => button.textContent === "Continue"
+  );
+  if (continueButton === undefined) {
+    throw new Error("Expected global style conflict continue button");
+  }
+  act(() => {
+    continueButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+
+  await expect(result).resolves.toBe("theirs");
+});
+
+test("cancels global style conflict resolution", async () => {
+  const result = showRootStyleConflictDialog([conflict]);
+  renderDialog();
+
+  const cancelButton = Array.from(document.querySelectorAll("button")).find(
+    (button) => button.textContent === "Cancel"
+  );
+  if (cancelButton === undefined) {
+    throw new Error("Expected global style conflict cancel button");
+  }
+  act(() => {
+    cancelButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+
+  await expect(result).resolves.toBe("cancel");
+});

--- a/apps/builder/app/shared/root-style-conflict-dialog.test.tsx
+++ b/apps/builder/app/shared/root-style-conflict-dialog.test.tsx
@@ -38,19 +38,28 @@ const renderDialog = () => {
 };
 
 const conflict = {
+  existingStyle: {
+    styleSourceId: "existing-local",
+    breakpointId: "base",
+    property: "backgroundColor",
+    value: { type: "keyword", value: "blue" },
+  },
   incomingStyle: {
     styleSourceId: "incoming-local",
     breakpointId: "base",
     property: "backgroundColor",
     value: { type: "keyword", value: "red" },
   },
+  breakpointLabel: "Base",
 } as const;
 
 test("keeps existing global styles by default", async () => {
   const result = showRootStyleConflictDialog([conflict]);
   renderDialog();
 
-  expect(document.body.textContent).toContain("background-color");
+  expect(document.body.textContent).toContain(
+    "background-color (Base): blue → red"
+  );
   const continueButton = Array.from(document.querySelectorAll("button")).find(
     (button) => button.textContent === "Continue"
   );

--- a/apps/builder/app/shared/root-style-conflict-dialog.tsx
+++ b/apps/builder/app/shared/root-style-conflict-dialog.tsx
@@ -1,30 +1,19 @@
 import { atom } from "nanostores";
 import { useStore } from "@nanostores/react";
-import { hyphenateProperty } from "@webstudio-is/css-engine";
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-  Flex,
-  Text,
-  theme,
-} from "@webstudio-is/design-system";
+import { hyphenateProperty, toValue } from "@webstudio-is/css-engine";
 import type {
   RootStyleConflict,
   RootStyleConflictResolution,
 } from "@webstudio-is/project-build/runtime";
-import { DialogRadioOptions } from "./dialog-radio-options";
+import { ConflictResolutionDialog } from "./conflict-resolution-dialog";
 
 export type RootStyleConflictDialogResult =
   | RootStyleConflictResolution
   | "cancel";
 export type RootStyleConflictDialogConflict = Pick<
   RootStyleConflict,
-  "incomingStyle"
->;
+  "existingStyle" | "incomingStyle"
+> & { breakpointLabel: string };
 
 const conflictResolutionOptions = [
   {
@@ -82,69 +71,38 @@ export const RootStyleConflictDialog = () => {
   }
 
   return (
-    <Dialog
-      open={true}
-      onOpenChange={(open) => {
-        if (open === false) {
-          handleCancel();
+    <ConflictResolutionDialog
+      title="Global style conflict detected"
+      description={
+        conflicts.length === 1
+          ? "A pasted global style conflicts with an existing value. Global styles affect every page."
+          : `${conflicts.length} pasted global styles conflict with existing values. Global styles affect every page.`
+      }
+      detailsLabel="Show conflicting styles"
+      details={conflicts
+        .map(({ existingStyle, incomingStyle, breakpointLabel }) => {
+          const property = hyphenateProperty(incomingStyle.property);
+          const state =
+            incomingStyle.state === undefined ? "" : `, ${incomingStyle.state}`;
+          return `${property} (${breakpointLabel}${state}): ${toValue(existingStyle.value)} → ${toValue(incomingStyle.value)}`;
+        })
+        .join("; ")}
+      resolution={resolution}
+      options={conflictResolutionOptions}
+      onResolutionChange={(nextResolution) => {
+        if ($dialogState.get()?.resolve === resolve) {
+          $dialogState.set({
+            conflicts,
+            resolution: nextResolution,
+            resolve,
+          });
         }
       }}
-    >
-      <DialogContent css={{ minWidth: "40ch" }}>
-        <DialogTitle>Global style conflict detected</DialogTitle>
-        <Flex direction="column" gap="2" css={{ padding: theme.panel.padding }}>
-          <DialogDescription asChild>
-            <Text as="p">
-              {conflicts.length === 1
-                ? "A pasted global style conflicts with an existing value. Global styles affect every page."
-                : `${conflicts.length} pasted global styles conflict with existing values. Global styles affect every page.`}
-            </Text>
-          </DialogDescription>
-
-          <DialogRadioOptions
-            value={resolution}
-            options={conflictResolutionOptions}
-            onValueChange={(nextResolution) => {
-              if ($dialogState.get()?.resolve === resolve) {
-                $dialogState.set({
-                  conflicts,
-                  resolution: nextResolution,
-                  resolve,
-                });
-              }
-            }}
-          />
-
-          <Flex as="details" direction="column" gap="1">
-            <Text as="summary">Show conflicting styles</Text>
-            <Text color="subtle" css={{ maxHeight: 150, overflow: "auto" }}>
-              {conflicts
-                .map(({ incomingStyle }) => {
-                  const property = hyphenateProperty(incomingStyle.property);
-                  return incomingStyle.state === undefined
-                    ? property
-                    : `${property} (${incomingStyle.state})`;
-                })
-                .join(", ")}
-            </Text>
-          </Flex>
-        </Flex>
-        <DialogActions>
-          <Button
-            autoFocus
-            color="positive"
-            onClick={() => {
-              resolve(resolution);
-              handleClose();
-            }}
-          >
-            Continue
-          </Button>
-          <Button color="ghost" onClick={handleCancel}>
-            Cancel
-          </Button>
-        </DialogActions>
-      </DialogContent>
-    </Dialog>
+      onResolve={() => {
+        resolve(resolution);
+        handleClose();
+      }}
+      onCancel={handleCancel}
+    />
   );
 };

--- a/apps/builder/app/shared/root-style-conflict-dialog.tsx
+++ b/apps/builder/app/shared/root-style-conflict-dialog.tsx
@@ -1,0 +1,150 @@
+import { atom } from "nanostores";
+import { useStore } from "@nanostores/react";
+import { hyphenateProperty } from "@webstudio-is/css-engine";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  Flex,
+  Text,
+  theme,
+} from "@webstudio-is/design-system";
+import type {
+  RootStyleConflict,
+  RootStyleConflictResolution,
+} from "@webstudio-is/project-build/runtime";
+import { DialogRadioOptions } from "./dialog-radio-options";
+
+export type RootStyleConflictDialogResult =
+  | RootStyleConflictResolution
+  | "cancel";
+export type RootStyleConflictDialogConflict = Pick<
+  RootStyleConflict,
+  "incomingStyle"
+>;
+
+const conflictResolutionOptions = [
+  {
+    value: "ours",
+    label: "Keep existing",
+    description: "Preserve your project's current global style values",
+  },
+  {
+    value: "theirs",
+    label: "Use incoming",
+    description: "Replace conflicting global style values with pasted values",
+  },
+] as const satisfies ReadonlyArray<{
+  value: RootStyleConflictResolution;
+  label: string;
+  description: string;
+}>;
+
+type DialogState =
+  | {
+      conflicts: RootStyleConflictDialogConflict[];
+      resolution: RootStyleConflictResolution;
+      resolve: (result: RootStyleConflictDialogResult) => void;
+    }
+  | undefined;
+
+const $dialogState = atom<DialogState>(undefined);
+
+export const showRootStyleConflictDialog = (
+  conflicts: RootStyleConflictDialogConflict[]
+): Promise<RootStyleConflictDialogResult> =>
+  new Promise((resolve) => {
+    $dialogState.get()?.resolve("cancel");
+    $dialogState.set({ conflicts, resolution: "ours", resolve });
+  });
+
+export const RootStyleConflictDialog = () => {
+  const dialogState = useStore($dialogState);
+  if (dialogState === undefined) {
+    return;
+  }
+
+  const { conflicts, resolution, resolve } = dialogState;
+  const handleClose = () => {
+    if ($dialogState.get()?.resolve === resolve) {
+      $dialogState.set(undefined);
+    }
+  };
+  const handleCancel = () => {
+    resolve("cancel");
+    handleClose();
+  };
+  if (conflicts.length === 0) {
+    return null;
+  }
+
+  return (
+    <Dialog
+      open={true}
+      onOpenChange={(open) => {
+        if (open === false) {
+          handleCancel();
+        }
+      }}
+    >
+      <DialogContent css={{ minWidth: "40ch" }}>
+        <DialogTitle>Global style conflict detected</DialogTitle>
+        <Flex direction="column" gap="2" css={{ padding: theme.panel.padding }}>
+          <DialogDescription asChild>
+            <Text as="p">
+              {conflicts.length === 1
+                ? "A pasted global style conflicts with an existing value. Global styles affect every page."
+                : `${conflicts.length} pasted global styles conflict with existing values. Global styles affect every page.`}
+            </Text>
+          </DialogDescription>
+
+          <DialogRadioOptions
+            value={resolution}
+            options={conflictResolutionOptions}
+            onValueChange={(nextResolution) => {
+              if ($dialogState.get()?.resolve === resolve) {
+                $dialogState.set({
+                  conflicts,
+                  resolution: nextResolution,
+                  resolve,
+                });
+              }
+            }}
+          />
+
+          <Flex as="details" direction="column" gap="1">
+            <Text as="summary">Show conflicting styles</Text>
+            <Text color="subtle" css={{ maxHeight: 150, overflow: "auto" }}>
+              {conflicts
+                .map(({ incomingStyle }) => {
+                  const property = hyphenateProperty(incomingStyle.property);
+                  return incomingStyle.state === undefined
+                    ? property
+                    : `${property} (${incomingStyle.state})`;
+                })
+                .join(", ")}
+            </Text>
+          </Flex>
+        </Flex>
+        <DialogActions>
+          <Button
+            autoFocus
+            color="positive"
+            onClick={() => {
+              resolve(resolution);
+              handleClose();
+            }}
+          >
+            Continue
+          </Button>
+          <Button color="ghost" onClick={handleCancel}>
+            Cancel
+          </Button>
+        </DialogActions>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/builder/app/shared/token-conflict-dialog.tsx
+++ b/apps/builder/app/shared/token-conflict-dialog.tsx
@@ -1,21 +1,10 @@
 import { atom } from "nanostores";
 import { useStore } from "@nanostores/react";
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  DialogDescription,
-  DialogActions,
-  Button,
-  Flex,
-  Text,
-  theme,
-} from "@webstudio-is/design-system";
 import type {
   ConflictResolution,
   TokenConflict,
 } from "@webstudio-is/project-build/runtime";
-import { DialogRadioOptions } from "./dialog-radio-options";
+import { ConflictResolutionDialog } from "./conflict-resolution-dialog";
 
 export type TokenConflictDialogResult = ConflictResolution | "cancel";
 export type TokenConflictDialogConflict = Pick<TokenConflict, "tokenName">;
@@ -78,11 +67,6 @@ export const TokenConflictDialog = () => {
     }
   };
 
-  const handleResolve = () => {
-    resolve(resolution);
-    handleClose();
-  };
-
   const handleCancel = () => {
     resolve("cancel");
     handleClose();
@@ -96,63 +80,27 @@ export const TokenConflictDialog = () => {
   const firstConflict = conflicts[0];
 
   return (
-    <Dialog
-      open={true}
-      onOpenChange={(open) => {
-        if (!open) {
-          handleCancel();
+    <ConflictResolutionDialog
+      title="Token conflict detected"
+      description={
+        conflictCount === 1
+          ? `The token "${firstConflict.tokenName}" already exists with different styles.`
+          : `${conflictCount} tokens already exist with the same names but different styles.`
+      }
+      detailsLabel="Show conflicting tokens"
+      details={conflicts.map((conflict) => conflict.tokenName).join(", ")}
+      resolution={resolution}
+      options={conflictResolutionOptions}
+      onResolutionChange={(nextResolution) => {
+        if ($dialogState.get()?.resolve === resolve) {
+          $dialogState.set({ conflicts, resolution: nextResolution, resolve });
         }
       }}
-    >
-      <DialogContent css={{ minWidth: "40ch" }}>
-        <DialogTitle>Token conflict detected</DialogTitle>
-        <Flex
-          direction="column"
-          gap="2"
-          css={{
-            padding: theme.panel.padding,
-          }}
-        >
-          <DialogDescription asChild>
-            <Text as="p">
-              {conflictCount === 1
-                ? `The token "${firstConflict.tokenName}" already exists with different styles.`
-                : `${conflictCount} tokens already exist with the same names but different styles.`}
-            </Text>
-          </DialogDescription>
-
-          <DialogRadioOptions
-            value={resolution}
-            options={conflictResolutionOptions}
-            onValueChange={(resolution) => {
-              if ($dialogState.get()?.resolve === resolve) {
-                $dialogState.set({ conflicts, resolution, resolve });
-              }
-            }}
-          />
-
-          <Flex as="details" direction="column" gap="1">
-            <Text as="summary">Show conflicting tokens</Text>
-            <Text
-              color="subtle"
-              css={{
-                maxHeight: 150,
-                overflow: "auto",
-              }}
-            >
-              {conflicts.map((conflict) => conflict.tokenName).join(", ")}
-            </Text>
-          </Flex>
-        </Flex>
-        <DialogActions>
-          <Button autoFocus color="positive" onClick={handleResolve}>
-            Continue
-          </Button>
-          <Button color="ghost" onClick={handleCancel}>
-            Cancel
-          </Button>
-        </DialogActions>
-      </DialogContent>
-    </Dialog>
+      onResolve={() => {
+        resolve(resolution);
+        handleClose();
+      }}
+      onCancel={handleCancel}
+    />
   );
 };

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -16068,6 +16068,10 @@ export const runtimeOperationContractData = [
           type: "string",
           enum: ["ours", "theirs", "merge"],
         },
+        rootStyleConflictResolution: {
+          type: "string",
+          enum: ["ours", "theirs"],
+        },
       },
       required: ["targetFolderId", "item"],
       $defs: {

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -2331,6 +2331,12 @@ export const runtimeOperationContractData = [
           type: "string",
           enum: ["ours", "theirs", "merge"],
         },
+        rootStyleConflictResolution: {
+          description:
+            'How to resolve conflicting global root-local declarations: "ours" keeps the target project values; "theirs" uses the incoming source values. Required when conflicts exist.',
+          type: "string",
+          enum: ["ours", "theirs"],
+        },
       },
       required: ["sourceData", "pageId"],
     },
@@ -16069,6 +16075,8 @@ export const runtimeOperationContractData = [
           enum: ["ours", "theirs", "merge"],
         },
         rootStyleConflictResolution: {
+          description:
+            'How to resolve conflicting global root-local declarations: "ours" keeps the target project values; "theirs" uses the incoming source values. Required when conflicts exist.',
           type: "string",
           enum: ["ours", "theirs"],
         },

--- a/packages/project-build/src/runtime/data-formats/page-transfer.ts
+++ b/packages/project-build/src/runtime/data-formats/page-transfer.ts
@@ -39,6 +39,15 @@ export type PageTransferItem =
   | TemplateTransferData
   | FolderTransferData;
 
+export const collectPageTransferItems = (
+  item: PageTransferItem
+): Array<PageTransferData | TemplateTransferData> => {
+  if (item.type === "page" || item.type === "template") {
+    return [item];
+  }
+  return item.children.flatMap(collectPageTransferItems);
+};
+
 export const pageTransferPageInput: z.ZodType<PageTransferData> = z.object({
   type: z.literal("page"),
   page: z.custom<Page>(),

--- a/packages/project-build/src/runtime/fragment.test.tsx
+++ b/packages/project-build/src/runtime/fragment.test.tsx
@@ -3,6 +3,7 @@ import {
   getCommonAncestorSelector,
   getPasteRootInstanceIds,
   copyWebstudioFragmentMutable,
+  detectFragmentRootStyleConflicts,
   extractWebstudioFragment,
   insertWebstudioFragmentCopy,
   mapFragmentChildrenToCopiedChildren,
@@ -484,6 +485,58 @@ test("should merge :root local styles", () => {
       }
     `).trim()
   );
+});
+
+test("does not conflict when a breakpoint id is remapped during insertion", () => {
+  const source = createStub(
+    <ws.root
+      ws:id={ROOT_INSTANCE_ID}
+      ws:style={css`
+        color: red;
+      `}
+    >
+      <$.Body></$.Body>
+    </ws.root>
+  );
+  const target = createStub(
+    <ws.root
+      ws:id={ROOT_INSTANCE_ID}
+      ws:style={css`
+        color: blue;
+      `}
+    >
+      <$.Body></$.Body>
+    </ws.root>
+  );
+  const sourceBreakpoint = source.breakpoints.values().next().value;
+  const targetBreakpoint = target.breakpoints.values().next().value;
+  const sourceStyle = source.styles.values().next().value;
+  if (
+    sourceBreakpoint === undefined ||
+    targetBreakpoint === undefined ||
+    sourceStyle === undefined
+  ) {
+    throw new Error("Expected root style fixtures");
+  }
+  source.breakpoints.clear();
+  source.breakpoints.set(targetBreakpoint.id, {
+    ...sourceBreakpoint,
+    id: targetBreakpoint.id,
+    minWidth: 640,
+  });
+  source.styles.clear();
+  const remappedSourceStyle = {
+    ...sourceStyle,
+    breakpointId: targetBreakpoint.id,
+  };
+  source.styles.set(getStyleDeclKey(remappedSourceStyle), remappedSourceStyle);
+
+  expect(
+    detectFragmentRootStyleConflicts({
+      fragment: extractWebstudioFragment(source, ROOT_INSTANCE_ID),
+      targetData: target,
+    })
+  ).toEqual([]);
 });
 
 test("should copy local styles of duplicated instance", () => {

--- a/packages/project-build/src/runtime/fragment.ts
+++ b/packages/project-build/src/runtime/fragment.ts
@@ -500,7 +500,7 @@ const insertFragmentBreakpointsMutable = ({
   createId,
   onBreakpointLimitMerge,
 }: {
-  fragment: WebstudioFragment;
+  fragment: Pick<WebstudioFragment, "breakpoints">;
   breakpoints: Breakpoints;
   createId: () => string;
   onBreakpointLimitMerge?: () => void;
@@ -537,6 +537,21 @@ const insertFragmentBreakpointsMutable = ({
   return { mergedBreakpointIds, didMergeBreakpointsDueToLimit };
 };
 
+const buildFragmentInsertionBreakpointIds = ({
+  fragmentBreakpoints,
+  targetBreakpoints,
+}: {
+  fragmentBreakpoints: WebstudioFragment["breakpoints"];
+  targetBreakpoints: Breakpoints;
+}) => {
+  let generatedIdIndex = 0;
+  return insertFragmentBreakpointsMutable({
+    fragment: { breakpoints: fragmentBreakpoints },
+    breakpoints: new Map(targetBreakpoints),
+    createId: () => `conflict-detection-breakpoint-${generatedIdIndex++}`,
+  }).mergedBreakpointIds;
+};
+
 export const fragmentTesting = {
   getFragmentInstancesData,
   insertFragmentAssetsMutable,
@@ -549,7 +564,6 @@ export const insertWebstudioFragmentCopy = ({
   availableVariables,
   projectId,
   conflictResolution = "theirs",
-  rootStyleConflictResolution = "theirs",
   onBreakpointLimitMerge,
   metas,
   contentModeCopyableProp,
@@ -563,7 +577,6 @@ export const insertWebstudioFragmentCopy = ({
   availableVariables: DataSource[];
   projectId: string;
   conflictResolution?: ConflictResolution;
-  rootStyleConflictResolution?: RootStyleConflictResolution;
   onBreakpointLimitMerge?: () => void;
   metas?: Map<string, WsComponentMeta>;
   contentModeCopyableProp?: ContentModeCopyableProp;
@@ -916,7 +929,6 @@ export const insertWebstudioFragmentCopy = ({
       contentMode: false,
       styleSourceIdMap,
       mergedBreakpointIds,
-      rootStyleConflictResolution,
       breakpoints,
       createId,
     });
@@ -1003,11 +1015,10 @@ export const detectFragmentRootStyleConflicts = ({
   fragment: WebstudioFragment;
   targetData: WebstudioData;
 }) => {
-  const mergedBreakpointIds = buildMergedBreakpointIds(
-    fragment.breakpoints,
-    targetData.breakpoints,
-    { maxBreakpointCount: maxBreakpoints }
-  );
+  const mergedBreakpointIds = buildFragmentInsertionBreakpointIds({
+    fragmentBreakpoints: fragment.breakpoints,
+    targetBreakpoints: targetData.breakpoints,
+  });
 
   return detectRootStyleConflicts({
     fragmentStyleSources: fragment.styleSources,
@@ -1018,6 +1029,34 @@ export const detectFragmentRootStyleConflicts = ({
     existingStyles: targetData.styles,
     mergedBreakpointIds,
   });
+};
+
+export const resolveFragmentRootStyleConflicts = ({
+  fragment,
+  targetData,
+  resolution,
+}: {
+  fragment: WebstudioFragment;
+  targetData: WebstudioData;
+  resolution: RootStyleConflictResolution | undefined;
+}): WebstudioFragment => {
+  if (resolution !== "ours") {
+    return fragment;
+  }
+  const conflictingStyles = new Set(
+    detectFragmentRootStyleConflicts({ fragment, targetData }).map(
+      (conflict) => conflict.incomingStyle
+    )
+  );
+  if (conflictingStyles.size === 0) {
+    return fragment;
+  }
+  return {
+    ...fragment,
+    styles: fragment.styles.filter(
+      (style) => conflictingStyles.has(style) === false
+    ),
+  };
 };
 
 /**

--- a/packages/project-build/src/runtime/fragment.ts
+++ b/packages/project-build/src/runtime/fragment.ts
@@ -33,11 +33,13 @@ import { clonePropForInstance, listPropExpressions } from "./props";
 import { buildMergedBreakpointIds, maxBreakpoints } from "./breakpoints";
 import {
   collectStyleSourcesFromInstances,
+  detectRootStyleConflicts,
   detectTokenConflicts,
   insertLocalStyleSourcesWithNewIds,
   insertPortalLocalStyleSources,
   insertTokenStyleSources,
   type ConflictResolution,
+  type RootStyleConflictResolution,
 } from "./style-copy";
 import { unwrap } from "./unwrap";
 import {
@@ -547,6 +549,7 @@ export const insertWebstudioFragmentCopy = ({
   availableVariables,
   projectId,
   conflictResolution = "theirs",
+  rootStyleConflictResolution = "theirs",
   onBreakpointLimitMerge,
   metas,
   contentModeCopyableProp,
@@ -560,6 +563,7 @@ export const insertWebstudioFragmentCopy = ({
   availableVariables: DataSource[];
   projectId: string;
   conflictResolution?: ConflictResolution;
+  rootStyleConflictResolution?: RootStyleConflictResolution;
   onBreakpointLimitMerge?: () => void;
   metas?: Map<string, WsComponentMeta>;
   contentModeCopyableProp?: ContentModeCopyableProp;
@@ -912,6 +916,7 @@ export const insertWebstudioFragmentCopy = ({
       contentMode: false,
       styleSourceIdMap,
       mergedBreakpointIds,
+      rootStyleConflictResolution,
       breakpoints,
       createId,
     });
@@ -987,6 +992,30 @@ export const detectFragmentTokenConflicts = ({
     existingStyleSources: targetData.styleSources,
     existingStyles: targetData.styles,
     breakpoints: targetData.breakpoints,
+    mergedBreakpointIds,
+  });
+};
+
+export const detectFragmentRootStyleConflicts = ({
+  fragment,
+  targetData,
+}: {
+  fragment: WebstudioFragment;
+  targetData: WebstudioData;
+}) => {
+  const mergedBreakpointIds = buildMergedBreakpointIds(
+    fragment.breakpoints,
+    targetData.breakpoints,
+    { maxBreakpointCount: maxBreakpoints }
+  );
+
+  return detectRootStyleConflicts({
+    fragmentStyleSources: fragment.styleSources,
+    fragmentStyleSourceSelections: fragment.styleSourceSelections,
+    fragmentStyles: fragment.styles,
+    existingStyleSources: targetData.styleSources,
+    existingStyleSourceSelections: targetData.styleSourceSelections,
+    existingStyles: targetData.styles,
     mergedBreakpointIds,
   });
 };

--- a/packages/project-build/src/runtime/page-copy.test.tsx
+++ b/packages/project-build/src/runtime/page-copy.test.tsx
@@ -21,6 +21,7 @@ import {
   pageCopyTesting,
   pageDuplicateInput,
   createPageTemplate,
+  createPageCopyData,
   createPageFromTemplate,
   createPageDuplicatePayload,
   createTemplateCopyData,
@@ -29,6 +30,7 @@ import {
   duplicatePage,
   duplicatePageTemplate,
   insertPageCopyMutable,
+  insertPageTransferItem,
   insertPageFromTemplateMutable,
   insertTemplateCopyFromFragmentsMutable,
   listPageTemplates,
@@ -37,6 +39,7 @@ import {
 } from "./page-copy";
 import {
   $,
+  css,
   expression,
   Parameter,
   renderData,
@@ -55,6 +58,60 @@ const getCopiedPages = (data: WebstudioData) =>
   Array.from(data.pages.pages.values()).filter(
     (page) => page.id !== data.pages.homePageId
   );
+
+test("requires an explicit resolution for conflicting transferred root styles", () => {
+  const sourcePages = createDefaultPages({
+    homePageId: "source-page",
+    rootInstanceId: "source-body",
+  });
+  const source = getWebstudioDataStub({
+    ...renderData(
+      <ws.root
+        ws:id={ROOT_INSTANCE_ID}
+        ws:style={css`
+          color: red;
+        `}
+      >
+        <$.Body ws:id="source-body"></$.Body>
+      </ws.root>
+    ),
+    pages: sourcePages,
+  });
+  const target = getWebstudioDataStub({
+    ...renderData(
+      <ws.root
+        ws:id={ROOT_INSTANCE_ID}
+        ws:style={css`
+          color: blue;
+        `}
+      >
+        <$.Body ws:id="target-body"></$.Body>
+      </ws.root>
+    ),
+    pages: createDefaultPages({
+      homePageId: "target-page",
+      rootInstanceId: "target-body",
+    }),
+  });
+
+  expect(() =>
+    insertPageTransferItem(
+      target,
+      {
+        projectId: "target-project",
+        targetFolderId: ROOT_FOLDER_ID,
+        item: {
+          type: "page",
+          ...createPageCopyData({
+            data: source,
+            page: getHomePage(sourcePages),
+          }),
+        },
+      },
+      { createId: nanoid }
+    )
+  ).toThrow(/root style conflicts require an explicit/i);
+});
 
 test("validates duplicate page substitutions", () => {
   expect(

--- a/packages/project-build/src/runtime/page-copy.test.tsx
+++ b/packages/project-build/src/runtime/page-copy.test.tsx
@@ -22,6 +22,7 @@ import {
   pageDuplicateInput,
   createPageTemplate,
   createPageCopyData,
+  copyPage,
   createPageFromTemplate,
   createPageDuplicatePayload,
   createTemplateCopyData,
@@ -60,39 +61,7 @@ const getCopiedPages = (data: WebstudioData) =>
   );
 
 test("requires an explicit resolution for conflicting transferred root styles", () => {
-  const sourcePages = createDefaultPages({
-    homePageId: "source-page",
-    rootInstanceId: "source-body",
-  });
-  const source = getWebstudioDataStub({
-    ...renderData(
-      <ws.root
-        ws:id={ROOT_INSTANCE_ID}
-        ws:style={css`
-          color: red;
-        `}
-      >
-        <$.Body ws:id="source-body"></$.Body>
-      </ws.root>
-    ),
-    pages: sourcePages,
-  });
-  const target = getWebstudioDataStub({
-    ...renderData(
-      <ws.root
-        ws:id={ROOT_INSTANCE_ID}
-        ws:style={css`
-          color: blue;
-        `}
-      >
-        <$.Body ws:id="target-body"></$.Body>
-      </ws.root>
-    ),
-    pages: createDefaultPages({
-      homePageId: "target-page",
-      rootInstanceId: "target-body",
-    }),
-  });
+  const { sourcePages, source, target } = createConflictingRootStyleProjects();
 
   expect(() =>
     insertPageTransferItem(
@@ -112,6 +81,47 @@ test("requires an explicit resolution for conflicting transferred root styles", 
     )
   ).toThrow(/root style conflicts require an explicit/i);
 });
+
+test("requires an explicit resolution for conflicting copied root styles", () => {
+  const { source, target } = createConflictingRootStyleProjects();
+
+  expect(() =>
+    copyPage(
+      target,
+      {
+        projectId: "target-project",
+        sourceData: source,
+        pageId: "source-page",
+      },
+      { createId: nanoid }
+    )
+  ).toThrow(/root style conflicts require an explicit/i);
+});
+
+test.each([
+  ["ours", "blue"],
+  ["theirs", "red"],
+] as const)(
+  "resolves copied root style conflicts with %s",
+  (rootStyleConflictResolution, expectedColor) => {
+    const { source, target } = createConflictingRootStyleProjects();
+    const mutation = copyPage(
+      target,
+      {
+        projectId: "target-project",
+        sourceData: source,
+        pageId: "source-page",
+        rootStyleConflictResolution,
+      },
+      { createId: nanoid }
+    );
+    const updated = applyBuilderPatchTransactions(target, [
+      { id: "copy-page", payload: mutation.payload },
+    ]).state as WebstudioData;
+
+    expect(getRootColor(updated)).toBe(expectedColor);
+  }
+);
 
 test("validates duplicate page substitutions", () => {
   expect(
@@ -150,6 +160,54 @@ const getWebstudioDataStub = (
   styles: new Map(),
   ...data,
 });
+
+const createConflictingRootStyleProjects = () => {
+  const sourcePages = createDefaultPages({
+    homePageId: "source-page",
+    rootInstanceId: "source-body",
+  });
+  const source = getWebstudioDataStub({
+    ...renderData(
+      <ws.root
+        ws:id={ROOT_INSTANCE_ID}
+        ws:style={css`
+          color: red;
+        `}
+      >
+        <$.Body ws:id="source-body"></$.Body>
+      </ws.root>
+    ),
+    pages: sourcePages,
+  });
+  const target = getWebstudioDataStub({
+    ...renderData(
+      <ws.root
+        ws:id={ROOT_INSTANCE_ID}
+        ws:style={css`
+          color: blue;
+        `}
+      >
+        <$.Body ws:id="target-body"></$.Body>
+      </ws.root>
+    ),
+    pages: createDefaultPages({
+      homePageId: "target-page",
+      rootInstanceId: "target-body",
+    }),
+  });
+  return { sourcePages, source, target };
+};
+
+const getRootColor = (data: WebstudioData) => {
+  const rootStyleSourceIds = new Set(
+    data.styleSourceSelections.get(ROOT_INSTANCE_ID)?.values
+  );
+  const color = Array.from(data.styles.values()).find(
+    (style) =>
+      rootStyleSourceIds.has(style.styleSourceId) && style.property === "color"
+  )?.value;
+  return color?.type === "keyword" ? color.value : undefined;
+};
 
 const getPagesWithSiblings = () =>
   migratePages({

--- a/packages/project-build/src/runtime/page-copy.ts
+++ b/packages/project-build/src/runtime/page-copy.ts
@@ -3,6 +3,7 @@ import {
   detectFragmentRootStyleConflicts,
   extractWebstudioFragment,
   insertWebstudioFragmentCopy,
+  resolveFragmentRootStyleConflicts,
 } from "./fragment";
 import { isFragmentContentModeCopyableProp } from "./content-mode-copy-policy";
 import { nanoid } from "nanoid";
@@ -58,9 +59,9 @@ import { unwrap } from "./unwrap";
 import { componentMetas } from "@webstudio-is/sdk-components-registry/metas";
 import {
   pageTransferItemInput,
+  collectPageTransferItems,
   type FolderCopyData,
   type PageCopyData,
-  type PageTransferItem,
   type TemplateCopyData,
 } from "./data-formats/page-transfer";
 
@@ -349,7 +350,11 @@ const copyPageFragmentsMutable = ({
   if (contentMode === false && rootFragment !== undefined) {
     insertWebstudioFragmentCopy({
       data: target,
-      fragment: rootFragment,
+      fragment: resolveFragmentRootStyleConflicts({
+        fragment: rootFragment,
+        targetData: target,
+        resolution: rootStyleConflictResolution,
+      }),
       availableVariables: findAvailableVariables({
         ...target,
         startingInstanceId: ROOT_INSTANCE_ID,
@@ -357,7 +362,6 @@ const copyPageFragmentsMutable = ({
       projectId,
       metas,
       conflictResolution,
-      rootStyleConflictResolution,
       contentModeCopyableProp,
       onBreakpointLimitMerge,
       createId,
@@ -1378,20 +1382,6 @@ export const pageTransferInsertInput = z.object({
   rootStyleConflictResolution: z.enum(["ours", "theirs"]).optional(),
 });
 
-const findFirstTransferRootFragment = (
-  item: PageTransferItem
-): WebstudioFragment | undefined => {
-  if (item.type === "page" || item.type === "template") {
-    return item.rootFragment;
-  }
-  for (const child of item.children) {
-    const rootFragment = findFirstTransferRootFragment(child);
-    if (rootFragment !== undefined) {
-      return rootFragment;
-    }
-  }
-};
-
 export const createPageCopyData = ({
   data,
   page,
@@ -1563,7 +1553,7 @@ export const insertPageTransferItem = (
     build: data,
     assets: Array.from(data.assets.values()),
   });
-  const rootFragment = findFirstTransferRootFragment(input.item);
+  const rootFragment = collectPageTransferItems(input.item)[0]?.rootFragment;
   if (
     input.rootStyleConflictResolution === undefined &&
     rootFragment !== undefined &&

--- a/packages/project-build/src/runtime/page-copy.ts
+++ b/packages/project-build/src/runtime/page-copy.ts
@@ -123,6 +123,12 @@ export const pageCopyInput = z.object({
     .describe("ID of the page in sourceData to copy into this project."),
   parentFolderId: z.string().optional(),
   conflictResolution: z.enum(["ours", "theirs", "merge"]).optional(),
+  rootStyleConflictResolution: z
+    .enum(["ours", "theirs"])
+    .optional()
+    .describe(
+      'How to resolve conflicting global root-local declarations: "ours" keeps the target project values; "theirs" uses the incoming source values. Required when conflicts exist.'
+    ),
 });
 
 export const folderDuplicateInput = z.object({
@@ -277,6 +283,7 @@ const copyPageRootAndBodyMutable = ({
   projectId,
   metas,
   conflictResolution,
+  rootStyleConflictResolution,
   contentModeCopyableProp,
   createId = nanoid,
   contentMode = false,
@@ -288,6 +295,7 @@ const copyPageRootAndBodyMutable = ({
   projectId?: string;
   metas?: Map<string, WsComponentMeta>;
   conflictResolution: ConflictResolution | undefined;
+  rootStyleConflictResolution?: RootStyleConflictResolution;
   contentModeCopyableProp?: ContentModeCopyableProp;
   createId?: CreateId;
   contentMode?: boolean;
@@ -310,6 +318,7 @@ const copyPageRootAndBodyMutable = ({
     projectId,
     metas,
     conflictResolution,
+    rootStyleConflictResolution,
     systemDataSourceId,
     contentModeCopyableProp,
     createId,
@@ -605,12 +614,14 @@ const copyPageMutable = ({
   target,
   projectId,
   conflictResolution,
+  rootStyleConflictResolution,
   createId = nanoid,
 }: {
   source: { data: WebstudioData; pageId: Page["id"] };
   target: { data: WebstudioData; folderId: Folder["id"] };
   projectId?: string;
   conflictResolution?: ConflictResolution;
+  rootStyleConflictResolution?: RootStyleConflictResolution;
   createId?: CreateId;
 }) => {
   const page = findPageByIdOrPath(source.pageId, source.data.pages);
@@ -624,6 +635,7 @@ const copyPageMutable = ({
     systemDataSourceId: page.systemDataSourceId,
     projectId,
     conflictResolution,
+    rootStyleConflictResolution,
     createId,
   });
   if (copied === undefined) {
@@ -868,6 +880,30 @@ export const duplicatePage = (
   });
 };
 
+const requireRootStyleConflictResolution = ({
+  rootFragment,
+  targetData,
+  resolution,
+}: {
+  rootFragment: WebstudioFragment | undefined;
+  targetData: WebstudioData;
+  resolution: RootStyleConflictResolution | undefined;
+}) => {
+  if (
+    resolution === undefined &&
+    rootFragment !== undefined &&
+    detectFragmentRootStyleConflicts({
+      fragment: rootFragment,
+      targetData,
+    }).length > 0
+  ) {
+    return throwBuilderRuntimeError(
+      "CONFLICT",
+      "Global root style conflicts require an explicit rootStyleConflictResolution (ours keeps target values; theirs uses incoming values)"
+    );
+  }
+};
+
 export const copyPage = (
   state: BuilderState,
   input: z.infer<typeof pageCopyInput>,
@@ -882,6 +918,15 @@ export const copyPage = (
     build: data,
     assets: Array.from(data.assets.values()),
   });
+  const sourcePage = findPageByIdOrPath(input.pageId, input.sourceData.pages);
+  if (sourcePage === undefined) {
+    return throwBuilderRuntimeError("BAD_REQUEST", "Page could not be copied");
+  }
+  requireRootStyleConflictResolution({
+    rootFragment: extractWebstudioFragment(input.sourceData, ROOT_INSTANCE_ID),
+    targetData: before,
+    resolution: input.rootStyleConflictResolution,
+  });
   let pageId: Page["id"] | undefined;
   const { payload } = produceWebstudioDataMutation(before, (draft) => {
     pageId = insertPageCopyMutable({
@@ -889,6 +934,7 @@ export const copyPage = (
       target: { data: draft, folderId: parentFolderId },
       projectId: input.projectId,
       conflictResolution: input.conflictResolution,
+      rootStyleConflictResolution: input.rootStyleConflictResolution,
       createId: context.createId,
     });
   });
@@ -1379,7 +1425,12 @@ export const pageTransferInsertInput = z.object({
   targetFolderId: z.string(),
   item: pageTransferItemInput,
   conflictResolution: z.enum(["ours", "theirs", "merge"]).optional(),
-  rootStyleConflictResolution: z.enum(["ours", "theirs"]).optional(),
+  rootStyleConflictResolution: z
+    .enum(["ours", "theirs"])
+    .optional()
+    .describe(
+      'How to resolve conflicting global root-local declarations: "ours" keeps the target project values; "theirs" uses the incoming source values. Required when conflicts exist.'
+    ),
 });
 
 export const createPageCopyData = ({
@@ -1554,19 +1605,11 @@ export const insertPageTransferItem = (
     assets: Array.from(data.assets.values()),
   });
   const rootFragment = collectPageTransferItems(input.item)[0]?.rootFragment;
-  if (
-    input.rootStyleConflictResolution === undefined &&
-    rootFragment !== undefined &&
-    detectFragmentRootStyleConflicts({
-      fragment: rootFragment,
-      targetData: before,
-    }).length > 0
-  ) {
-    return throwBuilderRuntimeError(
-      "CONFLICT",
-      "Global root style conflicts require an explicit rootStyleConflictResolution (ours or theirs)"
-    );
-  }
+  requireRootStyleConflictResolution({
+    rootFragment,
+    targetData: before,
+    resolution: input.rootStyleConflictResolution,
+  });
   let didReachBreakpointLimit = false;
   const onBreakpointLimitMerge = () => {
     didReachBreakpointLimit = true;

--- a/packages/project-build/src/runtime/page-copy.ts
+++ b/packages/project-build/src/runtime/page-copy.ts
@@ -1,5 +1,6 @@
 import {
   type ContentModeCopyableProp,
+  detectFragmentRootStyleConflicts,
   extractWebstudioFragment,
   insertWebstudioFragmentCopy,
 } from "./fragment";
@@ -33,7 +34,10 @@ import {
   type WebstudioData,
   ROOT_INSTANCE_ID,
 } from "@webstudio-is/sdk";
-import type { ConflictResolution } from "./style-copy";
+import type {
+  ConflictResolution,
+  RootStyleConflictResolution,
+} from "./style-copy";
 import type { BuilderState } from "../state/builder-state";
 import { paginateOutput, type PaginatedOutputInput } from "./output";
 import { pageCopyNamespaces } from "../contracts/namespaces";
@@ -56,6 +60,7 @@ import {
   pageTransferItemInput,
   type FolderCopyData,
   type PageCopyData,
+  type PageTransferItem,
   type TemplateCopyData,
 } from "./data-formats/page-transfer";
 
@@ -319,6 +324,7 @@ const copyPageFragmentsMutable = ({
   projectId,
   metas,
   conflictResolution,
+  rootStyleConflictResolution,
   contentModeCopyableProp,
   onBreakpointLimitMerge,
   createId = nanoid,
@@ -331,6 +337,7 @@ const copyPageFragmentsMutable = ({
   projectId?: string;
   metas?: Map<string, WsComponentMeta>;
   conflictResolution: ConflictResolution | undefined;
+  rootStyleConflictResolution?: RootStyleConflictResolution;
   contentModeCopyableProp?: ContentModeCopyableProp;
   onBreakpointLimitMerge?: () => void;
   createId?: CreateId;
@@ -350,6 +357,7 @@ const copyPageFragmentsMutable = ({
       projectId,
       metas,
       conflictResolution,
+      rootStyleConflictResolution,
       contentModeCopyableProp,
       onBreakpointLimitMerge,
       createId,
@@ -1275,6 +1283,7 @@ export const insertPageCopyFromFragmentsMutable = ({
   target,
   projectId,
   conflictResolution,
+  rootStyleConflictResolution,
   contentModeCopyableProp,
   onBreakpointLimitMerge,
   createId = nanoid,
@@ -1287,6 +1296,7 @@ export const insertPageCopyFromFragmentsMutable = ({
   target: { data: WebstudioData; folderId: Folder["id"] };
   projectId?: string;
   conflictResolution?: ConflictResolution;
+  rootStyleConflictResolution?: RootStyleConflictResolution;
   contentModeCopyableProp?: ContentModeCopyableProp;
   onBreakpointLimitMerge?: () => void;
   createId?: CreateId;
@@ -1298,6 +1308,7 @@ export const insertPageCopyFromFragmentsMutable = ({
     systemDataSourceId: source.page.systemDataSourceId,
     projectId,
     conflictResolution,
+    rootStyleConflictResolution,
     contentModeCopyableProp,
     onBreakpointLimitMerge,
     createId,
@@ -1318,6 +1329,7 @@ export const insertTemplateCopyFromFragmentsMutable = ({
   target,
   projectId,
   conflictResolution,
+  rootStyleConflictResolution,
   contentModeCopyableProp,
   onBreakpointLimitMerge,
   createId = nanoid,
@@ -1330,6 +1342,7 @@ export const insertTemplateCopyFromFragmentsMutable = ({
   target: { data: WebstudioData };
   projectId?: string;
   conflictResolution?: ConflictResolution;
+  rootStyleConflictResolution?: RootStyleConflictResolution;
   contentModeCopyableProp?: ContentModeCopyableProp;
   onBreakpointLimitMerge?: () => void;
   createId?: CreateId;
@@ -1341,6 +1354,7 @@ export const insertTemplateCopyFromFragmentsMutable = ({
     systemDataSourceId: undefined,
     projectId,
     conflictResolution,
+    rootStyleConflictResolution,
     contentModeCopyableProp,
     onBreakpointLimitMerge,
     createId,
@@ -1361,7 +1375,22 @@ export const pageTransferInsertInput = z.object({
   targetFolderId: z.string(),
   item: pageTransferItemInput,
   conflictResolution: z.enum(["ours", "theirs", "merge"]).optional(),
+  rootStyleConflictResolution: z.enum(["ours", "theirs"]).optional(),
 });
+
+const findFirstTransferRootFragment = (
+  item: PageTransferItem
+): WebstudioFragment | undefined => {
+  if (item.type === "page" || item.type === "template") {
+    return item.rootFragment;
+  }
+  for (const child of item.children) {
+    const rootFragment = findFirstTransferRootFragment(child);
+    if (rootFragment !== undefined) {
+      return rootFragment;
+    }
+  }
+};
 
 export const createPageCopyData = ({
   data,
@@ -1487,6 +1516,7 @@ export const insertFolderCopyFromDataMutable = ({
   target,
   projectId,
   conflictResolution,
+  rootStyleConflictResolution,
   contentModeCopyableProp,
   onBreakpointLimitMerge,
   forceFolderCopySuffix = false,
@@ -1496,6 +1526,7 @@ export const insertFolderCopyFromDataMutable = ({
   target: { data: WebstudioData; parentFolderId: Folder["id"] };
   projectId?: string;
   conflictResolution?: ConflictResolution;
+  rootStyleConflictResolution?: RootStyleConflictResolution;
   contentModeCopyableProp?: ContentModeCopyableProp;
   onBreakpointLimitMerge?: () => void;
   forceFolderCopySuffix?: boolean;
@@ -1510,6 +1541,7 @@ export const insertFolderCopyFromDataMutable = ({
     target,
     projectId,
     conflictResolution,
+    rootStyleConflictResolution,
     contentModeCopyableProp,
     onBreakpointLimitMerge,
     forceFolderCopySuffix,
@@ -1531,6 +1563,20 @@ export const insertPageTransferItem = (
     build: data,
     assets: Array.from(data.assets.values()),
   });
+  const rootFragment = findFirstTransferRootFragment(input.item);
+  if (
+    input.rootStyleConflictResolution === undefined &&
+    rootFragment !== undefined &&
+    detectFragmentRootStyleConflicts({
+      fragment: rootFragment,
+      targetData: before,
+    }).length > 0
+  ) {
+    return throwBuilderRuntimeError(
+      "CONFLICT",
+      "Global root style conflicts require an explicit rootStyleConflictResolution (ours or theirs)"
+    );
+  }
   let didReachBreakpointLimit = false;
   const onBreakpointLimitMerge = () => {
     didReachBreakpointLimit = true;
@@ -1543,6 +1589,7 @@ export const insertPageTransferItem = (
         target: { data: draft, folderId: input.targetFolderId },
         projectId: input.projectId,
         conflictResolution: input.conflictResolution,
+        rootStyleConflictResolution: input.rootStyleConflictResolution,
         onBreakpointLimitMerge,
         createId: context.createId,
       });
@@ -1552,6 +1599,7 @@ export const insertPageTransferItem = (
         target: { data: draft },
         projectId: input.projectId,
         conflictResolution: input.conflictResolution,
+        rootStyleConflictResolution: input.rootStyleConflictResolution,
         onBreakpointLimitMerge,
         createId: context.createId,
       });
@@ -1561,6 +1609,7 @@ export const insertPageTransferItem = (
         target: { data: draft, parentFolderId: input.targetFolderId },
         projectId: input.projectId,
         conflictResolution: input.conflictResolution,
+        rootStyleConflictResolution: input.rootStyleConflictResolution,
         onBreakpointLimitMerge,
         createId: context.createId,
       });
@@ -1588,6 +1637,7 @@ const insertFolderCopyFromDataWithContextMutable = ({
   target,
   projectId,
   conflictResolution,
+  rootStyleConflictResolution,
   contentModeCopyableProp,
   onBreakpointLimitMerge,
   forceFolderCopySuffix,
@@ -1598,6 +1648,7 @@ const insertFolderCopyFromDataWithContextMutable = ({
   target: { data: WebstudioData; parentFolderId: Folder["id"] };
   projectId?: string;
   conflictResolution?: ConflictResolution;
+  rootStyleConflictResolution?: RootStyleConflictResolution;
   contentModeCopyableProp?: ContentModeCopyableProp;
   onBreakpointLimitMerge?: () => void;
   forceFolderCopySuffix?: boolean;
@@ -1636,6 +1687,7 @@ const insertFolderCopyFromDataWithContextMutable = ({
         target: { data: target.data, parentFolderId: newFolder.id },
         projectId,
         conflictResolution,
+        rootStyleConflictResolution,
         contentModeCopyableProp,
         onBreakpointLimitMerge,
         forceFolderCopySuffix,
@@ -1652,6 +1704,7 @@ const insertFolderCopyFromDataWithContextMutable = ({
       target: { data: target.data, folderId: newFolder.id },
       projectId,
       conflictResolution,
+      rootStyleConflictResolution,
       contentModeCopyableProp,
       onBreakpointLimitMerge,
       createId,

--- a/packages/project-build/src/runtime/style-copy.test.ts
+++ b/packages/project-build/src/runtime/style-copy.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@webstudio-is/sdk";
 import {
   collectStyleSourcesFromInstances,
+  detectRootStyleConflicts,
   detectTokenConflicts,
   findTokenWithMatchingStyles,
   getStyleSourceStylesSignature,
@@ -51,6 +52,62 @@ const local = (id: string): StyleSource => ({ type: "local", id });
 const baseBreakpoints = toMap<Breakpoint>([{ id: "base", label: "Base" }]);
 const red = { type: "keyword", value: "red" } satisfies StyleValue;
 const blue = { type: "keyword", value: "blue" } satisfies StyleValue;
+
+describe("root style conflict helpers", () => {
+  test("detects different values after breakpoint remapping", () => {
+    const conflicts = detectRootStyleConflicts({
+      fragmentStyleSources: [local("incoming-local")],
+      fragmentStyleSourceSelections: [
+        { instanceId: ROOT_INSTANCE_ID, values: ["incoming-local"] },
+      ],
+      fragmentStyles: [style("incoming-local", "incoming-base", "color", red)],
+      existingStyleSources: toMap([local("existing-local")]),
+      existingStyleSourceSelections: new Map([
+        [
+          ROOT_INSTANCE_ID,
+          { instanceId: ROOT_INSTANCE_ID, values: ["existing-local"] },
+        ],
+      ]),
+      existingStyles: styleMap([
+        style("existing-local", "existing-base", "color", blue),
+      ]),
+      mergedBreakpointIds: new Map([["incoming-base", "existing-base"]]),
+    });
+
+    expect(conflicts).toEqual([
+      {
+        existingStyle: style("existing-local", "existing-base", "color", blue),
+        incomingStyle: style("incoming-local", "incoming-base", "color", red),
+      },
+    ]);
+  });
+
+  test("ignores identical and non-conflicting root declarations", () => {
+    const conflicts = detectRootStyleConflicts({
+      fragmentStyleSources: [local("incoming-local")],
+      fragmentStyleSourceSelections: [
+        { instanceId: ROOT_INSTANCE_ID, values: ["incoming-local"] },
+      ],
+      fragmentStyles: [
+        style("incoming-local", "base", "color", blue),
+        style("incoming-local", "base", "backgroundColor", red),
+      ],
+      existingStyleSources: toMap([local("existing-local")]),
+      existingStyleSourceSelections: new Map([
+        [
+          ROOT_INSTANCE_ID,
+          { instanceId: ROOT_INSTANCE_ID, values: ["existing-local"] },
+        ],
+      ]),
+      existingStyles: styleMap([
+        style("existing-local", "base", "color", blue),
+      ]),
+      mergedBreakpointIds: new Map(),
+    });
+
+    expect(conflicts).toEqual([]);
+  });
+});
 
 describe("token conflict helpers", () => {
   test("creates stable style signatures independent of declaration order", () => {

--- a/packages/project-build/src/runtime/style-copy.test.ts
+++ b/packages/project-build/src/runtime/style-copy.test.ts
@@ -89,7 +89,10 @@ describe("root style conflict helpers", () => {
         { instanceId: ROOT_INSTANCE_ID, values: ["incoming-local"] },
       ],
       fragmentStyles: [
-        style("incoming-local", "base", "color", blue),
+        style("incoming-local", "base", "color", {
+          type: "unparsed",
+          value: "blue",
+        }),
         style("incoming-local", "base", "backgroundColor", red),
       ],
       existingStyleSources: toMap([local("existing-local")]),

--- a/packages/project-build/src/runtime/style-copy.ts
+++ b/packages/project-build/src/runtime/style-copy.ts
@@ -1,5 +1,4 @@
 import { nanoid } from "nanoid";
-import deepEqual from "fast-deep-equal";
 import { toValue } from "@webstudio-is/css-engine";
 import {
   getStyleDeclKey,
@@ -96,7 +95,7 @@ export const detectRootStyleConflicts = ({
     );
     if (
       existingStyle !== undefined &&
-      deepEqual(existingStyle.value, incomingStyle.value) === false
+      toValue(existingStyle.value) !== toValue(incomingStyle.value)
     ) {
       conflicts.push({ existingStyle, incomingStyle });
     }
@@ -569,7 +568,6 @@ type InsertLocalStyleSourcesWithNewIdsOptions = {
   styleSourceSelections: StyleSourceSelections;
   styles: Styles;
   createId?: () => string;
-  rootStyleConflictResolution?: RootStyleConflictResolution;
 } & (
   | {
       contentMode: true;
@@ -605,7 +603,6 @@ export const insertLocalStyleSourcesWithNewIds = ({
   breakpoints,
   styleSourceIdMap = new Map(),
   mergedBreakpointIds = new Map(),
-  rootStyleConflictResolution = "theirs",
 }: InsertLocalStyleSourcesWithNewIdsOptions): void => {
   const newLocalStyleSources = new Map<StyleSource["id"], StyleSource>();
   for (const styleSource of fragmentStyleSources) {
@@ -613,14 +610,6 @@ export const insertLocalStyleSourcesWithNewIds = ({
       newLocalStyleSources.set(styleSource.id, styleSource);
     }
   }
-  const rootLocalStyleSourceIds = new Set(
-    findLocalStyleSourceIds({
-      instanceId: ROOT_INSTANCE_ID,
-      styleSourceSelections: fragmentStyleSourceSelections,
-      styleSources: fragmentStyleSources,
-    })
-  );
-
   const newLocalStyleSourceIds = new Map<
     StyleSource["id"],
     StyleSource["id"]
@@ -727,14 +716,6 @@ export const insertLocalStyleSourcesWithNewIds = ({
       if (
         contentMode &&
         breakpoints?.has(newStyleDecl.breakpointId) === false
-      ) {
-        continue;
-      }
-      if (
-        contentMode === false &&
-        rootStyleConflictResolution === "ours" &&
-        rootLocalStyleSourceIds.has(styleSourceId) &&
-        styles.has(getStyleDeclKey(newStyleDecl))
       ) {
         continue;
       }

--- a/packages/project-build/src/runtime/style-copy.ts
+++ b/packages/project-build/src/runtime/style-copy.ts
@@ -1,4 +1,5 @@
 import { nanoid } from "nanoid";
+import deepEqual from "fast-deep-equal";
 import { toValue } from "@webstudio-is/css-engine";
 import {
   getStyleDeclKey,
@@ -15,6 +16,93 @@ import {
 import { getUniqueNameWithSuffix } from "./style-utils";
 
 export type ConflictResolution = "ours" | "theirs" | "merge";
+export type RootStyleConflictResolution = "ours" | "theirs";
+
+export type RootStyleConflict = {
+  existingStyle: StyleDecl;
+  incomingStyle: StyleDecl;
+};
+
+const findLocalStyleSourceIds = ({
+  instanceId,
+  styleSourceSelections,
+  styleSources,
+}: {
+  instanceId: Instance["id"];
+  styleSourceSelections: Iterable<StyleSourceSelection>;
+  styleSources: Iterable<StyleSource>;
+}) => {
+  const localStyleSourceIds = new Set(
+    Array.from(styleSources)
+      .filter((styleSource) => styleSource.type === "local")
+      .map((styleSource) => styleSource.id)
+  );
+  const selection = Array.from(styleSourceSelections).find(
+    (candidate) => candidate.instanceId === instanceId
+  );
+  return selection?.values.filter((id) => localStyleSourceIds.has(id)) ?? [];
+};
+
+export const detectRootStyleConflicts = ({
+  fragmentStyleSources,
+  fragmentStyleSourceSelections,
+  fragmentStyles,
+  existingStyleSources,
+  existingStyleSourceSelections,
+  existingStyles,
+  mergedBreakpointIds,
+}: {
+  fragmentStyleSources: StyleSource[];
+  fragmentStyleSourceSelections: StyleSourceSelection[];
+  fragmentStyles: StyleDecl[];
+  existingStyleSources: StyleSources;
+  existingStyleSourceSelections: StyleSourceSelections;
+  existingStyles: Styles;
+  mergedBreakpointIds: Map<Breakpoint["id"], Breakpoint["id"]>;
+}): RootStyleConflict[] => {
+  const incomingStyleSourceIds = new Set(
+    findLocalStyleSourceIds({
+      instanceId: ROOT_INSTANCE_ID,
+      styleSourceSelections: fragmentStyleSourceSelections,
+      styleSources: fragmentStyleSources,
+    })
+  );
+  const existingStyleSourceId = findLocalStyleSourceIds({
+    instanceId: ROOT_INSTANCE_ID,
+    styleSourceSelections: existingStyleSourceSelections.values(),
+    styleSources: existingStyleSources.values(),
+  }).at(-1);
+  if (
+    incomingStyleSourceIds.size === 0 ||
+    existingStyleSourceId === undefined
+  ) {
+    return [];
+  }
+
+  const conflicts: RootStyleConflict[] = [];
+  for (const incomingStyle of fragmentStyles) {
+    if (incomingStyleSourceIds.has(incomingStyle.styleSourceId) === false) {
+      continue;
+    }
+    const normalizedIncomingStyle = {
+      ...incomingStyle,
+      styleSourceId: existingStyleSourceId,
+      breakpointId:
+        mergedBreakpointIds.get(incomingStyle.breakpointId) ??
+        incomingStyle.breakpointId,
+    };
+    const existingStyle = existingStyles.get(
+      getStyleDeclKey(normalizedIncomingStyle)
+    );
+    if (
+      existingStyle !== undefined &&
+      deepEqual(existingStyle.value, incomingStyle.value) === false
+    ) {
+      conflicts.push({ existingStyle, incomingStyle });
+    }
+  }
+  return conflicts;
+};
 
 export const getStyleSourceStylesSignature = (
   styleSourceId: StyleSource["id"],
@@ -481,6 +569,7 @@ type InsertLocalStyleSourcesWithNewIdsOptions = {
   styleSourceSelections: StyleSourceSelections;
   styles: Styles;
   createId?: () => string;
+  rootStyleConflictResolution?: RootStyleConflictResolution;
 } & (
   | {
       contentMode: true;
@@ -516,6 +605,7 @@ export const insertLocalStyleSourcesWithNewIds = ({
   breakpoints,
   styleSourceIdMap = new Map(),
   mergedBreakpointIds = new Map(),
+  rootStyleConflictResolution = "theirs",
 }: InsertLocalStyleSourcesWithNewIdsOptions): void => {
   const newLocalStyleSources = new Map<StyleSource["id"], StyleSource>();
   for (const styleSource of fragmentStyleSources) {
@@ -523,6 +613,13 @@ export const insertLocalStyleSourcesWithNewIds = ({
       newLocalStyleSources.set(styleSource.id, styleSource);
     }
   }
+  const rootLocalStyleSourceIds = new Set(
+    findLocalStyleSourceIds({
+      instanceId: ROOT_INSTANCE_ID,
+      styleSourceSelections: fragmentStyleSourceSelections,
+      styleSources: fragmentStyleSources,
+    })
+  );
 
   const newLocalStyleSourceIds = new Map<
     StyleSource["id"],
@@ -630,6 +727,14 @@ export const insertLocalStyleSourcesWithNewIds = ({
       if (
         contentMode &&
         breakpoints?.has(newStyleDecl.breakpointId) === false
+      ) {
+        continue;
+      }
+      if (
+        contentMode === false &&
+        rootStyleConflictResolution === "ours" &&
+        rootLocalStyleSourceIds.has(styleSourceId) &&
+        styles.has(getStyleDeclKey(newStyleDecl))
       ) {
         continue;
       }


### PR DESCRIPTION
## Summary

Prevent page, template, folder, and marketplace page imports from silently replacing local declarations on the shared global root. When incoming root styles differ at the same property, breakpoint, and state, Builder now asks whether to preserve the project values or use the incoming values. Cancellation happens before the runtime mutation.

## Technical choices

- Compare CSS values by their serialized meaning so equivalent keyword and unparsed values do not create false conflicts.
- Plan breakpoint remapping with the same insertion path used by fragment paste, including ID collisions and breakpoint limits.
- Keep named-token conflict resolution separate because token conflicts support suffixing and merging, while a shared root-local declaration has only an existing or incoming value.
- Default the root-style dialog to **Keep existing** because global root styles affect every page, and show the breakpoint plus current and incoming values for each conflict.
- Re-read current project data after the asynchronous token dialog before detecting root conflicts.
- Leave no-conflict resolution undefined so the runtime performs a final conflict check instead of treating it as an explicit **Use incoming** choice.
- Resolve root conflicts at the page-copy boundary before using the generic fragment/style insertion path.
- Reuse one root-conflict UI resolver for clipboard paste and marketplace imports, one page-transfer traversal helper in the UI and runtime, and one presentational shell for token and root-style conflict dialogs.
- Require an explicit `rootStyleConflictResolution` for conflicting `pageTransfer.insert` and `pages.copy` runtime operations so non-UI callers cannot overwrite global values accidentally.
- Document that `ours` keeps target-project values and `theirs` uses incoming values in both generated runtime contracts.

## Todo

- [x] Detect conflicting root-local declarations by property, breakpoint, and state
- [x] Add keep-existing, use-incoming, and cancel behavior
- [x] Cover page, template, nested-folder, marketplace, and direct runtime transfer paths
- [x] Preserve non-conflicting incoming root declarations with either resolution
- [x] Avoid false conflicts for equivalent CSS values and colliding breakpoint IDs
- [x] Revalidate root styles after asynchronous token resolution
- [x] Preserve existing named-token conflict behavior
- [x] Remove duplicated transfer traversal, conflict resolution mapping, and dialog layout
- [x] Regenerate the runtime operation contract
- [x] Verify regression tests fail when their corresponding behavior is disabled
- [x] Run targeted tests, typechecks, formatting, and lint

## Verification

- `pnpm --filter @webstudio-is/project-build test -- src/runtime/style-copy.test.ts src/runtime/fragment.test.tsx src/runtime/page-copy.test.tsx` — 80 passed
- `pnpm --filter @webstudio-is/builder test -- app/shared/copy-paste/plugin-page.test.ts app/shared/root-style-conflict-dialog.test.tsx app/shared/token-conflict-dialog.test.tsx` — 17 passed
- Retrospective fail/pass audit covered semantic CSS equality, breakpoint ID collisions, both runtime guards, both resolution directions, folder/template paths, conflict detail rendering, and stale target data after token resolution
- `pnpm --filter @webstudio-is/project-build typecheck` — passed
- `pnpm --filter @webstudio-is/builder typecheck` — passed
- `pnpm lint` — passed
- Runtime contract regeneration was repeated and produced identical output
- Fixture pipeline not run locally: no fixture inputs or outputs are affected; GitHub fixture checks passed on the previous revision
- Agent evaluations not run: repository guidance requires separate explicit approval before running them

## Compatibility and limitations

The new runtime inputs are optional for non-conflicting imports. Existing imports continue unchanged; only imports that would overwrite a conflicting shared root-local declaration require an explicit resolution. No migrations or persistence changes are required.

Closes #5970
