### PR TITLE
fix: Preserve instance deep links on Builder reload

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -326,7 +326,8 @@ export const Builder = (props: BuilderProps) => {
     $pages.set(undefined);
   });
 
-  useSyncPageUrl();
+  const dataLoadingState = useStore($dataLoadingState);
+  useSyncPageUrl({ isDataLoaded: dataLoadingState === "loaded" });
 
   const [publish, publishRef] = usePublish();
   useEffect(() => {
@@ -361,7 +362,6 @@ export const Builder = (props: BuilderProps) => {
   );
 
   const { navigatorLayout } = useStore($settings);
-  const dataLoadingState = useStore($dataLoadingState);
   const [loadingState, setLoadingState] = useState(() => $loadingState.get());
 
   useEffect(() => {

--- a/apps/builder/app/builder/features/publish/publish.tsx
+++ b/apps/builder/app/builder/features/publish/publish.tsx
@@ -133,7 +133,7 @@ const PrePublishAuditMessage = ({
   const href = builderUrl({
     projectId: project.id,
     pageId: pageId === pages.homePageId ? undefined : pageId,
-    instanceId,
+    instanceSelector,
     origin: window.location.origin,
     authToken: $authToken.get(),
     mode: $builderMode.get(),

--- a/apps/builder/app/routes/_ui.(builder).tsx
+++ b/apps/builder/app/routes/_ui.(builder).tsx
@@ -22,12 +22,7 @@ import {
 import { createContext } from "~/shared/context.server";
 import { getPlanInfo } from "@webstudio-is/plans/index.server";
 import { defaultPlanFeatures } from "@webstudio-is/plans";
-import {
-  builderReauthorizationUrl,
-  dashboardPath,
-  isBuilder,
-  isDashboard,
-} from "~/shared/router-utils";
+import { dashboardPath, isBuilder, isDashboard } from "~/shared/router-utils";
 
 import env from "~/env/env.server";
 
@@ -64,19 +59,6 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   return metas;
 };
 
-const reauthorizeBuilder = (loaderArgs: LoaderFunctionArgs) => {
-  const { request } = loaderArgs;
-  const authorizationRequest = new Request(
-    builderReauthorizationUrl(request.url),
-    {
-      headers: request.headers,
-      method: request.method,
-      signal: request.signal,
-    }
-  );
-  return authWsLoader({ ...loaderArgs, request: authorizationRequest });
-};
-
 export const loader = async (loaderArgs: LoaderFunctionArgs) => {
   const { request } = loaderArgs;
   preventCrossOriginCookie(request);
@@ -106,7 +88,7 @@ export const loader = async (loaderArgs: LoaderFunctionArgs) => {
   }
 
   if (context.authorization.type === "anonymous") {
-    throw await reauthorizeBuilder(loaderArgs);
+    throw await authWsLoader(loaderArgs);
   }
 
   if (
@@ -124,7 +106,7 @@ export const loader = async (loaderArgs: LoaderFunctionArgs) => {
       Date.now() - context.authorization.sessionCreatedAt >
       RELOAD_ON_NAVIGATE_TIMEOUT
     ) {
-      throw await reauthorizeBuilder(loaderArgs);
+      throw await authWsLoader(loaderArgs);
     }
   }
 
@@ -294,7 +276,7 @@ export const loader = async (loaderArgs: LoaderFunctionArgs) => {
   } catch (error) {
     if (error instanceof AuthorizationError) {
       // try to re-login user if he has no access to the project
-      throw await reauthorizeBuilder(loaderArgs);
+      throw await authWsLoader(loaderArgs);
     }
 
     throw error;

--- a/apps/builder/app/routes/_ui.(builder).tsx
+++ b/apps/builder/app/routes/_ui.(builder).tsx
@@ -22,7 +22,12 @@ import {
 import { createContext } from "~/shared/context.server";
 import { getPlanInfo } from "@webstudio-is/plans/index.server";
 import { defaultPlanFeatures } from "@webstudio-is/plans";
-import { dashboardPath, isBuilder, isDashboard } from "~/shared/router-utils";
+import {
+  builderReauthorizationUrl,
+  dashboardPath,
+  isBuilder,
+  isDashboard,
+} from "~/shared/router-utils";
 
 import env from "~/env/env.server";
 
@@ -59,6 +64,19 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
   return metas;
 };
 
+const reauthorizeBuilder = (loaderArgs: LoaderFunctionArgs) => {
+  const { request } = loaderArgs;
+  const authorizationRequest = new Request(
+    builderReauthorizationUrl(request.url),
+    {
+      headers: request.headers,
+      method: request.method,
+      signal: request.signal,
+    }
+  );
+  return authWsLoader({ ...loaderArgs, request: authorizationRequest });
+};
+
 export const loader = async (loaderArgs: LoaderFunctionArgs) => {
   const { request } = loaderArgs;
   preventCrossOriginCookie(request);
@@ -88,7 +106,7 @@ export const loader = async (loaderArgs: LoaderFunctionArgs) => {
   }
 
   if (context.authorization.type === "anonymous") {
-    throw await authWsLoader(loaderArgs); // redirect("/auth/ws");
+    throw await reauthorizeBuilder(loaderArgs);
   }
 
   if (
@@ -106,7 +124,7 @@ export const loader = async (loaderArgs: LoaderFunctionArgs) => {
       Date.now() - context.authorization.sessionCreatedAt >
       RELOAD_ON_NAVIGATE_TIMEOUT
     ) {
-      throw await authWsLoader(loaderArgs); // start immediately instead of redirect("/auth/ws");
+      throw await reauthorizeBuilder(loaderArgs);
     }
   }
 
@@ -276,7 +294,7 @@ export const loader = async (loaderArgs: LoaderFunctionArgs) => {
   } catch (error) {
     if (error instanceof AuthorizationError) {
       // try to re-login user if he has no access to the project
-      throw redirect(`/auth/ws`);
+      throw await reauthorizeBuilder(loaderArgs);
     }
 
     throw error;

--- a/apps/builder/app/routes/auth.ws.ts
+++ b/apps/builder/app/routes/auth.ws.ts
@@ -35,10 +35,13 @@ export const loader: LoaderFunction = async ({ request }) => {
         const response = new Response(noStoreResponse.body, noStoreResponse);
 
         const url = new URL(request.url);
-        let returnTo = url.searchParams.get("returnTo");
+        const isAuthRoute = url.pathname === "/auth/ws";
+        let returnTo = isAuthRoute
+          ? url.searchParams.get("returnTo")
+          : `${url.pathname}${url.search}`;
 
         if (returnTo !== null) {
-          if (comparePathnames(returnTo, request.url)) {
+          if (isAuthRoute && comparePathnames(returnTo, request.url)) {
             // avoid loops
             returnTo = "/";
           }

--- a/apps/builder/app/shared/pages/use-switch-page.test.tsx
+++ b/apps/builder/app/shared/pages/use-switch-page.test.tsx
@@ -3,8 +3,27 @@ import { createDefaultPages } from "@webstudio-is/project-build";
 import { $, renderData } from "@webstudio-is/template";
 import { __testing__ } from "./use-switch-page";
 
-const { getDeepLinkedInstanceSelection, shouldNavigateToPageState } =
-  __testing__;
+const {
+  getDeepLinkedInstanceSelection,
+  shouldInitializePageState,
+  shouldNavigateToPageState,
+} = __testing__;
+
+test("waits for complete Builder data before initializing URL state", () => {
+  expect(
+    shouldInitializePageState({
+      isDataLoaded: false,
+      isUrlStateInitialized: false,
+    })
+  ).toBe(false);
+
+  expect(
+    shouldInitializePageState({
+      isDataLoaded: true,
+      isUrlStateInitialized: false,
+    })
+  ).toBe(true);
+});
 
 test("preserves an instance deep link until URL state is initialized", () => {
   expect(

--- a/apps/builder/app/shared/pages/use-switch-page.test.tsx
+++ b/apps/builder/app/shared/pages/use-switch-page.test.tsx
@@ -70,6 +70,39 @@ test("resolves a deep-linked instance to its page and full selector", () => {
   });
 });
 
+test("resolves shared slot content through a deterministic slot instance", () => {
+  const pages = createDefaultPages({
+    homePageId: "home-page",
+    rootInstanceId: "body",
+  });
+  const { instances } = renderData(
+    <$.Body ws:id="body">
+      <$.Slot ws:id="slot-one">
+        <$.Fragment ws:id="fragment">
+          <$.Box ws:id="box"></$.Box>
+        </$.Fragment>
+      </$.Slot>
+      <$.Slot ws:id="slot-two">
+        <$.Fragment ws:id="fragment">
+          <$.Box ws:id="box"></$.Box>
+        </$.Fragment>
+      </$.Slot>
+    </$.Body>
+  );
+
+  expect(
+    getDeepLinkedInstanceSelection({
+      instanceId: "box",
+      canOpenPageTemplates: true,
+      pages,
+      instances,
+    })
+  ).toEqual({
+    pageId: "home-page",
+    instanceSelector: ["box", "fragment", "slot-two", "body"],
+  });
+});
+
 test("ignores missing deep-linked instances", () => {
   const pages = createDefaultPages({
     homePageId: "home-page",

--- a/apps/builder/app/shared/pages/use-switch-page.test.tsx
+++ b/apps/builder/app/shared/pages/use-switch-page.test.tsx
@@ -3,7 +3,28 @@ import { createDefaultPages } from "@webstudio-is/project-build";
 import { $, renderData } from "@webstudio-is/template";
 import { __testing__ } from "./use-switch-page";
 
-const { getDeepLinkedInstanceSelection } = __testing__;
+const { getDeepLinkedInstanceSelection, shouldNavigateToPageState } =
+  __testing__;
+
+test("preserves an instance deep link until URL state is initialized", () => {
+  expect(
+    shouldNavigateToPageState({
+      isUrlStateInitialized: false,
+      isSamePageState: true,
+      searchParamsInstanceId: "heading",
+      instanceId: undefined,
+    })
+  ).toBe(false);
+
+  expect(
+    shouldNavigateToPageState({
+      isUrlStateInitialized: true,
+      isSamePageState: true,
+      searchParamsInstanceId: "heading",
+      instanceId: undefined,
+    })
+  ).toBe(true);
+});
 
 test("resolves a deep-linked instance to its page and full selector", () => {
   const pages = createDefaultPages({

--- a/apps/builder/app/shared/pages/use-switch-page.test.tsx
+++ b/apps/builder/app/shared/pages/use-switch-page.test.tsx
@@ -3,27 +3,8 @@ import { createDefaultPages } from "@webstudio-is/project-build";
 import { $, renderData } from "@webstudio-is/template";
 import { __testing__ } from "./use-switch-page";
 
-const {
-  getDeepLinkedInstanceSelection,
-  shouldInitializePageState,
-  shouldNavigateToPageState,
-} = __testing__;
-
-test("waits for complete Builder data before initializing URL state", () => {
-  expect(
-    shouldInitializePageState({
-      isDataLoaded: false,
-      isUrlStateInitialized: false,
-    })
-  ).toBe(false);
-
-  expect(
-    shouldInitializePageState({
-      isDataLoaded: true,
-      isUrlStateInitialized: false,
-    })
-  ).toBe(true);
-});
+const { getDeepLinkedInstanceSelection, shouldNavigateToPageState } =
+  __testing__;
 
 test("preserves an instance deep link until URL state is initialized", () => {
   expect(

--- a/apps/builder/app/shared/pages/use-switch-page.test.tsx
+++ b/apps/builder/app/shared/pages/use-switch-page.test.tsx
@@ -30,8 +30,8 @@ test("preserves an instance deep link until URL state is initialized", () => {
     shouldNavigateToPageState({
       isUrlStateInitialized: false,
       isSamePageState: true,
-      searchParamsInstanceId: "heading",
-      instanceId: undefined,
+      searchParamsInstanceSelector: ["heading", "box", "body"],
+      instanceSelector: undefined,
     })
   ).toBe(false);
 
@@ -39,8 +39,19 @@ test("preserves an instance deep link until URL state is initialized", () => {
     shouldNavigateToPageState({
       isUrlStateInitialized: true,
       isSamePageState: true,
-      searchParamsInstanceId: "heading",
-      instanceId: undefined,
+      searchParamsInstanceSelector: ["heading", "box", "body"],
+      instanceSelector: undefined,
+    })
+  ).toBe(true);
+});
+
+test("updates the URL when a shared instance moves to another slot path", () => {
+  expect(
+    shouldNavigateToPageState({
+      isUrlStateInitialized: true,
+      isSamePageState: true,
+      searchParamsInstanceSelector: ["box", "fragment", "slot-two", "body"],
+      instanceSelector: ["box", "fragment", "slot-one", "body"],
     })
   ).toBe(true);
 });
@@ -59,7 +70,7 @@ test("resolves a deep-linked instance to its page and full selector", () => {
   );
   expect(
     getDeepLinkedInstanceSelection({
-      instanceId: "heading",
+      instanceSelector: ["heading", "box", "body"],
       canOpenPageTemplates: true,
       pages,
       instances,
@@ -70,7 +81,7 @@ test("resolves a deep-linked instance to its page and full selector", () => {
   });
 });
 
-test("resolves shared slot content through a deterministic slot instance", () => {
+test("restores the selected shared slot occurrence from its full selector", () => {
   const pages = createDefaultPages({
     homePageId: "home-page",
     rootInstanceId: "body",
@@ -92,14 +103,14 @@ test("resolves shared slot content through a deterministic slot instance", () =>
 
   expect(
     getDeepLinkedInstanceSelection({
-      instanceId: "box",
+      instanceSelector: ["box", "fragment", "slot-one", "body"],
       canOpenPageTemplates: true,
       pages,
       instances,
     })
   ).toEqual({
     pageId: "home-page",
-    instanceSelector: ["box", "fragment", "slot-two", "body"],
+    instanceSelector: ["box", "fragment", "slot-one", "body"],
   });
 });
 
@@ -112,7 +123,7 @@ test("ignores missing deep-linked instances", () => {
 
   expect(
     getDeepLinkedInstanceSelection({
-      instanceId: "missing",
+      instanceSelector: ["missing", "body"],
       canOpenPageTemplates: true,
       pages,
       instances,

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -100,6 +100,9 @@ export const __testing__ = {
   shouldNavigateToPageState,
 };
 
+const getInstanceSelectorFromUrl = (searchParams: URLSearchParams) =>
+  searchParams.get("instance")?.split(",");
+
 const setPageStateFromUrl = () => {
   const searchParams = new URLSearchParams(window.location.search);
   const pages = $pages.get();
@@ -126,12 +129,9 @@ const setPageStateFromUrl = () => {
     )?.id ?? pages.homePageId;
 
   $selectedPageHash.set({ hash: searchParams.get("pageHash") ?? "" });
-  const requestedInstanceSelector = searchParams.getAll("instanceSelector");
+  const requestedInstanceSelector = getInstanceSelectorFromUrl(searchParams);
   const instanceSelection = getDeepLinkedInstanceSelection({
-    instanceSelector:
-      requestedInstanceSelector.length === 0
-        ? undefined
-        : requestedInstanceSelector,
+    instanceSelector: requestedInstanceSelector,
     canOpenPageTemplates: $canOpenPageTemplates.get(),
     pages,
     instances: $instances.get(),
@@ -197,7 +197,7 @@ export const useSyncPageUrl = ({ isDataLoaded }: { isDataLoaded: boolean }) => {
     const searchParamsPageId = searchParams.get("pageId") ?? pages.homePageId;
     const searchParamsPageHash = searchParams.get("pageHash") ?? "";
     const searchParamsInstanceSelector =
-      searchParams.getAll("instanceSelector");
+      getInstanceSelectorFromUrl(searchParams);
     const searchParamsModeRaw = searchParams.get("mode");
     const searchParamsMode = isBuilderMode(searchParamsModeRaw)
       ? searchParamsModeRaw
@@ -223,10 +223,7 @@ export const useSyncPageUrl = ({ isDataLoaded }: { isDataLoaded: boolean }) => {
       shouldNavigateToPageState({
         isUrlStateInitialized,
         isSamePageState,
-        searchParamsInstanceSelector:
-          searchParamsInstanceSelector.length === 0
-            ? undefined
-            : searchParamsInstanceSelector,
+        searchParamsInstanceSelector,
         instanceSelector,
       }) === false
     ) {

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useStore } from "@nanostores/react";
 import { useNavigate } from "@remix-run/react";
 import { $instances, $pages, $project } from "~/shared/sync/data-stores";
@@ -53,7 +53,24 @@ const getDeepLinkedInstanceSelection = ({
   return selection;
 };
 
-export const __testing__ = { getDeepLinkedInstanceSelection };
+const shouldNavigateToPageState = ({
+  isUrlStateInitialized,
+  isSamePageState,
+  searchParamsInstanceId,
+  instanceId,
+}: {
+  isUrlStateInitialized: boolean;
+  isSamePageState: boolean;
+  searchParamsInstanceId: string | undefined;
+  instanceId: string | undefined;
+}) =>
+  isUrlStateInitialized &&
+  (isSamePageState === false || searchParamsInstanceId !== instanceId);
+
+export const __testing__ = {
+  getDeepLinkedInstanceSelection,
+  shouldNavigateToPageState,
+};
 
 const setPageStateFromUrl = () => {
   const searchParams = new URLSearchParams(window.location.search);
@@ -106,22 +123,39 @@ const setPageStateFromUrl = () => {
  */
 export const useSyncPageUrl = () => {
   const navigate = useNavigate();
+  const [isUrlStateInitialized, setIsUrlStateInitialized] = useState(false);
   const page = useStore($selectedPage);
   const pageHash = useStore($selectedPageHash);
   const builderMode = useStore($builderMode);
   const selectedInstanceSelector = useStore($selectedInstanceSelector);
   const canOpenPageTemplate = useStore($canOpenPageTemplates);
 
-  // Get pageId and pageHash from URL
-  // once pages are loaded
+  // Get page and instance state from the URL once both stores are loaded.
+  // Pages are populated before instances, so initializing from the pages
+  // notification can reject a valid instance deep link as missing.
   useEffect(() => {
-    const unsubscribe = $pages.subscribe((pages) => {
-      if (pages) {
-        unsubscribe();
-        setPageStateFromUrl();
+    let didInitialize = false;
+    const initialize = () => {
+      if (
+        didInitialize ||
+        $pages.get() === undefined ||
+        $instances.get().size === 0
+      ) {
+        return;
       }
-    });
-    return unsubscribe;
+
+      didInitialize = true;
+      setPageStateFromUrl();
+      setIsUrlStateInitialized(true);
+    };
+    const unsubscribePages = $pages.listen(initialize);
+    const unsubscribeInstances = $instances.listen(initialize);
+    initialize();
+
+    return () => {
+      unsubscribePages();
+      unsubscribeInstances();
+    };
   }, []);
 
   useEffect(() => {
@@ -162,8 +196,16 @@ export const useSyncPageUrl = () => {
       searchParamsPageHash === pageHash.hash &&
       searchParamsMode === builderModeParam;
 
-    // Do not navigate on popstate change or if params match
-    if (isSamePageState && searchParamsInstanceId === instanceId) {
+    // Do not navigate before initial URL state is applied, on popstate change,
+    // or if params match.
+    if (
+      shouldNavigateToPageState({
+        isUrlStateInitialized,
+        isSamePageState,
+        searchParamsInstanceId,
+        instanceId,
+      }) === false
+    ) {
       return;
     }
 
@@ -178,7 +220,14 @@ export const useSyncPageUrl = () => {
       }),
       { replace: isSamePageState }
     );
-  }, [builderMode, navigate, page, pageHash, selectedInstanceSelector]);
+  }, [
+    builderMode,
+    isUrlStateInitialized,
+    navigate,
+    page,
+    pageHash,
+    selectedInstanceSelector,
+  ]);
 
   useEffect(() => {
     const pages = $pages.get();

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -86,17 +86,8 @@ const shouldNavigateToPageState = ({
           instanceSelector
         ) === false));
 
-const shouldInitializePageState = ({
-  isDataLoaded,
-  isUrlStateInitialized,
-}: {
-  isDataLoaded: boolean;
-  isUrlStateInitialized: boolean;
-}) => isDataLoaded && isUrlStateInitialized === false;
-
 export const __testing__ = {
   getDeepLinkedInstanceSelection,
-  shouldInitializePageState,
   shouldNavigateToPageState,
 };
 
@@ -167,10 +158,8 @@ export const useSyncPageUrl = ({ isDataLoaded }: { isDataLoaded: boolean }) => {
   // Individual stores can contain intermediate data before then.
   useEffect(() => {
     if (
-      shouldInitializePageState({
-        isDataLoaded,
-        isUrlStateInitialized,
-      }) &&
+      isDataLoaded &&
+      isUrlStateInitialized === false &&
       setPageStateFromUrl()
     ) {
       setIsUrlStateInitialized(true);

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -67,8 +67,17 @@ const shouldNavigateToPageState = ({
   isUrlStateInitialized &&
   (isSamePageState === false || searchParamsInstanceId !== instanceId);
 
+const shouldInitializePageState = ({
+  isDataLoaded,
+  isUrlStateInitialized,
+}: {
+  isDataLoaded: boolean;
+  isUrlStateInitialized: boolean;
+}) => isDataLoaded && isUrlStateInitialized === false;
+
 export const __testing__ = {
   getDeepLinkedInstanceSelection,
+  shouldInitializePageState,
   shouldNavigateToPageState,
 };
 
@@ -76,7 +85,7 @@ const setPageStateFromUrl = () => {
   const searchParams = new URLSearchParams(window.location.search);
   const pages = $pages.get();
   if (pages === undefined) {
-    return;
+    return false;
   }
 
   let mode = searchParams.get("mode");
@@ -107,9 +116,10 @@ const setPageStateFromUrl = () => {
   if (instanceSelection !== undefined) {
     $selectedPageId.set(instanceSelection.pageId);
     selectInstance(instanceSelection.instanceSelector);
-    return;
+    return true;
   }
   selectPage(pageId);
+  return true;
 };
 
 /**
@@ -121,7 +131,7 @@ const setPageStateFromUrl = () => {
  *  - atoms to searchParams
  *    - on atom change
  */
-export const useSyncPageUrl = () => {
+export const useSyncPageUrl = ({ isDataLoaded }: { isDataLoaded: boolean }) => {
   const navigate = useNavigate();
   const [isUrlStateInitialized, setIsUrlStateInitialized] = useState(false);
   const page = useStore($selectedPage);
@@ -130,33 +140,19 @@ export const useSyncPageUrl = () => {
   const selectedInstanceSelector = useStore($selectedInstanceSelector);
   const canOpenPageTemplate = useStore($canOpenPageTemplates);
 
-  // Get page and instance state from the URL once both stores are loaded.
-  // Pages are populated before instances, so initializing from the pages
-  // notification can reject a valid instance deep link as missing.
+  // Apply initial URL state only after the sync client has finished loading.
+  // Individual stores can contain intermediate data before then.
   useEffect(() => {
-    let didInitialize = false;
-    const initialize = () => {
-      if (
-        didInitialize ||
-        $pages.get() === undefined ||
-        $instances.get().size === 0
-      ) {
-        return;
-      }
-
-      didInitialize = true;
-      setPageStateFromUrl();
+    if (
+      shouldInitializePageState({
+        isDataLoaded,
+        isUrlStateInitialized,
+      }) &&
+      setPageStateFromUrl()
+    ) {
       setIsUrlStateInitialized(true);
-    };
-    const unsubscribePages = $pages.listen(initialize);
-    const unsubscribeInstances = $instances.listen(initialize);
-    initialize();
-
-    return () => {
-      unsubscribePages();
-      unsubscribeInstances();
-    };
-  }, []);
+    }
+  }, [isDataLoaded, isUrlStateInitialized]);
 
   useEffect(() => {
     window.addEventListener("popstate", setPageStateFromUrl);

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -18,54 +18,73 @@ import { $selectedPage } from "../nano-states";
 import { selectPage } from "../nano-states";
 import {
   findPageByIdOrPath,
+  getAllPages,
   isPageTemplate,
   type Instances,
   type Pages,
 } from "@webstudio-is/sdk";
-import { findPageAndSelectorByInstanceId } from "@webstudio-is/project-build/runtime";
+import {
+  areInstanceSelectorsEqual,
+  type InstanceSelector,
+} from "@webstudio-is/project-build/runtime";
+import { canResolveInstanceSelector } from "../instance-utils/selection";
 
 const getDeepLinkedInstanceSelection = ({
-  instanceId,
+  instanceSelector,
   canOpenPageTemplates,
   pages,
   instances,
 }: {
-  instanceId: string | null;
+  instanceSelector: InstanceSelector | undefined;
   canOpenPageTemplates: boolean;
   pages: Pages;
   instances: Instances;
 }) => {
-  if (instanceId === null || instances.has(instanceId) === false) {
+  if (instanceSelector === undefined) {
     return;
   }
 
-  const selection = findPageAndSelectorByInstanceId(
-    pages,
-    instances,
-    instanceId
-  );
-  const page = canOpenPageTemplates
-    ? findPageByIdOrPath(selection.pageId, pages, { includeTemplates: true })
-    : findPageByIdOrPath(selection.pageId, pages);
-  if (page?.rootInstanceId !== selection.instanceSelector.at(-1)) {
+  const instanceId = instanceSelector[0];
+  if (
+    instanceId === undefined ||
+    instances.has(instanceId) === false ||
+    canResolveInstanceSelector(instanceSelector, instances) === false
+  ) {
     return;
   }
-  return selection;
+
+  const rootInstanceId = instanceSelector.at(-1);
+  const page = getAllPages(pages).find(
+    (page) => page.rootInstanceId === rootInstanceId
+  );
+  if (
+    page === undefined ||
+    (isPageTemplate(page) && canOpenPageTemplates === false)
+  ) {
+    return;
+  }
+  return { pageId: page.id, instanceSelector };
 };
 
 const shouldNavigateToPageState = ({
   isUrlStateInitialized,
   isSamePageState,
-  searchParamsInstanceId,
-  instanceId,
+  searchParamsInstanceSelector,
+  instanceSelector,
 }: {
   isUrlStateInitialized: boolean;
   isSamePageState: boolean;
-  searchParamsInstanceId: string | undefined;
-  instanceId: string | undefined;
+  searchParamsInstanceSelector: InstanceSelector | undefined;
+  instanceSelector: InstanceSelector | undefined;
 }) =>
   isUrlStateInitialized &&
-  (isSamePageState === false || searchParamsInstanceId !== instanceId);
+  (isSamePageState === false ||
+    (searchParamsInstanceSelector === undefined
+      ? instanceSelector !== undefined
+      : areInstanceSelectorsEqual(
+          searchParamsInstanceSelector,
+          instanceSelector
+        ) === false));
 
 const shouldInitializePageState = ({
   isDataLoaded,
@@ -107,8 +126,12 @@ const setPageStateFromUrl = () => {
     )?.id ?? pages.homePageId;
 
   $selectedPageHash.set({ hash: searchParams.get("pageHash") ?? "" });
+  const requestedInstanceSelector = searchParams.getAll("instanceSelector");
   const instanceSelection = getDeepLinkedInstanceSelection({
-    instanceId: searchParams.get("instanceId"),
+    instanceSelector:
+      requestedInstanceSelector.length === 0
+        ? undefined
+        : requestedInstanceSelector,
     canOpenPageTemplates: $canOpenPageTemplates.get(),
     pages,
     instances: $instances.get(),
@@ -173,19 +196,21 @@ export const useSyncPageUrl = ({ isDataLoaded }: { isDataLoaded: boolean }) => {
 
     const searchParamsPageId = searchParams.get("pageId") ?? pages.homePageId;
     const searchParamsPageHash = searchParams.get("pageHash") ?? "";
-    const searchParamsInstanceId = searchParams.get("instanceId") ?? undefined;
+    const searchParamsInstanceSelector =
+      searchParams.getAll("instanceSelector");
     const searchParamsModeRaw = searchParams.get("mode");
     const searchParamsMode = isBuilderMode(searchParamsModeRaw)
       ? searchParamsModeRaw
       : undefined;
     const builderModeParam = builderMode === "design" ? undefined : builderMode;
     const searchParamsSafemode = searchParams.get("safemode");
-    const selectedInstanceId = selectedInstanceSelector?.[0];
-    const instanceId =
-      selectedInstanceId === page.rootInstanceId ||
-      $instances.get().has(selectedInstanceId ?? "") === false
+    const instanceSelector =
+      selectedInstanceSelector === undefined ||
+      selectedInstanceSelector[0] === page.rootInstanceId ||
+      canResolveInstanceSelector(selectedInstanceSelector, $instances.get()) ===
+        false
         ? undefined
-        : selectedInstanceId;
+        : selectedInstanceSelector;
 
     const isSamePageState =
       searchParamsPageId === page.id &&
@@ -198,8 +223,11 @@ export const useSyncPageUrl = ({ isDataLoaded }: { isDataLoaded: boolean }) => {
       shouldNavigateToPageState({
         isUrlStateInitialized,
         isSamePageState,
-        searchParamsInstanceId,
-        instanceId,
+        searchParamsInstanceSelector:
+          searchParamsInstanceSelector.length === 0
+            ? undefined
+            : searchParamsInstanceSelector,
+        instanceSelector,
       }) === false
     ) {
       return;
@@ -208,7 +236,7 @@ export const useSyncPageUrl = ({ isDataLoaded }: { isDataLoaded: boolean }) => {
     navigate(
       builderPath({
         pageId: page.id === pages.homePageId ? undefined : page.id,
-        instanceId,
+        instanceSelector,
         authToken: $authToken.get(),
         pageHash: pageHash.hash === "" ? undefined : pageHash.hash,
         mode: builderModeParam,

--- a/apps/builder/app/shared/router-utils/path-utils.test.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.test.ts
@@ -9,7 +9,7 @@ test("includes an instance deep link in builder paths", () => {
       mode: "content",
     })
   ).toBe(
-    "/?pageId=page-id&instanceSelector=instance-id&instanceSelector=slot-id&instanceSelector=body-id&mode=content"
+    "/?pageId=page-id&instance=instance-id%2Cslot-id%2Cbody-id&mode=content"
   );
 });
 
@@ -22,7 +22,7 @@ test("includes an instance deep link in builder urls", () => {
       origin: "https://wstd.dev",
     })
   ).toBe(
-    "https://p-project-id.wstd.dev/?pageId=page-id&instanceSelector=instance-id&instanceSelector=body-id"
+    "https://p-project-id.wstd.dev/?pageId=page-id&instance=instance-id%2Cbody-id"
   );
 });
 

--- a/apps/builder/app/shared/router-utils/path-utils.test.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.test.ts
@@ -5,10 +5,12 @@ test("includes an instance deep link in builder paths", () => {
   expect(
     builderPath({
       pageId: "page-id",
-      instanceId: "instance-id",
+      instanceSelector: ["instance-id", "slot-id", "body-id"],
       mode: "content",
     })
-  ).toBe("/?pageId=page-id&instanceId=instance-id&mode=content");
+  ).toBe(
+    "/?pageId=page-id&instanceSelector=instance-id&instanceSelector=slot-id&instanceSelector=body-id&mode=content"
+  );
 });
 
 test("includes an instance deep link in builder urls", () => {
@@ -16,11 +18,11 @@ test("includes an instance deep link in builder urls", () => {
     builderUrl({
       projectId: "project-id",
       pageId: "page-id",
-      instanceId: "instance-id",
+      instanceSelector: ["instance-id", "body-id"],
       origin: "https://wstd.dev",
     })
   ).toBe(
-    "https://p-project-id.wstd.dev/?pageId=page-id&instanceId=instance-id"
+    "https://p-project-id.wstd.dev/?pageId=page-id&instanceSelector=instance-id&instanceSelector=body-id"
   );
 });
 

--- a/apps/builder/app/shared/router-utils/path-utils.test.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.test.ts
@@ -1,10 +1,5 @@
 import { expect, test } from "vitest";
-import {
-  builderPath,
-  builderReauthorizationUrl,
-  builderUrl,
-  restAssetsUploadPath,
-} from "./path-utils";
+import { builderPath, builderUrl, restAssetsUploadPath } from "./path-utils";
 
 test("includes an instance deep link in builder paths", () => {
   expect(
@@ -26,16 +21,6 @@ test("includes an instance deep link in builder urls", () => {
     })
   ).toBe(
     "https://p-project-id.wstd.dev/?pageId=page-id&instanceId=instance-id"
-  );
-});
-
-test("preserves an instance deep link through Builder reauthorization", () => {
-  expect(
-    builderReauthorizationUrl(
-      "https://p-project-id.wstd.dev/?pageId=page-id&instanceId=instance-id"
-    ).href
-  ).toBe(
-    "https://p-project-id.wstd.dev/auth/ws?returnTo=%2F%3FpageId%3Dpage-id%26instanceId%3Dinstance-id"
   );
 });
 

--- a/apps/builder/app/shared/router-utils/path-utils.test.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "vitest";
-import { builderPath, builderUrl, restAssetsUploadPath } from "./path-utils";
+import {
+  builderPath,
+  builderReauthorizationUrl,
+  builderUrl,
+  restAssetsUploadPath,
+} from "./path-utils";
 
 test("includes an instance deep link in builder paths", () => {
   expect(
@@ -21,6 +26,16 @@ test("includes an instance deep link in builder urls", () => {
     })
   ).toBe(
     "https://p-project-id.wstd.dev/?pageId=page-id&instanceId=instance-id"
+  );
+});
+
+test("preserves an instance deep link through Builder reauthorization", () => {
+  expect(
+    builderReauthorizationUrl(
+      "https://p-project-id.wstd.dev/?pageId=page-id&instanceId=instance-id"
+    ).href
+  ).toBe(
+    "https://p-project-id.wstd.dev/auth/ws?returnTo=%2F%3FpageId%3Dpage-id%26instanceId%3Dinstance-id"
   );
 });
 

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -66,14 +66,6 @@ export const builderUrl = ({
   return url.href;
 };
 
-export const builderReauthorizationUrl = (requestUrl: string) => {
-  const builderUrl = new URL(requestUrl);
-  const returnTo = `${builderUrl.pathname}${builderUrl.search}`;
-  const authorizationUrl = new URL("/auth/ws", builderUrl);
-  authorizationUrl.searchParams.set("returnTo", returnTo);
-  return authorizationUrl;
-};
-
 export const dashboardPath = (
   view: "templates" | "search" | "projects" = "projects"
 ) => {

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -3,17 +3,9 @@ import { getAssetUploadApiUrl } from "@webstudio-is/sdk/runtime";
 import { getAuthorizationServerOrigin } from "./origins";
 import type { BuilderMode } from "../nano-states/misc";
 
-const searchParams = (
-  params: Record<string, string | readonly string[] | undefined | null>
-) => {
+const searchParams = (params: Record<string, string | undefined | null>) => {
   const searchParams = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        searchParams.append(key, item);
-      }
-      continue;
-    }
     if (typeof value === "string") {
       searchParams.set(key, value);
     }
@@ -41,7 +33,7 @@ export const builderPath = ({
 }: BuilderLinkParams = {}) => {
   return `/${searchParams({
     pageId,
-    instanceSelector,
+    instance: instanceSelector?.join(","),
     authToken,
     pageHash,
     mode,

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -3,9 +3,17 @@ import { getAssetUploadApiUrl } from "@webstudio-is/sdk/runtime";
 import { getAuthorizationServerOrigin } from "./origins";
 import type { BuilderMode } from "../nano-states/misc";
 
-const searchParams = (params: Record<string, string | undefined | null>) => {
+const searchParams = (
+  params: Record<string, string | readonly string[] | undefined | null>
+) => {
   const searchParams = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, item);
+      }
+      continue;
+    }
     if (typeof value === "string") {
       searchParams.set(key, value);
     }
@@ -16,7 +24,7 @@ const searchParams = (params: Record<string, string | undefined | null>) => {
 
 export type BuilderLinkParams = {
   pageId?: string;
-  instanceId?: string;
+  instanceSelector?: readonly string[];
   authToken?: string;
   pageHash?: string;
   mode?: BuilderMode;
@@ -25,7 +33,7 @@ export type BuilderLinkParams = {
 
 export const builderPath = ({
   pageId,
-  instanceId,
+  instanceSelector,
   authToken,
   pageHash,
   mode,
@@ -33,7 +41,7 @@ export const builderPath = ({
 }: BuilderLinkParams = {}) => {
   return `/${searchParams({
     pageId,
-    instanceId,
+    instanceSelector,
     authToken,
     pageHash,
     mode,

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -66,6 +66,14 @@ export const builderUrl = ({
   return url.href;
 };
 
+export const builderReauthorizationUrl = (requestUrl: string) => {
+  const builderUrl = new URL(requestUrl);
+  const returnTo = `${builderUrl.pathname}${builderUrl.search}`;
+  const authorizationUrl = new URL("/auth/ws", builderUrl);
+  authorizationUrl.searchParams.set("returnTo", returnTo);
+  return authorizationUrl;
+};
+
 export const dashboardPath = (
   view: "templates" | "search" | "projects" = "projects"
 ) => {


### PR DESCRIPTION
## Summary

Preserve exact Builder instance selections during initial load, authentication, and hard reload, including shared content rendered through multiple Slot instances.

## Implementation

- [x] Store the complete selector in one comma-separated `instance` URL parameter.
- [x] Reuse `canResolveInstanceSelector` to validate every selector path before restoring it.
- [x] Resolve the selected page from the selector root.
- [x] Wait for the authoritative Builder data-loaded state before applying initial URL state.
- [x] Keep selection-to-URL synchronization paused until initial URL state is resolved.
- [x] Let the existing auth loader derive `returnTo` directly from Builder requests.
- [x] Update generated Builder links, including pre-publish audit links, to use full selectors.
- [x] Add regression coverage for incomplete sync data and duplicate shared-slot child IDs.

## Verification

- [x] A fresh browser session authenticates and opens a direct selector deep link.
- [x] Hard reload retains the exact selector URL and selection.
- [x] Clicking the first shared child creates an `instance` URL for the first Slot path; reload restores the first occurrence.
- [x] Clicking the second shared child creates a distinct `instance` URL for the second Slot path; reload restores the second occurrence.
- [x] Focused Vitest suite: 8 tests passed.
- [x] Builder TypeScript typecheck.
- [x] Focused oxlint.
- [x] Focused oxfmt check.
- [x] `git diff --check`.

## Compatibility and limitations

No schema, migration, or public API changes. This change uses one canonical full-selector URL format; ID-only deep links are not retained as a compatibility path.