### PR TITLE
fix: Show publish feedback immediately

### DIFF
--- a/apps/builder/app/builder/features/publish/publish.tsx
+++ b/apps/builder/app/builder/features/publish/publish.tsx
@@ -531,8 +531,6 @@ const Publish = ({
   }, [project.domain]);
 
   const publish = async (domains: string[]) => {
-    setIsPublishing(true);
-
     const publishResult = await nativeClient.domain.publish.mutate({
       projectId: project.id,
       domains,
@@ -657,6 +655,8 @@ const Publish = ({
     }
 
     startTransition(async () => {
+      setIsPublishing(true);
+
       try {
         await showContentDatabasePublishWarning({
           projectId: project.id,


### PR DESCRIPTION
## Summary

Move the optimistic publishing state update ahead of the asynchronous content-database diagnostics request. The publish button now shows its pending animation immediately after a valid click instead of waiting for that network round trip.

## Root cause

The content-database publish diagnostics were added before the function that set `isPublishing`. Any latency in that request left the publish button looking idle.

## Implementation

- Start the optimistic publishing state at the beginning of the publish transition.
- Preserve the existing pre-publish audit, content-database warning, publish request, polling, and error behavior.

## Todo

- [x] Trace the publish click and pending-state sequence.
- [x] Move pending feedback ahead of asynchronous diagnostics.
- [x] Run targeted lint and Builder typecheck.
- [x] Run the complete Builder test suite.

## Verification

- `pnpm exec oxlint --deny-warnings apps/builder/app/builder/features/publish/publish.tsx`
- `pnpm --filter @webstudio-is/builder typecheck`
- `pnpm --filter @webstudio-is/builder test` — 211 files, 2,472 tests passed

No fixture inputs or generated outputs are affected.

Closes #5976