### PR TITLE
fix: Skip unenumerated dynamic SSG pages

### DIFF
--- a/packages/cli/src/framework-vike-ssg.ts
+++ b/packages/cli/src/framework-vike-ssg.ts
@@ -64,9 +64,7 @@ export const createFramework = async (
       }
       const dynamic = isPathnamePattern(pagePath);
       if (dynamic && prerenderPaths.length === 0) {
-        throw new Error(
-          `Dynamic SSG page ${JSON.stringify(pagePath)} has no enumerable Assets query paths`
-        );
+        return [];
       }
       const route = generateVikeRoute(pagePath);
       const entries = [

--- a/packages/cli/src/prebuild.test.ts
+++ b/packages/cli/src/prebuild.test.ts
@@ -1498,6 +1498,41 @@ describe("prebuild", () => {
     );
   });
 
+  test("ignores dynamic SSG pages without enumerable Assets query paths", async () => {
+    await writeSiteData(
+      createSiteData({
+        pages: [
+          {
+            id: "home",
+            name: "Home",
+            title: "Home",
+            path: "",
+            rootInstanceId: "root",
+            meta: {},
+          },
+          {
+            id: "post",
+            name: "Post",
+            title: "Post",
+            path: "/blog/:slug",
+            rootInstanceId: "root",
+            meta: {},
+          },
+        ],
+      })
+    );
+
+    await expect(
+      prebuild({ assets: false, template: ["ssg"] })
+    ).resolves.toBeUndefined();
+    await expect(readFile("pages/index/+Page.tsx", "utf8")).resolves.toContain(
+      "Page"
+    );
+    await expect(
+      readFile("pages/blog/@slug/+Page.tsx", "utf8")
+    ).rejects.toThrow("ENOENT");
+  });
+
   test("prerenders dynamic SSG paths from parameterized Assets resources", async () => {
     const documents = [
       {


### PR DESCRIPTION
## Outcome

Restore SSG downloads for projects that contain dynamic pages without enumerable Assets query paths. Static pages continue to export, while unsupported dynamic routes are omitted as they were before Assets-backed SSG prerendering was introduced.

Closes #5981

## Root cause

Assets-backed dynamic prerendering changed the SSG framework from skipping every dynamic route to throwing whenever the computed prerender path list was empty. That empty list also represents existing dynamic routes without a configured Assets query, so otherwise valid static downloads began failing during scaffolding.

## Implementation

- Return no framework files for dynamic pages whose prerender path list is empty.
- Preserve generated Vike routes for Assets-backed pages that enumerate at least one path.
- Preserve the existing prebuild validation errors for Assets queries that bind parameters incompletely or cannot enumerate every query branch.
- Add an integration regression test covering a static home page alongside `/blog/:slug` with no Assets query.

## Todo

- [x] Reproduce the production failure in a regression test
- [x] Restore omission of unenumerated dynamic routes
- [x] Verify Assets-backed dynamic SSG behavior remains passing
- [x] Run focused lint, formatting, typecheck, and integration tests

## Verification

- [x] New regression test demonstrated failing before the implementation change and passing afterward
- [x] `pnpm --filter webstudio test -- src/prebuild.test.ts` — 49 passed
- [x] `pnpm --filter webstudio typecheck`
- [x] `pnpm exec oxfmt --check packages/cli/src/framework-vike-ssg.ts packages/cli/src/prebuild.test.ts`
- [x] `pnpm exec oxlint --deny-warnings packages/cli/src/framework-vike-ssg.ts packages/cli/src/prebuild.test.ts`
- [x] `git diff --check`

## Notes

- No fixture inputs or generated fixture outputs are affected.
- The agent evaluation suite was not run because repository policy requires separate explicit approval.
- Production failure: https://github.com/webstudio-is/webstudio-saas/actions/runs/30769678212/job/91554478283