### PR TITLE
fix: Trigger MCP docs after CLI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,21 @@ jobs:
           WEBSTUDIO_RELEASE_SMOKE_REPORT: ${{ github.workspace }}/artifacts/cli-release-smoke.json
         run: pnpm --filter webstudio test:release-smoke:registry
 
+      - name: Trigger MCP documentation update
+        env:
+          # Fine-grained token with Actions write access to webstudio-is/webstudio-community.
+          GH_TOKEN: ${{ secrets.WEBSTUDIO_COMMUNITY_ACTIONS_TOKEN }}
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "WEBSTUDIO_COMMUNITY_ACTIONS_TOKEN is required to trigger the MCP documentation updater." >&2
+            exit 1
+          fi
+          gh workflow run update-mcp-docs.yml \
+            --repo webstudio-is/webstudio-community \
+            --ref main \
+            --raw-field version="$VERSION"
+
       - name: Upload published CLI comparison report
         if: ${{ always() && (steps.registry-smoke.outcome == 'success' || steps.registry-smoke.outcome == 'failure') }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Trigger the community MCP documentation updater immediately after a published CLI passes the exact registry smoke gate. Pass the release version explicitly so documentation generation is deterministic.

## Root cause

The community updater only polled npm once per day. A successful release therefore had no event-driven path to documentation generation and could leave the public manual on the previous CLI version for hours.

## Implementation

- [x] Dispatch `webstudio-is/webstudio-community/.github/workflows/update-mcp-docs.yml` after the registry smoke gate succeeds.
- [x] Pass the exact release version through the workflow-dispatch input.
- [x] Keep the comparison artifact upload independent through its existing `always()` path.
- [x] Fail with an actionable message when the cross-repository credential is missing.

## Required configuration

Add `WEBSTUDIO_COMMUNITY_ACTIONS_TOKEN` to this repository or the `development` environment. Use a fine-grained token with Actions write access to `webstudio-is/webstudio-community`.

## Merge order

1. Merge webstudio-is/webstudio-community#275 so the target workflow accepts `version`.
2. Configure `WEBSTUDIO_COMMUNITY_ACTIONS_TOKEN`.
3. Merge this PR.

## Verification

- Parsed `.github/workflows/release.yml` as YAML.
- `git diff --check`.
- Confirmed the `gh workflow run` flags against the GitHub CLI workflow-run interface.

Closes #5984