### PR TITLE
fix: Validate authored fragments against HTML content models

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/request-inspector.test.tsx
+++ b/apps/builder/app/builder/features/settings-panel/request-inspector.test.tsx
@@ -64,9 +64,41 @@ test("loads diagnostics when their tab is opened", () => {
     container.querySelectorAll<HTMLElement>('[role="tab"]')
   ).find(({ textContent }) => textContent === "Diagnostics");
 
-  act(() => diagnostics?.click());
+  act(() => {
+    diagnostics?.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, button: 0 })
+    );
+    diagnostics?.click();
+  });
 
   expect(onDiagnosticsOpen).toHaveBeenCalledOnce();
+});
+
+test("shows when diagnostics are loading", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      <RequestInspector
+        preview={<div>Preview content</div>}
+        diagnosticsPending
+      />
+    );
+  });
+  const diagnostics = Array.from(
+    container.querySelectorAll<HTMLElement>('[role="tab"]')
+  ).find(({ textContent }) => textContent === "Diagnostics");
+
+  act(() => {
+    diagnostics?.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, button: 0 })
+    );
+    diagnostics?.click();
+  });
+
+  expect(container.textContent).toContain("Loading diagnostics...");
+  expect(container.textContent).not.toContain("No diagnostics available");
 });
 
 test("keeps preview first when no query editor is available", () => {

--- a/apps/builder/app/builder/features/settings-panel/request-inspector.test.tsx
+++ b/apps/builder/app/builder/features/settings-panel/request-inspector.test.tsx
@@ -4,7 +4,10 @@
 import { act } from "react-dom/test-utils";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, expect, test, vi } from "vitest";
-import { RequestInspector } from "./request-inspector";
+import {
+  clearSettledDiagnosticsKey,
+  RequestInspector,
+} from "./request-inspector";
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -16,6 +19,15 @@ afterEach(() => {
   act(() => root?.unmount());
   root = undefined;
   document.body.innerHTML = "";
+});
+
+test("keeps the current diagnostics request pending when an older one settles", () => {
+  expect(clearSettledDiagnosticsKey("resource-b", "resource-a")).toBe(
+    "resource-b"
+  );
+  expect(clearSettledDiagnosticsKey("resource-b", "resource-b")).toBe(
+    undefined
+  );
 });
 
 const renderInspector = (

--- a/apps/builder/app/builder/features/settings-panel/request-inspector.tsx
+++ b/apps/builder/app/builder/features/settings-panel/request-inspector.tsx
@@ -83,11 +83,13 @@ export const RequestInspector = ({
   queryContainerRef,
   preview,
   diagnostics,
+  diagnosticsPending = false,
   onDiagnosticsOpen,
 }: {
   queryContainerRef?: Ref<HTMLDivElement>;
   preview: ReactNode;
   diagnostics?: ReactNode;
+  diagnosticsPending?: boolean;
   onDiagnosticsOpen?: () => void;
 }) => (
   <PanelTabs
@@ -139,7 +141,11 @@ export const RequestInspector = ({
     >
       {diagnostics ?? (
         <Flex align="center" justify="center" css={{ height: "100%" }}>
-          <Text color="moreSubtle">No diagnostics available</Text>
+          <Text color="moreSubtle">
+            {diagnosticsPending
+              ? "Loading diagnostics..."
+              : "No diagnostics available"}
+          </Text>
         </Flex>
       )}
     </PanelTabsContent>

--- a/apps/builder/app/builder/features/settings-panel/request-inspector.tsx
+++ b/apps/builder/app/builder/features/settings-panel/request-inspector.tsx
@@ -13,6 +13,11 @@ import {
 } from "@webstudio-is/design-system";
 import { InfoCircleIcon } from "@webstudio-is/icons";
 
+export const clearSettledDiagnosticsKey = (
+  pendingKey: string | undefined,
+  settledKey: string
+) => (pendingKey === settledKey ? undefined : pendingKey);
+
 export const RequestDiagnosticsContent = ({
   children,
 }: {

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -687,6 +687,7 @@ const VariablePreview = ({
   queryActive: boolean;
   queryContainerRef: (element: HTMLDivElement | null) => void;
 }) => {
+  const [diagnosticsPending, setDiagnosticsPending] = useState(false);
   const isResource =
     variableType === "resource" ||
     variableType === "graphql-resource" ||
@@ -785,9 +786,15 @@ const VariablePreview = ({
         isAssetsResourceRequest(computedResourceRequest) &&
         resourceDiagnostics?.artifacts === undefined
           ? () => {
-              void loadResourceDiagnostics(computedResourceRequest);
+              setDiagnosticsPending(true);
+              void loadResourceDiagnostics(computedResourceRequest).finally(
+                () => setDiagnosticsPending(false)
+              );
             }
           : undefined
+      }
+      diagnosticsPending={
+        diagnosticsPending && resourceDiagnostics === undefined
       }
       diagnostics={
         requestErrorDiagnostics !== undefined ? (

--- a/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
+++ b/apps/builder/app/builder/features/settings-panel/variable-popover.tsx
@@ -98,7 +98,10 @@ import {
 } from "~/shared/resources";
 import { Row } from "./shared";
 import type { AssetQueryPreviewDiagnostics } from "@webstudio-is/content-engine";
-import { RequestInspector } from "./request-inspector";
+import {
+  clearSettledDiagnosticsKey,
+  RequestInspector,
+} from "./request-inspector";
 import { ContentDatabaseDiagnostics } from "./content-database-diagnostics";
 import {
   getRequestErrorDiagnostics,
@@ -687,7 +690,7 @@ const VariablePreview = ({
   queryActive: boolean;
   queryContainerRef: (element: HTMLDivElement | null) => void;
 }) => {
-  const [diagnosticsPending, setDiagnosticsPending] = useState(false);
+  const [pendingDiagnosticsKey, setPendingDiagnosticsKey] = useState<string>();
   const isResource =
     variableType === "resource" ||
     variableType === "graphql-resource" ||
@@ -701,6 +704,7 @@ const VariablePreview = ({
   let computedValue: unknown;
   let resourceDiagnostics: AssetQueryPreviewDiagnostics | undefined;
   let computedResourceRequest: ResourceRequest | undefined;
+  let computedResourceKey: string | undefined;
   if (variableType === "string" || variableType === "boolean") {
     computedValue = variableValue;
   } else if (variableType === "json") {
@@ -727,6 +731,7 @@ const VariablePreview = ({
     if (parsedResourceRequest) {
       computedResourceRequest = parsedResourceRequest;
       const resourceKey = getResourceKey(parsedResourceRequest);
+      computedResourceKey = resourceKey;
       computedValue = resourcesCache.get(resourceKey);
       resourceDiagnostics = resourceDiagnosticsCache.get(resourceKey);
     }
@@ -786,15 +791,20 @@ const VariablePreview = ({
         isAssetsResourceRequest(computedResourceRequest) &&
         resourceDiagnostics?.artifacts === undefined
           ? () => {
-              setDiagnosticsPending(true);
+              const diagnosticsKey = getResourceKey(computedResourceRequest);
+              setPendingDiagnosticsKey(diagnosticsKey);
               void loadResourceDiagnostics(computedResourceRequest).finally(
-                () => setDiagnosticsPending(false)
+                () =>
+                  setPendingDiagnosticsKey((pendingKey) =>
+                    clearSettledDiagnosticsKey(pendingKey, diagnosticsKey)
+                  )
               );
             }
           : undefined
       }
       diagnosticsPending={
-        diagnosticsPending && resourceDiagnostics === undefined
+        pendingDiagnosticsKey === computedResourceKey &&
+        resourceDiagnostics === undefined
       }
       diagnostics={
         requestErrorDiagnostics !== undefined ? (

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -227,6 +227,7 @@ const insertPastedFragment = async ({
         parentInstanceId: pasteTarget.parentSelector[0],
         fragment,
         conflictResolution,
+        allowContentModelWarnings: true,
         insertIndex:
           typeof pasteTarget.position === "number"
             ? pasteTarget.position

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -227,12 +227,12 @@ const insertPastedFragment = async ({
         parentInstanceId: pasteTarget.parentSelector[0],
         fragment,
         conflictResolution,
-        allowContentModelWarnings: true,
         insertIndex:
           typeof pasteTarget.position === "number"
             ? pasteTarget.position
             : undefined,
       },
+      context: { allowLegacyContentModelWarnings: true },
     });
     const rootInstanceIds = result?.result.rootInstanceIds;
     if (rootInstanceIds === undefined || rootInstanceIds.length === 0) {

--- a/apps/builder/app/shared/instance-utils/data.ts
+++ b/apps/builder/app/shared/instance-utils/data.ts
@@ -10,7 +10,10 @@ import {
   type BuilderRuntimeMutationOperationId,
   type BuilderRuntimeOperationResult,
 } from "@webstudio-is/project-build/runtime";
-import { builderRuntimeContext } from "@webstudio-is/project-build/runtime";
+import {
+  builderRuntimeContext,
+  type BuilderRuntimeContext,
+} from "@webstudio-is/project-build/runtime";
 import { type BuilderRuntimeMutation } from "@webstudio-is/project-build/runtime";
 import { $canOpenPageTemplates, $selectedPage } from "../nano-states";
 import { createTransactionFromBuilderPatchPayload } from "../sync/builder-patch";
@@ -60,6 +63,11 @@ const getRuntimeMutationContext = () => ({
   projectId: $project.get()?.id,
 });
 
+type RuntimeMutationContext = Pick<
+  BuilderRuntimeContext,
+  "allowLegacyContentModelWarnings"
+>;
+
 const requireSynchronousResult = <Result>(
   id: BuilderRuntimeMutationOperationId,
   result: Result | Promise<Result>
@@ -75,14 +83,16 @@ const createRuntimeMutationArgs = <
 >({
   id,
   input,
+  context,
 }: {
   id: Id;
   input: BuilderRuntimeOperationInput<Id>;
+  context?: RuntimeMutationContext;
 }) => ({
   id,
   state: getWebstudioData(),
   input,
-  context: getRuntimeMutationContext(),
+  context: { ...getRuntimeMutationContext(), ...context },
 });
 
 const commitRuntimeMutation = <Mutation extends BuilderRuntimeMutation>(
@@ -100,9 +110,11 @@ export const executeRuntimeMutation = <
 >({
   id,
   input,
+  context,
 }: {
   id: Id;
   input: BuilderRuntimeOperationInput<Id>;
+  context?: RuntimeMutationContext;
 }): RuntimeMutationResult<Id> | undefined => {
   if (canCommitWebstudioData() === false) {
     return;
@@ -111,7 +123,7 @@ export const executeRuntimeMutation = <
     requireSynchronousResult(
       id,
       executeBuilderRuntimeOperation<RuntimeMutationResult<Id>>(
-        createRuntimeMutationArgs({ id, input })
+        createRuntimeMutationArgs({ id, input, context })
       )
     )
   );
@@ -145,16 +157,18 @@ export const executeRuntimeMutationAsync = async <
 >({
   id,
   input,
+  context,
 }: {
   id: Id;
   input: BuilderRuntimeOperationInput<Id>;
+  context?: RuntimeMutationContext;
 }): Promise<RuntimeMutationResult<Id> | undefined> => {
   if (canCommitWebstudioData() === false) {
     return;
   }
   const result = await executeBuilderRuntimeOperation<
     RuntimeMutationResult<Id>
-  >(createRuntimeMutationArgs({ id, input }));
+  >(createRuntimeMutationArgs({ id, input, context }));
   return commitRuntimeMutation(result);
 };
 

--- a/apps/builder/app/shared/instance-utils/insert.test.tsx
+++ b/apps/builder/app/shared/instance-utils/insert.test.tsx
@@ -450,6 +450,34 @@ describe("insert webstudio fragment at", () => {
     );
   });
 
+  test("allows legacy fragment warnings through the internal paste context", async () => {
+    $pages.set(
+      createDefaultPages({ homePageId: "homePageId", rootInstanceId: "bodyId" })
+    );
+    selectPage("homePageId");
+    $instances.set(renderData(<$.Body ws:id="bodyId"></$.Body>).instances);
+    const onContentModelWarnings = vi.fn();
+
+    const inserted = insertWebstudioFragmentAt(
+      renderTemplate(
+        <ws.element ws:id="button" ws:tag="button">
+          <ws.element ws:id="heading" ws:tag="h3" />
+        </ws.element>
+      ),
+      { parentSelector: ["bodyId"], position: "end" },
+      undefined,
+      { allowContentModelWarnings: true, onContentModelWarnings }
+    );
+
+    expect(inserted).toBe(true);
+    expect($instances.get().get("bodyId")?.children).toHaveLength(1);
+    expect(onContentModelWarnings).toHaveBeenCalledWith([
+      expect.objectContaining({
+        message: "Placing <h3> element inside a <button> violates HTML spec.",
+      }),
+    ]);
+  });
+
   test("returns false for empty fragments", async () => {
     expect(await insertWebstudioFragmentAt(createFragment({}))).toBe(false);
   });

--- a/apps/builder/app/shared/instance-utils/insert.ts
+++ b/apps/builder/app/shared/instance-utils/insert.ts
@@ -209,6 +209,9 @@ export const insertWebstudioFragmentAt = (
       contentMode: options?.contentMode,
       insertIndex: target.insertIndex,
     },
+    context: {
+      allowLegacyContentModelWarnings: options?.allowContentModelWarnings,
+    },
   });
   const newInstanceId = result?.result.rootInstanceIds[0];
   if (result !== undefined && newInstanceId !== undefined) {

--- a/packages/asset-uploader/src/revision.test.ts
+++ b/packages/asset-uploader/src/revision.test.ts
@@ -118,14 +118,17 @@ describe("asset content revisions", () => {
         });
         return empty({ status: 201 });
       }),
-      db.get("File", () =>
-        json({
+      db.get("File", ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.has("updatedAt")).toBe(true);
+        expect(url.searchParams.has("createdAt")).toBe(false);
+        return json({
           ...oldFile,
           name: revisionName,
           format: "file",
           status: "UPLOADING",
-        })
-      ),
+        });
+      }),
       db.patch("File", () =>
         json({
           ...oldFile,

--- a/packages/asset-uploader/src/upload.ts
+++ b/packages/asset-uploader/src/upload.ts
@@ -394,7 +394,7 @@ export const uploadFileData = async (
     .eq("name", name)
     .eq("status", "UPLOADING")
     .gt(
-      "createdAt",
+      "updatedAt",
       new Date(Date.now() - UPLOADING_STALE_TIMEOUT).toISOString()
     )
     .single();

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -54821,6 +54821,11 @@ export const runtimeOperationContractData = [
         contentMode: {
           type: "boolean",
         },
+        allowContentModelWarnings: {
+          description:
+            "Allow legacy invalid content copied from existing projects to be pasted with a warning.",
+          type: "boolean",
+        },
         mode: {
           type: "string",
           enum: ["append", "prepend", "replace"],

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -54821,11 +54821,6 @@ export const runtimeOperationContractData = [
         contentMode: {
           type: "boolean",
         },
-        allowContentModelWarnings: {
-          description:
-            "Allow legacy invalid content copied from existing projects to be pasted with a warning.",
-          type: "boolean",
-        },
         mode: {
           type: "string",
           enum: ["append", "prepend", "replace"],

--- a/packages/project-build/src/runtime/components.test.ts
+++ b/packages/project-build/src/runtime/components.test.ts
@@ -591,6 +591,47 @@ test("rejects invalid HtmlEmbed code from externally authored fragments", async 
   ).toThrow("Entered HTML has a validation error");
 });
 
+test("rejects fragment trees that violate the HTML content model", async () => {
+  const parent = createParent();
+  const fragment = await parseWebstudioJsxFragment(
+    `<ws.element ws:tag="a"><ws.element ws:tag="span"><ws.element ws:tag="a">Nested link</ws.element></ws.element></ws.element>`
+  );
+
+  expect(() =>
+    insertFragment(
+      createState(parent),
+      { parentInstanceId: parent.id, fragment },
+      { createId: createIdFactory() }
+    )
+  ).toThrow("Placing <a> element inside a <span> violates HTML spec.");
+});
+
+test("rejects fragments that violate the destination HTML content model", async () => {
+  const parent: Instance = {
+    ...createParent(),
+    tag: "a",
+  };
+  const root: Instance = {
+    ...createParent(),
+    id: "root",
+    tag: "body",
+    children: [{ type: "id", value: parent.id }],
+  };
+  const state = createState(root);
+  state.instances.set(parent.id, parent);
+  const fragment = await parseWebstudioJsxFragment(
+    `<ws.element ws:tag="span"><ws.element ws:tag="button">Action</ws.element></ws.element>`
+  );
+
+  expect(() =>
+    insertFragment(
+      state,
+      { parentInstanceId: parent.id, fragment },
+      { createId: createIdFactory() }
+    )
+  ).toThrow("Placing <button> element inside a <span> violates HTML spec.");
+});
+
 test("rejects tag when inserting non-element component", async () => {
   const parent = createParent();
 

--- a/packages/project-build/src/runtime/components.test.ts
+++ b/packages/project-build/src/runtime/components.test.ts
@@ -643,12 +643,43 @@ test("allows legacy invalid fragments when warnings are explicitly enabled", asy
     {
       parentInstanceId: parent.id,
       fragment,
-      allowContentModelWarnings: true,
     },
-    { createId: createIdFactory() }
+    {
+      createId: createIdFactory(),
+      allowLegacyContentModelWarnings: true,
+    }
   );
 
   expect(mutation.result.rootInstanceIds).toEqual(["generated-0"]);
+});
+
+test("rejects new placement violations while allowing legacy fragment warnings", async () => {
+  const parent: Instance = {
+    ...createParent(),
+    tag: "a",
+  };
+  const root: Instance = {
+    ...createParent(),
+    id: "root",
+    tag: "body",
+    children: [{ type: "id", value: parent.id }],
+  };
+  const state = createState(root);
+  state.instances.set(parent.id, parent);
+  const fragment = await parseWebstudioJsxFragment(
+    `<ws.element ws:tag="button"><ws.element ws:tag="h3">Legacy heading</ws.element></ws.element>`
+  );
+
+  expect(() =>
+    insertFragment(
+      state,
+      { parentInstanceId: parent.id, fragment },
+      {
+        createId: createIdFactory(),
+        allowLegacyContentModelWarnings: true,
+      }
+    )
+  ).toThrow("Placing <button> element inside a <a> violates HTML spec.");
 });
 
 test("rejects tag when inserting non-element component", async () => {

--- a/packages/project-build/src/runtime/components.test.ts
+++ b/packages/project-build/src/runtime/components.test.ts
@@ -632,6 +632,25 @@ test("rejects fragments that violate the destination HTML content model", async 
   ).toThrow("Placing <button> element inside a <span> violates HTML spec.");
 });
 
+test("allows legacy invalid fragments when warnings are explicitly enabled", async () => {
+  const parent = createParent();
+  const fragment = await parseWebstudioJsxFragment(
+    `<ws.element ws:tag="button"><ws.element ws:tag="h3">Legacy heading</ws.element></ws.element>`
+  );
+
+  const mutation = insertFragment(
+    createState(parent),
+    {
+      parentInstanceId: parent.id,
+      fragment,
+      allowContentModelWarnings: true,
+    },
+    { createId: createIdFactory() }
+  );
+
+  expect(mutation.result.rootInstanceIds).toEqual(["generated-0"]);
+});
+
 test("rejects tag when inserting non-element component", async () => {
   const parent = createParent();
 

--- a/packages/project-build/src/runtime/components.ts
+++ b/packages/project-build/src/runtime/components.ts
@@ -61,6 +61,7 @@ import { getSlotFragmentDropTargetMutable } from "./slot";
 import type { ConflictResolution } from "./style-copy";
 import { findPageAndSelectorByInstanceId } from "./lookup";
 import { validateFragmentHtmlEmbedCode } from "./html-embed";
+import { isTreeSatisfyingContentModel } from "./content-model";
 import { z } from "zod";
 
 const conflictResolutionInput = z.enum(["ours", "theirs", "merge"]);
@@ -673,6 +674,7 @@ const createInsertFragmentMutation = <
   contentMode = false,
   additionalAvailableVariables = [],
   getResultDetails,
+  validateContentModel = true,
   context,
 }: {
   state: ComponentInsertState;
@@ -688,6 +690,7 @@ const createInsertFragmentMutation = <
     newInstanceIds: Map<string, string>;
     newDataSourceIds: Map<string, string>;
   }) => Details;
+  validateContentModel?: boolean;
   context: BuilderRuntimeContext;
 }) => {
   const mutationState = getRequiredComponentInsertState(state);
@@ -772,6 +775,50 @@ const createInsertFragmentMutation = <
       return child;
     }
   );
+
+  if (validateContentModel) {
+    const validationInstances = new Map(nextData.instances);
+    const validationParent: Instance = {
+      ...parent,
+      children:
+        mode === "replace"
+          ? insertedChildren
+          : [
+              ...parentChildren.slice(0, insertIndex),
+              ...insertedChildren,
+              ...parentChildren.slice(insertIndex),
+            ],
+    };
+    validationInstances.set(parent.id, validationParent);
+    const { instanceSelector: parentSelector } =
+      findPageAndSelectorByInstanceId(
+        mutationState.pages,
+        validationInstances,
+        parent.id
+      );
+    let contentModelError: string | undefined;
+    const isContentModelValid = insertedChildren.every((child) => {
+      if (child.type !== "id") {
+        return true;
+      }
+      return isTreeSatisfyingContentModel({
+        instances: validationInstances,
+        props: nextData.props,
+        metas: componentMetas,
+        instanceSelector: [child.value, ...parentSelector],
+        onError: (message) => {
+          contentModelError ??= message;
+        },
+      });
+    });
+    if (isContentModelValid === false) {
+      return throwBuilderRuntimeError(
+        "BAD_REQUEST",
+        contentModelError ?? "Inserted fragment violates the content model"
+      );
+    }
+  }
+
   const createResult = (
     parentInstanceId: string,
     removedInstanceIds: string[]
@@ -939,6 +986,7 @@ export const insertComponent = (
     templates,
     mode: input.mode,
     insertIndex: input.insertIndex,
+    validateContentModel: false,
     context,
   });
 };

--- a/packages/project-build/src/runtime/components.ts
+++ b/packages/project-build/src/runtime/components.ts
@@ -88,6 +88,12 @@ export const insertFragmentInput = z
     ),
     conflictResolution: conflictResolutionInput.optional(),
     contentMode: z.boolean().optional(),
+    allowContentModelWarnings: z
+      .boolean()
+      .optional()
+      .describe(
+        "Allow legacy invalid content copied from existing projects to be pasted with a warning."
+      ),
     mode: instanceInsertModeInput.optional(),
     insertIndex: insertIndexInput.optional(),
   })
@@ -1133,6 +1139,7 @@ export const insertFragment = (
     insertIndex: input.insertIndex,
     conflictResolution: input.conflictResolution,
     contentMode: input.contentMode,
+    validateContentModel: input.allowContentModelWarnings !== true,
     context,
   });
 };

--- a/packages/project-build/src/runtime/components.ts
+++ b/packages/project-build/src/runtime/components.ts
@@ -61,7 +61,10 @@ import { getSlotFragmentDropTargetMutable } from "./slot";
 import type { ConflictResolution } from "./style-copy";
 import { findPageAndSelectorByInstanceId } from "./lookup";
 import { validateFragmentHtmlEmbedCode } from "./html-embed";
-import { isTreeSatisfyingContentModel } from "./content-model";
+import {
+  getFragmentPlacementContentModelWarnings,
+  getNewFragmentContentModelWarnings,
+} from "./matcher";
 import { z } from "zod";
 
 const conflictResolutionInput = z.enum(["ours", "theirs", "merge"]);
@@ -88,12 +91,6 @@ export const insertFragmentInput = z
     ),
     conflictResolution: conflictResolutionInput.optional(),
     contentMode: z.boolean().optional(),
-    allowContentModelWarnings: z
-      .boolean()
-      .optional()
-      .describe(
-        "Allow legacy invalid content copied from existing projects to be pasted with a warning."
-      ),
     mode: instanceInsertModeInput.optional(),
     insertIndex: insertIndexInput.optional(),
   })
@@ -802,26 +799,27 @@ const createInsertFragmentMutation = <
         validationInstances,
         parent.id
       );
-    let contentModelError: string | undefined;
-    const isContentModelValid = insertedChildren.every((child) => {
-      if (child.type !== "id") {
-        return true;
-      }
-      return isTreeSatisfyingContentModel({
-        instances: validationInstances,
-        props: nextData.props,
-        metas: componentMetas,
-        instanceSelector: [child.value, ...parentSelector],
-        onError: (message) => {
-          contentModelError ??= message;
-        },
-      });
+    const allowedWarnings = context.allowLegacyContentModelWarnings
+      ? getFragmentPlacementContentModelWarnings({
+          children: insertedChildren,
+          instances: validationInstances,
+          props: nextData.props,
+          metas: componentMetas,
+        })
+      : [];
+    const warnings = getFragmentPlacementContentModelWarnings({
+      children: insertedChildren,
+      instances: validationInstances,
+      props: nextData.props,
+      metas: componentMetas,
+      parentSelector,
     });
-    if (isContentModelValid === false) {
-      return throwBuilderRuntimeError(
-        "BAD_REQUEST",
-        contentModelError ?? "Inserted fragment violates the content model"
-      );
+    const [contentModelError] = getNewFragmentContentModelWarnings({
+      warnings,
+      allowedWarnings,
+    });
+    if (contentModelError !== undefined) {
+      return throwBuilderRuntimeError("BAD_REQUEST", contentModelError.message);
     }
   }
 
@@ -1139,7 +1137,6 @@ export const insertFragment = (
     insertIndex: input.insertIndex,
     conflictResolution: input.conflictResolution,
     contentMode: input.contentMode,
-    validateContentModel: input.allowContentModelWarnings !== true,
     context,
   });
 };

--- a/packages/project-build/src/runtime/context.ts
+++ b/packages/project-build/src/runtime/context.ts
@@ -4,6 +4,7 @@ export type BuilderRuntimeContext = {
   createId: () => string;
   projectId?: string;
   projectVersion?: number;
+  allowLegacyContentModelWarnings?: boolean;
 };
 
 export const builderRuntimeContext: BuilderRuntimeContext = {

--- a/packages/project-build/src/runtime/matcher.ts
+++ b/packages/project-build/src/runtime/matcher.ts
@@ -15,6 +15,51 @@ export type FragmentContentModelWarning = {
 const getWarningKey = ({ instanceId, message }: FragmentContentModelWarning) =>
   `${instanceId}\0${message}`;
 
+export const getFragmentPlacementContentModelWarnings = ({
+  children,
+  instances,
+  props,
+  metas,
+  parentSelector = [],
+}: {
+  children: WebstudioFragment["children"];
+  instances: Instances;
+  props: Props;
+  metas: Map<string, WsComponentMeta>;
+  parentSelector?: Instance["id"][];
+}): FragmentContentModelWarning[] => {
+  const warnings = new Map<string, FragmentContentModelWarning>();
+  for (const child of children) {
+    if (child.type !== "id") {
+      continue;
+    }
+    isTreeSatisfyingContentModel({
+      instances,
+      props,
+      metas,
+      instanceSelector: [child.value, ...parentSelector],
+      onError: (message, instanceSelector) => {
+        const warning = { message, instanceId: instanceSelector[0] };
+        warnings.set(getWarningKey(warning), warning);
+      },
+    });
+  }
+  return Array.from(warnings.values());
+};
+
+export const getNewFragmentContentModelWarnings = ({
+  warnings,
+  allowedWarnings,
+}: {
+  warnings: FragmentContentModelWarning[];
+  allowedWarnings: FragmentContentModelWarning[];
+}) => {
+  const allowedWarningKeys = new Set(allowedWarnings.map(getWarningKey));
+  return warnings.filter(
+    (warning) => allowedWarningKeys.has(getWarningKey(warning)) === false
+  );
+};
+
 export const getFragmentContentModelWarnings = ({
   fragment,
   metas,
@@ -26,23 +71,12 @@ export const getFragmentContentModelWarnings = ({
     fragment.instances.map((instance) => [instance.id, instance])
   );
   const props: Props = new Map(fragment.props.map((prop) => [prop.id, prop]));
-  const warnings = new Map<string, FragmentContentModelWarning>();
-  for (const child of fragment.children) {
-    if (child.type !== "id") {
-      continue;
-    }
-    isTreeSatisfyingContentModel({
-      instances,
-      props,
-      metas,
-      instanceSelector: [child.value],
-      onError: (message, instanceSelector) => {
-        const warning = { message, instanceId: instanceSelector[0] };
-        warnings.set(getWarningKey(warning), warning);
-      },
-    });
-  }
-  return Array.from(warnings.values());
+  return getFragmentPlacementContentModelWarnings({
+    children: fragment.children,
+    instances,
+    props,
+    metas,
+  });
 };
 
 export const findClosestInstanceMatchingFragment = ({
@@ -70,11 +104,9 @@ export const findClosestInstanceMatchingFragment = ({
   for (const prop of fragment.props) {
     mergedProps.set(prop.id, prop);
   }
-  const allowedWarningKeys = new Set(
-    allowFragmentContentModelWarnings
-      ? getFragmentContentModelWarnings({ fragment, metas }).map(getWarningKey)
-      : []
-  );
+  const allowedWarnings = allowFragmentContentModelWarnings
+    ? getFragmentContentModelWarnings({ fragment, metas })
+    : [];
   let firstError = "";
   for (let index = 0; index < instanceSelector.length; index += 1) {
     const instanceId = instanceSelector[index];
@@ -86,33 +118,19 @@ export const findClosestInstanceMatchingFragment = ({
     if (meta === undefined) {
       continue;
     }
-    let matches = true;
-    for (const child of fragment.children) {
-      if (child.type !== "id") {
-        continue;
-      }
-      let hasNewViolation = false;
-      const isValid = isTreeSatisfyingContentModel({
-        instances: mergedInstances,
-        props: mergedProps,
-        metas,
-        instanceSelector: [child.value, ...instanceSelector.slice(index)],
-        onError: (message, errorSelector) => {
-          if (firstError === "") {
-            firstError = message;
-          }
-          if (
-            allowedWarningKeys.has(
-              getWarningKey({ instanceId: errorSelector[0], message })
-            ) === false
-          ) {
-            hasNewViolation = true;
-          }
-        },
-      });
-      matches &&= isValid || hasNewViolation === false;
-    }
-    if (matches) {
+    const warnings = getFragmentPlacementContentModelWarnings({
+      children: fragment.children,
+      instances: mergedInstances,
+      props: mergedProps,
+      metas,
+      parentSelector: instanceSelector.slice(index),
+    });
+    firstError ||= warnings[0]?.message ?? "";
+    const newWarnings = getNewFragmentContentModelWarnings({
+      warnings,
+      allowedWarnings,
+    });
+    if (newWarnings.length === 0) {
       return index;
     }
   }


### PR DESCRIPTION
## Summary

Prevent authored fragment insertion from creating invalid HTML structures while preserving the Builder's warning-only behavior for legacy clipboard content.

Also show an explicit loading state while Assets resource diagnostics are fetched lazily, instead of briefly reporting that no diagnostics are available.

Allow established text assets to be edited without their preserved creation timestamp being mistaken for an expired upload reservation.

## Root cause

The shared insert-fragment runtime mutation did not validate the final HTML content model.

Builder copy and paste uses the same mutation for legacy project content. The compatibility path must tolerate only violations already present in the copied fragment while still rejecting new violations caused by its destination.

The diagnostics inspector had no pending state, and an unkeyed pending state could be cleared by an older request after the inspected resource changed.

Asset revisions preserve the original file's `createdAt` value, but upload finalization used `createdAt` to enforce the 30-minute upload-ticket lifetime.

## Implementation

- [x] Enforce HTML content-model validation at the shared fragment-insertion mutation boundary.
- [x] Centralize fragment placement warning collection with the existing matcher logic.
- [x] Keep the legacy compatibility switch out of the public runtime/MCP contract.
- [x] Pass compatibility through trusted Builder runtime context only.
- [x] Ignore only violations already present in legacy clipboard content and reject new destination violations.
- [x] Preserve warning-only behavior across the shared Builder paste helper and instance-copy path.
- [x] Key diagnostics loading state to the active resource request.
- [x] Validate upload-ticket freshness with `updatedAt` while preserving logical asset `createdAt`.
- [x] Regenerate the runtime operation contract.
- [x] Add regression coverage for strict insertion, legacy compatibility, destination validation, paste context propagation, diagnostics request races, and established text assets.

## Impact

MCP and other public authored-fragment callers remain strictly validated and cannot opt out.

Legacy Builder clipboard content remains pasteable with warnings, but compatibility cannot introduce a new violation at the selected destination.

Assets diagnostics retain their loading state when an older request settles, and established text assets can be updated after 30 minutes without changing their displayed creation date.

## Verification

- [x] Project-build targeted tests: 80 passed.
- [x] Builder targeted tests: 86 passed.
- [x] Asset-uploader tests: 184 passed.
- [x] Builder typecheck passed.
- [x] Project-build typecheck passed.
- [x] Asset-uploader typecheck passed.
- [x] Generated runtime operation contracts are current.
- [x] New regression tests were demonstrated failing without their fixes and passing after restoration.
- [x] Fresh GitHub Main workflow passed, including both test/typecheck matrices and all six Builder E2E shards. Shard 3 was rerun successfully after Docker Hub rate-limited its initial database-image pull.

## External CI status

- Lost Pixel failed on an external TLS certificate handshake after Storybook built successfully.
- The staging deployment workflow failed before executing job steps, independently of code checks.
