### PR TITLE
fix: Show released CLI version in MCP docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git merge --no-edit "$RELEASE_SHA"
-          printf '**Webstudio MCP v%s**\n' "$RELEASE_VERSION" > docs/.gitbook/includes/mcp-cli-version.md
-          git add docs/.gitbook/includes/mcp-cli-version.md
+          git checkout "$RELEASE_SHA" -- docs/university/mcp.md
+          sed -i.bak "s/^# Webstudio MCP v0\\.0\\.0-webstudio-version$/# Webstudio MCP v$RELEASE_VERSION/" docs/university/mcp.md
+          rm docs/university/mcp.md.bak
+          grep -Fqx "# Webstudio MCP v$RELEASE_VERSION" docs/university/mcp.md
+          git add docs/university/mcp.md
           git commit -m "docs: publish Webstudio CLI $RELEASE_VERSION"
           git push origin docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,12 +142,30 @@ jobs:
   publish-docs:
     needs: [release, publish]
     runs-on: ubuntu-latest
+    concurrency:
+      group: publish-docs
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.sha }}
+          ref: docs
       - name: Publish released documentation snapshot
-        run: git push origin "$GITHUB_SHA:refs/heads/docs"
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          if git merge-base --is-ancestor "$RELEASE_SHA" HEAD; then
+            echo "The docs branch already contains release $RELEASE_VERSION or a newer revision."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git merge --no-edit "$RELEASE_SHA"
+          printf '**Webstudio MCP v%s**\n' "$RELEASE_VERSION" > docs/.gitbook/includes/mcp-cli-version.md
+          git add docs/.gitbook/includes/mcp-cli-version.md
+          git commit -m "docs: publish Webstudio CLI $RELEASE_VERSION"
+          git push origin docs

--- a/docs/.gitbook/includes/mcp-cli-version.md
+++ b/docs/.gitbook/includes/mcp-cli-version.md
@@ -1,1 +1,0 @@
-**Webstudio MCP development version**

--- a/docs/.gitbook/includes/mcp-cli-version.md
+++ b/docs/.gitbook/includes/mcp-cli-version.md
@@ -1,0 +1,1 @@
+**Webstudio MCP development version**

--- a/docs/university/mcp.md
+++ b/docs/university/mcp.md
@@ -9,6 +9,8 @@ icon: robot
 
 # Webstudio MCP
 
+{% include "../.gitbook/includes/mcp-cli-version.md" %}
+
 {% hint style="info" %}
 This reference is generated from the Webstudio CLI source in the same Builder
 revision. GitBook publishes it when that revision is successfully released.

--- a/docs/university/mcp.md
+++ b/docs/university/mcp.md
@@ -7,9 +7,7 @@ icon: robot
 
 <!-- Generated from the local Webstudio CLI with `webstudio man mcp --verbose`. Do not edit directly. -->
 
-# Webstudio MCP
-
-{% include "../.gitbook/includes/mcp-cli-version.md" %}
+# Webstudio MCP v0.0.0-webstudio-version
 
 {% hint style="info" %}
 This reference is generated from the Webstudio CLI source in the same Builder

--- a/scripts/docs/generate-mcp-docs.test.ts
+++ b/scripts/docs/generate-mcp-docs.test.ts
@@ -4,15 +4,12 @@ import { renderMcpDocumentation } from "./generate-mcp-docs.js";
 
 test("renders GitBook metadata around the complete CLI manual", () => {
   const generated = renderMcpDocumentation(
-    "# Webstudio MCP Manual\n\n## Startup\n\nStart here.\n"
+    "# Webstudio MCP Manual\n\n## Startup\n\nStart here.\n",
+    "1.2.3"
   );
 
   assert.match(generated, /^---\n/);
-  assert.match(generated, /# Webstudio MCP\n/);
-  assert.match(
-    generated,
-    /\{% include "\.\.\/\.gitbook\/includes\/mcp-cli-version\.md" %\}/
-  );
+  assert.match(generated, /# Webstudio MCP v1\.2\.3\n/);
   assert.match(
     generated,
     /GitBook publishes it when that revision is successfully released/
@@ -28,7 +25,14 @@ test("renders GitBook metadata around the complete CLI manual", () => {
 
 test("rejects an unexpected CLI manual", () => {
   assert.throws(
-    () => renderMcpDocumentation("# Different manual"),
+    () => renderMcpDocumentation("# Different manual", "1.2.3"),
     /Expected the CLI manual/
+  );
+});
+
+test("rejects a missing CLI version", () => {
+  assert.throws(
+    () => renderMcpDocumentation("# Webstudio MCP Manual\n\nBody", ""),
+    /Expected a CLI version/
   );
 });

--- a/scripts/docs/generate-mcp-docs.test.ts
+++ b/scripts/docs/generate-mcp-docs.test.ts
@@ -11,6 +11,10 @@ test("renders GitBook metadata around the complete CLI manual", () => {
   assert.match(generated, /# Webstudio MCP\n/);
   assert.match(
     generated,
+    /\{% include "\.\.\/\.gitbook\/includes\/mcp-cli-version\.md" %\}/
+  );
+  assert.match(
+    generated,
     /GitBook publishes it when that revision is successfully released/
   );
   assert.match(

--- a/scripts/docs/generate-mcp-docs.ts
+++ b/scripts/docs/generate-mcp-docs.ts
@@ -5,9 +5,20 @@ import { fileURLToPath } from "node:url";
 
 const manualTitle = "# Webstudio MCP Manual";
 const manualPlaceholder = "{{manual}}";
+const versionPlaceholder = "{{version}}";
 const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
 const outputPath = resolve(repositoryRoot, "docs/university/mcp.md");
 const template = readFileSync(new URL("mcp-page.md", import.meta.url), "utf8");
+
+const getCliVersion = () => {
+  const packageJson = JSON.parse(
+    readFileSync(resolve(repositoryRoot, "packages/cli/package.json"), "utf8")
+  ) as { version?: unknown };
+  if (typeof packageJson.version !== "string") {
+    throw new Error("Expected the CLI package to have a version.");
+  }
+  return packageJson.version;
+};
 
 const getMcpManual = () =>
   execFileSync(
@@ -31,7 +42,7 @@ const getMcpManual = () =>
     }
   ).trim();
 
-export const renderMcpDocumentation = (manual: string) => {
+export const renderMcpDocumentation = (manual: string, version: string) => {
   const normalizedManual = manual.replaceAll("\r\n", "\n").trim();
   if (normalizedManual.startsWith(`${manualTitle}\n`) === false) {
     throw new Error(
@@ -45,11 +56,20 @@ export const renderMcpDocumentation = (manual: string) => {
       `Expected one ${manualPlaceholder} placeholder, found ${placeholderCount}.`
     );
   }
-  return template.replace(manualPlaceholder, manualBody);
+  if (version.trim() === "") {
+    throw new Error("Expected a CLI version.");
+  }
+  return template
+    .replace(versionPlaceholder, version)
+    .replace(manualPlaceholder, manualBody);
 };
 
 export const generateMcpDocumentation = () => {
-  writeFileSync(outputPath, renderMcpDocumentation(getMcpManual()), "utf8");
+  writeFileSync(
+    outputPath,
+    renderMcpDocumentation(getMcpManual(), getCliVersion()),
+    "utf8"
+  );
 };
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/docs/generate-mcp-docs.ts
+++ b/scripts/docs/generate-mcp-docs.ts
@@ -9,16 +9,9 @@ const versionPlaceholder = "{{version}}";
 const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
 const outputPath = resolve(repositoryRoot, "docs/university/mcp.md");
 const template = readFileSync(new URL("mcp-page.md", import.meta.url), "utf8");
-
-const getCliVersion = () => {
-  const packageJson = JSON.parse(
-    readFileSync(resolve(repositoryRoot, "packages/cli/package.json"), "utf8")
-  ) as { version?: unknown };
-  if (typeof packageJson.version !== "string") {
-    throw new Error("Expected the CLI package to have a version.");
-  }
-  return packageJson.version;
-};
+const { version: cliVersion } = JSON.parse(
+  readFileSync(resolve(repositoryRoot, "packages/cli/package.json"), "utf8")
+) as { version: string };
 
 const getMcpManual = () =>
   execFileSync(
@@ -67,7 +60,7 @@ export const renderMcpDocumentation = (manual: string, version: string) => {
 export const generateMcpDocumentation = () => {
   writeFileSync(
     outputPath,
-    renderMcpDocumentation(getMcpManual(), getCliVersion()),
+    renderMcpDocumentation(getMcpManual(), cliVersion),
     "utf8"
   );
 };

--- a/scripts/docs/mcp-page.md
+++ b/scripts/docs/mcp-page.md
@@ -9,6 +9,8 @@ icon: robot
 
 # Webstudio MCP
 
+{% include "../.gitbook/includes/mcp-cli-version.md" %}
+
 {% hint style="info" %}
 This reference is generated from the Webstudio CLI source in the same Builder
 revision. GitBook publishes it when that revision is successfully released.

--- a/scripts/docs/mcp-page.md
+++ b/scripts/docs/mcp-page.md
@@ -7,9 +7,7 @@ icon: robot
 
 <!-- Generated from the local Webstudio CLI with `webstudio man mcp --verbose`. Do not edit directly. -->
 
-# Webstudio MCP
-
-{% include "../.gitbook/includes/mcp-cli-version.md" %}
+# Webstudio MCP v{{version}}
 
 {% hint style="info" %}
 This reference is generated from the Webstudio CLI source in the same Builder


### PR DESCRIPTION
## Summary

- make the MCP page generator render the CLI package version directly in the page title
- publish `Webstudio MCP v<release>` from the exact generated page in each successful release
- merge each successful release tag into the publication-only `docs` branch
- serialize publication and ignore reruns or older release tags already contained in `docs`

## Root cause

The first publication design advanced `docs` to the release commit without putting the CLI package version into the generated page. The repository uses `0.0.0-webstudio-version` until release time, so the release workflow now replaces that existing version placeholder with the successful tag version before publishing.

## Todo

- [x] Generate the CLI version in the MCP page title.
- [x] Publish the generated page from the exact release revision.
- [x] Make publication idempotent and prevent version downgrades.
- [x] Validate generation, formatting, linting, and release-branch behavior.
- [x] Merge this pull request.
- [x] Publish `0.285.0` as the initial version on the existing `docs` branch.

## Verification

- `pnpm docs:mcp:test`
- `pnpm docs:mcp:typecheck`
- `pnpm check:generated-docs`
- `pnpm lint`
- `pnpm oxfmt --check`
- `git diff --check`
- isolated Git simulation for release merge, exact generated-page selection, version replacement, and rerun detection
- regression tests demonstrated failing without version rendering and validation, then passing after restoration

Ref #5986

