### PR TITLE
fix: Resolve structured Asset paths in queries

### DIFF
--- a/packages/asset-uploader/src/asset-repository.ts
+++ b/packages/asset-uploader/src/asset-repository.ts
@@ -578,24 +578,36 @@ export class PostgresAssetRepository implements AssetRepository {
       assetReferences: Parameters<
         typeof createAssetIndex
       >[0]["assetReferences"],
+      assetValueReferences: Parameters<
+        typeof createAssetIndex
+      >[0]["assetValueReferences"],
       documentGraph: Parameters<typeof createAssetIndex>[0]["documentGraph"]
     ) =>
       await this.dependencies.createAssetIndex({
         projectId: this.projectId,
         entries,
         assetReferences,
+        ...(assetValueReferences === undefined ||
+        Object.keys(assetValueReferences).length === 0
+          ? {}
+          : { assetValueReferences }),
         documentGraph,
         maxBytes: this.contentDatabaseMaxBytes,
         ...(requirements === undefined ? {} : { plan: requirements }),
       });
     if (this.compilationCache === undefined) {
-      const { entries, assetReferences, documentGraph } =
+      const { entries, assetReferences, assetValueReferences, documentGraph } =
         await materializeContentSource({
           source,
           plan: requirements,
           maximumContentBytes: this.contentDatabaseMaxBytes,
         });
-      return await compile(entries, assetReferences, documentGraph);
+      return await compile(
+        entries,
+        assetReferences,
+        assetValueReferences,
+        documentGraph
+      );
     }
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const snapshot = await source.openSnapshot();
@@ -608,13 +620,22 @@ export class PostgresAssetRepository implements AssetRepository {
       });
       try {
         return await this.compilationCache.getOrCreate(key, async () => {
-          const { entries, assetReferences, documentGraph } =
-            await materializeContentSnapshot({
-              snapshot,
-              plan: requirements,
-              maximumContentBytes: this.contentDatabaseMaxBytes,
-            });
-          return await compile(entries, assetReferences, documentGraph);
+          const {
+            entries,
+            assetReferences,
+            assetValueReferences,
+            documentGraph,
+          } = await materializeContentSnapshot({
+            snapshot,
+            plan: requirements,
+            maximumContentBytes: this.contentDatabaseMaxBytes,
+          });
+          return await compile(
+            entries,
+            assetReferences,
+            assetValueReferences,
+            documentGraph
+          );
         });
       } catch (error) {
         if (error instanceof ContentSourceChangedError === false) {

--- a/packages/asset-uploader/src/content-compilation-cache.test.ts
+++ b/packages/asset-uploader/src/content-compilation-cache.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import type { ContentArtifactV1 } from "@webstudio-is/content-engine";
 import {
   canonicalAssetMetadataExtractorGeneration,
+  contentCompilationGeneration,
   createAssetIndex,
 } from "@webstudio-is/content-engine/compiler";
 import {
@@ -14,7 +15,7 @@ const artifact = (revision: string) =>
   ({ integrity: { checksum: revision } }) as ContentArtifactV1;
 
 describe("content compilation cache", () => {
-  test("keys compiled artifacts by metadata extraction generation", () => {
+  test("keys compiled artifacts by compiler generations", () => {
     const key = createContentCompilationCacheKey({
       projectId: "project",
       sourceRevision: "source",
@@ -24,6 +25,7 @@ describe("content compilation cache", () => {
 
     expect(JSON.parse(key)).toMatchObject({
       metadataExtractorGeneration: canonicalAssetMetadataExtractorGeneration,
+      contentCompilationGeneration,
     });
   });
 

--- a/packages/asset-uploader/src/content-compilation-cache.ts
+++ b/packages/asset-uploader/src/content-compilation-cache.ts
@@ -5,6 +5,7 @@ import {
 } from "@webstudio-is/content-engine";
 import {
   canonicalAssetMetadataExtractorGeneration,
+  contentCompilationGeneration,
   serializeJsonDeterministically,
 } from "@webstudio-is/content-engine/compiler";
 
@@ -29,6 +30,7 @@ export const createContentCompilationCacheKey = ({
     projectId,
     sourceRevision,
     metadataExtractorGeneration: canonicalAssetMetadataExtractorGeneration,
+    contentCompilationGeneration,
     plan: plan ?? null,
     strict,
     maxBytes,

--- a/packages/content-engine/src/asset-index.test.ts
+++ b/packages/content-engine/src/asset-index.test.ts
@@ -46,7 +46,7 @@ const entry = ({
   });
 
 describe("shared asset index", () => {
-  test("selects runtime assets from documents and Markdown references", () => {
+  test("selects runtime assets from documents and content references", () => {
     const artifact = {
       documents: [{ _id: "document" }, { _id: "shared" }],
       assetReferences: {
@@ -55,18 +55,24 @@ describe("shared asset index", () => {
           { start: 2, end: 3, assetId: "shared" },
         ],
       },
+      assetValueReferences: {
+        document: [
+          { path: ["properties", "image"], assetId: "structured-reference" },
+        ],
+      },
     };
 
     expect(getContentArtifactReferencedAssetIds(artifact)).toEqual([
       "reference",
       "shared",
+      "structured-reference",
     ]);
     expect(
       getContentArtifactRuntimeAssetIds({
         artifact,
         includeDocuments: true,
       })
-    ).toEqual(["document", "reference", "shared"]);
+    ).toEqual(["document", "reference", "shared", "structured-reference"]);
   });
 
   test("stores only fields required by an ID-only query", async () => {
@@ -328,6 +334,66 @@ describe("shared asset index", () => {
     await expect(verifyContentArtifact(materialized.artifact)).resolves.toEqual(
       materialized.artifact
     );
+  });
+
+  test("keeps queries that evaluate structured Asset values in the runtime database", async () => {
+    const post = createCanonicalAssetFileEntry({
+      projectId: "project",
+      document: {
+        ...entry({ id: "post" }).document,
+        properties: { featureImage: "./assets/hero.png" },
+      },
+    });
+    const query = assetQuery.parse({
+      where: {
+        all: [
+          {
+            field: ["properties", "featureImage"],
+            operator: "eq",
+            value: "/cgi/image/hero.png?format=raw",
+          },
+        ],
+      },
+      sort: [{ field: ["properties", "featureImage"], direction: "asc" }],
+      output: {
+        mode: "fields",
+        includeMetadata: false,
+        fields: [["properties", "featureImage"]],
+      },
+      content: { mode: "none" },
+    });
+    const { artifact } = await compileContentArtifact({
+      projectId: "project",
+      entries: [post],
+      assetValueReferences: {
+        post: [
+          {
+            path: ["properties", "featureImage"],
+            assetId: "hero",
+          },
+        ],
+      },
+      plan: createContentCompilationPlan([
+        createLiteralContentCompilationQuery({ id: "post", query }),
+      ]),
+    });
+
+    expect(artifact.queries).toBeUndefined();
+    expect(artifact.documents).toHaveLength(1);
+    await expect(
+      createContentDatabase({ artifact }).query({ query }, undefined, {
+        hero: { url: "/cgi/image/hero.png?format=raw" },
+      })
+    ).resolves.toMatchObject({
+      items: [
+        {
+          id: "post",
+          properties: {
+            featureImage: "/cgi/image/hero.png?format=raw",
+          },
+        },
+      ],
+    });
   });
 
   test("stores overview-only fields outside dynamic detail documents", async () => {

--- a/packages/content-engine/src/asset-index.ts
+++ b/packages/content-engine/src/asset-index.ts
@@ -35,6 +35,10 @@ import {
   type DocumentGraph,
   type DocumentGraphArtifactV1,
 } from "./document-graph";
+import { getQueryConditions } from "@webstudio-is/query-builder/runtime";
+import type { AssetValueReferences } from "./asset-value-references";
+
+export const contentCompilationGeneration = 1;
 
 export type ContentCompilerDiagnostics = {
   maxBytes: number;
@@ -60,6 +64,52 @@ const getDocumentBytes = (
     serializeJsonDeterministically(
       projectContentDatabaseDocument({ document: entry.document, plan })
     )
+  );
+
+const pathsOverlap = (
+  left: readonly (string | number)[],
+  right: readonly (string | number)[]
+) => {
+  const length = Math.min(left.length, right.length);
+  return left
+    .slice(0, length)
+    .every((segment, index) => segment === right[index]);
+};
+
+const isQueryEvaluationAffectedByAssetValues = ({
+  query,
+  assetValueReferences,
+}: {
+  query: ContentCompilationPlan["queries"][number];
+  assetValueReferences?: AssetValueReferences;
+}) => {
+  const evaluationPaths = [
+    ...getQueryConditions(query.where).map(({ field }) => field),
+    ...query.sort.map(({ field }) => field),
+  ];
+  return Object.values(assetValueReferences ?? {})
+    .flat()
+    .some(({ path }) =>
+      evaluationPaths.some((field) => pathsOverlap(path, field))
+    );
+};
+
+const isDocumentEvaluationAffectedByAssetValues = ({
+  documentId,
+  plan,
+  assetValueReferences,
+}: {
+  documentId: string;
+  plan: ContentCompilationPlan;
+  assetValueReferences?: AssetValueReferences;
+}) =>
+  plan.queries.some((query) =>
+    isQueryEvaluationAffectedByAssetValues({
+      query,
+      assetValueReferences: {
+        [documentId]: assetValueReferences?.[documentId] ?? [],
+      },
+    })
   );
 
 export type ContentCompilerInput = CanonicalAssetFileEntry & {
@@ -216,6 +266,7 @@ const buildAssetIndex = async ({
   maxBytes,
   unboundedBytes,
   assetReferences,
+  assetValueReferences,
   documentGraph,
   plan,
   finalize = true,
@@ -225,6 +276,7 @@ const buildAssetIndex = async ({
   maxBytes: number;
   unboundedBytes: number;
   assetReferences?: MarkdownAssetReferences;
+  assetValueReferences?: AssetValueReferences;
   documentGraph?: DocumentGraphArtifactV1;
   plan?: ContentCompilationPlan;
   finalize?: boolean;
@@ -236,9 +288,13 @@ const buildAssetIndex = async ({
   const materializableQueries =
     plan?.queries.filter(
       (query) =>
-        documentGraph === undefined ||
-        getDocumentGraphQueryRootIds({ graph: documentGraph, query }).length ===
-          0
+        isQueryEvaluationAffectedByAssetValues({
+          query,
+          assetValueReferences,
+        }) === false &&
+        (documentGraph === undefined ||
+          getDocumentGraphQueryRootIds({ graph: documentGraph, query })
+            .length === 0)
     ) ?? [];
   const materialized =
     plan === undefined
@@ -272,12 +328,18 @@ const buildAssetIndex = async ({
       ? entries
       : runtimePlan.queries.length === 0
         ? []
-        : entries.filter(({ document }) =>
-            isContentDocumentCandidate({
-              document,
-              plan: runtimePlan,
-              available: "all",
-            })
+        : entries.filter(
+            ({ document }) =>
+              isDocumentEvaluationAffectedByAssetValues({
+                documentId: document._id,
+                plan: runtimePlan,
+                assetValueReferences,
+              }) ||
+              isContentDocumentCandidate({
+                document,
+                plan: runtimePlan,
+                available: "all",
+              })
           );
   const documents = runtimeEntries
     .map(({ document }) =>
@@ -301,6 +363,12 @@ const buildAssetIndex = async ({
   const includedAssetReferences = Object.fromEntries(
     Object.entries(assetReferences ?? {}).filter(([contentRef]) =>
       includedContentRefs.has(contentRef)
+    )
+  );
+  const includedDocumentIds = new Set(entries.map(({ assetId }) => assetId));
+  const includedAssetValueReferences = Object.fromEntries(
+    Object.entries(assetValueReferences ?? {}).filter(([documentId]) =>
+      includedDocumentIds.has(documentId)
     )
   );
   const runtimeCatalog =
@@ -336,6 +404,9 @@ const buildAssetIndex = async ({
     ...(Object.keys(includedAssetReferences).length === 0
       ? {}
       : { assetReferences: includedAssetReferences }),
+    ...(Object.keys(includedAssetValueReferences).length === 0
+      ? {}
+      : { assetValueReferences: includedAssetValueReferences }),
     fieldCatalog,
     ...(Object.keys(materialized.values).length === 0
       ? {}
@@ -370,6 +441,7 @@ export const compileContentArtifact = async ({
   entries,
   maxBytes = contentEngineLimits.databaseBytes,
   assetReferences,
+  assetValueReferences,
   documentGraph,
   plan,
 }: {
@@ -377,6 +449,7 @@ export const compileContentArtifact = async ({
   entries: readonly ContentCompilerInput[];
   maxBytes?: number;
   assetReferences?: MarkdownAssetReferences;
+  assetValueReferences?: AssetValueReferences;
   documentGraph?: DocumentGraph;
   plan?: ContentCompilationPlan;
 }): Promise<{
@@ -434,6 +507,7 @@ export const compileContentArtifact = async ({
       maxBytes,
       unboundedBytes,
       assetReferences,
+      assetValueReferences,
       documentGraph: documentGraphArtifact,
       plan,
       finalize: false,
@@ -461,6 +535,7 @@ export const compileContentArtifact = async ({
       maxBytes,
       unboundedBytes,
       assetReferences,
+      assetValueReferences,
       documentGraph: documentGraphArtifact,
       plan,
       finalize: false,
@@ -493,6 +568,7 @@ export const compileContentArtifact = async ({
           maxBytes,
           unboundedBytes,
           assetReferences,
+          assetValueReferences,
           documentGraph: documentGraphArtifact,
           plan,
           finalize: false,
@@ -526,6 +602,7 @@ export const compileContentArtifact = async ({
     maxBytes,
     unboundedBytes,
     assetReferences,
+    assetValueReferences,
     documentGraph: documentGraphArtifact,
     plan,
   });
@@ -577,6 +654,7 @@ export const createAssetIndex = async (input: {
   entries: readonly ContentCompilerInput[];
   maxBytes?: number;
   assetReferences?: MarkdownAssetReferences;
+  assetValueReferences?: AssetValueReferences;
   documentGraph?: DocumentGraph;
   plan?: ContentCompilationPlan;
 }): Promise<ContentArtifactV1> =>

--- a/packages/content-engine/src/asset-value-references.test.ts
+++ b/packages/content-engine/src/asset-value-references.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+import {
+  discoverAssetValueReferences,
+  mergeAssetUrlSuffix,
+  resolveAssetValueReferences,
+} from "./asset-value-references";
+
+describe("structured asset value references", () => {
+  test("discovers nested object and array values relative to the source document", () => {
+    const properties = {
+      featureImage: "./assets/hero.png",
+      openGraph: { image: "../shared/social.png#cover" },
+      gallery: ["./assets/first.png?width=800", { src: "missing.png" }],
+      external: "https://example.com/image.png",
+      rootRelative: "/images/hero.png",
+      fragment: "#hero",
+    };
+
+    expect(
+      discoverAssetValueReferences({
+        properties,
+        sourcePath: "blog/posts/article.md",
+        assetIdsByPath: new Map([
+          ["blog/posts/assets/hero.png", "hero"],
+          ["blog/shared/social.png", "social"],
+          ["blog/posts/assets/first.png", "first"],
+        ]),
+      })
+    ).toEqual([
+      {
+        path: ["properties", "featureImage"],
+        assetId: "hero",
+      },
+      {
+        path: ["properties", "openGraph", "image"],
+        assetId: "social",
+        suffix: "#cover",
+      },
+      {
+        path: ["properties", "gallery", 0],
+        assetId: "first",
+        suffix: "?width=800",
+      },
+    ]);
+  });
+
+  test("leaves missing and non-unique paths undiscovered", () => {
+    expect(
+      discoverAssetValueReferences({
+        properties: {
+          ambiguous: "./hero.png",
+          missing: "./missing.png",
+          stableId: "asset-id",
+        },
+        sourcePath: "posts/article.json",
+        assetIdsByPath: new Map([["images/hero.png", "asset-id"]]),
+      })
+    ).toEqual([
+      {
+        path: ["properties", "stableId"],
+        assetId: "asset-id",
+      },
+    ]);
+  });
+
+  test("resolves without mutating source values and merges URL suffixes", () => {
+    const value = {
+      properties: {
+        image: "./hero.png?width=1200#cover",
+        gallery: ["./first.png"],
+      },
+    };
+
+    const resolved = resolveAssetValueReferences({
+      value,
+      references: [
+        {
+          path: ["properties", "image"],
+          assetId: "hero",
+          suffix: "?width=1200#cover",
+        },
+        {
+          path: ["properties", "gallery", 0],
+          assetId: "first",
+        },
+      ],
+      assetUrls: {
+        hero: "/cgi/image/hero.png?format=raw",
+        first: "/cgi/image/first.png?format=raw",
+      },
+    });
+
+    expect(resolved).toEqual({
+      properties: {
+        image: "/cgi/image/hero.png?format=raw&width=1200#cover",
+        gallery: ["/cgi/image/first.png?format=raw"],
+      },
+    });
+    expect(value.properties.image).toBe("./hero.png?width=1200#cover");
+    expect(
+      mergeAssetUrlSuffix(
+        "https://cdn.example.com/guide.pdf?format=raw",
+        "?download=1#section"
+      )
+    ).toBe("https://cdn.example.com/guide.pdf?format=raw&download=1#section");
+  });
+});

--- a/packages/content-engine/src/asset-value-references.ts
+++ b/packages/content-engine/src/asset-value-references.ts
@@ -1,0 +1,152 @@
+import { createAssetIdResolver } from "./markdown-assets";
+
+export type AssetValueReference = {
+  path: Array<string | number>;
+  assetId: string;
+  suffix?: string;
+};
+
+export type AssetValueReferences = Record<string, AssetValueReference[]>;
+
+const getUrlSuffix = (value: string) => {
+  let parsed: URL;
+  try {
+    parsed = new URL(value, "https://content.webstudio.invalid/");
+  } catch {
+    return;
+  }
+  const suffix = `${parsed.search}${parsed.hash}`;
+  return suffix === "" ? undefined : suffix;
+};
+
+export const discoverAssetValueReferences = ({
+  properties,
+  sourcePath,
+  assetIdsByPath,
+}: {
+  properties: Readonly<Record<string, unknown>>;
+  sourcePath: string;
+  assetIdsByPath: ReadonlyMap<string, string>;
+}): AssetValueReference[] => {
+  const resolveAssetId = createAssetIdResolver(assetIdsByPath, sourcePath);
+  const references: AssetValueReference[] = [];
+  const visit = (value: unknown, path: Array<string | number>) => {
+    if (typeof value === "string") {
+      const assetId = resolveAssetId(value);
+      if (assetId !== undefined) {
+        const suffix = getUrlSuffix(value);
+        references.push({
+          path,
+          assetId,
+          ...(suffix === undefined ? {} : { suffix }),
+        });
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const [index, item] of value.entries()) {
+        visit(item, [...path, index]);
+      }
+      return;
+    }
+    if (typeof value !== "object" || value === null) {
+      return;
+    }
+    for (const [key, item] of Object.entries(value)) {
+      visit(item, [...path, key]);
+    }
+  };
+  visit(properties, ["properties"]);
+  return references;
+};
+
+export const mergeAssetUrlSuffix = (url: string, suffix?: string) => {
+  if (suffix === undefined) {
+    return url;
+  }
+  const base = "https://content.webstudio.invalid";
+  const canonical = new URL(url, `${base}/`);
+  const authored = new URL(suffix, `${base}/`);
+  for (const [key, value] of authored.searchParams) {
+    canonical.searchParams.append(key, value);
+  }
+  if (authored.hash !== "") {
+    canonical.hash = authored.hash;
+  }
+  if (url.startsWith("//")) {
+    return `//${canonical.host}${canonical.pathname}${canonical.search}${canonical.hash}`;
+  }
+  if (url.startsWith("/")) {
+    return `${canonical.pathname}${canonical.search}${canonical.hash}`;
+  }
+  return canonical.href;
+};
+
+const replaceValueAtPath = ({
+  value,
+  path,
+  replacement,
+}: {
+  value: unknown;
+  path: readonly (string | number)[];
+  replacement: string;
+}): unknown => {
+  const [segment, ...rest] = path;
+  if (segment === undefined) {
+    return replacement;
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Object.hasOwn(value, segment) === false
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    if (typeof segment !== "number") {
+      return value;
+    }
+    const next = [...value];
+    next[segment] = replaceValueAtPath({
+      value: value[segment],
+      path: rest,
+      replacement,
+    });
+    return next;
+  }
+  if (typeof segment !== "string") {
+    return value;
+  }
+  return {
+    ...value,
+    [segment]: replaceValueAtPath({
+      value: (value as Readonly<Record<string, unknown>>)[segment],
+      path: rest,
+      replacement,
+    }),
+  };
+};
+
+export const resolveAssetValueReferences = <Value>({
+  value,
+  references,
+  assetUrls,
+}: {
+  value: Value;
+  references: readonly AssetValueReference[] | undefined;
+  assetUrls: Readonly<Record<string, string>>;
+}): Value => {
+  let resolved: unknown = value;
+  for (const reference of references ?? []) {
+    const assetUrl = assetUrls[reference.assetId];
+    if (assetUrl === undefined) {
+      continue;
+    }
+    resolved = replaceValueAtPath({
+      value: resolved,
+      path: reference.path,
+      replacement: mergeAssetUrlSuffix(assetUrl, reference.suffix),
+    });
+  }
+  return resolved as Value;
+};

--- a/packages/content-engine/src/compiler.ts
+++ b/packages/content-engine/src/compiler.ts
@@ -6,6 +6,7 @@ export * from "./asset-index";
 export * from "./content-runtime-artifact";
 export * from "./content-source";
 export * from "./document-metadata";
+export * from "./asset-value-references";
 export { serializeJsonDeterministically } from "./canonical-json";
 export { decodeUtf8, readBoundedBytes, readBytePrefix } from "./byte-stream";
 export { mapBounded } from "./async-utils";

--- a/packages/content-engine/src/content-artifact.ts
+++ b/packages/content-engine/src/content-artifact.ts
@@ -13,13 +13,16 @@ export const serializeContentArtifact = (value: unknown) =>
   serializeJsonDeterministically(contentArtifactV1.parse(value));
 
 export const getContentArtifactReferencedAssetIds = (
-  artifact: Pick<ContentArtifactV1, "assetReferences">
+  artifact: Pick<ContentArtifactV1, "assetReferences" | "assetValueReferences">
 ) =>
   [
     ...new Set(
-      Object.values(artifact.assetReferences ?? {})
-        .flat()
-        .map(({ assetId }) => assetId)
+      [artifact.assetReferences, artifact.assetValueReferences].flatMap(
+        (references) =>
+          Object.values(references ?? {})
+            .flat()
+            .map(({ assetId }) => assetId)
+      )
     ),
   ].sort();
 
@@ -28,7 +31,10 @@ export const getContentArtifactRuntimeAssetIds = ({
   includeDocuments,
   includeDocumentGraph = true,
 }: {
-  artifact: Pick<ContentArtifactV1, "assetReferences"> & {
+  artifact: Pick<
+    ContentArtifactV1,
+    "assetReferences" | "assetValueReferences"
+  > & {
     documents: readonly { _id: string }[];
     documentGraph?: { readonly nodes: readonly { id: string }[] };
   };

--- a/packages/content-engine/src/content-database.ts
+++ b/packages/content-engine/src/content-database.ts
@@ -35,6 +35,7 @@ import {
   assertDocumentSourceIdentity,
 } from "./document-graph";
 import { contentEngineLimits } from "./limits";
+import { resolveAssetValueReferences } from "./asset-value-references";
 
 type ContentDatabaseQueryArguments = [
   request: AssetQueryRequestInput,
@@ -135,7 +136,11 @@ const createQueryableContentDatabase = ({
 }: {
   artifact: Pick<
     ContentRuntimeArtifact,
-    "documents" | "contents" | "assetReferences" | "queries"
+    | "documents"
+    | "contents"
+    | "assetReferences"
+    | "assetValueReferences"
+    | "queries"
   >;
   revision: string;
   catalog?: BuilderAssetFieldCatalog;
@@ -158,12 +163,17 @@ const createQueryableContentDatabase = ({
     ) {
       throw new AssetIndexRevisionError();
     }
+    const assetUrls = Object.fromEntries(
+      Object.entries(runtimeAssets ?? {}).map(([id, asset]) => [id, asset.url])
+    );
     const materialized =
       options?.skipMaterialized === true
         ? undefined
         : await getMaterializedAssetQueryResult({
             queries: artifact.queries,
             query: request.query,
+            assetValueReferences: artifact.assetValueReferences,
+            assetUrls,
           });
     if (materialized !== undefined) {
       return materialized;
@@ -199,6 +209,7 @@ const createQueryableContentDatabase = ({
       read: readEmbeddedContent,
       runtimeAssets,
       assetReferences: artifact.assetReferences,
+      assetValueReferences: artifact.assetValueReferences,
     });
     return result;
   };
@@ -228,7 +239,20 @@ const createQueryableContentDatabase = ({
         graph: documentGraph,
         query,
       }).filter((rootId) => {
-        const document = documentsById.get(rootId);
+        const storedDocument = documentsById.get(rootId);
+        const document =
+          storedDocument === undefined
+            ? undefined
+            : resolveAssetValueReferences({
+                value: storedDocument,
+                references: artifact.assetValueReferences?.[rootId],
+                assetUrls: Object.fromEntries(
+                  Object.entries(runtimeAssets ?? {}).map(([id, asset]) => [
+                    id,
+                    asset.url,
+                  ])
+                ),
+              });
         if (document === undefined) {
           return false;
         }

--- a/packages/content-engine/src/content-runtime-artifact.ts
+++ b/packages/content-engine/src/content-runtime-artifact.ts
@@ -11,6 +11,7 @@ import {
   type DocumentRepresentation,
 } from "./document-graph";
 import type { MarkdownAssetReferences } from "./markdown-references";
+import type { AssetValueReferences } from "./asset-value-references";
 
 type RuntimeDocumentGraphEdge = Readonly<{
   sourceId: string;
@@ -28,6 +29,7 @@ export type ContentRuntimeArtifact = Readonly<{
   }>;
   contents?: Readonly<Record<string, string>>;
   assetReferences?: MarkdownAssetReferences;
+  assetValueReferences?: AssetValueReferences;
   queries?: Readonly<Record<string, MaterializedAssetQuery>>;
 }>;
 
@@ -80,6 +82,9 @@ export const createContentRuntimeArtifact = (
     ...(artifact.assetReferences === undefined
       ? {}
       : { assetReferences: artifact.assetReferences }),
+    ...(artifact.assetValueReferences === undefined
+      ? {}
+      : { assetValueReferences: artifact.assetValueReferences }),
     ...(artifact.queries === undefined ? {} : { queries: artifact.queries }),
   };
 };
@@ -96,9 +101,12 @@ export const getContentRuntimeArtifactRuntimeAssetIds = ({
   includeDocuments: boolean;
 }) => {
   const ids = new Set(
-    Object.values(artifact.assetReferences ?? {})
-      .flat()
-      .map(({ assetId }) => assetId)
+    [artifact.assetReferences, artifact.assetValueReferences].flatMap(
+      (references) =>
+        Object.values(references ?? {})
+          .flat()
+          .map(({ assetId }) => assetId)
+    )
   );
   if (includeDocuments) {
     for (const { _id } of artifact.documents) {

--- a/packages/content-engine/src/content-source.test.ts
+++ b/packages/content-engine/src/content-source.test.ts
@@ -504,6 +504,87 @@ describe("content source snapshots", () => {
     });
   });
 
+  test("discovers structured Asset values in Markdown and JSON documents", async () => {
+    const markdown = createFile({
+      id: "markdown",
+      path: "blog/posts/content-mode.md",
+    });
+    const json = createFile({
+      id: "json",
+      path: "team/member.json",
+      contentType: "application/json",
+      contentRef: "revisions/member.json",
+    });
+    const hero = createFile({
+      id: "hero",
+      path: "blog/posts/assets/content-mode.png",
+      contentType: "image/png",
+    });
+    const portrait = createFile({
+      id: "portrait",
+      path: "team/assets/portrait.png",
+      contentType: "image/png",
+    });
+    const source: ContentSource = {
+      async openSnapshot() {
+        return {
+          revision: "snapshot",
+          files: [markdown, json, hero, portrait],
+          async loadEntries() {
+            const markdownEntry = createEntry(markdown);
+            const jsonEntry = createEntry(json);
+            return [
+              {
+                ...markdownEntry,
+                document: {
+                  ...markdownEntry.document,
+                  properties: {
+                    featureImage: "./assets/content-mode.png",
+                    openGraph: {
+                      images: ["./assets/content-mode.png#social"],
+                    },
+                  },
+                },
+              } as typeof markdownEntry,
+              {
+                ...jsonEntry,
+                document: {
+                  ...jsonEntry.document,
+                  properties: { portrait: "./assets/portrait.png" },
+                },
+              } as typeof jsonEntry,
+            ];
+          },
+          async isCurrent() {
+            return true;
+          },
+        };
+      },
+    };
+
+    const result = await compileContentSource({ source, projectId });
+
+    expect(result.artifact.assetValueReferences).toEqual({
+      json: [
+        {
+          path: ["properties", "portrait"],
+          assetId: "portrait",
+        },
+      ],
+      markdown: [
+        {
+          path: ["properties", "featureImage"],
+          assetId: "hero",
+        },
+        {
+          path: ["properties", "openGraph", "images", 0],
+          assetId: "hero",
+          suffix: "#social",
+        },
+      ],
+    });
+  });
+
   test("resolves the same relative URL independently for each Markdown folder", async () => {
     const firstPost = createFile({
       id: "first-post",

--- a/packages/content-engine/src/content-source.ts
+++ b/packages/content-engine/src/content-source.ts
@@ -15,6 +15,10 @@ import {
   discoverMarkdownAssetReferenceRanges,
 } from "./markdown-assets";
 import type { MarkdownAssetReferences } from "./markdown-references";
+import {
+  discoverAssetValueReferences,
+  type AssetValueReferences,
+} from "./asset-value-references";
 import { compareStrings } from "./canonical-json";
 import { encodeUtf8, type ByteSource } from "./byte-stream";
 import { extractMarkdownBody } from "./markdown-body";
@@ -175,6 +179,30 @@ const discoverSnapshotAssetReferences = async ({
   return references;
 };
 
+const discoverSnapshotAssetValueReferences = ({
+  snapshot,
+  entries,
+}: {
+  snapshot: ContentSourceSnapshot;
+  entries: readonly ContentCompilerInput[];
+}): AssetValueReferences => {
+  const assetIdsByPath = createUniqueAssetIdsByPath(snapshot.files);
+  const references: AssetValueReferences = {};
+  for (const entry of [...entries].sort((left, right) =>
+    compareStrings(left.assetId, right.assetId)
+  )) {
+    const discovered = discoverAssetValueReferences({
+      properties: entry.document.properties ?? {},
+      sourcePath: entry.document.path,
+      assetIdsByPath,
+    });
+    if (discovered.length > 0) {
+      references[entry.assetId] = discovered;
+    }
+  }
+  return references;
+};
+
 const documentUrlBase = "https://content.webstudio.local/";
 
 const getDocumentUrl = (path: string) =>
@@ -288,11 +316,16 @@ export const materializeContentSnapshot = async ({
       entries,
       plan,
     });
+    const assetValueReferences = discoverSnapshotAssetValueReferences({
+      snapshot,
+      entries,
+    });
     if (await snapshot.isCurrent()) {
       return {
         sourceRevision: snapshot.revision,
         entries,
         assetReferences,
+        assetValueReferences,
         documentGraph,
       };
     }
@@ -320,16 +353,22 @@ export const compileContentSource = async ({
   artifact: ContentArtifactV1;
   diagnostics: ContentCompilerDiagnostics;
 }> => {
-  const { sourceRevision, entries, assetReferences, documentGraph } =
-    await materializeContentSource({
-      source,
-      plan,
-      maximumContentBytes: maxBytes,
-    });
+  const {
+    sourceRevision,
+    entries,
+    assetReferences,
+    assetValueReferences,
+    documentGraph,
+  } = await materializeContentSource({
+    source,
+    plan,
+    maximumContentBytes: maxBytes,
+  });
   const compiled = await compileContentArtifact({
     projectId,
     entries,
     assetReferences,
+    assetValueReferences,
     documentGraph,
     ...(plan === undefined ? {} : { plan }),
     ...(maxBytes === undefined ? {} : { maxBytes }),
@@ -349,6 +388,7 @@ export const materializeContentSource = async ({
   sourceRevision: string;
   entries: readonly ContentCompilerInput[];
   assetReferences: MarkdownAssetReferences;
+  assetValueReferences: AssetValueReferences;
   documentGraph?: DocumentGraph;
 }> => {
   for (let attempt = 0; attempt < 2; attempt += 1) {

--- a/packages/content-engine/src/document-graph/query-resolution.test.ts
+++ b/packages/content-engine/src/document-graph/query-resolution.test.ts
@@ -23,7 +23,10 @@ const createPostEntry = (id: string, authorPath: string) =>
       size: 1,
       revision: `${id}-r1`,
       contentRef: `content:${id}`,
-      properties: { author: { $ref: authorPath } },
+      properties: {
+        author: { $ref: authorPath },
+        featureImage: "./assets/hero.png",
+      },
     },
   });
 
@@ -78,11 +81,24 @@ describe("document graph query resolution", () => {
     const { artifact } = await compileContentArtifact({
       projectId: "project",
       entries,
+      assetValueReferences: Object.fromEntries(
+        entries.map(({ assetId }) => [
+          assetId,
+          [
+            {
+              path: ["properties", "featureImage"],
+              assetId: "hero",
+            },
+          ],
+        ])
+      ),
       documentGraph: graph,
     });
     const sources: Record<string, string> = {
-      "post-ada": '{"author":{"$ref":"../authors/ada.json"}}',
-      "post-grace": '{"author":{"$ref":"../authors/grace.json"}}',
+      "post-ada":
+        '{"author":{"$ref":"../authors/ada.json"},"featureImage":"./assets/hero.png"}',
+      "post-grace":
+        '{"author":{"$ref":"../authors/grace.json"},"featureImage":"./assets/hero.png"}',
       "author-ada": '{"name":"Ada"}',
       "author-grace": '{"name":"Grace"}',
     };
@@ -103,6 +119,11 @@ describe("document graph query resolution", () => {
                 operator: "eq",
                 value: "Ada",
               },
+              {
+                field: ["properties", "featureImage"],
+                operator: "startsWith",
+                value: "/cgi/image/",
+              },
             ],
           },
           sort: [
@@ -114,19 +135,28 @@ describe("document graph query resolution", () => {
           output: {
             mode: "fields",
             includeMetadata: false,
-            fields: [["properties", "author", "name"]],
+            fields: [
+              ["properties", "author", "name"],
+              ["properties", "featureImage"],
+            ],
           },
           content: { mode: "none" },
         },
       },
       load,
+      runtimeAssets: {
+        hero: { url: "/cgi/image/hero.png?format=raw" },
+      },
     });
 
     expect(result).toEqual({
       items: [
         {
           id: "post-ada",
-          properties: { author: { name: "Ada" } },
+          properties: {
+            author: { name: "Ada" },
+            featureImage: "/cgi/image/hero.png?format=raw",
+          },
         },
       ],
       totalCount: 1,

--- a/packages/content-engine/src/index.ts
+++ b/packages/content-engine/src/index.ts
@@ -11,3 +11,4 @@ export * from "./request";
 export * from "./query-source";
 export * from "./query-error";
 export * from "./document-graph";
+export * from "./asset-value-references";

--- a/packages/content-engine/src/markdown-assets.ts
+++ b/packages/content-engine/src/markdown-assets.ts
@@ -107,7 +107,7 @@ const getRelativeAssetPath = ({
   return segments.join("/");
 };
 
-const createAssetIdResolver = (
+export const createAssetIdResolver = (
   assetIdsByPath: ReadonlyMap<string, string>,
   sourcePath: string
 ) => {

--- a/packages/content-engine/src/materialized-query.ts
+++ b/packages/content-engine/src/materialized-query.ts
@@ -19,9 +19,14 @@ import {
   type MaterializedAssetQuery,
 } from "./schema";
 import {
+  assertAssetQueryResultSize,
   AssetQueryExecutionError,
   executeAssetQuery,
 } from "./structured-query";
+import {
+  resolveAssetValueReferences,
+  type AssetValueReferences,
+} from "./asset-value-references";
 
 const hasOverlappingFields = (fields: readonly AssetQueryFieldPath[]) =>
   fields.some((field, index) =>
@@ -249,13 +254,32 @@ const hydrateMaterializedQuery = (
 export const getMaterializedAssetQueryResult = async ({
   queries,
   query,
+  assetValueReferences,
+  assetUrls = {},
 }: {
   queries: Readonly<Record<string, MaterializedAssetQuery>> | undefined;
   query: AssetQueryInput;
+  assetValueReferences?: AssetValueReferences;
+  assetUrls?: Readonly<Record<string, string>>;
 }): Promise<AssetQueryResult | undefined> => {
   if (queries === undefined) {
     return;
   }
   const value = queries[await getAssetQueryHash(assetQuery.parse(query))];
-  return value === undefined ? undefined : hydrateMaterializedQuery(value);
+  if (value === undefined) {
+    return;
+  }
+  const result = hydrateMaterializedQuery(value);
+  const resolved = {
+    ...result,
+    items: result.items.map((item) =>
+      resolveAssetValueReferences({
+        value: item,
+        references: assetValueReferences?.[item.id],
+        assetUrls,
+      })
+    ),
+  };
+  assertAssetQueryResultSize(resolved);
+  return resolved;
 };

--- a/packages/content-engine/src/published-runtime.test.ts
+++ b/packages/content-engine/src/published-runtime.test.ts
@@ -820,6 +820,91 @@ describe("published asset resource runtime", () => {
     });
   });
 
+  test("resolves structured Asset values from materialized query rows", async () => {
+    const query = assetQuery.parse({
+      where: {
+        all: [
+          {
+            field: ["properties", "slug"],
+            operator: "eq",
+            value: "post",
+          },
+        ],
+      },
+      sort: [],
+      limit: 1,
+      offset: 0,
+      output: {
+        mode: "fields",
+        includeMetadata: false,
+        fields: [["properties", "featureImage"]],
+      },
+      content: { mode: "none" },
+    });
+    const index = await createAssetIndex({
+      projectId: "project-1",
+      entries: [
+        createCanonicalAssetFileEntry({
+          projectId: "project-1",
+          document: {
+            ...document,
+            properties: {
+              ...document.properties,
+              featureImage: "./assets/hero.png?width=1200#cover",
+            },
+          },
+        }),
+      ],
+      assetValueReferences: {
+        "post-1": [
+          {
+            path: ["properties", "featureImage"],
+            assetId: "hero",
+            suffix: "?width=1200#cover",
+          },
+        ],
+      },
+      plan: createContentCompilationPlan([
+        createLiteralContentCompilationQuery({ id: "posts", query }),
+      ]),
+    });
+
+    expect(index.documents).toEqual([]);
+    expect(() =>
+      createPublishedAssetResourceFetch({
+        baseUrl: "https://site.example",
+        deploymentId: "missing-structured-asset",
+        artifact: index,
+        runtimeAssets: {},
+      })
+    ).toThrow("Published referenced asset URL is unavailable for hero");
+    const runtimeFetch = createPublishedAssetResourceFetch({
+      baseUrl: "https://site.example",
+      deploymentId: "materialized-structured-asset",
+      artifact: index,
+      runtimeAssets: {
+        hero: { url: "/cgi/image/hero.png?format=raw" },
+      },
+    });
+    const response = await runtimeFetch("/$resources/assets", {
+      method: "POST",
+      body: JSON.stringify({ query }),
+    });
+
+    await expect(response?.json()).resolves.toEqual({
+      items: [
+        {
+          id: "post-1",
+          properties: {
+            featureImage: "/cgi/image/hero.png?format=raw&width=1200#cover",
+          },
+        },
+      ],
+      totalCount: 1,
+      hasMore: false,
+    });
+  });
+
   test("reuses one initialized runtime across deployment origins", async () => {
     const { index } = await createRuntime();
     const createGeneratedFetch = createGeneratedAssetResourceRuntime({

--- a/packages/content-engine/src/published-runtime.ts
+++ b/packages/content-engine/src/published-runtime.ts
@@ -181,8 +181,11 @@ const validateRuntimeAssets = ({
   artifact: ContentRuntimeArtifact;
   runtimeAssets: Readonly<Record<string, AssetRuntimeData>>;
 }) => {
-  const missingReferencedAssetId = Object.values(artifact.assetReferences ?? {})
-    .flat()
+  const missingReferencedAssetId = [
+    artifact.assetReferences,
+    artifact.assetValueReferences,
+  ]
+    .flatMap((references) => Object.values(references ?? {}).flat())
     .map(({ assetId }) => assetId)
     .find((assetId) => runtimeAssets[assetId] === undefined);
   if (missingReferencedAssetId !== undefined) {

--- a/packages/content-engine/src/schema.ts
+++ b/packages/content-engine/src/schema.ts
@@ -192,6 +192,16 @@ export const contentArtifactV1 = strictObject({
       })
     )
   ).optional(),
+  assetValueReferences: record(
+    string().min(1),
+    array(
+      strictObject({
+        path: array(string().min(1).or(number().int().nonnegative())).min(1),
+        assetId: string().min(1),
+        suffix: string().min(1).optional(),
+      })
+    )
+  ).optional(),
   fieldCatalog: builderAssetFieldCatalog,
   queries: record(sha256Revision, materializedAssetQuery).optional(),
   database: strictObject({

--- a/packages/content-engine/src/structured-query.test.ts
+++ b/packages/content-engine/src/structured-query.test.ts
@@ -93,6 +93,77 @@ const runtimeAssets = Object.fromEntries(
 );
 
 describe("structured asset query", () => {
+  test("filters, sorts, and projects resolved structured asset values", async () => {
+    const result = await executeAssetQuery({
+      documents: [
+        document({
+          id: "alpha",
+          properties: { featureImage: "./alpha.png" },
+        }),
+        document({
+          id: "beta",
+          properties: { featureImage: "./beta.png" },
+        }),
+      ],
+      assetValueReferences: {
+        alpha: [
+          {
+            path: ["properties", "featureImage"],
+            assetId: "alpha-image",
+          },
+        ],
+        beta: [
+          {
+            path: ["properties", "featureImage"],
+            assetId: "beta-image",
+          },
+        ],
+      },
+      runtimeAssets: {
+        "alpha-image": { url: "/cgi/image/z-alpha.png?format=raw" },
+        "beta-image": { url: "/cgi/image/a-beta.png?format=raw" },
+      },
+      query: {
+        where: {
+          all: [
+            {
+              field: ["properties", "featureImage"],
+              operator: "startsWith",
+              value: "/cgi/image/",
+            },
+          ],
+        },
+        sort: [
+          {
+            field: ["properties", "featureImage"],
+            direction: "asc",
+          },
+        ],
+        output: {
+          mode: "fields",
+          includeMetadata: false,
+          fields: [["properties", "featureImage"]],
+        },
+        content: { mode: "none" },
+      },
+    });
+
+    expect(result.items).toEqual([
+      {
+        id: "beta",
+        properties: {
+          featureImage: "/cgi/image/a-beta.png?format=raw",
+        },
+      },
+      {
+        id: "alpha",
+        properties: {
+          featureImage: "/cgi/image/z-alpha.png?format=raw",
+        },
+      },
+    ]);
+  });
+
   test("accepts only referenced Markdown body queries", () => {
     expect(
       assetQuery.safeParse({ content: { mode: "markdown-body-ref" } }).success

--- a/packages/content-engine/src/structured-query.ts
+++ b/packages/content-engine/src/structured-query.ts
@@ -34,6 +34,10 @@ import { appendAssetFieldPath } from "./canonical";
 import { selectAssetDocumentFields, selectAssetProperties } from "./projection";
 import { getUtf8ByteLength } from "./byte-stream";
 import type { MarkdownAssetReferences } from "./markdown-references";
+import {
+  resolveAssetValueReferences,
+  type AssetValueReferences,
+} from "./asset-value-references";
 
 export type AssetRuntimeData = {
   url: string;
@@ -425,6 +429,7 @@ export const executeAssetQuery = async ({
   read,
   runtimeAssets,
   assetReferences,
+  assetValueReferences,
 }: {
   query: AssetQueryInput;
   catalog?: BuilderAssetFieldCatalog;
@@ -432,6 +437,7 @@ export const executeAssetQuery = async ({
   read?: AssetResourceContentReader;
   runtimeAssets?: Readonly<Record<string, AssetRuntimeData>>;
   assetReferences?: MarkdownAssetReferences;
+  assetValueReferences?: AssetValueReferences;
 }): Promise<AssetQueryResult> => {
   const { query } = validateAssetQueryAgainstCatalog({ query: input, catalog });
   if (documents.length > contentEngineLimits.candidateDocuments) {
@@ -439,7 +445,17 @@ export const executeAssetQuery = async ({
       "Asset query document limit was exceeded"
     );
   }
-  const matched = documents.flatMap((document) => {
+  const assetUrls = Object.fromEntries(
+    Object.entries(runtimeAssets ?? {}).map(([id, asset]) => [id, asset.url])
+  );
+  const resolvedDocuments = documents.map((document) =>
+    resolveAssetValueReferences({
+      value: document,
+      references: assetValueReferences?.[document._id],
+      assetUrls,
+    })
+  );
+  const matched = resolvedDocuments.flatMap((document) => {
     const runtimeAsset = runtimeAssets?.[document._id];
     if (
       supportsAssetQueryContent({ document, content: query.content }) ===
@@ -480,15 +496,7 @@ export const executeAssetQuery = async ({
       options: contentOptions,
       read,
       assetReferences,
-      assetUrls:
-        assetReferences === undefined
-          ? undefined
-          : Object.fromEntries(
-              Object.entries(runtimeAssets ?? {}).map(([id, asset]) => [
-                id,
-                asset.url,
-              ])
-            ),
+      assetUrls: assetReferences === undefined ? undefined : assetUrls,
     });
     items = selectedDocuments.map((document, index) => {
       const content = hydrated.content[document._id];


### PR DESCRIPTION
## Summary

Resolve portable relative Asset paths stored in Markdown frontmatter and structured JSON properties to canonical runtime Asset URLs inside the content engine.

The authored source remains unchanged. Asset resource consumers now receive canonical URLs without Image, CSS, JSON-LD, or other binding-specific transformations.

## Root cause

Markdown body links already recorded relative Asset references for runtime rewriting, but structured values bypassed that pipeline. Browsers therefore resolved values such as `./assets/hero.png` against the page URL instead of the source document folder.

## Implementation

- Recursively discover unique structured Asset references using the existing canonical path resolver and the platform URL parser.
- Store optional `assetValueReferences` in content artifacts and runtime projections.
- Include referenced Assets in publication/runtime dependency collection and validation.
- Resolve values before filtering, sorting, and projection in normal and document-graph queries.
- Rewrite materialized query items at runtime without mutating canonical documents or compiled rows.
- Merge authored query parameters and fragments with canonical Asset URLs.
- Keep queries whose filter/sort semantics depend on runtime Asset URLs out of compile-time materialization.
- Add an explicit content-compilation cache generation so pre-feature artifacts are recompiled.

## Checklist

- [x] Add structured reference discovery for nested objects and arrays
- [x] Support Markdown frontmatter and JSON document properties
- [x] Preserve URL query strings and fragments
- [x] Thread references through build/runtime artifacts and publication dependencies
- [x] Resolve normal, materialized, and document-graph query results
- [x] Apply resolved values to filtering, sorting, and projection
- [x] Preserve compatibility with artifacts that omit the optional field
- [x] Add fail/pass regression coverage
- [x] Run package tests, typechecks, lint, and generated API checks
- [ ] Run fixture build once the remote development API accepts this local CLI version

## Verification

- `pnpm --filter @webstudio-is/content-engine test` — 269 passed
- `pnpm --filter @webstudio-is/content-engine typecheck` — passed
- `pnpm --filter @webstudio-is/asset-uploader test` — 184 passed
- `pnpm --filter @webstudio-is/asset-uploader typecheck` — passed
- `pnpm lint` — passed
- `pnpm check:generated-api` — passed; generated files clean
- Regression proof: neutralizing structured discovery/replacement caused 8 expected failures across source compilation, standard queries, document-graph queries, and materialized queries; restoring the implementation passed all tests.
- `pnpm fixtures` — blocked during fixture sync because the remote development API reports this local CLI version as incompatible; no tracked fixture changes were produced.
- `pnpm evaluations` — not run because explicit approval is required.

## Compatibility

The artifact field is optional, so older artifacts continue to parse and execute. Existing absolute, protocol-relative, root-relative, fragment-only, query-only, external-scheme, malformed, missing, and ambiguous values remain unchanged.