### PR TITLE
fix: Defer Builder resource loading by one frame

### DIFF
--- a/apps/builder/app/shared/resources.test.ts
+++ b/apps/builder/app/shared/resources.test.ts
@@ -16,6 +16,7 @@ const {
   queueInvalidatedResource,
   queueResources,
   reset,
+  scheduleLoading,
 } = __testing__;
 
 afterEach(() => {
@@ -44,7 +45,8 @@ test("removes obsolete queued requests but keeps cached results", () => {
   expect($hasPendingResources.get()).toBe(false);
 });
 
-test("dispatches resources synchronously", async () => {
+test("defers resource dispatch until the next animation frame", () => {
+  vi.useFakeTimers();
   const request: ResourceRequest = {
     name: "Immediate",
     method: "get",
@@ -52,14 +54,42 @@ test("dispatches resources synchronously", async () => {
     searchParams: [],
     headers: [],
   };
-  const error = vi.spyOn(console, "error").mockImplementation(() => {});
-
   preloadResources([request]);
-  expect(getLoaderState()).toEqual({ queueSize: 0, pendingSize: 1 });
-  await vi.waitFor(() => {
-    expect($hasPendingResources.get()).toBe(false);
-  });
-  error.mockRestore();
+  expect(getLoaderState()).toEqual({ queueSize: 1, pendingSize: 0 });
+});
+
+test("coalesces synchronous resource computations before dispatch", async () => {
+  vi.useFakeTimers();
+  const firstRequest: ResourceRequest = {
+    name: "First",
+    method: "get",
+    url: "https://example.com/first",
+    searchParams: [],
+    headers: [],
+  };
+  const finalRequest: ResourceRequest = {
+    name: "Final",
+    method: "get",
+    url: "https://example.com/final",
+    searchParams: [],
+    headers: [],
+  };
+
+  const fetch = vi.fn<typeof globalThis.fetch>(async () => Response.json([]));
+
+  queueResources([firstRequest]);
+  scheduleLoading(fetch);
+  queueResources([finalRequest]);
+
+  expect(getLoaderState()).toEqual({ queueSize: 1, pendingSize: 0 });
+  expect(fetch).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(16);
+
+  expect(fetch).toHaveBeenCalledOnce();
+  expect(JSON.parse(String(fetch.mock.calls[0][1]?.body))).toEqual([
+    finalRequest,
+  ]);
 });
 
 test("batches all resources from one computation", async () => {

--- a/apps/builder/app/shared/resources.ts
+++ b/apps/builder/app/shared/resources.ts
@@ -101,6 +101,18 @@ const startLoading = (requestFetch: typeof fetch = fetch) => {
   void loadResources(requestFetch);
 };
 
+let loadingFrameId: number | undefined;
+
+const scheduleLoading = (requestFetch: typeof fetch = fetch) => {
+  if (pending.size > 0 || queue.size === 0 || loadingFrameId !== undefined) {
+    return;
+  }
+  loadingFrameId = window.requestAnimationFrame(() => {
+    loadingFrameId = undefined;
+    startLoading(requestFetch);
+  });
+};
+
 const preloadResource = (resource: ResourceRequest) => {
   const key = getResourceKey(resource);
   knownRequests.set(key, resource);
@@ -146,7 +158,7 @@ const queueResources = (resources: readonly ResourceRequest[]) => {
 
 export const preloadResources = (resources: readonly ResourceRequest[]) => {
   queueResources(resources);
-  startLoading();
+  scheduleLoading();
 };
 
 const queueInvalidatedResource = (resource: ResourceRequest) => {
@@ -161,7 +173,7 @@ const queueInvalidatedResource = (resource: ResourceRequest) => {
 
 export const invalidateResource = (resource: ResourceRequest) => {
   queueInvalidatedResource(resource);
-  startLoading();
+  scheduleLoading();
 };
 
 /**
@@ -233,7 +245,7 @@ export const invalidateAssets = () => {
   }
   updateCache();
   updatePending();
-  startLoading();
+  scheduleLoading();
 };
 
 export const computeResourceRequest = (
@@ -260,6 +272,10 @@ export const computeResourceRequest = (
 };
 
 const reset = () => {
+  if (loadingFrameId !== undefined) {
+    window.cancelAnimationFrame(loadingFrameId);
+    loadingFrameId = undefined;
+  }
   queue.clear();
   pending.clear();
   cache.clear();
@@ -282,4 +298,5 @@ export const __testing__ = {
   queueInvalidatedResource,
   queueResources,
   reset,
+  scheduleLoading,
 };


### PR DESCRIPTION
## Summary

- Defer initial Builder resource dispatch until the next animation frame.
- Coalesce synchronous resource computations so the canvas receives only the current resource set.
- Keep follow-up queue draining immediate after an in-flight batch completes.

## Root cause

PR #5980 removed the one-second resource debounce, then a later refactor also removed the remaining scheduling boundary. That allowed the first intermediate Nanostores computation to enter the pending batch synchronously. Subsequent computations were dispatched separately, which could render partial resource data before the final layout.

## Implementation checklist

- [x] Schedule initial loads and invalidations on one animation-frame boundary.
- [x] Deduplicate scheduled frames and cancel pending work during test reset.
- [x] Add regression coverage for deferred dispatch and synchronous computation coalescing.
- [x] Verify the new test fails against the previous synchronous implementation.
- [x] Review documentation impact; no product documentation changes are required.
- [x] Review fixture impact; no fixture inputs or generated outputs are affected.

## Verification

- `pnpm exec oxfmt --check apps/builder/app/shared/resources.ts apps/builder/app/shared/resources.test.ts`
- `pnpm lint`
- `pnpm check:package-boundaries`
- `pnpm --filter @webstudio-is/builder typecheck`
- `pnpm --filter @webstudio-is/builder test` — 211 files, 2,490 tests passed

Ref #5980