### PR TITLE
fix: Constrain the asset settings popover width

### DIFF
--- a/apps/builder/app/builder/shared/asset-manager/asset-settings.test.tsx
+++ b/apps/builder/app/builder/shared/asset-manager/asset-settings.test.tsx
@@ -97,26 +97,6 @@ test("uses an auto-growing textarea for the asset description", () => {
   ).toEqual(["Name", "Folder", "Description", "ID"]);
 });
 
-test("keeps the asset settings popover at a fixed width", () => {
-  renderer.render(
-    <TooltipProvider>
-      <AssetSettings
-        open
-        onOpenChange={vi.fn()}
-        asset={createImageAsset({ description: "A".repeat(1_000) })}
-      >
-        <button>Anchor</button>
-      </AssetSettings>
-    </TooltipProvider>
-  );
-
-  const popover = document.querySelector(
-    "[data-radix-popper-content-wrapper] > div"
-  );
-  expect(popover).not.toBeNull();
-  expect((popover as HTMLElement).style.width).toBe("250px");
-});
-
 test("closes asset settings before replacing an asset", () => {
   const onOpenChange = vi.fn();
   const onReplace = vi.fn();

--- a/apps/builder/app/builder/shared/asset-manager/asset-settings.test.tsx
+++ b/apps/builder/app/builder/shared/asset-manager/asset-settings.test.tsx
@@ -97,6 +97,26 @@ test("uses an auto-growing textarea for the asset description", () => {
   ).toEqual(["Name", "Folder", "Description", "ID"]);
 });
 
+test("keeps the asset settings popover at a fixed width", () => {
+  renderer.render(
+    <TooltipProvider>
+      <AssetSettings
+        open
+        onOpenChange={vi.fn()}
+        asset={createImageAsset({ description: "A".repeat(1_000) })}
+      >
+        <button>Anchor</button>
+      </AssetSettings>
+    </TooltipProvider>
+  );
+
+  const popover = document.querySelector(
+    "[data-radix-popper-content-wrapper] > div"
+  );
+  expect(popover).not.toBeNull();
+  expect((popover as HTMLElement).style.width).toBe("250px");
+});
+
 test("closes asset settings before replacing an asset", () => {
   const onOpenChange = vi.fn();
   const onReplace = vi.fn();

--- a/apps/builder/app/builder/shared/asset-manager/asset-settings.tsx
+++ b/apps/builder/app/builder/shared/asset-manager/asset-settings.tsx
@@ -668,7 +668,7 @@ export const AssetSettings = ({
         />
       )}
       <PopoverAnchor asChild>{children}</PopoverAnchor>
-      <PopoverContent style={{ width: 250 }}>
+      <PopoverContent css={{ width: 250 }}>
         <PopoverTitle>Asset settings</PopoverTitle>
         <AssetSettingsContent
           asset={asset}

--- a/apps/builder/app/builder/shared/asset-manager/asset-settings.tsx
+++ b/apps/builder/app/builder/shared/asset-manager/asset-settings.tsx
@@ -668,7 +668,7 @@ export const AssetSettings = ({
         />
       )}
       <PopoverAnchor asChild>{children}</PopoverAnchor>
-      <PopoverContent css={{ minWidth: 250 }}>
+      <PopoverContent style={{ width: 250 }}>
         <PopoverTitle>Asset settings</PopoverTitle>
         <AssetSettingsContent
           asset={asset}


### PR DESCRIPTION
## Summary

- Set the asset settings popover to a fixed 250px width using the existing `css` prop.

## Root cause

The popover used a minimum width while its shared content style allowed intrinsic `max-content` sizing. Long descriptions could therefore expand the popover beyond the intended layout.

## Impact

Asset settings now stay consistently sized, and long descriptions remain contained within the popover.

## Todo

- [x] Constrain the asset settings popover width.
- [x] Keep styling on the existing `css` prop.
- [x] Avoid a constant-only regression test, in line with the existing agent testing guidance.
- [x] Confirm fixture inputs and outputs are unaffected.
- [x] Review documentation impact; no user-facing documentation changes are needed.
- [x] Run targeted tests, formatting, linting, and Builder typecheck.

## Verification

- `pnpm --filter=@webstudio-is/builder test -- asset-settings.test.tsx`
- `pnpm exec oxfmt --check apps/builder/app/builder/shared/asset-manager/asset-settings.tsx`
- `pnpm exec oxlint --deny-warnings apps/builder/app/builder/shared/asset-manager/asset-settings.tsx`
- `pnpm --filter=@webstudio-is/builder typecheck`

Closes #6001