### PR TITLE
perf: Speed up Builder resource loading

### DIFF
--- a/apps/builder/app/shared/resources.test.ts
+++ b/apps/builder/app/shared/resources.test.ts
@@ -16,6 +16,7 @@ const {
   queueInvalidatedResource,
   queueResources,
   reset,
+  startLoading,
 } = __testing__;
 
 afterEach(() => {
@@ -164,6 +165,97 @@ test("replaces an invalidated in-flight request without caching stale data", asy
 
   expect(JSON.parse(String(requestFetch.mock.calls[1][1]?.body))).toEqual([
     request,
+  ]);
+});
+
+test("starts fresh page resources while a shared request is still pending", async () => {
+  const shared: ResourceRequest = {
+    name: "Shared navigation",
+    method: "get",
+    url: "https://example.com/shared-navigation",
+    searchParams: [],
+    headers: [],
+  };
+  const obsolete: ResourceRequest = {
+    name: "Obsolete page",
+    method: "get",
+    url: "https://example.com/obsolete-page",
+    searchParams: [],
+    headers: [],
+  };
+  const fresh: ResourceRequest = {
+    name: "Fresh page",
+    method: "get",
+    url: "https://example.com/fresh-page",
+    searchParams: [],
+    headers: [],
+  };
+  let resolveFirst: (response: Response) => void = () => {};
+  const firstResponse = new Promise<Response>((resolve) => {
+    resolveFirst = resolve;
+  });
+  const requestFetch = vi
+    .fn<typeof globalThis.fetch>()
+    .mockImplementationOnce(() => firstResponse)
+    .mockResolvedValueOnce(Response.json([]));
+
+  queueResources([shared, obsolete]);
+  const firstLoad = loadResources(requestFetch as typeof globalThis.fetch);
+  queueResources([shared, fresh]);
+  startLoading(requestFetch as typeof globalThis.fetch);
+
+  await vi.waitFor(() => {
+    expect(requestFetch).toHaveBeenCalledTimes(2);
+  });
+  expect(JSON.parse(String(requestFetch.mock.calls[1][1]?.body))).toEqual([
+    fresh,
+  ]);
+  expect(requestFetch.mock.calls[0][1]?.signal?.aborted).toBe(false);
+
+  resolveFirst(Response.json([]));
+  await firstLoad;
+});
+
+test("cancels a batch when all of its resources become obsolete", async () => {
+  const obsolete: ResourceRequest = {
+    name: "Obsolete page",
+    method: "get",
+    url: "https://example.com/obsolete-page",
+    searchParams: [],
+    headers: [],
+  };
+  const fresh: ResourceRequest = {
+    name: "Fresh page",
+    method: "get",
+    url: "https://example.com/fresh-page",
+    searchParams: [],
+    headers: [],
+  };
+  const requestFetch = vi
+    .fn<typeof globalThis.fetch>()
+    .mockImplementationOnce((_input, init) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("Aborted", "AbortError")),
+          { once: true }
+        );
+      });
+    })
+    .mockResolvedValueOnce(Response.json([]));
+
+  queueResources([obsolete]);
+  const obsoleteLoad = loadResources(requestFetch as typeof globalThis.fetch);
+  queueResources([fresh]);
+  startLoading(requestFetch as typeof globalThis.fetch);
+
+  await obsoleteLoad;
+  await vi.waitFor(() => {
+    expect(requestFetch).toHaveBeenCalledTimes(2);
+  });
+  expect(requestFetch.mock.calls[0][1]?.signal?.aborted).toBe(true);
+  expect(JSON.parse(String(requestFetch.mock.calls[1][1]?.body))).toEqual([
+    fresh,
   ]);
 });
 

--- a/apps/builder/app/shared/resources.ts
+++ b/apps/builder/app/shared/resources.ts
@@ -19,6 +19,10 @@ const diagnosticsCache = new Map<string, AssetQueryPreviewDiagnostics>();
 const pendingDiagnostics = new Map<string, Promise<void>>();
 const knownRequests = new Map<string, ResourceRequest>();
 const resourceVersions = new Map<string, number>();
+const inFlightBatches = new Set<{
+  controller: AbortController;
+  versions: Map<string, number>;
+}>();
 
 export const $resourcesCache = atom(cache);
 export const $resourceDiagnosticsCache = atom(diagnosticsCache);
@@ -40,7 +44,14 @@ export const $hasPendingResources = computed(
 );
 
 const loadResources = async (requestFetch: typeof fetch = fetch) => {
-  const list = Array.from(queue.values()).slice(0, MAX_PENDING_RESOURCES);
+  const availableSlots = MAX_PENDING_RESOURCES - pending.size;
+  if (availableSlots <= 0) {
+    return;
+  }
+  const list = Array.from(queue.values()).slice(0, availableSlots);
+  if (list.length === 0) {
+    return;
+  }
   const dispatched = new Map<string, ResourceRequest>();
   const dispatchedVersions = new Map<string, number>();
   for (const resource of list) {
@@ -50,12 +61,16 @@ const loadResources = async (requestFetch: typeof fetch = fetch) => {
     dispatched.set(key, resource);
     dispatchedVersions.set(key, resourceVersions.get(key) ?? 0);
   }
+  const controller = new AbortController();
+  const batch = { controller, versions: dispatchedVersions };
+  inFlightBatches.add(batch);
   updatePending();
 
   try {
     const response = await requestFetch(restResourcesLoader(), {
       method: "POST",
       body: JSON.stringify(list),
+      signal: controller.signal,
     });
     if (response.ok === false) {
       return;
@@ -79,8 +94,11 @@ const loadResources = async (requestFetch: typeof fetch = fetch) => {
       }
     }
   } catch {
-    console.error("Resource batch request failed");
+    if (controller.signal.aborted === false) {
+      console.error("Resource batch request failed");
+    }
   } finally {
+    inFlightBatches.delete(batch);
     for (const [key, request] of dispatched) {
       if (pending.get(key) === request) {
         pending.delete(key);
@@ -95,10 +113,23 @@ const loadResources = async (requestFetch: typeof fetch = fetch) => {
 };
 
 const startLoading = (requestFetch: typeof fetch = fetch) => {
-  if (pending.size > 0 || queue.size === 0) {
+  if (pending.size >= MAX_PENDING_RESOURCES || queue.size === 0) {
     return;
   }
   void loadResources(requestFetch);
+};
+
+const abortObsoleteBatches = () => {
+  for (const batch of inFlightBatches) {
+    const obsolete = Array.from(batch.versions).every(
+      ([key, version]) =>
+        knownRequests.has(key) === false ||
+        resourceVersions.get(key) !== version
+    );
+    if (obsolete) {
+      batch.controller.abort();
+    }
+  }
 };
 
 const preloadResource = (resource: ResourceRequest) => {
@@ -131,8 +162,10 @@ const queueResources = (resources: readonly ResourceRequest[]) => {
       invalidateRequestState(key);
       diagnosticsChanged = true;
       pendingChanged = queue.delete(key) || pendingChanged;
+      pendingChanged = pending.delete(key) || pendingChanged;
     }
   }
+  abortObsoleteBatches();
   if (diagnosticsChanged) {
     updateCache();
   }
@@ -153,8 +186,10 @@ const queueInvalidatedResource = (resource: ResourceRequest) => {
   const key = getResourceKey(resource);
   cache.delete(key);
   invalidateRequestState(key);
+  pending.delete(key);
   knownRequests.set(key, resource);
   queue.set(key, resource);
+  abortObsoleteBatches();
   updateCache();
   updatePending();
 };
@@ -260,6 +295,10 @@ export const computeResourceRequest = (
 };
 
 const reset = () => {
+  for (const batch of inFlightBatches) {
+    batch.controller.abort();
+  }
+  inFlightBatches.clear();
   queue.clear();
   pending.clear();
   cache.clear();
@@ -282,4 +321,5 @@ export const __testing__ = {
   queueInvalidatedResource,
   queueResources,
   reset,
+  startLoading,
 };

--- a/packages/project-build/src/db/build.test.ts
+++ b/packages/project-build/src/db/build.test.ts
@@ -12,6 +12,7 @@ import {
   loadRawBuildById,
   loadBuildById,
   loadDevBuildByProjectId,
+  loadDevBuildContentCompilationDataByProjectId,
   createBuild,
   createProductionBuild,
   unpublishBuild,
@@ -220,6 +221,88 @@ describe("loadDevBuildByProjectId (msw)", () => {
     await expect(
       loadDevBuildByProjectId(createContext(), "proj-1")
     ).rejects.toThrow("No dev build found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadDevBuildContentCompilationDataByProjectId
+// ---------------------------------------------------------------------------
+
+describe("loadDevBuildContentCompilationDataByProjectId (msw)", () => {
+  test("selects only the Build fields used for content compilation", async () => {
+    let requestedUrl: URL | undefined;
+    server.use(
+      db.get("Build", ({ request }) => {
+        requestedUrl = new URL(request.url);
+        return json([
+          {
+            props: JSON.stringify([]),
+            dataSources: JSON.stringify([]),
+            resources: JSON.stringify([]),
+          },
+        ]);
+      })
+    );
+
+    const result = await loadDevBuildContentCompilationDataByProjectId(
+      createContext(),
+      "proj-1"
+    );
+
+    expect(requestedUrl?.searchParams.get("select")).toBe(
+      "props,dataSources,resources"
+    );
+    expect(requestedUrl?.searchParams.get("projectId")).toBe("eq.proj-1");
+    expect(requestedUrl?.searchParams.get("deployment")).toBe("is.null");
+    expect(result).toEqual({ props: [], dataSources: [], resources: [] });
+  });
+
+  test("parses the selected fields identically to the full dev Build loader", async () => {
+    const row = {
+      ...buildRow,
+      props: JSON.stringify([
+        {
+          id: "title-prop",
+          instanceId: "body-1",
+          name: "title",
+          type: "string",
+          value: "Blog",
+        },
+      ]),
+      dataSources: JSON.stringify([
+        {
+          type: "resource",
+          id: "posts-data-source",
+          name: "posts",
+          resourceId: "assets",
+        },
+      ]),
+      resources: JSON.stringify([
+        {
+          id: "assets",
+          name: "Assets",
+          control: "system",
+          method: "get",
+          url: '"/$resources/assets"',
+          searchParams: [],
+          headers: [],
+        },
+      ]),
+    };
+    server.use(db.get("Build", () => json([row])));
+
+    const contentCompilationData =
+      await loadDevBuildContentCompilationDataByProjectId(
+        createContext(),
+        "proj-1"
+      );
+    const fullBuild = await loadDevBuildByProjectId(createContext(), "proj-1");
+
+    expect(contentCompilationData).toEqual({
+      props: fullBuild.props,
+      dataSources: fullBuild.dataSources,
+      resources: fullBuild.resources,
+    });
   });
 });
 

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -72,12 +72,31 @@ const parseMarketplaceProduct = (serialized: string | null | undefined) => {
   return marketplaceProduct.parse(value);
 };
 
+type ContentCompilationBuildRow = Pick<
+  Database["public"]["Tables"]["Build"]["Row"],
+  "props" | "dataSources" | "resources"
+>;
+
+const parseCompactContentCompilationData = (
+  build: ContentCompilationBuildRow
+) => {
+  const resources = parseCompactData<Resource>(build.resources);
+  migrateResourcesMutable(resources);
+
+  return {
+    props: parseCompactData<Prop>(build.props),
+    dataSources: parseCompactData<unknown>(build.dataSources).map((value) =>
+      dataSource.parse(value)
+    ),
+    resources,
+  } satisfies Pick<CompactBuild, "props" | "dataSources" | "resources">;
+};
+
 const parseCompactBuild = async (
   build: Database["public"]["Tables"]["Build"]["Row"]
 ) => {
   const pages = migratePages(parseConfig<unknown>(build.pages));
-  const resources = parseCompactData<Resource>(build.resources);
-  migrateResourcesMutable(resources);
+  const contentCompilationData = parseCompactContentCompilationData(build);
   const parsedProjectSettings =
     build.projectSettings === undefined || build.projectSettings === null
       ? createProjectSettingsFromPages(pages)
@@ -96,11 +115,7 @@ const parseCompactBuild = async (
     styleSourceSelections: parseCompactData<StyleSourceSelection>(
       build.styleSourceSelections
     ),
-    props: parseCompactData<Prop>(build.props),
-    dataSources: parseCompactData<unknown>(build.dataSources).map((value) =>
-      dataSource.parse(value)
-    ),
-    resources,
+    ...contentCompilationData,
     instances: parseCompactInstanceData(build.instances),
     deployment: parseDeployment(build.deployment),
     marketplaceProduct: parseMarketplaceProduct(build.marketplaceProduct),
@@ -178,6 +193,29 @@ export const loadDevBuildByProjectId = async (
   }
 
   return parseCompactBuild(build.data[0]);
+};
+
+export const loadDevBuildContentCompilationDataByProjectId = async (
+  context: AppContext,
+  projectId: Build["projectId"]
+) => {
+  const build = await context.postgrest.client
+    .from("Build")
+    .select("props,dataSources,resources")
+    .eq("projectId", projectId)
+    .is("deployment", null)
+    .order("createdAt", { ascending: false })
+    .limit(1);
+
+  if (build.error) {
+    throw build.error;
+  }
+
+  if (build.data.length === 0) {
+    throw new Error("No dev build found");
+  }
+
+  return parseCompactContentCompilationData(build.data[0]);
 };
 
 export const loadApprovedProdBuildByProjectId = async (


### PR DESCRIPTION
## Summary

Reduce initial Builder latency for Assets-backed pages while improving the generic remote-resource loading path.

The production Blog copy currently issues four Assets queries as two dependent batches and takes 6–7 seconds in production. A local copy with 352 assets reproduces the architecture and reaches the data-bound canvas in roughly 4.1–4.4 seconds on warmed Vite runs.

## Technical approach

- Keep SDK `loadResource` as the common serialization/result boundary for Assets, system resources, and arbitrary remote resources.
- Let current-page resources use available loader capacity instead of waiting for obsolete navigation work; cancel an outer batch only when every dispatched request is obsolete.
- Propagate outer request cancellation through the server loader to inner requests.
- Create one lazy, request-scoped Assets executor per resource batch.
- Authorize and prepare the project Assets preview once, then execute each Assets query independently with unchanged response and error semantics.
- Load only `props`, `dataSources`, and `resources` when building the Assets content compilation plan.
- Reuse one request-scoped canonical snapshot, compiled database artifact, runtime asset load, and revision-keyed document reads.
- Preserve the build-wide compilation plan so Builder preview and published content-database omission behavior remain aligned.
- Do not add implicit cross-request caching for arbitrary remote resources; their auth, session, methods, and cache policy are not safely interchangeable.

## Ordered todo

- [x] Create and link the implementation issue.
- [x] Copy the production Blog into an isolated local project with all 352 assets.
- [x] Record the pre-change Blog timing and four-query batch shape.
- [x] Unblock current resources during navigation and cancel fully obsolete batches.
- [x] Add a partial Build loader for Assets compilation inputs.
- [ ] Add one lazy Assets executor/session per resource batch.
- [ ] Reuse authorization, snapshot preparation, compilation, runtime rows, and document reads within that session.
- [ ] Preserve direct one-shot Assets query behavior and per-item failure isolation.
- [ ] Add and prove regression tests fail without each behavior and pass with it.
- [ ] Benchmark the built Remix server before and after, including process-cold and warm samples.
- [ ] Review fixture impact and run affected fixture generation when required.
- [ ] Review authoritative `docs/` content and record whether documentation changes are needed.
- [ ] Run formatting, package tests, typechecks, lint, package-boundary checks, and broader Builder verification.
- [ ] Update this description with final benchmark data, verification, tradeoffs, and any follow-ups.

## Verification so far

- `pnpm --filter @webstudio-is/builder test -- app/shared/resources.test.ts` — 15 passed
- `pnpm --filter @webstudio-is/project-build test -- src/db/build.test.ts` — 22 passed
- Full Project Build suite — 2,068 passed
- Project Build typecheck — passed

The partial Build loader tests were demonstrated to fail before the implementation and pass afterward. Final verification remains pending while this PR is a draft.

## Known limitations / follow-ups

- Local filesystem storage is faster than production object storage, so absolute local timings are not production-equivalent; before/after ratios and duplicated preparation counts are the primary evidence.
- Streaming independent results from the JSON batch endpoint is intentionally out of scope unless the request-scoped work still leaves material head-of-line latency.

Closes #6004