### PR TITLE
fix: Preserve optional MCP input types

### DIFF
--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -7482,7 +7482,22 @@ describe("project session mcp adapter", () => {
           listedTools.tools.find(({ name }) => name === "list-pages")
             ?.inputSchema
         ).includeFolders
-      ).toEqual({});
+      ).toEqual({ type: "boolean" });
+      expect(
+        getSchemaProperties(
+          listedTools.tools.find(({ name }) => name === "audit")?.inputSchema
+        )
+      ).toMatchObject({
+        cursor: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 200 },
+        verbose: { type: "boolean" },
+      });
+      expect(
+        getSchemaProperties(
+          listedTools.tools.find(({ name }) => name === "list-instances")
+            ?.inputSchema
+        ).maxDepth
+      ).toMatchObject({ type: "integer", minimum: 0 });
       expect(
         getSchemaProperties(
           listedTools.tools.find(({ name }) => name === "publish")?.inputSchema

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -6307,15 +6307,7 @@ const getSdkInputSchema = (
       required.has(name) ||
       includeOptionalProperties ||
       sdkDetailedOptionalSchemaProperties.has(name)
-        ? [
-            [
-              name,
-              required.has(name) ||
-              sdkDetailedOptionalSchemaProperties.has(name)
-                ? getSdkSchemaProperty(value)
-                : {},
-            ],
-          ]
+        ? [[name, getSdkSchemaProperty(value)]]
         : []
     )
   );


### PR DESCRIPTION
Closes #6009

## Summary

Preserve machine-readable scalar constraints for every optional MCP input property advertised through `tools/list`.

MCP clients now receive the declared string, integer, and boolean types, along with bounds, enums, defaults, and related scalar constraints, instead of empty property schemas.

## Root cause

The compact SDK handshake intentionally retained full scalar schemas for required fields and destructive-safety controls, but replaced ordinary optional property schemas with `{}`. Clients therefore lacked the type information needed to serialize values such as `limit`, `verbose`, and `maxDepth` correctly.

## Implementation

- Reuse the existing compact scalar-schema projection for every advertised optional property.
- Keep descriptions and large structured contracts out of the initial handshake.
- Preserve the existing focused-discovery behavior for complete schemas.
- Add protocol-level regression coverage through the official MCP SDK for string, integer, and boolean optional inputs.

## Todo

- [x] Preserve optional MCP property types and scalar constraints.
- [x] Add regression coverage for representative string, integer, and boolean inputs.
- [x] Demonstrate the regression test fails before the fix and passes afterward.
- [x] Run project-build and CLI MCP/schema tests.
- [x] Run relevant typechecks, lint, formatting, and package-boundary validation.
- [x] Review fixture impact; no fixture inputs or generated fixture bundles are affected.
- [x] Review documentation impact; existing documentation describes the intended typed schema behavior, so no documentation update is required.
- [ ] Run agent evaluations after separate explicit approval.

## Verification

- `@webstudio-is/project-build`: 2,077 tests passed.
- CLI MCP/schema tests: 51 passed.
- Project-build and CLI typechecks passed.
- Repository lint passed.
- Changed-file formatting passed.
- Package-boundary validation passed.
- `git diff --check` passed.
- The protocol regression assertion failed against the previous implementation and passed after the fix.

Agent evaluations were not run because repository policy requires separate explicit approval.