### PR TITLE
fix: Retry published CLI registry lookup

### DIFF
--- a/packages/cli/scripts/release-smoke-registry.test.ts
+++ b/packages/cli/scripts/release-smoke-registry.test.ts
@@ -1,0 +1,51 @@
+import { expect, test, vi } from "vitest";
+import { resolveRegistryTarget } from "./release-smoke-registry";
+
+test("retries while an exact npm version is still propagating", async () => {
+  let versionAttempts = 0;
+  const readNpmJson = vi.fn(async (args: string[]) => {
+    if (args.includes("version")) {
+      versionAttempts += 1;
+      if (versionAttempts === 1) {
+        throw new Error("npm returned 404");
+      }
+      return "0.286.0";
+    }
+    return "sha512-integrity";
+  });
+  const delay = vi.fn(async () => {});
+
+  await expect(
+    resolveRegistryTarget("webstudio@0.286.0", {
+      attempts: 3,
+      delay,
+      readNpmJson,
+    })
+  ).resolves.toEqual({
+    source: "registry",
+    version: "0.286.0",
+    installSpec: "webstudio@0.286.0",
+    integrity: "sha512-integrity",
+  });
+  expect(delay).toHaveBeenCalledOnce();
+  expect(readNpmJson).toHaveBeenCalledTimes(3);
+});
+
+test("reports the final registry error after retries are exhausted", async () => {
+  const readNpmJson = vi.fn(async () => {
+    throw new Error("npm returned 404");
+  });
+  const delay = vi.fn(async () => {});
+
+  await expect(
+    resolveRegistryTarget("webstudio@0.286.0", {
+      attempts: 2,
+      delay,
+      readNpmJson,
+    })
+  ).rejects.toThrow(
+    "Could not resolve registry package webstudio@0.286.0 after 2 attempts: npm returned 404"
+  );
+  expect(delay).toHaveBeenCalledOnce();
+  expect(readNpmJson).toHaveBeenCalledTimes(2);
+});

--- a/packages/cli/scripts/release-smoke-registry.ts
+++ b/packages/cli/scripts/release-smoke-registry.ts
@@ -1,0 +1,62 @@
+export type ReleaseTarget = {
+  source: "local" | "registry";
+  version: string;
+  installSpec: string;
+  integrity?: string;
+};
+
+type ResolveRegistryTargetOptions = {
+  readNpmJson: (args: string[]) => Promise<unknown>;
+  attempts?: number;
+  delay?: () => Promise<void>;
+};
+
+const defaultDelay = () =>
+  new Promise<void>((resolve) => setTimeout(resolve, 10_000));
+
+export const resolveRegistryTarget = async (
+  spec: string,
+  {
+    readNpmJson,
+    attempts = 30,
+    delay = defaultDelay,
+  }: ResolveRegistryTargetOptions
+): Promise<ReleaseTarget> => {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const version = await readNpmJson(["view", spec, "version", "--json"]);
+      const integrity = await readNpmJson([
+        "view",
+        spec,
+        "dist.integrity",
+        "--json",
+      ]);
+      if (typeof version !== "string" || version.length === 0) {
+        throw new Error(`Could not resolve registry package ${spec}.`);
+      }
+      if (typeof integrity !== "string" || integrity.length === 0) {
+        throw new Error(
+          `Registry package webstudio@${version} has no integrity.`
+        );
+      }
+      return {
+        source: "registry",
+        version,
+        installSpec: `webstudio@${version}`,
+        integrity,
+      };
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        await delay();
+      }
+    }
+  }
+  const message =
+    lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `Could not resolve registry package ${spec} after ${attempts} attempts: ${message}`,
+    { cause: lastError }
+  );
+};

--- a/packages/cli/scripts/release-smoke.ts
+++ b/packages/cli/scripts/release-smoke.ts
@@ -42,6 +42,10 @@ import {
   startRuntimeFixtureApi,
 } from "./runtime-fixture-api";
 import { runAgentCommand } from "./run-agent-command";
+import {
+  resolveRegistryTarget,
+  type ReleaseTarget,
+} from "./release-smoke-registry";
 import { isPlainRecord } from "../src/type-utils";
 
 const execFileAsync = promisify(execFile);
@@ -76,37 +80,8 @@ const reporter = createReleaseSmokeReporter({
 });
 const reportPhase = reporter.complete;
 
-type ReleaseTarget = {
-  source: "local" | "registry";
-  version: string;
-  installSpec: string;
-  integrity?: string;
-};
-
 const readNpmJson = async (args: string[]) =>
   JSON.parse((await execFileAsync("npm", args)).stdout) as unknown;
-
-const resolveRegistryTarget = async (spec: string): Promise<ReleaseTarget> => {
-  const version = await readNpmJson(["view", spec, "version", "--json"]);
-  const integrity = await readNpmJson([
-    "view",
-    spec,
-    "dist.integrity",
-    "--json",
-  ]);
-  if (typeof version !== "string" || version.length === 0) {
-    throw new Error(`Could not resolve registry package ${spec}.`);
-  }
-  if (typeof integrity !== "string" || integrity.length === 0) {
-    throw new Error(`Registry package webstudio@${version} has no integrity.`);
-  }
-  return {
-    source: "registry",
-    version,
-    installSpec: `webstudio@${version}`,
-    integrity,
-  };
-};
 
 const installReleaseTarget = async ({
   directory,
@@ -1246,7 +1221,8 @@ const run = async () => {
     if (requestedCandidate === "local") {
       const releaseVersion =
         process.env.WEBSTUDIO_RELEASE_SMOKE_VERSION ??
-        (await resolveRegistryTarget("webstudio@latest")).version;
+        (await resolveRegistryTarget("webstudio@latest", { readNpmJson }))
+          .version;
       const packStartedAt = Date.now();
       await packReleaseShapedCli({
         stagingDirectory,
@@ -1266,10 +1242,13 @@ const run = async () => {
         installSpec: join(packDirectory, tarballName),
       };
     } else {
-      candidate = await resolveRegistryTarget(requestedCandidate);
+      candidate = await resolveRegistryTarget(requestedCandidate, {
+        readNpmJson,
+      });
     }
     const baseline = await resolveRegistryTarget(
-      process.env.WEBSTUDIO_RELEASE_SMOKE_BASELINE ?? "webstudio@latest"
+      process.env.WEBSTUDIO_RELEASE_SMOKE_BASELINE ?? "webstudio@latest",
+      { readNpmJson }
     );
     reporter.setSubjects({
       candidate: { source: candidate.source, version: candidate.version },


### PR DESCRIPTION
## What changed

- Retry npm version and integrity resolution inside the CLI registry smoke test.
- Keep retry timing injectable so the propagation race is covered by a fast unit test.
- Preserve the final npm error when all registry attempts are exhausted.

## Why

CLI 0.286.0 was published successfully, but npm briefly exposed integrity metadata while the exact version lookup still returned 404. The post-publish smoke failed and the dependent docs publication job was skipped.

The 0.286.0 documentation snapshot has been recovered directly on the `docs` branch.

Ref #6007

## Verification

- [x] Regression test demonstrated failing before the implementation and passing afterward
- [x] CLI registry/versioning tests: 3 passed
- [x] CLI typecheck
- [x] Formatting and diff checks
- [x] Documentation impact reviewed: no product-doc source change is needed in this PR; the missed 0.286.0 snapshot was published separately to `docs`
