### PR TITLE
fix: Include runtime metadata in CLI issue reports

### DIFF
--- a/packages/cli/src/project-session.test.ts
+++ b/packages/cli/src/project-session.test.ts
@@ -731,4 +731,78 @@ describe("cli project session transport", () => {
     expect(requestText).toContain("project-1");
     expect(requestText).not.toContain("other-project");
   });
+
+  test("adds anonymous runtime metadata to issue report requests", async () => {
+    let requestBody = "";
+    const fetch = vi.fn(
+      async (request: URL | RequestInfo, init?: RequestInit) => {
+        if (request instanceof Request) {
+          requestBody = await request.clone().text();
+        } else if (typeof init?.body === "string") {
+          requestBody = init.body;
+        }
+        return new Response(
+          JSON.stringify([
+            {
+              result: {
+                data: {
+                  status: "created",
+                  issueNumber: 1,
+                  issueUrl: "https://example.com/issues/1",
+                },
+              },
+            },
+          ]),
+          { headers: { "content-type": "application/json" } }
+        );
+      }
+    );
+    vi.stubGlobal("fetch", fetch);
+    const transport = createCliProjectSessionTransport({
+      connection: {
+        projectId: "project-1",
+        origin: "https://example.com",
+        authToken: "token",
+      },
+    });
+
+    await transport.executeServerOperation?.({
+      operationId: "reports.issue",
+      input: {
+        trigger: "user-requested",
+        category: "tool-failure",
+        deduplicationKey: "report-runtime",
+        title: "fix: Include report runtime",
+        agent: {
+          client: "Codex",
+          model: "test-model",
+          reasoningEffort: "medium",
+        },
+        report: {
+          userStory: "Use issue reporting.",
+          summary: "Runtime metadata was omitted.",
+          attemptedWorkflow: ["Submit an issue report."],
+          expectedBehavior: "The report includes runtime metadata.",
+          actualResult: "The report omitted runtime metadata.",
+          recoveryAttempts: ["Inspect the created issue."],
+          userImpact: "The report is harder to diagnose.",
+          technicalContext: "The CLI transport submitted the report.",
+          acceptanceCriteria: ["The report includes runtime metadata."],
+        },
+      },
+    });
+
+    const body = JSON.parse(requestBody) as {
+      0: { runtime?: Record<string, unknown> };
+    };
+    expect(body[0].runtime).toEqual({
+      cliVersion: expect.any(String),
+      nodeVersion: process.versions.node,
+      os: process.platform,
+      osVersion: expect.any(String),
+      architecture: process.arch,
+      executionMode: "mcp",
+      apiContractVersion: expect.any(String),
+    });
+  });
 });

--- a/packages/cli/src/project-session.ts
+++ b/packages/cli/src/project-session.ts
@@ -16,6 +16,7 @@ import {
   publicApiOperationRequiresServerSupport,
   publicApiOperations,
   type IssueReportRuntime,
+  type PublicApiCommand,
   type PublishedProjectBundle,
 } from "@webstudio-is/protocol";
 import packageJson from "../package.json";
@@ -238,11 +239,11 @@ const getIssueReportRuntime = (): IssueReportRuntime => ({
 });
 
 export const addIssueReportRuntime = (
-  operationId: string,
+  command: PublicApiCommand,
   input: unknown,
   runtime: IssueReportRuntime = getIssueReportRuntime()
 ) => {
-  if (operationId !== "report-issue" || isPlainRecord(input) === false) {
+  if (command !== "report-issue" || isPlainRecord(input) === false) {
     return input;
   }
   return { ...input, runtime };
@@ -271,7 +272,10 @@ const executePublicServerOperation = async ({
   }
   return await client({
     ...connection,
-    ...(addIssueReportRuntime(operationId, input) as Record<string, unknown>),
+    ...(addIssueReportRuntime(operation.command, input) as Record<
+      string,
+      unknown
+    >),
     projectId: connection.projectId,
   });
 };


### PR DESCRIPTION
## Summary

Automatically attach anonymous CLI runtime metadata when the resolved public API command is `report-issue`. The transport previously compared the route operation ID (`reports.issue`) with the command name (`report-issue`), so enrichment was skipped.

The change keeps enrichment owned by the CLI transport and preserves the existing server contract for Builder UI and other clients.

## Technical choices

- Resolve the public operation by route ID as before.
- Pass its typed command to runtime enrichment, removing ambiguity between route IDs and commands.
- Exercise the real `reports.issue` transport path and inspect the serialized request body.
- Keep runtime fields limited to CLI version, Node.js version, OS family/version, architecture, execution mode, and API contract version.

## Todo

- [x] Attach runtime metadata using the resolved report command.
- [x] Add transport-level regression coverage for the outgoing request.
- [x] Confirm non-report operations preserve existing behavior.
- [x] Review documentation impact; no documentation changes are required because the public report schema and workflow are unchanged.
- [x] Confirm fixture inputs and generated fixture outputs are unaffected.
- [ ] Run `pnpm evaluations` after explicit approval for agent evaluations.

## Verification

- Regression test demonstrated failure before the implementation and passed afterward.
- `pnpm --filter webstudio test -- project-session.test.ts` — 20 passed.
- `pnpm --filter webstudio test` — 943 passed.
- `pnpm --filter webstudio typecheck` — passed.
- `pnpm exec oxlint --deny-warnings packages/cli/src/project-session.ts packages/cli/src/project-session.test.ts` — passed.
- `git diff --check` — passed.

## Known limitations

The complete agent evaluation suite has not been run because repository policy requires separate explicit approval before invoking it.

Closes #6025