### PR TITLE
fix: Make bound fields read-only

### DIFF
--- a/apps/builder/app/builder/features/pages/custom-metadata.tsx
+++ b/apps/builder/app/builder/features/pages/custom-metadata.tsx
@@ -76,7 +76,6 @@ const MetadataItem = (props: {
         expression={props.content}
         value={String(content ?? "")}
         bound={isLiteralExpression(props.content) === false}
-        allowBindingOverwrite={false}
         showBinding={props.showBindingControls}
         scope={scope}
         aliases={aliases}

--- a/apps/builder/app/builder/features/pages/page-settings/section-general.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings/section-general.tsx
@@ -155,11 +155,9 @@ const StatusField = ({
         expression={value ?? ""}
         value={String(computeExpression(value, variableValues) ?? "")}
         bound={value !== undefined && isLiteralExpression(value) === false}
-        allowBindingOverwrite={false}
         showBinding={showBindingControls}
         scope={scope}
         aliases={aliases}
-        parseValue={parseStatus}
         onChangeValue={(value) => {
           const status = parseStatus(value);
           if (status === undefined) {
@@ -251,7 +249,6 @@ const RedirectField = ({
         expression={value ?? ""}
         value={computePageSettingsText(value, variableValues)}
         bound={value !== undefined && isLiteralExpression(value) === false}
-        allowBindingOverwrite={false}
         showBinding={showBindingControls}
         scope={scope}
         aliases={aliases}

--- a/apps/builder/app/builder/features/pages/page-settings/section-search.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings/section-search.tsx
@@ -45,7 +45,6 @@ const LanguageField = ({
         expression={value}
         value={computePageSettingsText(value, variableValues)}
         bound={isLiteralExpression(value) === false}
-        allowBindingOverwrite={false}
         showBinding={showBindingControls}
         scope={scope}
         aliases={aliases}
@@ -147,7 +146,6 @@ export const SearchSection = ({
           expression={values.title}
           value={title}
           bound={isLiteralExpression(values.title) === false}
-          allowBindingOverwrite={false}
           showBinding={showBindingControls}
           scope={scope}
           aliases={aliases}
@@ -180,7 +178,6 @@ export const SearchSection = ({
           expression={values.description}
           value={description}
           bound={isLiteralExpression(values.description) === false}
-          allowBindingOverwrite={false}
           showBinding={showBindingControls}
           scope={scope}
           aliases={aliases}
@@ -215,7 +212,6 @@ export const SearchSection = ({
           expression={values.excludePageFromSearch}
           value={excludePageFromSearch}
           bound={isLiteralExpression(values.excludePageFromSearch) === false}
-          allowBindingOverwrite={false}
           showBinding={showBindingControls}
           scope={scope}
           aliases={aliases}

--- a/apps/builder/app/builder/features/pages/page-settings/section-social-image.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings/section-social-image.tsx
@@ -59,7 +59,6 @@ export const SocialImageSection = ({
         expression={values.socialImageUrl}
         value={socialImageUrl}
         bound={isLiteralExpression(values.socialImageUrl) === false}
-        allowBindingOverwrite={false}
         showBinding={showBindingControls}
         scope={scope}
         aliases={aliases}

--- a/apps/builder/app/builder/features/pages/page-settings/section-text-content.tsx
+++ b/apps/builder/app/builder/features/pages/page-settings/section-text-content.tsx
@@ -34,7 +34,6 @@ export const TextContentSection = ({
             computeExpression(values.content, variableValues) ?? ""
           )}
           bound={isLiteralExpression(values.content) === false}
-          allowBindingOverwrite={false}
           scope={scope}
           aliases={aliases}
           onChangeValue={(value) =>

--- a/apps/builder/app/builder/features/settings-panel/controls/code.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/code.tsx
@@ -19,10 +19,7 @@ import {
 } from "@webstudio-is/design-system";
 import { InfoCircleIcon } from "@webstudio-is/icons";
 import { CodeEditor } from "~/shared/code-editor";
-import {
-  BindableExpressionControl,
-  updateBindableValue,
-} from "~/builder/shared/bindable-expression";
+import { BindableExpressionControl } from "~/builder/shared/bindable-expression";
 import {
   validateHtmlEmbedCode,
   type HtmlEmbedCodeError,
@@ -169,6 +166,9 @@ export const CodeControl = ({
   const localValue = useDraftValue(
     editorValue,
     (value) => {
+      if (prop?.type === "expression") {
+        return;
+      }
       let storedValue = value;
 
       if (behavior) {
@@ -193,11 +193,7 @@ export const CodeControl = ({
         }
       }
 
-      updateBindableValue({
-        expression: prop?.type === "expression" ? prop.value : undefined,
-        value: storedValue,
-        onChangeValue: (value) => onChange({ type: "string", value }),
-      });
+      onChange({ type: "string", value: storedValue });
     },
     { autoSave: behavior?.autoSave ?? true }
   );

--- a/apps/builder/app/builder/features/settings-panel/controls/file.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/file.tsx
@@ -1,9 +1,6 @@
 import { useId } from "react";
 import { Flex, InputField, theme } from "@webstudio-is/design-system";
-import {
-  BindableExpressionControl,
-  updateBindableValue,
-} from "~/builder/shared/bindable-expression";
+import { BindableExpressionControl } from "~/builder/shared/bindable-expression";
 import { validatePrimitiveValue } from "@webstudio-is/project-build/runtime";
 import { useDraftValue } from "~/builder/shared/use-draft-value";
 import {
@@ -56,14 +53,10 @@ export const FileControl = ({
       ? String(computedValue)
       : undefined,
     (value) => {
-      if (value === undefined) {
+      if (value === undefined || prop?.type === "expression") {
         return;
       }
-      updateBindableValue({
-        expression: prop?.type === "expression" ? prop.value : undefined,
-        value,
-        onChangeValue: (value) => onChange({ type: "string", value }),
-      });
+      onChange({ type: "string", value });
     }
   );
 

--- a/apps/builder/app/builder/features/settings-panel/controls/json.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/json.tsx
@@ -1,10 +1,7 @@
 import { useState } from "react";
 import { isLiteralExpression } from "@webstudio-is/expression";
 import { useDraftValue } from "~/builder/shared/use-draft-value";
-import {
-  BindableExpressionControl,
-  updateBindableValue,
-} from "~/builder/shared/bindable-expression";
+import { BindableExpressionControl } from "~/builder/shared/bindable-expression";
 import { type ControlProps, VerticalLayout } from "../shared";
 import {
   ExpressionEditor,
@@ -22,6 +19,9 @@ export const JsonControl = ({
   const [error, setError] = useState<boolean>(false);
   const valueString = formatValue(computedValue ?? "");
   const localValue = useDraftValue(valueString, (value) => {
+    if (prop?.type === "expression") {
+      return;
+    }
     const isLiteral = isLiteralExpression(value);
     setError(isLiteral ? false : true);
     // prevent executing expressions which depends on global variables
@@ -31,11 +31,7 @@ export const JsonControl = ({
     try {
       // wrap into parens to treat object expression as value instead of block
       const parsedValue = eval(`(${value})`);
-      updateBindableValue({
-        expression: prop?.type === "expression" ? prop.value : undefined,
-        value: parsedValue,
-        onChangeValue: (value) => onChange({ type: "json", value }),
-      });
+      onChange({ type: "json", value: parsedValue });
     } catch {
       // empty block
     }

--- a/apps/builder/app/builder/features/settings-panel/controls/number.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/number.tsx
@@ -1,10 +1,7 @@
 import { useId, useState } from "react";
 import { InputField } from "@webstudio-is/design-system";
 import { useDraftValue } from "~/builder/shared/use-draft-value";
-import {
-  BindableExpressionControl,
-  updateBindableValue,
-} from "~/builder/shared/bindable-expression";
+import { BindableExpressionControl } from "~/builder/shared/bindable-expression";
 import {
   type ControlProps,
   ResponsiveLayout,
@@ -27,12 +24,11 @@ export const NumberControl = ({
   const localValue = useDraftValue(
     Number.isNaN(number) ? "" : number,
     (value) => {
+      if (prop?.type === "expression") {
+        return;
+      }
       if (typeof value === "number") {
-        updateBindableValue({
-          expression: prop?.type === "expression" ? prop.value : undefined,
-          value,
-          onChangeValue: (value) => onChange({ type: "number", value }),
-        });
+        onChange({ type: "number", value });
       }
       if (value === "") {
         setIsInvalid(true);

--- a/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/resource-control.tsx
@@ -287,7 +287,6 @@ export const ResourceControl = ({
         expression={urlExpression}
         value={localValue.value}
         bound={bound}
-        allowBindingOverwrite={false}
         scope={scope}
         aliases={aliases}
         validate={(value) => validatePrimitiveValue(value, "URL")}

--- a/apps/builder/app/builder/features/settings-panel/controls/text-content.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text-content.tsx
@@ -15,10 +15,7 @@ import { AlertIcon } from "@webstudio-is/icons";
 import { $instances } from "~/shared/sync/data-stores";
 import { validatePrimitiveValue } from "@webstudio-is/project-build/runtime";
 import { useDraftValue } from "~/builder/shared/use-draft-value";
-import {
-  BindableExpressionControl,
-  updateBindableValue,
-} from "~/builder/shared/bindable-expression";
+import { BindableExpressionControl } from "~/builder/shared/bindable-expression";
 import { executeRuntimeMutation } from "~/shared/instance-utils/data";
 import { CodeEditor } from "~/shared/code-editor";
 import { type ControlProps, VerticalLayout } from "../shared";
@@ -100,11 +97,10 @@ export const TextContent = ({
     }
   }
   const localValue = useDraftValue(String(displayedValue ?? ""), (value) => {
-    updateBindableValue({
-      expression: child.type === "expression" ? child.value : undefined,
-      value,
-      onChangeValue: (value) => updateChild("text", value),
-    });
+    if (child.type === "expression") {
+      return;
+    }
+    updateChild("text", value);
   });
 
   const isBindingResetForbidden = useIsBindingResetForbidden();

--- a/apps/builder/app/builder/features/settings-panel/controls/text.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/text.tsx
@@ -2,10 +2,7 @@ import { useId } from "react";
 import { TextArea } from "@webstudio-is/design-system";
 import { validatePrimitiveValue } from "@webstudio-is/project-build/runtime";
 import { useDraftValue } from "~/builder/shared/use-draft-value";
-import {
-  BindableExpressionControl,
-  updateBindableValue,
-} from "~/builder/shared/bindable-expression";
+import { BindableExpressionControl } from "~/builder/shared/bindable-expression";
 import {
   type ControlProps,
   ResponsiveLayout,
@@ -22,11 +19,10 @@ export const TextControl = ({
   onChange,
 }: ControlProps<"text">) => {
   const localValue = useDraftValue(String(computedValue ?? ""), (value) => {
-    updateBindableValue({
-      expression: prop?.type === "expression" ? prop.value : undefined,
-      value,
-      onChangeValue: (value) => onChange({ type: "string", value }),
-    });
+    if (prop?.type === "expression") {
+      return;
+    }
+    onChange({ type: "string", value });
   });
   const id = useId();
   const label = humanizeAttribute(meta.label || propName);

--- a/apps/builder/app/builder/features/settings-panel/controls/time-zone.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/time-zone.tsx
@@ -4,10 +4,7 @@ import { matchSorter } from "match-sorter";
 import { Box, Combobox, Text, theme } from "@webstudio-is/design-system";
 import { validatePrimitiveValue } from "@webstudio-is/project-build/runtime";
 import { useDraftValue } from "~/builder/shared/use-draft-value";
-import {
-  BindableExpressionControl,
-  updateBindableValue,
-} from "~/builder/shared/bindable-expression";
+import { BindableExpressionControl } from "~/builder/shared/bindable-expression";
 import { $props } from "~/shared/sync/data-stores";
 import {
   type ControlProps,
@@ -196,11 +193,10 @@ export const TimeZoneControl = ({
     computedValue ?? meta.defaultValue ?? defaultTimeZone
   );
   const localValue = useDraftValue(savedValue, (value) => {
-    updateBindableValue({
-      expression: prop?.type === "expression" ? prop.value : undefined,
-      value,
-      onChangeValue: (value) => onChange({ type: "string", value }),
-    });
+    if (prop?.type === "expression") {
+      return;
+    }
+    onChange({ type: "string", value });
   });
   const timeZoneItems = getTimeZoneItems(meta.options);
   const selectedItem = getTimeZoneItem(savedValue);

--- a/apps/builder/app/builder/features/settings-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/url.tsx
@@ -31,10 +31,7 @@ import {
 import { $instances, $pages, $props } from "~/shared/sync/data-stores";
 import { validatePrimitiveValue } from "@webstudio-is/project-build/runtime";
 import { useDraftValue } from "~/builder/shared/use-draft-value";
-import {
-  BindableExpressionControl,
-  updateBindableValue,
-} from "~/builder/shared/bindable-expression";
+import { BindableExpressionControl } from "~/builder/shared/bindable-expression";
 import { getPageDisplayName } from "~/builder/features/pages/page-utils";
 import {
   type ControlProps,
@@ -108,11 +105,10 @@ const addHttpsIfMissing = (url: string) => {
 
 const BaseUrl = ({ readOnly, prop, value, onChange, id }: BaseControlProps) => {
   const localValue = useDraftValue(value, (value) => {
-    updateBindableValue({
-      expression: prop?.type === "expression" ? prop.value : undefined,
-      value,
-      onChangeValue: (value) => onChange({ type: "string", value }),
-    });
+    if (prop?.type === "expression") {
+      return;
+    }
+    onChange({ type: "string", value });
   });
 
   useEffect(() => {
@@ -154,12 +150,11 @@ const BasePhone = ({
   const localValue = useDraftValue(
     value.startsWith("tel:") ? value.slice(4) : "",
     (value) => {
+      if (prop?.type === "expression") {
+        return;
+      }
       const nextValue = `tel:${value}`;
-      updateBindableValue({
-        expression: prop?.type === "expression" ? prop.value : undefined,
-        value: nextValue,
-        onChangeValue: (value) => onChange({ type: "string", value }),
-      });
+      onChange({ type: "string", value: nextValue });
     }
   );
 
@@ -232,12 +227,11 @@ const BaseEmail = ({
   id,
 }: BaseControlProps) => {
   const localValue = useDraftValue(propToEmail(value), ({ email, subject }) => {
+    if (prop?.type === "expression") {
+      return;
+    }
     const value = emailToProp({ email, subject });
-    updateBindableValue({
-      expression: prop?.type === "expression" ? prop.value : undefined,
-      value,
-      onChangeValue: (value) => onChange({ type: "string", value }),
-    });
+    onChange({ type: "string", value });
   });
 
   return (

--- a/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/resource-panel.tsx
@@ -131,7 +131,6 @@ export const UrlField = ({
         expression={value}
         value={String(evaluateExpressionWithinScope(value, scope))}
         bound={isLiteralExpression(value) === false}
-        allowBindingOverwrite={false}
         scope={scope}
         aliases={aliases}
         onChangeValue={(value) => onChange(JSON.stringify(value))}
@@ -250,7 +249,6 @@ const ExpressionNameValuePair = ({
         expression={value}
         value={serializeValue(evaluatedValue)}
         bound={isLiteralExpression(value) === false}
-        allowBindingOverwrite={false}
         scope={scope}
         aliases={aliases}
         onChangeValue={(value) => onChange(name, JSON.stringify(value))}
@@ -605,12 +603,8 @@ const BodyField = ({
         expression={value}
         value={displayedValue}
         bound={isBodyLiteral === false}
-        allowBindingOverwrite={false}
         scope={scope}
         aliases={aliases}
-        parseValue={(value) =>
-          bodyType === "json" ? evaluateExpressionWithinScope(value, {}) : value
-        }
         onChangeValue={(value) =>
           updateBody(bodyType === "json" ? value : JSON.stringify(value))
         }
@@ -1161,10 +1155,8 @@ export const GraphqlResourceForm = forwardRef<
                   ) ?? "")
             }
             bound={isVariablesLiteral === false}
-            allowBindingOverwrite={false}
             scope={scope}
             aliases={aliases}
-            parseValue={(value) => evaluateExpressionWithinScope(value, {})}
             onChangeValue={setVariables}
             onChangeExpression={(value) => {
               setVariables(value);

--- a/apps/builder/app/builder/shared/bindable-expression.test.tsx
+++ b/apps/builder/app/builder/shared/bindable-expression.test.tsx
@@ -4,9 +4,7 @@
 import { act } from "react-dom/test-utils";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, expect, test, vi } from "vitest";
-import { encodeDataSourceVariable, type DataSource } from "@webstudio-is/sdk";
-import { $dataSourceVariables } from "~/shared/nano-states";
-import { $dataSources } from "~/shared/sync/data-stores";
+import { encodeDataSourceVariable } from "@webstudio-is/sdk";
 import { BindableExpressionControl } from "./bindable-expression";
 
 (
@@ -19,21 +17,15 @@ afterEach(() => {
   act(() => root?.unmount());
   root = undefined;
   document.body.innerHTML = "";
-  $dataSources.set(new Map());
-  $dataSourceVariables.set(new Map());
 });
 
 const renderControl = ({
   expression,
   bound,
-  allowBindingOverwrite,
-  parseValue,
   onChangeValue,
 }: {
   expression: string;
   bound: boolean;
-  allowBindingOverwrite?: boolean;
-  parseValue?: (value: string) => unknown;
   onChangeValue: (value: string) => void;
 }) => {
   const container = document.createElement("div");
@@ -46,8 +38,6 @@ const renderControl = ({
         value="displayed"
         bound={bound}
         showBinding={false}
-        allowBindingOverwrite={allowBindingOverwrite}
-        parseValue={parseValue}
         scope={{}}
         aliases={new Map()}
         onChangeValue={onChangeValue}
@@ -68,27 +58,6 @@ const renderControl = ({
   return container.querySelector("button") as HTMLButtonElement;
 };
 
-test("updates a directly bound variable without replacing its expression", () => {
-  const variable: DataSource = {
-    type: "variable",
-    id: "variable-id",
-    name: "Variable",
-    value: { type: "string", value: "initial" },
-  };
-  $dataSources.set(new Map([[variable.id, variable]]));
-  const onChangeValue = vi.fn();
-  const button = renderControl({
-    expression: encodeDataSourceVariable(variable.id),
-    bound: true,
-    onChangeValue,
-  });
-
-  act(() => button.click());
-
-  expect($dataSourceVariables.get().get(variable.id)).toBe("changed");
-  expect(onChangeValue).not.toHaveBeenCalled();
-});
-
 test("passes literal input changes to its consumer", () => {
   const onChangeValue = vi.fn();
   const button = renderControl({
@@ -102,56 +71,10 @@ test("passes literal input changes to its consumer", () => {
   expect(onChangeValue).toHaveBeenCalledExactlyOnceWith("changed");
 });
 
-test("parses bound values before updating the variable", () => {
-  const variable: DataSource = {
-    type: "variable",
-    id: "variable-id",
-    name: "Variable",
-    value: { type: "string", value: "initial" },
-  };
-  $dataSources.set(new Map([[variable.id, variable]]));
-  const parseValue = vi.fn((value: string) => ({ value }));
+test("keeps directly bound values read-only", () => {
   const button = renderControl({
-    expression: encodeDataSourceVariable(variable.id),
+    expression: encodeDataSourceVariable("variable-id"),
     bound: true,
-    parseValue,
-    onChangeValue: () => {},
-  });
-
-  act(() => button.click());
-
-  expect(parseValue).toHaveBeenCalledExactlyOnceWith("changed");
-  expect($dataSourceVariables.get().get(variable.id)).toEqual({
-    value: "changed",
-  });
-});
-
-test("does not parse literal input", () => {
-  const parseValue = vi.fn((value: string) => ({ value }));
-  const onChangeValue = vi.fn();
-  const literalButton = renderControl({
-    expression: '"displayed"',
-    bound: false,
-    parseValue,
-    onChangeValue,
-  });
-  act(() => literalButton.click());
-  expect(parseValue).not.toHaveBeenCalled();
-  expect(onChangeValue).toHaveBeenCalledExactlyOnceWith("changed");
-});
-
-test("can keep directly bound values read-only", () => {
-  const variable: DataSource = {
-    type: "variable",
-    id: "variable-id",
-    name: "Variable",
-    value: { type: "string", value: "initial" },
-  };
-  $dataSources.set(new Map([[variable.id, variable]]));
-  const button = renderControl({
-    expression: encodeDataSourceVariable(variable.id),
-    bound: true,
-    allowBindingOverwrite: false,
     onChangeValue: () => {},
   });
 

--- a/apps/builder/app/builder/shared/bindable-expression.tsx
+++ b/apps/builder/app/builder/shared/bindable-expression.tsx
@@ -1,9 +1,4 @@
-import { useMemo, type ReactNode } from "react";
-import { useStore } from "@nanostores/react";
-import { atom, computed, type ReadableAtom } from "nanostores";
-import { decodeDataSourceVariable } from "@webstudio-is/sdk";
-import { $dataSourceVariables } from "~/shared/nano-states";
-import { $dataSources } from "~/shared/sync/data-stores";
+import type { ReactNode } from "react";
 import {
   BindingControl,
   BindingPopover,
@@ -15,64 +10,10 @@ export type BindingState = {
   variant: BindingVariant;
 };
 
-const updateExpressionValue = (expression: string, value: unknown) => {
-  const potentialVariableId = decodeDataSourceVariable(expression);
-  if (
-    potentialVariableId === undefined ||
-    $dataSources.get().has(potentialVariableId) === false
-  ) {
-    return;
-  }
-  const dataSourceVariables = new Map($dataSourceVariables.get());
-  dataSourceVariables.set(potentialVariableId, value);
-  $dataSourceVariables.set(dataSourceVariables);
-};
-
-export const updateBindableValue = <Value,>({
-  expression,
-  value,
-  expressionValue = value,
-  onChangeValue,
-}: {
-  expression: string | undefined;
-  value: Value;
-  expressionValue?: unknown;
-  onChangeValue: (value: Value) => void;
-}) => {
-  if (expression !== undefined) {
-    updateExpressionValue(expression, expressionValue);
-    return;
-  }
-  onChangeValue(value);
-};
-
 export const useBindingState = (expression: string | undefined) => {
-  const $bindingState = useMemo((): ReadableAtom<BindingState> => {
-    if (expression === undefined) {
-      return atom({ overwritable: true, variant: "default" });
-    }
-    const potentialVariableId = decodeDataSourceVariable(expression);
-    if (potentialVariableId === undefined) {
-      return atom({ overwritable: false, variant: "bound" });
-    }
-    return computed(
-      [$dataSources, $dataSourceVariables],
-      (dataSources, dataSourceVariables): BindingState => {
-        const dataSource = dataSources.get(potentialVariableId);
-        if (dataSource?.type !== "variable") {
-          return { overwritable: false, variant: "bound" };
-        }
-        return {
-          overwritable: true,
-          variant:
-            dataSourceVariables.get(potentialVariableId) === undefined
-              ? "bound"
-              : "overwritten",
-        };
-      }
-    );
-  }, [expression]);
-  return useStore($bindingState);
+  return expression === undefined
+    ? ({ overwritable: true, variant: "default" } satisfies BindingState)
+    : ({ overwritable: false, variant: "bound" } satisfies BindingState);
 };
 
 export const BindableExpressionControl = <Value,>({
@@ -83,9 +24,7 @@ export const BindableExpressionControl = <Value,>({
   aliases,
   validate,
   showBinding = true,
-  allowBindingOverwrite = true,
   renderControl,
-  parseValue = (value) => value,
   onChangeValue,
   onChangeExpression,
   onRemove,
@@ -98,13 +37,11 @@ export const BindableExpressionControl = <Value,>({
   aliases: Map<string, string>;
   validate?: (value: unknown) => string | undefined;
   showBinding?: boolean;
-  allowBindingOverwrite?: boolean;
   renderControl: (props: {
     value: Value;
     readOnly: boolean;
     onChangeValue: (value: Value) => void;
   }) => ReactNode;
-  parseValue?: (value: Value) => unknown;
   onChangeValue: (value: Value) => void;
   onChangeExpression: (expression: string) => void;
   onRemove?: (evaluatedValue: unknown) => void;
@@ -120,9 +57,7 @@ export const BindableExpressionControl = <Value,>({
         aliases={aliases}
         validate={validate}
         showBinding={showBinding}
-        allowBindingOverwrite={allowBindingOverwrite}
         renderControl={renderControl}
-        parseValue={parseValue}
         onChangeValue={onChangeValue}
         onChangeExpression={onChangeExpression}
         onRemove={onRemove}
@@ -131,21 +66,12 @@ export const BindableExpressionControl = <Value,>({
   }
 
   const { overwritable, variant } = bindingState;
-  const readOnly =
-    overwritable === false || (bound && allowBindingOverwrite === false);
   return (
     <BindingControl>
       {renderControl({
         value,
-        readOnly,
-        onChangeValue: (nextValue) => {
-          updateBindableValue({
-            expression: bound ? expression : undefined,
-            value: nextValue,
-            expressionValue: bound ? parseValue(nextValue) : nextValue,
-            onChangeValue,
-          });
-        },
+        readOnly: overwritable === false,
+        onChangeValue,
       })}
       {showBinding && (
         <BindingPopover

--- a/apps/builder/app/builder/shared/binding-popover.tsx
+++ b/apps/builder/app/builder/shared/binding-popover.tsx
@@ -11,7 +11,6 @@ import {
   DotIcon,
   InfoCircleIcon,
   PlusIcon,
-  ResetIcon,
   TrashIcon,
 } from "@webstudio-is/icons";
 import {
@@ -22,8 +21,8 @@ import {
   DialogTitleActions,
   DialogClose,
   DialogTitle,
-  Flex,
   FloatingPanel,
+  Flex,
   Label,
   ScrollArea,
   ScrollAreaNative,
@@ -33,9 +32,8 @@ import {
   theme,
 } from "@webstudio-is/design-system";
 import { getExpressionIdentifiers } from "@webstudio-is/expression";
-import { decodeDataSourceVariable } from "@webstudio-is/sdk";
 import { getExpressionErrorMessages } from "@webstudio-is/project-build/runtime";
-import { $dataSourceVariables, $isDesignMode } from "~/shared/nano-states";
+import { $isDesignMode } from "~/shared/nano-states";
 import {
   computeExpressionWithinScope,
   encodeDataVariableName,
@@ -212,44 +210,21 @@ export const BindingControl = ({ children }: { children: ReactNode }) => {
   );
 };
 
-export type BindingVariant = "default" | "bound" | "overwritten";
+export type BindingVariant = "default" | "bound";
 
 const BindingButton = forwardRef<
   HTMLButtonElement,
   ButtonHTMLAttributes<HTMLButtonElement> & {
     variant: BindingVariant;
     error?: string;
-    value: string;
   }
->(({ variant, error, value, ...props }, ref) => {
+>(({ variant, error, ...props }, ref) => {
   const expanded = props["aria-expanded"];
-  const overwrittenMessage =
-    variant === "overwritten" ? (
-      <Flex direction="column" gap="2" css={{ maxWidth: theme.spacing[28] }}>
-        <Text>Bound variable is overwritten with temporary value</Text>
-        <Button
-          color="dark"
-          prefix={<ResetIcon />}
-          css={{ flexGrow: 1 }}
-          onClick={() => {
-            const potentialVariableId = decodeDataSourceVariable(value);
-            const dataSourceVariables = new Map($dataSourceVariables.get());
-            if (potentialVariableId !== undefined) {
-              dataSourceVariables.delete(potentialVariableId);
-              $dataSourceVariables.set(dataSourceVariables);
-            }
-          }}
-        >
-          Reset value
-        </Button>
-      </Flex>
-    ) : undefined;
-  const tooltipContent = error ?? overwrittenMessage;
   return (
     // prevent giving content to tooltip when popover is open
     // to avoid button remounting and popover flickering
     // when switch between valid and error value
-    <Tooltip content={expanded ? undefined : tooltipContent} delayDuration={0}>
+    <Tooltip content={expanded ? undefined : error} delayDuration={0}>
       <SmallIconButton
         ref={ref}
         data-variant={variant}
@@ -270,7 +245,7 @@ const BindingButton = forwardRef<
           transitionTimingFunction: "cubic-bezier(0.37, 0, 0.63, 1)",
           "--dot-display": "block",
           "--plus-display": "none",
-          "&[data-variant=bound], &[data-variant=overwritten]": {
+          "&[data-variant=bound]": {
             opacity: 1,
           },
           "&:hover, &:focus-visible, &[aria-expanded=true]": {
@@ -297,9 +272,6 @@ const BindingButton = forwardRef<
               alignItems: "center",
               "&[data-variant=bound]": {
                 backgroundColor: theme.colors.backgroundStyleSourceSelected,
-              },
-              "&[data-variant=overwritten]": {
-                backgroundColor: theme.colors.borderOverwrittenMain,
               },
               "&[data-variant=error]": {
                 backgroundColor: theme.colors.backgroundDestructiveMain,
@@ -438,11 +410,7 @@ export const BindingPopover = ({
         />
       }
     >
-      <BindingButton
-        variant={variant}
-        error={valueError}
-        value={normalizedValue}
-      />
+      <BindingButton variant={variant} error={valueError} />
     </FloatingPanel>
   );
 };

--- a/apps/builder/app/builder/shared/query-builder.test.tsx
+++ b/apps/builder/app/builder/shared/query-builder.test.tsx
@@ -5,6 +5,8 @@ import { act } from "react-dom/test-utils";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, expect, test } from "vitest";
 import type { QueryDefinition } from "@webstudio-is/query-builder";
+import { encodeDataSourceVariable, type DataSource } from "@webstudio-is/sdk";
+import { $dataSources } from "~/shared/sync/data-stores";
 import { BindableQueryBuilder } from "./query-builder";
 
 (
@@ -24,6 +26,7 @@ afterEach(() => {
   act(() => root?.unmount());
   root = undefined;
   document.body.innerHTML = "";
+  $dataSources.set(new Map());
 });
 
 const renderQueryBuilder = <Query extends Record<string, unknown>>({
@@ -140,6 +143,83 @@ test("shows an evaluated value for a bound number input", () => {
 
   expect(input?.value).toBe("20");
   expect(input?.step).toBe("1");
+  expect(input?.disabled).toBe(true);
+});
+
+test("keeps query values bound to mutable variables read-only", () => {
+  const textVariable: DataSource = {
+    type: "variable",
+    id: "text-variable-id",
+    name: "Text variable",
+    value: { type: "string", value: "article" },
+  };
+  const numberVariable: DataSource = {
+    type: "variable",
+    id: "number-variable-id",
+    name: "Number variable",
+    value: { type: "number", value: 20 },
+  };
+  $dataSources.set(
+    new Map([
+      [textVariable.id, textVariable],
+      [numberVariable.id, numberVariable],
+    ])
+  );
+  const textIdentifier = encodeDataSourceVariable(textVariable.id);
+  const numberIdentifier = encodeDataSourceVariable(numberVariable.id);
+  const capabilities = {
+    version: 1,
+    fields: [{ path: ["path"], label: "Path", types: ["string"] }],
+    operators: [
+      {
+        value: "eq",
+        label: "Equals",
+        types: ["string"],
+        input: { control: "expression", defaultValue: '""' },
+      },
+    ],
+    source: {
+      fieldPathSchema: {
+        type: "array",
+        items: { type: "string" },
+        minItems: 1,
+      },
+      controls: [
+        {
+          type: "filter",
+          key: "where",
+          label: "Filters",
+          defaultValue: { all: [] },
+          combinators: ["all"],
+          limits: { conditions: 8, depth: 3 },
+          defaultCondition: { field: ["path"], operator: "eq" },
+        },
+        {
+          type: "expression",
+          key: "limit",
+          label: "Limit",
+          defaultValue: "20",
+          input: "number",
+        },
+      ],
+    },
+  } as const satisfies QueryDefinition<string, string>;
+
+  const container = renderQueryBuilder({
+    value: {
+      where: {
+        all: [{ field: ["path"], operator: "eq", value: textIdentifier }],
+      },
+      limit: numberIdentifier,
+    },
+    capabilities,
+  });
+  const editor = container.querySelector<HTMLElement>(".cm-content");
+  const input = container.querySelector<HTMLInputElement>(
+    'input[aria-label="Limit"]'
+  );
+
+  expect(editor?.getAttribute("contenteditable")).toBe("false");
   expect(input?.disabled).toBe(true);
 });
 

--- a/apps/builder/app/builder/shared/query-builder.tsx
+++ b/apps/builder/app/builder/shared/query-builder.tsx
@@ -62,7 +62,6 @@ const BoundExpression = ({
             return `${label} expects a value ${exclusiveMax ? "less than" : "less than or equal to"} ${max}`;
           }
         }}
-        parseValue={Number}
         onChangeValue={onChange}
         onChangeExpression={onChange}
         onRemove={(value) => onChange(String(Number(value) || 0))}
@@ -90,7 +89,6 @@ const BoundExpression = ({
       bound={bound}
       scope={scope}
       aliases={aliases}
-      parseValue={(value) => evaluateExpressionWithinScope(value, {})}
       onChangeValue={onChange}
       onChangeExpression={onChange}
       onRemove={(value) => onChange(JSON.stringify(value) ?? "undefined")}


### PR DESCRIPTION
Closes #6027

## Summary

Bound values currently remain editable when the expression directly references a mutable variable. Editing the field writes a temporary runtime override while leaving the binding in place, which makes the source of truth unclear and behaves differently across Builder fields.

This change makes every expression-bound field read-only. To enter a literal value, remove the binding first.

## Implementation

- Simplify binding state to two states: unbound/editable and bound/read-only.
- Remove temporary data-variable override writes and the overwritten/reset binding UI.
- Remove `allowBindingOverwrite` and bound-value parsing APIs and their call-site exceptions.
- Guard pending draft saves so a draft started before binding cannot replace the new binding.
- Add query-builder regression coverage for string and numeric filters bound to mutable variables.

## Checklist

- [x] Add regression tests and confirm they fail with the previous behavior.
- [x] Make all expression-bound controls read-only.
- [x] Remove temporary override state and UI.
- [x] Verify literal controls remain editable.
- [x] Run the full Builder unit test suite.
- [x] Run Builder typecheck and repository lint.
- [x] Review documentation impact: no documentation change is needed; this makes the existing remove-binding-before-edit interaction consistent.
- [x] Review fixture impact: no fixture inputs or generated fixture outputs are affected.

## Verification

- `pnpm --filter @webstudio-is/builder test` — 2,509 tests passed across 217 files.
- `pnpm --filter @webstudio-is/builder typecheck` — passed.
- `pnpm lint` — passed.
- Agent evaluations were not run because they require separate explicit approval and this change does not modify agent-facing behavior.