### PR TITLE
fix: Preserve MCP run results on termination

### DIFF
--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -16,12 +16,11 @@ const {
   createMcpResourceErrorPayload,
   createMcpRunCheckpointStopPayload,
   createMcpRunErrorPayload,
-  createMcpRunTerminationPayload,
   createMcpSingleOpCallErrorPayload,
   createMcpStatusReporter,
   getLoadedProjectSessionSnapshot,
   getMcpOperationInput,
-  installMcpRunTerminationHandlers,
+  reportMcpRunTermination,
   parseMcpRunCalls,
   parseMcpRunInput,
   parseMcpSingleOpCallInput,
@@ -884,15 +883,20 @@ test("preserves completed calls when a run terminates during an asset query prev
     structuredContent: { ok: true, data: {}, meta: {} },
   }));
 
-  expect(
-    createMcpRunTerminationPayload({
-      reason: { type: "beforeExit", exitCode: 0 },
-      activeCall: { number: 4, tool: "preview-asset-query" },
-      totalCalls: 4,
-      results: completedResults,
-      elapsedMs: 123,
-    })
-  ).toEqual({
+  const writeResult = vi.fn();
+  const setExitCode = vi.fn();
+  reportMcpRunTermination({
+    exitCode: 0,
+    activeCall: { number: 4, tool: "preview-asset-query" },
+    totalCalls: 4,
+    results: completedResults,
+    elapsedMs: 123,
+    writeStatus: vi.fn(),
+    writeResult,
+    setExitCode,
+  });
+
+  expect(writeResult).toHaveBeenCalledWith({
     ok: false,
     error: {
       code: "MCP_RUN_TERMINATED",
@@ -910,45 +914,7 @@ test("preserves completed calls when a run terminates during an asset query prev
       termination: { type: "beforeExit", exitCode: 0 },
     },
   });
-});
-
-test("reports the active MCP call when Node exits with an unresolved tool promise", () => {
-  let beforeExit: ((exitCode: number) => void) | undefined;
-  const writeResult = vi.fn();
-  const setExitCode = vi.fn();
-  const dispose = installMcpRunTerminationHandlers({
-    getActiveCall: () => ({ number: 4, tool: "preview-asset-query" }),
-    totalCalls: 4,
-    results: [
-      { tool: "status", ok: true },
-      { tool: "list-assets", ok: true },
-      { tool: "get-asset-field-catalog", ok: true },
-    ],
-    startedAt: Date.now(),
-    registerBeforeExit: (listener) => {
-      beforeExit = listener;
-      return vi.fn();
-    },
-    registerSignal: () => vi.fn(),
-    writeStatus: vi.fn(),
-    writeResult,
-    setExitCode,
-  });
-
-  beforeExit?.(0);
-
-  expect(writeResult).toHaveBeenCalledWith(
-    expect.objectContaining({
-      ok: false,
-      error: expect.objectContaining({ code: "MCP_RUN_TERMINATED" }),
-      data: expect.objectContaining({
-        completedCalls: 3,
-        unfinishedCall: { number: 4, tool: "preview-asset-query" },
-      }),
-    })
-  );
   expect(setExitCode).toHaveBeenCalledWith(1);
-  dispose();
 });
 
 test("preserves already structured MCP run errors", () => {

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -16,10 +16,12 @@ const {
   createMcpResourceErrorPayload,
   createMcpRunCheckpointStopPayload,
   createMcpRunErrorPayload,
+  createMcpRunTerminationPayload,
   createMcpSingleOpCallErrorPayload,
   createMcpStatusReporter,
   getLoadedProjectSessionSnapshot,
   getMcpOperationInput,
+  installMcpRunTerminationHandlers,
   parseMcpRunCalls,
   parseMcpRunInput,
   parseMcpSingleOpCallInput,
@@ -869,6 +871,84 @@ test("formats MCP run failures as structured JSON payloads", () => {
       elapsedMs: 12,
     },
   });
+});
+
+test("preserves completed calls when a run terminates during an asset query preview", () => {
+  const completedResults = [
+    "status",
+    "list-assets",
+    "get-asset-field-catalog",
+  ].map((tool) => ({
+    tool,
+    ok: true,
+    structuredContent: { ok: true, data: {}, meta: {} },
+  }));
+
+  expect(
+    createMcpRunTerminationPayload({
+      reason: { type: "beforeExit", exitCode: 0 },
+      activeCall: { number: 4, tool: "preview-asset-query" },
+      totalCalls: 4,
+      results: completedResults,
+      elapsedMs: 123,
+    })
+  ).toEqual({
+    ok: false,
+    error: {
+      code: "MCP_RUN_TERMINATED",
+      message:
+        "MCP run terminated before call 4/4 preview-asset-query returned a result.",
+    },
+    data: {
+      completedCalls: 3,
+      unfinishedCall: { number: 4, tool: "preview-asset-query" },
+      totalCalls: 4,
+      results: completedResults,
+    },
+    meta: {
+      elapsedMs: 123,
+      termination: { type: "beforeExit", exitCode: 0 },
+    },
+  });
+});
+
+test("reports the active MCP call when Node exits with an unresolved tool promise", () => {
+  let beforeExit: ((exitCode: number) => void) | undefined;
+  const writeResult = vi.fn();
+  const setExitCode = vi.fn();
+  const dispose = installMcpRunTerminationHandlers({
+    getActiveCall: () => ({ number: 4, tool: "preview-asset-query" }),
+    totalCalls: 4,
+    results: [
+      { tool: "status", ok: true },
+      { tool: "list-assets", ok: true },
+      { tool: "get-asset-field-catalog", ok: true },
+    ],
+    startedAt: Date.now(),
+    registerBeforeExit: (listener) => {
+      beforeExit = listener;
+      return vi.fn();
+    },
+    registerSignal: () => vi.fn(),
+    writeStatus: vi.fn(),
+    writeResult,
+    setExitCode,
+  });
+
+  beforeExit?.(0);
+
+  expect(writeResult).toHaveBeenCalledWith(
+    expect.objectContaining({
+      ok: false,
+      error: expect.objectContaining({ code: "MCP_RUN_TERMINATED" }),
+      data: expect.objectContaining({
+        completedCalls: 3,
+        unfinishedCall: { number: 4, tool: "preview-asset-query" },
+      }),
+    })
+  );
+  expect(setExitCode).toHaveBeenCalledWith(1);
+  dispose();
 });
 
 test("preserves already structured MCP run errors", () => {

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -779,6 +779,127 @@ const createMcpRunErrorPayload = ({
   },
 });
 
+type McpRunTerminationReason =
+  | { type: "beforeExit"; exitCode: number }
+  | { type: "signal"; signal: "SIGINT" | "SIGTERM" };
+
+type ActiveMcpRunCall = {
+  number: number;
+  tool: string;
+};
+
+const createMcpRunTerminationPayload = ({
+  reason,
+  activeCall,
+  totalCalls,
+  results,
+  elapsedMs,
+}: {
+  reason: McpRunTerminationReason;
+  activeCall: ActiveMcpRunCall;
+  totalCalls: number;
+  results: unknown[];
+  elapsedMs: number;
+}) => ({
+  ok: false,
+  error: {
+    code: "MCP_RUN_TERMINATED",
+    message:
+      reason.type === "signal"
+        ? `MCP run received ${reason.signal} before call ${activeCall.number}/${totalCalls} ${activeCall.tool} returned a result.`
+        : `MCP run terminated before call ${activeCall.number}/${totalCalls} ${activeCall.tool} returned a result.`,
+  },
+  data: {
+    completedCalls: results.length,
+    unfinishedCall: activeCall,
+    totalCalls,
+    results,
+  },
+  meta: {
+    elapsedMs,
+    termination: reason,
+  },
+});
+
+const installMcpRunTerminationHandlers = ({
+  getActiveCall,
+  totalCalls,
+  results,
+  startedAt,
+  registerBeforeExit = (listener) => {
+    process.once("beforeExit", listener);
+    return () => process.off("beforeExit", listener);
+  },
+  registerSignal = (signal, listener) => {
+    process.once(signal, listener);
+    return () => process.off(signal, listener);
+  },
+  writeStatus = (message) => stderr.write(`${message}\n`),
+  writeResult = printJson,
+  setExitCode = (exitCode) => {
+    process.exitCode = exitCode;
+  },
+  exitProcess = (exitCode) => process.exit(exitCode),
+}: {
+  getActiveCall: () => ActiveMcpRunCall | undefined;
+  totalCalls: number;
+  results: unknown[];
+  startedAt: number;
+  registerBeforeExit?: (listener: (exitCode: number) => void) => () => void;
+  registerSignal?: (
+    signal: "SIGINT" | "SIGTERM",
+    listener: () => void
+  ) => () => void;
+  writeStatus?: (message: string) => unknown;
+  writeResult?: (result: unknown) => void;
+  setExitCode?: (exitCode: number) => void;
+  exitProcess?: (exitCode: number) => never;
+}) => {
+  let reported = false;
+  const report = (reason: McpRunTerminationReason) => {
+    const activeCall = getActiveCall();
+    if (reported || activeCall === undefined) {
+      return false;
+    }
+    reported = true;
+    const payload = createMcpRunTerminationPayload({
+      reason,
+      activeCall,
+      totalCalls,
+      results,
+      elapsedMs: Date.now() - startedAt,
+    });
+    writeStatus(
+      formatMcpStatusLine(
+        `run ${activeCall.number}/${totalCalls} ${activeCall.tool} terminated: ${payload.error.message}`
+      )
+    );
+    writeResult(payload);
+    return true;
+  };
+  const beforeExit = (exitCode: number) => {
+    if (report({ type: "beforeExit", exitCode })) {
+      setExitCode(1);
+    }
+  };
+  const sigint = () => {
+    report({ type: "signal", signal: "SIGINT" });
+    exitProcess(130);
+  };
+  const sigterm = () => {
+    report({ type: "signal", signal: "SIGTERM" });
+    exitProcess(143);
+  };
+  const disposeBeforeExit = registerBeforeExit(beforeExit);
+  const disposeSigint = registerSignal("SIGINT", sigint);
+  const disposeSigterm = registerSignal("SIGTERM", sigterm);
+  return () => {
+    disposeBeforeExit();
+    disposeSigint();
+    disposeSigterm();
+  };
+};
+
 const reportMcpRunPreflightFailure = ({
   error,
   startedAt,
@@ -1246,6 +1367,8 @@ export const __testing__ = {
     meta: { elapsedMs },
   }),
   createMcpRunErrorPayload,
+  createMcpRunTerminationPayload,
+  installMcpRunTerminationHandlers,
   createMcpRunCheckpointStopPayload,
   getLoadedProjectSessionSnapshot,
   getResultCheckpoint,
@@ -1507,97 +1630,112 @@ export const mcpRun = async (options: McpRunOptions) => {
     });
     throw new HandledCliError();
   }
-  for (const [index, call] of calls.entries()) {
-    const callNumber = index + 1;
-    stderr.write(
-      `${formatMcpStatusLine(
-        `run ${callNumber}/${calls.length} ${call.tool} started${call.dryRun ? " (dry run)" : ""}`
-      )}\n`
-    );
-    try {
-      const { result, checkpoint } = await executeMcpRunCall({
-        core,
-        call,
-        scope,
-      });
-      const session = result.structuredContent.meta.session;
-      const committed =
-        session === undefined ? "" : `; committed=${session.committed}`;
+  let activeCall: ActiveMcpRunCall | undefined;
+  const disposeTerminationHandlers = installMcpRunTerminationHandlers({
+    getActiveCall: () => activeCall,
+    totalCalls: calls.length,
+    results,
+    startedAt,
+  });
+  try {
+    for (const [index, call] of calls.entries()) {
+      const callNumber = index + 1;
+      activeCall = { number: callNumber, tool: call.tool };
       stderr.write(
         `${formatMcpStatusLine(
-          `run ${callNumber}/${calls.length} ${call.tool} succeeded${committed}`
+          `run ${callNumber}/${calls.length} ${call.tool} started${call.dryRun ? " (dry run)" : ""}`
         )}\n`
       );
-      results.push({
-        tool: call.tool,
-        ok: true,
-        structuredContent: result.structuredContent,
-      });
-      const nextTool = calls[callNumber]?.tool;
-      if (
-        checkpoint !== undefined &&
-        callNumber < calls.length &&
-        (nextTool === undefined ||
-          isReadOnlyProjectSessionMcpToolCall(nextTool, core.listTools()) ===
-            false)
-      ) {
-        const checkpointStopPayload = createMcpRunCheckpointStopPayload({
-          checkpoint,
-          completedCalls: callNumber,
+      try {
+        const { result, checkpoint } = await executeMcpRunCall({
+          core,
+          call,
+          scope,
+        });
+        const session = result.structuredContent.meta.session;
+        const committed =
+          session === undefined ? "" : `; committed=${session.committed}`;
+        stderr.write(
+          `${formatMcpStatusLine(
+            `run ${callNumber}/${calls.length} ${call.tool} succeeded${committed}`
+          )}\n`
+        );
+        results.push({
+          tool: call.tool,
+          ok: true,
+          structuredContent: result.structuredContent,
+        });
+        activeCall = undefined;
+        const nextTool = calls[callNumber]?.tool;
+        if (
+          checkpoint !== undefined &&
+          callNumber < calls.length &&
+          (nextTool === undefined ||
+            isReadOnlyProjectSessionMcpToolCall(nextTool, core.listTools()) ===
+              false)
+        ) {
+          const checkpointStopPayload = createMcpRunCheckpointStopPayload({
+            checkpoint,
+            completedCalls: callNumber,
+            totalCalls: calls.length,
+            results,
+            elapsedMs: Date.now() - startedAt,
+          });
+          stderr.write(
+            `${formatMcpStatusLine(
+              `run stopped after ${callNumber}/${calls.length} ${call.tool}: ${checkpointStopPayload.error.message}`
+            )}\n`
+          );
+          printJson(checkpointStopPayload);
+          throw new McpRunCheckpointStop();
+        }
+      } catch (error) {
+        activeCall = undefined;
+        if (error instanceof McpRunCheckpointStop) {
+          throw new HandledCliError();
+        }
+        const structuredError = getMcpRunError(error);
+        results.push({
+          tool: call.tool,
+          ok: false,
+          error: structuredError,
+        });
+        const payload = createMcpRunErrorPayload({
+          error: structuredError,
+          completedCalls: index,
+          failedCall: callNumber,
           totalCalls: calls.length,
           results,
           elapsedMs: Date.now() - startedAt,
         });
         stderr.write(
           `${formatMcpStatusLine(
-            `run stopped after ${callNumber}/${calls.length} ${call.tool}: ${checkpointStopPayload.error.message}`
+            `run ${callNumber}/${calls.length} ${call.tool} failed: ${payload.error.message}`
           )}\n`
         );
-        printJson(checkpointStopPayload);
-        throw new McpRunCheckpointStop();
-      }
-    } catch (error) {
-      if (error instanceof McpRunCheckpointStop) {
+        printJson(payload);
         throw new HandledCliError();
       }
-      const structuredError = getMcpRunError(error);
-      results.push({
-        tool: call.tool,
-        ok: false,
-        error: structuredError,
-      });
-      const payload = createMcpRunErrorPayload({
-        error: structuredError,
-        completedCalls: index,
-        failedCall: callNumber,
+    }
+    stderr.write(
+      `${formatMcpStatusLine(
+        `run succeeded in ${Date.now() - startedAt}ms with ${calls.length} calls`
+      )}\n`
+    );
+    printJson({
+      ok: true,
+      data: {
         totalCalls: calls.length,
         results,
+      },
+      meta: {
         elapsedMs: Date.now() - startedAt,
-      });
-      stderr.write(
-        `${formatMcpStatusLine(
-          `run ${callNumber}/${calls.length} ${call.tool} failed: ${payload.error.message}`
-        )}\n`
-      );
-      printJson(payload);
-      throw new HandledCliError();
-    }
+      },
+    });
+  } finally {
+    activeCall = undefined;
+    disposeTerminationHandlers();
   }
-  stderr.write(
-    `${formatMcpStatusLine(
-      `run succeeded in ${Date.now() - startedAt}ms with ${calls.length} calls`
-    )}\n`
-  );
-  printJson({
-    ok: true,
-    data: {
-      totalCalls: calls.length,
-      results,
-    },
-    meta: {
-      elapsedMs: Date.now() - startedAt,
-    },
-  });
 };
 
 export const mcpListTools = async (options: McpListToolsOptions) => {

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -779,124 +779,86 @@ const createMcpRunErrorPayload = ({
   },
 });
 
-type McpRunTerminationReason =
-  | { type: "beforeExit"; exitCode: number }
-  | { type: "signal"; signal: "SIGINT" | "SIGTERM" };
-
 type ActiveMcpRunCall = {
   number: number;
   tool: string;
 };
 
-const createMcpRunTerminationPayload = ({
-  reason,
+const reportMcpRunTermination = ({
+  exitCode,
   activeCall,
   totalCalls,
   results,
   elapsedMs,
+  writeStatus = (message) => stderr.write(`${message}\n`),
+  writeResult = printJson,
+  setExitCode = (code) => {
+    process.exitCode = code;
+  },
 }: {
-  reason: McpRunTerminationReason;
+  exitCode: number;
   activeCall: ActiveMcpRunCall;
   totalCalls: number;
   results: unknown[];
   elapsedMs: number;
-}) => ({
-  ok: false,
-  error: {
+  writeStatus?: (message: string) => void;
+  writeResult?: (result: unknown) => void;
+  setExitCode?: (code: number) => void;
+}) => {
+  const error = {
     code: "MCP_RUN_TERMINATED",
-    message:
-      reason.type === "signal"
-        ? `MCP run received ${reason.signal} before call ${activeCall.number}/${totalCalls} ${activeCall.tool} returned a result.`
-        : `MCP run terminated before call ${activeCall.number}/${totalCalls} ${activeCall.tool} returned a result.`,
-  },
-  data: {
+    message: `MCP run terminated before call ${activeCall.number}/${totalCalls} ${activeCall.tool} returned a result.`,
+  };
+  const payload = createMcpRunErrorPayload({
+    error,
     completedCalls: results.length,
-    unfinishedCall: activeCall,
     totalCalls,
     results,
-  },
-  meta: {
     elapsedMs,
-    termination: reason,
-  },
-});
+  });
+  writeStatus(
+    formatMcpStatusLine(
+      `run ${activeCall.number}/${totalCalls} ${activeCall.tool} terminated: ${error.message}`
+    )
+  );
+  writeResult({
+    ...payload,
+    data: { ...payload.data, unfinishedCall: activeCall },
+    meta: {
+      ...payload.meta,
+      termination: { type: "beforeExit", exitCode },
+    },
+  });
+  setExitCode(1);
+};
 
 const installMcpRunTerminationHandlers = ({
   getActiveCall,
   totalCalls,
   results,
   startedAt,
-  registerBeforeExit = (listener) => {
-    process.once("beforeExit", listener);
-    return () => process.off("beforeExit", listener);
-  },
-  registerSignal = (signal, listener) => {
-    process.once(signal, listener);
-    return () => process.off(signal, listener);
-  },
-  writeStatus = (message) => stderr.write(`${message}\n`),
-  writeResult = printJson,
-  setExitCode = (exitCode) => {
-    process.exitCode = exitCode;
-  },
-  exitProcess = (exitCode) => process.exit(exitCode),
 }: {
   getActiveCall: () => ActiveMcpRunCall | undefined;
   totalCalls: number;
   results: unknown[];
   startedAt: number;
-  registerBeforeExit?: (listener: (exitCode: number) => void) => () => void;
-  registerSignal?: (
-    signal: "SIGINT" | "SIGTERM",
-    listener: () => void
-  ) => () => void;
-  writeStatus?: (message: string) => unknown;
-  writeResult?: (result: unknown) => void;
-  setExitCode?: (exitCode: number) => void;
-  exitProcess?: (exitCode: number) => never;
 }) => {
-  let reported = false;
-  const report = (reason: McpRunTerminationReason) => {
+  const beforeExit = (exitCode: number) => {
     const activeCall = getActiveCall();
-    if (reported || activeCall === undefined) {
-      return false;
+    if (activeCall === undefined) {
+      return;
     }
-    reported = true;
-    const payload = createMcpRunTerminationPayload({
-      reason,
+    reportMcpRunTermination({
+      exitCode,
       activeCall,
       totalCalls,
       results,
       elapsedMs: Date.now() - startedAt,
     });
-    writeStatus(
-      formatMcpStatusLine(
-        `run ${activeCall.number}/${totalCalls} ${activeCall.tool} terminated: ${payload.error.message}`
-      )
-    );
-    writeResult(payload);
-    return true;
   };
-  const beforeExit = (exitCode: number) => {
-    if (report({ type: "beforeExit", exitCode })) {
-      setExitCode(1);
-    }
-  };
-  const sigint = () => {
-    report({ type: "signal", signal: "SIGINT" });
-    exitProcess(130);
-  };
-  const sigterm = () => {
-    report({ type: "signal", signal: "SIGTERM" });
-    exitProcess(143);
-  };
-  const disposeBeforeExit = registerBeforeExit(beforeExit);
-  const disposeSigint = registerSignal("SIGINT", sigint);
-  const disposeSigterm = registerSignal("SIGTERM", sigterm);
+  process.once("beforeExit", beforeExit);
   return () => {
-    disposeBeforeExit();
-    disposeSigint();
-    disposeSigterm();
+    process.off("beforeExit", beforeExit);
   };
 };
 
@@ -1367,8 +1329,7 @@ export const __testing__ = {
     meta: { elapsedMs },
   }),
   createMcpRunErrorPayload,
-  createMcpRunTerminationPayload,
-  installMcpRunTerminationHandlers,
+  reportMcpRunTermination,
   createMcpRunCheckpointStopPayload,
   getLoadedProjectSessionSnapshot,
   getResultCheckpoint,
@@ -1637,105 +1598,102 @@ export const mcpRun = async (options: McpRunOptions) => {
     results,
     startedAt,
   });
-  try {
-    for (const [index, call] of calls.entries()) {
-      const callNumber = index + 1;
-      activeCall = { number: callNumber, tool: call.tool };
+  for (const [index, call] of calls.entries()) {
+    const callNumber = index + 1;
+    activeCall = { number: callNumber, tool: call.tool };
+    stderr.write(
+      `${formatMcpStatusLine(
+        `run ${callNumber}/${calls.length} ${call.tool} started${call.dryRun ? " (dry run)" : ""}`
+      )}\n`
+    );
+    try {
+      const { result, checkpoint } = await executeMcpRunCall({
+        core,
+        call,
+        scope,
+      });
+      const session = result.structuredContent.meta.session;
+      const committed =
+        session === undefined ? "" : `; committed=${session.committed}`;
       stderr.write(
         `${formatMcpStatusLine(
-          `run ${callNumber}/${calls.length} ${call.tool} started${call.dryRun ? " (dry run)" : ""}`
+          `run ${callNumber}/${calls.length} ${call.tool} succeeded${committed}`
         )}\n`
       );
-      try {
-        const { result, checkpoint } = await executeMcpRunCall({
-          core,
-          call,
-          scope,
-        });
-        const session = result.structuredContent.meta.session;
-        const committed =
-          session === undefined ? "" : `; committed=${session.committed}`;
-        stderr.write(
-          `${formatMcpStatusLine(
-            `run ${callNumber}/${calls.length} ${call.tool} succeeded${committed}`
-          )}\n`
-        );
-        results.push({
-          tool: call.tool,
-          ok: true,
-          structuredContent: result.structuredContent,
-        });
-        activeCall = undefined;
-        const nextTool = calls[callNumber]?.tool;
-        if (
-          checkpoint !== undefined &&
-          callNumber < calls.length &&
-          (nextTool === undefined ||
-            isReadOnlyProjectSessionMcpToolCall(nextTool, core.listTools()) ===
-              false)
-        ) {
-          const checkpointStopPayload = createMcpRunCheckpointStopPayload({
-            checkpoint,
-            completedCalls: callNumber,
-            totalCalls: calls.length,
-            results,
-            elapsedMs: Date.now() - startedAt,
-          });
-          stderr.write(
-            `${formatMcpStatusLine(
-              `run stopped after ${callNumber}/${calls.length} ${call.tool}: ${checkpointStopPayload.error.message}`
-            )}\n`
-          );
-          printJson(checkpointStopPayload);
-          throw new McpRunCheckpointStop();
-        }
-      } catch (error) {
-        activeCall = undefined;
-        if (error instanceof McpRunCheckpointStop) {
-          throw new HandledCliError();
-        }
-        const structuredError = getMcpRunError(error);
-        results.push({
-          tool: call.tool,
-          ok: false,
-          error: structuredError,
-        });
-        const payload = createMcpRunErrorPayload({
-          error: structuredError,
-          completedCalls: index,
-          failedCall: callNumber,
+      results.push({
+        tool: call.tool,
+        ok: true,
+        structuredContent: result.structuredContent,
+      });
+      activeCall = undefined;
+      const nextTool = calls[callNumber]?.tool;
+      if (
+        checkpoint !== undefined &&
+        callNumber < calls.length &&
+        (nextTool === undefined ||
+          isReadOnlyProjectSessionMcpToolCall(nextTool, core.listTools()) ===
+            false)
+      ) {
+        const checkpointStopPayload = createMcpRunCheckpointStopPayload({
+          checkpoint,
+          completedCalls: callNumber,
           totalCalls: calls.length,
           results,
           elapsedMs: Date.now() - startedAt,
         });
         stderr.write(
           `${formatMcpStatusLine(
-            `run ${callNumber}/${calls.length} ${call.tool} failed: ${payload.error.message}`
+            `run stopped after ${callNumber}/${calls.length} ${call.tool}: ${checkpointStopPayload.error.message}`
           )}\n`
         );
-        printJson(payload);
+        printJson(checkpointStopPayload);
+        throw new McpRunCheckpointStop();
+      }
+    } catch (error) {
+      activeCall = undefined;
+      disposeTerminationHandlers();
+      if (error instanceof McpRunCheckpointStop) {
         throw new HandledCliError();
       }
-    }
-    stderr.write(
-      `${formatMcpStatusLine(
-        `run succeeded in ${Date.now() - startedAt}ms with ${calls.length} calls`
-      )}\n`
-    );
-    printJson({
-      ok: true,
-      data: {
+      const structuredError = getMcpRunError(error);
+      results.push({
+        tool: call.tool,
+        ok: false,
+        error: structuredError,
+      });
+      const payload = createMcpRunErrorPayload({
+        error: structuredError,
+        completedCalls: index,
+        failedCall: callNumber,
         totalCalls: calls.length,
         results,
-      },
-      meta: {
         elapsedMs: Date.now() - startedAt,
-      },
-    });
-  } finally {
-    activeCall = undefined;
-    disposeTerminationHandlers();
+      });
+      stderr.write(
+        `${formatMcpStatusLine(
+          `run ${callNumber}/${calls.length} ${call.tool} failed: ${payload.error.message}`
+        )}\n`
+      );
+      printJson(payload);
+      throw new HandledCliError();
+    }
   }
+  disposeTerminationHandlers();
+  stderr.write(
+    `${formatMcpStatusLine(
+      `run succeeded in ${Date.now() - startedAt}ms with ${calls.length} calls`
+    )}\n`
+  );
+  printJson({
+    ok: true,
+    data: {
+      totalCalls: calls.length,
+      results,
+    },
+    meta: {
+      elapsedMs: Date.now() - startedAt,
+    },
+  });
 };
 
 export const mcpListTools = async (options: McpListToolsOptions) => {


### PR DESCRIPTION
## Summary

- emit a structured terminal result when an active `mcp run` reaches Node `beforeExit`
- preserve completed call results and identify the unfinished call
- add regression coverage for a four-call run that terminates during `preview-asset-query`

## Root cause

`mcp run` only wrote its final JSON after the awaited tool call settled. An unresolved tool promise does not keep Node's event loop alive by itself, so a read-only preview call could reach `beforeExit` after its start lifecycle event without producing either a terminal call event or the run result.

## Implementation

The CLI tracks only the currently active call while a run is executing and installs one scoped `beforeExit` handler. If Node would exit while that call is unresolved, the handler reuses the existing MCP run error envelope to return `MCP_RUN_TERMINATED` with completed results, total call count, the unfinished call number and tool, elapsed time, and the original exit code. Existing success, tool-failure, and checkpoint control flow remains unchanged.

OS-level termination that cannot be intercepted, such as `SIGKILL`, remains outside the process's ability to report.

## Checklist

- [x] Preserve completed MCP call results on unexpected termination
- [x] Identify the unfinished call in the terminal payload
- [x] Emit a nonzero exit status
- [x] Add fail-then-pass regression coverage for asset query preview termination
- [x] Review implementation for correctness, unnecessary work, and duplication
- [x] Review documentation impact: no update needed because this restores the existing documented stdout JSON contract
- [x] Verify fixture impact: no fixture inputs or generated fixture outputs are affected

## Verification

- `pnpm --filter webstudio typecheck`
- `pnpm exec oxlint --deny-warnings packages/cli/src/commands/mcp.ts packages/cli/src/commands/mcp.test.ts`
- `pnpm --filter webstudio test` — 943 tests passed
- `git diff --check`

The separate `pnpm evaluations` agent evaluation suite was not run because it requires explicit approval.

Closes #6032