### PR TITLE
chore: remove stale authz todo comments in project-router

### DIFF
--- a/packages/project/src/trpc/project-router.ts
+++ b/packages/project/src/trpc/project-router.ts
@@ -20,14 +20,12 @@ export const projectRouter = router({
       })
     )
     .mutation(async ({ input, ctx }) => {
-      // @todo pass ctx for authorization
       return await projectApi.rename(input, ctx);
     }),
 
   delete: procedure
     .input(z.object({ projectId: z.string() }))
     .mutation(async ({ input, ctx }) => {
-      // @todo pass ctx for authorization
       return await projectApi.markAsDeleted(input.projectId, ctx);
     }),
 


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)
The rename and delete mutations already thread ctx into authorization
(edit and own permits respectively). Drops the leftover `@todo pass ctx
for authorization` comments. No behavior change.

## Code Review

- [x] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [x] made a self-review