### PR TITLE
fix: Stop managed preview process groups

### DIFF
--- a/packages/cli/src/preview-server.test.ts
+++ b/packages/cli/src/preview-server.test.ts
@@ -35,6 +35,13 @@ const createDependencies = (
   readFile: vi.fn(async () => "") as never,
   writeFile: vi.fn(async () => undefined) as never,
   sleep: vi.fn(async () => undefined),
+  killProcess: vi.fn(() => true),
+  parentProcess: {
+    pid: 456,
+    once: vi.fn(),
+    off: vi.fn(),
+    kill: vi.fn(() => true),
+  },
   nodeExecPath: "/usr/bin/node",
   npmExecPath: undefined,
   platform: "linux",
@@ -302,6 +309,7 @@ test("preview controller builds once and reuses a running server", async () => {
   expect(spawn).toHaveBeenCalledTimes(2);
   expect(spawn).toHaveBeenLastCalledWith("npm", ["run", "start"], {
     cwd: "/tmp/preview",
+    detached: true,
     stdio: ["ignore", "pipe", "pipe"],
     env: expect.objectContaining({
       HOST: "127.0.0.1",
@@ -453,6 +461,7 @@ test("preview controller stops the running server", async () => {
   const controller = createPreviewController(
     { host: "127.0.0.1", port: 5173, cwd: "/tmp/preview" },
     createDependencies({
+      platform: "win32",
       spawn: vi
         .fn()
         .mockReturnValueOnce(buildProcess)
@@ -489,6 +498,78 @@ test("preview controller stops the running server", async () => {
     running: false,
     mode: "production",
   });
+});
+
+test("preview controller stops the entire POSIX preview process group", async () => {
+  const process = createPreviewProcess();
+  const killProcess = vi.fn(() => true);
+  const controller = createPreviewController(
+    {
+      host: "127.0.0.1",
+      port: 5173,
+      cwd: "/tmp/preview",
+      mode: "iterative",
+    },
+    createDependencies({
+      spawn: vi.fn(() => process) as never,
+      killProcess,
+    })
+  );
+  let exitListener: (() => void) | undefined;
+  vi.mocked(
+    process.once as (event: string, callback: unknown) => unknown
+  ).mockImplementation((event, callback) => {
+    if (event === "exit" && typeof callback === "function") {
+      exitListener = callback as () => void;
+    }
+    return process;
+  });
+  killProcess.mockImplementation(() => {
+    exitListener?.();
+    return true;
+  });
+
+  await controller.start();
+  await controller.stop();
+
+  expect(killProcess).toHaveBeenCalledWith(-123, "SIGTERM");
+  expect(process.kill).not.toHaveBeenCalled();
+});
+
+test("preview controller stops its process group before propagating termination", async () => {
+  const process = createPreviewProcess();
+  const killProcess = vi.fn(() => true);
+  const parentProcess = {
+    pid: 456,
+    once: vi.fn(),
+    off: vi.fn(),
+    kill: vi.fn(() => true),
+  };
+  const controller = createPreviewController(
+    {
+      host: "127.0.0.1",
+      port: 5173,
+      cwd: "/tmp/preview",
+      mode: "iterative",
+    },
+    createDependencies({
+      spawn: vi.fn(() => process) as never,
+      killProcess,
+      parentProcess,
+    })
+  );
+
+  await controller.start();
+  const signalHandler = vi
+    .mocked(parentProcess.once)
+    .mock.calls.find(([signal]) => signal === "SIGTERM")?.[1] as
+    | (() => void)
+    | undefined;
+  signalHandler?.();
+
+  expect(killProcess).toHaveBeenCalledWith(-123, "SIGTERM");
+  expect(parentProcess.kill).toHaveBeenCalledWith(456, "SIGTERM");
+  expect(controller.status().running).toBe(false);
 });
 
 test("preview controller reuses custom running options when start has no options", async () => {
@@ -530,12 +611,13 @@ test("preview controller can restart a running server after rebuilding", async (
     .mockReturnValueOnce(firstProcess)
     .mockReturnValueOnce(secondBuildProcess)
     .mockReturnValueOnce(secondProcess);
+  const killProcess = vi.fn(() => true);
   resolveProcessExit(firstBuildProcess);
   resolveProcessExit(secondBuildProcess);
 
   const controller = createPreviewController(
     { host: "127.0.0.1", port: 5173, cwd: "/tmp/preview" },
-    createDependencies({ spawn: spawn as never })
+    createDependencies({ spawn: spawn as never, killProcess })
   );
 
   await expect(controller.start()).resolves.toEqual({
@@ -552,7 +634,7 @@ test("preview controller can restart a running server after rebuilding", async (
     mode: "production",
   });
 
-  expect(firstProcess.kill).toHaveBeenCalledOnce();
+  expect(killProcess).toHaveBeenCalledWith(-123, "SIGTERM");
   expect(spawn).toHaveBeenCalledTimes(4);
 });
 
@@ -579,7 +661,10 @@ test("ignores a delayed exit from a previously owned preview server", async () =
       cwd: "/tmp/preview",
       mode: "iterative",
     },
-    createDependencies({ spawn: spawn as never })
+    createDependencies({
+      spawn: spawn as never,
+      killProcess: vi.fn(() => false),
+    })
   );
 
   await controller.start();

--- a/packages/cli/src/preview-server.ts
+++ b/packages/cli/src/preview-server.ts
@@ -26,6 +26,13 @@ export type PreviewServerResult = {
 
 export type PreviewServerDependencies = {
   spawn: typeof spawn;
+  killProcess: (pid: number, signal: NodeJS.Signals) => boolean;
+  parentProcess: {
+    pid: number;
+    once: (signal: NodeJS.Signals, handler: () => void) => unknown;
+    off: (signal: NodeJS.Signals, handler: () => void) => unknown;
+    kill: (pid: number, signal: NodeJS.Signals) => boolean;
+  };
   fetch: typeof fetch;
   cp: typeof cp;
   mkdir: typeof mkdir;
@@ -40,6 +47,8 @@ export type PreviewServerDependencies = {
 
 export const defaultPreviewServerDependencies: PreviewServerDependencies = {
   spawn,
+  killProcess: process.kill,
+  parentProcess: process,
   fetch,
   cp,
   mkdir,
@@ -218,7 +227,10 @@ export const materializePreviewAssets = async (
 };
 
 export const startPreviewServer = (
-  options: PreviewServerOptions & { stdio?: StdioOptions },
+  options: PreviewServerOptions & {
+    stdio?: StdioOptions;
+    detached?: boolean;
+  },
   dependencies = defaultPreviewServerDependencies
 ): PreviewServerResult => {
   const invocation = getNpmInvocation(
@@ -230,6 +242,7 @@ export const startPreviewServer = (
     invocation.args,
     {
       cwd: options.cwd,
+      ...(options.detached === undefined ? {} : { detached: options.detached }),
       stdio: options.stdio ?? "inherit",
       env: getPreviewEnv(options.cwd, {
         ...processEnv(),
@@ -249,6 +262,24 @@ export const startPreviewServer = (
     url: getPreviewUrl(options),
     process: previewProcess,
   };
+};
+
+const killPreviewProcess = (
+  previewProcess: ChildProcess,
+  signal: NodeJS.Signals,
+  dependencies: PreviewServerDependencies
+) => {
+  if (dependencies.platform !== "win32" && previewProcess.pid !== undefined) {
+    try {
+      return dependencies.killProcess(-previewProcess.pid, signal);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ESRCH") {
+        return false;
+      }
+      throw error;
+    }
+  }
+  return previewProcess.kill(signal);
 };
 
 export const waitForPreviewExit = async (process: ChildProcess) => {
@@ -479,6 +510,43 @@ export const createPreviewController = (
   let currentOptions = defaults;
   let currentCwd = defaults.cwd;
   let serverOutput = "";
+  const terminationSignals = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
+  let isTerminating = false;
+  const terminationHandlers = new Map<NodeJS.Signals, () => void>();
+  const removeTerminationHandlers = () => {
+    for (const [signal, handler] of terminationHandlers) {
+      dependencies.parentProcess.off(signal, handler);
+    }
+    terminationHandlers.clear();
+  };
+  const installTerminationHandlers = () => {
+    if (terminationHandlers.size > 0) {
+      return;
+    }
+    for (const signal of terminationSignals) {
+      const handler = () => {
+        if (isTerminating) {
+          return;
+        }
+        isTerminating = true;
+        const activeServer = server;
+        server = undefined;
+        removeTerminationHandlers();
+        try {
+          if (activeServer !== undefined) {
+            killPreviewProcess(activeServer.process, "SIGTERM", dependencies);
+          }
+        } finally {
+          dependencies.parentProcess.kill(
+            dependencies.parentProcess.pid,
+            signal
+          );
+        }
+      };
+      terminationHandlers.set(signal, handler);
+      dependencies.parentProcess.once(signal, handler);
+    }
+  };
   const appendServerOutput = (chunk: unknown) => {
     serverOutput = `${serverOutput}${String(chunk)}`.slice(-4000);
   };
@@ -532,6 +600,7 @@ export const createPreviewController = (
     }
     const process = server.process;
     server = undefined;
+    removeTerminationHandlers();
     if (
       process.killed ||
       process.exitCode !== null ||
@@ -542,7 +611,7 @@ export const createPreviewController = (
     await new Promise<void>((resolve, reject) => {
       process.once("error", reject);
       process.once("exit", () => resolve());
-      if (process.kill() === false) {
+      if (killPreviewProcess(process, "SIGTERM", dependencies) === false) {
         resolve();
       }
     });
@@ -592,16 +661,19 @@ export const createPreviewController = (
     const startedServer = startPreviewServer(
       {
         ...nextOptions,
+        detached: dependencies.platform !== "win32",
         stdio: ["ignore", "pipe", "pipe"],
       },
       dependencies
     );
     server = startedServer;
+    installTerminationHandlers();
     startedServer.process.stdout?.on("data", appendServerOutput);
     startedServer.process.stderr?.on("data", appendServerOutput);
     startedServer.process.once("exit", () => {
       if (server === startedServer) {
         server = undefined;
+        removeTerminationHandlers();
       }
     });
     return getStatus();


### PR DESCRIPTION
## Summary

- start managed POSIX preview servers in their own process group
- terminate the complete preview process group from `preview.stop`
- clean up the owned preview group before propagating `SIGHUP`, `SIGINT`, or `SIGTERM`
- preserve the existing child-process fallback on Windows
- keep standalone `webstudio preview` signal behavior unchanged

## Root cause

The managed preview controller spawned an npm wrapper and stopped only that direct child with `ChildProcess.kill()`. React Router runs below that wrapper, so the dev server could survive as an orphan. Its inherited stdout/stderr pipes could also keep `webstudio mcp run` alive after the manifest had completed.

## Impact

`preview.stop` now terminates the npm wrapper and all descendants. If the CLI is terminated while it owns a managed preview, it kills that process group before re-propagating the original signal to itself.

## Todo

- [x] Reproduce the missing process-group cleanup in regression tests
- [x] Isolate managed POSIX previews in their own process group
- [x] Stop the full group on `preview.stop`
- [x] Stop the full group on CLI termination signals
- [x] Preserve standalone preview behavior
- [x] Run an independent real subprocess test with an npm wrapper and long-lived grandchild
- [x] Review documentation impact — existing MCP documentation already describes `preview.stop` as ending the owned preview, so no docs change is required
- [x] Verify fixture impact — no fixture inputs or generated outputs are affected

## Verification

- `pnpm --filter webstudio test` — 58 files, 945 tests passed
- `pnpm --filter webstudio typecheck` — passed
- targeted `oxlint`, `oxfmt`, and `git diff --check` — passed
- regression tests were demonstrated failing without the process-group and signal cleanup, then passing with it
- independent real-process test on macOS / Node 22.22.1:
  - `preview.stop` removed the npm wrapper, server, and long-lived grandchild in 458 ms; harness exited in 0.93 s
  - parent `SIGTERM` removed the complete process group in 0.01 s; harness exited with expected status 143
  - all observed PIDs were absent afterward
- agent evaluations were not run because they require separate explicit approval

Closes #5958