### PR TITLE
ci: Restore safe-to-deploy workflows

### DIFF
--- a/.github/actions/add-status/action.yaml
+++ b/.github/actions/add-status/action.yaml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Add URL to vercel deployment through *.prs.webstudio.is
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const branch = context.payload.pull_request?.head?.ref ?? context.payload.ref?.replace('refs/heads/', '')

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -12,8 +12,8 @@ runs:
   using: "composite"
 
   steps:
-    - uses: pnpm/action-setup@v4
-    - uses: actions/setup-node@v4
+    - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v5
       with:
         node-version: 22
         cache: pnpm

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           fetch-depth: 2 # we need to fetch at least parent commit to satisfy Chromatic
           ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy' }}
 
       # Storybook with submodules
       - uses: ./.github/actions/submodules-checkout

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -32,7 +32,7 @@ jobs:
       name: development
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2 # we need to fetch at least parent commit to satisfy Chromatic
           ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
@@ -47,7 +47,7 @@ jobs:
 
       - name: Chromatic
         id: chromatic
-        uses: chromaui/action@v11.3.0
+        uses: chromaui/action@v16
         with:
           projectToken: bea8dc1981d4
           buildScriptName: storybook:build

--- a/.github/workflows/delete-github-deployments.yml
+++ b/.github/workflows/delete-github-deployments.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Delete Previous deployments
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           REF: ${{ inputs.ref }}
         with:

--- a/.github/workflows/fixtures-test.yml
+++ b/.github/workflows/fixtures-test.yml
@@ -35,7 +35,7 @@ jobs:
       BUILDER_HOST: ${{ inputs.builder-host }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       # Test that everything is working with submodules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy' }}
 
       # Will not checkout submodules on empty environment, and will on development
       - uses: ./.github/actions/submodules-checkout
@@ -105,6 +106,12 @@ jobs:
           pnpm -r typecheck
 
   check-size:
+    # Run on push, regular PR (for repo branches), or labeled PR with safe-to-deploy (for forks)
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
+
     runs-on: ubuntu-24.04-arm
 
     environment:
@@ -114,6 +121,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy' }}
 
       - uses: ./.github/actions/submodules-checkout
         with:
@@ -184,6 +192,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy' }}
 
       - uses: ./.github/actions/submodules-checkout
         with:
@@ -244,6 +253,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy' }}
 
       - uses: ./.github/actions/submodules-checkout
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy' }}
@@ -52,9 +52,9 @@ jobs:
         with:
           submodules-ssh-key: ${{ secrets.PRIVATE_GITHUB_DEPLOY_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -85,7 +85,7 @@ jobs:
           pnpm check:generated-docs
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
@@ -118,7 +118,7 @@ jobs:
       name: development
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy' }}
@@ -131,7 +131,7 @@ jobs:
 
       - run: pnpm --filter "{./fixtures/*}..." build
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           script: |
             const assertSize = async (directory, maxSize) => {
@@ -189,7 +189,7 @@ jobs:
       shards: ${{ steps.shards.outputs.value }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy' }}
@@ -215,10 +215,10 @@ jobs:
         run: pnpm e2e:builder:refresh-schema-cache
 
       - name: Upload builder e2e prerequisites
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: builder-e2e-build
-          retention-days: 1
+          retention-days: 7
           path: |
             apps/builder/build/server
             apps/builder/build/client/assets
@@ -250,7 +250,7 @@ jobs:
       BUILDER_E2E_COMPOSE_ARGS: "--env-file apps/builder/.env -f apps/builder/docker-compose.yaml -f apps/builder/docker-compose.e2e.yaml"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy' }}
@@ -264,13 +264,13 @@ jobs:
           run-scripts: "true"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: builder-e2e-playwright-${{ runner.os }}-${{ hashFiles('apps/builder/package.json', 'pnpm-lock.yaml') }}
 
       - name: Download builder e2e build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: builder-e2e-build
           path: .

--- a/.github/workflows/vercel-deploy-staging.yml
+++ b/.github/workflows/vercel-deploy-staging.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove safe-to-deploy label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.removeLabel({
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}
@@ -70,9 +70,9 @@ jobs:
         with:
           submodules-ssh-key: ${{ secrets.PRIVATE_GITHUB_DEPLOY_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -110,7 +110,7 @@ jobs:
 
       - name: Comment on PR with deployment URL
         if: github.event_name == 'pull_request_target' && matrix.environment == 'development'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const deployUrl = 'https://${{ steps.vercel.outputs.alias }}.${{ matrix.environment }}.webstudio.is';
@@ -134,7 +134,7 @@ jobs:
     outputs:
       development-builder-host: ${{ steps.host.outputs.value }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}

--- a/.github/workflows/vercel-deploy-staging.yml
+++ b/.github/workflows/vercel-deploy-staging.yml
@@ -64,6 +64,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}
 
       - uses: ./.github/actions/submodules-checkout
         with:
@@ -124,6 +125,11 @@ jobs:
       builder-host: "${{ steps.vercel.outputs.alias }}.${{ matrix.environment }}.webstudio.is"
 
   deployment-host:
+    # Run on push (for repo branches) OR on labeled event with safe-to-deploy label (for fork PRs)
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy')
+
     runs-on: ubuntu-latest
     outputs:
       development-builder-host: ${{ steps.host.outputs.value }}
@@ -131,6 +137,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}
 
       - id: host
         shell: bash

--- a/.github/workflows/vis-reg-tests.yml
+++ b/.github/workflows/vis-reg-tests.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }} # HEAD commit instead of merge commit
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy' }}
 
       - uses: ./.github/actions/ci-setup
 


### PR DESCRIPTION
## Summary

Restore CI, visual testing, and Vercel preview workflows for reviewed fork pull requests after `actions/checkout` began refusing fork code in `pull_request_target` jobs by default.

The affected workflows now also use Node 24-compatible action releases, and the shared Builder E2E artifact is retained long enough for delayed failed-job reruns.

Closes #6053

## Root cause

Applying `safe-to-deploy` still triggered the intended workflows, but each job stopped at checkout with:

> Refusing to check out fork pull request code from a `pull_request_target` workflow.

The label is the repository's explicit human-review gate for trusted fork code, but the checkout steps did not pass the action's new explicit opt-in.

A later failed-job rerun also could not download `builder-e2e-build` because its one-day retention period had elapsed. The affected JavaScript actions additionally targeted the deprecated Node 20 action runtime.

## Implementation

- Opt into fork checkout only when the event is `pull_request_target` and the applied label is exactly `safe-to-deploy`.
- Apply the opt-in to Main, Chromatic, Visual Regression Tests, and Vercel staging checkout steps.
- Gate `check-size` with the same push, regular PR, or reviewed-fork condition as the other Main workflow jobs.
- Gate `deployment-host` so synchronize events only remove the approval label and do not check out fork code.
- Upgrade the affected Checkout, Setup Node, pnpm setup, Cache, artifact, GitHub Script, and Chromatic actions to Node 24-compatible majors.
- Retain `builder-e2e-build` for seven days so delayed failed-job reruns can download it.
- Preserve existing push and normal `pull_request` paths.

## Security tradeoff

`pull_request_target` jobs have base-repository credentials and secrets. This change deliberately permits fork checkout only after a maintainer applies `safe-to-deploy`; no other label or synchronize event receives the opt-in.

## Todo

- [x] Reproduce and inspect the checkout failure on fork PR #6041.
- [x] Add explicit checkout opt-in behind the trusted label.
- [x] Gate previously unconditional jobs before enabling fork checkout.
- [x] Upgrade affected JavaScript actions to Node 24-compatible releases.
- [x] Keep Builder E2E prerequisites available for delayed reruns.
- [x] Review documentation impact; no product documentation is affected.
- [x] Verify fixture inputs and outputs are unaffected.
- [ ] Verify the labeled fork path after this workflow version reaches `main`.

## Verification

- `git diff --check`
- Parsed all changed workflow and composite-action YAML files with Ruby's YAML parser.
- Verified each upgraded action manifest declares the Node 24 runtime.
- Verified `actions/checkout@v5` retains the `allow-unsafe-pr-checkout` input.
- Audited every `actions/checkout` step in the affected `pull_request_target` workflows for the exact label guard.
- PR checks passed for Main, Chromatic, Vercel staging, submodules, and PR title validation; Lost Pixel remains excluded from this fix.

The live labeled-fork execution cannot be proven from this PR itself because `pull_request_target` loads workflow definitions from the base branch. It should be verified with a fork PR after this change reaches `main`.